### PR TITLE
fix: Added padding, margin and border to fd-reset mixin

### DIFF
--- a/scss/components/alert.scss
+++ b/scss/components/alert.scss
@@ -161,7 +161,6 @@ $block: #{$fd-namespace}-alert;
       }
     }
     &__text {
-      margin-bottom: 0;
-      margin-top: 0;
+      @include fd-reset();
     }
 }

--- a/scss/components/side-nav.scss
+++ b/scss/components/side-nav.scss
@@ -36,8 +36,7 @@ $block: #{$fd-namespace}-side-nav;
 
     background-color: $fd-side-nav-background-color;
     min-width: $fd-side-nav-max-width;
-    margin: 0;
-    padding: 0;
+    @include fd-reset();
 
     //ELEMENTS *******************************************
     &__group {
@@ -75,8 +74,14 @@ $block: #{$fd-namespace}-side-nav;
         }
     }
 
+    &__item,
+    &__subitem {
+        @include fd-reset();
+    }
+
     &__link,
     &__sublink {
+        @include fd-reset();
         display: flex;
         padding: $fd-side-nav-link-padding;
         color: $fd-side-nav-link-color;

--- a/scss/components/status-label.scss
+++ b/scss/components/status-label.scss
@@ -48,133 +48,119 @@ $fd-status-label-icon-size: fd-space(4) !default;
   --fd-status-label-color: var(--fd-color-text-2);
   --fd-status-label-icon-background-color: var(--fd-color-text-2);
 
-    //LOCAL VARS (set all themeable properties, always include !default)
+  //LOCAL VARS (set all themeable properties, always include !default)
 
-    $fd-status-indicator-available: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCA2IDUuOSIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgNiA1Ljk7IiB4bWw6c3BhY2U9InByZXNlcnZlIj4KPHN0eWxlIHR5cGU9InRleHQvY3NzIj4KCS5zdDB7ZmlsbDojRkZGRkZGO30KPC9zdHlsZT4KPHBhdGggY2xhc3M9InN0MCIgZD0iTTIuNywzLjJsMS40LTIuOEM0LjQsMCw1LTAuMSw1LjUsMC4xYzAuNCwwLjMsMC42LDAuOCwwLjQsMS4ybC0yLDRDMy42LDUuOSwzLDYuMSwyLjYsNS44CgljLTAuMSwwLTAuMi0wLjEtMC4zLTAuMmwtMi0yYy0wLjQtMC40LTAuNC0xLDAtMS40YzAuNC0wLjQsMS0wLjQsMS40LDBsMCwwTDIuNywzLjJ6Ii8+Cjwvc3ZnPg==" !default;
-    $fd-status-indicator-away: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCA1IDUiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDUgNTsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiNGRkZGRkY7fQo8L3N0eWxlPgo8cGF0aCBjbGFzcz0ic3QwIiBkPSJNMSw1QzAuNCw1LDAsNC42LDAsNFYxYzAtMC42LDAuNC0xLDEtMXMxLDAuNCwxLDF2MmgyYzAuNiwwLDEsMC40LDEsMVM0LjYsNSw0LDVIMXoiLz4KPC9zdmc+" !default;
-    $fd-status-indicator-busy: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCA0IDQiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDQgNDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiNGRkZGRkY7fQo8L3N0eWxlPgo8cGF0aCBjbGFzcz0ic3QwIiBkPSJNNCwyYzAsMS4xLTAuOSwyLTIsMlMwLDMuMSwwLDJzMC45LTIsMi0yUzQsMC45LDQsMiIvPgo8L3N2Zz4=" !default;
-    $fd-status-indicator-offline: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCA3LjkgNy45IiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA3LjkgNy45OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+Cgkuc3Qwe2ZpbGw6I0ZGRkZGRjt9Cjwvc3R5bGU+CjxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik03LjksNGMwLDIuMi0xLjgsNC00LDRTMCw2LjIsMCw0czEuOC00LDQtNFM3LjksMS44LDcuOSw0Ii8+Cjwvc3ZnPg==" !default;
+  $fd-status-indicator-available: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCA2IDUuOSIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgNiA1Ljk7IiB4bWw6c3BhY2U9InByZXNlcnZlIj4KPHN0eWxlIHR5cGU9InRleHQvY3NzIj4KCS5zdDB7ZmlsbDojRkZGRkZGO30KPC9zdHlsZT4KPHBhdGggY2xhc3M9InN0MCIgZD0iTTIuNywzLjJsMS40LTIuOEM0LjQsMCw1LTAuMSw1LjUsMC4xYzAuNCwwLjMsMC42LDAuOCwwLjQsMS4ybC0yLDRDMy42LDUuOSwzLDYuMSwyLjYsNS44CgljLTAuMSwwLTAuMi0wLjEtMC4zLTAuMmwtMi0yYy0wLjQtMC40LTAuNC0xLDAtMS40YzAuNC0wLjQsMS0wLjQsMS40LDBsMCwwTDIuNywzLjJ6Ii8+Cjwvc3ZnPg==" !default;
+  $fd-status-indicator-away: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCA1IDUiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDUgNTsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiNGRkZGRkY7fQo8L3N0eWxlPgo8cGF0aCBjbGFzcz0ic3QwIiBkPSJNMSw1QzAuNCw1LDAsNC42LDAsNFYxYzAtMC42LDAuNC0xLDEtMXMxLDAuNCwxLDF2MmgyYzAuNiwwLDEsMC40LDEsMVM0LjYsNSw0LDVIMXoiLz4KPC9zdmc+" !default;
+  $fd-status-indicator-busy: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCA0IDQiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDQgNDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiNGRkZGRkY7fQo8L3N0eWxlPgo8cGF0aCBjbGFzcz0ic3QwIiBkPSJNNCwyYzAsMS4xLTAuOSwyLTIsMlMwLDMuMSwwLDJzMC45LTIsMi0yUzQsMC45LDQsMiIvPgo8L3N2Zz4=" !default;
+  $fd-status-indicator-offline: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCA3LjkgNy45IiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA3LjkgNy45OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+Cgkuc3Qwe2ZpbGw6I0ZGRkZGRjt9Cjwvc3R5bGU+CjxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik03LjksNGMwLDIuMi0xLjgsNC00LDRTMCw2LjIsMCw0czEuOC00LDQtNFM3LjksMS44LDcuOSw0Ii8+Cjwvc3ZnPg==" !default;
 
+  //BLOCK BASE *******************************************
+  position: relative;
+  @include fd-reset();
 
-    @mixin fd-status-icon-bg {
-        width: $fd-status-label-icon-size;
-        height: $fd-status-label-icon-size;
-        display: inline-block;
-        content: "";
-        line-height: 1;
-        border-radius: 50%;
-        position: absolute;
-        top: 0;
-        left: 0;
-    }
-    @mixin fd-status-icon {
-        position: absolute;
-        z-index: map-get($fd-z-index-levels, "first");
-        background-repeat: no-repeat;
-        content: "";
-        line-height: 1;
-    }
-
-    //BLOCK BASE *******************************************
-    position: relative;
-    @include fd-reset();
-
-    @include fd-var-color("color", map-get($fd-colors-text, 2), --fd-status-label-color);
+  @include fd-var-color("color", map-get($fd-colors-text, 2), --fd-status-label-color);
 
 
+  &::before {
+      vertical-align: -8%;
+      width: fd-space(5);
+      height: $fd-status-label-icon-size;
+      line-height: 1;
+  }
+
+  //BLOCK MODIFIERS ************
+  &.#{$block}--success {
+    --fd-status-label-color: var(--fd-color-positive);
+    @include fd-var-color("color", $fd-color--success, --fd-status-label-color);
+  }
+
+  &.#{$block}--warning {
+    --fd-status-label-color: var(--fd-color-alert);
+    @include fd-var-color("color", $fd-color--warning, --fd-status-label-color);
+  }
+
+  &.#{$block}--error {
+    --fd-status-label-color: var(--fd-color-negative);
+    @include fd-var-color("color", $fd-color--error, --fd-status-label-color);
+  }
+
+  &.#{$block}--available {
+    --fd-status-label-icon-background-color: var(--fd-color-positive);
+    @extend %fd-status-icon;
     &::before {
-        vertical-align: -8%;
-        width: fd-space(5);
-        height: $fd-status-label-icon-size;
-        line-height: 1;
+      width: 7px;
+      height: 7px;
+      top: 4px;
+      left: 4px;
+      background-image: url($fd-status-indicator-available);
     }
