### PR TITLE
fix: refactor form-message inside popover

### DIFF
--- a/docs/pages/components/form.md
+++ b/docs/pages/components/form.md
@@ -165,9 +165,13 @@ Along with Invalid and Warning, error messages should be displayed below the fie
 
 <div class="fd-form-item">
     <label class="fd-form-label" for="input-1">Valid input:</label>
-    <div class="fd-form-input-message-group fd-popover">
-        <input class="fd-input is-valid fd-popover__control" type="text" id="input-1" placeholder="Field placeholder text" aria-label="Image label" aria-controls="popoverB2" aria-expanded="false" aria-haspopup="true">
-        <span class="fd-popover__body fd-popover__body--no-arrow fd-form-message fd-form-message--success" aria-hidden="true" id="popoverB2">Success message</span>
+    <div class="fd-form-input-message-group fd-popover fd-popover--input-message-group">
+        <div class="fd-popover__control" aria-controls="popoverB2" aria-expanded="false" aria-haspopup="true">
+            <input class="fd-input is-valid" type="text" id="input-1" placeholder="Field placeholder text" aria-label="Image label">
+        </div>
+        <div class="fd-popover__body fd-popover__body--no-arrow" aria-hidden="true" id="popoverB2">
+            <div class="fd-form-message fd-form-message--success">Success message</div>
+        </div>
     </div>
 </div>
 
@@ -175,9 +179,13 @@ Along with Invalid and Warning, error messages should be displayed below the fie
 
 <div class="fd-form-item">
     <label class="fd-form-label" for="input-1">Error input:</label>
-    <div class="fd-form-input-message-group fd-popover">
-        <input class="fd-input is-invalid fd-popover__control" type="text" id="input-1" placeholder="Field placeholder text" aria-label="Image label" aria-controls="popoverB3" aria-expanded="false" aria-haspopup="true">
-        <span class="fd-popover__body fd-popover__body--no-arrow fd-form-message fd-form-message--error" aria-hidden="true" id="popoverB3">Error message</span>
+    <div class="fd-form-input-message-group fd-popover fd-popover--input-message-group">
+        <div class="fd-popover__control" aria-controls="popoverB3" aria-expanded="false" aria-haspopup="true">
+            <input class="fd-input is-invalid" type="text" id="input-1" placeholder="Field placeholder text" aria-label="Image label">
+        </div>
+        <div class="fd-popover__body fd-popover__body--no-arrow" aria-hidden="true" id="popoverB3">
+            <div class="fd-form-message fd-form-message--error" >Error message</div>
+        </div>
     </div>
 </div>
 
@@ -185,9 +193,13 @@ Along with Invalid and Warning, error messages should be displayed below the fie
 
 <div class="fd-form-item">
     <label class="fd-form-label" for="input-1">Warning input:</label>
-    <div class="fd-form-input-message-group fd-popover">
-        <input class="fd-input is-warning fd-popover__control" type="text" id="input-1" placeholder="Field placeholder text" aria-label="Image label" aria-controls="popoverB4" aria-expanded="false" aria-haspopup="true">
-        <span class="fd-popover__body fd-popover__body--no-arrow fd-form-message fd-form-message--warning" aria-hidden="true" id="popoverB4">Warning message</span>
+    <div class="fd-form-input-message-group fd-popover fd-popover--input-message-group">
+        <div class="fd-popover__control" aria-controls="popoverB4" aria-expanded="false" aria-haspopup="true">
+            <input class="fd-input is-warning" type="text" id="input-1" placeholder="Field placeholder text" aria-label="Image label">
+        </div>
+        <div class="fd-popover__body fd-popover__body--no-arrow" aria-hidden="true" id="popoverB4">
+            <div class="fd-form-message fd-form-message--warning">Warning message</div>
+        </div>
     </div>
 </div>
 
@@ -195,9 +207,13 @@ Along with Invalid and Warning, error messages should be displayed below the fie
 
 <div class="fd-form-item">
     <label class="fd-form-label" for="input-1">Information input:</label>
-    <div class="fd-form-input-message-group fd-popover">
-        <input class="fd-input is-information fd-popover__control" type="text" id="input-1" placeholder="Field placeholder text" aria-label="Image label" aria-controls="popoverB5" aria-expanded="false" aria-haspopup="true">
-        <span class="fd-popover__body fd-popover__body--no-arrow fd-form-message fd-form-message--information" aria-hidden="true" id="popoverB5">Information message</span>
+    <div class="fd-form-input-message-group fd-popover fd-popover--input-message-group">
+        <div class="fd-popover__control" aria-controls="popoverB5" aria-expanded="false" aria-haspopup="true">
+            <input class="fd-input fd-input--compact is-information" type="text" id="input-1" placeholder="Field placeholder text" aria-label="Image label">
+        </div>
+        <div class="fd-popover__body fd-popover__body--no-arrow" aria-hidden="true" id="popoverB5">
+            <div class="fd-form-message fd-form-message--information">Information message</div>
+        </div>
     </div>
 </div>
 

--- a/src/form-message.scss
+++ b/src/form-message.scss
@@ -9,30 +9,20 @@ $block: #{$fd-namespace}-form-message;
 
 .#{$block} {
   @include fd-reset();
+  @include fd-ellipsis();
 
-  z-index: 3;
-  clear: both;
-  height: auto;
-  width: fit-content;
+  padding: 0.5rem;
   min-width: 6rem;
   max-width: 22rem;
-  padding: 0.5rem;
-  margin-top: -0.25rem;
+  width: 100%;
   font-size: var(--sapFontSmallSize);
   font-weight: normal;
   line-height: normal;
   color: var(--sapTextColor);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  border-radius: 0 !important;
   white-space: pre-line !important;
 
   @include fd-rtl() {
     right: 0;
-  }
-
-  &--compact {
-    margin-top: -0.1875rem;
   }
 
   &--error {
@@ -49,9 +39,5 @@ $block: #{$fd-namespace}-form-message;
 
   &--information {
     background-color: var(--sapInformationBackground);
-  }
-
-  & + .#{$fd-namespace}-input {
-    margin-top: 0;
   }
 }

--- a/src/popover.scss
+++ b/src/popover.scss
@@ -206,6 +206,15 @@ $block: #{$fd-namespace}-popover;
     }
   }
 
+  &--input-message-group {
+    .#{$block}__body,
+    .#{$block}__body--no-arrow {
+      box-shadow: none;
+      border: none;
+      margin-top: -0.25rem;
+    }
+  }
+
   &__popper {
     @include fd-reset();
 
@@ -224,6 +233,12 @@ $block: #{$fd-namespace}-popover;
       .#{$block}__arrow {
         display: none;
       }
+    }
+
+    &--input-message-group {
+      box-shadow: none;
+      border: none;
+      margin-top: -0.25rem !important;
     }
 
     .#{$block}__arrow {


### PR DESCRIPTION
I added a modifier class in Popover component to handle the case when we have input group with messages. 
- The `fd-popover__control` is no longer used at the same level as the `fd-input` in the documentation.
- The `fd-popover__body` is no longer used at the same level as the `fd-message` in the documentation.

Because `fd-popover` scss file was imported first in `src/fundamental-styles.scss` the problem wasn't noticeable. We shouldn't rely on the order of file import. 

Please take a look at the code and we will discuss it tomorrow