### PR TITLE
fix: add overflow rules for bar-element

### DIFF
--- a/src/bar.scss
+++ b/src/bar.scss
@@ -69,6 +69,8 @@ $block: #{$fd-namespace}-bar;
     justify-content: center;
     margin-right: $fd-bar-element-spacing;
     max-width: 100%;
+    max-height: 100%;
+    overflow: hidden;
 
     @include fd-rtl() {
       margin-right: 0;
@@ -78,6 +80,10 @@ $block: #{$fd-namespace}-bar;
 
   &__element--full-width {
     width: 100%;
+
+    & > *:first-child {
+      flex-grow: 1;
+    }
   }
 
   &__element:last-child {


### PR DESCRIPTION

## Description
I added overflow rules to handle the case when a Bar element contains text only. These rules apply in X and Y direction. 

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![Screen Shot 2020-02-20 at 3 00 38 PM](https://user-images.githubusercontent.com/39598672/74973725-f2907a80-53f1-11ea-901e-92b89c8b16be.png)


### After:
![Screen Shot 2020-02-20 at 3 01 35 PM](https://user-images.githubusercontent.com/39598672/74973735-f7552e80-53f1-11ea-85fc-3c894c691d26.png)

