### PR TITLE
fix: borders for list

### DIFF
--- a/docs/pages/components/breadcrumb.md
+++ b/docs/pages/components/breadcrumb.md
@@ -42,7 +42,7 @@ there should be popover with missing options.
                 </a>
             </div>
             <div class="fd-popover__body fd-popover__body--no-arrow" aria-hidden="true" id="breadcrumb1">
-                <ul class="fd-list fd-list--compact">
+                <ul class="fd-list fd-list--in-popover fd-list--compact">
                     <li class="fd-list__item">
                       <a class="fd-list__title" href="#">Link Text</a>
                     </li>

--- a/src/breadcrumb.scss
+++ b/src/breadcrumb.scss
@@ -8,7 +8,6 @@
     .fd-breadcrump__link
 */
 
-$fd-breadcrumb-margin-bottom: 0.5rem;
 $fd-breadcrumb-spacing: 0.25rem;
 
 $fd-breadcrumb-separator-color: var(--sapContent_LabelColor);
@@ -24,7 +23,6 @@ $block: #{$fd-namespace}-breadcrumb;
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  margin-bottom: $fd-breadcrumb-margin-bottom;
   list-style: none;
 
   // ELEMENTS *******************************************

--- a/src/list.scss
+++ b/src/list.scss
@@ -86,6 +86,19 @@ $block: #{$fd-namespace}-list;
     }
   }
 
+  &--in-popover {
+    :first-child {
+      border-top-left-radius: var(--sapElement_BorderCornerRadius);
+      border-top-right-radius: var(--sapElement_BorderCornerRadius);
+    }
+
+    :last-child {
+      border-bottom: none;
+      border-bottom-left-radius: var(--sapElement_BorderCornerRadius);
+      border-bottom-right-radius: var(--sapElement_BorderCornerRadius);
+    }
+  }
+
   &__title,
   &__secondary {
     @include fd-reset();


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#681
 Closes SAP/fundamental-styles#678
## Description
Change the border radius of the list items that need to be modified to go along with the popover radius
Removes border-bottom styling from breadcrumb
## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![Screen Shot 2020-02-20 at 10 17 35 AM](https://user-images.githubusercontent.com/50607147/74958164-86ece400-53d6-11ea-9e61-18915ac46411.png)


### After:
![Screen Shot 2020-02-20 at 11 45 32 AM](https://user-images.githubusercontent.com/50607147/74958172-8a806b00-53d6-11ea-9187-471f09c605b6.png)
