### PR TITLE
chore: improve travis build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,12 @@ jobs:
   - stage: Lint, Test and Size
     script:
       - docker pull backstopjs/backstopjs:3.9.2
-      - npm run build:prod
-      - npm run lint
       - npm run test:ci-config
       - npm run test
-      - npm run size
+  -
+    script: npm run lint
+  -
+    script: npm run build:prod && npm run size
   - stage: Pre-release
     if: branch = master
     before_deploy:


### PR DESCRIPTION
This run the test, lint and size commands in different containers:

![Screen Shot 2020-05-05 at 6 42 29 AM](https://user-images.githubusercontent.com/29607818/81072973-cf775200-8e9b-11ea-8348-8022cc563e29.png)


They can run concurrently if builds are available.
