### PR TITLE
fix: add rtl support for Notification indicator

### DIFF
--- a/src/notification.scss
+++ b/src/notification.scss
@@ -39,6 +39,10 @@ $block: #{$fd-namespace}-notification;
     margin: 1px 0 0 0;
     padding: 1rem 0.5rem 0 1rem;
 
+    @include fd-rtl() {
+      padding: 1rem 1rem 0 0.5rem;
+    }
+
     @include fd-icon("message-#{$type}", "m");
   }
 


### PR DESCRIPTION
## Related Issue
part of [660](https://github.com/SAP/fundamental-styles/issues/660)

## Description
The RTL support for Notification indicator was missing

## Screenshots
### Before:
Default:
![Screen Shot 2020-02-14 at 2 19 38 PM](https://user-images.githubusercontent.com/39598672/74560766-43592c80-4f35-11ea-9ef2-f32579550b8d.png)

RTL:
![Screen Shot 2020-02-14 at 2 19 09 PM](https://user-images.githubusercontent.com/39598672/74560779-4a803a80-4f35-11ea-8abb-d1330305cc88.png)


### After:
![Screen Shot 2020-02-14 at 2 18 04 PM](https://user-images.githubusercontent.com/39598672/74560785-4e13c180-4f35-11ea-875f-87f413b9a0b0.png)
