### PR TITLE
feat: normalize validation states

### DIFF
--- a/docs/pages/components/form.md
+++ b/docs/pages/components/form.md
@@ -56,14 +56,14 @@ Do not use the input field if:
     <br />
     <br />
     <div class="fd-form-item">
-        <label class="fd-form-label" for="input-01">Invalid (Error) Input:</label>
-        <input class="fd-input is-invalid" type="text" id="input-01" placeholder="Field placeholder text">
+        <label class="fd-form-label" for="input-01">Error Input:</label>
+        <input class="fd-input is-error" type="text" id="input-01" placeholder="Field placeholder text">
     </div>
     <br />
     <br />
     <div class="fd-form-item">
-        <label class="fd-form-label" for="input-02">Valid (Success) Input:</label>
-        <input class="fd-input is-valid" type="text" id="input-02" placeholder="Field placeholder text">
+        <label class="fd-form-label" for="input-02">Success Input:</label>
+        <input class="fd-input is-success" type="text" id="input-02" placeholder="Field placeholder text">
     </div>
     <br />
     <br />
@@ -125,14 +125,14 @@ Do not use the input field if:
 
 ## Input States
 The state of the input field can reflect validity of the data entered, whether the input data is editable or disabled.
-* **Normal**: The field is editable but no validation has occurred
-* **Valid**: The data format entered has been validated and it's correct, such as an email address.
-* **Invalid**: The data entered is not valid and must be corrected.
+* **Default**: The field is editable but no validation has occurred
+* **Success**: The data format entered has been validated and it's correct, such as an email address.
+* **Error**: The data entered is not valid and must be corrected.
 * **Warning**: The data entered is formatted correctly but there are other issues are problematic but will not stop the user from moving forward.
 * **Disabled**: This indicates the field is not editable. A common use case is that this field is dependent on a previous entry or selection within the form.
 * **Read Only**: Used to display static information in the context of a form.
 
-Along with Invalid and Warning, error messages should be displayed below the field so the user can correct the error and move forward.
+Along with Error and Warning, error messages should be displayed below the field so the user can correct the error and move forward.
 
 {% capture inputs %}
 <div class="fd-form-item">
@@ -143,10 +143,10 @@ Along with Invalid and Warning, error messages should be displayed below the fie
 <br /><br />
 
 <div class="fd-form-item">
-    <label class="fd-form-label" for="input-1bb">Valid input:</label>
+    <label class="fd-form-label" for="input-1bb">Success input:</label>
     <div class="fd-form-input-message-group fd-popover fd-popover--input-message-group">
         <div class="fd-popover__control" aria-controls="popoverB2" aria-expanded="false" aria-haspopup="true">
-            <input class="fd-input is-valid" type="text" id="input-1bb" placeholder="Field placeholder text" aria-label="Image label">
+            <input class="fd-input is-success" type="text" id="input-1bb" placeholder="Field placeholder text" aria-label="Image label">
         </div>
         <div class="fd-popover__body fd-popover__body--no-arrow" aria-hidden="true" id="popoverB2">
             <div class="fd-form-message fd-form-message--success">Success message</div>
@@ -160,7 +160,7 @@ Along with Invalid and Warning, error messages should be displayed below the fie
     <label class="fd-form-label" for="input-1cc">Error input:</label>
     <div class="fd-form-input-message-group fd-popover fd-popover--input-message-group">
         <div class="fd-popover__control" aria-controls="popoverB3" aria-expanded="false" aria-haspopup="true">
-            <input class="fd-input is-invalid" type="text" id="input-1cc" placeholder="Field placeholder text" aria-label="Image label">
+            <input class="fd-input is-error" type="text" id="input-1cc" placeholder="Field placeholder text" aria-label="Image label">
         </div>
         <div class="fd-popover__body fd-popover__body--no-arrow" aria-hidden="true" id="popoverB3">
             <div class="fd-form-message fd-form-message--error" >Error message</div>
