### PR TITLE
fix: Making input placeholder text italic

### DIFF
--- a/scss/components/input.scss
+++ b/scss/components/input.scss
@@ -12,6 +12,7 @@ $block: #{$fd-namespace}-input;
     &::placeholder {
         @include fd-reset();
         @include fd-var-color("color", $fd-forms-color--placeholder, --fd-color-neutral-4);
+        font-style: italic;
     }
     &--compact {
         @include fd-var-size("height", $fd-forms-height--compact, --fd-forms-height-compact);


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#293

## Description
Applied `font-style: italic` to input placeholder text.

## Screenshots

### Before:
<img width="900" alt="Screen Shot 2019-08-28 at 8 57 45 AM" src="https://user-images.githubusercontent.com/48103491/63872466-9d0f6f80-c972-11e9-8508-51fe1a29775e.png">


### After:
<img width="898" alt="Screen Shot 2019-08-28 at 9 03 43 AM" src="https://user-images.githubusercontent.com/48103491/63872587-cc25e100-c972-11e9-929c-ca43bcab9daf.png">

