### PR TITLE
fix: self-contained styles for label component

### DIFF
--- a/components/label.scss
+++ b/components/label.scss
@@ -1,0 +1,6 @@
+$fd-icons-path: "../scss/icons/";
+$fd-fonts-path: "../scss/fonts/";
+
+@import "../scss/components/label";
+@import "../scss/icons/icon";
+@import "../scss/fonts/72";

--- a/components/label.scss
+++ b/components/label.scss
@@ -2,5 +2,5 @@ $fd-icons-path: "../scss/icons/";
 $fd-fonts-path: "../scss/fonts/";
 
 @import "../scss/components/label";
-@import "../scss/icons/icon";
+@import "../scss/core/elements";
 @import "../scss/fonts/72";

--- a/components/label.scss
+++ b/components/label.scss
@@ -1,6 +1,4 @@
-$fd-icons-path: "../scss/icons/";
 $fd-fonts-path: "../scss/fonts/";
 
 @import "../scss/components/label";
-@import "../scss/core/elements";
 @import "../scss/fonts/72";

--- a/test/resources/theme-ugly.css
+++ b/test/resources/theme-ugly.css
@@ -1,5 +1,6 @@
 :root {
     --fd-color-action-1: magenta;
+    --fd-color-action: orangered;
     --fd-color-action-2: purple;
     --fd-color-background-2: palegoldenrod;
     --fd-color-action-hover: lime;


### PR DESCRIPTION
Closes #102 

This PR contains the self-contained styling for the label component. 
This PR is part of the larger task of making all components self-contained.