@@ -235,26 +235,26 @@ Do not use the text area if
     </div>
     <br/>
     <div class="fd-form-item">
-        <label class="fd-form-label" for="textarea-3">Success (valid) text area:</label>
+        <label class="fd-form-label" for="textarea-3">Success text area:</label>
         <div class="fd-form-input-message-group fd-popover fd-popover--input-message-group">
             <div class="fd-popover__control" aria-controls="popoverT51" aria-expanded="false" aria-haspopup="true">
-                <textarea class="fd-textarea is-valid" id="textarea-3" placeholder="Write something here"></textarea>
+                <textarea class="fd-textarea is-success" id="textarea-3" placeholder="Write something here"></textarea>
             </div>
             <div class="fd-popover__body fd-popover__body--no-arrow"  aria-hidden="true" id="popoverT51">
-                <div class="fd-form-message fd-form-message--success">Valid message</div>
+                <div class="fd-form-message fd-form-message--success">Success message</div>
             </div>
         </div>
         <div class="fd-textarea-counter">150 characters left</div>
     </div>
     <br/>
     <div class="fd-form-item">
-        <label class="fd-form-label" for="textarea-4">Error(invalid) text area:</label>
+        <label class="fd-form-label" for="textarea-4">Error text area:</label>
         <div class="fd-form-input-message-group fd-popover fd-popover--input-message-group">
             <div class="fd-popover__control" aria-controls="popoverT52" aria-expanded="false" aria-haspopup="true">
-                <textarea class="fd-textarea is-invalid" id="textarea-4" placeholder="Write something here"></textarea>
+                <textarea class="fd-textarea is-error" id="textarea-4" placeholder="Write something here"></textarea>
             </div>
             <div class="fd-popover__body fd-popover__body--no-arrow"  aria-hidden="true" id="popoverT52">
-                <div class="fd-form-message fd-form-message--error">Invalid message</div>
+                <div class="fd-form-message fd-form-message--error">Error message</div>
             </div>
         </div>
     </div>
@@ -451,13 +451,13 @@ In special cases, there are only two mutually exclusive options. Combine them in
             </label>
         </div>
         <div class="fd-form-item">
-            <input type="radio" class="fd-radio is-valid" id="iSpDidh7612" name="radio5">
+            <input type="radio" class="fd-radio is-success" id="iSpDidh7612" name="radio5">
             <label class="fd-radio__label" for="iSpDidh7612">
                 Field label
             </label>
         </div>
         <div class="fd-form-item">
-            <input type="radio" class="fd-radio is-invalid" id="iSpDidh7613" name="radio5">
+            <input type="radio" class="fd-radio is-error" id="iSpDidh7613" name="radio5">
             <label class="fd-radio__label" for="iSpDidh7613">
                 Field label
             </label>
@@ -487,13 +487,13 @@ In special cases, there are only two mutually exclusive options. Combine them in
             </label>
         </div>
         <div class="fd-form-item">
-            <input type="radio" class="fd-radio fd-radio--compact is-valid" id="iSpDidh76129" name="radio6">
+            <input type="radio" class="fd-radio fd-radio--compact is-success" id="iSpDidh76129" name="radio6">
             <label class="fd-radio__label" for="iSpDidh76129">
                 Field label
             </label>
         </div>
         <div class="fd-form-item">
-            <input type="radio" class="fd-radio fd-radio--compact is-invalid" id="iSpDidh76139" name="radio6">
+            <input type="radio" class="fd-radio fd-radio--compact is-error" id="iSpDidh76139" name="radio6">
             <label class="fd-radio__label" for="iSpDidh76139">
                 Field label
             </label>
@@ -521,13 +521,13 @@ In special cases, there are only two mutually exclusive options. Combine them in
             <label class="fd-radio__label" for="iSpDidh7619d">Field label</label>
         </div>
         <div class="fd-form-item">
