### PR TITLE
fix: Remove additional spacing on Breadcrumb element on RTL

### DIFF
--- a/src/breadcrumb.scss
+++ b/src/breadcrumb.scss
@@ -30,22 +30,6 @@ $block: #{$fd-namespace}-breadcrumb;
   margin-bottom: $fd-breadcrumb-margin-bottom;
   list-style: none;
 
-  @include fd-rtl() {
-    padding: 0;
-
-    &__item {
-      &::after {
-        content: "/";
-        margin-right: $fd-breadcrumb-spacing;
-        margin-left: $fd-breadcrumb-spacing;
-      }
-
-      &:last-child::after {
-        content: none;
-      }
-    }
-  }
-
   // ELEMENTS *******************************************
   &__item {
     @include fd-reset();
@@ -62,28 +46,10 @@ $block: #{$fd-namespace}-breadcrumb;
     &:last-child::after {
       content: none;
     }
-
-    @include fd-rtl() {
-      &::after {
-        content: "/";
-        margin-right: $fd-breadcrumb-spacing;
-        margin-left: $fd-breadcrumb-spacing;
-      }
-
-      &:last-child::after {
-        content: none;
-      }
-    }
   }
 
   &__link {
     @include fd-reset();
-
-    @include fd-rtl() {
-      margin-right: $fd-breadcrumb-spacing;
-      margin-left: $fd-breadcrumb-spacing;
-    }
-
     @include fd-link();
 
     display: inline-block;


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#656

## Description
Breadcrumb element had additional margins on RTL mode.

## Screenshots
### Before:
![image](https://user-images.githubusercontent.com/17496353/74833623-2009f500-531a-11ea-8d56-e916d29fd8e1.png)

### After:
![image](https://user-images.githubusercontent.com/17496353/74833577-0b2d6180-531a-11ea-8991-6a1332beeb4b.png)
