### PR TITLE
fix: dialog resize handle in RTL mode

### DIFF
--- a/src/dialog.scss
+++ b/src/dialog.scss
@@ -173,6 +173,13 @@ $button: #{$fd-namespace}-button;
     overflow: hidden;
     border-bottom-right-radius: $fd-dialog-content-border-radius;
 
+    @include fd-rtl() {
+      right: unset;
+      left: 0;
+      cursor: sw-resize;
+      transform: scaleX(-1);
+    }
+
     @include fd-icon("resize-corner", "m", "after") {
       display: flex;
       color: $fd-dialog-resize-handle-color;


### PR DESCRIPTION
Moves the dialog resize to the left side in RTL mode