### PR TITLE
docs: apply unified approach for loading images in the documentation

### DIFF
--- a/docs/pages/components/identifier.md
+++ b/docs/pages/components/identifier.md
@@ -82,13 +82,13 @@ A circle style can be rendered using the `--circle` modifier.
 A background image can be applied to any style using the `--thumbnail` modifier.
 
 {% capture identifier-thumbnail %}
-<span class="fd-identifier fd-identifier--xxs fd-identifier--circle fd-identifier--thumbnail" style="background-image: url('{{site.baseurl}}/images/thumbs/headshot-male.jpg')" role="presentation" aria-label="John Doe"></span>
-<span class="fd-identifier fd-identifier--xs fd-identifier--circle fd-identifier--thumbnail" style="background-image: url('{{site.baseurl}}/images/thumbs/headshot-male.jpg')" role="presentation" aria-label="John Doe"></span>
-<span class="fd-identifier fd-identifier--s fd-identifier--circle fd-identifier--thumbnail" style="background-image: url('{{site.baseurl}}/images/thumbs/headshot-male.jpg')" role="presentation" aria-label="John Doe"></span>
-<span class="fd-identifier fd-identifier--m fd-identifier--circle fd-identifier--thumbnail" style="background-image: url('{{site.baseurl}}/images/thumbs/headshot-male.jpg')" role="presentation" aria-label="John Doe"></span>
-<span class="fd-identifier fd-identifier--l fd-identifier--circle fd-identifier--thumbnail" style="background-image: url('{{site.baseurl}}/images/thumbs/headshot-male.jpg')" role="presentation" aria-label="John Doe"></span>
-<span class="fd-identifier fd-identifier--xl fd-identifier--circle fd-identifier--thumbnail" style="background-image: url('{{site.baseurl}}/images/thumbs/headshot-male.jpg')" role="presentation" aria-label="John Doe"></span>
-<span class="fd-identifier fd-identifier--xxl fd-identifier--circle fd-identifier--thumbnail" style="background-image: url('{{site.baseurl}}/images/thumbs/headshot-male.jpg')" role="presentation" aria-label="John Doe"></span>
+<span class="fd-identifier fd-identifier--xxs fd-identifier--circle fd-identifier--thumbnail" style="background-image: url('https://placeimg.com/400/400/nature')" role="presentation" aria-label="John Doe"></span>
+<span class="fd-identifier fd-identifier--xs fd-identifier--circle fd-identifier--thumbnail" style="background-image: url('https://placeimg.com/400/400/nature')" role="presentation" aria-label="John Doe"></span>
+<span class="fd-identifier fd-identifier--s fd-identifier--circle fd-identifier--thumbnail" style="background-image: url('https://placeimg.com/400/400/nature')" role="presentation" aria-label="John Doe"></span>
+<span class="fd-identifier fd-identifier--m fd-identifier--circle fd-identifier--thumbnail" style="background-image: url('https://placeimg.com/400/400/nature')" role="presentation" aria-label="John Doe"></span>
+<span class="fd-identifier fd-identifier--l fd-identifier--circle fd-identifier--thumbnail" style="background-image: url('https://placeimg.com/400/400/nature')" role="presentation" aria-label="John Doe"></span>
+<span class="fd-identifier fd-identifier--xl fd-identifier--circle fd-identifier--thumbnail" style="background-image: url('https://placeimg.com/400/400/nature')" role="presentation" aria-label="John Doe"></span>
+<span class="fd-identifier fd-identifier--xxl fd-identifier--circle fd-identifier--thumbnail" style="background-image: url('https://placeimg.com/400/400/nature')" role="presentation" aria-label="John Doe"></span>
 
 
 {% endcapture %}

--- a/docs/pages/components/image.md
+++ b/docs/pages/components/image.md
@@ -26,24 +26,24 @@ Shape Option: `--circle` will render a round image
 
 {% capture default %}
 <span class="fd-image--s" aria-label="Image label"
