### PR TITLE
fix: overflow removed in order to show popover

### DIFF
--- a/src/shellbar.scss
+++ b/src/shellbar.scss
@@ -52,7 +52,6 @@ $block: #{$fd-namespace}-shellbar;
     display: flex;
     align-items: center;
     flex: 1 1 0;
-    overflow: hidden;
 
     &--product {
       justify-content: flex-start;


### PR DESCRIPTION
## Related Issue
Related to #938

## Description
Fix brings back popover for shellbar

**IMPORTANT**
Please double-check #968 because this PR revert one change made there.

## Screenshots
### Before:
![Screen Shot 2020-05-05 at 10 57 44 PM](https://user-images.githubusercontent.com/4380815/81134861-0e50ea80-8f24-11ea-97e5-ac6ec956a545.png)
![Screen Shot 2020-05-05 at 10 59 39 PM](https://user-images.githubusercontent.com/4380815/81134879-1e68ca00-8f24-11ea-84e0-c96ae9f8c22d.png)

### After:
![image](https://user-images.githubusercontent.com/10849982/81161604-1d6b8300-8f8c-11ea-8495-0dbfa79427b6.png)
