### PR TITLE
fix: Minimal input width on IE11 

### DIFF
--- a/src/input-group.scss
+++ b/src/input-group.scss
@@ -13,6 +13,7 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
 
 .#{$block} {
 
+  $fd-input-width-basis: 10rem;
   $fd-input-group-add-on-border: 0.0625rem;
   $fd-input-group-button-active-text-color: var(--sapButton_Active_TextColor);
   $fd-input-group-button-active-background: var(--sapButton_Active_Background);
@@ -69,7 +70,7 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
 
     background-color: transparent;
     border: none;
-    flex: 1;
+    flex: 1 1 $fd-input-width-basis;
     padding-right: 0.25rem;
     padding-left: 0.25rem;
 
@@ -101,11 +102,6 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
         padding-left: 0.625rem;
         padding-right: 0.25rem;
       }
-    }
-
-    /** Behaviour only for IE10+ */
-    @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-      flex-basis: 160px;
     }
   }
 

--- a/src/input-group.scss
+++ b/src/input-group.scss
@@ -105,7 +105,7 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
 
     /** Behaviour only for IE10+ */
     @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-      min-width: 160px;
+      flex-basis: 160px;
     }
   }
 


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#690

## Description
On IE11 when container uses `display: flex` `min-width` property is ignored. Basic width can be set using `flex-basis` property.

Before:
![image](https://user-images.githubusercontent.com/17496353/75038705-35685600-54b7-11ea-8a2c-4bb5c103e3e0.png)

After:
![image](https://user-images.githubusercontent.com/17496353/75038582-ef12f700-54b6-11ea-85ee-901cff732bd8.png)