### PR TITLE
fix: busy-indicator margin for firefox

### DIFF
--- a/docs/_sass/_docs-display-component.scss
+++ b/docs/_sass/_docs-display-component.scss
@@ -16,6 +16,14 @@
     > .fd-tile__content {
         padding: 60px 20px;
         width: 100%;
+
+        .break {
+            margin-bottom: 2rem;
+
+            &--single {
+                margin-bottom: 1rem; 
+            }
+        }
     }
 
     > p {

--- a/docs/pages/components/busy-indicator.md
+++ b/docs/pages/components/busy-indicator.md
@@ -17,17 +17,17 @@ Busy indicators are not visible all the time, only when needed.
 ## Busy indicator usage and size options
 {% capture busy-indicator %}
 <div style="display:flex;justify-content:center;flex-direction:column;align-items:center">
-    <div class="fd-busy-indicator--l" aria-hidden="false" aria-label="Loading"  style="margin-bottom:2rem">
+    <div class="fd-busy-indicator--l break" aria-hidden="false" aria-label="Loading">
         <div class="fd-busy-indicator--circle-0"></div>
         <div class="fd-busy-indicator--circle-1"></div>
         <div class="fd-busy-indicator--circle-2"></div>
     </div>
-    <div class="fd-busy-indicator--m" aria-hidden="false" aria-label="Loading"  style="margin-bottom:2rem">
+    <div class="fd-busy-indicator--m break" aria-hidden="false" aria-label="Loading">
         <div class="fd-busy-indicator--circle-0"></div>
         <div class="fd-busy-indicator--circle-1"></div>
         <div class="fd-busy-indicator--circle-2"></div>
     </div>
-    <div class="fd-busy-indicator" aria-hidden="false" aria-label="Loading">
+    <div class="fd-busy-indicator break" aria-hidden="false" aria-label="Loading">
         <div class="fd-busy-indicator--circle-0"></div>
         <div class="fd-busy-indicator--circle-1"></div>
         <div class="fd-busy-indicator--circle-2"></div>

--- a/docs/pages/components/busy-indicator.md
+++ b/docs/pages/components/busy-indicator.md
@@ -17,16 +17,16 @@ Busy indicators are not visible all the time, only when needed.
 ## Busy indicator usage and size options
 {% capture busy-indicator %}
 <div style="display:flex;justify-content:center;flex-direction:column;align-items:center">
-    <div class="fd-busy-indicator--l" aria-hidden="false" aria-label="Loading">
+    <div class="fd-busy-indicator--l" aria-hidden="false" aria-label="Loading"  style="margin-bottom:2rem">
         <div class="fd-busy-indicator--circle-0"></div>
         <div class="fd-busy-indicator--circle-1"></div>
         <div class="fd-busy-indicator--circle-2"></div>
-    </div><br /><br />
-    <div class="fd-busy-indicator--m" aria-hidden="false" aria-label="Loading">
+    </div>
+    <div class="fd-busy-indicator--m" aria-hidden="false" aria-label="Loading"  style="margin-bottom:2rem">
         <div class="fd-busy-indicator--circle-0"></div>
         <div class="fd-busy-indicator--circle-1"></div>
         <div class="fd-busy-indicator--circle-2"></div>
-    </div><br /><br />
+    </div>
     <div class="fd-busy-indicator" aria-hidden="false" aria-label="Loading">
         <div class="fd-busy-indicator--circle-0"></div>
         <div class="fd-busy-indicator--circle-1"></div>

--- a/docs/pages/components/button.md
+++ b/docs/pages/components/button.md
@@ -86,29 +86,36 @@ The buttons can also be set to a state:
 * **Disabled**: It cannot be clicked/tapped. This state can be rendered using `is-disabled` class or `aria-disabled="true"` attribute for accessibility.
 
 {% capture button-standard-state %}
+<div class ="break break--single">
 <button class="fd-button--emphasized">Normal State</button>
 <button class="fd-button--emphasized" aria-selected="true">Selected State</button>
 <button class="fd-button--emphasized" aria-disabled="true">Disabled State</button>
-<br><br>
+</div>
+<div class ="break break--single">
 <button class="fd-button">Normal State</button>
 <button class="fd-button" aria-selected="true">Selected State</button>
 <button class="fd-button" aria-disabled="true">Disabled State</button>
-<br><br>
+</div>
+<div class ="break break--single">
 <button class="fd-button--light">Normal State</button>
 <button class="fd-button--light" aria-selected="true">Selected State</button>
 <button class="fd-button--light" aria-disabled="true">Disabled State</button>
-<br><br>
+</div>
+<div class ="break break--single">
 <button class="fd-button--standard">Normal State</button>
 <button class="fd-button--standard" aria-selected="true">Selected State</button>
 <button class="fd-button--standard" aria-disabled="true">Disabled State</button>
-<br><br>
+</div>
+<div class ="break break--single">
 <button class="fd-button--positive">Normal State</button>
 <button class="fd-button--positive" aria-selected="true">Selected State</button>
 <button class="fd-button--positive" aria-disabled="true">Disabled State</button>
-<br><br>
+</div>
+<div class ="break break--single">
 <button class=" fd-button--negative">Normal State</button>
 <button class=" fd-button--negative" aria-selected="true">Selected State</button>
 <button class=" fd-button--negative" aria-disabled="true">Disabled State</button>
+</div>
 {% endcapture %}
 
 {% include display-component.html component=button-standard-state %}
@@ -177,34 +184,37 @@ Button with multiple actions
 
 
 {% capture button-group-small %}
-<div dir="rtl">
-  <button class="fd-button--emphasized sap-icon--cart">Add to Cart</button>
-  <button class="fd-button sap-icon--cart">Add to Cart</button>
-  <button class="fd-button--light sap-icon--cart">Add to Cart</button>
-  <button class="fd-button--positive sap-icon--accept">Approve</button>
-  <button class="fd-button--negative sap-icon--decline">Reject</button>
-  <br><br>
-  <button class="fd-button--emphasized fd-button--menu sap-icon--cart">Add to Cart</button>
-  <button class="fd-button fd-button--menu sap-icon--cart">Add to Cart</button>
-  <button class="fd-button--light fd-button--menu sap-icon--cart">Add to Cart</button>
-  <button class="fd-button--emphasized fd-button--positive fd-button--menu sap-icon--accept">Approve</button>
-  <button class="fd-button--emphasized fd-button--negative fd-button--menu sap-icon--decline">Reject</button>
-  <br><br>
-  <button class="fd-button sap-icon--cart"></button>
-  <button class="fd-button--light sap-icon--cart"></button>
-  <button class="fd-button--standard sap-icon--filter"></button>
-  <button class="fd-button--positive sap-icon--accept"></button>
-  <button class="fd-button--negative sap-icon--decline"></button>
-  <div class="fd-button-group" role="group" aria-label="Group label">
-    <button class="fd-button sap-icon--survey"></button>
-    <button class="fd-button sap-icon--pie-chart" aria-pressed="true"></button>
-    <button class="fd-button sap-icon--pool"></button>
+<div  dir="rtl">
+  <div class ="break break--single">
+    <button class="fd-button--emphasized sap-icon--cart">Add to Cart</button>
+    <button class="fd-button sap-icon--cart">Add to Cart</button>
+    <button class="fd-button--light sap-icon--cart">Add to Cart</button>
+    <button class="fd-button--positive sap-icon--accept">Approve</button>
+    <button class="fd-button--negative sap-icon--decline">Reject</button>
   </div>
-
-  <div class="fd-button-group" role="group" aria-label="Group label">
-    <button class="fd-button fd-button--compact" aria-pressed="true">Left</button>
-    <button class="fd-button fd-button--compact">Middle</button>
-    <button class="fd-button fd-button--compact">Right</button>
+  <div class ="break break--single">
+    <button class="fd-button--emphasized fd-button--menu sap-icon--cart">Add to Cart</button>
+    <button class="fd-button fd-button--menu sap-icon--cart">Add to Cart</button>
+    <button class="fd-button--light fd-button--menu sap-icon--cart">Add to Cart</button>
+    <button class="fd-button--emphasized fd-button--positive fd-button--menu sap-icon--accept">Approve</button>
+    <button class="fd-button--emphasized fd-button--negative fd-button--menu sap-icon--decline">Reject</button>
+  </div>
+  <div class ="break break--single">
+    <button class="fd-button sap-icon--cart"></button>
+    <button class="fd-button--light sap-icon--cart"></button>
+    <button class="fd-button--standard sap-icon--filter"></button>
+    <button class="fd-button--positive sap-icon--accept"></button>
+    <button class="fd-button--negative sap-icon--decline"></button>
+    <div class="fd-button-group" role="group" aria-label="Group label">
+      <button class="fd-button sap-icon--survey"></button>
+      <button class="fd-button sap-icon--pie-chart" aria-pressed="true"></button>
+      <button class="fd-button sap-icon--pool"></button>
+    </div>
+    <div class="fd-button-group" role="group" aria-label="Group label">
+      <button class="fd-button fd-button--compact" aria-pressed="true">Left</button>
+      <button class="fd-button fd-button--compact">Middle</button>
+      <button class="fd-button fd-button--compact">Right</button>
+    </div>
   </div>
 </div>
 {% endcapture %}
@@ -214,28 +224,32 @@ Button with multiple actions
 ## Menu Button
 
 {% capture button-menu %}
+<div class ="break break--single">
 <button class="fd-button fd-button--menu">Action Button</button>
 <button class="fd-button--standard fd-button--menu">Standard Button</button>
 <button class="fd-button--positive fd-button--menu">Positive Button</button>
 <button class="fd-button--negative fd-button--menu">Negative Button</button>
-<br><br>
+</div>
+<div class ="break break--single">
 <button class="fd-button fd-button--menu" aria-disabled="true">Action Button</button>
 <button class="fd-button--standard fd-button--menu" aria-disabled="true">Standard Button</button>
 <button class="fd-button--positive fd-button--menu" aria-disabled="true">Positive Button</button>
 <button class="fd-button--negative fd-button--menu" aria-disabled="true">Negative Button</button>
-<br><br>
+</div>
+<div class ="break break--single">
 <button class="fd-button--emphasized fd-button--menu sap-icon--cart">Add to Cart</button>
 <button class="fd-button fd-button--menu sap-icon--cart">Add to Cart</button>
 <button class="fd-button--light fd-button--menu sap-icon--cart">Add to Cart</button>
 <button class="fd-button--emphasized fd-button--menu fd-button--positive sap-icon--accept">Approve</button>
 <button class="fd-button--negative fd-button--menu sap-icon--decline">Reject</button>
-<br><br>
+</div>
+<div class ="break break--single">
 <button class="fd-button fd-button--menu sap-icon--cart"></button>
 <button class="fd-button--light fd-button--menu sap-icon--cart"></button>
 <button class="fd-button--standard fd-button--menu sap-icon--filter"></button>
 <button class="fd-button--menu fd-button--positive sap-icon--accept"></button>
 <button class="fd-button--menu fd-button--negative sap-icon--decline"></button>
-<br><br>
+</div>
 <button class="fd-button fd-button--menu">Default</button>
 <button class="fd-button--compact fd-button--menu">Compact</button>
 {% endcapture %}

--- a/docs/pages/components/form.md
+++ b/docs/pages/components/form.md
@@ -32,93 +32,68 @@ Do not use the input field if:
 - The user needs to carry out a search. In this case, use the search field.
 
 {% capture inputs %} 
-    <div class="fd-form-item fd-has-margin-none">
+    <div class="fd-form-item fd-has-margin-none break">
         <label class="fd-form-label" for="input-1">Default input:</label>
         <input class="fd-input" type="text" id="input-1" placeholder="Field placeholder text">
     </div>
-    <br><br>
-    <div class="fd-form-item">
+    <div class="fd-form-item break">
         <label class="fd-form-label" for="input-1b">Compact Input:</label>
         <input class="fd-input fd-input--compact" type="text" id="input-1b" placeholder="Field placeholder text">
     </div>
-    <br />
-    <br />
-    <div class="fd-form-item">
+    <div class="fd-form-item break">
         <label class="fd-form-label fd-form-label--required" for="input-1c">Required Input:</label>
         <input class="fd-input" type="text" id="input-1c" placeholder="Field placeholder text">
     </div>
-    <br />
-    <br />
-    <div class="fd-form-item">
+    <div class="fd-form-item break">
         <label class="fd-form-label" aria-required="true" for="input-1d">Password:</label>
         <input class="fd-input" type="password" id="input-1d">
     </div>
-    <br />
-    <br />
-    <div class="fd-form-item">
+    <div class="fd-form-item break">
         <label class="fd-form-label" for="input-01">Invalid (Error) Input:</label>
         <input class="fd-input is-invalid" type="text" id="input-01" placeholder="Field placeholder text">
     </div>
-    <br />
-    <br />
-    <div class="fd-form-item">
+    <div class="fd-form-item break">
         <label class="fd-form-label" for="input-02">Valid (Success) Input:</label>
         <input class="fd-input is-valid" type="text" id="input-02" placeholder="Field placeholder text">
     </div>
-    <br />
-    <br />
-    <div class="fd-form-item">
+    <div class="fd-form-item break">
         <label class="fd-form-label" for="input-03">Warning (Alert) Input:</label>
         <input class="fd-input is-warning" type="text" id="input-03" placeholder="Field placeholder text">
     </div>
-    <br />
-    <br />
-    <div class="fd-form-item">
+    <div class="fd-form-item break">
         <label class="fd-form-label" for="input-04">Information Input:</label>
         <input class="fd-input is-information" type="text" id="input-04">
     </div>
-    <br />
-    <br />
-    <div class="fd-form-item">
+    <div class="fd-form-item break">
         <label class="fd-form-label" for="input-05">Disabled Input:</label>
         <input class="fd-input is-disabled" type="text" id="input-05" placeholder="Field placeholder text">
     </div>
-    <br />
-    <br />
-    <div class="fd-form-item">
+    <div class="fd-form-item break">
         <label class="fd-form-label" for="input-06">Read-Only Input:</label>
         <input class="fd-input" type="text" id="input-06" readonly placeholder="Field placeholder text">
     </div>
-    <br />
-    <br />
-    <div class="fd-form-item fd-form-item--horizontal fd-has-margin-none fd-popover">
+    <div class="fd-form-item fd-form-item--horizontal fd-has-margin-none fd-popover break">
         <label class="fd-form-label" for="input-1">Default input:</label>
         <div class="fd-form-input-message-group">
             <input class="fd-input fd-popover__control" type="text" id="input-1" placeholder="Field placeholder text" aria-label="Image label" aria-controls="popoverD1" aria-expanded="false" aria-haspopup="true">
             <span class="fd-popover__body fd-popover__body--no-arrow fd-form-message" aria-hidden="true" id="popoverD1">Normal message</span>
         </div>
     </div>
-    <br><br>
-    <div class="fd-form-item fd-form-item--horizontal fd-has-margin-none fd-popover">
+    <div class="fd-form-item fd-form-item--horizontal fd-has-margin-none fd-popover break">
         <label class="fd-form-label" for="input-1">Compact input:</label>
         <div class="fd-form-input-message-group">
             <input class="fd-input fd-input--compact fd-popover__control" type="text" id="input-1" placeholder="Field placeholder text" aria-label="Image label" aria-controls="popoverD2" aria-expanded="false" aria-haspopup="true">
             <span class="fd-popover__body fd-popover__body--no-arrow fd-form-message fd-form-message--compact" aria-hidden="true" id="popoverD2">Normal message</span>
         </div>
     </div>
-    <br /><br />
     <div class="fd-form-item fd-form-item--horizontal">
         <label class="fd-form-label fd-form-label--required" for="input-1c">Required Input:</label>
         <input class="fd-input" type="text" id="input-1c" placeholder="Field placeholder text">
     </div>
-    <br />
-    <br />
-    <div class="fd-form-item fd-form-item--horizontal">
+    <div class="fd-form-item fd-form-item--horizontal break">
         <label class="fd-form-label" aria-required="true" for="input-1d">Password:</label>
         <input class="fd-input" type="password" id="input-1d">
     </div>
-    <br />
-    <br />
     <div class="fd-form-item fd-form-item--horizontal">
         <label class="fd-form-label" aria-required="true" for="input-1ee">Input:</label>
         <input class="fd-input" type="text" id="input-1ee">
@@ -166,87 +141,57 @@ The state of the input field can reflect validity of the data entered, whether t
 Along with Invalid and Warning, error messages should be displayed below the field so the user can correct the error and move forward.
 
 {% capture inputs %}
-<div class="fd-form-item fd-has-margin-none fd-popover">
+<div class="fd-form-item fd-has-margin-none fd-popover break">
     <label class="fd-form-label" for="input-1">Normal input:</label>
     <div class="fd-form-input-message-group">
         <input class="fd-input fd-popover__control" type="text" id="input-1" placeholder="Field placeholder text" aria-label="Image label" aria-controls="popoverB1" aria-expanded="false" aria-haspopup="true">
         <span class="fd-popover__body fd-popover__body--no-arrow fd-form-message" aria-hidden="true" id="popoverB1">Normal message</span>
     </div>
 </div>
-<br />
-<br />
-
-<div class="fd-form-item fd-has-margin-none fd-popover">
+<div class="fd-form-item fd-has-margin-none fd-popover break">
     <label class="fd-form-label" for="input-1">Valid input:</label>
     <div class="fd-form-input-message-group">
         <input class="fd-input is-valid fd-popover__control" type="text" id="input-1" placeholder="Field placeholder text" aria-label="Image label" aria-controls="popoverB2" aria-expanded="false" aria-haspopup="true">
         <span class="fd-popover__body fd-popover__body--no-arrow fd-form-message fd-form-message--success" aria-hidden="true" id="popoverB2">Success message</span>
     </div>
 </div>
-
-<br />
-<br />
-
-<div class="fd-form-item fd-has-margin-none fd-popover">
+<div class="fd-form-item fd-has-margin-none fd-popover break">
     <label class="fd-form-label" for="input-1">Error input:</label>
     <div class="fd-form-input-message-group">
         <input class="fd-input is-invalid fd-popover__control" type="text" id="input-1" placeholder="Field placeholder text" aria-label="Image label" aria-controls="popoverB3" aria-expanded="false" aria-haspopup="true">
         <span class="fd-popover__body fd-popover__body--no-arrow fd-form-message fd-form-message--error" aria-hidden="true" id="popoverB3">Error message</span>
     </div>
 </div>
-
-<br />
-<br />
-
-<div class="fd-form-item fd-has-margin-none fd-popover">
+<div class="fd-form-item fd-has-margin-none fd-popover break">
     <label class="fd-form-label" for="input-1">Warning input:</label>
     <div class="fd-form-input-message-group">
         <input class="fd-input is-warning fd-popover__control" type="text" id="input-1" placeholder="Field placeholder text" aria-label="Image label" aria-controls="popoverB4" aria-expanded="false" aria-haspopup="true">
         <span class="fd-popover__body fd-popover__body--no-arrow fd-form-message fd-form-message--warning" aria-hidden="true" id="popoverB4">Warning message</span>
     </div>
 </div>
-
-<br />
-<br />
-
-<div class="fd-form-item fd-has-margin-none fd-popover">
+<div class="fd-form-item fd-has-margin-none fd-popover break">
     <label class="fd-form-label" for="input-1">Information input:</label>
     <div class="fd-form-input-message-group">
         <input class="fd-input is-information fd-popover__control" type="text" id="input-1" placeholder="Field placeholder text" aria-label="Image label" aria-controls="popoverB5" aria-expanded="false" aria-haspopup="true">
         <span class="fd-popover__body fd-popover__body--no-arrow fd-form-message fd-form-message--information" aria-hidden="true" id="popoverB5">Information message</span>
     </div>
 </div>
-
-<br />
-<br />
-
-<div class="fd-form-item">
+<div class="fd-form-item break">
     <label class="fd-form-label" for="input-6">Disabled Input:</label>
     <input class="fd-input" type="text" id="input-6" value="Non editable data" disabled>
 </div>
-
-<br />
-<br />
-
-<div class="fd-form-item">
+<div class="fd-form-item break">
     <label class="fd-form-label" for="input-7">Read Only Input:</label>
     <input class="fd-input" type="text" id="input-7" value="Read only data" readonly>
 </div>
-
-<br />
-<br />
-
-<div class="fd-form-item fd-has-margin-none fd-popover" dir="rtl">
+<div class="fd-form-item fd-has-margin-none fd-popover break" dir="rtl">
     <label class="fd-form-label" for="input-1">Normal input:</label>
     <div class="fd-form-input-message-group">
         <input class="fd-input fd-popover__control" type="text" id="input-1" placeholder="Field placeholder text" aria-label="Image label" aria-controls="popoverC1" aria-expanded="false" aria-haspopup="true">
         <span class="fd-popover__body fd-popover__body--no-arrow fd-form-message" aria-hidden="true" id="popoverC1">Normal message</span>
     </div>
 </div>
-<br />
-<br />
-
-<div class="fd-form-item fd-has-margin-none fd-popover" dir="rtl">
+<div class="fd-form-item fd-has-margin-none fd-popover break" dir="rtl">
     <label class="fd-form-label" for="input-1">Valid input:</label>
     <div class="fd-form-input-message-group">
         <input class="fd-input is-valid fd-popover__control" type="text" id="input-1" placeholder="Field placeholder text" aria-label="Image label" aria-controls="popoverC2" aria-expanded="false" aria-haspopup="true">
@@ -254,19 +199,13 @@ Along with Invalid and Warning, error messages should be displayed below the fie
     </div>
 </div>
 
-<br />
-<br />
-
 <div class="fd-form-item fd-form-item--horizontal fd-has-margin-none fd-popover" dir="rtl">
     <label class="fd-form-label" for="input-1">Normal input:</label>
     <div class="fd-form-input-message-group">
         <input class="fd-input fd-popover__control" type="text" id="input-1" placeholder="Field placeholder text" aria-label="Image label" aria-controls="popoverC3" aria-expanded="false" aria-haspopup="true">
         <span class="fd-popover__body fd-popover__body--no-arrow fd-form-message" aria-hidden="true" id="popoverC3">Normal message</span>
     </div>
-</div>
-<br />
-<br />
-{% endcapture %}
+</div>{% endcapture %}
 
 {% include display-component.html component=inputs %}
 
@@ -280,49 +219,41 @@ Do not use the text area if
 - Users need to enter formatted text. Use the rich text editor instead.
 
 {% capture inputs %}
-    <div class="fd-form-item">
+    <div class="fd-form-item break">
         <label class="fd-form-label" for="textarea-1">Text area:</label>
         <textarea class="fd-textarea" id="textarea-1" placeholder="Write something here"></textarea>
         <div class="fd-textarea-counter">150 characters left</div>
     </div>
-    <br/>
-    <div class="fd-form-item">
+    <div class="fd-form-item break">
         <label class="fd-form-label" for="textarea-2">Compact text area:</label>
         <textarea class="fd-textarea fd-textarea--compact" id="textarea-2">Pellentesque metus lacus commodo eget justo ut rutrum varius nunc.</textarea>
         <div class="fd-textarea-counter">150 characters left</div>
     </div>
-    <br/>
-    <div class="fd-form-item">
+    <div class="fd-form-item break">
         <label class="fd-form-label" for="textarea-1">Text area:</label>
         <textarea class="fd-textarea is-valid" id="textarea-1" placeholder="Write something here"></textarea>
         <div class="fd-textarea-counter">150 characters left</div>
     </div>
-    <br/>
-    <div class="fd-form-item">
+    <div class="fd-form-item break">
         <label class="fd-form-label" for="textarea-1">Text area:</label>
         <textarea class="fd-textarea is-invalid" id="textarea-1" placeholder="Write something here"></textarea>
     </div>
-    <br/>
-    <div class="fd-form-item">
+    <div class="fd-form-item break">
         <label class="fd-form-label" for="textarea-1">Text area:</label>
         <textarea class="fd-textarea is-warning" id="textarea-1" placeholder="Write something here"></textarea>
     </div>
-    <br/>
-    <div class="fd-form-item">
+    <div class="fd-form-item break">
         <label class="fd-form-label" for="textarea-1">Text area:</label>
         <textarea class="fd-textarea is-information" id="textarea-1" placeholder="Write something here"></textarea>
     </div>
-    <br/>
-    <div class="fd-form-item">
+    <div class="fd-form-item break">
         <label class="fd-form-label" for="textarea-1">Text area:</label>
         <textarea class="fd-textarea" id="textarea-1" placeholder="Write something here" disabled></textarea>
     </div>
-    <br/>
-    <div class="fd-form-item">
+    <div class="fd-form-item break">
         <label class="fd-form-label" for="textarea-1">Text area:</label>
         <textarea class="fd-textarea" id="textarea-1" placeholder="Write something here" readonly></textarea>
     </div>
-    <br/>
     <div class="fd-form-item" dir="rtl">
         <label class="fd-form-label" for="textarea-1">Text area:</label>
         <textarea class="fd-textarea" id="textarea-1" placeholder="Write something here"></textarea>
@@ -375,7 +306,7 @@ In special cases, there are only two mutually exclusive options. Combine them in
 - The options are numbers with fixed steps. Use a slider control.
 
 {% capture radio-buttons%}
-<fieldset class="fd-fieldset">
+<fieldset class="fd-fieldset break">
     <legend class="fd-fieldset__legend">Radio Buttons Cozy Mode</legend>
     <div class="fd-form-item">
         <label class="fd-form-label fd-form-label--radio" for="pDidh761">
@@ -393,8 +324,7 @@ In special cases, there are only two mutually exclusive options. Combine them in
         </label>
     </div>
 </fieldset>
-<br /><br />
-<fieldset class="fd-fieldset">
+<fieldset class="fd-fieldset break">
     <legend class="fd-fieldset__legend">Radio Buttons Compact Mode</legend>
     <div class="fd-form-item">
         <label class="fd-form-label fd-form-label--radio" for="pDidh76111">
@@ -412,8 +342,7 @@ In special cases, there are only two mutually exclusive options. Combine them in
         </label>
     </div>
 </fieldset>
-<br /><br />
-<fieldset class="fd-fieldset">
+<fieldset class="fd-fieldset break">
     <legend class="fd-fieldset__legend">Radio buttons Disabled</legend>
     <div class="fd-form-item">
         <label class="fd-form-label fd-form-label--radio" for="pDidh764">
@@ -431,8 +360,7 @@ In special cases, there are only two mutually exclusive options. Combine them in
         </label>
     </div>
 </fieldset>
-<br /><br />
-<fieldset class="fd-fieldset">
+<fieldset class="fd-fieldset break">
     <legend class="fd-fieldset__legend">Inline Radio buttons</legend>
     <div class="fd-form-item fd-form-item--inline">
         <label class="fd-form-label fd-form-label--radio" for="pDidh767">
@@ -450,8 +378,7 @@ In special cases, there are only two mutually exclusive options. Combine them in
         </label>
     </div>
 </fieldset>
-<br /><br />
-<fieldset class="fd-fieldset">
+<fieldset class="fd-fieldset break">
     <legend class="fd-fieldset__legend">Interaction States</legend>
     <div class="fd-form-item">
         <label class="fd-form-label fd-form-label--radio" for="iSpDidh761">
@@ -479,8 +406,7 @@ In special cases, there are only two mutually exclusive options. Combine them in
         </label>
     </div>
 </fieldset>
-<br /><br />
-<fieldset class="fd-fieldset">
+<fieldset class="fd-fieldset break">
     <legend class="fd-fieldset__legend">Interaction States Compact Mode</legend>
     <div class="fd-form-item">
         <label class="fd-form-label fd-form-label--radio" for="iSpDidh7619">
@@ -508,7 +434,6 @@ In special cases, there are only two mutually exclusive options. Combine them in
         </label>
     </div>
 </fieldset>
-<br /><br />
 <fieldset class="fd-fieldset">
     <legend class="fd-fieldset__legend">Interaction States Compact Mode Disabled</legend>
     <div class="fd-form-item">

--- a/docs/pages/components/image.md
+++ b/docs/pages/components/image.md
@@ -25,23 +25,19 @@ Size Options: `--s` 24x24, `--m` 36x36, `--l` 48x48
 Shape Option: `--circle` will render a round image
 
 {% capture default %}
-<span class="fd-image--s" aria-label="Image label"
-style="background-image: url('{{site.baseurl}}/images/thumbs/headshot-male.jpg');"></span>
-
-<span class="fd-image--m" aria-label="Image label"
-style="background-image: url('{{site.baseurl}}/images/thumbs/headshot-male.jpg');"></span>
-
-<span class="fd-image--l" aria-label="Image label"
-style="background-image: url('{{site.baseurl}}/images/thumbs/headshot-male.jpg');"></span>
-
-<br><br>
+<div class="break">
+    <span class="fd-image--s" aria-label="Image label"
+    style="background-image: url('{{site.baseurl}}/images/thumbs/headshot-male.jpg');"></span>
+    <span class="fd-image--m" aria-label="Image label"
+    style="background-image: url('{{site.baseurl}}/images/thumbs/headshot-male.jpg');"></span>
+    <span class="fd-image--l" aria-label="Image label"
+    style="background-image: url('{{site.baseurl}}/images/thumbs/headshot-male.jpg');"></span>
+</div>
 
 <span class=" fd-image--s fd-image--circle" aria-label="Image label"
 style="background-image: url('{{site.baseurl}}/images/thumbs/headshot-male.jpg');"></span>
-
 <span class=" fd-image--m fd-image--circle" aria-label="Image label"
 style="background-image: url('{{site.baseurl}}/images/thumbs/headshot-male.jpg');"></span>
-
 <span class=" fd-image--l fd-image--circle" aria-label="Image label"
 style="background-image: url('{{site.baseurl}}/images/thumbs/headshot-male.jpg');"></span>
 {% endcapture %}

--- a/docs/pages/components/input-group.md
+++ b/docs/pages/components/input-group.md
@@ -17,14 +17,13 @@ The input group includes form inputs with add-ons that allow the user to better 
 The Input Group supports **compact** mode (by virtue of the `--compact` modifier on child components).
 
 {% capture sizes %}
-<div class="fd-form-item">
+<div class="fd-form-item break break--single">
     <label class="fd-form-label" for="">Default Size </label>
     <div class="fd-input-group">
         <span class="fd-input-group__addon">$</span>
         <input class="fd-input fd-input-group__input" type="text" id="" name="" value="1234568910 ">
     </div>
 </div>
-<br />
 <div class="fd-form-item">
     <label class="fd-form-label" for="">Compact Size </label>
     <div class="fd-input-group">
@@ -42,31 +41,28 @@ The Input Group with text add-on component is typically used to specify the type
 
 {% capture text-addon %}
 
-<div class="fd-form-item">
+<div class="fd-form-item break break--single">
     <label class="fd-form-label" for="">Left Aligned Text Add-on</label>
     <div class="fd-input-group">
         <span class="fd-input-group__addon">$</span>
         <input class="fd-input fd-input-group__input" type="text" id="" name="" value="1234568910 ">
     </div>
 </div>
-<br />
-<div class="fd-form-item">
+<div class="fd-form-item break break--single">
     <label class="fd-form-label" for="">Right Aligned Text Add-on</label>
     <div class="fd-input-group">
         <input class="fd-input fd-input-group__input" type="text" id="" name="" value="1234568910 ">
         <span class="fd-input-group__addon">€</span>
     </div>
 </div>
-<br />
-<div class="fd-form-item">
+<div class="fd-form-item break break--single">
     <label class="fd-form-label" for="">Right Aligned Text Add-on With Right Aligned Input Text</label>
     <div class="fd-input-group">
         <input class="fd-input fd-input-group__input right-align" type="text" id="" name="" value="1234568910 ">
         <span class="fd-input-group__addon">€</span>
     </div>
 </div>
-<br />
-<div class="fd-form-item">
+<div class="fd-form-item break break--single">
     <label class="fd-form-label" for="">Left and Right Aligned Text Add-ons</label>
     <div class="fd-input-group">
         <span class="fd-input-group__addon">$</span>
@@ -74,7 +70,6 @@ The Input Group with text add-on component is typically used to specify the type
         <span class="fd-input-group__addon">.00</span>
     </div>
 </div>
-<br />
 <div class="fd-form-item">
     <label class="fd-form-label" for="">Multiple Left and Right Aligned Text Add-ons</label>
     <div class="fd-input-group">
@@ -99,7 +94,7 @@ The Input Group with text add-on component is typically used to specify the type
 The Input with add-on supports icons.
 
 {% capture input-action %}
-<div class="fd-form-item">
+<div class="fd-form-item break break--single">
     <label class="fd-form-label" for="">Input with icon on the left</label>
     <div class="fd-input-group">
         <span class="fd-input-group__addon">
@@ -108,8 +103,7 @@ The Input with add-on supports icons.
         <input class="fd-input fd-input-group__input" type="text" id="" name="" value="1000000">
     </div>
 </div>
-<br />
-<div class="fd-form-item">
+<div class="fd-form-item break break--single">
     <label class="fd-form-label" for="">Input with icon on the right</label>
     <div class="fd-input-group">
         <input class="fd-input fd-input-group__input" type="text" id="" name="" value="1000000">
@@ -118,7 +112,6 @@ The Input with add-on supports icons.
         </span>
     </div>
 </div>
-<br />
 <div class="fd-form-item">
     <label class="fd-form-label" for="">Input with icon on the right and right aligned input text</label>
     <div class="fd-input-group">
@@ -138,7 +131,7 @@ The Input with add-on supports icons.
 The Input with add-on supports actions. Actions can be shown with a text label or icon.
 
 {% capture button-addon %}
-<div class="fd-form-item">
+<div class="fd-form-item break break--single">
     <label class="fd-form-label" for="">Input with text add-on</label>
     <div class="fd-input-group">
         <input class="fd-input fd-input-group__input" type="text" id="" name="" value="1000000">
@@ -149,8 +142,7 @@ The Input with add-on supports actions. Actions can be shown with a text label o
         </span>
     </div>
 </div>
-<br />
-<div class="fd-form-item">
+<div class="fd-form-item break break--single">
     <label class="fd-form-label" for="">Input with icon action</label>
     <div class="fd-input-group">
         <input class="fd-input fd-input-group__input" type="text" id="" name="" value="1000000">
@@ -159,8 +151,7 @@ The Input with add-on supports actions. Actions can be shown with a text label o
         </span>
     </div>
 </div>
-<br />
-<div class="fd-form-item">
+<div class="fd-form-item break break--single">
     <label class="fd-form-label" for="">Compact Input with icon action</label>
     <div class="fd-input-group">
         <input class="fd-input fd-input--compact fd-input-group__input" type="text" id="" name="" value="1000000">
@@ -169,8 +160,7 @@ The Input with add-on supports actions. Actions can be shown with a text label o
         </span>
     </div>
 </div>
-<br />
-<div class="fd-form-item">
+<div class="fd-form-item break break--single">
     <label class="fd-form-label" for="">Input with text action on left</label>
     <div class="fd-input-group">
         <span class="fd-input-group__addon fd-input-group__addon--button">
@@ -181,8 +171,7 @@ The Input with add-on supports actions. Actions can be shown with a text label o
         <input class="fd-input fd-input-group__input" type="text" id="" name="" value="1000000">
     </div>
 </div>
-<br />
-<div class="fd-form-item">
+<div class="fd-form-item break break--single">
     <label class="fd-form-label" for="">Input with actions on left and on right</label>
     <div class="fd-input-group">
         <span class="fd-input-group__addon fd-input-group__addon--button">
@@ -200,7 +189,6 @@ The Input with add-on supports actions. Actions can be shown with a text label o
         </span>
     </div>
 </div>
-<br />
 <div class="fd-form-item">
     <label class="fd-form-label" for="">Input with mixed actions on left and on right</label>
     <div class="fd-input-group">
@@ -226,15 +214,14 @@ The Input with add-on supports actions. Actions can be shown with a text label o
 ## States
 
 {% capture states %}
-<div class="fd-form-item">
+<div class="fd-form-item break break--single">
     <label class="fd-form-label" for="">Valid (Success)</label>
     <div class="fd-input-group is-valid">
         <span class="fd-input-group__addon">$</span>
         <input class="fd-input fd-input-group__input" type="text" id="" name="" value="1234568910">
     </div>
 </div>
-<br />
-<div class="fd-form-item">
+<div class="fd-form-item break break--single">
     <label class="fd-form-label" for="">Invalid (Error)</label>
     <div class="fd-input-group is-invalid">
         <input class="fd-input fd-input-group__input" type="text" id="" name="" value="1000000">
@@ -243,16 +230,14 @@ The Input with add-on supports actions. Actions can be shown with a text label o
         </span>
     </div>
 </div>
-<br />
-<div class="fd-form-item">
+<div class="fd-form-item break break--single">
     <label class="fd-form-label" for="">Warning (Alert)</label>
     <div class="fd-input-group is-warning">
         <span class="fd-input-group__addon">$</span>
         <input class="fd-input fd-input-group__input" type="text" id="" name="" value="1234568910">
     </div>
 </div>
-<br />
-<div class="fd-form-item">
+<div class="fd-form-item break break--single">
     <label class="fd-form-label" for="">Information</label>
     <div class="fd-input-group is-information">
         <input class="fd-input fd-input--compact fd-input-group__input" type="text" id="" name="" value="1000000">
@@ -263,24 +248,21 @@ The Input with add-on supports actions. Actions can be shown with a text label o
         </span>
     </div>
 </div>
-<br />
-<div class="fd-form-item">
+<div class="fd-form-item break break--single">
     <label class="fd-form-label" for="">Disabled</label>
     <div class="fd-input-group is-disabled">
         <span class="fd-input-group__addon">$</span>
         <input class="fd-input fd-input-group__input" type="text" id="" name="" placeholder="Enter a value">
     </div>
 </div>
-<br />
-<div class="fd-form-item">
+<div class="fd-form-item break break--single">
     <label class="fd-form-label" for="">Disabled Valid (Success)</label>
     <div class="fd-input-group is-valid is-disabled">
         <span class="fd-input-group__addon">$</span>
         <input class="fd-input fd-input-group__input" type="text" id="" name="" value="1234568910">
     </div>
 </div>
-<br />
-<div class="fd-form-item">
+<div class="fd-form-item break break--single">
     <label class="fd-form-label" for="">Disabled Invalid (Error)</label>
     <div class="fd-input-group is-invalid is-disabled">
         <input class="fd-input fd-input-group__input" type="text" id="" name="" value="1000000">
@@ -289,15 +271,13 @@ The Input with add-on supports actions. Actions can be shown with a text label o
         </span>
     </div>
 </div>
-<br />
-<div class="fd-form-item">
+<div class="fd-form-item break break--single">
     <label class="fd-form-label" for="">Disabled Warning (Alert)</label>
     <div class="fd-input-group is-warning is-disabled">
         <span class="fd-input-group__addon">$</span>
         <input class="fd-input fd-input-group__input" type="text" id="" name="" value="1234568910">
     </div>
 </div>
-<br />
 <div class="fd-form-item">
     <label class="fd-form-label" for="">Disabled Information</label>
     <div class="fd-input-group is-information is-disabled">
@@ -317,7 +297,7 @@ The Input with add-on supports actions. Actions can be shown with a text label o
 ## Textareas
 
 {% capture button-addon %}
-<div class="fd-form-item">
+<div class="fd-form-item break break--single">
     <label class="fd-form-label" for="">Textarea with text add-on</label>
     <div class="fd-input-group">
         <textarea class="fd-textarea fd-input-group__input" id=""></textarea>
@@ -326,8 +306,7 @@ The Input with add-on supports actions. Actions can be shown with a text label o
         </span>
     </div>
 </div>
-<br />
-<div class="fd-form-item">
+<div class="fd-form-item break break--single">
     <label class="fd-form-label" for="">Textarea with action</label>
     <div class="fd-input-group">
         <textarea class="fd-textarea fd-input-group__input" id=""></textarea>
@@ -338,8 +317,7 @@ The Input with add-on supports actions. Actions can be shown with a text label o
         </span>
     </div>
 </div>
-<br />
-<div class="fd-form-item">
+<div class="fd-form-item break break--single">
     <label class="fd-form-label" for="">Compact textarea with action</label>
     <div class="fd-input-group is-valid">
         <textarea class="fd-textarea fd-textarea--compact fd-input-group__input" id=""></textarea>
@@ -350,7 +328,6 @@ The Input with add-on supports actions. Actions can be shown with a text label o
         </span>
     </div>
 </div>
-<br />
 <div class="fd-form-item">
     <label class="fd-form-label" for="">Compact textarea with action</label>
     <div class="fd-input-group is-invalid">

--- a/docs/pages/components/link.md
+++ b/docs/pages/components/link.md
@@ -15,17 +15,13 @@ Used when extra emphasis is needed especially when a link needs to standout from
 <br>
 
 {% capture default %}
-<a href="#" class="fd-link">Standard Link</a>
-<br><br>
-<a href="#" class="fd-link"><strong>Emphasized Link</strong></a>
-<br><br>
-<a href="#" class="fd-link" aria-disabled="true">Disabled Link</a>
-<br><br>
-<a href="#" class="fd-link">
+<a href="#" class="fd-link break break--single">Standard Link</a>
+<a href="#" class="fd-link break break--single"><strong>Emphasized Link</strong></a>
+<a href="#" class="fd-link break break--single" aria-disabled="true">Disabled Link</a>
+<a href="#" class="fd-link break break--single">
     Icon Left Link 
     <span class="sap-icon--slim-arrow-right sap-icon--s"></span>
 </a>
-<br><br>
 <a href="#" class="fd-link">
     <span class="sap-icon--slim-arrow-left sap-icon--s"></span> 
     Icon Right Link

--- a/docs/pages/components/localization-editor.md
+++ b/docs/pages/components/localization-editor.md
@@ -12,7 +12,7 @@ summary:
 ## With input
 
 {% capture default %}
-<div class="fd-localization-editor">
+<div class="fd-localization-editor break break--single">
    <div class="fd-popover">
       <div class="fd-popover__control">
          <div class="fd-form-item">
@@ -59,9 +59,6 @@ summary:
       </div>
    </div>
 </div>
-
-<br>
-
 <div class="fd-localization-editor">
    <div class="fd-popover">
       <div class="fd-popover__control">

--- a/docs/pages/components/select.md
+++ b/docs/pages/components/select.md
@@ -14,7 +14,7 @@ The select control (also known as a dropdown) is commonly used to enable users t
 ## Sizes
 
 {% capture select-sizes %}
-<div class="documentation-site-popover-container">
+<div class="documentation-site-popover-container break break--single">
    <div class="fd-popover">
       <div class="fd-popover__control">
          <div class="fd-select">
@@ -41,9 +41,6 @@ The select control (also known as a dropdown) is commonly used to enable users t
       </div>
    </div>
 </div>
-
-<br />
-
 <h4>Compact Size</h4>
 <div class="documentation-site-popover-container">
    <div class="fd-popover">

--- a/docs/pages/components/status-indicators.md
+++ b/docs/pages/components/status-indicators.md
@@ -31,17 +31,19 @@ Status indicators are used to easily highlight the state of an object. `badge`, 
 ### Badge Color Options
 In addition the the default grey, there are three additional Semantic color options available: `--success`, `--warning` and `-error`
 {% capture badge %}
-<span class="fd-badge fd-badge--success">Label</span>
-<span class="fd-badge fd-badge--warning">Label</span>
-<span class="fd-badge fd-badge--error">Label</span>
-<br><br>
-<span class="fd-badge fd-badge--success fd-badge--pill">Label</span>
-<span class="fd-badge fd-badge--warning fd-badge--pill">Label</span>
-<span class="fd-badge fd-badge--error fd-badge--pill">Label</span>
-<br><br>
-<span class="fd-badge fd-badge--success fd-badge--filled">Label</span>
-<span class="fd-badge fd-badge--warning fd-badge--filled">Label</span>
-<span class="fd-badge fd-badge--error fd-badge--filled">Label</span>
+<div class="break">
+    <span class="fd-badge fd-badge--success">Label</span>
+    <span class="fd-badge fd-badge--warning">Label</span>
+    <span class="fd-badge fd-badge--error">Label</span>
+</div>
+<div class="break">
+    <span class="fd-badge fd-badge--success fd-badge--pill">Label</span>
+    <span class="fd-badge fd-badge--warning fd-badge--pill">Label</span>
+    <span class="fd-badge fd-badge--error fd-badge--pill">Label</span>
+</div>
+    <span class="fd-badge fd-badge--success fd-badge--filled">Label</span>
+    <span class="fd-badge fd-badge--warning fd-badge--filled">Label</span>
+    <span class="fd-badge fd-badge--error fd-badge--filled">Label</span>
 
 {% endcapture %}
 {% include display-component.html component=badge %}


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#458

## Description
Removing all <br> tags and adding a break class for the documentation site with break giving a margin-below of 2rem and break break--single for a margin-below of 1 rem.