-
-    //BLOCK MODIFIERS ************
-    &--success {
-      --fd-status-label-color: var(--fd-color-positive);
-      @include fd-var-color("color", $fd-color--success, --fd-status-label-color);
+    &::after {
+      @include fd-var-color("background-color", $fd-color--success, --fd-status-label-icon-background-color);
     }
-    &--warning {
-      --fd-status-label-color: var(--fd-color-alert);
-      @include fd-var-color("color", $fd-color--warning, --fd-status-label-color);
-    }
-    &--error {
-      --fd-status-label-color: var(--fd-color-negative);
-      @include fd-var-color("color", $fd-color--error, --fd-status-label-color);
-    }
-    &--available {
-      --fd-status-label-icon-background-color: var(--fd-color-positive);
-      @extend %fd-status-icon;
+    @include fd-rtl() {
       &::before {
-        width: 7px;
-        height: 7px;
+        right: 4px;
+      }
+    }
+  }
+
+  &.#{$block}--away {
+    --fd-status-label-icon-background-color: var(--fd-color-alert);
+    @extend %fd-status-icon;
+    &::before {
+      width: 6px;
+      height: 6px;
+      top: 4px;
+      left: 6px;
+      background-image: url($fd-status-indicator-away);
+    }
+    &::after {
+      @include fd-var-color("background-color", $fd-color--warning, --fd-status-label-icon-background-color);
+    }
+    @include fd-rtl() {
+      &::before {
+        right: 4px;
+      }
+    }
+  }
+
+  &.#{$block}--busy {
+    --fd-status-label-icon-background-color: var(--fd-color-negative);
+    @extend %fd-status-icon;
+    &::before {
+      width: 4px;
+      height: 4px;
+      top: 6px;
+      left: 6px;
+      background-image: url($fd-status-indicator-busy);
+    }
+    &::after {
+      @include fd-var-color("background-color", $fd-color--error, --fd-status-label-icon-background-color);
+    }
+    @include fd-rtl() {
+      &::before {
+        right: 6px;
+      }
+    }
+  }
+
+  &.#{$block}--offline {
+    @extend %fd-status-icon;
+    &::before {
+        width: 8px;
+        height: 8px;
         top: 4px;
         left: 4px;
-        background-image: url($fd-status-indicator-available);
-      }
-      &::after {
-        @include fd-var-color("background-color", $fd-color--success, --fd-status-label-icon-background-color);
-      }
-      @include fd-rtl() {
-        &::before {
-          right: 4px;
-        }
-      }
+        background-image: url($fd-status-indicator-offline);
     }
