### PR TITLE
fix: Input sizing in input groups

### DIFF
--- a/scss/components/input-group.scss
+++ b/scss/components/input-group.scss
@@ -8,6 +8,7 @@
 */
 
 $block: #{$fd-namespace}-input-group;
+
 .#{$block} {
     @include fd-reset();
     display: flex;
@@ -44,7 +45,7 @@ $block: #{$fd-namespace}-input-group;
         }
     }
 
-    &__input {
+    .#{$block}__input {
         @include fd-reset-child-spacing();
         flex: 1 0 auto;
         width: auto;


### PR DESCRIPTION
## Description
Changed the class `fd-input-group__input` to be a descendant selector of `fd-input-group` so the specificity will be applied.

## Screenshots
n/a
