### PR TITLE
fix: remove x for IE in input

### DIFF
--- a/src/input.scss
+++ b/src/input.scss
@@ -19,6 +19,10 @@ $block: #{$fd-namespace}-input;
   cursor: text;
   overflow: hidden;
 
+  &::-ms-clear {
+    display: none;
+  }
+
   &[aria-expanded="false"] {
     z-index: 0;
   }


### PR DESCRIPTION
## Related Issue
https://github.com/SAP/fundamental-styles/issues/938
## Description
Removes the x for search inputs in IE on focus
## Screenshots
### Before:
![image](https://user-images.githubusercontent.com/50607147/81078235-f5acea00-8ebb-11ea-8633-8a1b7580ef70.png)


### After:
![Screen Shot 2020-05-05 at 10 33 58 AM](https://user-images.githubusercontent.com/50607147/81078248-f8a7da80-8ebb-11ea-8808-856147606b55.png)
