### PR TITLE
fix: Fix product switch mobile mode on ie11

### DIFF
--- a/src/product-switch.scss
+++ b/src/product-switch.scss
@@ -273,6 +273,7 @@ $block: #{$fd-namespace}-product-switch;
       border-radius: 0;
       border: none;
       border-bottom: 0.0625rem solid;
+      flex: auto;
       border-bottom-color: var(--sapList_GroupHeaderBorderColor);
 
       @include fd-product-pseudo-element-background(var(--sapTile_Background));


### PR DESCRIPTION
## Related Issue
Relates https://github.com/SAP/fundamental-styles/issues/938

## Description
There is `flex` property changed on mobile mode, for columns

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/26483208/81085521-9bca1580-8ef7-11ea-834c-6550f4c9fecb.png)


### After:
![image](https://user-images.githubusercontent.com/26483208/81085458-87861880-8ef7-11ea-8eaf-2b36235f9842.png)
