### PR TITLE
fix: possible fix for dimension issue with links

### DIFF
--- a/scss/mixins/_mixins.scss
+++ b/scss/mixins/_mixins.scss
@@ -225,28 +225,47 @@
 
 @mixin fd-link($color: $fd-color--action) {
   @include fd-var-color("color", $fd-color--action, --fd-color-action-1);
-  text-decoration: none;
+  //text-decoration: underline;
   display: inline-block;
   transition: all $fd-animation--speed ease-in;
-  border-bottom-style: solid;
-  border-bottom-width: 1px;
-  @include fd-var-color("border-bottom-color", $fd-color--action, --fd-color-action-1);
+  //border-bottom-style: solid;
+  //border-bottom-width: 1px;
+  text-decoration: none;
+  position: relative;
+  &::after {
+    content: '';
+    width: 100%;
+    position: absolute;
+    left: 0;
+    bottom: 1px;
+    border-width: 0 0 1px;
+    border-style: solid;
+    @include fd-var-color("border-bottom-color", $fd-color--action, --fd-color-action-1);
+  }
   @include fd-hover() {
     @include fd-var-color("color", map-get($fd-colors-action-states, "hover"), --fd-color-action-hover);
-    @include fd-var-color("border-bottom-color", map-get($fd-colors-action-states, "hover"), --fd-color-action-hover);
+    &::after {
+      @include fd-var-color("border-bottom-color", map-get($fd-colors-action-states, "hover"), --fd-color-action-hover);
+    }
   }
   &:visited {
     @include fd-var-color("color", map-get($fd-colors-action-states, "visited"), --fd-color-action-visited);
-    @include fd-var-color("border-bottom-color", map-get($fd-colors-action-states, "visited"), --fd-color-action-visited);
+    &::after {
+      @include fd-var-color("border-bottom-color", map-get($fd-colors-action-states, "visited"), --fd-color-action-visited);
+    }
   }
   @include fd-active-pressed-selected() {
     @include fd-var-color("color", map-get($fd-colors-action-states, "selected"), --fd-color-action-selected);
+  &::after {
     @include fd-var-color("border-bottom-color", map-get($fd-colors-action-states, "selected"), --fd-color-action-selected);
-    outline: none;
+  }
+  outline: none;
   }
   @include fd-disabled() {
     @include fd-var-color("color", map-get($fd-colors-action-states, "disabled"), --fd-color-action-disabled);
-    @include fd-var-color("border-bottom-color", map-get($fd-colors-action-states, "disabled"), --fd-color-action-disabled);
+    &::after {
+      @include fd-var-color("border-bottom-color", map-get($fd-colors-action-states, "disabled"), --fd-color-action-disabled);
+    }
     @include fd-var-color("outline-color", fd-color-state("disabled", "action"), --fd-color-action-disabled);
     cursor: not-allowed;
   }

--- a/scss/mixins/_mixins.scss
+++ b/scss/mixins/_mixins.scss
@@ -225,11 +225,8 @@
 
 @mixin fd-link($color: $fd-color--action) {
   @include fd-var-color("color", $fd-color--action, --fd-color-action-1);
-  //text-decoration: underline;
   display: inline-block;
   transition: all $fd-animation--speed ease-in;
-  //border-bottom-style: solid;
-  //border-bottom-width: 1px;
   text-decoration: none;
   position: relative;
   &::after {


### PR DESCRIPTION
Closes #142 

using bottom-border as a stand-in for underline has some stylistic advantages (it will underline text and icons paired together for example), however it can cause the bounding box to have a different dimension than text without a bottom-border.

This solution uses a `:after` absolutely positioned element to get the same underline effect, but without affecting bounding-box dimension changes.

worth considering, but may not be merge worthy