### PR TITLE
fix: remove border on last child of list

### DIFF
--- a/src/list.scss
+++ b/src/list.scss
@@ -202,6 +202,10 @@ $semantic-color: (
   list-style: none;
   width: 100%;
 
+  :last-child {
+    border-bottom: none;
+  }
+
   &__item,
   &__group-header,
   &__footer {


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#960

## Description
This PR will remove the bottom border on the last element of the list. When looking at fiori 3 they do not have one
## Screenshots
### Before:
![Screen Shot 2020-05-05 at 9 09 28 AM](https://user-images.githubusercontent.com/50607147/81069664-30108a00-8eb0-11ea-8294-88acc7fe08a4.png)

### After:
![Screen Shot 2020-05-05 at 9 09 34 AM](https://user-images.githubusercontent.com/50607147/81069676-343ca780-8eb0-11ea-84c9-dc8bc53a2363.png)


> I am not ok with this fix. Need confirmation from the designers.

@InnaAtanasova 
I agree i will put it as blocked for now