### PR TITLE
fix: Specify background-image: none; for product-menu control

### DIFF
--- a/src/_product-menu.scss
+++ b/src/_product-menu.scss
@@ -26,6 +26,7 @@ $block-product-menu: #{$fd-namespace}-product-menu;
   &__control {
     @include fd-var-color("background-color", fd-color("shell", 2), --fd-color-shell-2);
 
+    background-image: none;
     position: relative;
 
     @include fd-button-reset();

--- a/src/_product-menu.scss
+++ b/src/_product-menu.scss
@@ -26,7 +26,6 @@ $block-product-menu: #{$fd-namespace}-product-menu;
   &__control {
     @include fd-var-color("background-color", fd-color("shell", 2), --fd-color-shell-2);
 
-    background-image: none;
     position: relative;
 
     @include fd-button-reset();

--- a/src/mixins/_mixins.scss
+++ b/src/mixins/_mixins.scss
@@ -182,6 +182,7 @@
 }
 
 @mixin fd-button-reset {
+  background-image: none;
   display: inline-block;
   margin: 0;
   padding: 0;


### PR DESCRIPTION
## Related Issue
N/A

## Description

A background-image from global styling can creep into the fundamental control:


## Screenshots


### Before:
<img width="166" alt="Screen Shot 2020-02-05 at 11 29 31 AM" src="https://user-images.githubusercontent.com/5314713/73870412-a817d700-4811-11ea-8d1f-0bda6431bd4c.png">


### After:
<img width="163" alt="Screen Shot 2020-02-05 at 11 29 40 AM" src="https://user-images.githubusercontent.com/5314713/73870423-ab12c780-4811-11ea-8179-6203be8bfa01.png">
