### PR TITLE
feat: updates to SideNavigation for accessibility

### DIFF
--- a/docs/pages/components/side-navigation.md
+++ b/docs/pages/components/side-navigation.md
@@ -142,11 +142,11 @@ On expand, the `is-expanded` class should be propagated also to `__content` elem
                 </a>
             </li>            
             <li class="fd-nested-list__item">
-                <div class="fd-nested-list__content has-child" tabindex="0">
-                    <a class="fd-nested-list__link" role="button" tabindex="-1">
+                <div class="fd-nested-list__content has-child">
+                    <span class="fd-nested-list__link">
                         <span class="fd-nested-list__title">Level 1 Item</span>
-                    </a>
-                    <a class="fd-nested-list__expand-icon" role="button" tabindex="-1" aria-controls="EX100L2" aria-haspopup="true"></a>
+                    </span>
+                    <button class="fd-nested-list__expand-icon" aria-controls="EX100L2" aria-haspopup="true" aria-expanded="false"></button>
                 </div>
                 <ul class="fd-nested-list level-2" id="EX100L2" aria-hidden="true">
                     <li class="fd-nested-list__item">
@@ -221,12 +221,12 @@ On expand, the `is-expanded` class should be propagated also to `__content` elem
                 </a>
             </li>
             <li class="fd-nested-list__item">
-                 <div class="fd-nested-list__content is-selected has-child" tabindex="0">
-                    <a class="fd-nested-list__link" role="button" tabindex="-1">
+                <div class="fd-nested-list__content is-selected has-child">
+                    <span class="fd-nested-list__link">
                         <span aria-hidden="true" class="fd-nested-list__icon sap-icon--employee"></span>
                         <span class="fd-nested-list__title">Level 1 Item</span>
-                    </a>
-                    <a class="fd-nested-list__expand-icon" role="button" aria-controls="EX400L2" tabindex="-1" aria-haspopup="true"></a>
+                    </span>
+                    <button class="fd-nested-list__expand-icon" aria-controls="EX100L2" aria-haspopup="true" aria-expanded="false"></button>
                 </div>
                 <ul class="fd-nested-list fd-nested-list--text-only level-2" id="EX400L2" aria-hidden="true">
                     <li class="fd-nested-list__item">
@@ -317,12 +317,12 @@ The lists in both sections (Main and Utility) should have the `fd-nested-list--c
                 </a>
             </li>
             <li class="fd-nested-list__item">
-                <div class="fd-nested-list__content has-child" tabindex="0">
-                    <a class="fd-nested-list__link" href="#" tabindex="-1">
+                <div class="fd-nested-list__content has-child">
+                    <span class="fd-nested-list__link">
                         <span aria-hidden="true" class="fd-nested-list__icon sap-icon--employee"></span>
                         <span class="fd-nested-list__title">Level 1 Item</span>
-                    </a>
-                    <a class="fd-nested-list__expand-icon" href="#" tabindex="-1" aria-controls="EX500L2" aria-haspopup="true"></a>
+                    </span>
+                    <button class="fd-nested-list__expand-icon" aria-controls="EX100L2" aria-haspopup="true" aria-expanded="false"></button>
                 </div>
                 <ul class="fd-nested-list fd-nested-list--text-only level-2" id="EX500L2" aria-hidden="true">
                     <li class="fd-nested-list__item">
@@ -417,12 +417,12 @@ The following requirements must be met:
                 </a>
             </li>
             <li class="fd-nested-list__item">
-                <div class="fd-nested-list__content is-selected has-child" tabindex="0">
-                    <a class="fd-nested-list__link" href="#" tabindex="-1">
-                        <span aria-label="Level 1 Item" class="fd-nested-list__icon sap-icon--employee"></span>
+                <div class="fd-nested-list__content is-selected has-child">
+                    <span class="fd-nested-list__link">
+                        <span aria-hidden="true" class="fd-nested-list__icon sap-icon--employee"></span>
                         <span class="fd-nested-list__title">Level 1 Item</span>
-                    </a>
-                    <a class="fd-nested-list__expand-icon" href="#" tabindex="-1" aria-haspopup="true"></a>
+                    </span>
+                    <button class="fd-nested-list__expand-icon" aria-controls="EX100L2" aria-haspopup="true" aria-expanded="false"></button>
                 </div>
             </li>
             <li class="fd-nested-list__item">
@@ -481,12 +481,12 @@ The following requirements must be met:
                 </a>
             </li>
             <li class="fd-nested-list__item">
-                <div class="fd-nested-list__content is-selected has-child" tabindex="0">
-                    <a class="fd-nested-list__link" href="#" tabindex="-1">
-                        <span aria-label="Level 1 Item" class="fd-nested-list__icon sap-icon--employee"></span>
+                <div class="fd-nested-list__content is-selected has-child">
+                    <span class="fd-nested-list__link">
+                        <span aria-hidden="true" class="fd-nested-list__icon sap-icon--employee"></span>
                         <span class="fd-nested-list__title">Level 1 Item</span>
-                    </a>
-                    <a class="fd-nested-list__expand-icon" href="#" tabindex="-1" aria-haspopup="true"></a>
+                    </span>
+                    <button class="fd-nested-list__expand-icon" aria-controls="EX100L2" aria-haspopup="true" aria-expanded="false"></button>
                 </div>
             </li>
             <li class="fd-nested-list__item">

--- a/docs/pages/components/side-navigation.md
+++ b/docs/pages/components/side-navigation.md
@@ -226,7 +226,7 @@ On expand, the `is-expanded` class should be propagated also to `__content` elem
                         <span aria-hidden="true" class="fd-nested-list__icon sap-icon--employee"></span>
                         <span class="fd-nested-list__title" href="#">Level 1 Item</span>
                     </a>
-                    <button class="fd-button fd-nested-list__button" aria-controls="EX100L2" aria-haspopup="true" aria-expanded="false" aria-label="Expand submenu"></button>
+                    <button class="fd-button fd-nested-list__button" aria-controls="EX400L2" aria-haspopup="true" aria-expanded="false" aria-label="Expand submenu"></button>
                 </div>
                 <ul class="fd-nested-list fd-nested-list--text-only level-2" id="EX400L2" aria-hidden="true">
                     <li class="fd-nested-list__item">
@@ -418,11 +418,10 @@ The following requirements must be met:
             </li>
             <li class="fd-nested-list__item">
                 <div class="fd-nested-list__content is-selected has-child" tabindex="0">
-                    <a class="fd-nested-list__link" href="#">
+                    <button class="fd-nested-list__link" aria-controls="EX500L2" aria-haspopup="true" aria-expanded="false" aria-label="Expand submenu">
                         <span aria-hidden="true" class="fd-nested-list__icon sap-icon--employee"></span>
                         <span class="fd-nested-list__title" href="#">Level 1 Item</span>
-                    </a>
-                    <button class="fd-button fd-nested-list__button" aria-controls="EX100L2" aria-haspopup="true" aria-expanded="false" aria-label="Expand submenu"></button>
+                    </button>
                 </div>
             </li>
             <li class="fd-nested-list__item">
@@ -482,11 +481,10 @@ The following requirements must be met:
             </li>
             <li class="fd-nested-list__item">
                 <div class="fd-nested-list__content is-selected has-child" tabindex="0">
-                    <a class="fd-nested-list__link" href="#">
+                    <button class="fd-nested-list__link" aria-controls="EX600L2" aria-haspopup="true" aria-expanded="false" aria-label="Expand submenu">
                         <span aria-hidden="true" class="fd-nested-list__icon sap-icon--employee"></span>
                         <span class="fd-nested-list__title">Level 1 Item</span>
-                    </a>
-                    <button class="fd-button fd-nested-list__button" aria-controls="EX100L2" aria-haspopup="true" aria-expanded="false"></button>
+                    </button>
                 </div>
             </li>
             <li class="fd-nested-list__item">

--- a/docs/pages/components/side-navigation.md
+++ b/docs/pages/components/side-navigation.md
@@ -146,7 +146,7 @@ On expand, the `is-expanded` class should be propagated also to `__content` elem
                     <a class="fd-nested-list__link" href="#">
                         <span class="fd-nested-list__title">Level 1 Item</span>
                     </a>
-                    <button class="fd-button fd-nested-list__button" aria-controls="EX100L2" aria-haspopup="true" aria-expanded="false"></button>
+                    <button class="fd-button fd-nested-list__button" aria-controls="EX100L2" aria-haspopup="true" aria-expanded="false" aria-label="Expand submenu"></button>
                 </div>
                 <ul class="fd-nested-list level-2" id="EX100L2" aria-hidden="true">
                     <li class="fd-nested-list__item">
@@ -222,11 +222,11 @@ On expand, the `is-expanded` class should be propagated also to `__content` elem
             </li>
             <li class="fd-nested-list__item">
                 <div class="fd-nested-list__content is-selected has-child">
-                    <span class="fd-nested-list__link">
+                    <a class="fd-nested-list__link" href="#">
                         <span aria-hidden="true" class="fd-nested-list__icon sap-icon--employee"></span>
-                        <a class="fd-nested-list__title" href="#">Level 1 Item</a>
-                    </span>
-                    <button class="fd-button fd-nested-list__button" aria-controls="EX100L2" aria-haspopup="true" aria-expanded="false"></button>
+                        <span class="fd-nested-list__title" href="#">Level 1 Item</span>
+                    </a>
+                    <button class="fd-button fd-nested-list__button" aria-controls="EX100L2" aria-haspopup="true" aria-expanded="false" aria-label="Expand submenu"></button>
                 </div>
                 <ul class="fd-nested-list fd-nested-list--text-only level-2" id="EX400L2" aria-hidden="true">
                     <li class="fd-nested-list__item">
@@ -318,11 +318,11 @@ The lists in both sections (Main and Utility) should have the `fd-nested-list--c
             </li>
             <li class="fd-nested-list__item">
                 <div class="fd-nested-list__content has-child">
