### PR TITLE
fix: Not allow to put empty comma in vars

### DIFF
--- a/src/mixins/_vars.scss
+++ b/src/mixins/_vars.scss
@@ -2,9 +2,17 @@
 @import "./../functions";
 
 @mixin fd-var-color($property, $value, $var: null, $important: false) {
-  #{$property}: var(#{$var}, #{$value});
+  @if $var {
+    #{$property}: var(#{$var}, #{$value});
+  } @else {
+    #{$property}: #{$value};
+  }
 }
 
 @mixin fd-var-size($property, $value, $var: null) {
-  #{$property}: var(#{$var}, #{$value});
+  @if $var {
+    #{$property}: var(#{$var}, #{$value});
+  } @else {
+    #{$property}: #{$value};
+  }
 }


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/348

## Description
I added statements to `var` mixins, because the empty commas were causing errors on angular's compiler.