### PR TITLE
fix: active state of list item for combobox

### DIFF
--- a/docs/pages/components/select.md
+++ b/docs/pages/components/select.md
@@ -32,16 +32,18 @@ For lists that require more than 12 options, the <a href="/patterns/combobox-inp
   <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown" aria-hidden="true" id="h0C6A325">
      <ul class="fd-list fd-list--dropdown" role="listbox">
         <li class="fd-list__item is-selected" role="option" tabindex="0">
-           <span class="fd-list__title">List item 1</span>
+            <span class="fd-list__icon sap-icon--history"></span>
+           <span class="fd-list__title">Selected List item 1</span>
         </li>
         <li class="fd-list__item" role="option" tabindex="0">
-           <span class="fd-list__title">List item 2</span>
+          <span class="fd-list__icon sap-icon--history"></span>
+          <span class="fd-list__title">List item 2</span>
        </li>
         <li class="fd-list__item" role="option" tabindex="0">
            <span class="fd-list__title">List item 3</span>
         </li>
-        <li class="fd-list__item" role="option" tabindex="0">
-           <span class="fd-list__title">List item 4</span>
+        <li class="fd-list__item" role="option" tabindex="0" disabled>
+           <span class="fd-list__title">Disabled List item 4</span>
         </li>
      </ul>
   </div>

--- a/docs/pages/patterns/combobox-input.md
+++ b/docs/pages/patterns/combobox-input.md
@@ -34,8 +34,8 @@ If the entries are not validated by the application, users can also enter custom
       </div>
   </div>
   <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown fd-popover__body--dropdown-fill" aria-hidden="true" id="F4GcX348">
-        <ul class="fd-list fd-list--dropdown" role="listbox">
-            <li role="option" tabindex="0" class="fd-list__item is-selected">
+        <ul class="fd-list fd-list--interactive fd-list--dropdown" role="listbox">
+            <li role="option" tabindex="0" class="fd-list__item fd-list__item--interactive is-selected">
                 <span class="fd-list__title">
                     <span class="fd-list__bold">App</span>le
                 </span>
@@ -70,7 +70,7 @@ If the entries are not validated by the application, users can also enter custom
         </div>
     </div>
   <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown fd-popover__body--dropdown-fill" aria-hidden="true" id="F4GcX34">
-        <ul class="fd-list fd-list--dropdown fd-list--compact" role="listbox">
+        <ul class="fd-list fd-list--dropdown fd-list--interactive fd-list--compact" role="listbox">
             <li role="option" tabindex="0" class="fd-list__item is-selected">
                 <span class="fd-list__title">
                     <span class="fd-list__bold">App</span>le
@@ -105,7 +105,7 @@ The `ComboBox` component can be customized by adding additional information in a
       </div>
   </div>
   <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown fd-popover__body--dropdown-fill" aria-hidden="true" id="F4GRTGLK6">
-        <ul class="fd-list fd-list--dropdown" role="listbox">
+        <ul class="fd-list fd-list--dropdown fd-list--interactive" role="listbox">
            <li class="fd-list__item is-selected" role="option" tabindex="0">
                <span class="fd-list__title">Product 1</span>
                <span class="fd-list__secondary">1000 EUR</span>
@@ -142,7 +142,7 @@ In cases where the list items need to be categorized into groups, it is possible
       </div>
   </div>
   <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown fd-popover__body--dropdown-fill" aria-hidden="true" id="F4GcXLK6">
-        <ul class="fd-list fd-list--dropdown" role="listbox">
+        <ul class="fd-list fd-list--dropdown fd-list--interactive" role="listbox">
             <li class="fd-list__group-header">
                 Fruits
             </li>
@@ -198,7 +198,7 @@ In the example you can see how the `Combobox` component looks without the `fd-po
       </div>
   </div>
   <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown" aria-hidden="true" id="F4HTFDLK6">
-        <ul class="fd-list fd-list--dropdown" role="listbox">
+        <ul class="fd-list fd-list--dropdown fd-list--interactive" role="listbox">
             <li role="option" tabindex="0" class="fd-list__item is-selected">
                 <span class="fd-list__title">Apple</span>
             </li>
@@ -271,7 +271,7 @@ To add text in the `body` of the component, simply include your text in the `fd-
             </div>
         </div>
   <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown fd-popover__body--dropdown-fill" aria-hidden="true" id="F4GcEX34">
-        <ul class="fd-list fd-list--has-message fd-list--dropdown fd-list--compact" role="listbox">
+        <ul class="fd-list fd-list--has-message fd-list--dropdown fd-list--compact fd-list--interactive" role="listbox">
             <li class="fd-list__message fd-list__message--success">Success message</li>
             <li role="option" tabindex="0" class="fd-list__item is-selected">
                 <span class="fd-list__title">

