### PR TITLE
fix: add fix for Action Bar actions not taking the whole width

### DIFF
--- a/src/action-bar.scss
+++ b/src/action-bar.scss
@@ -91,6 +91,7 @@ $block: #{$fd-namespace}-action-bar;
     font-family: var(--sapFontHeaderFamily);
     color: $fd-action-bar-title-color;
     flex-grow: 1;
+    flex-basis: 0;
     line-height: 1.375rem;
     padding-right: 0.5rem;
     vertical-align: middle;


### PR DESCRIPTION
## Related Issue
Related to SAP/fundamental-styles#938

## Description
In IE 11 the actions section container was not expanding to fit the content.

