### PR TITLE
feat: Modify examples with doubled menu box shadow

### DIFF
--- a/docs/pages/components/action-bar.md
+++ b/docs/pages/components/action-bar.md
@@ -164,7 +164,7 @@ When there are several main actions for a page, consider displaying them under a
                 </div>
                 <div class="fd-popover__body fd-popover__body--right" aria-hidden="true" id="wgxzK859">
                     <nav class="fd-menu" id="">
-                        <ul class="fd-menu__list">
+                        <ul class="fd-menu__list fd-menu__list--no-shadow">
                             <li class="fd-menu__item">
                                 <a class="fd-menu__link" href="#">
                                     <span class="fd-menu__title">Edit</span>
@@ -322,7 +322,7 @@ When there are several main actions for a page, consider displaying them under a
                     </div>
                     <div class="fd-popover__body" aria-hidden="true" id="wgxzK85">
                         <nav class="fd-menu" id="">
-                            <ul class="fd-menu__list">
+                            <ul class="fd-menu__list fd-menu__list--no-shadow">
                                 <li class="fd-menu__item">
                                     <a class="fd-menu__link" href="#">
                                         <span class="fd-menu__title">Option 1</span>
@@ -369,7 +369,7 @@ When there are several main actions for a page, consider displaying them under a
                     </div>
                     <div class="fd-popover__body" aria-hidden="true" id="wgxzK86">
                         <nav class="fd-menu" id="">
-                            <ul class="fd-menu__list">
+                            <ul class="fd-menu__list fd-menu__list--no-shadow">
                                 <li class="fd-menu__item">
                                     <a class="fd-menu__link" href="#">
                                         <span class="fd-menu__title">Option 1</span>

--- a/docs/pages/components/button.md
+++ b/docs/pages/components/button.md
@@ -150,7 +150,7 @@ The button triggers the last action chosen by the user. Initially, it also trigg
   <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right"  aria-hidden="true" 
   id="t4c0o273">
     <nav class="fd-menu">
-        <ul class="fd-menu__list">
+        <ul class="fd-menu__list fd-menu__list--no-shadow">
           <li class="fd-menu__item">
               <a class="fd-menu__link" role="button" href="#">
                   <span class="fd-menu__title">Add to list</span>
@@ -173,7 +173,7 @@ The button triggers the last action chosen by the user. Initially, it also trigg
   <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right"  aria-hidden="true" 
     id="t4c0o2732">
     <nav class="fd-menu">
-        <ul class="fd-menu__list">
+        <ul class="fd-menu__list fd-menu__list--no-shadow">
           <li class="fd-menu__item">
               <a class="fd-menu__link" role="button" href="#">
                   <span class="fd-menu__title">Add to list</span>

--- a/docs/pages/components/localization-editor.md
+++ b/docs/pages/components/localization-editor.md
@@ -29,7 +29,7 @@ summary:
       </div>
       <div class="fd-popover__body fd-popover__body--no-arrow"  aria-hidden="true" id="NJvVh542c">
          <nav class="fd-menu">
-            <ul class="fd-menu__list">
+            <ul class="fd-menu__list fd-menu__list--no-shadow">
                <li class="fd-localization-editor__language">
                   <div class="fd-input-group">
                      <input type="text" class="fd-input fd-input-group__input" id="" placeholder="Enter Label">
@@ -79,7 +79,7 @@ summary:
       </div>
       <div class="fd-popover__body fd-popover__body--no-arrow"  aria-hidden="true" id="test22">
          <nav class="fd-menu">
-            <ul class="fd-menu__list">
+            <ul class="fd-menu__list fd-menu__list--no-shadow">
                <li class="fd-localization-editor__language">
                   <div class="fd-input-group">
                      <input type="text" class="fd-input fd-input--compact fd-input-group__input" id="" placeholder="Enter Label">
@@ -134,7 +134,7 @@ summary:
       </div>
       <div class="fd-popover__body fd-popover__body--no-arrow"  aria-hidden="true" id="NJvVh542">
          <nav class="fd-menu">
-            <ul class="fd-menu__list">
+            <ul class="fd-menu__list fd-menu__list--no-shadow">
                <li class="fd-localization-editor__language">
                   <div class="fd-input-group ">
                      <textarea class="fd-textarea fd-input-group__input" id=""></textarea>

--- a/docs/pages/components/popover.md
+++ b/docs/pages/components/popover.md
@@ -53,7 +53,7 @@ There are four placement options:
     </div>
     <div class="fd-popover__body" aria-hidden="true" id="popoverA1">
         <nav class="fd-menu" id="">
-            <ul class="fd-menu__list">
+            <ul class="fd-menu__list fd-menu__list--no-shadow">
                 <li class="fd-menu__item">
                     <a class="fd-menu__link" href="#">
                         <span class="fd-menu__title">Option 1</span>
