### PR TITLE
docs: hide Selection List and List with Byline from documentation page

### DIFF
--- a/docs/pages/components/list.md
+++ b/docs/pages/components/list.md
@@ -288,7 +288,7 @@ If only a subset of the list items are navigable you should indicate those by di
 
 {% include display-component.html component=list-without-borders %}
 
-## Selection
+<!-- ## Selection
 {% capture list-selection %}
 <ul class="fd-list fd-list--selection" role="listbox">
   <li role="listitem" tabindex="0" class="fd-list__item">
@@ -464,9 +464,9 @@ If only a subset of the list items are navigable you should indicate those by di
 {% endcapture %}
 
 {% include display-component.html component=list-selection %}
+-->
 
-
-## Standard List with Byline
+<!-- ## Standard List with Byline
 Add the `fd-list--byline` modifier class for a Standard List with Byline (description).
 For a two-column byline you need to add the `fd-list__byline--2-col` modifier class to the element. The first text item (`fd-list__byline-left`) is a standard text (description) and takes 60% of the available space. The second text item (`fd-list__byline-right`) could be a standard text or semantic (status) and takes the remaining 40% of the available space. For semantic (status) use a modifier class (`fd-list__byline-right--* `) to represent `neutral`, `positive`, `critical`, `negative` and `informative` status.
 
@@ -1239,4 +1239,4 @@ style="background-image: url('https://placeimg.com/400/400/nature');"></span>
   </li>
 </ul>
 {% endcapture %}
-{% include display-component.html component=list-byline-selection-navigation-indication %}
+{% include display-component.html component=list-byline-selection-navigation-indication %} -->


### PR DESCRIPTION
Hiding the Selection List and List with Byline from documentation page in order to test the markup in NGX