### PR TITLE
fix: Fixed is-disabled class on span element in time picker component

### DIFF
--- a/scss/components/input-group.scss
+++ b/scss/components/input-group.scss
@@ -163,6 +163,11 @@ $block: #{$fd-namespace}-input-group;
                 width: 0;
             }
         }
+        &.is-disabled {
+            border-color: var(--fd-color-neutral-2);
+            opacity: 0.4;
+            cursor: not-allowed;
+        }
     }
     &--before {
         #{$fd-elements-inputs--text} {
@@ -174,6 +179,9 @@ $block: #{$fd-namespace}-input-group;
         #{$fd-elements-inputs--text} {
             border-top-right-radius: 0;
             border-bottom-right-radius: 0;
+            &:disabled {
+                opacity: 0.4;
+            }
         }
     }
     &__button {


### PR DESCRIPTION
Closes SAP/fundamental-styles#69

Fixed is-disabled class on span element in time picker component. See screenshot below. 

<img width="681" alt="Screen Shot 2019-07-04 at 11 39 27 AM" src="https://user-images.githubusercontent.com/25252963/60678124-80aef500-9e51-11e9-9007-18fbfec69743.png">

