### PR TITLE
fix: Remove IE11 Dropdown default icon

### DIFF
--- a/src/form-select.scss
+++ b/src/form-select.scss
@@ -28,6 +28,10 @@ $block: #{$fd-namespace}-form-select;
     padding-left: $fd-forms-padding + $fd-forms-select-width--background-image;
   }
 
+  &::-ms-expand {
+    display: none;
+  }
+
   &:focus,
   &:hover {
     background-image: url(#{$fd-forms-select-background-image});


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/529

## Description
there is removed dropdown default icon

### Before:
![image](https://user-images.githubusercontent.com/26483208/71166517-354ba000-2253-11ea-9f10-4b23ca2544ed.png)

### After:
![image](https://user-images.githubusercontent.com/26483208/71166510-2ebd2880-2253-11ea-8511-0a3bee8176b1.png)