@@ -96,7 +96,7 @@ There are four placement options:
     </div>
     <div class="fd-popover__body fd-popover__body--no-arrow" aria-hidden="true" id="popoverA3">
         <nav class="fd-menu" id="">
-            <ul class="fd-menu__list">
+            <ul class="fd-menu__list fd-menu__list--no-shadow">
                 <li class="fd-menu__item">
                     <a class="fd-menu__link" href="#">
                         <span class="fd-menu__title">Option 1</span>
@@ -128,7 +128,7 @@ There are four placement options:
     </div>
     <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow" aria-hidden="true" id="popoverA4">
         <nav class="fd-menu" id="">
-            <ul class="fd-menu__list">
+            <ul class="fd-menu__list fd-menu__list--no-shadow">
                 <li class="fd-menu__item">
                     <a class="fd-menu__link" href="#">
                         <span class="fd-menu__title">Option 1</span>
@@ -182,7 +182,7 @@ There are four placement options:
             </div>
         </div>
         <nav class="fd-menu" id="">
-            <ul class="fd-menu__list">
+            <ul class="fd-menu__list fd-menu__list--no-shadow">
                 <li class="fd-menu__item">
                     <a class="fd-menu__link" href="#">
                         <span class="fd-menu__title">Option 1</span>
@@ -343,7 +343,7 @@ Virtually any component can be used as a `fd-popover__control` to control the di
     </div>
     <div class="fd-popover__body" aria-hidden="true" id="popoverB1">
         <nav class="fd-menu" id="">
-            <ul class="fd-menu__list">
+            <ul class="fd-menu__list fd-menu__list--no-shadow">
                 <li class="fd-menu__item">
                     <a class="fd-menu__link" href="#">
                         <span class="fd-menu__title">Option 1</span>
@@ -376,7 +376,7 @@ style="background-image: url('https://placeimg.com/400/400/nature');"></span>
     </div>
     <div class="fd-popover__body fd-popover__body--right" aria-hidden="true" id="popoverB2">
         <nav class="fd-menu" id="">
-            <ul class="fd-menu__list">
+            <ul class="fd-menu__list fd-menu__list--no-shadow">
                 <li class="fd-menu__item">
                     <a class="fd-menu__link" href="#">
                         <span class="fd-menu__title">Option 1</span>
@@ -410,7 +410,7 @@ style="background-image: url('https://placeimg.com/400/400/nature');"></span>
     </div>
     <div class="fd-popover__body fd-popover__body--no-arrow" aria-hidden="true" id="popoverB3">
         <nav class="fd-menu" id="">
-            <ul class="fd-menu__list">
+            <ul class="fd-menu__list fd-menu__list--no-shadow">
                 <li class="fd-menu__item">
                     <a class="fd-menu__link" href="#">
                         <span class="fd-menu__title">Option 1</span>
@@ -443,7 +443,7 @@ style="background-image: url('https://placeimg.com/400/400/nature');"></span>
     </div>
     <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow" aria-hidden="true" id="popoverB4">
         <nav class="fd-menu" id="">
-            <ul class="fd-menu__list">
+            <ul class="fd-menu__list fd-menu__list--no-shadow">
                 <li class="fd-menu__item">
                     <a class="fd-menu__link" href="#">
                         <span class="fd-menu__title">Option 1</span>

--- a/docs/pages/components/shellbar.md
+++ b/docs/pages/components/shellbar.md
@@ -63,7 +63,7 @@ This example shows the minimum shellbar for a single application product with on
         </div>
         <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right" aria-hidden="true" id="WV3AY276">
           <nav class="fd-menu">
-            <ul class="fd-menu__list">
+            <ul class="fd-menu__list fd-menu__list--no-shadow">
               <li class="fd-menu__item">
                 <a role="button" class="fd-menu__link">
                   <span class="fd-menu__title">Settings</span>
@@ -105,7 +105,7 @@ This example includes the product menu for navigating to applications within the
       </div>
       <div class="fd-popover__body fd-popover__body--no-arrow" aria-hidden="true" id="9GLB26941">
         <nav class="fd-menu">
-          <ul class="fd-menu__list">
+          <ul class="fd-menu__list fd-menu__list--no-shadow">
             <li class="fd-menu__item">
               <a role="button" class="fd-menu__link">
                 <span class="fd-menu__title">Application A</span>
@@ -157,7 +157,7 @@ This example includes the product menu for navigating to applications within the
         </div>
         <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right" aria-hidden="true" id="ZY3AY276">
           <nav class="fd-menu">
-            <ul class="fd-menu__list">
+            <ul class="fd-menu__list fd-menu__list--no-shadow">
               <li class="fd-menu__item">
                 <a role="button" class="fd-menu__link">
                   <span class="fd-menu__title">Settings</span>
