### PR TITLE
docs: toggle on docs site missing fd-toggle__input class

### DIFF
--- a/docs/_includes/display-component.html
+++ b/docs/_includes/display-component.html
@@ -5,7 +5,7 @@
 <div class="fd-tile docs-component docs-component__{{include.class}}">
     <label class="fd-form__label docs-component__bg-toggle" for="{{ randomNumber }}" title="Change Background">
         <span class="fd-toggle fd-toggle--xs fd-form__control">
-            <input type="checkbox" name="" value="" id="{{ randomNumber }}" class="toggle-bg">
+            <input type="checkbox" name="" value="" id="{{ randomNumber }}" class="toggle-bg fd-toggle__input">
             <span class="fd-toggle__switch" role="presentation"></span>
         </span>
 

--- a/docs/_sass/_docs-display-component.scss
+++ b/docs/_sass/_docs-display-component.scss
@@ -374,10 +374,6 @@
         background: white;
     }
 
-    .fd-toggle input {
-        border-radius: 15px;
-    }
-
     &__spacing-example {
         .fd-tile__content [class^="fd-has"] {
             border: 1px solid #ccc;

--- a/docs/css/customstyles.css
+++ b/docs/css/customstyles.css
@@ -1112,6 +1112,3 @@ pre code{
     overflow-x: scroll;
 }
 
-.fd-toggle input:focus{
-    outline: none;
-}


### PR DESCRIPTION
In https://github.com/SAP/fundamental-styles/pull/227 I changed the selector from `input` element to class `fd-toggle__input` and forgot to update the docs site where we are using them in our display containers.

Also removed some unnecessary css overrides.

Before:
<img width="173" alt="screen_shot_2019-08-14_at_3 00 29_pm" src="https://user-images.githubusercontent.com/29607818/63060665-b7901600-bea7-11e9-8113-8112a8976b53.png">

After:
![2019-08-14 15 21 22](https://user-images.githubusercontent.com/29607818/63060655-afd07180-bea7-11e9-9421-2cabc2255477.gif)