-                    <span class="fd-nested-list__link">
+                    <a class="fd-nested-list__link" href="#">
                         <span aria-hidden="true" class="fd-nested-list__icon sap-icon--employee"></span>
-                        <a class="fd-nested-list__title" href="#">Level 1 Item</a>
-                    </span>
-                    <button class="fd-button fd-nested-list__button" aria-controls="EX100L2" aria-haspopup="true" aria-expanded="false"></button>
+                        <span class="fd-nested-list__title" href="#">Level 1 Item</span>
+                    </a>
+                    <button class="fd-button fd-nested-list__button" aria-controls="EX500L2" aria-haspopup="true" aria-expanded="false" aria-label="Expand submenu"></button>
                 </div>
                 <ul class="fd-nested-list fd-nested-list--text-only level-2" id="EX500L2" aria-hidden="true">
                     <li class="fd-nested-list__item">
@@ -371,7 +371,7 @@ The lists in both sections (Main and Utility) should have the `fd-nested-list--c
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
                     <span aria-hidden="true" class="fd-nested-list__icon sap-icon--compare"></span>
-                    <a class="fd-nested-list__title" href="#">Level 1 Item</a>
+                    <span class="fd-nested-list__title" href="#">Level 1 Item</span>
                 </a>
             </li>
             <li class="fd-nested-list__item">
@@ -418,11 +418,11 @@ The following requirements must be met:
             </li>
             <li class="fd-nested-list__item">
                 <div class="fd-nested-list__content is-selected has-child" tabindex="0">
-                    <span class="fd-nested-list__link">
+                    <a class="fd-nested-list__link" href="#">
                         <span aria-hidden="true" class="fd-nested-list__icon sap-icon--employee"></span>
-                        <a class="fd-nested-list__title" href="#">Level 1 Item</a>
-                    </span>
-                    <button class="fd-button fd-nested-list__button" aria-controls="EX100L2" aria-haspopup="true" aria-expanded="false"></button>
+                        <span class="fd-nested-list__title" href="#">Level 1 Item</span>
+                    </a>
+                    <button class="fd-button fd-nested-list__button" aria-controls="EX100L2" aria-haspopup="true" aria-expanded="false" aria-label="Expand submenu"></button>
                 </div>
             </li>
             <li class="fd-nested-list__item">
@@ -477,15 +477,15 @@ The following requirements must be met:
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
                     <span aria-label="Level 1 Item" class="fd-nested-list__icon sap-icon--calendar"></span>
-                    <a class="fd-nested-list__title" href="#">Level 1 Item</a>
+                    <span class="fd-nested-list__title" href="#">Level 1 Item</span>
                 </a>
             </li>
             <li class="fd-nested-list__item">
                 <div class="fd-nested-list__content is-selected has-child" tabindex="0">
-                    <span class="fd-nested-list__link">
+                    <a class="fd-nested-list__link" href="#">
                         <span aria-hidden="true" class="fd-nested-list__icon sap-icon--employee"></span>
                         <span class="fd-nested-list__title">Level 1 Item</span>
-                    </span>
+                    </a>
                     <button class="fd-button fd-nested-list__button" aria-controls="EX100L2" aria-haspopup="true" aria-expanded="false"></button>
                 </div>
             </li>

--- a/docs/pages/components/side-navigation.md
+++ b/docs/pages/components/side-navigation.md
@@ -143,9 +143,9 @@ On expand, the `is-expanded` class should be propagated also to `__content` elem
             </li>            
             <li class="fd-nested-list__item">
                 <div class="fd-nested-list__content has-child">
-                    <span class="fd-nested-list__link">
+                    <a class="fd-nested-list__link" href="#">
                         <span class="fd-nested-list__title">Level 1 Item</span>
-                    </span>
+                    </a>
                     <button class="fd-button fd-nested-list__button" aria-controls="EX100L2" aria-haspopup="true" aria-expanded="false"></button>
                 </div>
                 <ul class="fd-nested-list level-2" id="EX100L2" aria-hidden="true">
@@ -224,7 +224,7 @@ On expand, the `is-expanded` class should be propagated also to `__content` elem
                 <div class="fd-nested-list__content is-selected has-child">
                     <span class="fd-nested-list__link">
                         <span aria-hidden="true" class="fd-nested-list__icon sap-icon--employee"></span>
-                        <span class="fd-nested-list__title">Level 1 Item</span>
+                        <a class="fd-nested-list__title" href="#">Level 1 Item</a>
                     </span>
                     <button class="fd-button fd-nested-list__button" aria-controls="EX100L2" aria-haspopup="true" aria-expanded="false"></button>
                 </div>
@@ -320,7 +320,7 @@ The lists in both sections (Main and Utility) should have the `fd-nested-list--c
                 <div class="fd-nested-list__content has-child">
                     <span class="fd-nested-list__link">
                         <span aria-hidden="true" class="fd-nested-list__icon sap-icon--employee"></span>
