### PR TITLE
fix: Remove invalid code, correct RTL for tabs

### DIFF
--- a/src/tabs.scss
+++ b/src/tabs.scss
@@ -172,14 +172,6 @@ $block: #{$fd-namespace}-tabs;
       @include tabs-semantic(var(--sapNeutralColor));
     }
 
-    &:last-child {
-      margin-right: 0;
-
-      .#{$block}__link {
-        padding-right: 0;
-      }
-    }
-
     &:first-child {
       margin-left: 0;
 


### PR DESCRIPTION
## Description
There is removed part of invalid code on tabs.
Following documentation, last item should not have different styling than other elements. Only first tab shouldn't have spacing.
![image](https://user-images.githubusercontent.com/26483208/74045241-b1996e80-49cc-11ea-8d50-89fd92b49364.png)

It also caused some bugs on RTL mode, when latest element hadn't spacing

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/26483208/74044836-0688b500-49cc-11ea-91c7-2ce63a137709.png)


### After:
![image](https://user-images.githubusercontent.com/26483208/74044856-0f798680-49cc-11ea-8e64-45e5f22debd1.png)

