### PR TITLE
fix: IE11 popover list overflow fix

### DIFF
--- a/src/list.scss
+++ b/src/list.scss
@@ -276,6 +276,10 @@ $semantic-color: (
   &__title {
     flex: 3 3 10%;
     font-size: $fd-list-large-font-size;
+
+    &:last-child:first-child {
+      flex-basis: auto;
+    }
   }
 
   &__secondary {


### PR DESCRIPTION
## Related Issue
Relates: https://github.com/SAP/fundamental-styles/issues/938

## Description
There is added `flex-basis: auto` for alone titles. other percentage values for `flex-basis` are not well seen by IE11

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/26483208/81081303-06785280-8ef2-11ea-8538-6eb865a62b3c.png)


### After:
![image](https://user-images.githubusercontent.com/26483208/81081279-011b0800-8ef2-11ea-84fb-35f7c27d08a4.png)