-                        <span class="fd-nested-list__title">Level 1 Item</span>
+                        <a class="fd-nested-list__title" href="#">Level 1 Item</a>
                     </span>
                     <button class="fd-button fd-nested-list__button" aria-controls="EX100L2" aria-haspopup="true" aria-expanded="false"></button>
                 </div>
@@ -371,7 +371,7 @@ The lists in both sections (Main and Utility) should have the `fd-nested-list--c
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
                     <span aria-hidden="true" class="fd-nested-list__icon sap-icon--compare"></span>
-                    <span aria-hidden="true" class="fd-nested-list__title">Level 1 Item</span>
+                    <a class="fd-nested-list__title" href="#">Level 1 Item</a>
                 </a>
             </li>
             <li class="fd-nested-list__item">
@@ -420,7 +420,7 @@ The following requirements must be met:
                 <div class="fd-nested-list__content is-selected has-child" tabindex="0">
                     <span class="fd-nested-list__link">
                         <span aria-hidden="true" class="fd-nested-list__icon sap-icon--employee"></span>
-                        <span class="fd-nested-list__title">Level 1 Item</span>
+                        <a class="fd-nested-list__title" href="#">Level 1 Item</a>
                     </span>
                     <button class="fd-button fd-nested-list__button" aria-controls="EX100L2" aria-haspopup="true" aria-expanded="false"></button>
                 </div>
@@ -477,7 +477,7 @@ The following requirements must be met:
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
                     <span aria-label="Level 1 Item" class="fd-nested-list__icon sap-icon--calendar"></span>
-                    <span class="fd-nested-list__title">Level 1 Item</span>
+                    <a class="fd-nested-list__title" href="#">Level 1 Item</a>
                 </a>
             </li>
             <li class="fd-nested-list__item">

--- a/docs/pages/components/side-navigation.md
+++ b/docs/pages/components/side-navigation.md
@@ -224,7 +224,7 @@ On expand, the `is-expanded` class should be propagated also to `__content` elem
                 <div class="fd-nested-list__content is-selected has-child">
                     <a class="fd-nested-list__link" href="#">
                         <span aria-hidden="true" class="fd-nested-list__icon sap-icon--employee"></span>
-                        <span class="fd-nested-list__title" href="#">Level 1 Item</span>
+                        <span class="fd-nested-list__title">Level 1 Item</span>
                     </a>
                     <button class="fd-button fd-nested-list__button" aria-controls="EX400L2" aria-haspopup="true" aria-expanded="false" aria-label="Expand submenu"></button>
                 </div>
@@ -320,7 +320,7 @@ The lists in both sections (Main and Utility) should have the `fd-nested-list--c
                 <div class="fd-nested-list__content has-child">
                     <a class="fd-nested-list__link" href="#">
                         <span aria-hidden="true" class="fd-nested-list__icon sap-icon--employee"></span>
-                        <span class="fd-nested-list__title" href="#">Level 1 Item</span>
+                        <span class="fd-nested-list__title">Level 1 Item</span>
                     </a>
                     <button class="fd-button fd-nested-list__button" aria-controls="EX500L2" aria-haspopup="true" aria-expanded="false" aria-label="Expand submenu"></button>
                 </div>
@@ -331,7 +331,7 @@ The lists in both sections (Main and Utility) should have the `fd-nested-list--c
                         </a>
                     </li>
                     <li class="fd-nested-list__item">
-                        <a class="fd-nested-list__link">
+                        <a class="fd-nested-list__link" href="#">
                             <span class="fd-nested-list__title">Level 2 Item</span>
                         </a>
                     </li>
@@ -371,7 +371,7 @@ The lists in both sections (Main and Utility) should have the `fd-nested-list--c
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
                     <span aria-hidden="true" class="fd-nested-list__icon sap-icon--compare"></span>
-                    <span class="fd-nested-list__title" href="#">Level 1 Item</span>
+                    <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
             <li class="fd-nested-list__item">
@@ -420,7 +420,7 @@ The following requirements must be met:
                 <div class="fd-nested-list__content is-selected has-child" tabindex="0">
                     <button class="fd-nested-list__link" aria-controls="EX500L2" aria-haspopup="true" aria-expanded="false" aria-label="Expand submenu">
                         <span aria-hidden="true" class="fd-nested-list__icon sap-icon--employee"></span>
-                        <span class="fd-nested-list__title" href="#">Level 1 Item</span>
+                        <span class="fd-nested-list__title">Level 1 Item</span>
                     </button>
                 </div>
             </li>
@@ -476,7 +476,7 @@ The following requirements must be met:
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
                     <span aria-label="Level 1 Item" class="fd-nested-list__icon sap-icon--calendar"></span>
-                    <span class="fd-nested-list__title" href="#">Level 1 Item</span>
+                    <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
             <li class="fd-nested-list__item">

