### PR TITLE
fix:breadcrumb link border bottom style none fix

### DIFF
--- a/src/breadcrumb.scss
+++ b/src/breadcrumb.scss
@@ -82,7 +82,7 @@ $block: #{$fd-namespace}-breadcrumb;
     text-decoration: none;
     display: inline-block;
     transition: all $fd-animation--speed ease-in;
-    border-style: none;
+    border-bottom-style: none;
 
     &:focus {
       outline-style: dotted;


### PR DESCRIPTION
*Description*

After the adoption of self-contained styles in Fundamental-ngx the Breadcrumb links have border-bottom `1px solid #0a6ed1` due to the fact that the `border-style: none;` rule is not taken into account. Adding a more specific rule `border-bottom-style: none;` fixes the issue (the border disappears). 