### PR TITLE
fix: (tab) Add fully RTL support for tabs

### DIFF
--- a/src/tabs.scss
+++ b/src/tabs.scss
@@ -182,6 +182,9 @@ $block: #{$fd-namespace}-tabs;
 
     @include fd-rtl() {
       &:first-child {
+        margin-right: 0;
+        margin-left: $fd-tabs-item-spacing-x;
+
         .#{$block}__link {
           padding-right: 0;
           padding-left: 0.875rem;
@@ -391,6 +394,10 @@ $block: #{$fd-namespace}-tabs;
       width: 5.375rem;
       padding: 0 $fd-tabs-item-spacing-x;
       margin: 0;
+
+      @include fd-rtl() {
+        margin: 0;
+      }
 
       &--header {
         width: auto;


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/668

## Description
There are changed some margins/paddings on RTL mode for tabs component. Mostly on `:first-child`

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/26483208/74737278-cf7c9400-5254-11ea-8b19-638469e7090d.png)


### After:
![image](https://user-images.githubusercontent.com/26483208/74737240-b8d63d00-5254-11ea-9e54-31da112b7269.png)
