### PR TITLE
fix: added self-contained style for product-tile component 

### DIFF
--- a/components/product-tile.scss
+++ b/components/product-tile.scss
@@ -1,0 +1,2 @@
+
+@import "../scss/components/product-tile";

--- a/scss/components/product-tile.scss
+++ b/scss/components/product-tile.scss
@@ -58,9 +58,8 @@ $block: #{$fd-namespace}-product-tile;
     padding: $fd-product-tile-content-padding-x $fd-product-tile-content-padding-x;
   }
   &__title {
+    @include fd-reset-spacing();
     @include fd-type("1");
     @include fd-var-color("color", $fd-product-tile-title-color, --fd-product-tile-title-color);
-    margin-bottom: 0;
-    margin-bottom: 0;
   }
 }


### PR DESCRIPTION
Closes SAP/fundamental-styles#160

This PR contains the self-contained styling for the product-tile component.
This PR is part of the larger task of making all components self-contained. #136
