### PR TITLE
fix: latest firefox bugs

### DIFF
--- a/docs/_sass/_docs-display-component.scss
+++ b/docs/_sass/_docs-display-component.scss
@@ -16,6 +16,7 @@
     > .fd-tile__content {
         padding: 60px 20px;
         width: 100%;
+        max-width: 100%;
     }
 
     > p {

--- a/src/inline-help.scss
+++ b/src/inline-help.scss
@@ -39,6 +39,7 @@ $block: #{$fd-namespace}-inline-help;
     content: "?";
     width: $fd-tooltip-icon-size;
     height: $fd-tooltip-icon-size;
+    line-height: $fd-tooltip-icon-size;
     font-style: normal;
     position: absolute;
     left: 0;

--- a/src/mixins/_mixins.scss
+++ b/src/mixins/_mixins.scss
@@ -193,6 +193,10 @@
   white-space: nowrap;
   background-color: transparent;
   border-radius: var(--sapButton_BorderCornerRadius);
+
+  &::-moz-focus-inner {
+    border: 0;
+  }
   @content;
 }
 


### PR DESCRIPTION
## Description
I did some smoke tests on firefox, there is list of things, that was wrong
*  Docs - Width of fd-tile__content was exceeded, when there was overflow
* Scss - Height of the icon inside inline-help was not middle aligned
* Scss - There as bug with `moz-focus-inner`, which provided double focus on button elements.
## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/26483208/70906067-ce857700-2005-11ea-857b-2daf4f2ec5f5.png)
![image](https://user-images.githubusercontent.com/26483208/70906120-f5dc4400-2005-11ea-9b4d-bb177d5f5f13.png)
![buttno](https://user-images.githubusercontent.com/26483208/70906289-4f447300-2006-11ea-94f5-7c258e2418ae.gif)

### After:
![image](https://user-images.githubusercontent.com/26483208/70906078-d7764880-2005-11ea-9f87-545ada4d22c0.png)
![image](https://user-images.githubusercontent.com/26483208/70906091-e0671a00-2005-11ea-8171-0d3249fd4997.png)
![image](https://user-images.githubusercontent.com/26483208/70906254-39cf4900-2006-11ea-88d0-dc5c709b3982.png)