-    &--away {
-      --fd-status-label-icon-background-color: var(--fd-color-alert);
-      @extend %fd-status-icon;
+    &::after {
+      //default
+    }
+    @include fd-rtl() {
       &::before {
-        width: 6px;
-        height: 6px;
-        top: 4px;
-        left: 6px;
-        background-image: url($fd-status-indicator-away);
-      }
-      &::after {
-        @include fd-var-color("background-color", $fd-color--warning, --fd-status-label-icon-background-color);
-      }
-      @include fd-rtl() {
-        &::before {
-          right: 4px;
-        }
+        right: 4px;
       }
     }
-    &--busy {
-      --fd-status-label-icon-background-color: var(--fd-color-negative);
-      @extend %fd-status-icon;
-      &::before {
-        width: 4px;
-        height: 4px;
-        top: 6px;
-        left: 6px;
-        background-image: url($fd-status-indicator-busy);
-      }
-      &::after {
-        @include fd-var-color("background-color", $fd-color--error, --fd-status-label-icon-background-color);
-      }
-      @include fd-rtl() {
-        &::before {
-          right: 6px;
-        }
-      }
-    }
-    &--offline {
-      @extend %fd-status-icon;
-      &::before {
-          width: 8px;
-          height: 8px;
-          top: 4px;
-          left: 4px;
-          background-image: url($fd-status-indicator-offline);
-      }
-      &::after {
-        //default
-      }
-      @include fd-rtl() {
-        &::before {
-          right: 4px;
-        }
-      }
-    }
+  }
 }

--- a/scss/mixins/_mixins.scss
+++ b/scss/mixins/_mixins.scss
@@ -7,6 +7,9 @@
     font-family: $fd-font-family;
     -webkit-font-smoothing: antialiased;
     box-sizing: border-box;
+    padding: 0;
+    margin: 0;
+    border: 0;
     &::before,
     &::after {
         box-sizing: inherit;

--- a/test/resources/unnormalize.css
+++ b/test/resources/unnormalize.css
@@ -1,6 +1,6 @@
 body {
     font-size: 24px;
-    font-family: Courier, monospace;
+    font-family: "Comic Sans MS", Courier, monospace;
     color: brown;
 }
 

--- a/test/resources/unnormalize.css
+++ b/test/resources/unnormalize.css
@@ -1,14 +1,18 @@
 body {
     font-size: 24px;
     font-family: Courier, monospace;
+    color: brown;
 }
 
 p,
 a,
+ul,
+li,
 button {
-    font-size: 20px;
+    font-size: 30px;
     padding: 20px;
     margin: 20px;
+    border: 2px dashed orangered;
 }
 
 h1,


### PR DESCRIPTION
After checking pages with the "Un-normalize" playground toggle, it was found that a number of components were allowing styles to bleed in.  This adds padding, margin and border resets to the `fd-reset` mixin.

Once that was in place, there were a few components that were adjusted to prevent the bleed in of external styling.  They were:

* Alert
* Link (no additional changes were necessary after the `fd-reset` mixin was adjusted)
* Side Nav
* Status Label (changed the modifier classes to be sibling classes rather than standalone)