### PR TITLE
fix: Introduce center mixin

### DIFF
--- a/scss/components/radio.scss
+++ b/scss/components/radio.scss
@@ -19,9 +19,7 @@ $block: #{$fd-namespace}-radio;
         border-radius: 50%;
         width: $check-size_;
         height: $check-size_;
-        position: absolute;
-        top: calc(50% - (#{$check-size_}/2));
-        left: calc(50% - (#{$check-size_}/2));
+		@include absolute-center();
         transition: background-color $fd-forms-transition-params;
         background-color: transparent;
     }

--- a/scss/components/spinner.scss
+++ b/scss/components/spinner.scss
@@ -52,10 +52,8 @@ $block: #{$fd-namespace}-spinner;
                 content: "";
             }
             .#{$block} {
-                position: absolute;
+				@include absolute-center();
                 z-index: map-get($fd-z-index-levels, "second");
-                left: calc(50% - #{$_width}/2);
-                top: calc(50% - #{$_height}/2);
             }
         }
     }

--- a/scss/mixins/_mixins.scss
+++ b/scss/mixins/_mixins.scss
@@ -276,3 +276,10 @@
 @mixin action-cursor {
   cursor: pointer;
 }
+
+@mixin absolute-center {
+	position: absolute;
+	transform: translate(-50%, -50%);
+	left: 50%;
+	top: 50%;
+}


### PR DESCRIPTION
## Related Issue
There is not any related issue.

## Description

Reopened. https://github.com/SAP/fundamental-styles/pull/304 just to check if CLA works for me.

As I noticed, the position of some elements in loading-spinner and radio button was hard coded. The goal was to center the elements, so I created absolute-center mixin. The main advante of using this mixin is when the user changes size of these elements, it will be positioned on the center., no matter what size is. It will also be handy for later implementations.