### PR TITLE
fix: add rtl support for mobile mode

### DIFF
--- a/docs/pages/components/product-switch.md
+++ b/docs/pages/components/product-switch.md
@@ -388,3 +388,110 @@ Add the modifier class `fd-product-switch__body--mobile` for a list layout.
 </div>
 {% endcapture %}
 {% include display-component.html component=product-switch-body-mobile %}
+
+
+<br>
+
+## Product Switch - Smallest Screen, RTL
+
+{% capture product-switch-body-mobile %}
+<div style="width:450px;" dir="rtl">
+    <div class="fd-product-switch__body fd-product-switch__body--mobile">
+        <ul class="fd-product-switch__list">
+            <li class="fd-product-switch__item" tabindex="0">
+                <div class="fd-product-switch__icon sap-icon--home"></div>
+                <div class="fd-product-switch__text">
+                    <div class="fd-product-switch__title">Home</div>
+                    <div class="fd-product-switch__subtitle">Central Home</div>
+                </div>
+            </li>
+            <li class="fd-product-switch__item selected" tabindex="0">
+                <div class="fd-product-switch__icon sap-icon--business-objects-experience"></div>
+                <div class="fd-product-switch__text">
+                    <div class="fd-product-switch__title">Analytics Cloud</div>
+                    <div class="fd-product-switch__subtitle">Analytics Cloud</div>
+                </div>
+            </li>
+            <li class="fd-product-switch__item" tabindex="0">
+                <div class="fd-product-switch__icon sap-icon--contacts"></div>
+                <div class="fd-product-switch__text">
+                    <div class="fd-product-switch__title">Catalog</div>
+                    <div class="fd-product-switch__subtitle">Ariba</div>
+                </div>
+            </li>
+            <li class="fd-product-switch__item" tabindex="0">
+                <div class="fd-product-switch__icon sap-icon--credit-card"></div>
+                <div class="fd-product-switch__text">
+                    <div class="fd-product-switch__title">Guided Buying</div>
+                </div>
+            </li>
+            <li class="fd-product-switch__item" tabindex="0">
+                <div class="fd-product-switch__icon sap-icon--cart-3"></div>
+                <div class="fd-product-switch__text">
+                    <div class="fd-product-switch__title">Strategic Procurement</div>
+                </div>
+            </li>
+            <li class="fd-product-switch__item" tabindex="0">
+                <div class="fd-product-switch__icon sap-icon--flight"></div>
+                <div class="fd-product-switch__text">
+                    <div class="fd-product-switch__title">Travel & Expense</div>
+                    <div class="fd-product-switch__subtitle">Concur</div>
+                </div>
+            </li>
+            <li class="fd-product-switch__item" tabindex="0">
+                <div class="fd-product-switch__icon sap-icon--shipping-status"></div>
+                <div class="fd-product-switch__text">
+                    <div class="fd-product-switch__title">Vendor Management</div>
+                    <div class="fd-product-switch__subtitle">Fieldglass</div>
+                </div>
+            </li>
+            <li class="fd-product-switch__item" tabindex="0">
+                <div class="fd-product-switch__icon sap-icon--customer"></div>
+                <div class="fd-product-switch__text">
+                    <div class="fd-product-switch__title">Human Capital Management</div>
+                </div>
+            </li>
+            <li class="fd-product-switch__item" tabindex="0">
+                <div class="fd-product-switch__icon sap-icon--sales-notification"></div>
+                <div class="fd-product-switch__text">
+                    <div class="fd-product-switch__title">Sales Cloud</div>
+                    <div class="fd-product-switch__subtitle">Sales Cloud</div>
+                </div>
+            </li>
+            <li class="fd-product-switch__item" tabindex="0">
+                <div class="fd-product-switch__icon sap-icon--retail-store"></div>
+                <div class="fd-product-switch__text">
+                    <div class="fd-product-switch__title">Commerce Cloud</div>
+                    <div class="fd-product-switch__subtitle">Commerce Cloud</div>
+                </div>
+            </li>
+            <li class="fd-product-switch__item" tabindex="0">
+                <div class="fd-product-switch__icon sap-icon--marketing-campaign"></div>
+                <div class="fd-product-switch__text">
+                    <div class="fd-product-switch__title">Marketing Cloud</div>
+                    <div class="fd-product-switch__subtitle">Marketing Cloud</div>
+                </div>
+            </li>
+            <li class="fd-product-switch__item" tabindex="0">
+                <div class="fd-product-switch__icon sap-icon--family-care"></div>
+                <div class="fd-product-switch__text">
+                    <div class="fd-product-switch__title">Service Cloud</div>
+                </div>
+            </li>
+            <li class="fd-product-switch__item" tabindex="0">
+                <div class="fd-product-switch__icon sap-icon--customer-briefing"></div>
+                <div class="fd-product-switch__text">
+                    <div class="fd-product-switch__title">Customer Data Cloud</div>
+                </div>
+            </li>
+            <li class="fd-product-switch__item" tabindex="0">
+                <div class="fd-product-switch__icon sap-icon--batch-payments"></div>
+                <div class="fd-product-switch__text">
+                    <div class="fd-product-switch__title">S/4HANA</div>
+                </div>
+            </li>
+        </ul>
+    </div>
+</div>
+{% endcapture %}
+{% include display-component.html component=product-switch-body-mobile %}

--- a/src/product-switch.scss
+++ b/src/product-switch.scss
@@ -104,6 +104,17 @@ $block: #{$fd-namespace}-product-switch;
       margin-bottom: 0;
       margin-right: 0.75rem;
     }
+
+    @include fd-rtl() {
+      .#{$block}__icon {
+        margin-right: 0;
+        margin-left: 0.75rem;
+      }
+
+      .#{$block}__text {
+        align-items: flex-start;
+      }
+    }
   }
 
   &__list {

--- a/src/product-switch.scss
+++ b/src/product-switch.scss
@@ -110,6 +110,7 @@ $block: #{$fd-namespace}-product-switch;
         margin-right: 0;
         margin-left: 0.75rem;
       }
+
       .#{$block}__text {
         align-items: flex-start;
       }

--- a/src/product-switch.scss
+++ b/src/product-switch.scss
@@ -110,7 +110,6 @@ $block: #{$fd-namespace}-product-switch;
         margin-right: 0;
         margin-left: 0.75rem;
       }
-
       .#{$block}__text {
         align-items: flex-start;
       }


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#381

## Description
In mobile mode, the RTL support for the Product Switch component shows the icon on the right but the text stays on the left. The margin between the icon and the text should go to the left.


## Screenshots
### Before:
<img width="636" alt="Screen Shot 2019-10-22 at 4 11 17 PM" src="https://user-images.githubusercontent.com/39598672/67327869-a0dcef80-f4e6-11e9-8314-0f870fb23583.png">


### After:
<img width="533" alt="Screen Shot 2019-10-22 at 4 11 31 PM" src="https://user-images.githubusercontent.com/39598672/67327892-a63a3a00-f4e6-11e9-8e84-e4f25af80b57.png">
