### PR TITLE
fix: Cannot close example alert on IE11

### DIFF
--- a/docs/js/customscripts.js
+++ b/docs/js/customscripts.js
@@ -30,7 +30,7 @@ $(document).ready(function () {
             var isAlert = this.parentElement.getAttribute("role") === "alert";
             if (isAlert) {
                 //remove or hide if we want some animation
-                target.remove();
+                $(target).remove();
                 return;
             }
             //dropdown


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#524

## Description
IE11 does not support `.remove()` method on `Element` object.
Using jQuery to remove element solves the problem.