-            <input type="radio" class="fd-radio fd-radio--compact is-valid" id="iSpDidh76129d" name="radio7" disabled>
+            <input type="radio" class="fd-radio fd-radio--compact is-success" id="iSpDidh76129d" name="radio7" disabled>
             <label class="fd-radio__label" for="iSpDidh76129d">
                 Field label
             </label>
         </div>
         <div class="fd-form-item">
-            <input type="radio" class="fd-radio fd-radio--compact is-invalid" id="iSpDidh76139d" name="radio7" disabled>
+            <input type="radio" class="fd-radio fd-radio--compact is-error" id="iSpDidh76139d" name="radio7" disabled>
             <label class="fd-radio__label" for="iSpDidh76139d">
                 Field label
             </label>
@@ -556,13 +556,13 @@ In special cases, there are only two mutually exclusive options. Combine them in
             </label>
         </div>
         <div class="fd-form-item">
-            <input type="radio" class="fd-radio is-valid" id="radioRtl2" name="radiortl">
+            <input type="radio" class="fd-radio is-success" id="radioRtl2" name="radiortl">
             <label class="fd-radio__label" for="radioRtl2">
                 Field label
             </label>
         </div>
         <div class="fd-form-item">
-            <input type="radio" class="fd-radio is-invalid" id="radioRtl3" name="radiortl">
+            <input type="radio" class="fd-radio is-error" id="radioRtl3" name="radiortl">
             <label class="fd-radio__label" for="radioRtl3">
                 Field label
             </label>
@@ -704,19 +704,19 @@ Do not use the checkbox control if:
     <legend class="fd-fieldset__legend">Checkboxes Error</legend>
     <div class="fd-form-group">
         <div class="fd-form-item">
-            <input type="checkbox" class="fd-checkbox is-invalid" id="Ai4ez6119">
+            <input type="checkbox" class="fd-checkbox is-error" id="Ai4ez6119">
             <label class="fd-checkbox__label" for="Ai4ez6119">
                 Text Option
             </label>
         </div>
         <div class="fd-form-item">
-            <input type="checkbox" class="fd-checkbox is-invalid" id="Ai4ez6129" checked>
+            <input type="checkbox" class="fd-checkbox is-error" id="Ai4ez6129" checked>
             <label class="fd-checkbox__label" for="Ai4ez6129">
                 Selected State
             </label>
         </div>
         <div class="fd-form-item">
-            <input type="checkbox" class="fd-checkbox is-invalid" id="Ai4ez613i1">
+            <input type="checkbox" class="fd-checkbox is-error" id="Ai4ez613i1">
             <label class="fd-checkbox__label" for="Ai4ez613i1">
                 TriState Text
             </label>
@@ -728,19 +728,19 @@ Do not use the checkbox control if:
     <legend class="fd-fieldset__legend">Checkboxes Success</legend>
     <div class="fd-form-group">
         <div class="fd-form-item">
-            <input type="checkbox" class="fd-checkbox is-valid" id="Ai4ez61192">
+            <input type="checkbox" class="fd-checkbox is-success" id="Ai4ez61192">
             <label class="fd-checkbox__label" for="Ai4ez61192">
                 Text Option
             </label>
         </div>
         <div class="fd-form-item">
-            <input type="checkbox" class="fd-checkbox is-valid" id="Ai4ez61292" checked>
+            <input type="checkbox" class="fd-checkbox is-success" id="Ai4ez61292" checked>
             <label class="fd-checkbox__label" for="Ai4ez61292">
                 Selected State
             </label>
         </div>
         <div class="fd-form-item">
-            <input type="checkbox" class="fd-checkbox is-valid" id="Ai4ez613i2">
+            <input type="checkbox" class="fd-checkbox is-success" id="Ai4ez613i2">
             <label class="fd-checkbox__label" for="Ai4ez613i2">
                 TriState Text
             </label>

