### PR TITLE
fix: remove 100% height from localizationEditor button

### DIFF
--- a/scss/components/localization-editor.scss
+++ b/scss/components/localization-editor.scss
@@ -29,11 +29,6 @@ $block: #{$fd-namespace}-localization-editor;
         }
     }
 
-    &__button {
-        height: 100% !important;
-        max-height: 100% !important;
-    }
-
     .fd-popover__body {
         width: 100%;
     }


### PR DESCRIPTION
Closes SAP/fundamental-styles#34

Before: 
![Screen Shot 2019-06-07 at 9 35 17 AM](https://user-images.githubusercontent.com/29607818/59119645-25e4b500-8908-11e9-9ed7-8f79b92ef9bc.png)


After:
![Screen Shot 2019-06-07 at 9 34 48 AM](https://user-images.githubusercontent.com/29607818/59119647-29783c00-8908-11e9-97e8-093e37143a2e.png)


We might want to look into making our tests more sensitive - it should have caught this error when I introduced it in https://github.com/SAP/fundamental/pull/1401 and it should have caught these changes in this pr in the tests. 

I can't find any side effects of removing this, but since our tests aren't picking up these changes I'm nervous about just deleting it. Thoughts?