### PR TITLE
fix: Miss-aligned menu icons

### DIFF
--- a/src/menu.scss
+++ b/src/menu.scss
@@ -41,15 +41,11 @@ $block: #{$fd-namespace}-menu;
   width: 100%;
   display: inline-block;
 
-  &__group,
-  &__list {
+  &__group {
     @include fd-reset();
 
     list-style: none;
     margin-bottom: 0;
-  }
-
-  &__group {
     padding-left: 0;
   }
 
@@ -157,20 +153,17 @@ $block: #{$fd-namespace}-menu;
   }
 
   &__addon-before {
-    background-color: white;
-    float: left;
-    clear: left;
+    @include fd-flex-center();
 
     @include fd-rtl() {
       float: right;
       clear: right;
     }
 
-    height: 14px;
-    line-height: 1.42857;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+    background-color: transparent;
+    float: left;
+    clear: left;
+    min-height: 1px;
     width: 30px;
   }
 }


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#466

## Description
Bug occurred due to fixed span height.
Fixed white background of an icon has been changed to transparent.
Merge also includes a little cleanup in `fd-menu__addon-before`, `fd-menu__list` and `fd-menu__group`.

## Screenshots
### Before:
Alignment:
![image](https://user-images.githubusercontent.com/17496353/70420844-dcb51f80-1a68-11ea-8503-1554a747b257.png)
Hover:
![image](https://user-images.githubusercontent.com/17496353/70421110-711f8200-1a69-11ea-877b-54aed7ff248e.png)


### After:
Alignment:
![image](https://user-images.githubusercontent.com/17496353/70420925-0a01cd80-1a69-11ea-81c3-799d932d544f.png)
Hover:
![image](https://user-images.githubusercontent.com/17496353/70421018-3a496c00-1a69-11ea-90f0-e693f12b5763.png)

