### PR TITLE
fix: Remove flex property from input-message-group IE11

### DIFF
--- a/src/form-input-message-group.scss
+++ b/src/form-input-message-group.scss
@@ -9,6 +9,6 @@
 $block: #{$fd-namespace}-form-input-message-group;
 
 .#{$block} {
-  flex: 1;
+  display: flex;
   position: relative;
 }

--- a/src/form-input-message-group.scss
+++ b/src/form-input-message-group.scss
@@ -10,5 +10,6 @@ $block: #{$fd-namespace}-form-input-message-group;
 
 .#{$block} {
   display: flex;
+  flex-grow: 1;
   position: relative;
 }


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/528

## Description
So after some research, I came up to think, that `flex: 1` on IE11 cause problem with message-group container. It's changed to `display:flex`. Now also the example looks better, before the container was interpreted like it has `0px height`

## Screenshots

### Before:
![image](https://user-images.githubusercontent.com/26483208/71165532-4abfca80-2251-11ea-9fc6-10f27509e56b.png)


### After:
![image](https://user-images.githubusercontent.com/26483208/71165503-38459100-2251-11ea-9c7f-a59517a7322c.png)

