### PR TITLE
docs: remove SAP from the library name

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,12 +8,12 @@ output: web
 topnav_title: Fundamental Styles
 
 # this appears in the html browser tab for the site title (seen mostly by search engines, not users)
-site_title: SAP Fundamental Styles
+site_title: Fundamental Styles
 
-site_description: SAP Fundamental Styles is a Fiori 3 component library and SASS toolkit for building SAP user interfaces with any technology.
+site_description: Fundamental Styles is a Fiori 3 component library and SASS toolkit for building SAP user interfaces with any technology.
 
 # this appears in the footer
-company_name: SAP Fundamental Styles
+company_name: Fundamental Styles
 
 # if you have google-analytics ID, put it in. if not, edit this value to blank.
 google_analytics: UA-126805333-1

--- a/docs/_data/sidebars/left-navigation-sidebar.yml
+++ b/docs/_data/sidebars/left-navigation-sidebar.yml
@@ -235,7 +235,7 @@ entries:
       url: /resources/design-system-utilities.html
       output: web
 
-    - title: SAP Fundamental Styles Implementation Libraries
+    - title: Fundamental Styles Implementation Libraries
       url: /resources/fundamentals-libraries.html
       output: web
       

--- a/docs/_includes/topnav.html
+++ b/docs/_includes/topnav.html
@@ -4,7 +4,7 @@
 
         <!-- logo -->
         <a class="docs-top-nav__logo" href="{{site.baseurl}}/index.html">
-            SAP Fundamental <span class="docs-top-nav__logo__accent">Styles</span>
+            Fundamental <span class="docs-top-nav__logo__accent">Styles</span>
         </a>
 
         <button id="mobile-sidenav-btn" class="fd-button--light sap-icon--menu2" aria-haspopup="true" aria-expanded="false" aria-label="Menu"></button>

--- a/docs/index.html
+++ b/docs/index.html
@@ -71,3 +71,16 @@ layout: default-no-sidebar
         </div>
     </div>
 </div>
+
+<div class="docs-home_panel docs-home_panel--alt">
+    <div class="fd-container fd-container--fluid">
+        <div class="fd-col--6">
+            <h1 class="docs-home_panel-title"><a href="components/index.html">implementation libraries.</a></h1>
+
+            <a href="https://sap.github.io/fundamental-ngx" target="_blank" class="docs-home_panel-resources-link">Fundamental for Angular <span class="sap-icon--navigation-right-arrow"></span> </a>
+            <a href="https://sap.github.io/fundamental-react" target="_blank" class="docs-home_panel-resources-link">Fundamental for React <span class="sap-icon--navigation-right-arrow"></span> </a>
+            <a href="https://github.com/SAP/fundamental-vue" target="_blank" class="docs-home_panel-resources-link">Fundamental for Vue <span class="sap-icon--navigation-right-arrow"></span> </a>
+        </div>
+
+    </div>
+</div>

--- a/docs/pages/getting-started.md
+++ b/docs/pages/getting-started.md
@@ -7,7 +7,7 @@ permalink: getting-started.html
 folder:
 summary: SAP Fiori Fundamentals is a light-weight presentation layer using HTML and CSS. With Fiori Fundamentals’ library of stylesheets and HTML tags, developers can build consistent Fiori apps in any web-based technology.
 ---
- SAP Fundamental Styles is a light-weight presentation layer using HTML and CSS with the following implementations under active development: [Angular](https://sap.github.io/fundamental-ngx/){:target="_blank"}, [React](https://sap.github.io/fundamental-react/){:target="_blank"}, and [Vue](https://sap.github.io/fundamental-vue/){:target="_blank"}. With Fundamental Styles’ library of stylesheets and HTML tags, developers can build consistent Fiori apps in any web-based technology.
+ Fundamental Styles is a light-weight presentation layer using HTML and CSS with the following implementations under active development: [Angular](https://sap.github.io/fundamental-ngx/){:target="_blank"}, [React](https://sap.github.io/fundamental-react/){:target="_blank"}, and [Vue](https://sap.github.io/fundamental-vue/){:target="_blank"}. With Fundamental Styles’ library of stylesheets and HTML tags, developers can build consistent Fiori apps in any web-based technology.
  
 <hr>
 

--- a/docs/pages/resources/fundamentals-libraries.md
+++ b/docs/pages/resources/fundamentals-libraries.md
@@ -1,22 +1,22 @@
 ---
-title: SAP Fundamental Styles Implementation Libraries
+title: Fundamental Styles Implementation Libraries
 keywords: libraries frameworks angular vue react
 sidebar: left-navigation-sidebar
 toc: false
 permalink: resources/fundamentals-libraries.html
 folder: resources
-summary: SAP Fundamental Styles can be used with your framework of choice, however fundamentals-react, fundamentals-ngx, and fundamentals-vue are currently in active development.
+summary: Fundamental Styles can be used with your framework of choice, however fundamentals-react, fundamentals-ngx, and fundamentals-vue are currently in active development.
 ---
 <hr> 
 
 ## Fundamental NGX ([GitHub](https://github.com/SAP/fundamental-ngx){:target="_blank"})
 {: .docs-header-h2}
-[Fundamental NGX](https://sap.github.io/fundamental-ngx/){:target="_blank"} is a set of Angular components built with the SAP Fundamental Styles library. 
+[Fundamental NGX](https://sap.github.io/fundamental-ngx/){:target="_blank"} is a set of Angular components built with the Fundamental Styles library. 
 
 ## Fundamental React ([GitHub](https://github.com/SAP/fundamental-react){:target="_blank"})
 {: .docs-header-h2}
-[Fundamental React](https://sap.github.io/fundamental-react/){:target="_blank"} is a set of React components built with the SAP Fundamental Styles library. 
+[Fundamental React](https://sap.github.io/fundamental-react/){:target="_blank"} is a set of React components built with the Fundamental Styles library. 
 
 ## Fundamental Vue ([GitHub](https://github.com/SAP/fundamental-vue){:target="_blank"})
 {: .docs-header-h2}
-[Fundamental Vue](https://sap.github.io/fundamental-vue/){:target="_blank"} is a set of Vue components built with the SAP Fundamental Styles library. 
+[Fundamental Vue](https://sap.github.io/fundamental-vue/){:target="_blank"} is a set of Vue components built with the Fundamental Styles library. 

--- a/docs/pages/resources/index.md
+++ b/docs/pages/resources/index.md
@@ -21,7 +21,7 @@ summary:
     <a class="fd-tile" role="button" href="fundamentals-libraries.html">
         <div class="fd-tile__content">
             <h2 class="fd-tile__header">
-                SAP Fundamental Styles Implementation Libraries
+                Fundamental Styles Implementation Libraries
             </h2>
         </div>
     </a>


### PR DESCRIPTION
changes:
- remove SAP from the name of the library(per recommendation)
- add links to the implementation libraries on the landing documentation page