### PR TITLE
chore: edit mergeable regex for dependabot prs

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -28,5 +28,5 @@ mergeable:
               reviewers: [ 'bcullman' ]  
           - required:
               reviewers: [ 'hertweckhr1' ]
-          min:
-            count: 2
+          - min:
+              count: 2

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -15,9 +15,7 @@ mergeable:
           regex: \[ \]
           message: There are incomplete TODO task(s) unchecked.
       - do: approvals
-        or: 
-          min:
-            count: 2
+        or:
           - required:
               reviewers: [ 'InnaAtanasova' ] 
           - required:
@@ -29,4 +27,6 @@ mergeable:
           - required:
               reviewers: [ 'bcullman' ]  
           - required:
-              reviewers: [ 'hertweckhr1' ]  
+              reviewers: [ 'hertweckhr1' ]
+          min:
+            count: 2

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -17,16 +17,16 @@ mergeable:
       - do: approvals
         min:
           count: 2
-        or: 
-          - required:
-              reviewers: [ 'InnaAtanasova' ] 
-          - required:
-              reviewers: [ 'droshev' ]  
-          - required:
-              reviewers: [ 'jbadan' ]  
-          - required:
-              reviewers: [ 'greg-a-smith' ]  
-          - required:
-              reviewers: [ 'bcullman' ]  
-          - required:
-              reviewers: [ 'hertweckhr1' ]  
+          or: 
+            - required:
+                reviewers: [ 'InnaAtanasova' ] 
+            - required:
+                reviewers: [ 'droshev' ]  
+            - required:
+                reviewers: [ 'jbadan' ]  
+            - required:
+                reviewers: [ 'greg-a-smith' ]  
+            - required:
+                reviewers: [ 'bcullman' ]  
+            - required:
+                reviewers: [ 'hertweckhr1' ]  

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -8,7 +8,7 @@ mergeable:
           regex: ^\[WIP\]
           message: This is work in progress. Do not merge yet.
         must_include:
-          regex: ^(feat|docs|chore|fix|test)(\(\w+\))?:.+$
+          regex: ^(feat|docs|chore|fix|test)(\(\w+\))?(:|\().+$
           message: Semantic release conventions must be followed.
       - do: description
         must_exclude:

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -15,18 +15,18 @@ mergeable:
           regex: \[ \]
           message: There are incomplete TODO task(s) unchecked.
       - do: approvals
-        min:
-          count: 2
-          or: 
-            - required:
-                reviewers: [ 'InnaAtanasova' ] 
-            - required:
-                reviewers: [ 'droshev' ]  
-            - required:
-                reviewers: [ 'jbadan' ]  
-            - required:
-                reviewers: [ 'greg-a-smith' ]  
-            - required:
-                reviewers: [ 'bcullman' ]  
-            - required:
-                reviewers: [ 'hertweckhr1' ]  
+        or: 
+          min:
+            count: 1
+          - required:
+              reviewers: [ 'InnaAtanasova' ] 
+          - required:
+              reviewers: [ 'droshev' ]  
+          - required:
+              reviewers: [ 'jbadan' ]  
+          - required:
+              reviewers: [ 'greg-a-smith' ]  
+          - required:
+              reviewers: [ 'bcullman' ]  
+          - required:
+              reviewers: [ 'hertweckhr1' ]  

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -17,7 +17,7 @@ mergeable:
       - do: approvals
         or: 
           min:
-            count: 1
+            count: 2
           - required:
               reviewers: [ 'InnaAtanasova' ] 
           - required:


### PR DESCRIPTION
edits mergeable title regex to accept `chore(` as well as `chore:`. Edit the `or` block so it doesn't require min 2 AND one of the listed required reviewers.