### PR TITLE
fix: message strip dismiss button styling

### DIFF
--- a/src/alert.scss
+++ b/src/alert.scss
@@ -78,10 +78,8 @@ $block: #{$fd-namespace}-alert;
 
   // Elements
   &__close {
-    @include fd-button-reset();
     @include fd-alert-close-btn-container();
     @include fd-icon("decline", "m");
-    @include fd-focus();
 
     @include fd-rtl() {
       left: 0.125rem;

--- a/src/message-strip.scss
+++ b/src/message-strip.scss
@@ -78,10 +78,8 @@ $block: #{$fd-namespace}-message-strip;
 
   // Elements
   &__close {
-    @include fd-button-reset();
     @include fd-message-strip-close-btn-container();
     @include fd-icon("decline", "m");
-    @include fd-focus();
 
     @include fd-rtl() {
       left: 0.125rem;


### PR DESCRIPTION
fix: message strip dismiss button styling
https://github.com/SAP/fundamental-styles/issues/709

Before:
<img width="1266" alt="Screen Shot 2020-02-28 at 3 22 39 PM" src="https://user-images.githubusercontent.com/4380815/75591756-91e6ea80-5a4e-11ea-9061-3f83801f7e32.png">
After:
<img width="135" alt="Screen Shot 2020-02-28 at 5 20 30 PM" src="https://user-images.githubusercontent.com/4380815/75591781-a3c88d80-5a4e-11ea-8d70-45d4200f6309.png">
