### PR TITLE
fix: add css style to disable the specific menu item.

### DIFF
--- a/scss/components/menu.scss
+++ b/scss/components/menu.scss
@@ -115,7 +115,9 @@ $block: #{$fd-namespace}-menu;
       }
       @include fd-disabled() {
         @include fd-var-color("outline-color", fd-color-state("disabled", "action"), --fd-color-action-disabled);
+        @include fd-var-color("color", $fd-forms-color--disabled, --fd-color-text-4);
         cursor: not-allowed;
+        text-decoration: none;
       }
     }
     &--addon-before {


### PR DESCRIPTION
## Related Issue
add style to disable the menu item.
## Description
Added css class to disable specific menu item

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:


### After:
