### PR TITLE
fix(input): Fixing vertical alignment of placeholder text in input field

### DIFF
--- a/src/input.scss
+++ b/src/input.scss
@@ -15,11 +15,17 @@ $block: #{$fd-namespace}-input;
   width: 100%;
 
   &::placeholder {
+    @include fd-reset();
+    @include fd-var-size("line-height", $fd-forms-height, --fd-forms-height);
     @include fd-var-color("color", $fd-forms-color--placeholder, --fd-color-neutral-4);
   }
 
   &--compact {
     @include fd-var-size("height", $fd-forms-height--compact, --fd-forms-height-compact);
+    @include fd-var-size("line-height", $fd-forms-height--compact, --fd-forms-height-compact);
+  }
+
+  &--compact::placeholder {
     @include fd-var-size("line-height", $fd-forms-height--compact, --fd-forms-height-compact);
   }
 

--- a/src/input.scss
+++ b/src/input.scss
@@ -10,16 +10,17 @@ $block: #{$fd-namespace}-input;
 .#{$block} {
   @include fd-form-text();
   @include fd-var-size("height", $fd-forms-height, --fd-forms-height);
+  @include fd-var-size("line-height", $fd-forms-height, --fd-forms-height);
 
   width: 100%;
 
   &::placeholder {
-    @include fd-reset();
     @include fd-var-color("color", $fd-forms-color--placeholder, --fd-color-neutral-4);
   }
 
   &--compact {
     @include fd-var-size("height", $fd-forms-height--compact, --fd-forms-height-compact);
+    @include fd-var-size("line-height", $fd-forms-height--compact, --fd-forms-height-compact);
   }
 
   &--no-number-spinner {

--- a/src/input.scss
+++ b/src/input.scss
@@ -9,24 +9,24 @@ $block: #{$fd-namespace}-input;
 
 .#{$block} {
   @include fd-form-text();
-  @include fd-var-size("height", $fd-forms-height, --fd-forms-height);
-  @include fd-var-size("line-height", $fd-forms-height, --fd-forms-height);
+  @include fd-var-size("height", $fd-forms-height, --sapElement_Height);
+  @include fd-var-size("line-height", $fd-forms-height, --sapElement_Height);
 
   width: 100%;
 
   &::placeholder {
     @include fd-reset();
-    @include fd-var-size("line-height", $fd-forms-height, --fd-forms-height);
-    @include fd-var-color("color", $fd-forms-color--placeholder, --fd-color-neutral-4);
+    @include fd-var-size("line-height", $fd-forms-height, --sapElement_Height);
+    @include fd-var-color("color", $fd-forms-color--placeholder, --sapField_PlaceholderTextColor);
   }
 
   &--compact {
-    @include fd-var-size("height", $fd-forms-height--compact, --fd-forms-height-compact);
-    @include fd-var-size("line-height", $fd-forms-height--compact, --fd-forms-height-compact);
+    @include fd-var-size("height", $fd-forms-height--compact, --sapElement_Compact_Height);
+    @include fd-var-size("line-height", $fd-forms-height--compact, --sapElement_Compact_Height);
   }
 
   &--compact::placeholder {
-    @include fd-var-size("line-height", $fd-forms-height--compact, --fd-forms-height-compact);
+    @include fd-var-size("line-height", $fd-forms-height--compact, --sapElement_Compact_Height);
   }
 
   &--no-number-spinner {

--- a/src/input.scss
+++ b/src/input.scss
@@ -9,24 +9,25 @@ $block: #{$fd-namespace}-input;
 
 .#{$block} {
   @include fd-form-text();
-  @include fd-var-size("height", $fd-forms-height, --sapElement_Height);
-  @include fd-var-size("line-height", $fd-forms-height, --sapElement_Height);
 
+  height: var(--sapElement_Height);
+  line-height: var(--sapElement_Height);
   width: 100%;
 
   &::placeholder {
     @include fd-reset();
-    @include fd-var-size("line-height", $fd-forms-height, --sapElement_Height);
-    @include fd-var-color("color", $fd-forms-color--placeholder, --sapField_PlaceholderTextColor);
+
+    line-height: var(--sapElement_Height);
+    color: var(--sapField_PlaceholderTextColor);
   }
 
   &--compact {
-    @include fd-var-size("height", $fd-forms-height--compact, --sapElement_Compact_Height);
-    @include fd-var-size("line-height", $fd-forms-height--compact, --sapElement_Compact_Height);
+    height: var(--sapElement_Compact_Height);
+    line-height: var(--sapElement_Compact_Height);
   }
 
   &--compact::placeholder {
-    @include fd-var-size("line-height", $fd-forms-height--compact, --sapElement_Compact_Height);
+    line-height: var(--sapElement_Compact_Height);
   }
 
   &--no-number-spinner {

--- a/test/resources/theme-ugly.css
+++ b/test/resources/theme-ugly.css
@@ -37,6 +37,7 @@
   --fd-color-neutral-1: rgb(117, 7, 7);
   --fd-color-neutral-2: yellow;
   --fd-color-neutral-3: green;
+  --fd-color-neutral-4: orange;
   --fd-color-accent-1: #bc3f8c;
   --fd-color-accent-2: #6a68a8;
   --fd-color-accent-3: #4f9344;
@@ -81,4 +82,7 @@
   --sapList_Hover_SelectionBackground: rgb(93%, 2%, 45%);
   --sapContent_IconColor: purple;
   --sapList_TextColor: #00D1B2;
+  --sapElement_Height: 50px;
+  --sapElement_Compact_Height: 25px;
+  --sapField_PlaceholderTextColor: orange;
 }


### PR DESCRIPTION
Fixing `height` and `line-height` values for input so that the placeholder text is vertically centered for Firefox browsers.

## Related Issue
Closes SAP/fundamental-styles#404

## Description
Added CSS rules to set `height` and `line-height` to the same values for input field for both "default" and "compact" modes.

Updated CSS rules to use the SAP theming variables.

Added missing SAP theming variables to test/playground "ugly" theme.

## Screenshots

Using Firefox (69.0.3):

### Before:
<img width="653" alt="Screen Shot 2019-10-30 at 3 14 44 PM" src="https://user-images.githubusercontent.com/48103491/67903130-1587dd80-fb28-11e9-8657-412bfec549a1.png">
<img width="645" alt="Screen Shot 2019-10-30 at 3 14 54 PM" src="https://user-images.githubusercontent.com/48103491/67903163-20db0900-fb28-11e9-8b2c-d796e8973784.png">


### After:
<img width="654" alt="Screen Shot 2019-10-30 at 3 14 04 PM" src="https://user-images.githubusercontent.com/48103491/67903180-29334400-fb28-11e9-97fa-732776a74526.png">
<img width="645" alt="Screen Shot 2019-10-30 at 3 14 13 PM" src="https://user-images.githubusercontent.com/48103491/67903187-2df7f800-fb28-11e9-82f7-03c9bed29c9b.png">
