### PR TITLE
fix: Number input increment/decrement not working on IE11

### DIFF
--- a/docs/js/customscripts.js
+++ b/docs/js/customscripts.js
@@ -233,5 +233,19 @@ $(document).ready(function () {
                 break;
         }
     }
-
 });
+
+function stepInputValue(inputId, stepDirection) {
+    let inputRef = document.getElementById(inputId);
+
+    if (inputRef) {
+        if(stepDirection === "up") {
+            ++inputRef.value;
+        } else if (stepDirection === "down") {
+            --inputRef.value;
+        }
+    } else {
+        console.warn("No element with id='" + inputId + "' found");
+    }
+}
+

--- a/docs/pages/components/input-group.md
+++ b/docs/pages/components/input-group.md
@@ -269,8 +269,8 @@ For an integer value input, a spinner can be added allowing the user to increase
     <div class="fd-input-group">
         <input class="fd-input fd-input--no-number-spinner fd-input-group__input" id="spinner-1" type="number" value="100" />
         <span class="fd-input-group__addon fd-input-group__addon--button">
-            <button class="fd-input-group__button fd-button--light fd-button--half sap-icon--slim-arrow-up" aria-label="Step up" onclick="document.getElementById('spinner-1').stepUp();"></button>
-            <button class="fd-input-group__button fd-button--light fd-button--half sap-icon--slim-arrow-down" aria-label="Step down" onclick="document.getElementById('spinner-1').stepDown();"></button>
+            <button class="fd-input-group__button fd-button--light fd-button--half sap-icon--slim-arrow-up" aria-label="Step up" onclick="stepInputValue('spinner-1', 'up');"></button>
+            <button class="fd-input-group__button fd-button--light fd-button--half sap-icon--slim-arrow-down" aria-label="Step down" onclick="stepInputValue('spinner-1', 'down');"></button>
         </span>
     </div>
 </div>


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#530

## Description
IE11 does not support `stepUp` and `stepDown` methods on input element.
Separate function for this case has been created.