### PR TITLE
feat: ActionBar: rework description class names

### DIFF
--- a/docs/_sass/_docs-display-component.scss
+++ b/docs/_sass/_docs-display-component.scss
@@ -164,10 +164,6 @@
         .fd-breadcrumb {
             margin-left: 0;
         }
-
-        .fd-action-bar__description {
-            padding: 0;
-        }
     }
 
     &__page {
@@ -312,7 +308,7 @@
         text-decoration: none;
     }
 
-    .fd-panel__description, .fd-action-bar__description {
+    .fd-panel__description {
         padding: 0;
     }
 

--- a/docs/pages/components/action-bar.md
+++ b/docs/pages/components/action-bar.md
@@ -25,7 +25,7 @@ The Action Bar is located at the top of the page and is used for the following:
             <button class="fd-button fd-button--compact fd-button--emphasized">Button</button>
         </div>
     </div>
-    <p class="fd-action-bar__description--with-backBtn">Action bar Description </p>
+    <p class="fd-action-bar__description fd-action-bar__description--back">Action bar Description </p>
 </div>
 <br><br>
 <h3>RTL Support</h3>
@@ -41,7 +41,7 @@ The Action Bar is located at the top of the page and is used for the following:
             <button class="fd-button fd-button--compact fd-button--emphasized">Button</button>
         </div>
     </div>
-    <p class="fd-action-bar__description--with-backBtn">Action bar Description </p>
+    <p class="fd-action-bar__description fd-action-bar__description--back">Action bar Description </p>
 </div>
 {% endcapture %}
 {% include display-component.html component=default-action-bar %}
@@ -123,7 +123,7 @@ The Action Bar is located at the top of the page and is used for the following:
             <button class="fd-button fd-button--compact fd-button--emphasized">Button</button>
         </div>
     </div>
-    <p class="fd-action-bar__description--with-backBtn">Action bar Description Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Long
+    <p class="fd-action-bar__description fd-action-bar__description--back">Action bar Description Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Long
     </p>
 </div>
 <br><br>
@@ -142,7 +142,7 @@ The Action Bar is located at the top of the page and is used for the following:
             <button class="fd-button fd-button--compact fd-button--emphasized">Button</button>
         </div>
     </div>
-     <p class="fd-action-bar__description--with-backBtn">Action bar Description Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Long
+     <p class="fd-action-bar__description fd-action-bar__description--back">Action bar Description Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Long
      </p>
 </div>
 {% endcapture %}
@@ -195,7 +195,7 @@ When there are several main actions for a page, consider displaying them under a
             <button class="fd-button fd-button--compact fd-button--emphasized">Button</button>
         </div>
     </div>
-    <p class="fd-action-bar__description--with-backBtn">Action bar Description</p>
+    <p class="fd-action-bar__description fd-action-bar__description--back">Action bar Description</p>
 </div>
 <br><br>
 <h3>RTL Support</h3>
@@ -211,7 +211,7 @@ When there are several main actions for a page, consider displaying them under a
             <button class="fd-button fd-button--compact fd-button--emphasized">Button</button>
         </div>
     </div>
-    <p class="fd-action-bar__description--with-backBtn">Action bar Description</p>
+    <p class="fd-action-bar__description fd-action-bar__description--back">Action bar Description</p>
 </div>
 {% endcapture %}
 {% include display-component.html component=default-action-bar %}
@@ -229,7 +229,7 @@ When there are several main actions for a page, consider displaying them under a
             <button class="fd-button fd-button--compact fd-button--emphasized">Button</button>
         </div>
     </div>
-    <p class="fd-action-bar__description--with-backBtn">Action bar Description </p>
+    <p class="fd-action-bar__description fd-action-bar__description--back">Action bar Description </p>
 </div>
 <br><br>
 <h3>RTL Support</h3>
@@ -245,7 +245,7 @@ When there are several main actions for a page, consider displaying them under a
             <button class="fd-button fd-button--compact fd-button--emphasized">Button</button>
         </div>
     </div>
-    <p class="fd-action-bar__description--with-backBtn">Action bar Description </p>
+    <p class="fd-action-bar__description fd-action-bar__description--back">Action bar Description </p>
 </div>
 {% endcapture %}
 {% include display-component.html component=default-action-bar %}
@@ -263,7 +263,7 @@ When there are several main actions for a page, consider displaying them under a
             <button class="fd-button fd-button--compact fd-button--emphasized">Button</button>
         </div> 
     </div>
-    <p class="fd-action-bar__description--with-backBtn">Action bar Description </p>
+    <p class="fd-action-bar__description fd-action-bar__description--back">Action bar Description </p>
 </div>
 <br><br>
 <h3>RTL Support</h3>
@@ -279,7 +279,7 @@ When there are several main actions for a page, consider displaying them under a
             <button class="fd-button fd-button--compact fd-button--emphasized">Button</button>
         </div> 
     </div>
-    <p class="fd-action-bar__description--with-backBtn">Action bar Description </p>
+    <p class="fd-action-bar__description fd-action-bar__description--back">Action bar Description </p>
 </div>
 {% endcapture %}
 {% include display-component.html component=default-action-bar %}

--- a/src/action-bar.scss
+++ b/src/action-bar.scss
@@ -104,16 +104,14 @@ $block: #{$fd-namespace}-action-bar;
 
   &__description {
     @include fd-action-bar-description();
-  }
 
-  &__description--with-backBtn {
-    @include fd-action-bar-description();
+    &--back {
+      padding-left: 2.5rem;
 
-    padding-left: 2.5rem;
-
-    @include fd-rtl() {
-      padding-left: 0;
-      padding-right: 2.5rem;
+      @include fd-rtl() {
+        padding-left: 0;
+        padding-right: 2.5rem;
+      }
     }
   }
 

--- a/test/templates/action-bar/component.njk
+++ b/test/templates/action-bar/component.njk
@@ -21,7 +21,7 @@
                 </div>
                 
                  {%- if properties.description %}
-                                <p class="fd-action-bar__description--with-backBtn">{{ properties.description }}</p>
+                                <p class="fd-action-bar__description fd-action-bar__description--back">{{ properties.description }}</p>
                 {%- endif %}
         </div>
 {%- endmacro %}


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#

## Description
`<p class="fd-action-bar__description--with-backBtn">` 

changed to

`<p class="fd-action-bar__description fd-action-bar__description--back">`

We don't want to have 2 classes that were essentially the same thing, `fd-action-bar__description` and `fd-action-bar__description--with-backBtn`. With these changes, the majority of the css is in `fd-action-bar__description`, with the additional padding changes need when there is a back button are inside of `--back`.
