### PR TITLE
fix: IE11 popover with bar component

### DIFF
--- a/src/bar.scss
+++ b/src/bar.scss
@@ -44,7 +44,8 @@ $block: #{$fd-namespace}-bar;
 
     display: flex;
     align-items: center;
-    flex: 1;
+    flex: 1 1 auto;
+    width: 100%;
     max-width: 100%;
   }
 


### PR DESCRIPTION
## Related Issue
fixes: https://github.com/SAP/fundamental-styles/issues/755

## Description
There was some issue on popover using bar. The bar component didn't expand container.

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/26483208/80102690-67f40500-8573-11ea-9279-4adf82474fce.png)


### After:
![image](https://user-images.githubusercontent.com/26483208/80102611-4c88fa00-8573-11ea-9471-eda9da5b4cda.png)
