### PR TITLE
fix: added support for text truncation if button width is set

### DIFF
--- a/src/button.scss
+++ b/src/button.scss
@@ -61,6 +61,9 @@ $block: #{$fd-namespace}-button;
   max-height: $fd-button-height;
   min-width: $fd-button-min-width;
   line-height: $fd-button-line-height;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 
   @include iconSize($fd-button-icon-font-size);
 


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#
[ngx #2110](https://github.com/SAP/fundamental-ngx/issues/2110)
## Description
Button text is now truncated (as described in fiori3) when button width is set

![image](https://user-images.githubusercontent.com/10849982/75967440-1b257380-5ecc-11ea-90cc-bd39e1080cb2.png)



## Screenshots
### Before:
![image](https://user-images.githubusercontent.com/10849982/75967265-dd284f80-5ecb-11ea-9e08-f50db3276b28.png)

### After:
![image](https://user-images.githubusercontent.com/10849982/75967318-eaddd500-5ecb-11ea-98f7-5d85929df98c.png)
