### PR TITLE
fix: added self contained style for inline-help component

### DIFF
--- a/components/inline-help.scss
+++ b/components/inline-help.scss
@@ -1,0 +1,6 @@
+$fd-icons-path: "../scss/icons/";
+$fd-fonts-path: "../scss/fonts/";
+
+@import "../scss/components/inline-help";
+@import "../scss/icons/icon";
+@import "../scss/fonts/72";


### PR DESCRIPTION
Closes SAP/fundamental-styles#146

This PR contains the self-contained styling for the inline-help component.
This PR is part of the larger task of making all components self-contained. #136