--- a/docs/pages/components/side-navigation.md
+++ b/docs/pages/components/side-navigation.md
@@ -417,7 +417,7 @@ The following requirements must be met:
                 </a>
             </li>
             <li class="fd-nested-list__item">
-                <div class="fd-nested-list__content is-selected has-child" tabindex="0">
+                <div class="fd-nested-list__content is-selected has-child">
                     <button class="fd-nested-list__link" aria-controls="EX500L2" aria-haspopup="true" aria-expanded="false" aria-label="Expand submenu">
                         <span aria-hidden="true" class="fd-nested-list__icon sap-icon--employee"></span>
                         <span class="fd-nested-list__title">Level 1 Item</span>
@@ -480,7 +480,7 @@ The following requirements must be met:
                 </a>
             </li>
             <li class="fd-nested-list__item">
-                <div class="fd-nested-list__content is-selected has-child" tabindex="0">
+                <div class="fd-nested-list__content is-selected has-child">
                     <button class="fd-nested-list__link" aria-controls="EX600L2" aria-haspopup="true" aria-expanded="false" aria-label="Expand submenu">
                         <span aria-hidden="true" class="fd-nested-list__icon sap-icon--employee"></span>
                         <span class="fd-nested-list__title">Level 1 Item</span>

--- a/docs/pages/components/side-navigation.md
+++ b/docs/pages/components/side-navigation.md
@@ -124,7 +124,7 @@ The lists in both sections (Main and Utility) should have the `fd-nested-list--t
 
 ## Side navigation with multiple levels - cozy mode
 Use this when there is more than one level of hierarchy in the left navigation. The entries on the first level are just group headers(don't trigger navigation themselves). It's recommended to use up to two levels of navigation. For more levels of navigation, use the content area. 
-On expand, the `is-expanded` class should be propagated also to `__content` element. `fd-nested-list__expand-icon` is element, which triggers another level.
+On expand, the `is-expanded` class should be propagated also to `__content` element. `fd-nested-list__button` is the element which triggers another level.
 
 {% capture default %}
 <div class="fd-side-nav">
@@ -146,7 +146,7 @@ On expand, the `is-expanded` class should be propagated also to `__content` elem
                     <span class="fd-nested-list__link">
                         <span class="fd-nested-list__title">Level 1 Item</span>
                     </span>
-                    <button class="fd-nested-list__expand-icon" aria-controls="EX100L2" aria-haspopup="true" aria-expanded="false"></button>
+                    <button class="fd-button fd-nested-list__button" aria-controls="EX100L2" aria-haspopup="true" aria-expanded="false"></button>
                 </div>
                 <ul class="fd-nested-list level-2" id="EX100L2" aria-hidden="true">
                     <li class="fd-nested-list__item">
@@ -226,7 +226,7 @@ On expand, the `is-expanded` class should be propagated also to `__content` elem
                         <span aria-hidden="true" class="fd-nested-list__icon sap-icon--employee"></span>
                         <span class="fd-nested-list__title">Level 1 Item</span>
                     </span>
-                    <button class="fd-nested-list__expand-icon" aria-controls="EX100L2" aria-haspopup="true" aria-expanded="false"></button>
+                    <button class="fd-button fd-nested-list__button" aria-controls="EX100L2" aria-haspopup="true" aria-expanded="false"></button>
                 </div>
                 <ul class="fd-nested-list fd-nested-list--text-only level-2" id="EX400L2" aria-hidden="true">
                     <li class="fd-nested-list__item">
@@ -322,7 +322,7 @@ The lists in both sections (Main and Utility) should have the `fd-nested-list--c
                         <span aria-hidden="true" class="fd-nested-list__icon sap-icon--employee"></span>
                         <span class="fd-nested-list__title">Level 1 Item</span>
                     </span>
-                    <button class="fd-nested-list__expand-icon" aria-controls="EX100L2" aria-haspopup="true" aria-expanded="false"></button>
+                    <button class="fd-button fd-nested-list__button" aria-controls="EX100L2" aria-haspopup="true" aria-expanded="false"></button>
                 </div>
                 <ul class="fd-nested-list fd-nested-list--text-only level-2" id="EX500L2" aria-hidden="true">
                     <li class="fd-nested-list__item">
@@ -417,12 +417,12 @@ The following requirements must be met:
                 </a>
             </li>
             <li class="fd-nested-list__item">
-                <div class="fd-nested-list__content is-selected has-child">
+                <div class="fd-nested-list__content is-selected has-child" tabindex="0">
                     <span class="fd-nested-list__link">
                         <span aria-hidden="true" class="fd-nested-list__icon sap-icon--employee"></span>
                         <span class="fd-nested-list__title">Level 1 Item</span>
                     </span>
-                    <button class="fd-nested-list__expand-icon" aria-controls="EX100L2" aria-haspopup="true" aria-expanded="false"></button>
+                    <button class="fd-button fd-nested-list__button" aria-controls="EX100L2" aria-haspopup="true" aria-expanded="false"></button>
                 </div>
             </li>
             <li class="fd-nested-list__item">
@@ -481,12 +481,12 @@ The following requirements must be met:
                 </a>
             </li>
             <li class="fd-nested-list__item">
-                <div class="fd-nested-list__content is-selected has-child">
+                <div class="fd-nested-list__content is-selected has-child" tabindex="0">
                     <span class="fd-nested-list__link">
                         <span aria-hidden="true" class="fd-nested-list__icon sap-icon--employee"></span>
                         <span class="fd-nested-list__title">Level 1 Item</span>
                     </span>
-                    <button class="fd-nested-list__expand-icon" aria-controls="EX100L2" aria-haspopup="true" aria-expanded="false"></button>
+                    <button class="fd-button fd-nested-list__button" aria-controls="EX100L2" aria-haspopup="true" aria-expanded="false"></button>
                 </div>
             </li>
             <li class="fd-nested-list__item">

