### PR TITLE
docs: removed functionality of es6 because it brokes IE and fixed 2 issues

### DIFF
--- a/docs/js/customscripts.js
+++ b/docs/js/customscripts.js
@@ -13,10 +13,9 @@ $(document).ready(function () {
         $('#mobile-sidenav-btn').hide();
     }
 
-    $('#mobile-sidenav-btn').click(() => {
+    $('#mobile-sidenav-btn').click(function () {
         $("#tg-sb-sidebar").toggleClass('fd-styles__mobile-list');
     });
-
 });
 
 $(document).ready(function () {
@@ -48,8 +47,8 @@ $(document).ready(function () {
                 //target
                 target.setAttribute("aria-hidden", isExpanded);
                 //searchinput for shellbar
-                if(document.getElementById(`${targetId}1`) !== null) {
-                    document.getElementById(`${targetId}1`).setAttribute("aria-hidden", isExpanded);
+                if (document.getElementById('' + targetId + '1') !== null) {
+                    document.getElementById('' + targetId + '1').setAttribute("aria-hidden", isExpanded);
                 }
                 return;
             }
@@ -203,20 +202,22 @@ $(document).ready(function () {
 
     // display responsive component controls
     const displayControls = document.querySelectorAll('.docs-component--responsive-display__controls');
-    displayControls.forEach((displayControl) => {
-        const frame = displayControl.parentElement.querySelector('.docs-component--responsive-display__frame');
-        displayControl.addEventListener('click', event => {
+
+    for (var i = 0; i < displayControls.length; i++) {
+        const frame = displayControls[i].parentElement.querySelector('.docs-component--responsive-display__frame');
+        displayControls[i].addEventListener('click', function (event) {
             const clickTarget = event.target;
-            clearControls(displayControl);
+            clearControls(displayControls[i]);
             resizeFrame(clickTarget, frame);
             clickTarget.setAttribute('aria-pressed', true);
         })
-    });
+    }
 
     function clearControls(displayControl) {
-        Array.from(displayControl.children).forEach(button => {
-            button.setAttribute('aria-pressed', false);
-        });
+        let childrens = Array.from(displayControl.children)
+        for (var i = 0; i < childrens.length; i++) {
+            childrens[i].setAttribute('aria-pressed', false);
+        }
     }
 
     function resizeFrame(target, frame) {


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#484
Closes SAP/fundamental-styles#479

## Description
ES6 specification is not supported in IE 11 and ended up in displaying error in console. After fix, aria-controls which are handled by jquery works fine

## Screenshots
### Before:

### After:
![after](https://user-images.githubusercontent.com/10849982/70317254-b2bbed00-181d-11ea-8a8a-b3278cf8c667.png)