### PR TITLE
fix: add li directly with list style

### DIFF
--- a/src/product-switch.scss
+++ b/src/product-switch.scss
@@ -57,6 +57,10 @@ $block: #{$fd-namespace}-product-switch;
     }
 
     width: 47rem;
+
+    > li {
+      list-style-type: none;
+    }
   }
 
   &__item {


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles #768

## Description
This pull request is to help target product switch that enables drag and drop. The drag and drop features changes the structure of the DOM, therefore, we need to explicitly target the li to remove bullets
## Screenshots
###Before
<img width="202" alt="Screen Shot 2020-03-05 at 1 30 12 PM" src="https://user-images.githubusercontent.com/50607147/76013143-7a43b200-5ee5-11ea-814e-8734d57c789a.png">
###After
<img width="213" alt="Screen Shot 2020-03-05 at 1 29 23 PM" src="https://user-images.githubusercontent.com/50607147/76013189-8c255500-5ee5-11ea-8461-5a0becf05404.png">