--- a/docs/pages/components/side-navigation.md
+++ b/docs/pages/components/side-navigation.md
@@ -76,25 +76,25 @@ The lists in both sections (Main and Utility) should have the `fd-nested-list--t
         <ul class="fd-nested-list">
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
-                    <span class="fd-nested-list__icon sap-icon--home"></span>
+                    <span aria-hidden="true" class="fd-nested-list__icon sap-icon--home"></span>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link is-selected" href="#">
-                    <span class="fd-nested-list__icon sap-icon--calendar"></span>
+                    <span aria-hidden="true" class="fd-nested-list__icon sap-icon--calendar"></span>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
-                    <span class="fd-nested-list__icon sap-icon--employee"></span>
+                    <span aria-hidden="true" class="fd-nested-list__icon sap-icon--employee"></span>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
-                    <span class="fd-nested-list__icon sap-icon--activities"></span>
+                    <span aria-hidden="true" class="fd-nested-list__icon sap-icon--activities"></span>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
@@ -104,13 +104,13 @@ The lists in both sections (Main and Utility) should have the `fd-nested-list--t
         <ul class="fd-nested-list">
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
-                    <span class="fd-nested-list__icon sap-icon--compare"></span>
+                    <span aria-hidden="true" class="fd-nested-list__icon sap-icon--compare"></span>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
-                    <span class="fd-nested-list__icon sap-icon--chain-link"></span>
+                    <span aria-hidden="true" class="fd-nested-list__icon sap-icon--chain-link"></span>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>

--- a/docs/pages/components/side-navigation.md
+++ b/docs/pages/components/side-navigation.md
@@ -21,8 +21,9 @@ There is only one level of navigation; all further navigation is shown in the co
 The lists in both sections (Main and Utility) should have the `fd-nested-list--text-only` modifier class.
 
 {% capture default %}
-<nav class="fd-side-nav">
-    <div class="fd-side-nav__main-navigation">
+<div class="fd-side-nav">
+    <a class="fd-side-nav__skip-link" href="#content">Skip navigation</a>
+    <nav class="fd-side-nav__main-navigation">
         <ul class="fd-nested-list fd-nested-list--text-only">
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
@@ -45,9 +46,9 @@ The lists in both sections (Main and Utility) should have the `fd-nested-list--t
                 </a>
             </li>
         </ul>
-    </div>
-    <div class="fd-side-nav__utility">
-        <ul class="fd-nested-list fd-nested-list--text-only">
+    </nav>
+    <nav class="fd-side-nav__utility">
+        <ul class="fd-nested-list fd-nested-list--text-only" aria-label="Utility Menu">
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
                     <span class="fd-nested-list__title">Level 1 Item</span>
@@ -59,8 +60,8 @@ The lists in both sections (Main and Utility) should have the `fd-nested-list--t
                 </a>
             </li>
         </ul>
-    </div>
-</nav>
+    </nav>
+</div>
 {% endcapture %}
 {% include display-component.html component=default %}
 
@@ -69,8 +70,9 @@ The lists in both sections (Main and Utility) should have the `fd-nested-list--t
 ## Side Navigation with one level - with icons, cozy mode
 
 {% capture default %}
-<nav class="fd-side-nav">
-    <div class="fd-side-nav__main-navigation">
+<div class="fd-side-nav">
+    <a class="fd-side-nav__skip-link" href="#content">Skip navigation</a>
+    <nav class="fd-side-nav__main-navigation">
         <ul class="fd-nested-list">
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
@@ -97,8 +99,8 @@ The lists in both sections (Main and Utility) should have the `fd-nested-list--t
                 </a>
             </li>
         </ul>
