### PR TITLE
fix: Remove overflow:hidden from switch

### DIFF
--- a/src/switch.scss
+++ b/src/switch.scss
@@ -58,7 +58,6 @@ $block: #{$fd-namespace}-switch;
   display: inline-block;
   position: relative;
   padding: $fd-switch-container-padding-y 0;
-  overflow: hidden;
 
   &__label {
     @include fd-form-label();

--- a/src/switch.scss
+++ b/src/switch.scss
@@ -53,6 +53,9 @@ $block: #{$fd-namespace}-switch;
   $fd-switch-track-semantic-offset: 1.9375rem;
   $fd-switch-track-border-offset: 0.0625rem;
 
+  $fd-switch-off-opacity: 0;
+  $fd-switch-on-opacity: 1;
+
   @include fd-reset();
 
   cursor: pointer;
@@ -123,7 +126,7 @@ $block: #{$fd-namespace}-switch;
     &--on {
       color: var(--sapPositiveElementColor);
       margin: 0 0 0 0.125rem;
-      opacity: 0;
+      opacity: $fd-switch-off-opacity;
     }
   }
 
@@ -142,7 +145,7 @@ $block: #{$fd-namespace}-switch;
   &__input {
     @include fd-reset();
 
-    opacity: 0;
+    opacity: $fd-switch-off-opacity;
     width: 0;
     height: 0;
     position: absolute;
@@ -194,11 +197,11 @@ $block: #{$fd-namespace}-switch;
 
     .#{$block}__icon {
       &--off {
-        opacity: 0;
+        opacity: $fd-switch-off-opacity;
       }
 
       &--on {
-        opacity: 1;
+        opacity: $fd-switch-on-opacity;
       }
     }
   }

--- a/src/switch.scss
+++ b/src/switch.scss
@@ -27,7 +27,7 @@ $block: #{$fd-namespace}-switch;
   $fd-switch-label-width: 1.75rem;
 
   $fd-switch-transition: all 0.1s;
-  $fd-switch-semantic-icon-transition: opacity 0s ease 0.03s;
+  $fd-switch-semantic-icon-transition: visibility 0s ease 0.03s, opacity 0s ease 0.03s;
 
   $fd-switch-container-padding-y: 0.375rem;
   $fd-switch-size-x: 3.75rem;
@@ -126,6 +126,7 @@ $block: #{$fd-namespace}-switch;
     &--on {
       color: var(--sapPositiveElementColor);
       margin: 0 0 0 0.125rem;
+      visibility: hidden;
       opacity: $fd-switch-off-opacity;
     }
   }
@@ -198,10 +199,12 @@ $block: #{$fd-namespace}-switch;
     .#{$block}__icon {
       &--off {
         opacity: $fd-switch-off-opacity;
+        visibility: hidden;
       }
 
       &--on {
         opacity: $fd-switch-on-opacity;
+        visibility: visible;
       }
     }
   }

--- a/src/switch.scss
+++ b/src/switch.scss
@@ -27,6 +27,7 @@ $block: #{$fd-namespace}-switch;
   $fd-switch-label-width: 1.75rem;
 
   $fd-switch-transition: all 0.1s;
+  $fd-switch-semantic-icon-transition: opacity 0s ease 0.03s;
 
   $fd-switch-container-padding-y: 0.375rem;
   $fd-switch-size-x: 3.75rem;
@@ -112,6 +113,7 @@ $block: #{$fd-namespace}-switch;
     font-size: 0.75rem;
     line-height: 1.375rem;
     text-align: center;
+    transition: $fd-switch-semantic-icon-transition;
 
     &--off {
       color: var(--sapNegativeElementColor);
@@ -121,6 +123,7 @@ $block: #{$fd-namespace}-switch;
     &--on {
       color: var(--sapPositiveElementColor);
       margin: 0 0 0 0.125rem;
+      opacity: 0;
     }
   }
 
@@ -187,6 +190,16 @@ $block: #{$fd-namespace}-switch;
 
     .#{$block}__track {
       transform: translate($fd-switch-track-border-offset, -50%);
+    }
+
+    .#{$block}__icon {
+      &--off {
+        opacity: 0;
+      }
+
+      &--on {
+        opacity: 1;
+      }
     }
   }
 


### PR DESCRIPTION
## Related Issue
fixes: https://github.com/SAP/fundamental-styles/issues/869

## Description
It will prevent from cutting switch, if it doesn't fit on some browsers, or when it's squashed by content in flex container.