### PR TITLE
docs: Add deprecated note for native select

### DIFF
--- a/docs/pages/components/form.md
+++ b/docs/pages/components/form.md
@@ -305,7 +305,8 @@ Do not use the text area if
 <br>
 
 ## Form Select
-The Form Select component is similar to a dropdown but is more commonly used within a form. It can also be set to a disabled state.
+> **DEPRECATED**. Form Select does not exist as a Fiori 3 component so it has been deprecated.
+> Instead of it use [Custom Select Component]({{site.baseurl}}/components/select.html).
 
 {% capture select %}
     <div class="fd-form-item">

--- a/docs/pages/components/form.md
+++ b/docs/pages/components/form.md
@@ -306,7 +306,7 @@ Do not use the text area if
 
 ## Form Select
 > **DEPRECATED**. Form Select does not exist as a Fiori 3 component so it has been deprecated.
-> Instead of it use [Custom Select Component]({{site.baseurl}}/components/select.html).
+> It has been replaced by the [Custom Select Component]({{site.baseurl}}/components/select.html).
 
 {% capture select %}
     <div class="fd-form-item">


### PR DESCRIPTION
## Related Issue
fixes: https://github.com/SAP/fundamental-styles/issues/872

## Description
Due to limited native select styling, there is deprecation note for form select
