### PR TITLE
fix: (input/input-group) zooming in/out and IE11 issues

### DIFF
--- a/src/input-group.scss
+++ b/src/input-group.scss
@@ -27,6 +27,7 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
   border-radius: var(--sapField_BorderCornerRadius);
   background-color: var(--sapField_Background);
   width: 100%;
+  overflow: hidden;
 
   // states
   @include fd-form-states();

--- a/src/input.scss
+++ b/src/input.scss
@@ -18,6 +18,7 @@ $block: #{$fd-namespace}-input;
   padding: 0 0.625rem;
   z-index: 1;
   cursor: text;
+  overflow: hidden;
 
   &[aria-expanded="false"] {
     z-index: 0;


### PR DESCRIPTION
## Related Issue
closes: https://github.com/SAP/fundamental-styles/issues/673
closes: https://github.com/SAP/fundamental-styles/issues/666

## Description
There was some troubles, on zoom in/out. Mostly because of rem units usage, for example
0.0625rem. Multiplying it by 90% for example, was changing size of particular elements.
IE11 also has that issues, but without even zooming.

Adding overflow: hidden, to containers elements, fixed it.

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
90%:
![image](https://user-images.githubusercontent.com/26483208/75028039-d9460780-549f-11ea-959f-40ed3128118c.png)
![image](https://user-images.githubusercontent.com/26483208/75028056-e4009c80-549f-11ea-94b2-e835c1138463.png)
![image](https://user-images.githubusercontent.com/26483208/75028070-e9f67d80-549f-11ea-96f0-11e30add1043.png)


### After:

90%:
![image](https://user-images.githubusercontent.com/26483208/75028017-cd5a4580-549f-11ea-8195-af1816f690e4.png)
![image](https://user-images.githubusercontent.com/26483208/75028114-faa6f380-549f-11ea-9773-f55249568be7.png)
![image](https://user-images.githubusercontent.com/26483208/75028126-fed31100-549f-11ea-8649-a2291ac1ea17.png)
