### PR TITLE
fix: add root import to select

### DIFF
--- a/src/select.scss
+++ b/src/select.scss
@@ -1,6 +1,7 @@
 @import "./settings";
 @import "./mixins";
 @import "./functions";
+@import './root';
 
 $block: #{$fd-namespace}-select;
 


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#

## Description
`--fd-forms-height-compact` was not having the postcss fallback added due to missing the `root` import.

<img width="1468" alt="Screen Shot 2020-02-28 at 1 58 49 PM" src="https://user-images.githubusercontent.com/29607818/75590661-a917df00-5a32-11ea-8d2d-815da084d433.png">


## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:


### After:
