### PR TITLE
docs: update search.json to remove summary

### DIFF
--- a/docs/js/search.json
+++ b/docs/js/search.json
@@ -12,7 +12,6 @@ layout:
 "tags": "{{ page.tags }}",
 "keywords": "{{page.keywords}}",
 "url": "{{ page.url}}",
-"summary": "{{page.summary | strip }}",
 "folder": "{{page.folder | strip }}"
 }
 {% unless forloop.last and site.posts.size < 1 %},{% endunless %}
@@ -25,8 +24,7 @@ layout:
 "title": "{{ post.title | escape }}",
 "tags": "{{ post.tags }}",
 "keywords": "{{post.keywords}}",
-"url": "{{ post.url | remove: "/" }}",
-"summary": "{{post.summary | strip }}"
+"url": "{{ post.url | remove: "/" }}"
 }
 {% unless forloop.last %},{% endunless %}
 {% endfor %}


### PR DESCRIPTION
Remove `summary` parameter from search.json template. This is not needed and often breaks search functionality due to quotes in summary content. 

#### Test

* http://127.0.0.1:4000/components/index.html

#### Changelog

**Removed**

* removed summary parameter from search.json template 
