### PR TITLE
feat: added tag component

### DIFF
--- a/docs/pages/components/tag.md
+++ b/docs/pages/components/tag.md
@@ -1,0 +1,73 @@
+---
+title: Tag
+id: tag
+keywords: tag, token
+sidebar: left-navigation-sidebar
+toc: false
+permalink: components/tag.html
+folder: components
+summary:
+---
+
+Tags are used to represent contextualizing information. They can be useful to show applied filters, selected values for form field or object metadata.
+{: .docs-intro}
+
+<br>
+
+{% capture default-tag %}
+<span class="fd-tag" role="button">
+  Bibendum
+  <span class="fd-tag__close"></span>
+</span>
+
+<span class="fd-tag" role="button">
+  Lorem
+  <span class="fd-tag__close"></span>
+</span>
+
+<span class="fd-tag" role="button">
+  Dolor
+  <span class="fd-tag__close"></span>
+</span>
+
+<span class="fd-tag" role="button">
+  Filter
+  <span class="fd-tag__close"></span>
+</span>
+
+<span class="fd-tag" role="button">
+  Filter
+  <span class="fd-tag__close"></span>
+</span>
+{% endcapture %}
+{% include display-component.html component=default-tag %}
+
+{% capture rtl-tag %}
+<div dir="rtl">
+  <span class="fd-tag" role="button">
+    Bibendum
+    <span class="fd-tag__close"></span>
+  </span>
+
+  <span class="fd-tag" role="button">
+    Lorem
+    <span class="fd-tag__close"></span>
+  </span>
+
+  <span class="fd-tag" role="button">
+    Dolor
+    <span class="fd-tag__close"></span>
+  </span>
+
+  <span class="fd-tag" role="button">
+    Filter
+    <span class="fd-tag__close"></span>
+  </span>
+
+  <span class="fd-tag" role="button">
+    Filter
+    <span class="fd-tag__close"></span>
+  </span>
+</div>
+{% endcapture %}
+{% include display-component.html component=rtl-tag %}

--- a/docs/pages/components/token.md
+++ b/docs/pages/components/token.md
@@ -19,6 +19,9 @@ Token are used to represent contextualizing information. They can be useful to s
 <span class="fd-token" role="button">Lorem</span>
 <span class="fd-token" role="button">Dolor</span>
 <span class="fd-token" role="button">Filter</span>
+<span class="fd-token" role="button">
+Filter <span class="sap-icon--decline sap-icon--s"></span>
+</span>
 {% endcapture %}
 
 {% include display-component.html component=default-alert %}

--- a/scss/components.scss
+++ b/scss/components.scss
@@ -18,6 +18,7 @@
 @import "components/inline-help";
 @import "components/nav";
 @import "components/tabs";
+@import "components/tag";
 @import "components/toggle";
 @import "components/spinner";
 @import "components/image";

--- a/scss/components/tag.scss
+++ b/scss/components/tag.scss
@@ -1,0 +1,57 @@
+@import "./../settings";
+@import "./../mixins";
+@import "./../icons/mixins";
+@import "./../functions";
+
+
+/*!
+.fd-tag+(--no-border)
+    .fd-tag__content+()
+    .fd-tag__title+()
+*/
+$block: #{$fd-namespace}-tag;
+
+.#{$block} {
+  &__close {
+    @include fd-icon("decline", "s") {
+      @include fd-var-color("color", fd-color("action", 1), --fd-color-action-1);
+      margin-left: fd-space(tiny);
+      margin-right: 0;
+      vertical-align: bottom;
+      line-height: fd-space(6);
+      cursor: pointer;
+    }
+    @include fd-focus();
+    @include fd-rtl() {
+      @include fd-icon("decline", "s") {
+        @include fd-var-color("color", fd-color("action", 1), --fd-color-action-1);
+        margin-left: 0;
+        margin-right: fd-space(tiny);
+        vertical-align: bottom;
+        line-height: fd-space(6);
+        cursor: pointer;
+      }
+    }
+  }
+    //LOCAL VARS (set all themeable properties, always include !default)
+    $fd-tag-border-color: fd-color("neutral", 3) !default;
+    $fd-tag-color: fd-color("text", 2) !default;
+    $fd-tag-background-color: fd-color("neutral", 1) !default;
+    --fd-tag-color: var(--fd-color-text-2);
+    --fd-tag-background-color: var(--fd-color-neutral-1);
+    --fd-tag-border-color: var(--fd-color-neutral-3);
+
+    @include fd-reset();
+    @include fd-type("-1");
+    @include fd-var-color("color", $fd-tag-color, --fd-tag-color);
+    @include fd-var-color("background-color", $fd-tag-background-color, --fd-tag-background-color);
+    line-height: fd-space(6);
+    vertical-align: middle;
+    display: inline-block;
+    padding-left: fd-space(2);
+    padding-right: fd-space(2);
+    border-radius: $fd-border-radius;
+    border-width: 1px;
+    border-style: solid;
+    @include fd-var-color("border-color", $fd-tag-border-color, --fd-tag-border-color);
+}


### PR DESCRIPTION
This PR adds a *tag*-component.

- I have absolutely no strong feelings about the naming.
- The *tag*-component tries to be just like the already existing *token*-component with one small difference: The *close*-button is it's own element.

Other than that those two components should be identical.

Why is that important?

1. `fd-tag` can be used without the *close*-button: Just don't add `<span class="fd-tag__close"></span>` inside the `fd-tag`-span.
2. You can detect clicks on the close-button/element and differentiate clicks on the close button from clicks on the tag-title.

I have adjusted the docs and include two examples: Default tags and RTL-tags.

I would also like to add some kind of `selected`-state – but let's take one step at a time. I have a feeling this PR may require some talking. :D 

<img width="968" alt="Screenshot 2019-07-15 at 15 12 21" src="https://user-images.githubusercontent.com/153225/61218729-f8630680-a712-11e9-839f-0b3c4ede0429.png">
