### PR TITLE
feat: add additional markup to handle the overflow of the popover body

### DIFF
--- a/docs/pages/components/breadcrumb.md
+++ b/docs/pages/components/breadcrumb.md
@@ -42,23 +42,25 @@ there should be popover with missing options.
                 </a>
             </div>
             <div class="fd-popover__body fd-popover__body--no-arrow fd-breadcrumb__popover-body" aria-hidden="true" id="breadcrumb1">
-              <ul class="fd-list fd-list--navigation" role="list">
-                <li tabindex="-1" role="listitem" class="fd-list__item fd-list__item--link">
-                    <a tabindex="0" class="fd-list__link" href="https://sap.github.io/fundamental-styles/">
-                      <span class="fd-list__title">List item 1</span>
-                    </a>
-                </li>
-                <li tabindex="-1" role="listitem" class="fd-list__item fd-list__item--link">
-                    <a tabindex="0" class="fd-list__link" href="https://sap.github.io/fundamental-styles/">
-                      <span class="fd-list__title">List item 2</span>
-                    </a>
-                </li>
-                <li tabindex="-1" role="listitem" class="fd-list__item fd-list__item--link">
-                    <a tabindex="0" class="fd-list__link" href="https://sap.github.io/fundamental-styles/">
-                      <span class="fd-list__title">List item 3</span>
-                    </a>
-                </li>
-              </ul>
+                <div class="fd-popover__content-wrapper">
+                  <ul class="fd-list fd-list--navigation" role="list">
+                    <li tabindex="-1" role="listitem" class="fd-list__item fd-list__item--link">
+                        <a tabindex="0" class="fd-list__link" href="https://sap.github.io/fundamental-styles/">
+                          <span class="fd-list__title">List item 1</span>
+                        </a>
+                    </li>
+                    <li tabindex="-1" role="listitem" class="fd-list__item fd-list__item--link">
+                        <a tabindex="0" class="fd-list__link" href="https://sap.github.io/fundamental-styles/">
+                          <span class="fd-list__title">List item 2</span>
+                        </a>
+                    </li>
+                    <li tabindex="-1" role="listitem" class="fd-list__item fd-list__item--link">
+                        <a tabindex="0" class="fd-list__link" href="https://sap.github.io/fundamental-styles/">
+                          <span class="fd-list__title">List item 3</span>
+                        </a>
+                    </li>
+                  </ul>
+                </div>
             </div>
         </div>
     </li>

--- a/src/popover.scss
+++ b/src/popover.scss
@@ -234,6 +234,10 @@ $block: #{$fd-namespace}-popover;
     }
   }
 
+  &__content-wrapper {
+    overflow: hidden;
+  }
+
   &--input-message-group {
     .#{$block}__body,
     .#{$block}__body--no-arrow,


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#876

## Description
a `div` element is added as a child of popover body to handle the overflow of the content. A modifier class cannot be added to the `fd-popover__body` because the popover arrow is an ::after element.

BREAKING CHANGE
The breadcrumb now needs an additional markup

## Screenshots

### Before:
![Screen Shot 2020-05-06 at 11 13 12 AM](https://user-images.githubusercontent.com/39598672/81194459-ab466e80-8f8a-11ea-9879-ea64d6cb5277.png)


### After:
![Screen Shot 2020-05-06 at 11 13 35 AM](https://user-images.githubusercontent.com/39598672/81194482-b13c4f80-8f8a-11ea-963f-b58bda8c46e4.png)
