### PR TITLE
fix: fixed negative bottom margin

### DIFF
--- a/scss/components/breadcrumb.scss
+++ b/scss/components/breadcrumb.scss
@@ -20,7 +20,7 @@ $block: #{$fd-namespace}-breadcrumb;
     display: flex;
     flex-wrap: wrap;
     padding-left: 0;
-    margin-bottom: -#{fd-space(3)};
+    margin-bottom: 0;
     list-style: none;
     padding-right: fd-space(4);
 


### PR DESCRIPTION
Closes SAP/fundamental-styles#12

set bottom margin to 0 in breadcrumb component to avoid overlapping of components.