--- a/docs/pages/components/input-group.md
+++ b/docs/pages/components/input-group.md
@@ -174,16 +174,16 @@ The Input with add-on supports actions. Actions can be shown with a text label o
 
 {% capture states %}
 <div class="fd-form-item">
-    <label class="fd-form-label" for="">Valid (Success)</label>
-    <div class="fd-input-group is-valid">
+    <label class="fd-form-label" for="">Success</label>
+    <div class="fd-input-group is-success">
         <span class="fd-input-group__addon">$</span>
         <input class="fd-input fd-input-group__input" type="text" id="" name="" value="1234568910">
     </div>
 </div>
 <br />
 <div class="fd-form-item">
-    <label class="fd-form-label" for="">Invalid (Error)</label>
-    <div class="fd-input-group is-invalid">
+    <label class="fd-form-label" for="">Error</label>
+    <div class="fd-input-group is-error">
         <input class="fd-input fd-input-group__input" type="text" id="" name="" value="1000000">
         <span class="fd-input-group__addon">
             <span class="sap-icon--hide" role="presentation"></span>
@@ -220,16 +220,16 @@ The Input with add-on supports actions. Actions can be shown with a text label o
 </div>
 <br />
 <div class="fd-form-item">
-    <label class="fd-form-label" for="">Disabled Valid (Success)</label>
-    <div class="fd-input-group is-valid is-disabled">
+    <label class="fd-form-label" for="">Disabled Success</label>
+    <div class="fd-input-group is-success is-disabled">
         <span class="fd-input-group__addon">$</span>
         <input class="fd-input fd-input-group__input" disabled type="text" id="" name="" value="1234568910">
     </div>
 </div>
 <br />
 <div class="fd-form-item">
-    <label class="fd-form-label" for="">Disabled Invalid (Error)</label>
-    <div class="fd-input-group is-invalid is-disabled">
+    <label class="fd-form-label" for="">Disabled Error</label>
+    <div class="fd-input-group is-error is-disabled">
         <input class="fd-input fd-input-group__input" disabled type="text" id="" name="" value="1000000">
         <span class="fd-input-group__addon">
             <span class="sap-icon--hide" role="presentation"></span>
@@ -274,7 +274,7 @@ The Input Group supports **focus** state, it can be added by putting `.is-focus`
 <br />
 <div class="fd-form-item">
     <label class="fd-form-label" for="">Error State</label>
-    <div class="fd-input-group is-invalid is-focus">
+    <div class="fd-input-group is-error is-focus">
         <input class="fd-input fd-input-group__input" type="text" id="" name="" value="1000000">
         <span class="fd-input-group__addon">
             <span class="sap-icon--hide" role="presentation"></span>

--- a/docs/pages/components/select.md
+++ b/docs/pages/components/select.md
@@ -430,15 +430,15 @@ This can also be done by adding the `.is-readonly` class or the `aria-readonly="
 
 ## Semantic States
 The semantic mode can be used to modify the  select component by adding one of the 
-`is-invalid` | `is-valid` | `is-warning` | `is-information` classes into the `fd-select__control` element.
+`is-error` | `is-success` | `is-warning` | `is-information` classes into the `fd-select__control` element.
 To add text in the body of the component, simply include your text in the `fd-list__message` under the `ul` element. 
 
 {% capture semantic-select %}
 <div class="fd-popover">
     <div class="fd-popover__control">
         <div class="fd-select">
-            <div class="fd-select__control is-valid" tabindex="0" aria-controls="h07jjhYH"  aria-expanded="false" aria-haspopup="true">
-                Valid
+            <div class="fd-select__control is-success" tabindex="0" aria-controls="h07jjhYH"  aria-expanded="false" aria-haspopup="true">
+                Success
                 <button class="fd-button sap-icon--slim-arrow-down fd-select__button"></button>
             </div>
         </div>
@@ -476,7 +476,7 @@ To add text in the body of the component, simply include your text in the `fd-li
 <div class="fd-popover">
    <div class="fd-popover__control">
        <div class="fd-select">
