### PR TITLE
fix: add input-message-group popover specific rules to popper elements

### DIFF
--- a/src/popover.scss
+++ b/src/popover.scss
@@ -224,7 +224,9 @@ $block: #{$fd-namespace}-popover;
 
   &--input-message-group {
     .#{$block}__body,
-    .#{$block}__body--no-arrow {
+    .#{$block}__body--no-arrow,
+    .#{$block}__popper,
+    .#{$block}__popper--no-arrow {
       box-shadow: none;
       border: none;
       margin-top: -0.25rem;


### PR DESCRIPTION
## Description 
For a11y reasons the input field has margin-top and margin-bottom. When the input field is used as a popover control this causes the popover body to look "detached" from the control element. One example is the form-messages that are used for input validation. For this reason we added a modifier class to the popover `--input-message-group` that is removing the shadow (border) from the popover body and is bringing it 0.25rem top. In NGX we are using Popper.js and we need to apply the same rules as we did for the popover body in Fundamental-styles. We added the `--input-message-group` modifier class to the `__popper` but due to the fundamental-ngx Popover specific implementation we don't have the option to apply this class to the body. We are keeping the modifier class as it was since other libs can use it but we are also adding additional rules.