--- a/src/list.scss
+++ b/src/list.scss
@@ -383,6 +383,56 @@ $semantic-color: (
     .#{$block}__item {
       height: auto;
       padding: $fd-dropdown-vertical-padding $fd-list-item-padding-x;
+
+      @include fd-disabled() {
+        pointer-events: none;
+        opacity: 0.5;
+      }
+
+      @include fd-selected() {
+        border-bottom-color: var(--sapSelectedColor);
+        background-color: var(--sapList_SelectionBackgroundColor);
+        cursor: grabbing;
+
+        .#{$block}__title,
+        .#{$block}__subtitle,
+        .#{$block}__secondary {
+          color: var(--sapList_TextColor);
+        }
+
+        .#{$block}__icon {
+          color: var(--sapList_TextColor);
+        }
+
+        &:hover {
+          border-bottom-color: var(--sapSelectedColor);
+          background-color: var(--sapList_Hover_SelectionBackground);
+        }
+      }
+
+      &:hover {
+        background-color: var(--sapList_Hover_Background);
+        cursor: grabbing;
+      }
+
+      &:active {
+        background: var(--sapList_Active_Background);
+        cursor: grabbing;
+
+        &::before {
+          border: none;
+        }
+
+        .#{$block}__title,
+        .#{$block}__subtitle,
+        .#{$block}__secondary {
+          color: var(--sapContent_ContrastTextColor);
+        }
+
+        .#{$block}__icon {
+          color: var(--sapContent_ContrastIconColor);
+        }
+      }
     }
 
     &.#{$block}--compact {
@@ -907,22 +957,6 @@ $semantic-color: (
     // NAVIGATION + BYLINE + SELECTION + NAVIGATION INDICATION + Borderless
     &.#{$block}--byline.#{$block}--selection.#{$block}--navigation-indication.#{$block}--no-border {
       @include navigation-byline-borderless();
-    }
-  }
-
-  &--interactive {
-    > * {
-      &:active {
-        background: var(--sapList_Active_Background);
-
-        &::before {
-          border: none;
-        }
-
-        .#{$block}__title, .#{$block}__subtitle {
-          color: var(--sapContent_ContrastTextColor);
-        }
-      }
     }
   }
 }

--- a/src/list.scss
+++ b/src/list.scss
@@ -392,7 +392,7 @@ $semantic-color: (
       @include fd-selected() {
         border-bottom-color: var(--sapSelectedColor);
         background-color: var(--sapList_SelectionBackgroundColor);
-        cursor: grabbing;
+        cursor: grab;
 
         .#{$block}__title,
         .#{$block}__subtitle,
@@ -404,6 +404,14 @@ $semantic-color: (
           color: var(--sapList_TextColor);
         }
 
+        &:active {
+          background: var(--sapList_Active_Background);
+
+          &:hover {
+            background: var(--sapList_Active_Background);
+          }
+        }
+
         &:hover {
           border-bottom-color: var(--sapSelectedColor);
           background-color: var(--sapList_Hover_SelectionBackground);
@@ -412,12 +420,12 @@ $semantic-color: (
 
       &:hover {
         background-color: var(--sapList_Hover_Background);
-        cursor: grabbing;
+        cursor: grab;
       }
 
       &:active {
         background: var(--sapList_Active_Background);
-        cursor: grabbing;
+        cursor: grab;
 
         &::before {
           border: none;

--- a/src/list.scss
+++ b/src/list.scss
@@ -909,4 +909,20 @@ $semantic-color: (
       @include navigation-byline-borderless();
     }
   }
+
+  &--interactive {
+    > * {
+      &:active {
+        background: var(--sapList_Active_Background);
+
+        &::before {
+          border: none;
+        }
+
+        .#{$block}__title, .#{$block}__subtitle {
+          color: var(--sapContent_ContrastTextColor);
+        }
+      }
+    }
+  }
 }

--- a/src/mixins/_states.scss
+++ b/src/mixins/_states.scss
@@ -13,6 +13,7 @@
 @mixin fd-disabled {
   &[aria-disabled="true"],
   &.is-disabled,
+  &[disabled],
   &:disabled {
     @content;
   }


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#924

## Description
This Pr will change the background color and the text color of the active state for the list item for combobox. It will not become the appropriate fiori 3 theming color. There is no focus outline as shown in the specs for these items. This example is for combobox but I would keep it under the list styling for future possible purposes

## Screenshots
### Before:
<img width="214" alt="Screen Shot 2020-04-30 at 4 19 38 PM" src="https://user-images.githubusercontent.com/50607147/80757243-d0a62900-8b01-11ea-9e0a-016f2901d020.png">


### After:
<img width="215" alt="Screen Shot 2020-04-30 at 4 21 06 PM" src="https://user-images.githubusercontent.com/50607147/80757225-cbe17500-8b01-11ea-8f65-671033ba59b6.png">
