### PR TITLE
fix: added self-contained styles for image component

### DIFF
--- a/components/image.scss
+++ b/components/image.scss
@@ -1,4 +1,3 @@
-$fd-fonts-path: "../scss/fonts/";
 
 @import "../scss/components/image";
-@import "../scss/fonts/72";
+

--- a/components/image.scss
+++ b/components/image.scss
@@ -1,0 +1,4 @@
+$fd-fonts-path: "../scss/fonts/";
+
+@import "../scss/components/image";
+@import "../scss/fonts/72";


### PR DESCRIPTION
Closes SAP/fundamental-styles#124

This PR contains the self-contained styling for the image component.
This PR is part of the larger task of making all components self-contained. #136 
