### PR TITLE
fix: line height changed to match the font

### DIFF
--- a/src/shellbar.scss
+++ b/src/shellbar.scss
@@ -110,7 +110,7 @@ $block: #{$fd-namespace}-shellbar;
     @include fd-type("1");
     @include fd-weight("bold");
 
-    line-height: 1;
+    line-height: 1.1;
 
     @include fd-var-color("color", $fd-shellbar-color, --fd-color-text-5);
 


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#467

## Description
Line height changed to match a character which went out of boundaries 

## Screenshots
### Before:
![before](https://user-images.githubusercontent.com/10849982/70325388-2831b880-1832-11ea-94fc-1981386853e4.png)

### After:
It is fixed but I can't upload the screenshot (github returns error)