### PR TITLE
fix: added fix for icon not being centered in IE11 win8.1

### DIFF
--- a/src/button.scss
+++ b/src/button.scss
@@ -12,7 +12,7 @@
 
 $fd-button-border-width: var(--sapButton_BorderWidth);
 $fd-button-font-size: var(--sapFontMediumSize);
-$fd-button-icon-font-size: 1rem;
+$fd-button-icon-font-size: 1em;
 
 $fd-button-clickable-height: 2.75rem;
 $fd-button-height: 2.25rem;


### PR DESCRIPTION
## Related Issue
Closes #799 

## Description
Changed `rem` value to `em`

## Screenshots
### Before:
![image](https://user-images.githubusercontent.com/10849982/77531648-8ba02e80-6e93-11ea-9873-ffbf6bfac78b.png)

### After:
![image](https://user-images.githubusercontent.com/10849982/77531784-c904bc00-6e93-11ea-881f-1bb1bafdf01f.png)