### PR TITLE
fix: remove input:last-child rules from popover control

### DIFF
--- a/src/popover.scss
+++ b/src/popover.scss
@@ -52,11 +52,10 @@ $block: #{$fd-namespace}-popover;
 
   &__control {
     @include fd-reset();
+    @include action-cursor();
 
     position: relative;
     margin-left: 0;
-
-    @include action-cursor();
   }
 
   &__body {

--- a/src/popover.scss
+++ b/src/popover.scss
@@ -56,10 +56,6 @@ $block: #{$fd-namespace}-popover;
     position: relative;
     margin-left: 0;
 
-    .#{$fd-namespace}-input:last-child {
-      margin-bottom: 0;
-    }
-
     @include action-cursor();
   }
 


### PR DESCRIPTION
This PR removes the input:last-child rule from popover control. The margin-bottom of the input should be there for a11y purpose (to achieve the 44px touchable area). 