-style="background-image: url('{{site.baseurl}}/images/thumbs/headshot-male.jpg');"></span>
+style="background-image: url('https://placeimg.com/400/400/nature');"></span>
 
 <span class="fd-image--m" aria-label="Image label"
-style="background-image: url('{{site.baseurl}}/images/thumbs/headshot-male.jpg');"></span>
+style="background-image: url('https://placeimg.com/400/400/nature');"></span>
 
 <span class="fd-image--l" aria-label="Image label"
-style="background-image: url('{{site.baseurl}}/images/thumbs/headshot-male.jpg');"></span>
+style="background-image: url('https://placeimg.com/400/400/nature');"></span>
 
 <br><br>
 
 <span class=" fd-image--s fd-image--circle" aria-label="Image label"
-style="background-image: url('{{site.baseurl}}/images/thumbs/headshot-male.jpg');"></span>
+style="background-image: url('https://placeimg.com/400/400/nature');"></span>
 
 <span class=" fd-image--m fd-image--circle" aria-label="Image label"
-style="background-image: url('{{site.baseurl}}/images/thumbs/headshot-male.jpg');"></span>
+style="background-image: url('https://placeimg.com/400/400/nature');"></span>
 
 <span class=" fd-image--l fd-image--circle" aria-label="Image label"
-style="background-image: url('{{site.baseurl}}/images/thumbs/headshot-male.jpg');"></span>
+style="background-image: url('https://placeimg.com/400/400/nature');"></span>
 {% endcapture %}
 
 {% include display-component.html component=default %}

--- a/docs/pages/components/popover.md
+++ b/docs/pages/components/popover.md
@@ -69,7 +69,7 @@ There are four placement options:
     </div>
     <div class="fd-popover__body fd-popover__body--right" aria-hidden="true" id="popoverA2">
         <div style="margin: 20px;">
-            <span class="fd-identifier fd-identifier--xxl fd-identifier--circle fd-identifier--thumbnail" style="background-image: url('/images/product-tile.jpg');" role="presentation" aria-label="Nature"></span>
+            <span class="fd-identifier fd-identifier--xxl fd-identifier--circle fd-identifier--thumbnail" style="background-image: url('https://placeimg.com/400/400/nature');" role="presentation" aria-label="Nature"></span>
         </div>
     </div>
 </div>
@@ -144,7 +144,7 @@ There are four placement options:
     </div>
     <div class="fd-popover__body fd-popover__body--right" aria-hidden="true" id="popoverHSF2">
         <div style="margin: 20px;">
-            <span class="fd-identifier fd-identifier--xxl fd-identifier--circle fd-identifier--thumbnail" style="background-image: url('/images/product-tile.jpg');" role="presentation" aria-label="Nature"></span>
+            <span class="fd-identifier fd-identifier--xxl fd-identifier--circle fd-identifier--thumbnail" style="background-image: url('https://placeimg.com/400/400/nature');" role="presentation" aria-label="Nature"></span>
         </div>
         <div class="fd-popover__body-footer">Popover Footer</div>
     </div>
@@ -158,7 +158,7 @@ There are four placement options:
         <div class="fd-popover__body-header fd-popover__body-header--with-subheader">Popover Header</div>
         <div class="fd-popover__body-subheader">Popover Subheader</div>
         <div style="margin: 20px;">
-            <span class="fd-identifier fd-identifier--xxl fd-identifier--circle fd-identifier--thumbnail" style="background-image: url('/images/product-tile.jpg');" role="presentation" aria-label="Nature"></span>
+            <span class="fd-identifier fd-identifier--xxl fd-identifier--circle fd-identifier--thumbnail" style="background-image: url('https://placeimg.com/400/400/nature');" role="presentation" aria-label="Nature"></span>
         </div>
         <div class="fd-popover__body-footer">Popover Footer</div>
     </div>