@@ -223,7 +223,7 @@ When a product has multiple links, the product links should collapse into an ove
             </div>
             <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right" aria-hidden="true" id="CWaGX278">
               <nav class="fd-menu">
-                <ul class="fd-menu__list">
+                <ul class="fd-menu__list fd-menu__list--no-shadow">
                   <li class="fd-menu__item">
                     <a role="button" class="fd-menu__link">
                       <span class="fd-menu__title">Search</span>
@@ -254,7 +254,7 @@ When a product has multiple links, the product links should collapse into an ove
           </div>
           <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right" aria-hidden="true" id="DD35G276">
             <nav class="fd-menu">
-              <ul class="fd-menu__list">
+              <ul class="fd-menu__list fd-menu__list--no-shadow">
                 <li class="fd-menu__item">
                   <a role="button" class="fd-menu__link">
                     <span class="fd-menu__title">Settings</span>
@@ -304,7 +304,7 @@ For more information about the Product Switch, see [Product Switch](product-swit
           </div>
           <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right" aria-hidden="true" id="MKFAY276">
             <nav class="fd-menu">
-              <ul class="fd-menu__list">
+              <ul class="fd-menu__list fd-menu__list--no-shadow">
                 <li class="fd-menu__item">
                   <a role="button" class="fd-menu__link">
                     <span class="fd-menu__title">Settings</span>

--- a/docs/pages/components/table.md
+++ b/docs/pages/components/table.md
@@ -358,8 +358,8 @@ a contextual menu can be substituted in order to display all actions in one menu
                         <button class="fd-button fd-button--transparent sap-icon--overflow" aria-controls="pQqQR213a" aria-haspopup="true" aria-expanded="false" aria-label="More"></button>
                     </div>
                     <div class="fd-popover__body fd-popover__body--no-arrow" aria-hidden="true" id="pQqQR213a">
-                        <nav class="fd-menu">
-                            <ul class="fd-menu__list">
+                        <nav class="fd-menu fd-menu--compact">
+                            <ul class="fd-menu__list fd-menu__list--no-shadow">
                                 <li class="fd-menu__item">
                                     <a href="#" class="fd-menu__link">
                                         <span class="fd-menu__title">Edit</span>
@@ -396,8 +396,8 @@ a contextual menu can be substituted in order to display all actions in one menu
                         <button class="fd-button fd-button--transparent sap-icon--overflow" aria-controls="lkjlkj23" aria-haspopup="true" aria-expanded="false" aria-label="More"></button>
                     </div>
                     <div class="fd-popover__body fd-popover__body--no-arrow" aria-hidden="true" id="lkjlkj23">
-                        <nav class="fd-menu">
-                            <ul class="fd-menu__list">
+                        <nav class="fd-menu fd-menu--compact">
+                            <ul class="fd-menu__list fd-menu__list--no-shadow">
                                 <li class="fd-menu__item">
                                     <a href="#" class="fd-menu__link">
                                         <span class="fd-menu__title">Edit</span>
@@ -434,8 +434,8 @@ a contextual menu can be substituted in order to display all actions in one menu
                         <button class="fd-button fd-button--transparent sap-icon--overflow" aria-controls="uu4324" aria-haspopup="true" aria-expanded="false" aria-label="More"></button>
                     </div>
                     <div class="fd-popover__body fd-popover__body--no-arrow" aria-hidden="true" id="uu4324">
-                        <nav class="fd-menu">
-                            <ul class="fd-menu__list">
+                        <nav class="fd-menu fd-menu--compact">
+                            <ul class="fd-menu__list fd-menu__list--no-shadow">
                                 <li class="fd-menu__item">
                                     <a href="#" class="fd-menu__link">
                                         <span class="fd-menu__title">Edit</span>
@@ -579,16 +579,25 @@ a contextual menu can be substituted in order to display all actions in one menu
                   <span class="fd-table__context-menu-label">Header Column</span>
                </div>
                <div class="fd-popover__body fd-popover__body--no-arrow"  aria-hidden="true" id="col1">
-                  <nav class="fd-menu fd-menu--addon-before">
-                     <ul class="fd-menu__list">
-                        <li><a href="#" class="fd-menu__item">Ascending</a>
-                        </li>
-                        <li><a href="#" class="fd-menu__item">Decensing</a>
-                        </li>
-                        <li><a href="#" class="fd-menu__item">Fix Column</a>
-                        </li>
-                     </ul>
-                  </nav>
+                   <div class="fd-menu fd-menu--compact">
+                       <ul class="fd-menu__list fd-menu__list--no-shadow">
+                           <li class="fd-menu__item">
+                               <div class="fd-menu__link">
+                                   <span class="fd-menu__title">Ascending</span>
+                               </div>
+                           </li>
+                           <li class="fd-menu__item">
+                               <div class="fd-menu__link">
+                                   <span class="fd-menu__title">Decensing</span>
+                               </div>
+                           </li>
+                           <li class="fd-menu__item">
+                               <div class="fd-menu__link">
+                                   <span class="fd-menu__title">Fix Column</span>
+                               </div>
+                           </li>
+                       </ul>
+                   </div>
                </div>
             </div>
          </th>
@@ -598,16 +607,25 @@ a contextual menu can be substituted in order to display all actions in one menu
                   <span class="fd-table__context-menu-label">Header Column</span>
                </div>
                <div class="fd-popover__body fd-popover__body--no-arrow"  aria-hidden="true" id="col2">
-                  <nav class="fd-menu fd-menu--addon-before">
-                     <ul class="fd-menu__list">
-                        <li><a href="#" class="fd-menu__item">Ascending</a>
-                        </li>
-                        <li><a href="#" class="fd-menu__item">Decensing</a>
-                        </li>
-                        <li><a href="#" class="fd-menu__item">Fix Column</a>
-                        </li>
+                  <div class="fd-menu fd-menu--compact">
+                     <ul class="fd-menu__list fd-menu__list--no-shadow">
+                         <li class="fd-menu__item">
+                             <div class="fd-menu__link">
+                                 <span class="fd-menu__title">Ascending</span>
+                             </div>
+                         </li>
+                         <li class="fd-menu__item">
+                             <div class="fd-menu__link">
+                                 <span class="fd-menu__title">Decensing</span>
+                             </div>
+                         </li>
+                         <li class="fd-menu__item">
+                             <div class="fd-menu__link">
+                                 <span class="fd-menu__title">Fix Column</span>
+                             </div>
+                         </li>
                      </ul>
-                  </nav>
+                 </div>
                </div>
             </div>
          </th>
@@ -617,16 +635,25 @@ a contextual menu can be substituted in order to display all actions in one menu
                   <span class="fd-table__context-menu-label">Header Column</span>
                </div>
                <div class="fd-popover__body fd-popover__body--no-arrow" aria-hidden="true" id="col3">
-                  <nav class="fd-menu fd-menu--addon-before">
-                     <ul class="fd-menu__list">
-                        <li><a href="#" class="fd-menu__item">Ascending</a>
-                        </li>
-                        <li><a href="#" class="fd-menu__item">Decensing</a>
-                        </li>
-                        <li><a href="#" class="fd-menu__item">Fix Column</a>
-                        </li>
-                     </ul>
-                  </nav>
+                    <div class="fd-menu fd-menu--compact">
+                       <ul class="fd-menu__list fd-menu__list--no-shadow">
+                           <li class="fd-menu__item">
+                               <div class="fd-menu__link">
+                                   <span class="fd-menu__title">Ascending</span>
+                               </div>
+                           </li>
+                           <li class="fd-menu__item">
+                               <div class="fd-menu__link">
+                                   <span class="fd-menu__title">Decensing</span>
+                               </div>
+                           </li>
+                           <li class="fd-menu__item">
+                               <div class="fd-menu__link">
+                                   <span class="fd-menu__title">Fix Column</span>
+                               </div>
+                           </li>
+                       </ul>
+                   </div>
                </div>
             </div>
          </th>
@@ -675,28 +702,26 @@ a contextual menu can be substituted in order to display all actions in one menu
                         <span class="fd-table__context-menu-label">Header Column</span>
                      </div>
                      <div class="fd-popover__body fd-popover__body--no-arrow" aria-hidden="true" id="col1.2">
-                        <nav class="fd-menu fd-menu--addon-before">
-                           <ul class="fd-menu__list">
-                              <li>
-                                 <a href="#" class="fd-menu__item">
-                                    <span class="fd-menu__addon-before"></span>
-                                    Ascending
-                                 </a>
-                              </li>
-                              <li>
-                                 <a href="#" class="fd-menu__item">
-                                    <span class="fd-menu__addon-before"></span>
-                                    Decensing
-                                 </a>
-                              </li>
-                              <li>
-                                 <a href="#" class="fd-menu__item">
-                                    <span class="fd-menu__addon-before sap-icon--accept"></span>
-                                    Fix Column
-                                 </a>
-                              </li>
+                        <div class="fd-menu fd-menu--compact">
+                           <ul class="fd-menu__list fd-menu__list--no-shadow">
+                               <li class="fd-menu__item">
+                                   <div class="fd-menu__link is-active">
+                                        <span class="fd-menu__addon-before sap-icon--accept"></span>
+                                       <span class="fd-menu__title">Ascending</span>
+                                   </div>
+                               </li>
+                               <li class="fd-menu__item">
+                                   <div class="fd-menu__link">
+                                       <span class="fd-menu__title">Decensing</span>
+                                   </div>
+                               </li>
+                               <li class="fd-menu__item">
+                                   <div class="fd-menu__link">
+                                       <span class="fd-menu__title">Fix Column</span>
+                                   </div>
+                               </li>
                            </ul>
-                        </nav>
+                       </div>
                      </div>
                   </div>
                </th>
@@ -706,13 +731,25 @@ a contextual menu can be substituted in order to display all actions in one menu
                         <span class="fd-table__context-menu-label">Header Column</span>
                      </div>
                      <div class="fd-popover__body fd-popover__body--no-arrow" aria-hidden="true" id="col2.2">
-                        <nav class="fd-menu fd-menu--addon-before">
-                           <ul class="fd-menu__list">
-                              <li><a href="#" class="fd-menu__item">Ascending</a></li>
-                              <li><a href="#" class="fd-menu__item">Decensing</a></li>
-                              <li><a href="#" class="fd-menu__item">Fix Column</a></li>
+                        <div class="fd-menu fd-menu--compact">
+                           <ul class="fd-menu__list fd-menu__list--no-shadow">
+                               <li class="fd-menu__item">
+                                   <div class="fd-menu__link">
+                                       <span class="fd-menu__title">Ascending</span>
+                                   </div>
+                               </li>
+                               <li class="fd-menu__item">
+                                   <div class="fd-menu__link">
+                                       <span class="fd-menu__title">Decensing</span>
+                                   </div>
+                               </li>
+                               <li class="fd-menu__item">
+                                   <div class="fd-menu__link">
+                                       <span class="fd-menu__title">Fix Column</span>
+                                   </div>
+                               </li>
                            </ul>
-                        </nav>
+                       </div>
                      </div>
                   </div>
                </th>
@@ -722,14 +759,26 @@ a contextual menu can be substituted in order to display all actions in one menu
                         <span class="fd-table__context-menu-label">Header Column</span>
                      </div>
                      <div class="fd-popover__body fd-popover__body--no-arrow" aria-hidden="true" id="col3.2">
-                        <nav class="fd-menu fd-menu--addon-before">
-                           <ul class="fd-menu__list">
-                              <li><a href="#" class="fd-menu__item">Ascending</a></li>
-                              <li><a href="#" class="fd-menu__item">Decensing</a></li>
-                              <li><a href="#" class="fd-menu__item">Fix Column</a></li>
+                        <div class="fd-menu fd-menu--compact">
+                           <ul class="fd-menu__list fd-menu__list--no-shadow">
+                               <li class="fd-menu__item">
+                                   <div class="fd-menu__link">
+                                       <span class="fd-menu__title">Ascending</span>
+                                   </div>
+                               </li>
+                               <li class="fd-menu__item">
+                                   <div class="fd-menu__link">
+                                       <span class="fd-menu__title">Decensing</span>
+                                   </div>
+                               </li>
+                               <li class="fd-menu__item">
+                                   <div class="fd-menu__link">
+                                       <span class="fd-menu__title">Fix Column</span>
+                                   </div>
+                               </li>
                            </ul>
-                        </nav>
-                     </div>
+                       </div>
+                    </div>
                   </div>
                </th>
                <th class="fd-table__cell fd-table__context-menu" aria-controls="col4.2" aria-haspopup="true" scope="col">
@@ -738,13 +787,25 @@ a contextual menu can be substituted in order to display all actions in one menu
                         <span class="fd-table__context-menu-label">Header Column</span>
                      </div>
                      <div class="fd-popover__body fd-popover__body--no-arrow" aria-hidden="true" id="col4.2">
-                        <nav class="fd-menu fd-menu--addon-before">
-                           <ul class="fd-menu__list">
-                              <li><a href="#" class="fd-menu__item">Ascending</a></li>
-                              <li><a href="#" class="fd-menu__item">Decensing</a></li>
-                              <li><a href="#" class="fd-menu__item">Fix Column</a></li>
+                        <div class="fd-menu fd-menu--compact">
+                           <ul class="fd-menu__list fd-menu__list--no-shadow">
+                               <li class="fd-menu__item">
+                                   <div class="fd-menu__link">
+                                       <span class="fd-menu__title">Ascending</span>
+                                   </div>
+                               </li>
+                               <li class="fd-menu__item">
+                                   <div class="fd-menu__link">
+                                       <span class="fd-menu__title">Decensing</span>
+                                   </div>
+                               </li>
+                               <li class="fd-menu__item">
+                                   <div class="fd-menu__link">
+                                       <span class="fd-menu__title">Fix Column</span>
+                                   </div>
+                               </li>
                            </ul>
-                        </nav>
+                       </div>
                      </div>
                   </div>
                </th>
@@ -754,13 +815,25 @@ a contextual menu can be substituted in order to display all actions in one menu
                         <span class="fd-table__context-menu-label">Header Column</span>
                      </div>
                      <div class="fd-popover__body fd-popover__body--no-arrow" aria-hidden="true" id="col5.2">
-                        <nav class="fd-menu fd-menu--addon-before">
-                           <ul class="fd-menu__list">
-                              <li><a href="#" class="fd-menu__item">Ascending</a></li>
-                              <li><a href="#" class="fd-menu__item">Decensing</a></li>
-                              <li><a href="#" class="fd-menu__item">Fix Column</a></li>
+                        <div class="fd-menu fd-menu--compact">
+                           <ul class="fd-menu__list fd-menu__list--no-shadow">
+                               <li class="fd-menu__item">
+                                   <div class="fd-menu__link">
+                                       <span class="fd-menu__title">Ascending</span>
+                                   </div>
+                               </li>
+                               <li class="fd-menu__item">
+                                   <div class="fd-menu__link">
+                                       <span class="fd-menu__title">Decensing</span>
+                                   </div>
+                               </li>
+                               <li class="fd-menu__item">
+                                   <div class="fd-menu__link">
+                                       <span class="fd-menu__title">Fix Column</span>
+                                   </div>
+                               </li>
                            </ul>
-                        </nav>
+                       </div>
                      </div>
                   </div>
                </th>
@@ -770,13 +843,25 @@ a contextual menu can be substituted in order to display all actions in one menu
                         <span class="fd-table__context-menu-label">Header Column</span>
                      </div>
                      <div class="fd-popover__body fd-popover__body--no-arrow" aria-hidden="true" id="col6.2">
-                        <nav class="fd-menu fd-menu--addon-before">
-                           <ul class="fd-menu__list">
-                              <li><a href="#" class="fd-menu__item">Ascending</a></li>
-                              <li><a href="#" class="fd-menu__item">Decensing</a></li>
-                              <li><a href="#" class="fd-menu__item">Fix Column</a></li>
+                        <div class="fd-menu fd-menu--compact">
+                           <ul class="fd-menu__list fd-menu__list--no-shadow">
+                               <li class="fd-menu__item">
+                                   <div class="fd-menu__link">
+                                       <span class="fd-menu__title">Ascending</span>
+                                   </div>
+                               </li>
+                               <li class="fd-menu__item">
+                                   <div class="fd-menu__link">
+                                       <span class="fd-menu__title">Decensing</span>
+                                   </div>
+                               </li>
+                               <li class="fd-menu__item">
+                                   <div class="fd-menu__link">
+                                       <span class="fd-menu__title">Fix Column</span>
+                                   </div>
+                               </li>
                            </ul>
-                        </nav>
+                       </div>
                      </div>
                   </div>
                </th>
@@ -786,13 +871,25 @@ a contextual menu can be substituted in order to display all actions in one menu
                         <span class="fd-table__context-menu-label">Header Column</span>
                      </div>
                      <div class="fd-popover__body fd-popover__body--no-arrow" aria-hidden="true" id="col7.2">
-                        <nav class="fd-menu fd-menu--addon-before">
-                           <ul class="fd-menu__list">
-                              <li><a href="#" class="fd-menu__item">Ascending</a></li>
-                              <li><a href="#" class="fd-menu__item">Decensing</a></li>
-                              <li><a href="#" class="fd-menu__item">Fix Column</a></li>
+                        <div class="fd-menu fd-menu--compact">
+                           <ul class="fd-menu__list fd-menu__list--no-shadow">
+                               <li class="fd-menu__item">
+                                   <div class="fd-menu__link">
+                                       <span class="fd-menu__title">Ascending</span>
+                                   </div>
+                               </li>
+                               <li class="fd-menu__item">
+                                   <div class="fd-menu__link">
+                                       <span class="fd-menu__title">Decensing</span>
+                                   </div>
+                               </li>
+                               <li class="fd-menu__item">
+                                   <div class="fd-menu__link">
+                                       <span class="fd-menu__title">Fix Column</span>
+                                   </div>
+                               </li>
                            </ul>
-                        </nav>
+                       </div>
                      </div>
                   </div>
                </th>
@@ -802,13 +899,25 @@ a contextual menu can be substituted in order to display all actions in one menu
                         <span class="fd-table__context-menu-label">Header Column</span>
                      </div>
                      <div class="fd-popover__body fd-popover__body--no-arrow" aria-hidden="true" id="col8.2">
-                        <nav class="fd-menu fd-menu--addon-before">
-                           <ul class="fd-menu__list">
-                              <li><a href="#" class="fd-menu__item">Ascending</a></li>
-                              <li><a href="#" class="fd-menu__item">Decensing</a></li>
-                              <li><a href="#" class="fd-menu__item">Fix Column</a></li>
+                        <div class="fd-menu fd-menu--compact">
+                           <ul class="fd-menu__list fd-menu__list--no-shadow">
+                               <li class="fd-menu__item">
+                                   <div class="fd-menu__link">
+                                       <span class="fd-menu__title">Ascending</span>
+                                   </div>
+                               </li>
+                               <li class="fd-menu__item">
+                                   <div class="fd-menu__link">
+                                       <span class="fd-menu__title">Decensing</span>
+                                   </div>
+                               </li>
+                               <li class="fd-menu__item">
+                                   <div class="fd-menu__link">
+                                       <span class="fd-menu__title">Fix Column</span>
+                                   </div>
+                               </li>
                            </ul>
-                        </nav>
+                       </div>
                      </div>
                   </div>
                </th>

--- a/docs/pages/components/tile.md
+++ b/docs/pages/components/tile.md
@@ -94,7 +94,7 @@ The component is ideal for displaying collection data when a grid or list layout
             </div>
             <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow" aria-hidden="true" id="WQIDD179">
                 <nav class="fd-menu" id="">
-                    <ul class="fd-menu__list">
+                    <ul class="fd-menu__list fd-menu__list--no-shadow">
                         <li class="fd-menu__item">
                             <a href="#" class="fd-menu__link">
                                 <span class="fd-menu__title">Option 1</span>

--- a/docs/pages/components/tree.md
+++ b/docs/pages/components/tree.md
@@ -63,7 +63,7 @@ Items that contain additional items are called nodes, while items that do not co
                     </div>
                     <div class="fd-popover__body fd-popover__body--right" aria-hidden="true" id="j2lk3j">
                         <nav class="fd-menu">
-                            <ul class="fd-menu__list">
+                            <ul class="fd-menu__list fd-menu__list--no-shadow">
                                 <li class="fd-menu__item">
                                     <a href="#" class="fd-menu__link">
                                         <span class="fd-menu__title">Edit</span>
@@ -116,7 +116,7 @@ Items that contain additional items are called nodes, while items that do not co
                             </div>
                             <div class="fd-popover__body fd-popover__body--right" aria-hidden="true" id="lklkj3">
                                 <nav class="fd-menu">
-                                    <ul class="fd-menu__list">
+                                    <ul class="fd-menu__list fd-menu__list--no-shadow">
                                         <li class="fd-menu__item">
                                             <a href="#" class="fd-menu__link">
                                                 <span class="fd-menu__title">Edit</span>
@@ -169,7 +169,7 @@ Items that contain additional items are called nodes, while items that do not co
                                     </div>
                                     <div class="fd-popover__body fd-popover__body--right" aria-hidden="true" id="asofjh3">
                                         <nav class="fd-menu">
-                                            <ul class="fd-menu__list">
+                                            <ul class="fd-menu__list fd-menu__list--no-shadow">
                                                 <li class="fd-menu__item">
                                                     <a href="#" class="fd-menu__link">
                                                         <span class="fd-menu__title">Edit</span>
@@ -221,7 +221,7 @@ Items that contain additional items are called nodes, while items that do not co
                                             </div>
                                             <div class="fd-popover__body fd-popover__body--right" aria-hidden="true" id="iouh3">
                                                 <nav class="fd-menu">
-                                                    <ul class="fd-menu__list">
+                                                    <ul class="fd-menu__list fd-menu__list--no-shadow">
                                                         <li class="fd-menu__item">
                                                             <a href="#" class="fd-menu__link">
                                                                 <span class="fd-menu__title">Edit</span>
@@ -276,7 +276,7 @@ Items that contain additional items are called nodes, while items that do not co
                             </div>
                             <div class="fd-popover__body fd-popover__body--right" aria-hidden="true" id="jk3333">
                                 <nav class="fd-menu">
-                                    <ul class="fd-menu__list">
+                                    <ul class="fd-menu__list fd-menu__list--no-shadow">
                                         <li class="fd-menu__item">
                                             <a href="#" class="fd-menu__link">
                                                 <span class="fd-menu__title">Edit</span>
@@ -331,7 +331,7 @@ Items that contain additional items are called nodes, while items that do not co
                     </div>
                     <div class="fd-popover__body fd-popover__body--right" aria-hidden="true" id="asdhjb3">
                         <nav class="fd-menu">
-                            <ul class="fd-menu__list">
+                            <ul class="fd-menu__list fd-menu__list--no-shadow">
                                 <li class="fd-menu__item">
                                     <a href="#" class="fd-menu__link">
                                         <span class="fd-menu__title">Edit</span>
@@ -382,7 +382,7 @@ Items that contain additional items are called nodes, while items that do not co
                             </div>
                             <div class="fd-popover__body fd-popover__body--right" aria-hidden="true" id="hkjhkjh3">
                                 <nav class="fd-menu">
-                                    <ul class="fd-menu__list">
+                                    <ul class="fd-menu__list fd-menu__list--no-shadow">
                                         <li class="fd-menu__item">
                                             <a href="#" class="fd-menu__link">
                                                 <span class="fd-menu__title">Edit</span>
@@ -435,7 +435,7 @@ Items that contain additional items are called nodes, while items that do not co
                     </div>
                     <div class="fd-popover__body fd-popover__body--right" aria-hidden="true" id="ggiuhwer">
                         <nav class="fd-menu">
-                            <ul class="fd-menu__list">
+                            <ul class="fd-menu__list fd-menu__list--no-shadow">
                                 <li class="fd-menu__item">
                                     <a href="#" class="fd-menu__link">
                                         <span class="fd-menu__title">Edit</span>

--- a/docs/pages/patterns/contextual-menu.md
+++ b/docs/pages/patterns/contextual-menu.md
@@ -31,7 +31,7 @@ Implementation Guidelines:
     </div>
     <div class="fd-popover__body" aria-hidden="true" id="pQqQR213">
         <nav class="fd-menu">
-            <ul class="fd-menu__list">
+            <ul class="fd-menu__list fd-menu__list--no-shadow">
                 <li class="fd-menu__item">
                     <a href="#" class="fd-menu__link">
                         <span class="fd-menu__title">Option 1</span>
@@ -65,7 +65,7 @@ Implementation Guidelines:
     </div>
     <div class="fd-popover__body" aria-hidden="true" id="jhqD0558">
         <nav class="fd-menu">
-            <ul class="fd-menu__list">
+            <ul class="fd-menu__list fd-menu__list--no-shadow">
                 <li class="fd-menu__item">
                     <a href="#" class="fd-menu__link">
                         <span class="fd-menu__title">Option 1</span>

--- a/docs/pages/patterns/multi-input.md
+++ b/docs/pages/patterns/multi-input.md
@@ -445,7 +445,7 @@ This can also be done by using the `.is-readonly` class or `aria-readonly="true"
                             </div>
                             <div class="fd-popover__body" aria-hidden="true" id="F4GF5348a">
                                 <nav class="fd-menu" id="">
-                                    <ul class="fd-menu__list">
+                                    <ul class="fd-menu__list fd-menu__list--no-shadow">
                                         <li class="fd-menu__item">
                                             <a href="#" class="fd-menu__link">
                                                 <span class="fd-menu__title">Option 1</span>
@@ -516,7 +516,7 @@ The disabled state can also be achieved by adding the `.is-disabled` class or th
                             </div>
                             <div class="fd-popover__body" aria-hidden="true" id="F4GcX34Xa">
                                 <nav class="fd-menu" id="">
-                                    <ul class="fd-menu__list">
+                                    <ul class="fd-menu__list fd-menu__list--no-shadow">
                                         <li class="fd-menu__item">
                                             <a href="#" class="fd-menu__link">
                                                 <span class="fd-menu__title">Option 1</span>

--- a/docs/pages/patterns/search-input.md
+++ b/docs/pages/patterns/search-input.md
@@ -29,7 +29,7 @@ The search input component is an opinionated composition of the `input group`, `
         </div>
         <div class="fd-popover__body fd-popover__body--no-arrow" aria-hidden="true" id="F4GcX348bc">
             <nav class="fd-menu fd-menu--full-width">
-                <ul class="fd-menu__list">
+                <ul class="fd-menu__list fd-menu__list--no-shadow">
                     <li class="fd-menu__item">
                         <a href="#" class="fd-menu__link">
                             <span class="fd-menu__title"><strong>Ba</strong>nana</span>
@@ -67,7 +67,7 @@ The search input component is an opinionated composition of the `input group`, `
         </div>
         <div class="fd-popover__body fd-popover__body--no-arrow" aria-hidden="true" id="F4GcX34b">
             <nav class="fd-menu fd-menu--compact">
-                <ul class="fd-menu__list">
+                <ul class="fd-menu__list fd-menu__list--no-shadow">
                     <li class="fd-menu__item">
                         <a href="#" class="fd-menu__link">
                             <span class="fd-menu__title"><strong>Ba</strong>nana</span>


### PR DESCRIPTION
In the aftermath of: #855

## Description
New Menu implementation brings by default menu box-shadow. Examples using menu within popover need to be modified to prevent using double box shadows coming separately from Menu and Popover.

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/17496353/80368696-6ab16b80-888d-11ea-8b01-b777c32f4b30.png)

### After
![image](https://user-images.githubusercontent.com/17496353/80368613-48b7e900-888d-11ea-86c9-e6cf437036fb.png)

- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes)