### PR TITLE
feat: typo

### DIFF
--- a/docs/pages/components/form.md
+++ b/docs/pages/components/form.md
@@ -231,7 +231,7 @@ Do not use the text area if
     <div class="fd-form-item">
         <label class="fd-form-label" for="textarea-2">Compact text area:</label>
         <textarea class="fd-textarea fd-textarea--compact" id="textarea-2">Pellentesque metus lacus commodo eget justo ut rutrum varius nunc.</textarea>
-        <div class="fd-textarea-counter">150 characters left</div>
+        <div class="fd-textarea__counter">150 characters left</div>
     </div>
     <br/>
     <div class="fd-form-item">
@@ -244,7 +244,7 @@ Do not use the text area if
                 <div class="fd-form-message fd-form-message--success">Success message</div>
             </div>
         </div>
-        <div class="fd-textarea-counter">150 characters left</div>
+        <div class="fd-textarea__counter">150 characters left</div>
     </div>
     <br/>
     <div class="fd-form-item">
@@ -296,7 +296,7 @@ Do not use the text area if
     <div class="fd-form-item" dir="rtl">
         <label class="fd-form-label" for="textarea-9">Text area:</label>
         <textarea class="fd-textarea" id="textarea-9" placeholder="Write something here"></textarea>
-        <div class="fd-textarea-counter">150 characters left</div>
+        <div class="fd-textarea__counter">150 characters left</div>
     </div>
 {% endcapture %}
 

--- a/src/textarea.scss
+++ b/src/textarea.scss
@@ -35,7 +35,7 @@ $block: #{$fd-namespace}-textarea;
     padding: 0.1875rem 0.5rem;
   }
 
-  &-counter {
+  &__counter {
     @include fd-reset();
     @include fd-ellipsis();
 


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#667

## Description
Fix the typo in text-area class
removed text-area-counter
add text-area__counter
## Screenshots
No changes visually
