### PR TITLE
docs: Example fixes on firefox

### DIFF
--- a/docs/_data/sidebars/left-navigation-sidebar.yml
+++ b/docs/_data/sidebars/left-navigation-sidebar.yml
@@ -176,10 +176,6 @@ entries:
       url: /components/modal.html
       output: web
 
-    - title: Multi Input
-      url: /components/multi-input.html
-      output: web
-
     - title: Notification
       url: /components/notification.html
       output: web

--- a/docs/pages/components/busy-indicator.md
+++ b/docs/pages/components/busy-indicator.md
@@ -16,7 +16,7 @@ Busy indicators are not visible all the time, only when needed.
 <br>
 ## Busy indicator usage and size options
 {% capture busy-indicator %}
-<div style="display:flex;justify-content:center;flex-direction:column;align-items:center">
+<div style="text-align: center">
     <div class="fd-busy-indicator--l" aria-hidden="false" aria-label="Loading">
         <div class="fd-busy-indicator--circle-0"></div>
         <div class="fd-busy-indicator--circle-1"></div>

--- a/docs/pages/layouts/shell-layout.md
+++ b/docs/pages/layouts/shell-layout.md
@@ -188,8 +188,8 @@ The container visibility can be toggled with the `aria-hidden` attribute.
     </div>
     <div class="fd-shell__overlay fd-overlay fd-overlay--alert" aria-hidden="false">
         <div class="fd-alert fd-alert--warning fd-alert--dismissible" role="alert" id="4Nolz351">
-          <button class="fd-alert__close" aria-controls="4Nolz351" aria-label="Close"></button>
-          Lorem ipsum dolor sit amet, consectetur adipisicing elit
+          <button class="fd-button fd-button--light fd-button--compact fd-alert__close" aria-controls="4Nolz351" aria-label="Close"></button>
+          <span class="fd-alert__text">Lorem ipsum dolor sit amet, consectetur adipisicing elit</span>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Description
On smoke tests, I found some of components examples doesn't look good on Firefox. So:
* (All) I removed `multi-input` link from component group - it was redirecting to wrong url. Place for `multi-input` is in Patterns section.
* ShellLayout example with `Alert` wasn't up to date with latest changes.  
* Busy Indicator - Flex wasn't good idea there, `<br>` Didn't work inside `flex` on firefox
 

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![busyindbad](https://user-images.githubusercontent.com/26483208/70907406-178afa80-2009-11ea-80e6-f4a70a918e8c.gif)
![image](https://user-images.githubusercontent.com/26483208/70907434-24a7e980-2009-11ea-9f0e-2a8a93a40400.png)


### After:
![busyindgood](https://user-images.githubusercontent.com/26483208/70907414-1a85eb00-2009-11ea-9337-332cdfbabe90.gif)
![image](https://user-images.githubusercontent.com/26483208/70907461-35f0f600-2009-11ea-84d5-95ddd1588ecc.png)