@@ -172,7 +172,7 @@ There are four placement options:
         <div class="fd-popover__body-header fd-popover__body-header--compact fd-popover__body-header--with-subheader">Popover Header Compact</div>
         <div class="fd-popover__body-subheader fd-popover__body-subheader--compact">Popover Subheader Compact</div>
         <div style="margin: 20px;">
-            <span class="fd-identifier fd-identifier--xxl fd-identifier--circle fd-identifier--thumbnail" style="background-image: url('/images/product-tile.jpg');" role="presentation" aria-label="Nature"></span>
+            <span class="fd-identifier fd-identifier--xxl fd-identifier--circle fd-identifier--thumbnail" style="background-image: url('https://placeimg.com/400/400/nature');" role="presentation" aria-label="Nature"></span>
         </div>
         <div class="fd-popover__body-footer fd-popover__body-footer--compact">Popover Footer Compact</div>
     </div>

--- a/docs/pages/components/shellbar.md
+++ b/docs/pages/components/shellbar.md
@@ -128,7 +128,7 @@ This example includes the product menu for navigating to applications within the
       <div class="fd-popover fd-popover--right">
         <div class="fd-popover__control">
           <div class="fd-button fd-shellbar__button fd-user-menu__control" aria-controls="ZY3AY276" aria-expanded="false" aria-haspopup="true" role="button">
-            <span class="fd-identifier fd-identifier--xs fd-identifier--circle fd-identifier--thumbnail" style="background-image: url({{site.baseurl}}/images/thumbs/headshot-male.jpg);" aria-label="William Wallingham">WW</span>
+            <span class="fd-identifier fd-identifier--xs fd-identifier--circle fd-identifier--thumbnail" style="background-image: url('https://placeimg.com/400/400/nature');" aria-label="William Wallingham">WW</span>
           </div>
         </div>
         <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right" aria-hidden="true" id="ZY3AY276">
