### PR TITLE
fix: Fixed cursor of checkboxes/radio—buttons with label

### DIFF
--- a/src/form-label.scss
+++ b/src/form-label.scss
@@ -73,6 +73,7 @@ $block: #{$fd-namespace}-form-label;
   &--radio {
     display: flex;
     align-items: center;
+    cursor: pointer;
 
     &:focus-within {
       outline-offset: -0.25rem;


### PR DESCRIPTION
## Related Issue
none

## Description
Checkbox + Radio-Input labels had `cursor: text`. Now they have `cursor: pointer;`
