### PR TITLE
fix: Broken product switch on mobile devices - IE11

### DIFF
--- a/src/product-switch.scss
+++ b/src/product-switch.scss
@@ -79,6 +79,7 @@ $block: #{$fd-namespace}-product-switch;
       padding: 1rem;
       text-align: left;
       border-radius: 0;
+      flex-basis: auto;
 
       &.selected {
         border: none;
@@ -394,6 +395,7 @@ $block: #{$fd-namespace}-product-switch;
     @include fd-reset();
 
     @include fd-flex() {
+      align-self: stretch;
       align-items: center;
       justify-content: center;
     }


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#531

## Description
IE11 has problem with `flex-basis` value. For some reason IE11 doesn't respect elements `height` value if `flex-basis: 25%` is used.
Since in mobile mode products are aligned as a list, my solution is changing to `flex-basis: auto` on mobiles.

To be honest product-switch styles are a little bit messy. I'd recommend small refactor in the future.

### Before:
![image](https://user-images.githubusercontent.com/17496353/71259015-bc724400-2337-11ea-9e39-5940069514b5.png)

### After:
![image](https://user-images.githubusercontent.com/17496353/71259241-47533e80-2338-11ea-94a4-e3709765e508.png)
