### PR TITLE
fix: Show readonly mode popover on multi input

### DIFF
--- a/src/input-group.scss
+++ b/src/input-group.scss
@@ -210,4 +210,9 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
   .#{$fd-namespace}-textarea {
     resize: vertical;
   }
+
+  &[readonly],
+  &.is-readonly {
+    overflow: visible;
+  }
 }

--- a/src/tokenizer.scss
+++ b/src/tokenizer.scss
@@ -85,6 +85,9 @@ $block: #{$fd-namespace}-tokenizer;
   &--readonly {
     overflow: visible;
     background-color: var(--sapField_ReadOnly_Background);
+    .#{$block}__inner {
+      overflow: visible;
+    }
   }
 
   &--scrollable {


### PR DESCRIPTION
## Description
There is removed `overflow: hidden` for readonly mode on input group and tokenizer__inner.

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/26483208/78132823-ae938b00-741d-11ea-8a6c-635de8e7ecbc.png)


### After:
![image](https://user-images.githubusercontent.com/26483208/78133073-1e097a80-741e-11ea-8b6a-450ec9327f28.png)
