### PR TITLE
fix: fixed datepicker popper styling

### DIFF
--- a/scss/components/date-picker.scss
+++ b/scss/components/date-picker.scss
@@ -11,7 +11,7 @@ $block: #{$fd-namespace}-date-picker;
 
 .#{$block} {
     .#{$fd-namespace}-popover {
-        &__body {
+        &__body, &__popper {
             padding: 0 fd-space(xs);
         }
     }


### PR DESCRIPTION
Closes SAP/fundamental-styles#8

There is no example of this in the documentation, but padding was not applied to the popover body when using popper.js and a date picker. This PR fixes this. If there's any issues or concerns please let me know as this is my first non-fundamental-ngx contribution in quite some time 😅