-    </div>
-    <div class="fd-side-nav__utility">
+    </nav>
+    <nav class="fd-side-nav__utility">
         <ul class="fd-nested-list">
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
@@ -113,8 +115,8 @@ The lists in both sections (Main and Utility) should have the `fd-nested-list--t
                 </a>
             </li>
         </ul>
-    </div>
-</nav>
+    </nav>
+</div>
 {% endcapture %}
 {% include display-component.html component=default %}
 
@@ -125,8 +127,9 @@ Use this when there is more than one level of hierarchy in the left navigation. 
 On expand, the `is-expanded` class should be propagated also to `__content` element. `fd-nested-list__expand-icon` is element, which triggers another level.
 
 {% capture default %}
-<nav class="fd-side-nav">
-    <div class="fd-side-nav__main-navigation">
+<div class="fd-side-nav">
+    <a class="fd-side-nav__skip-link" href="#content">Skip navigation</a>
+    <nav class="fd-side-nav__main-navigation">
         <ul class="fd-nested-list fd-nested-list--text-only">
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
@@ -140,10 +143,10 @@ On expand, the `is-expanded` class should be propagated also to `__content` elem
             </li>            
             <li class="fd-nested-list__item">
                 <div class="fd-nested-list__content has-child" tabindex="0">
-                    <a class="fd-nested-list__link" href="#" tabindex="-1">
+                    <a class="fd-nested-list__link" role="button" tabindex="-1">
                         <span class="fd-nested-list__title">Level 1 Item</span>
                     </a>
-                    <a class="fd-nested-list__expand-icon" href="#" tabindex="-1" aria-controls="EX100L2" aria-haspopup="true"></a>
+                    <a class="fd-nested-list__expand-icon" role="button" tabindex="-1" aria-controls="EX100L2" aria-haspopup="true"></a>
                 </div>
                 <ul class="fd-nested-list level-2" id="EX100L2" aria-hidden="true">
                     <li class="fd-nested-list__item">
@@ -174,9 +177,9 @@ On expand, the `is-expanded` class should be propagated also to `__content` elem
                 </a>
             </li>
         </ul>
-    </div>
-    <div class="fd-side-nav__utility">
-        <ul class="fd-nested-list fd-nested-list--text-only">
+    </nav>
+    <nav class="fd-side-nav__utility">
+        <ul class="fd-nested-list fd-nested-list--text-only" aria-label="Utility Menu">
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
                     <span class="fd-nested-list__title">Level 1 Item</span>
@@ -188,8 +191,8 @@ On expand, the `is-expanded` class should be propagated also to `__content` elem
                 </a>
             </li>
         </ul>
-    </div>
-</nav>
+    </nav>
+</div>
 {% endcapture %}
 {% include display-component.html component=default %}
 
@@ -198,31 +201,32 @@ On expand, the `is-expanded` class should be propagated also to `__content` elem
 ## Side navigation with 2 levels - with icons and group headers, cozy mode
 
 {% capture default %}
-<nav class="fd-side-nav">
-    <div class="fd-side-nav__main-navigation">
-        <ul class="fd-nested-list">
-            <li class="fd-nested-list__group-header">
-                Group Header 1
-            </li>
+<div class="fd-side-nav">
+    <a class="fd-side-nav__skip-link" href="#content">Skip navigation</a>
+    <div class="fd-side-nav__group-header" id="EX400H1">
+        Group Header 1
+    </div>
+    <nav class="fd-side-nav__main-navigation">
+        <ul class="fd-nested-list" aria-labelledby="EX400H1">
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
-                    <span class="fd-nested-list__icon sap-icon--home"></span>
+                    <span aria-hidden="true" class="fd-nested-list__icon sap-icon--home"></span>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
-                    <span class="fd-nested-list__icon sap-icon--calendar"></span>
+                    <span aria-hidden="true" class="fd-nested-list__icon sap-icon--calendar"></span>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
             <li class="fd-nested-list__item">
                  <div class="fd-nested-list__content is-selected has-child" tabindex="0">
-                    <a class="fd-nested-list__link" href="#" tabindex="-1">
-                        <span class="fd-nested-list__icon sap-icon--employee"></span>
+                    <a class="fd-nested-list__link" role="button" tabindex="-1">
+                        <span aria-hidden="true" class="fd-nested-list__icon sap-icon--employee"></span>
                         <span class="fd-nested-list__title">Level 1 Item</span>
                     </a>
-                    <a class="fd-nested-list__expand-icon" href="#" aria-controls="EX400L2" tabindex="-1" aria-haspopup="true"></a>
+                    <a class="fd-nested-list__expand-icon" role="button" aria-controls="EX400L2" tabindex="-1" aria-haspopup="true"></a>
                 </div>
                 <ul class="fd-nested-list fd-nested-list--text-only level-2" id="EX400L2" aria-hidden="true">
                     <li class="fd-nested-list__item">
@@ -231,8 +235,7 @@ On expand, the `is-expanded` class should be propagated also to `__content` elem
                         </a>
                     </li>
                     <li class="fd-nested-list__item">
-                        <a class="fd-nested-list__link is-selected" 
-                            href="#" aria-controls="EX400L3" aria-haspopup="true">
+                        <a class="fd-nested-list__link is-selected" href="#">
                             <span class="fd-nested-list__title">Level 2 Item</span>
                         </a>
                     </li>
@@ -245,16 +248,18 @@ On expand, the `is-expanded` class should be propagated also to `__content` elem
             </li>
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
-                    <span class="fd-nested-list__icon sap-icon--activities"></span>
+                    <span aria-hidden="true" class="fd-nested-list__icon sap-icon--activities"></span>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
-            <li class="fd-nested-list__group-header">
-                Group Header 2
-            </li>
+        </ul>
+        <div class="fd-side-nav__group-header" id="EX400H2">
+            Group Header 2
+        </div>
+        <ul class="fd-nested-list" aria-labelledby="EX400H2">
             <li class="fd-nested-list__item">
-                <a class="fd-nested-list__link" href="#">
-                    <span class="fd-nested-list__icon sap-icon--bar-chart"></span>
+                <a class="fd-nested-list__link" href="#" aria-labelledby="group-2-header">
+                    <span aria-hidden="true" class="fd-nested-list__icon sap-icon--bar-chart"></span>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
@@ -264,24 +269,24 @@ On expand, the `is-expanded` class should be propagated also to `__content` elem
                 </a>
             </li>
         </ul>
-    </div>
-    <div class="fd-side-nav__utility">
-        <ul class="fd-nested-list">
+    </nav>
+    <nav class="fd-side-nav__utility">
+        <ul class="fd-nested-list" aria-label="Utility Menu">
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
-                    <span class="fd-nested-list__icon sap-icon--compare"></span>
+                    <span aria-hidden="true" class="fd-nested-list__icon sap-icon--compare"></span>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
-                    <span class="fd-nested-list__icon sap-icon--chain-link"></span>
+                    <span aria-hidden="true" class="fd-nested-list__icon sap-icon--chain-link"></span>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
         </ul>
-    </div>
-</nav>
+    </nav>
+</div>
 {% endcapture %}
 {% include display-component.html component=default %}
 
@@ -292,28 +297,29 @@ In compact mode the dimensions of the controls are reduced, allowing more inform
 The lists in both sections (Main and Utility) should have the `fd-nested-list--compact` modifier class.
 
 {% capture default %}
-<nav class="fd-side-nav">
-    <div class="fd-side-nav__main-navigation">
-        <ul class="fd-nested-list fd-nested-list--compact">
-            <li class="fd-nested-list__group-header">
-                Group Header 1
-            </li>
+<div class="fd-side-nav">
+    <a class="fd-side-nav__skip-link" href="#content">Skip navigation</a>
+    <div class="fd-side-nav__group-header" id="EX500H1">
+        Group Header 1
+    </div>
+    <nav class="fd-side-nav__main-navigation">
+        <ul class="fd-nested-list fd-nested-list--compact" aria-labelledby="EX500H1">
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
-                    <span class="fd-nested-list__icon sap-icon--home"></span>
+                    <span aria-hidden="true" class="fd-nested-list__icon sap-icon--home"></span>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link is-selected" href="#">
-                    <span class="fd-nested-list__icon sap-icon--calendar"></span>
+                    <span aria-hidden="true" class="fd-nested-list__icon sap-icon--calendar"></span>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
             <li class="fd-nested-list__item">
                 <div class="fd-nested-list__content has-child" tabindex="0">
                     <a class="fd-nested-list__link" href="#" tabindex="-1">
-                        <span class="fd-nested-list__icon sap-icon--employee"></span>
+                        <span aria-hidden="true" class="fd-nested-list__icon sap-icon--employee"></span>
                         <span class="fd-nested-list__title">Level 1 Item</span>
                     </a>
                     <a class="fd-nested-list__expand-icon" href="#" tabindex="-1" aria-controls="EX500L2" aria-haspopup="true"></a>
@@ -325,8 +331,7 @@ The lists in both sections (Main and Utility) should have the `fd-nested-list--c
                         </a>
                     </li>
                     <li class="fd-nested-list__item">
-                        <a class="fd-nested-list__link" 
-                            href="#" aria-controls="EX500L3" aria-haspopup="true">
+                        <a class="fd-nested-list__link">
                             <span class="fd-nested-list__title">Level 2 Item</span>
                         </a>
                     </li>
@@ -339,16 +344,18 @@ The lists in both sections (Main and Utility) should have the `fd-nested-list--c
             </li>
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
-                    <span class="fd-nested-list__icon sap-icon--activities"></span>
+                    <span aria-hidden="true" class="fd-nested-list__icon sap-icon--activities"></span>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
-            <li class="fd-nested-list__group-header">
+        </ul>
+        <div class="fd-side-nav__group-header" id="EX500H2">
                 Group Header 2
-            </li>
+        </div>
+        <ul class="fd-nested-list fd-nested-list--compact" aria-labelledby="EX500H2">
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
-                    <span class="fd-nested-list__icon sap-icon--bar-chart"></span>
+                    <span aria-hidden="true" class="fd-nested-list__icon sap-icon--bar-chart"></span>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
@@ -358,13 +365,13 @@ The lists in both sections (Main and Utility) should have the `fd-nested-list--c
                 </a>
             </li>
         </ul>
