### PR TITLE
fix: Misaligned check in table header context menu (documentation)

### DIFF
--- a/docs/pages/components/table.md
+++ b/docs/pages/components/table.md
@@ -588,16 +588,22 @@ a contextual menu can be substituted in order to display all actions in one menu
                         <nav class="fd-menu fd-menu--addon-before">
                            <ul class="fd-menu__list">
                               <li>
-                                 <div class="fd-menu__addon-before"></div>
-                                 <a href="#" class="fd-menu__item">Ascending</a>
+                                 <a href="#" class="fd-menu__item">
+                                    <span class="fd-menu__addon-before"></span>
+                                    Ascending
+                                 </a>
                               </li>
                               <li>
-                                 <div class="fd-menu__addon-before"></div>
-                                 <a href="#" class="fd-menu__item">Decensing</a>
+                                 <a href="#" class="fd-menu__item">
+                                    <span class="fd-menu__addon-before"></span>
+                                    Decensing
+                                 </a>
                               </li>
                               <li>
-                                 <div class="fd-menu__addon-before"><span class="sap-icon--accept"></span></div>
-                                 <a href="#" class="fd-menu__item">Fix Column</a>
+                                 <a href="#" class="fd-menu__item">
+                                    <span class="fd-menu__addon-before sap-icon--accept"></span>
+                                    Fix Column
+                                 </a>
                               </li>
                            </ul>
                         </nav>


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#534

## Description
Table header with context menu used wrong context menu implementation.
Documentation example has been fixed.

### Before:
![image](https://user-images.githubusercontent.com/17496353/71264369-40322d80-2344-11ea-87d5-b1ce1b5922f9.png)

### After:
![image](https://user-images.githubusercontent.com/17496353/71264434-648e0a00-2344-11ea-92e4-c36f222a1b2a.png)