### PR TITLE
fix: add style for the backbutton in the shellbar

### DIFF
--- a/src/shellbar.scss
+++ b/src/shellbar.scss
@@ -296,6 +296,11 @@ $block: #{$fd-namespace}-shellbar;
     background: $fd-shellbar-background-color;
     color: $fd-shellbar-color;
 
+    &--back {
+      margin: 1em;
+      flex: none;
+    }
+
     &:hover {
       background: $fd-shell-hover-background;
     }


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#

## Description
add the style for the shellbar back button i am trying to bring into [fundamental-react](https://github.com/SAP/fundamental-react/pull/967)
