### PR TITLE
fix: product switch list style

### DIFF
--- a/src/product-switch.scss
+++ b/src/product-switch.scss
@@ -43,6 +43,8 @@ $block: #{$fd-namespace}-product-switch;
   &__list {
     @include fd-reset();
 
+    list-style-type: none;
+
     @include fd-flex() {
       flex-wrap: wrap;
     }


### PR DESCRIPTION
## Related Issue
#403 

## Description
To add a default list style being none to remove dots being used outside of styles

## Screenshots
In styles default does not show bullets, therefore, will be shown in other libraries
