### PR TITLE
fix: input-group-pickers

### DIFF
--- a/src/input-group.scss
+++ b/src/input-group.scss
@@ -60,7 +60,9 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
     @include fd-reset-child-spacing();
 
     border: none;
-    flex: 1;
+    flex: 0;
+    flex-grow: 1;
+    width: auto;
     padding-right: 0.25rem;
     padding-left: 0.25rem;
 

--- a/src/input-group.scss
+++ b/src/input-group.scss
@@ -61,7 +61,6 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
 
     border: none;
     flex: 1 1 auto;
-    width: auto;
     padding-right: 0.25rem;
     padding-left: 0.25rem;
 

--- a/src/input-group.scss
+++ b/src/input-group.scss
@@ -60,7 +60,8 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
     @include fd-reset-child-spacing();
 
     border: none;
-    flex: 0;
+    flex: none;
+    flex-shrink: 1;
     flex-grow: 1;
     width: auto;
     padding-right: 0.25rem;

--- a/src/input-group.scss
+++ b/src/input-group.scss
@@ -60,9 +60,7 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
     @include fd-reset-child-spacing();
 
     border: none;
-    flex: none;
-    flex-shrink: 1;
-    flex-grow: 1;
+    flex: 1 1 auto;
     width: auto;
     padding-right: 0.25rem;
     padding-left: 0.25rem;


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#538

## Description
Fixes the sizing in IE11 for input groups with time picker and date picker.
Currently no screeenshots, using netlify for IE testing
## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:


### After:
