### PR TITLE
fix: fix the width issue of time after refactoring forms

### DIFF
--- a/src/time.scss
+++ b/src/time.scss
@@ -27,6 +27,7 @@ $block: #{$fd-namespace}-time;
       padding-left: fd-space(2);
       padding-right: fd-space(2);
       text-align: center;
+      width: 100%;
     }
   }
 


### PR DESCRIPTION
## Screenshots

### Before:
<img width="485" alt="Screen Shot 2019-11-13 at 4 36 07 PM" src="https://user-images.githubusercontent.com/39598672/68806420-d7b0ac00-0633-11ea-8974-b839998ae0ed.png">
<img width="460" alt="Screen Shot 2019-11-13 at 4 36 02 PM" src="https://user-images.githubusercontent.com/39598672/68806421-d7b0ac00-0633-11ea-9ac0-20f5f261b9a7.png">


### After:
 
<img width="338" alt="Screen Shot 2019-11-13 at 4 35 53 PM" src="https://user-images.githubusercontent.com/39598672/68806436-e303d780-0633-11ea-9a46-13339d22f497.png">
<img width="389" alt="Screen Shot 2019-11-13 at 4 35 56 PM" src="https://user-images.githubusercontent.com/39598672/68806437-e39c6e00-0633-11ea-8492-0e5b250e7043.png">