-           <div class="fd-select__control is-invalid" tabindex="0" aria-controls="h07j9978H"  aria-expanded="false" aria-haspopup="true">
+           <div class="fd-select__control is-error" tabindex="0" aria-controls="h07j9978H"  aria-expanded="false" aria-haspopup="true">
                Error
                <button class="fd-button sap-icon--slim-arrow-down fd-select__button"></button>
            </div>

--- a/docs/pages/components/table.md
+++ b/docs/pages/components/table.md
@@ -219,7 +219,7 @@ It is recommended to add the parameter `aria-selected="true"` to the row that is
 
 
 ## Table with semantic row highlighting 
-Table rows support semantic row highlighting with the modifiers `fd-table__row--valid`, `fd-table__row--warning`, `fd-table__row--error` and `fd-table__row--information` 
+Table rows support semantic row highlighting with the modifiers `fd-table__row--success`, `fd-table__row--warning`, `fd-table__row--error` and `fd-table__row--information` 
 
 {% capture table-checkbox %}
 <table class="fd-table">
@@ -246,7 +246,7 @@ Table rows support semantic row highlighting with the modifiers `fd-table__row--
             <td class="fd-table__cell">Last Name</td>
             <td class="fd-table__cell">01/26/17</td>
         </tr>
-        <tr class="fd-table__row fd-table__row--valid">
+        <tr class="fd-table__row fd-table__row--success">
             <th class="fd-table__cell" scope="col">
                 <input type="checkbox" class="fd-checkbox" id="Ai4ez617">
                 <label class="fd-checkbox__label" for="Ai4ez617"></label>

--- a/docs/pages/components/time.md
+++ b/docs/pages/components/time.md
@@ -128,7 +128,7 @@ Multiple instances can be used in the `time-picker` to choose hours, minutes, se
 
 ## With Button State
 Since the controls and inputs are standard components, they can take all states available to
-buttons and forms respectively, e.g., disabled, .is-invalid. In this case, the buttons are
+buttons and forms respectively, e.g., disabled, .is-error. In this case, the buttons are
 disabled when the first or last values are reached.
 
 {% capture default-timewplaceholder %}

--- a/docs/pages/patterns/combobox-input.md
+++ b/docs/pages/patterns/combobox-input.md
@@ -255,14 +255,14 @@ This can also be done by using the `.is-readonly` class or `aria-readonly="true"
 For a complete list of states supported by the `combobox` component, please see the documentation for the form or select components.
 <br/><br/> 
 The semantic mode can be used to modify the combobox component by adding one of 
-`is-invalid` | `is-valid` | `is-warning` | `is-information` classes into fd-input-group element. 
+`is-error` | `is-success` | `is-warning` | `is-information` classes into fd-input-group element. 
 To add text in the `body` of the component, simply include your text in the `fd-list__message` under the `ul` element.
 
 
 {% capture semantic %}
 <div class="fd-popover">
   <div class="fd-popover__control" aria-controls="F4GcEX34" aria-expanded="false" aria-haspopup="true">
-            <div class="fd-input-group fd-input-group--control is-valid">
+            <div class="fd-input-group fd-input-group--control is-success">
                 <input type="text" class="fd-input fd-input--compact fd-input-group__input" id="" placeholder="Select Fruit">
                 <span class="fd-input-group__addon fd-input-group__addon--compact fd-input-group__addon--button">
                     <button class="fd-input-group__button fd-button--compact fd-button--light sap-icon--navigation-down-arrow fd-select__button" 

--- a/docs/pages/patterns/multi-input.md
+++ b/docs/pages/patterns/multi-input.md
@@ -533,13 +533,13 @@ The disabled state can also be achieved by adding the `.is-disabled` class or th
 For a complete list of states supported by the `Multi Input` component, please see the documentation for the form or select components.
 <br/><br/> 
 The semantic mode can be used to modify the combobox component by adding one of 
