### PR TITLE
fix: add max-width to bar elements

### DIFF
--- a/src/bar.scss
+++ b/src/bar.scss
@@ -45,6 +45,7 @@ $block: #{$fd-namespace}-bar;
     display: flex;
     align-items: center;
     flex: 1;
+    max-width: 100%;
   }
 
   &__middle {
@@ -67,6 +68,7 @@ $block: #{$fd-namespace}-bar;
     align-items: center;
     justify-content: center;
     margin-right: $fd-bar-element-spacing;
+    max-width: 100%;
 
     @include fd-rtl() {
       margin-right: 0;


### PR DESCRIPTION
## Description
This PR adds `max-width: 100%` properties to Bar component sections `__left` `__middle` `__right` and sections `__element`.

This modification is needed to detect when the growth of the Bar elements started overflowing its parent element and limit flex growth behavior.

## Screenshots
### Before:
![image](https://user-images.githubusercontent.com/17496353/74831061-c226de80-5314-11ea-8c09-a3372de53215.png)

![image](https://user-images.githubusercontent.com/17496353/74831111-dcf95300-5314-11ea-8da6-7a296d5b68c1.png)

![image](https://user-images.githubusercontent.com/17496353/74831138-ec789c00-5314-11ea-85fc-eb20fbb2d243.png)


### After:
![image](https://user-images.githubusercontent.com/17496353/74831003-a4597980-5314-11ea-8581-f28c29c0722d.png)
