### PR TITLE
fix: Added self-contained style for token component

### DIFF
--- a/components/token.scss
+++ b/components/token.scss
@@ -2,6 +2,5 @@ $fd-icons-path: "../scss/icons/";
 $fd-fonts-path: "../scss/fonts/";
 
 @import "../scss/components/token";
-@import "../scss/components/button";
 @import "../scss/icons/icon";
 @import "../scss/fonts/72";

--- a/components/token.scss
+++ b/components/token.scss
@@ -1,0 +1,5 @@
+$fd-icons-path: "../scss/icons/";
+
+@import "../scss/components/token";
+@import "../scss/components/button.scss";
+@import "../scss/icons/icon";

--- a/components/token.scss
+++ b/components/token.scss
@@ -1,5 +1,7 @@
 $fd-icons-path: "../scss/icons/";
+$fd-fonts-path: "../scss/fonts/";
 
 @import "../scss/components/token";
-@import "../scss/components/button.scss";
+@import "../scss/components/button";
 @import "../scss/icons/icon";
+@import "../scss/fonts/72";

--- a/test/resources/theme-ugly.css
+++ b/test/resources/theme-ugly.css
@@ -8,6 +8,7 @@
     --fd-color-status-2: #666;
     --fd-color-status-3: #999;
     --fd-color-status-4: #ccc;
+    --fd-color-text-2: mediumaquamarine;
 
     --fd-forms-height: 50px;
     --fd-forms-height-compact: 25px;

--- a/test/templates/token/index.njk
+++ b/test/templates/token/index.njk
@@ -6,7 +6,6 @@
 {% block content %}
 
     <h1>token</h1>
-    <p>Example shows the link for "Clear All" even though it is not part of the component.</p>
 
     <!-- output the component example and the code snippet -->
     {% set example %}
@@ -32,7 +31,6 @@
         properties=data.properties
     )
 }}
-<button type="button" name="button" class="fd-button--light fd-button--xs">Clear All</button>
     {% endset %}
     {{ format(example) }}
 


### PR DESCRIPTION
Closes #132 

This PR contains the self-contained styling for the token component.
This PR is part of the larger task of making all components self-contained. #136 
