### PR TITLE
fix: debug standard version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## [0.9.0-rc.15](https://github.com/SAP/fundamental-styles/compare/v0.9.0-rc.14...v0.9.0-rc.15) (2020-04-30)
-
 <a name="0.9.0-rc.14"></a>
 # [0.9.0-rc.14](https://github.com/SAP/fundamental-styles/compare/v0.9.0-rc.13...v0.9.0-rc.14) (2020-04-30)
 

--- a/ci-scripts/publish.sh
+++ b/ci-scripts/publish.sh
@@ -11,15 +11,6 @@ git push "https://$GH_TOKEN@github.com/$TRAVIS_REPO_SLUG" ":$TRAVIS_BRANCH" > /d
 std_ver=$(npm run std-version)
 release_tag=$(echo "$std_ver" | grep "tagging release" | awk '{print $4}')
 
-if  [[ $release_tag == v* ]]; then
-  echo ""
-else
-  release_tag="v$release_tag"
-fi
-
-echo "$std_ver"
-echo "$release_tag"
-
 git push --follow-tags "https://$GH_TOKEN@github.com/$TRAVIS_REPO_SLUG" master > /dev/null 2>&1;
 
 # build dist and component folders


### PR DESCRIPTION
After upgrading standard-verison, only the changelog was updated in the first commit:

https://github.com/SAP/fundamental-styles/commit/6b4cc32fca9e7484205b3fff01defce8513a952b

This caused subsequent builds to fail. This is working fine in fundamental-react, so hopefully it was just a one off. 

It also works if you run the standard-version npm command with `--dry-run` enabled.