### PR TITLE
docs: align icon copy script with other fonts

### DIFF
--- a/scripts/create-library-config.js
+++ b/scripts/create-library-config.js
@@ -25,6 +25,6 @@ fs.copyFile(fontPathLight, 'docs/css/72-Light.woff', (err) => {
 fs.copyFile(fontPathBold, 'docs/css/72-Bold.woff', (err) => {
     if (err) throw err;
 });
-fs.copyFile(iconPath, 'docs/css/fonts/SAP-icons.woff', (err) => {
+fs.copyFile(iconPath, 'docs/css/SAP-icons.woff', (err) => {
     if (err) throw err;
 });


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#

## Description
The script that copies fonts and icons for the documentation site accidentally has an incorrect path for icons - sending it to a fonts folder that doesn't exist. 


