### PR TITLE
fix: use different icon for shellbar menu arrow

### DIFF
--- a/src/shellbar.scss
+++ b/src/shellbar.scss
@@ -327,6 +327,7 @@ $block: #{$fd-namespace}-shellbar;
 
     &::after {
       color: $fd-shellbar-color;
+      content: "\e287";
     }
 
     &:hover {


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles# #802 

## Description
Use different arrow icon for menu

## Screenshots
### Before:
![Screen Shot 2020-03-25 at 2 49 46 PM](https://user-images.githubusercontent.com/2471874/77584353-43d7d200-6ea8-11ea-8e9f-61a32b725731.png)

### After:
![Screen Shot 2020-03-25 at 2 49 58 PM](https://user-images.githubusercontent.com/2471874/77584358-46d2c280-6ea8-11ea-8b00-399795c51b9b.png)