@@ -247,7 +247,7 @@ For more information about the Product Switch, see [Product Switch](product-swit
         <div class="fd-popover fd-popover--right">
           <div class="fd-popover__control">
             <div class="fd-button fd-shellbar__button fd-user-menu__control" aria-controls="MKFAY276" aria-expanded="false" aria-haspopup="true" role="button">
-              <span class="fd-identifier fd-identifier--xs fd-identifier--circle fd-identifier--thumbnail" style="background-image: url({{site.baseurl}}/images/thumbs/headshot-male.jpg);" aria-label="William Wallingham">WW</span>
+              <span class="fd-identifier fd-identifier--xs fd-identifier--circle fd-identifier--thumbnail" style="background-image: url('https://placeimg.com/400/400/nature');" aria-label="William Wallingham">WW</span>
             </div>
           </div>
           <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right" aria-hidden="true" id="MKFAY276">

--- a/docs/pages/components/table.md
+++ b/docs/pages/components/table.md
@@ -29,7 +29,7 @@ A table is a set of tabular data. Line items can support data, images and action
     <tbody class="fd-table__body">
         <tr class="fd-table__row">
             <td class="fd-table__cell"><span class=" fd-image--s fd-image--circle" aria-label="Image label"
-            style="background-image: url('{{site.baseurl}}/images/thumbs/rodney.artichoke.png');">
+            style="background-image: url('https://placeimg.com/400/400/nature');">
             </span></td>
             <td class="fd-table__cell"><a href="#" class="fd-has-font-weight-semi">user.name@email.com</a></td>
             <td class="fd-table__cell">First Name</td>
@@ -38,7 +38,7 @@ A table is a set of tabular data. Line items can support data, images and action
         </tr>
         <tr class="fd-table__row">
             <td class="fd-table__cell"><span class=" fd-image--s fd-image--circle" aria-label="Image label"
-            style="background-image: url('{{site.baseurl}}/images/thumbs/rodney.artichoke.png');">
+            style="background-image: url('https://placeimg.com/400/400/nature');">
             </span></td>
             <td class="fd-table__cell"><a href="#" class="fd-has-font-weight-semi">user.name@email.com</a></td>
             <td class="fd-table__cell">First Name</td>
@@ -47,7 +47,7 @@ A table is a set of tabular data. Line items can support data, images and action
         </tr>
         <tr class="fd-table__row">
             <td class="fd-table__cell"><span class=" fd-image--s fd-image--circle" aria-label="Image label"
-            style="background-image: url('{{site.baseurl}}/images/thumbs/rodney.artichoke.png');">
+            style="background-image: url('https://placeimg.com/400/400/nature');">
             </span></td>
             <td class="fd-table__cell"><a href="#" class="fd-has-font-weight-semi">user.name@email.com</a></td>
             <td class="fd-table__cell">First Name</td>
@@ -79,7 +79,7 @@ A table is a set of tabular data. Line items can support data, images and action
     <tbody class="fd-table__body">
         <tr class="fd-table__row">
             <td class="fd-table__cell"><span class=" fd-image--s fd-image--circle" aria-label="Image label"
-            style="background-image: url('{{site.baseurl}}/images/thumbs/rodney.artichoke.png');">
+            style="background-image: url('https://placeimg.com/400/400/nature');">
             </span></td>
             <td class="fd-table__cell"><a href="#" class="fd-has-font-weight-semi">user.name@email.com</a></td>
             <td class="fd-table__cell">First Name</td>
@@ -88,7 +88,7 @@ A table is a set of tabular data. Line items can support data, images and action
         </tr>
         <tr class="fd-table__row">
             <td class="fd-table__cell"><span class=" fd-image--s fd-image--circle" aria-label="Image label"
-            style="background-image: url('{{site.baseurl}}/images/thumbs/rodney.artichoke.png');">
+            style="background-image: url('https://placeimg.com/400/400/nature');">
             </span></td>
             <td class="fd-table__cell"><a href="#" class="fd-has-font-weight-semi">user.name@email.com</a></td>
             <td class="fd-table__cell">First Name</td>
@@ -97,7 +97,7 @@ A table is a set of tabular data. Line items can support data, images and action
         </tr>
         <tr class="fd-table__row">
             <td class="fd-table__cell"><span class=" fd-image--s fd-image--circle" aria-label="Image label"
-            style="background-image: url('{{site.baseurl}}/images/thumbs/rodney.artichoke.png');">
+            style="background-image: url('https://placeimg.com/400/400/nature');">
             </span></td>
             <td class="fd-table__cell"><a href="#" class="fd-has-font-weight-semi">user.name@email.com</a></td>
             <td class="fd-table__cell">First Name</td>
@@ -129,7 +129,7 @@ A table is a set of tabular data. Line items can support data, images and action
     <tbody class="fd-table__body">
         <tr class="fd-table__row">
             <td class="fd-table__cell"><span class=" fd-image--s fd-image--circle" aria-label="Image label"
-            style="background-image: url('{{site.baseurl}}/images/thumbs/rodney.artichoke.png');">
+            style="background-image: url('https://placeimg.com/400/400/nature');">
             </span></td>
             <td class="fd-table__cell"><a href="#" class="fd-has-font-weight-semi">user.name@email.com</a></td>
             <td class="fd-table__cell">First Name</td>
@@ -138,7 +138,7 @@ A table is a set of tabular data. Line items can support data, images and action
         </tr>
         <tr class="fd-table__row">
             <td class="fd-table__cell"><span class=" fd-image--s fd-image--circle" aria-label="Image label"
-            style="background-image: url('{{site.baseurl}}/images/thumbs/rodney.artichoke.png');">
+            style="background-image: url('https://placeimg.com/400/400/nature');">
             </span></td>
             <td class="fd-table__cell"><a href="#" class="fd-has-font-weight-semi">user.name@email.com</a></td>
             <td class="fd-table__cell">First Name</td>
@@ -147,7 +147,7 @@ A table is a set of tabular data. Line items can support data, images and action
         </tr>
         <tr class="fd-table__row">
             <td class="fd-table__cell"><span class=" fd-image--s fd-image--circle" aria-label="Image label"
-            style="background-image: url('{{site.baseurl}}/images/thumbs/rodney.artichoke.png');">
+            style="background-image: url('https://placeimg.com/400/400/nature');">
             </span></td>
             <td class="fd-table__cell"><a href="#" class="fd-has-font-weight-semi">user.name@email.com</a></td>
             <td class="fd-table__cell">First Name</td>

--- a/docs/pages/components/tile.md
+++ b/docs/pages/components/tile.md
@@ -58,7 +58,7 @@ The component is ideal for displaying collection data when a grid or list layout
 
 <div class="fd-tile">
     <div class="fd-tile__media">
-        <span class=" fd-image--m" aria-label="TILE_MEDIA_ALT" style="background-image: url('{{site.baseurl}}/images/thumbs/rodney.artichoke.png');"></span>
+        <span class=" fd-image--m" aria-label="TILE_MEDIA_ALT" style="background-image: url('https://placeimg.com/400/400/nature');"></span>
     </div>
     <div class="fd-tile__content">
         <h3 class="fd-tile__title">Tile Title</h3>
@@ -69,7 +69,7 @@ The component is ideal for displaying collection data when a grid or list layout
 
 <div class="fd-tile">
     <div class="fd-tile__media">
-        <span class=" fd-image--m fd-image--circle" aria-label="TILE_MEDIA_ALT" style="background-image: url('{{site.baseurl}}/images/thumbs/rodney.artichoke.png');"></span>
+        <span class=" fd-image--m fd-image--circle" aria-label="TILE_MEDIA_ALT" style="background-image: url('https://placeimg.com/400/400/nature');"></span>
     </div>
     <div class="fd-tile__content">
         <h3 class="fd-tile__title">Tile Title</h3>
@@ -128,7 +128,7 @@ Add `role=button` to rendering a tile as a button
 
 {% capture tile %}
 <div class="fd-product-tile">
-    <div class="fd-product-tile__media" style="background-image: url('{{site.baseurl}}/images/product-tile.jpg');"></div>
+    <div class="fd-product-tile__media" style="background-image: url('https://placeimg.com/400/400/nature');"></div>
     <div class="fd-product-tile__content">
         <h3 class="fd-product-tile__title">Default Product Tile</h3>
         <p class="fd-product-tile__text">Tile Description</p>
@@ -136,7 +136,7 @@ Add `role=button` to rendering a tile as a button
 </div>
 
 <div class="fd-product-tile" role="button">
-    <div class="fd-product-tile__media" style="background-image: url('{{site.baseurl}}/images/product-tile.jpg');"></div>
+    <div class="fd-product-tile__media" style="background-image: url('https://placeimg.com/400/400/nature');"></div>
     <div class="fd-product-tile__content">
         <h3 class="fd-product-tile__title">Product Tile Button</h3>
     </div>
@@ -171,7 +171,7 @@ Add class `is-disabled`
 <br>
 
 <div class="fd-product-tile is-disabled" aria-disabled="true">
-    <div class="fd-product-tile__media" style="background-image: url('{{site.baseurl}}/images/product-tile.jpg');"></div>
+    <div class="fd-product-tile__media" style="background-image: url('https://placeimg.com/400/400/nature');"></div>
     <div class="fd-product-tile__content">
         <h3 class="fd-product-tile__title">Disabled Product Tile</h3>
     </div>


### PR DESCRIPTION
## Description
The images in the documentation were loaded in two different ways. We agreed to use only one approach which is using `https://placeimg.com` online library. For this reason the "static" images were replaced by `https://placeimg.com/400/400/nature` dynamic images.