### PR TITLE
docs: removed empty th

### DIFF
--- a/docs/pages/patterns/date-picker.md
+++ b/docs/pages/patterns/date-picker.md
@@ -51,7 +51,6 @@ This component mostly relies on the CSS of other components and has very little 
 						<table class="fd-calendar__table" role="grid">
 						<thead class="fd-calendar__group">
 					        <tr class="fd-calendar__row">
-                                <th class="fd-calendar__item fd-calendar__item--side-helper"></th>
                                 <th class="fd-calendar__item fd-calendar__item--side-helper">
                                     <span class="fd-calendar__text" role="button">S</span>
                                 </th>
@@ -235,7 +234,6 @@ This component mostly relies on the CSS of other components and has very little 
 						<table class="fd-calendar__table" role="grid">
 	                    <thead class="fd-calendar__group">
 					        <tr class="fd-calendar__row">
-                                <th class="fd-calendar__item fd-calendar__item--side-helper"></th>
                                 <th class="fd-calendar__item fd-calendar__item--side-helper">
                                     <span class="fd-calendar__text" role="button">S</span>
                                 </th>


### PR DESCRIPTION
## Related Issue
Related to #938

## Description
Pr removes empty th from datepicker

## Screenshots
### Before:
![Screen Shot 2020-05-04 at 10 11 19 PM](https://user-images.githubusercontent.com/4380815/81029809-586a9b00-8e54-11ea-98af-aeaafd4f1c4f.png)

### After:
![image](https://user-images.githubusercontent.com/10849982/81062219-e2a71380-8ed5-11ea-96df-9aa483a2de47.png)
