### PR TITLE
fix: Remove bleeding styles to page from documentation

### DIFF
--- a/docs/_sass/_docs-display-component.scss
+++ b/docs/_sass/_docs-display-component.scss
@@ -204,12 +204,6 @@
     }
 
     &__page {
-        .fd-page,
-        .fd-page__header,
-        .fd-page__intro,
-        .fd-page__content {
-            padding: 10px;
-        }
 
         .fd-tile__content {
             padding: 20px 20px;
@@ -220,14 +214,6 @@
     }
 
     &__section {
-        .fd-section,
-        .fd-section__header,
-        .fd-section__title,
-        .fd-section__actions,
-        .fd-section__footer,
-        .fd-container {
-            //padding:10px;
-        }
 
         .fd-section {
             background-color: $docs-example-bg-color;

--- a/docs/pages/layouts/page-layout.md
+++ b/docs/pages/layouts/page-layout.md
@@ -31,14 +31,14 @@ The `.fd-page__header` container most often will include the `.fd-breadcrumb` an
 The `.fd-page__content` container should have one or more `.fd-section` containers. The content container does not include padding — allows for full-bleed content — so child sections are necessary.
 
 {% capture page-layout %}
-<article class="fd-page">
+<main class="fd-page">
     <header class="fd-page__header fd-has-background-color-background-2">
         fd-page_header
     </header>
     <div class="fd-page__content fd-has-background-color-neutral-2">
         fd-page_content
     </div>
-</article>
+</main>
 {% endcapture %}
 {% include display-component.html component=page-layout  class="page"%}
 


### PR DESCRIPTION
fixes #283 
1. remove bleeding styles to page from documentation
2. replace `<article>` with `<main>` in the documentation