-    </div>
-    <div class="fd-side-nav__utility">
-        <ul class="fd-nested-list fd-nested-list--compact">
+    </nav>
+    <nav class="fd-side-nav__utility">
+        <ul class="fd-nested-list fd-nested-list--compact" aria-label="Utility Menu">
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
-                    <span class="fd-nested-list__icon sap-icon--compare"></span>
-                    <span class="fd-nested-list__title">Level 1 Item</span>
+                    <span aria-hidden="true" class="fd-nested-list__icon sap-icon--compare"></span>
+                    <span aria-hidden="true" class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
             <li class="fd-nested-list__item">
@@ -374,8 +381,8 @@ The lists in both sections (Main and Utility) should have the `fd-nested-list--c
                 </a>
             </li>
         </ul>
-    </div>
-</nav>
+    </nav>
+</div>
 {% endcapture %}
 {% include display-component.html component=default %}
 
@@ -394,24 +401,25 @@ The following requirements must be met:
 </ul>
 {% capture default %}
 <nav class="fd-side-nav fd-side-nav--condensed">
+    <a class="fd-side-nav__skip-link" href="#content">Skip navigation</a>
     <div class="fd-side-nav__main-navigation">
         <ul class="fd-nested-list">
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
-                    <span class="fd-nested-list__icon sap-icon--home"></span>
+                    <span aria-label="Level 1 Item" class="fd-nested-list__icon sap-icon--home"></span>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
-                    <span class="fd-nested-list__icon sap-icon--calendar"></span>
+                    <span aria-label="Level 1 Item" class="fd-nested-list__icon sap-icon--calendar"></span>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
             <li class="fd-nested-list__item">
                 <div class="fd-nested-list__content is-selected has-child" tabindex="0">
                     <a class="fd-nested-list__link" href="#" tabindex="-1">
-                        <span class="fd-nested-list__icon sap-icon--employee"></span>
+                        <span aria-label="Level 1 Item" class="fd-nested-list__icon sap-icon--employee"></span>
                         <span class="fd-nested-list__title">Level 1 Item</span>
                     </a>
                     <a class="fd-nested-list__expand-icon" href="#" tabindex="-1" aria-haspopup="true"></a>
@@ -419,29 +427,29 @@ The following requirements must be met:
             </li>
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
-                    <span class="fd-nested-list__icon sap-icon--activities"></span>
+                    <span aria-label="Level 1 Item" class="fd-nested-list__icon sap-icon--activities"></span>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
-                    <span class="fd-nested-list__icon sap-icon--bar-chart"></span>
+                    <span aria-label="Level 1 Item" class="fd-nested-list__icon sap-icon--bar-chart"></span>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
         </ul>
     </div>
-    <div class="fd-side-nav__utility">
+    <div class="fd-side-nav__utility" aria-label="Utility Menu">
         <ul class="fd-nested-list">
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
-                    <span class="fd-nested-list__icon sap-icon--compare"></span>
+                    <span aria-label="Level 1 Item" class="fd-nested-list__icon sap-icon--compare"></span>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
-                    <span class="fd-nested-list__icon sap-icon--chain-link"></span>
+                    <span aria-label="Level 1 Item" class="fd-nested-list__icon sap-icon--chain-link"></span>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
@@ -457,24 +465,25 @@ The following requirements must be met:
 
 {% capture default %}
 <nav class="fd-side-nav fd-side-nav--condensed">
+    <a class="fd-side-nav__skip-link" href="#content">Skip navigation</a>
     <div class="fd-side-nav__main-navigation">
         <ul class="fd-nested-list fd-nested-list--compact">
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
-                    <span class="fd-nested-list__icon sap-icon--home"></span>
+                    <span aria-label="Level 1 Item" class="fd-nested-list__icon sap-icon--home"></span>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
-                    <span class="fd-nested-list__icon sap-icon--calendar"></span>
+                    <span aria-label="Level 1 Item" class="fd-nested-list__icon sap-icon--calendar"></span>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
             <li class="fd-nested-list__item">
                 <div class="fd-nested-list__content is-selected has-child" tabindex="0">
                     <a class="fd-nested-list__link" href="#" tabindex="-1">
-                        <span class="fd-nested-list__icon sap-icon--employee"></span>
+                        <span aria-label="Level 1 Item" class="fd-nested-list__icon sap-icon--employee"></span>
                         <span class="fd-nested-list__title">Level 1 Item</span>
                     </a>
                     <a class="fd-nested-list__expand-icon" href="#" tabindex="-1" aria-haspopup="true"></a>
@@ -482,29 +491,29 @@ The following requirements must be met:
             </li>
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
-                    <span class="fd-nested-list__icon sap-icon--activities"></span>
+                    <span aria-label="Level 1 Item" class="fd-nested-list__icon sap-icon--activities"></span>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
-                    <span class="fd-nested-list__icon sap-icon--bar-chart"></span>
+                    <span aria-label="Level 1 Item" class="fd-nested-list__icon sap-icon--bar-chart"></span>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
         </ul>
     </div>
     <div class="fd-side-nav__utility">
-        <ul class="fd-nested-list fd-nested-list--compact">
+        <ul class="fd-nested-list fd-nested-list--compact" aria-label="Utility Menu">
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
-                    <span class="fd-nested-list__icon sap-icon--compare"></span>
+                    <span aria-label="Level 1 Item" class="fd-nested-list__icon sap-icon--compare"></span>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
-                    <span class="fd-nested-list__icon sap-icon--chain-link"></span>
+                    <span aria-label="Level 1 Item" class="fd-nested-list__icon sap-icon--chain-link"></span>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>

--- a/src/_nested-list.scss
+++ b/src/_nested-list.scss
@@ -211,28 +211,8 @@ $block: #{$fd-namespace}-nested-list;
     }
   }
 
-  &__group-header {
-    @include fd-reset();
-
-    height: 2.75rem;
-    background: var(--sapList_GroupHeaderBackground);
-    border-bottom: var(--sapList_BorderWidth) solid var(--sapList_GroupHeaderBorderColor);
-    color: var(--sapList_GroupHeaderTextColor);
-    display: flex;
-    align-items: flex-end;
-    font-size: var(--sapFontSize);
-    font-weight: bold;
-    line-height: 2rem;
-    padding-right: 1rem;
-    padding-left: 1rem;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
   &--no-border {
-    .#{$block}__item,
-    .#{$block}__group-header {
+    .#{$block}__item {
       border-bottom: none;
     }
   }

--- a/src/_nested-list.scss
+++ b/src/_nested-list.scss
@@ -77,6 +77,10 @@ $block: #{$fd-namespace}-nested-list;
 
     @include fd-hover() {
       background: var(--sapList_Hover_Background);
+
+      .#{$block}__expand-icon {
+        background: var(--sapList_Hover_Background);
+      }
     }
 
     @include fd-fiori-focus();
@@ -90,16 +94,32 @@ $block: #{$fd-namespace}-nested-list;
       border-bottom: var(--sapList_BorderWidth) solid;
       border-bottom-color: var(--sapList_SelectionBorderColor);
 
+      .#{$block}__expand-icon {
+        background: var(--sapList_SelectionBackgroundColor);
+      }
+
       @include fd-hover() {
         background: var(--sapList_Hover_SelectionBackground);
+
+        .#{$block}__expand-icon {
+          background: var(--sapList_Hover_SelectionBackground);
+        }
       }
     }
 
     @include fd-active() {
       background: var(--sapList_Active_Background);
 
+      .#{$block}__expand-icon {
+        background: var(--sapList_Active_Background);
+      }
+
       @include fd-selected() {
         background: var(--sapList_Active_Background);
+
+        .#{$block}__expand-icon {
+          background: var(--sapList_Active_Background);
+        }
       }
 
       .#{$block}__title,
@@ -211,8 +231,28 @@ $block: #{$fd-namespace}-nested-list;
     }
   }
 
+  &__group-header {
+    @include fd-reset();
+
+    height: 2.75rem;
+    background: var(--sapList_GroupHeaderBackground);
+    border-bottom: var(--sapList_BorderWidth) solid var(--sapList_GroupHeaderBorderColor);
+    color: var(--sapList_GroupHeaderTextColor);
+    display: flex;
+    align-items: flex-end;
+    font-size: var(--sapFontSize);
+    font-weight: bold;
+    line-height: 2rem;
+    padding-right: 1rem;
+    padding-left: 1rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
   &--no-border {
-    .#{$block}__item {
+    .#{$block}__item,
+    .#{$block}__group-header {
       border-bottom: none;
     }
   }

--- a/src/_nested-list.scss
+++ b/src/_nested-list.scss
@@ -78,7 +78,7 @@ $block: #{$fd-namespace}-nested-list;
     @include fd-hover() {
       background: var(--sapList_Hover_Background);
 
-      .#{$block}__expand-icon {
+      .#{$block}__button {
         background: var(--sapList_Hover_Background);
       }
     }
@@ -94,14 +94,14 @@ $block: #{$fd-namespace}-nested-list;
       border-bottom: var(--sapList_BorderWidth) solid;
       border-bottom-color: var(--sapList_SelectionBorderColor);
 
-      .#{$block}__expand-icon {
+      .#{$block}__button {
         background: var(--sapList_SelectionBackgroundColor);
       }
 
       @include fd-hover() {
         background: var(--sapList_Hover_SelectionBackground);
 
-        .#{$block}__expand-icon {
+        .#{$block}__button {
           background: var(--sapList_Hover_SelectionBackground);
         }
       }
@@ -110,21 +110,21 @@ $block: #{$fd-namespace}-nested-list;
     @include fd-active() {
       background: var(--sapList_Active_Background);
 
-      .#{$block}__expand-icon {
+      .#{$block}__button {
         background: var(--sapList_Active_Background);
       }
 
       @include fd-selected() {
         background: var(--sapList_Active_Background);
 
-        .#{$block}__expand-icon {
+        .#{$block}__button {
           background: var(--sapList_Active_Background);
         }
       }
 
       .#{$block}__title,
       .#{$block}__icon,
-      .#{$block}__expand-icon {
+      .#{$block}__button {
         color: var(--sapList_Active_TextColor);
       }
     }
@@ -148,15 +148,13 @@ $block: #{$fd-namespace}-nested-list;
       }
 
       > .#{$block}__link,
-      > .#{$block}__expand-icon {
-        @include fd-fiori-focus() {
-          outline: none;
-        }
+      > .#{$block}__button {
+        @include fd-fiori-focus();
       }
     }
   }
 
-  &__expand-icon {
+  &__button {
     @include fd-reset();
     @include fd-fiori-focus();
 

--- a/src/side-nav.scss
+++ b/src/side-nav.scss
@@ -36,6 +36,7 @@ $has-child-content-arrow-margin: 0.125rem;
 
     &:focus {
       @include fd-link();
+
       position: static;
       width: auto;
       height: auto;

--- a/src/side-nav.scss
+++ b/src/side-nav.scss
@@ -85,7 +85,7 @@ $has-child-content-arrow-margin: 0.125rem;
     .#{$fd-namespace}-nested-list {
       &__title,
       &__group-header,
-      &__expand-icon {
+      &__button {
         display: none;
       }
 

--- a/src/side-nav.scss
+++ b/src/side-nav.scss
@@ -4,6 +4,7 @@
 
 /*!
 .fd-side-nav
+    .fd-side-nav__skip-link
     .fd-side-nav__group
         .fd-side-nav__title
         .fd-side-nav__list
@@ -28,6 +29,37 @@ $has-child-content-arrow-margin: 0.125rem;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+
+  &__skip-link {
+    @include fd-reset();
+    @include fd-screen-reader-only();
+
+    &:focus {
+      @include fd-link();
+      position: static;
+      width: auto;
+      height: auto;
+    }
+  }
+
+  &__group-header {
+    @include fd-reset();
+
+    height: 2.75rem;
+    background: var(--sapList_GroupHeaderBackground);
+    border-bottom: var(--sapList_BorderWidth) solid var(--sapList_GroupHeaderBorderColor);
+    color: var(--sapList_GroupHeaderTextColor);
+    display: flex;
+    align-items: flex-end;
+    font-size: var(--sapFontSize);
+    font-weight: bold;
+    line-height: 2rem;
+    padding-right: 1rem;
+    padding-left: 1rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 
   &__main-navigation {
     @include fd-reset();


### PR DESCRIPTION
## Description
- Updated SideNavigation to be a collection of `nav` sections for multiple groups
- Moved group header out of the list so it can be correctly associated as the title of each nav
- Added aria-hidden to icons except in compact mode, where aria-label was added to replace the text
- Added aria-label to utility menu as it does not have an option for a visible header
- Updated role of nested group header to `button` and removed `href` as it is not a link
- Added skip link to top of navigation list so users can skip to the next content if desired

## Screenshots
No visual changes