### PR TITLE
fix: playground: use inline block to keep checkbox with label in rtl mode

### DIFF
--- a/test/resources/layout.css
+++ b/test/resources/layout.css
@@ -5,6 +5,7 @@ body {
 }
 .test-label {
     margin-right: 20px;
+    display: inline-block;
 }
 
 .test-header {


### PR DESCRIPTION
Closes SAP/fundamental-styles#

when "RTL" is selected, the label is not staying next to the checkbox. See 

![image](https://user-images.githubusercontent.com/5056972/62502434-487a3980-b7a4-11e9-9cc8-d2618821859d.png)

inline-block keeps them together. see

![image](https://user-images.githubusercontent.com/5056972/62502491-92fbb600-b7a4-11e9-983e-d8ed5aa41ccc.png)
