### PR TITLE
fix: Fix dropdown fill content no ie11

### DIFF
--- a/src/popover.scss
+++ b/src/popover.scss
@@ -220,6 +220,7 @@ $block: #{$fd-namespace}-popover;
       border-top-right-radius: 0;
 
       &-fill {
+        display: block;
         max-width: 37.5rem;
         width: calc(100% - #{$fd-popover-body-shadow-offset} * 2);
       }


### PR DESCRIPTION
## Related Issue
Relates: https://github.com/SAP/fundamental-styles/issues/938

## Description
There is `-ms-grid` removed on dropdown, when fill mode is activated. We don't need to use this property, because width is 100%.

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/26483208/81086530-e8fab700-8ef8-11ea-9354-5ebe75bdd06c.png)


### After:
![image](https://user-images.githubusercontent.com/26483208/81086587-ffa10e00-8ef8-11ea-97d4-8cc7a0bb4015.png)
