### PR TITLE
chore: Remove approvals from mergeable

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -14,21 +14,3 @@ mergeable:
         must_exclude:
           regex: \[ \]
           message: There are incomplete TODO task(s) unchecked.
-      - do: approvals
-        or:
-          - required:
-              reviewers: [ 'InnaAtanasova' ] 
-          - required:
-              reviewers: [ 'droshev' ]  
-          - required:
-              reviewers: [ 'jbadan' ]  
-          - required:
-              reviewers: [ 'greg-a-smith' ]  
-          - required:
-              reviewers: [ 'bcullman' ]  
-          - required:
-              reviewers: [ 'hertweckhr1' ]
-          - required:
-              reviewers: [ 'markpalfreeman' ]
-          - min:
-              count: 2


### PR DESCRIPTION
## Description
Removing the approvals check from Mergeable -- GitHub already does this.  And when Mergeable does this, it marks all open PRs with a ❌, which makes it look like the build failed or there are other issues with the branch.  It's nice to see green checks and yellow dots when branches are successfully built or being built.