### PR TITLE
fix: added self-contained style for link component

### DIFF
--- a/components/link.scss
+++ b/components/link.scss
@@ -2,6 +2,5 @@ $fd-icons-path: "../scss/icons/";
 $fd-fonts-path: "../scss/fonts/";
 
 @import "../scss/components/link";
-@import "../scss/core/elements";
 @import "../scss/icons/icon";
 @import "../scss/fonts/72";

--- a/components/link.scss
+++ b/components/link.scss
@@ -1,0 +1,7 @@
+$fd-icons-path: "../scss/icons/";
+$fd-fonts-path: "../scss/fonts/";
+
+@import "../scss/components/link";
+@import "../scss/core/elements";
+@import "../scss/icons/icon";
+@import "../scss/fonts/72";

--- a/scss/components/link.scss
+++ b/scss/components/link.scss
@@ -10,3 +10,10 @@ $block: #{$fd-namespace}-link;
 .#{$block} {
   @include fd-link();
 }
+
+a.#{$block} {
+  font-size: $fd-font-size;
+  font-family: $fd-font-family;
+  line-height: $fd-line-height;
+  -webkit-font-smoothing: antialiased;
+}

--- a/scss/components/link.scss
+++ b/scss/components/link.scss
@@ -8,12 +8,6 @@
 $block: #{$fd-namespace}-link;
 
 .#{$block} {
+  @include fd-reset();
   @include fd-link();
-}
-
-a.#{$block} {
-  font-size: $fd-font-size;
-  font-family: $fd-font-family;
-  line-height: $fd-line-height;
-  -webkit-font-smoothing: antialiased;
 }

--- a/scss/mixins/_mixins.scss
+++ b/scss/mixins/_mixins.scss
@@ -225,6 +225,9 @@
 
 @mixin fd-link($color: $fd-color--action) {
   @include fd-var-color("color", $fd-color--action, --fd-color-action-1);
+  text-decoration: none;
+  display: inline-block;
+  transition: all $fd-animation--speed ease-in;
   border-bottom-style: solid;
   border-bottom-width: 1px;
   @include fd-var-color("border-bottom-color", $fd-color--action, --fd-color-action-1);
@@ -239,10 +242,18 @@
   @include fd-active-pressed-selected() {
     @include fd-var-color("color", map-get($fd-colors-action-states, "selected"), --fd-color-action-selected);
     @include fd-var-color("border-bottom-color", map-get($fd-colors-action-states, "selected"), --fd-color-action-selected);
+    outline: none;
   }
   @include fd-disabled() {
     @include fd-var-color("color", map-get($fd-colors-action-states, "disabled"), --fd-color-action-disabled);
     @include fd-var-color("border-bottom-color", map-get($fd-colors-action-states, "disabled"), --fd-color-action-disabled);
+    @include fd-var-color("outline-color", fd-color-state("disabled", "action"), --fd-color-action-disabled);
+    cursor: not-allowed;
+  }
+  &:focus {
+    outline-style: dotted;
+    outline-width: 1px;
+    @include fd-var-color("outline-color", fd-color-state("hover", "action"), --fd-color-action-focus);
   }
 }
 


### PR DESCRIPTION
Closes #101 

This PR contains the self-contained styling for the link component. 
This PR is part of the larger task of making all components self-contained. #136 