### PR TITLE
docs: responsive issue for both component pages and grid pages

### DIFF
--- a/docs/_includes/head_print.html
+++ b/docs/_includes/head_print.html
@@ -1,6 +1,7 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="viewport" content="width=device-width,initial-scale=1.0">
+
 <meta name="description" content="{% if page.summary %}{{ page.summary | strip_html | strip_newlines | truncate: 160 }}{% endif %}">
 <meta name="keywords" content="{{page.tags}}{% if page.tags %}, {% endif %} {{page.keywords}}">
 <title>{% if page.homepage == true %} {{site.homepage_title}} {% elsif page.title %}{{ page.title }}{% endif %}  | {{ site.site_title }}</title>

--- a/docs/_sass/_docs-component-list.scss
+++ b/docs/_sass/_docs-component-list.scss
@@ -4,27 +4,71 @@ $grid-item-bg-color: fd-color(background, 2);
 $grid-transition-delay: 100ms;
 
 .docs-component-grid {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    grid-gap: 1px;
     border: 1px solid $gird-border-color;
     border-left: none;
     border-right: none;
     margin: 0 -40px -80px -40px;
+    display: flex;
+    flex-wrap: wrap;
 
-    @include media("<=tablet") {
-        grid-template-columns: auto;
+    > * {
+        border: 1px solid $gird-border-color;
+        box-sizing: border-box;
     }
+
+    // @include media("<=tablet") {
+    //     > * {
+    //         width: 100%;
+    //     }
+    // }
+    // @include media(">=tablet") {
+    //     > * {
+    //         width: 50%;
+    //     }    
+    // }
+    // @include media(">=desktop") {
+    //     > * {
+    //         width: (4/12)*100%;
+    //         padding: 1% 1rem;
+    //     }    
+    // }
 
     &--item {
         background: $grid-item-bg-color;
-        padding: 40px 10px;
-        display: block;
-        text-align: center;
         position: relative;
         height: 280px;
         z-index: 1;
         transition: all ease-in-out $grid-transition-delay;
+
+        display: flex;
+        flex-direction: column;
+        padding: 5rem 1rem;
+        align-items: center;
+        justify-content: flex-end;
+
+        @include media("<=tablet") {
+            
+                width: 100%;
+            
+        }
+        @include media(">=tablet") {
+            
+                width: 50%;
+                padding: 5rem 1rem;
+
+        }
+        @include media(">=desktop") {
+            
+                width: (4/12)*100%;
+              
+        }
+
+        @include media(">=display") {
+            
+            width: (2/12)*100%;
+            padding: 5rem 1rem;
+        }
+        
 
         &:hover {
             background-color: $grid-item-bg-color;
@@ -32,6 +76,12 @@ $grid-transition-delay: 100ms;
             text-decoration: none;
             z-index: 2;
             transition: all ease-in-out $grid-transition-delay;
+        }
+
+        h3 {
+            margin-top: 0;
+            position: relative;
+            bottom: 0;
         }
     }
 
@@ -52,150 +102,347 @@ $grid-transition-delay: 100ms;
     &--img {
 
         &__action-bar {
-            width: 300px;
-            margin-top: 60px;
+            width: 95%;
+
+            @include media("<=tablet") {
+                width: 80%;
+            }
+
+            @include media(">=desktop") {
+                width: 50%;
+            }
+        }
+
+        &__bar {
+            width: 95%;
+
+            @include media("<=tablet") {
+                width: 80%;
+            }
+
+            @include media(">=desktop") {
+                width: 80%;
+            }
+        }
+
+        &__busy-indicator {
+            width: 100%;
+
+            @include media("<=tablet") {
+                width: 40%;
+            }
+
+            @include media(">=desktop") {
+                width: 40%;
+            }
         }
 
         &__message-strip {
-            width: 250px;
-            margin-top: 20px;
+            width: 70%;
+
+            @include media("<=tablet") {
+                width: 40%;
+            }
+
+            @include media(">=desktop") {
+                width: 30%;
+            }
         }
 
         &__status-indicators {
-            width: 250px;
-            margin-top: 60px;
+            width: 70%;
         }
 
 	    &__info-label {
-            width: 250px;
-            margin-top: 60px;
+            width: 70%;
         }
 
         &__button {
-            width: 150px;
-            margin-top: 40px;
+            width: 40%;
+
+            @include media("<=tablet") {
+                width: 30%;
+            }
+
+            @include media(">=desktop") {
+                width: 25%;
+            }
         }
 
         &__combobox-input {
-            margin-top: 10px;
+
+            @include media("<=tablet") {
+                width: 30%;
+            }
+
+            @include media(">=desktop") {
+                width: 45%;
+            }
         }
 
         &__contextual-menu {
-            width: 100px;
-            margin-top: 10px;
+            width: 40%;
+
+            @include media("<=tablet") {
+                width: 20%;
+            }
+
+            @include media(">=desktop") {
+                width: 25%;
+            }
+
+            @include media(">=display") {
+                width: 20%;
+            }
         }
 
         &__dropdown {
-            width: 250px;
-            margin-top: 20px;
+            width: 70%;
         }
 
         &__icons {
-            width: 250px;
-            margin-top: 70px;
+            width: 70%;
         }
 
         &__identifier {
-            width: 200px;
-            margin-top: 50px;
+            width: 65%;
+
+            @include media("<=tablet") {
+                width: 40%;
+            }
+
+            @include media(">=desktop") {
+                width: 40%;
+            }
         }
 
         &__image {
-            width: 100px;
-            margin-top: 20px;
+            width: 30%;
+
+            @include media("<=tablet") {
+                width: 15%;
+            }
+
+            @include media(">=desktop") {
+                width: 10%;
+            }
         }
 
         &__inline-help {
-            width: 250px;
-            margin-top: 30px;
+            width: 70%;
+
+            @include media("<=tablet") {
+                width: 40%;
+            }
+
+            @include media(">=desktop") {
+                width: 30%;
+            }
         }
 
         &__link {
-            width: 100px;
-            margin-top: 60px;
+            width: 55%;
+
+            @include media("<=tablet") {
+                width: 25%;
+            }
+
+            @include media(">=desktop") {
+                width: 25%;
+            }
+        }
+
+        &__list {
+            width: 75%;
+
+            @include media("<=tablet") {
+                width: 30%;
+            }
+
+            @include media(">=desktop") {
+                width: 30%;
+            }
         }
 
         &__localization-editor {
-            margin-top: 60px;
         }
 
         &__form {
-            width: 250px;
-            margin-top: 30px;
+            width: 70%;
+
+            @include media("<=tablet") {
+                width: 35%;
+            }
+
+            @include media(">=desktop") {
+                width: 25%;
+            }
         }
 
         &__input-group {
-            width: 250px;
-            margin-top: 30px;
+            width: 70%;
+
+            @include media("<=tablet") {
+                width: 40%;
+            }
+
+            @include media(">=desktop") {
+                width: 40%;
+            }
         }
 
         &__list-group {
-            width: 300px;
-            margin-top: 40px;
+            width: 90%;
         }
 
         &__loading-spinner {
-            width: 50px;
-            margin-top: 50px;
+            width: 25%;
+
+            @include media("<=tablet") {
+                width: 12%;
+            }
+
+            @include media(">=desktop") {
+                width: 12%;
+            }
+        }
+
+        &__product-switch {
+            @include media("<=tablet") {
+                width: 40%;
+            }
+
+            @include media(">=desktop") {
+                width:30%;
+            }
         }
 
         &__dialog {
-            width: 230px;
-            margin-top: 0;
+            width: 50%;
+
+            @include media("<=tablet") {
+                width: 25%;
+            }
+
+            @include media(">=desktop") {
+                width: 20%;
+            }
         }
 
         &__multi-input {
-            width: 230px;
-            margin-top: 50px;
+            width: 75%;
         }
 
         &__pagination {
-            width: 300px;
-            margin-top: 60px;
+            width: 90%;
+
+            @include media("<=tablet") {
+                width: 80%;
+            }
+
+            @include media(">=desktop") {
+                width: 80%;
+            }
         }
 
-        &__search-input {
-            margin-top: 50px;
+        &__select {
+            width: 40%;
+
+            @include media("<=tablet") {
+                width: 20%;
+            }
+
+            @include media(">=desktop") {
+                width: 20%;
+            }
         }
 
         &__side-navigation {
-            width: 100px;
-            margin-top: 0;
+            width: 30%;
+
+            @include media("<=tablet") {
+                width: 12%;
+            }
+
+            @include media(">=desktop") {
+                width: 12%;
+            }
         }
 
         &__shellbar {
-            width: 300px;
-            margin-top: 50px;
+            width: 90%;
+
+            @include media("<=tablet") {
+                width: 80%;
+            }
+
+            @include media(">=desktop") {
+                width: 80%;
+            }
         }
 
         &__switch {
-            width: 60px;
-            margin-top: 30px;
+            width: 20%;
+
+            @include media("<=tablet") {
+                width: 10%;
+            }
+
+            @include media(">=desktop") {
+                width: 10%;
+            }
         }
 
         &__table {
-            width: 300px;
-            margin-top: 0;
+            width: 90%;
+
+            @include media("<=tablet") {
+                width: 45%;
+            }
+
+            @include media(">=desktop") {
+                width: 45%;
+            }
         }
 
         &__tabs {
-            width: 300px;
-            margin-top: 60px;
+            width: 90%;
+
+            @include media("<=tablet") {
+                width: 50%;
+            }
+
+            @include media(">=desktop") {
+                width: 50%;
+            }
         }
 
         &__tile {
-            width: 300px;
-            margin-top: 40px;
+            width: 90%;
+
+            @include media("<=tablet") {
+                width: 50%;
+            }
+
+            @include media(">=desktop") {
+                width: 50%;
+            }
         }
 
         &__toolbar {
-            width: 320px;
-            margin-top: 60px;
+            width: 95%;
         }
 
         &__tree {
-            width: 300px;
-            margin-top: 0;
+            width: 90%;
+
+            @include media("<=tablet") {
+                width: 50%;
+            }
+
+            @include media(">=desktop") {
+                width: 50%;
+            }
         }
     }
 }

--- a/docs/_sass/_docs-component-list.scss
+++ b/docs/_sass/_docs-component-list.scss
@@ -16,23 +16,6 @@ $grid-transition-delay: 100ms;
         box-sizing: border-box;
     }
 
-    // @include media("<=tablet") {
-    //     > * {
-    //         width: 100%;
-    //     }
-    // }
-    // @include media(">=tablet") {
-    //     > * {
-    //         width: 50%;
-    //     }    
-    // }
-    // @include media(">=desktop") {
-    //     > * {
-    //         width: (4/12)*100%;
-    //         padding: 1% 1rem;
-    //     }    
-    // }
-
     &--item {
         background: $grid-item-bg-color;
         position: relative;

--- a/docs/_sass/_docs-component-list.scss
+++ b/docs/_sass/_docs-component-list.scss
@@ -7,7 +7,6 @@ $grid-transition-delay: 100ms;
     border: 1px solid $gird-border-color;
     border-left: none;
     border-right: none;
-    margin: 0 -40px -80px -40px;
     display: flex;
     flex-wrap: wrap;
 
@@ -81,102 +80,27 @@ $grid-transition-delay: 100ms;
         right: 0;
         margin: 0 auto;
     }
-
+    
     &--img {
 
         &__action-bar {
             width: 95%;
-
-            @include media("<=tablet") {
-                width: 80%;
-            }
-
-            @include media(">=desktop") {
-                width: 50%;
-            }
         }
 
         &__bar {
             width: 95%;
-
-            @include media("<=tablet") {
-                width: 80%;
-            }
-
-            @include media(">=desktop") {
-                width: 80%;
-            }
         }
 
         &__busy-indicator {
             width: 100%;
-
-            @include media("<=tablet") {
-                width: 40%;
-            }
-
-            @include media(">=desktop") {
-                width: 40%;
-            }
-        }
-
-        &__message-strip {
-            width: 70%;
-
-            @include media("<=tablet") {
-                width: 40%;
-            }
-
-            @include media(">=desktop") {
-                width: 30%;
-            }
-        }
-
-        &__status-indicators {
-            width: 70%;
-        }
-
-	    &__info-label {
-            width: 70%;
         }
 
         &__button {
             width: 40%;
-
-            @include media("<=tablet") {
-                width: 30%;
-            }
-
-            @include media(">=desktop") {
-                width: 25%;
-            }
-        }
-
-        &__combobox-input {
-
-            @include media("<=tablet") {
-                width: 30%;
-            }
-
-            @include media(">=desktop") {
-                width: 45%;
-            }
         }
 
         &__contextual-menu {
             width: 40%;
-
-            @include media("<=tablet") {
-                width: 20%;
-            }
-
-            @include media(">=desktop") {
-                width: 25%;
-            }
-
-            @include media(">=display") {
-                width: 20%;
-            }
         }
 
         &__dropdown {
@@ -189,89 +113,35 @@ $grid-transition-delay: 100ms;
 
         &__identifier {
             width: 65%;
-
-            @include media("<=tablet") {
-                width: 40%;
-            }
-
-            @include media(">=desktop") {
-                width: 40%;
-            }
         }
 
         &__image {
             width: 30%;
-
-            @include media("<=tablet") {
-                width: 15%;
-            }
-
-            @include media(">=desktop") {
-                width: 10%;
-            }
         }
 
         &__inline-help {
             width: 70%;
-
-            @include media("<=tablet") {
-                width: 40%;
-            }
-
-            @include media(">=desktop") {
-                width: 30%;
-            }
         }
 
         &__link {
             width: 55%;
-
-            @include media("<=tablet") {
-                width: 25%;
-            }
-
-            @include media(">=desktop") {
-                width: 25%;
-            }
         }
 
         &__list {
             width: 75%;
-
-            @include media("<=tablet") {
-                width: 30%;
-            }
-
-            @include media(">=desktop") {
-                width: 30%;
-            }
-        }
-
-        &__localization-editor {
         }
 
         &__form {
             width: 70%;
 
-            @include media("<=tablet") {
-                width: 35%;
-            }
+        }
 
-            @include media(">=desktop") {
-                width: 25%;
-            }
+        &__info-label {
+            width: 70%;
         }
 
         &__input-group {
             width: 70%;
-
-            @include media("<=tablet") {
-                width: 40%;
-            }
-
-            @include media(">=desktop") {
-                width: 40%;
-            }
         }
 
         &__list-group {
@@ -280,36 +150,14 @@ $grid-transition-delay: 100ms;
 
         &__loading-spinner {
             width: 25%;
-
-            @include media("<=tablet") {
-                width: 12%;
-            }
-
-            @include media(">=desktop") {
-                width: 12%;
-            }
-        }
-
-        &__product-switch {
-            @include media("<=tablet") {
-                width: 40%;
-            }
-
-            @include media(">=desktop") {
-                width:30%;
-            }
         }
 
         &__dialog {
             width: 50%;
+        }
 
-            @include media("<=tablet") {
-                width: 25%;
-            }
-
-            @include media(">=desktop") {
-                width: 20%;
-            }
+        &__message-strip {
+            width: 70%;
         }
 
         &__multi-input {
@@ -318,98 +166,38 @@ $grid-transition-delay: 100ms;
 
         &__pagination {
             width: 90%;
-
-            @include media("<=tablet") {
-                width: 80%;
-            }
-
-            @include media(">=desktop") {
-                width: 80%;
-            }
         }
 
         &__select {
             width: 40%;
-
-            @include media("<=tablet") {
-                width: 20%;
-            }
-
-            @include media(">=desktop") {
-                width: 20%;
-            }
         }
 
         &__side-navigation {
             width: 30%;
-
-            @include media("<=tablet") {
-                width: 12%;
-            }
-
-            @include media(">=desktop") {
-                width: 12%;
-            }
         }
 
         &__shellbar {
             width: 90%;
+        }
 
-            @include media("<=tablet") {
-                width: 80%;
-            }
-
-            @include media(">=desktop") {
-                width: 80%;
-            }
+        &__status-indicators {
+            width: 70%;
         }
 
         &__switch {
             width: 20%;
-
-            @include media("<=tablet") {
-                width: 10%;
-            }
-
-            @include media(">=desktop") {
-                width: 10%;
-            }
         }
 
         &__table {
             width: 90%;
-
-            @include media("<=tablet") {
-                width: 45%;
-            }
-
-            @include media(">=desktop") {
-                width: 45%;
-            }
         }
 
         &__tabs {
             width: 90%;
-
-            @include media("<=tablet") {
-                width: 50%;
-            }
-
-            @include media(">=desktop") {
-                width: 50%;
-            }
         }
 
         &__tile {
             width: 90%;
-
-            @include media("<=tablet") {
-                width: 50%;
-            }
-
-            @include media(">=desktop") {
-                width: 50%;
-            }
         }
 
         &__toolbar {
@@ -418,13 +206,245 @@ $grid-transition-delay: 100ms;
 
         &__tree {
             width: 90%;
+        }
+    }
 
-            @include media("<=tablet") {
+    @include media("<=tablet") {
+        &--img {
+            &__action-bar {
+                width: 80%;
+            }
+
+            &__bar {
+                width: 80%;
+            }
+
+            &__busy-indicator {
+                width: 40%;
+            }
+
+            &__message-strip {
+                width: 40%;
+            }
+
+            &__button {
+                width: 30%;
+            }
+
+            &__combobox-input {
+                width: 30%;
+            }
+
+            &__contextual-menu {
+                width: 20%;
+            }
+
+            &__identifier {
+                width: 40%;
+            }
+
+            &__image {
+                width: 15%;
+            }
+
+            &__inline-help {
+                width: 40%;
+            }
+
+            &__link {
+                width: 25%;
+            }
+
+            &__list {
+                width: 30%;
+            }
+
+            &__form {
+                width: 35%;
+            }
+
+            &__input-group {
+                    width: 40%;
+            }
+
+            &__list-group {
+                width: 90%;
+            }
+
+            &__loading-spinner {
+                width: 12%;
+            }
+
+            &__dialog {
+                width: 25%;
+            }
+
+            &__multi-input {
+                width: 75%;
+            }
+
+            &__pagination {
+                width: 80%;
+            }
+
+            &__select {
+                width: 20%;
+            }
+
+            &__side-navigation {
+                width: 12%;
+            }
+
+            &__shellbar {
+                width: 80%;
+            }
+
+            &__switch {
+                width: 10%;
+            }
+
+            &__table {
+                width: 45%;
+            }
+
+            &__tabs {
                 width: 50%;
             }
 
-            @include media(">=desktop") {
+            &__tile {
                 width: 50%;
+            }
+
+            &__toolbar {
+                width: 95%;
+            }
+
+            &__tree {
+                width: 50%;
+            }
+        }
+    }
+
+    @include media(">=desktop") {
+        &--img {
+            &__action-bar {
+                    width: 50%;
+            }
+
+            &__bar {
+                width: 80%;
+            }
+
+            &__busy-indicator {
+                    width: 40%;
+            }
+
+            &__message-strip {
+                width: 30%;
+            }
+
+            &__button {
+                width: 25%;
+            }
+
+            &__combobox-input {
+                width: 45%;
+            }
+
+            &__contextual-menu {
+                width: 25%;
+            }
+
+            &__dropdown {
+                width: 70%;
+            }
+
+            &__icons {
+                width: 70%;
+            }
+
+            &__identifier {
+                width: 40%;
+            }
+
+            &__image {
+                width: 10%;
+            }
+
+            &__inline-help {
+                width: 30%;
+            }
+
+            &__link {
+                width: 25%;
+            }
+
+            &__list {
+                width: 30%;
+            }
+
+            &__form {
+                width: 25%;
+            }
+
+            &__input-group {
+                width: 40%;
+            }
+
+            &__loading-spinner {
+                width: 12%;
+            }
+
+            &__product-switch {
+                width:30%;
+            }
+
+            &__dialog {
+                width: 20%;
+            }
+
+            &__pagination {
+                width: 80%;
+            }
+
+            &__select {
+                width: 20%;
+            }
+
+            &__side-navigation {
+                width: 12%;
+            }
+
+            &__shellbar {
+                width: 80%;
+            }
+
+            &__switch {
+                width: 10%;
+            }
+
+            &__table {
+                width: 45%;
+            }
+
+            &__tabs {
+                width: 50%;
+            }
+
+            &__tile {
+                width: 50%;
+            }
+
+            &__tree {
+                width: 50%;
+            }
+        }
+    }
+
+    @include media(">=display") {
+        &--img {
+            &__contextual-menu {
+                width: 20%;
             }
         }
     }

--- a/docs/_sass/_docs-general.scss
+++ b/docs/_sass/_docs-general.scss
@@ -92,7 +92,7 @@ hr {
 }
 
 .highlight {
-    max-width: 1440px;
+    max-width: 100%;
     margin: 25px 0 0 0;
 }
 

--- a/docs/_sass/_docs-main-content.scss
+++ b/docs/_sass/_docs-main-content.scss
@@ -11,6 +11,7 @@
 }
 .docs-content {
     padding: 40px 40px 80px 60px;
+    box-sizing: border-box;
     width: 100%;
     @include media("<=tablet") {
         padding: 10px;

--- a/docs/_sass/_docs-main-content.scss
+++ b/docs/_sass/_docs-main-content.scss
@@ -5,15 +5,13 @@
     height: calc(100vh - 27px - 40px - 20px);
     flex-grow: 1;
     display: flex;
-    flex-direction: column;
+    flex-wrap: wrap;
     background-color: $docs-home-grey-color;
     scroll-behavior: smooth;
 }
 .docs-content {
     padding: 40px 40px 80px 60px;
-    min-width: 1024px;
-    max-width: 1440px;
-    width: 80%;
+    width: 100%;
     @include media("<=tablet") {
         padding: 10px;
         min-width: auto;

--- a/docs/_sass/_docs-main-content.scss
+++ b/docs/_sass/_docs-main-content.scss
@@ -10,11 +10,11 @@
     scroll-behavior: smooth;
 }
 .docs-content {
-    padding: 40px 40px 80px 60px;
+    padding: 2rem 2rem 4rem 2rem;
     box-sizing: border-box;
     width: 100%;
     @include media("<=tablet") {
-        padding: 10px;
+        padding: 2rem 0 0 0;
         min-width: auto;
         width: 100%;
     }

--- a/docs/_sass/_docs-side-nav.scss
+++ b/docs/_sass/_docs-side-nav.scss
@@ -15,7 +15,7 @@ $side-nav-links-color: $docs-home-white-color;
         display: none;
         &.fd-styles__mobile-list {
             width: auto;
-            display: block;
+            display: flex;
         }
     }
 
@@ -50,6 +50,7 @@ $side-nav-links-color: $docs-home-white-color;
 
     &__links-container {
         padding-left: 20px;
+        padding-bottom: 7rem;
         margin: 0;
         overflow-y: auto;
     }

--- a/docs/_sass/_docs-side-nav.scss
+++ b/docs/_sass/_docs-side-nav.scss
@@ -37,10 +37,13 @@ $side-nav-links-color: $docs-home-white-color;
         &-link {
             color: $side-nav-links-color !important;
             font-family: '72', sans-serif;
-            padding: 20px 20px 5px 20px;
+            padding: 1rem 0rem 1rem 1rem;
             display: block;
             &:hover {
                 color: $side-nav-links-color;
+            }
+            &:focus {
+                background-color: #5FA8EF;
             }
         }
         ol, ul {
@@ -49,7 +52,6 @@ $side-nav-links-color: $docs-home-white-color;
     }
 
     &__links-container {
-        padding-left: 20px;
         padding-bottom: 7rem;
         margin: 0;
         overflow-y: auto;
@@ -80,7 +82,7 @@ $side-nav-links-color: $docs-home-white-color;
     }
 
     &__seperator {
-        margin: 15px 20px 0 20px;
+        margin: 0 1rem;
         border-bottom: 1px solid #242424;
         opacity: .3;
     }

--- a/docs/_sass/_docs-top-nav.scss
+++ b/docs/_sass/_docs-top-nav.scss
@@ -1,10 +1,11 @@
 .docs-top-nav {
+    display: flex;
+    align-items: center;
     background-color: $docs-home-white-color;
-    min-height: 87px;
+    min-height: 6rem;
+    padding: 0 1rem;
 
     &__logo {
-        margin-top: 25px;
-        margin-left: 35px;
         display: inline-block;
         font-size: 24px;
         font-weight: bold;
@@ -24,7 +25,6 @@
         font-size: 1.14286rem;
         line-height: 1.25;
         font-weight: 400;
-        padding: 30px 20px 0 0;
         display: inline-block;
         @include media("<=tablet") {
             display: none;
@@ -45,10 +45,13 @@
     }
 
     &__mobile {
+        width: 100%;
+
         @include media("<=tablet") {
             display: flex;
-            justify-content: space-around;
-            align-items: baseline;
+            justify-content: space-between;
+            padding: 0 1rem;
+            align-items: center;
         }
     }
 }

--- a/docs/_sass/_include-media.scss
+++ b/docs/_sass/_include-media.scss
@@ -34,7 +34,8 @@
 $breakpoints: (
   'phone': 320px,
   'tablet': 768px,
-  'desktop': 1024px
+  'desktop': 1024px,
+  'display': 1920px
 ) !default;
 
 

--- a/docs/_sass/_landingPage.scss
+++ b/docs/_sass/_landingPage.scss
@@ -724,12 +724,7 @@ body {
 .header-section__sap-icon--menu2::before {
   transition: opacity 0.3s, transform 0.3s;
   color: $home-page-action-color;
-  @media only screen and (max-width: 1024px) {
    font-size: 14px;
-  }
-  @media only screen and (min-width: 1024px) {
-    font-size: 20px;
-  }
 }
 
 .header-section__sap-icon--decline::before {

--- a/docs/_sass/_landingPage.scss
+++ b/docs/_sass/_landingPage.scss
@@ -721,8 +721,6 @@ body {
 }
 
 .header-section__sap-icon--menu2 {
-  
-  height: 50px;
   background-color: white;
   border: none;
 }

--- a/docs/_sass/_landingPage.scss
+++ b/docs/_sass/_landingPage.scss
@@ -175,7 +175,7 @@ body {
   }
 
   &__container {
-    max-width: 1440px;
+    max-width: 100%;
     margin: 0 auto;
   }
 
@@ -188,7 +188,7 @@ body {
 
 .libraries-section {
   padding: 140px 120px 64px 120px;
-  max-width: 1440px;
+  max-width: 100%;
   margin: 0 auto;
 
   &__logo {

--- a/docs/_sass/_landingPage.scss
+++ b/docs/_sass/_landingPage.scss
@@ -715,15 +715,21 @@ body {
 
 // HAMBURGER MENU
 .header-section__hamburger {
-  min-width: 25px;
+  min-width: 15px;
   -moz-transition: all 0.3s ease;
   transition: all 0.3s ease;
 }
 
+
 .header-section__sap-icon--menu2::before {
-  font-size: 20px;
   transition: opacity 0.3s, transform 0.3s;
   color: $home-page-action-color;
+  @media only screen and (max-width: 1024px) {
+   font-size: 14px;
+  }
+  @media only screen and (min-width: 1024px) {
+    font-size: 20px;
+  }
 }
 
 .header-section__sap-icon--decline::before {

--- a/docs/_sass/_landingPage.scss
+++ b/docs/_sass/_landingPage.scss
@@ -720,11 +720,17 @@ body {
   transition: all 0.3s ease;
 }
 
+.header-section__sap-icon--menu2 {
+  
+  height: 50px;
+  background-color: white;
+  border: none;
+}
 
 .header-section__sap-icon--menu2::before {
   transition: opacity 0.3s, transform 0.3s;
   color: $home-page-action-color;
-   font-size: 14px;
+   font-size: 20px;
 }
 
 .header-section__sap-icon--decline::before {


### PR DESCRIPTION
## Related Issue
Closes #732 and #409

## Description
This PR does the following for our docs page

1. Adds display to one of the breakpoint options, it is classified in Fiori but forgot to be added
2. Makes our grids responsive no matter the size of the page when the user wants to select a component or pattern. I made the grid go to 2 columns for sizing at a certain size. Also the images themselves shrink proportionately.

3. Makes the actual component responsive
4. Makes our navigation bar scrollable on ipad
5. Fix the hamburger menu size for all types 
## Screenshots

### Before:
![Screen Shot 2020-03-26 at 1 58 12 PM](https://user-images.githubusercontent.com/50607147/77681841-56b3da80-6f6c-11ea-9e42-069b75d342d7.png)
![Screen Shot 2020-03-26 at 1 58 04 PM](https://user-images.githubusercontent.com/50607147/77681857-5ddae880-6f6c-11ea-8c36-8c75e83562fe.png)
![Screen Shot 2020-03-26 at 1 56 17 PM](https://user-images.githubusercontent.com/50607147/77681920-777c3000-6f6c-11ea-9349-2b425bd36b6a.png)
![Screen Shot 2020-03-26 at 1 56 50 PM](https://user-images.githubusercontent.com/50607147/77681943-7e0aa780-6f6c-11ea-8415-ad2e882d0dae.png)

### After:
![Screen Shot 2020-03-26 at 1 57 24 PM](https://user-images.githubusercontent.com/50607147/77682003-98448580-6f6c-11ea-8f62-8f71b417daae.png)
![Screen Shot 2020-03-26 at 1 57 53 PM](https://user-images.githubusercontent.com/50607147/77681896-6e8b5e80-6f6c-11ea-9da9-f9fb96591dbf.png)
![Screen Shot 2020-03-26 at 2 18 08 PM](https://user-images.githubusercontent.com/50607147/77682027-a2ff1a80-6f6c-11ea-8bef-fbc3c4bcd142.png)
