### PR TITLE
docs: correct alert navigation link in the documentation

### DIFF
--- a/docs/_includes/demo-page-components/alert-app-overlay.html
+++ b/docs/_includes/demo-page-components/alert-app-overlay.html
@@ -1,6 +1,10 @@
 <div class="fd-shell__overlay fd-overlay fd-overlay--alert" aria-hidden="false">
     <div class="fd-alert fd-alert--warning fd-alert--dismissible" role="alert" id="4Nolz351">
-        <button class="fd-alert__close" aria-controls="4Nolz351" aria-label="Close"></button>
-        Lorem ipsum dolor sit amet, consectetur adipisicing elit
+        <button class="fd-button fd-button--light fd-button--compact fd-alert__close" aria-controls="4Nolz351"
+                aria-label="Close"></button>
+        <p class="fd-alert__text">
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit
+        </p>
     </div>
 </div>
+

--- a/docs/pages/components/alert.md
+++ b/docs/pages/components/alert.md
@@ -11,7 +11,7 @@ summary:
 
 Alerts provide messages within the application that are color-coded to emphasize the level of urgency.
 {: .docs-intro}
-For Alert placement guidelines within the application, see [Application Layout page]({{site.baseurl}}/layouts/shell-layout.html#application-with-ui-overlay) and [Application Alerts overlay Demo Page]({{site.baseurl}}/demo-pages/alert-overlay-demo-page.html)
+For Alert placement guidelines within the application, see [Application Layout page]({{site.baseurl}}/layouts/shell-layout.html#application-overlay-alert-example) and [Application Alerts overlay Demo Page]({{site.baseurl}}/demo-pages/alert-overlay-demo-page.html)
 
 <br>
 


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#582

## Description
Link now points to correct page section.
Alert component used in alert demo has been updated to newest styles.