-`is-invalid` | `is-valid` | `is-warning` | `is-information` classes into fd-input-group element. 
+`is-error` | `is-success` | `is-warning` | `is-information` classes into fd-input-group element. 
 To add text in the `body` of the component, simply include your text in the `fd-list__message` under the `ul` element.
 
 {% capture semantic-input %}
 <div class="fd-popover">
     <div class="fd-popover__control fd-input-group__control" aria-controls="F4GcKJH8a" aria-expanded="false" aria-haspopup="true">
-        <div class="fd-input-group fd-input-group--control is-valid">
+        <div class="fd-input-group fd-input-group--control is-success">
             <div class="fd-tokenizer">
                  <div class="fd-tokenizer__inner">
                      <span class="fd-token" role="button">

--- a/src/checkbox.scss
+++ b/src/checkbox.scss
@@ -92,11 +92,11 @@ $block: #{$fd-namespace}-checkbox;
     @include fd-checkbox-state(var(--sapField_WarningBackground), var(--sapField_TextColor), var(--sapField_WarningColor), 0.125rem);
   }
 
-  &.is-invalid {
+  &.is-error {
     @include fd-checkbox-state(var(--sapField_InvalidBackground), var(--sapField_InvalidColor), var(--sapField_InvalidColor), 0.125rem);
   }
 
-  &.is-valid {
+  &.is-success {
     @include fd-checkbox-state(var(--sapField_SuccessBackground), var(--sapField_SuccessColor), var(--sapField_SuccessColor), var(--sapField_BorderWidth));
   }
 

--- a/src/mixins/_forms.scss
+++ b/src/mixins/_forms.scss
@@ -13,7 +13,7 @@
     border-color: var(--sapField_Hover_BorderColor);
   }
 
-  &.is-valid {
+  &.is-success {
     background-color: var(--sapField_SuccessBackground);
     border-color: var(--sapField_SuccessColor);
     border-width: $fd-form-border-thin-width;
@@ -24,7 +24,7 @@
     }
   }
 
-  &.is-invalid {
+  &.is-error {
     background-color: var(--sapField_InvalidBackground);
     border-color: var(--sapField_InvalidColor);
 
@@ -66,7 +66,7 @@
   &.is-warning,
   &.is-alert,
   &.is-information,
-  &.is-invalid {
+  &.is-error {
     border-width: $fd-form-border-thick-width;
 
     @include fd-focus() {

--- a/src/radio.scss
+++ b/src/radio.scss
@@ -82,11 +82,11 @@ $block: #{$fd-namespace}-radio;
     @include fd-radio-state(var(--sapField_WarningBackground), var(--sapField_TextColor), var(--sapField_WarningColor), 0.125rem);
   }
 
-  &.is-invalid {
+  &.is-error {
     @include fd-radio-state(var(--sapField_InvalidBackground), var(--sapField_InvalidColor), var(--sapField_InvalidColor), 0.125rem);
   }
 
-  &.is-valid {
+  &.is-success {
     @include fd-radio-state(var(--sapField_SuccessBackground), var(--sapField_SuccessColor), var(--sapField_SuccessColor), var(--sapField_BorderWidth));
   }
 

--- a/src/table.scss
+++ b/src/table.scss
@@ -70,7 +70,7 @@ $block: #{$fd-namespace}-table;
       }
     }
 
-    &--valid,
+    &--success,
     &--warning,
     &--error,
     &--information {
@@ -103,7 +103,7 @@ $block: #{$fd-namespace}-table;
       }
     }
 
-    &--valid {
+    &--success {
       @include fd-var-color("background-color", fd-color('background', 3), --fd-color-background-3);
 
       .#{$block}__cell:first-child {

--- a/test/templates/checkbox/index.njk
+++ b/test/templates/checkbox/index.njk
@@ -42,16 +42,16 @@
 <h2>Interaction States</h2>
 
 {% set example %}
-  {{ checkbox(state='valid') }}
-  {{ checkbox(state='invalid') }}
+  {{ checkbox(state='success') }}
+  {{ checkbox(state='error') }}
   {{ checkbox(state='warning') }}
   {{ checkbox(state='information') }}
-  {{ checkbox(state='valid', properties='checked') }}
-  {{ checkbox(state='invalid', properties='checked') }}
+  {{ checkbox(state='success', properties='checked') }}
+  {{ checkbox(state='error', properties='checked') }}
   {{ checkbox(state='warning', properties='checked') }}
   {{ checkbox(state='information', properties='checked') }}
-  {{ checkbox(state='valid', properties='indeterminate') }}
-  {{ checkbox(state='invalid', properties='indeterminate') }}
+  {{ checkbox(state='success', properties='indeterminate') }}
+  {{ checkbox(state='error', properties='indeterminate') }}
   {{ checkbox(state='warning', properties='indeterminate') }}
   {{ checkbox(state='information', properties='indeterminate') }}
 {% endset %}

--- a/test/templates/input-group/index.njk
+++ b/test/templates/input-group/index.njk
@@ -7,7 +7,7 @@
 {% set types = ["text", "textarea"] %}
 {% set addons = [["", "km/h"], ["$", ""], ["$", ".00"]] %}
 {% set readonly = [false, true] %}
-{% set states = ["valid", "invalid", "warning", "information"] %}
+{% set states = ["success", "error", "warning", "information"] %}
 {% set compact = [true] %}
 
 <h2>Input Groups w/ addon text</h2>

--- a/test/templates/input/index.njk
+++ b/test/templates/input/index.njk
@@ -32,9 +32,9 @@
 <h2>States</h2>
 
 {% set example %}
-  {{ input(class="is-valid") }}
+  {{ input(class="is-success") }}
   
-  {{ input(class="is-invalid") }}
+  {{ input(class="is-error") }}
   
   {{ input(class="is-warning") }}
 

--- a/test/templates/radio/index.njk
+++ b/test/templates/radio/index.njk
@@ -41,12 +41,12 @@
 <h2>Interaction States</h2>
 
 {% set example %}
-  {{ radio(state='valid') }}
-  {{ radio(state='invalid') }}
+  {{ radio(state='success') }}
+  {{ radio(state='error') }}
   {{ radio(state='warning') }}
   {{ radio(state='information') }}
-  {{ radio(state='valid', properties='checked') }}
-  {{ radio(state='invalid', properties='checked') }}
+  {{ radio(state='success', properties='checked') }}
+  {{ radio(state='error', properties='checked') }}
   {{ radio(state='warning', properties='checked') }}
   {{ radio(state='information', properties='checked') }}
 {% endset %}

--- a/test/templates/table/index.njk
+++ b/test/templates/table/index.njk
@@ -395,7 +395,7 @@
 {% set example %}
 {{  table(properties={
         rows: [row, row, row],
-        rowClass : {"rowIndex": 2, "class": "fd-table__row--valid"},
+        rowClass : {"rowIndex": 2, "class": "fd-table__row--success"},
         headers: [
             {
                 label: "Header Column"

--- a/test/templates/textarea/index.njk
+++ b/test/templates/textarea/index.njk
@@ -34,9 +34,9 @@
 <h2>Interaction States</h2>
 
 {% set example %}
-  {{ textarea(state='valid') }}
+  {{ textarea(state='success') }}
   <br><br>
-  {{ textarea(state='invalid') }}
+  {{ textarea(state='error') }}
   <br><br>
   {{ textarea(state='warning') }}
   <br><br>


### PR DESCRIPTION
## Description

Validation states need to be normalized. This is one option.. the other is to switch `success` to `valid` and `error` to `invalid`. Either way is fine with me, but we should be consistent. 

Breaking:

* `is-invalid` renamed to `is-error`
* `is-vaild` renamed to `is-success`
* `fd-table__row--valid` renamed to `fd-table__row--success`

## Screenshots

No style changes
