### PR TITLE
fix: (InputGroup) Add min-width property only for ie10+, fix addon truncation

### DIFF
--- a/src/input-group.scss
+++ b/src/input-group.scss
@@ -72,7 +72,7 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
 
     background-color: transparent;
     border: none;
-    flex: 1 1 auto;
+    flex: 1;
     padding-right: 0.25rem;
     padding-left: 0.25rem;
 
@@ -104,6 +104,11 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
         padding-left: 0.625rem;
         padding-right: 0.25rem;
       }
+    }
+
+    /** Behaviour only for IE10+ */
+    @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+      min-width: 160px;
     }
   }
 


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/554

## Description
We had some bug on input-group component, which was caused by setting `auto` property for `flex-basis`. It was mostly because of IE11, which doesn't have any native `min-width` for `inputs` 

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
IE11:
![image](https://user-images.githubusercontent.com/26483208/71589022-be03ef00-2b23-11ea-9b10-e4bcb10e1af3.png)

All browsers:
![image](https://user-images.githubusercontent.com/26483208/71589047-d2e08280-2b23-11ea-98c3-246b00119991.png)



### After:
IE11:
![image](https://user-images.githubusercontent.com/26483208/71589005-b2b0c380-2b23-11ea-95ca-462000fcf238.png)

All browsers:
![image](https://user-images.githubusercontent.com/26483208/71589062-db38bd80-2b23-11ea-9ec6-8ac7e8ca41be.png)
