### PR TITLE
fix: added self-contained style for Tabs component

### DIFF
--- a/components/tabs.scss
+++ b/components/tabs.scss
@@ -1,0 +1,1 @@
+@import "../scss/components/tabs";

--- a/components/tabs.scss
+++ b/components/tabs.scss
@@ -1,2 +1,4 @@
+$fd-fonts-path: "../scss/fonts/";
+
 @import "../scss/components/tabs";
 @import "../scss/fonts/72";

--- a/components/tabs.scss
+++ b/components/tabs.scss
@@ -1,1 +1,2 @@
 @import "../scss/components/tabs";
+@import "../scss/fonts/72";

--- a/scss/components/tabs.scss
+++ b/scss/components/tabs.scss
@@ -44,6 +44,7 @@ $block: #{$fd-namespace}-tabs;
     display: block;
     position: relative;
     padding: $fd-tabs-link-padding-y 0;
+    text-decoration: none;
     @include fd-type("0");
     @include action-cursor();
     @include fd-var-color("color", $fd-tabs-link-color, --fd-tabs-link-color);

--- a/scss/components/tabs.scss
+++ b/scss/components/tabs.scss
@@ -38,9 +38,11 @@ $block: #{$fd-namespace}-tabs;
   border-bottom-width: $fd-tabs-border-width;
   @include fd-var-color("border-bottom-color", $fd-tabs-background-color, --fd-tabs-background-color);
   &__item {
+    @include fd-reset();
       padding: 0 $fd-tabs-link-padding-x;
   }
   &__link {
+    @include fd-reset();
     display: block;
     position: relative;
     padding: $fd-tabs-link-padding-y 0;


### PR DESCRIPTION
Closes SAP/fundamental-styles#166

This PR contains the self-contained styling for the Tabs component.
This PR is part of the larger task of making all components self-contained. #136