### PR TITLE
feat: Select component reference markup

### DIFF
--- a/docs/pages/components/select.md
+++ b/docs/pages/components/select.md
@@ -31,16 +31,16 @@ For lists that require more than 12 options, the <a href="/patterns/combobox-inp
   </div>
   <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown" aria-hidden="true" id="h0C6A325">
      <ul class="fd-list fd-list--dropdown" role="listbox">
-        <li class="fd-list__item is-selected" aria-selected="true" role="option">
+        <li class="fd-list__item is-selected" aria-selected="true" role="option" tabindex="0">
            <span class="fd-list__title">List item 1</span>
         </li>
-        <li class="fd-list__item" role="option">
+        <li class="fd-list__item" role="option" tabindex="-1">
            <span class="fd-list__title">List item 2</span>
        </li>
-        <li class="fd-list__item" role="option">
+        <li class="fd-list__item" role="option" tabindex="-1">
            <span class="fd-list__title">List item 3</span>
         </li>
-        <li class="fd-list__item" role="option">
+        <li class="fd-list__item" role="option" tabindex="-1">
            <span class="fd-list__title">List item 4</span>
         </li>
      </ul>
@@ -64,19 +64,19 @@ For lists that require more than 12 options, the <a href="/patterns/combobox-inp
   </div>
   <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown" aria-hidden="true" id="h0C6A326">
      <ul class="fd-list fd-list--dropdown fd-list--compact" role="listbox">
-        <li class="fd-list__item is-selected" aria-selected="true" role="option">
+        <li class="fd-list__item is-selected" aria-selected="true" role="option" tabindex="0">
            <span class="fd-list__title">
                Very long text, Very long text, Very long text, Very long text, Very long text, Very long text, Very long text, Very long text, Very long text, Very long text, Very long text
                Very long text, Very long text, Very long text
            </span>
         </li>
-        <li class="fd-list__item" role="option">
+        <li class="fd-list__item" role="option" tabindex="-1">
            <span class="fd-list__title">List item 2</span>
         </li>
-        <li class="fd-list__item" role="option">
+        <li class="fd-list__item" role="option" tabindex="-1">
            <span class="fd-list__title">List item 3</span>
         </li>
-        <li class="fd-list__item" role="option">
+        <li class="fd-list__item" role="option" tabindex="-1">
            <span class="fd-list__title">List item 4</span>
         </li>
      </ul>
@@ -105,19 +105,19 @@ The `Select` component can be customized by adding additional information in add
   </div>
   <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown" aria-hidden="true" id="h0C62325">
      <ul class="fd-list fd-list--dropdown" role="listbox">
-        <li class="fd-list__item is-selected" aria-selected="true" role="option">
+        <li class="fd-list__item is-selected" aria-selected="true" role="option" tabindex="0">
            <span class="fd-list__title">Product 1</span>
            <span class="fd-list__secondary">1000 EUR</span>
         </li>
-        <li class="fd-list__item" role="option">
+        <li class="fd-list__item" role="option" tabindex="-1">
            <span class="fd-list__title">Product 2</span>
            <span class="fd-list__secondary">750 EUR</span>
        </li>
-        <li class="fd-list__item" role="option">
+        <li class="fd-list__item" role="option" tabindex="-1">
            <span class="fd-list__title">Product 3</span>
            <span class="fd-list__secondary">780 EUR</span>
         </li>
-        <li class="fd-list__item" role="option">
+        <li class="fd-list__item" role="option" tabindex="-1">
            <span class="fd-list__title">Product 4</span>
            <span class="fd-list__secondary">40 EUR</span>
         </li>
@@ -143,19 +143,19 @@ The `Select` component can be customized by adding additional information in add
   </div>
   <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown" aria-hidden="true" id="h07jj326">
      <ul class="fd-list fd-list--dropdown fd-list--compact" role="listbox">
-        <li class="fd-list__item is-selected" aria-selected="true" role="option">
+        <li class="fd-list__item is-selected" aria-selected="true" role="option" tabindex="0">
            <span class="fd-list__title">Product 1</span>
            <span class="fd-list__secondary">1000 EUR</span>
         </li>
-        <li class="fd-list__item" role="option">
+        <li class="fd-list__item" role="option" tabindex="-1">
            <span class="fd-list__title">Product 2</span>
            <span class="fd-list__secondary">750 EUR</span>
        </li>
-        <li class="fd-list__item" role="option">
+        <li class="fd-list__item" role="option" tabindex="-1">
            <span class="fd-list__title">Product 3</span>
            <span class="fd-list__secondary">780 EUR</span>
         </li>
-        <li class="fd-list__item" role="option">
+        <li class="fd-list__item" role="option" tabindex="-1">
            <span class="fd-list__title">Product 4</span>
            <span class="fd-list__secondary">40 EUR</span>
         </li>
@@ -183,22 +183,22 @@ The `Select` component can be customized by adding additional information in add
   </div>
   <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown" aria-hidden="true" id="h090G325">
      <ul class="fd-list fd-list--dropdown" role="listbox">
-        <li class="fd-list__item is-selected" aria-selected="true" role="option">
+        <li class="fd-list__item is-selected" aria-selected="true" role="option" tabindex="0">
            <span class="fd-list__icon sap-icon--marketing-campaign"></span>
            <span class="fd-list__title">Marketing</span>
            <span class="fd-list__secondary">1000 EUR</span>
         </li>
-        <li class="fd-list__item" role="option">
+        <li class="fd-list__item" role="option" tabindex="-1">
            <span class="fd-list__icon sap-icon--save"></span>
            <span class="fd-list__title">Backups</span>
            <span class="fd-list__secondary">500 EUR</span>
        </li>
-        <li class="fd-list__item" role="option">
+        <li class="fd-list__item" role="option" tabindex="-1">
            <span class="fd-list__icon sap-icon--shipping-status"></span>
            <span class="fd-list__title">Shipping</span>
            <span class="fd-list__secondary">125 EUR</span>
         </li>
-        <li class="fd-list__item" role="option">
+        <li class="fd-list__item" role="option" tabindex="-1">
            <span class="fd-list__icon sap-icon--headset"></span>
            <span class="fd-list__title">Consulting</span>
            <span class="fd-list__secondary">200 EUR</span>
@@ -230,31 +230,31 @@ In cases where the list items need to be categorized into groups, it is possible
             <li class="fd-list__group-header">
                 Fruits
             </li>
-            <li role="option" class="fd-list__item is-selected" aria-selected="true">
+            <li role="option" tabindex="0" class="fd-list__item is-selected" aria-selected="true">
                 <span class="fd-list__title">Apple</span>
             </li>
-            <li role="option" class="fd-list__item">
+            <li role="option" tabindex="-1" class="fd-list__item">
                 <span class="fd-list__title">Orange</span>
             </li>
-            <li role="option" class="fd-list__item">
+            <li role="option" tabindex="-1" class="fd-list__item">
                 <span class="fd-list__title">Banana</span>
             </li>
-            <li role="option" class="fd-list__item">
+            <li role="option" tabindex="-1" class="fd-list__item">
                 <span class="fd-list__title">Kiwi</span>
             </li>
             <li class="fd-list__group-header">
                 Vegetables
             </li>
-            <li role="option" class="fd-list__item">
+            <li role="option" tabindex="-1" class="fd-list__item">
                 <span class="fd-list__title">Tomato</span>
             </li>
-            <li role="option" class="fd-list__item">
+            <li role="option" tabindex="-1" class="fd-list__item">
                 <span class="fd-list__title">Onion</span>
             </li>
-            <li role="option" class="fd-list__item">
+            <li role="option" tabindex="-1" class="fd-list__item">
                 <span class="fd-list__title">Spinach</span>
             </li>
-            <li role="option" class="fd-list__item">
+            <li role="option" tabindex="-1" class="fd-list__item">
                 <span class="fd-list__title">Potato</span>
             </li>
         </ul>
@@ -283,19 +283,19 @@ the `--no-wrap` modifier can be added to the `fd-list__title`, or `fd-list__seco
   </div>
   <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown" aria-hidden="true" id="h0GFF2325">
      <ul class="fd-list fd-list--dropdown" role="listbox">
-        <li class="fd-list__item is-selected" aria-selected="true" role="option">
+        <li class="fd-list__item is-selected" aria-selected="true" role="option" tabindex="0">
            <span class="fd-list__title">Very Long Text Very Long Text Very Long Text Very Long Text Very Long Text Very Long Text Very Long Text Very Long Text Very Long Text Very Long Text Very Long Text Very Long Text </span>
            <span class="fd-list__secondary">A1</span>
         </li>
-        <li class="fd-list__item" role="option">
+        <li class="fd-list__item" role="option" tabindex="-1">
            <span class="fd-list__title">List item 2</span>
            <span class="fd-list__secondary">A2</span>
        </li>
-        <li class="fd-list__item" role="option">
+        <li class="fd-list__item" role="option" tabindex="-1">
            <span class="fd-list__title">List item 3</span>
            <span class="fd-list__secondary">A3</span>
         </li>
-        <li class="fd-list__item" role="option">
+        <li class="fd-list__item" role="option" tabindex="-1">
            <span class="fd-list__title">List item 4</span>
            <span class="fd-list__secondary">A4</span>
         </li>
@@ -321,21 +321,21 @@ the `--no-wrap` modifier can be added to the `fd-list__title`, or `fd-list__seco
   </div>
   <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown" aria-hidden="true" id="h0GZH2325">
      <ul class="fd-list fd-list--dropdown fd-list--compact" role="listbox">
-        <li class="fd-list__item is-selected" aria-selected="true" role="option">
+        <li class="fd-list__item is-selected" aria-selected="true" role="option" tabindex="0">
            <span class="fd-list__title fd-list__title--no-wrap">
                Very Long Text Very Long Text Very Long Text Very Long Text Very Long Text Very Long Text Very Long Text Very Long Text Very Long Text Very Long Text Very Long Text Very Long Text 
            </span>
            <span class="fd-list__secondary">A1</span>
         </li>
-        <li class="fd-list__item" role="option">
+        <li class="fd-list__item" role="option" tabindex="-1">
            <span class="fd-list__title">List item 2</span>
            <span class="fd-list__secondary">A2</span>
         </li>
-        <li class="fd-list__item" role="option">
+        <li class="fd-list__item" role="option" tabindex="-1">
            <span class="fd-list__title">List item 3</span>
            <span class="fd-list__secondary">A3</span>
         </li>
-        <li class="fd-list__item" role="option">
+        <li class="fd-list__item" role="option" tabindex="-1">
            <span class="fd-list__title">List item 4</span>
            <span class="fd-list__secondary">A4</span>
         </li>
@@ -366,19 +366,19 @@ The length can be adjusted to match the text length by adding the `fd-popover__b
   </div>
   <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown fd-popover__body--dropdown-fill" aria-hidden="true" id="h0GTKE325">
      <ul class="fd-list fd-list--dropdown" role="listbox">
-        <li class="fd-list__item is-selected" aria-selected="true" role="option">
+        <li class="fd-list__item is-selected" aria-selected="true" role="option" tabindex="0">
            <span class="fd-list__title">List item 1</span>
            <span class="fd-list__secondary">A1</span>
         </li>
-        <li class="fd-list__item" role="option">
+        <li class="fd-list__item" role="option" tabindex="-1">
            <span class="fd-list__title">List item 2</span>
            <span class="fd-list__secondary">A2</span>
        </li>
-        <li class="fd-list__item" role="option">
+        <li class="fd-list__item" role="option" tabindex="-1">
            <span class="fd-list__title">List item 3</span>
            <span class="fd-list__secondary">A3</span>
         </li>
-        <li class="fd-list__item" role="option">
+        <li class="fd-list__item" role="option" tabindex="-1">
            <span class="fd-list__title">List item 4</span>
            <span class="fd-list__secondary">A4</span>
         </li>
@@ -446,21 +446,21 @@ To add text in the body of the component, simply include your text in the `fd-li
     <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown" aria-hidden="true" id="h07jjhYH">
          <ul class="fd-list fd-list--has-message fd-list--dropdown fd-list--compact" role="listbox">
             <li class="fd-list__message fd-list__message--success">Success message</li>
-            <li class="fd-list__item is-selected" aria-selected="true" role="option">
+            <li class="fd-list__item is-selected" aria-selected="true" role="option" tabindex="0">
                <span class="fd-list__title">
                    List Item 1
                </span>
                <span class="fd-list__secondary">A1</span>
             </li>
-            <li class="fd-list__item" role="option">
+            <li class="fd-list__item" role="option" tabindex="-1">
                <span class="fd-list__title">List item 2</span>
                <span class="fd-list__secondary">A2</span>
             </li>
-            <li class="fd-list__item" role="option">
+            <li class="fd-list__item" role="option" tabindex="-1">
                <span class="fd-list__title">List item 3</span>
                <span class="fd-list__secondary">A3</span>
             </li>
-            <li class="fd-list__item" role="option">
+            <li class="fd-list__item" role="option" tabindex="-1">
                <span class="fd-list__title">List item 4</span>
                <span class="fd-list__secondary">A4</span>
             </li>
@@ -485,21 +485,21 @@ To add text in the body of the component, simply include your text in the `fd-li
    <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown" aria-hidden="true" id="h07j9978H">
         <ul class="fd-list fd-list--has-message fd-list--dropdown fd-list--compact" role="listbox">
            <li class="fd-list__message fd-list__message--error">Error message</li>
-           <li class="fd-list__item is-selected" aria-selected="true" role="option">
+           <li class="fd-list__item is-selected" aria-selected="true" role="option" tabindex="0">
               <span class="fd-list__title">
                   List Item 1
               </span>
               <span class="fd-list__secondary">A1</span>
            </li>
-           <li class="fd-list__item" role="option">
+           <li class="fd-list__item" role="option" tabindex="-1">
               <span class="fd-list__title">List item 2</span>
               <span class="fd-list__secondary">A2</span>
            </li>
-           <li class="fd-list__item" role="option">
+           <li class="fd-list__item" role="option" tabindex="-1">
               <span class="fd-list__title">List item 3</span>
               <span class="fd-list__secondary">A3</span>
            </li>
-           <li class="fd-list__item" role="option">
+           <li class="fd-list__item" role="option" tabindex="-1">
               <span class="fd-list__title">List item 4</span>
               <span class="fd-list__secondary">A4</span>
            </li>
@@ -524,21 +524,21 @@ To add text in the body of the component, simply include your text in the `fd-li
    <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown" aria-hidden="true" id="h07j998hhH">
         <ul class="fd-list fd-list--has-message fd-list--dropdown fd-list--compact" role="listbox">
            <li class="fd-list__message fd-list__message--warning">Warning message</li>
-           <li class="fd-list__item is-selected" aria-selected="true" role="option">
+           <li class="fd-list__item is-selected" aria-selected="true" role="option" tabindex="0">
               <span class="fd-list__title">
                   List Item 1
               </span>
               <span class="fd-list__secondary">A1</span>
            </li>
-           <li class="fd-list__item" role="option">
+           <li class="fd-list__item" role="option" tabindex="-1">
               <span class="fd-list__title">List item 2</span>
               <span class="fd-list__secondary">A2</span>
            </li>
-           <li class="fd-list__item" role="option">
+           <li class="fd-list__item" role="option" tabindex="-1">
               <span class="fd-list__title">List item 3</span>
               <span class="fd-list__secondary">A3</span>
            </li>
-           <li class="fd-list__item" role="option">
+           <li class="fd-list__item" role="option" tabindex="-1">
               <span class="fd-list__title">List item 4</span>
               <span class="fd-list__secondary">A4</span>
            </li>
@@ -563,21 +563,21 @@ To add text in the body of the component, simply include your text in the `fd-li
    <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown" aria-hidden="true" id="hkhh998hhH">
         <ul class="fd-list fd-list--has-message fd-list--dropdown fd-list--compact" role="listbox">
            <li class="fd-list__message fd-list__message--information">Information message</li>
-           <li class="fd-list__item is-selected" aria-selected="true" role="option">
+           <li class="fd-list__item is-selected" aria-selected="true" role="option" tabindex="0">
               <span class="fd-list__title">
                   List Item 1
               </span>
               <span class="fd-list__secondary">A1</span>
            </li>
-           <li class="fd-list__item" role="option">
+           <li class="fd-list__item" role="option" tabindex="-1">
               <span class="fd-list__title">List item 2</span>
               <span class="fd-list__secondary">A2</span>
            </li>
-           <li class="fd-list__item" role="option">
+           <li class="fd-list__item" role="option" tabindex="-1">
               <span class="fd-list__title">List item 3</span>
               <span class="fd-list__secondary">A3</span>
            </li>
-           <li class="fd-list__item" role="option">
+           <li class="fd-list__item" role="option" tabindex="-1">
               <span class="fd-list__title">List item 4</span>
               <span class="fd-list__secondary">A4</span>
            </li>

--- a/docs/pages/components/select.md
+++ b/docs/pages/components/select.md
@@ -23,24 +23,24 @@ For lists that require more than 12 options, the <a href="/patterns/combobox-inp
 <div class="fd-popover">
   <div class="fd-popover__control">
      <div class="fd-select">
-         <div class="fd-select__control" tabindex="0" aria-controls="h0C6A325" aria-expanded="false" aria-haspopup="true">
+         <div class="fd-select__control" role="button" tabindex="0" aria-controls="h0C6A325" aria-expanded="false" aria-haspopup="true">
              Select
-             <button class="fd-button fd-button--transparent sap-icon--slim-arrow-down fd-select__button"></button>
+             <span class="fd-button fd-button--transparent sap-icon--slim-arrow-down fd-select__button"></span>
          </div>
       </div>
   </div>
   <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown" aria-hidden="true" id="h0C6A325">
      <ul class="fd-list fd-list--dropdown" role="listbox">
-        <li class="fd-list__item is-selected" role="option" tabindex="0">
+        <li class="fd-list__item is-selected" aria-selected="true" role="option">
            <span class="fd-list__title">List item 1</span>
         </li>
-        <li class="fd-list__item" role="option" tabindex="0">
+        <li class="fd-list__item" role="option">
            <span class="fd-list__title">List item 2</span>
        </li>
-        <li class="fd-list__item" role="option" tabindex="0">
+        <li class="fd-list__item" role="option">
            <span class="fd-list__title">List item 3</span>
         </li>
-        <li class="fd-list__item" role="option" tabindex="0">
+        <li class="fd-list__item" role="option">
            <span class="fd-list__title">List item 4</span>
         </li>
      </ul>
@@ -56,27 +56,27 @@ For lists that require more than 12 options, the <a href="/patterns/combobox-inp
 <div class="fd-popover">
   <div class="fd-popover__control">
      <div class="fd-select fd-select--compact">
-        <div class="fd-select__control" tabindex="0" aria-controls="h0C6A326" aria-expanded="false" aria-haspopup="true">
+        <div class="fd-select__control" role="button" tabindex="0" aria-controls="h0C6A326" aria-expanded="false" aria-haspopup="true">
             Select
-            <button class="fd-button fd-button--transparent sap-icon--slim-arrow-down fd-select__button"></button>
+            <span class="fd-button fd-button--transparent sap-icon--slim-arrow-down fd-select__button"></span>
         </div>
      </div>
   </div>
   <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown" aria-hidden="true" id="h0C6A326">
      <ul class="fd-list fd-list--dropdown fd-list--compact" role="listbox">
-        <li class="fd-list__item is-selected" role="option" tabindex="0">
+        <li class="fd-list__item is-selected" aria-selected="true" role="option">
            <span class="fd-list__title">
                Very long text, Very long text, Very long text, Very long text, Very long text, Very long text, Very long text, Very long text, Very long text, Very long text, Very long text
                Very long text, Very long text, Very long text
            </span>
         </li>
-        <li class="fd-list__item" role="option" tabindex="0">
+        <li class="fd-list__item" role="option">
            <span class="fd-list__title">List item 2</span>
         </li>
-        <li class="fd-list__item" role="option" tabindex="0">
+        <li class="fd-list__item" role="option">
            <span class="fd-list__title">List item 3</span>
         </li>
-        <li class="fd-list__item" role="option" tabindex="0">
+        <li class="fd-list__item" role="option">
            <span class="fd-list__title">List item 4</span>
         </li>
      </ul>
@@ -97,27 +97,27 @@ The `Select` component can be customized by adding additional information in add
 <div class="fd-popover">
   <div class="fd-popover__control">
      <div class="fd-select">
-         <div class="fd-select__control" tabindex="0" aria-controls="h0C62325" aria-expanded="false" aria-haspopup="true">
+         <div class="fd-select__control" role="button" tabindex="0" aria-controls="h0C62325" aria-expanded="false" aria-haspopup="true">
              Select Product
-             <button class="fd-button fd-button--transparent sap-icon--slim-arrow-down fd-select__button"></button>
+             <span class="fd-button fd-button--transparent sap-icon--slim-arrow-down fd-select__button"></span>
          </div>
       </div>
   </div>
   <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown" aria-hidden="true" id="h0C62325">
      <ul class="fd-list fd-list--dropdown" role="listbox">
-        <li class="fd-list__item is-selected" role="option" tabindex="0">
+        <li class="fd-list__item is-selected" aria-selected="true" role="option">
            <span class="fd-list__title">Product 1</span>
            <span class="fd-list__secondary">1000 EUR</span>
         </li>
-        <li class="fd-list__item" role="option" tabindex="0">
+        <li class="fd-list__item" role="option">
            <span class="fd-list__title">Product 2</span>
            <span class="fd-list__secondary">750 EUR</span>
        </li>
-        <li class="fd-list__item" role="option" tabindex="0">
+        <li class="fd-list__item" role="option">
            <span class="fd-list__title">Product 3</span>
            <span class="fd-list__secondary">780 EUR</span>
         </li>
-        <li class="fd-list__item" role="option" tabindex="0">
+        <li class="fd-list__item" role="option">
            <span class="fd-list__title">Product 4</span>
            <span class="fd-list__secondary">40 EUR</span>
         </li>
@@ -135,27 +135,27 @@ The `Select` component can be customized by adding additional information in add
 <div class="fd-popover">
   <div class="fd-popover__control">
      <div class="fd-select fd-select--compact">
-        <div class="fd-select__control" tabindex="0" aria-controls="h07jj326" aria-expanded="false" aria-haspopup="true">
+        <div class="fd-select__control" role="button" tabindex="0" aria-controls="h07jj326" aria-expanded="false" aria-haspopup="true">
             Select Product
-            <button class="fd-button fd-button--transparent sap-icon--slim-arrow-down fd-select__button"></button>
+            <span class="fd-button fd-button--transparent sap-icon--slim-arrow-down fd-select__button"></span>
         </div>
      </div>
   </div>
   <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown" aria-hidden="true" id="h07jj326">
      <ul class="fd-list fd-list--dropdown fd-list--compact" role="listbox">
-        <li class="fd-list__item is-selected" role="option" tabindex="0">
+        <li class="fd-list__item is-selected" aria-selected="true" role="option">
            <span class="fd-list__title">Product 1</span>
            <span class="fd-list__secondary">1000 EUR</span>
         </li>
-        <li class="fd-list__item" role="option" tabindex="0">
+        <li class="fd-list__item" role="option">
            <span class="fd-list__title">Product 2</span>
            <span class="fd-list__secondary">750 EUR</span>
        </li>
-        <li class="fd-list__item" role="option" tabindex="0">
+        <li class="fd-list__item" role="option">
            <span class="fd-list__title">Product 3</span>
            <span class="fd-list__secondary">780 EUR</span>
         </li>
-        <li class="fd-list__item" role="option" tabindex="0">
+        <li class="fd-list__item" role="option">
            <span class="fd-list__title">Product 4</span>
            <span class="fd-list__secondary">40 EUR</span>
         </li>
@@ -175,30 +175,30 @@ The `Select` component can be customized by adding additional information in add
 <div class="fd-popover">
   <div class="fd-popover__control">
      <div class="fd-select">
-         <div class="fd-select__control" tabindex="0" aria-controls="h090G325" aria-expanded="false" aria-haspopup="true">
+         <div class="fd-select__control" role="button" tabindex="0" aria-controls="h090G325" aria-expanded="false" aria-haspopup="true">
              Select Product
-             <button class="fd-button fd-button--transparent sap-icon--slim-arrow-down fd-select__button"></button>
+             <span class="fd-button fd-button--transparent sap-icon--slim-arrow-down fd-select__button"></span>
          </div>
       </div>
   </div>
   <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown" aria-hidden="true" id="h090G325">
      <ul class="fd-list fd-list--dropdown" role="listbox">
-        <li class="fd-list__item is-selected" role="option" tabindex="0">
+        <li class="fd-list__item is-selected" aria-selected="true" role="option">
            <span class="fd-list__icon sap-icon--marketing-campaign"></span>
            <span class="fd-list__title">Marketing</span>
            <span class="fd-list__secondary">1000 EUR</span>
         </li>
-        <li class="fd-list__item" role="option" tabindex="0">
+        <li class="fd-list__item" role="option">
            <span class="fd-list__icon sap-icon--save"></span>
            <span class="fd-list__title">Backups</span>
            <span class="fd-list__secondary">500 EUR</span>
        </li>
-        <li class="fd-list__item" role="option" tabindex="0">
+        <li class="fd-list__item" role="option">
            <span class="fd-list__icon sap-icon--shipping-status"></span>
            <span class="fd-list__title">Shipping</span>
            <span class="fd-list__secondary">125 EUR</span>
         </li>
-        <li class="fd-list__item" role="option" tabindex="0">
+        <li class="fd-list__item" role="option">
            <span class="fd-list__icon sap-icon--headset"></span>
            <span class="fd-list__title">Consulting</span>
            <span class="fd-list__secondary">200 EUR</span>
@@ -219,9 +219,9 @@ In cases where the list items need to be categorized into groups, it is possible
 <div class="fd-popover">
   <div class="fd-popover__control">
      <div class="fd-select">
-         <div class="fd-select__control" tabindex="0" aria-controls="h09GDGG325" aria-expanded="false" aria-haspopup="true">
+         <div class="fd-select__control" role="button" tabindex="0" aria-controls="h09GDGG325" aria-expanded="false" aria-haspopup="true">
              Select Ingredient
-             <button class="fd-button fd-button--transparent sap-icon--slim-arrow-down fd-select__button"></button>
+             <span class="fd-button fd-button--transparent sap-icon--slim-arrow-down fd-select__button"></span>
          </div>
       </div>
   </div>
@@ -230,31 +230,31 @@ In cases where the list items need to be categorized into groups, it is possible
             <li class="fd-list__group-header">
                 Fruits
             </li>
-            <li role="option" tabindex="0" class="fd-list__item is-selected">
+            <li role="option" class="fd-list__item is-selected" aria-selected="true">
                 <span class="fd-list__title">Apple</span>
             </li>
-            <li role="option" tabindex="0" class="fd-list__item">
+            <li role="option" class="fd-list__item">
                 <span class="fd-list__title">Orange</span>
             </li>
-            <li role="option" tabindex="0" class="fd-list__item">
+            <li role="option" class="fd-list__item">
                 <span class="fd-list__title">Banana</span>
             </li>
-            <li role="option" tabindex="0" class="fd-list__item">
+            <li role="option" class="fd-list__item">
                 <span class="fd-list__title">Kiwi</span>
             </li>
             <li class="fd-list__group-header">
                 Vegetables
             </li>
-            <li role="option" tabindex="0" class="fd-list__item">
+            <li role="option" class="fd-list__item">
                 <span class="fd-list__title">Tomato</span>
             </li>
-            <li role="option" tabindex="0" class="fd-list__item">
+            <li role="option" class="fd-list__item">
                 <span class="fd-list__title">Onion</span>
             </li>
-            <li role="option" tabindex="0" class="fd-list__item">
+            <li role="option" class="fd-list__item">
                 <span class="fd-list__title">Spinach</span>
             </li>
-            <li role="option" tabindex="0" class="fd-list__item">
+            <li role="option" class="fd-list__item">
                 <span class="fd-list__title">Potato</span>
             </li>
         </ul>
@@ -275,27 +275,27 @@ the `--no-wrap` modifier can be added to the `fd-list__title`, or `fd-list__seco
 <div class="fd-popover">
   <div class="fd-popover__control">
      <div class="fd-select">
-         <div class="fd-select__control" tabindex="0" aria-controls="h0GFF2325" aria-expanded="false" aria-haspopup="true">
+         <div class="fd-select__control" role="button" tabindex="0" aria-controls="h0GFF2325" aria-expanded="false" aria-haspopup="true">
              Select
-             <button class="fd-button fd-button--transparent sap-icon--slim-arrow-down fd-select__button"></button>
+             <span class="fd-button fd-button--transparent sap-icon--slim-arrow-down fd-select__button"></span>
          </div>
       </div>
   </div>
   <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown" aria-hidden="true" id="h0GFF2325">
      <ul class="fd-list fd-list--dropdown" role="listbox">
-        <li class="fd-list__item is-selected" role="option" tabindex="0">
+        <li class="fd-list__item is-selected" aria-selected="true" role="option">
            <span class="fd-list__title">Very Long Text Very Long Text Very Long Text Very Long Text Very Long Text Very Long Text Very Long Text Very Long Text Very Long Text Very Long Text Very Long Text Very Long Text </span>
            <span class="fd-list__secondary">A1</span>
         </li>
-        <li class="fd-list__item" role="option" tabindex="0">
+        <li class="fd-list__item" role="option">
            <span class="fd-list__title">List item 2</span>
            <span class="fd-list__secondary">A2</span>
        </li>
-        <li class="fd-list__item" role="option" tabindex="0">
+        <li class="fd-list__item" role="option">
            <span class="fd-list__title">List item 3</span>
            <span class="fd-list__secondary">A3</span>
         </li>
-        <li class="fd-list__item" role="option" tabindex="0">
+        <li class="fd-list__item" role="option">
            <span class="fd-list__title">List item 4</span>
            <span class="fd-list__secondary">A4</span>
         </li>
@@ -313,29 +313,29 @@ the `--no-wrap` modifier can be added to the `fd-list__title`, or `fd-list__seco
 <div class="fd-popover">
   <div class="fd-popover__control">
      <div class="fd-select fd-select--compact">
-        <div class="fd-select__control" tabindex="0" aria-controls="h0GZH2325" aria-expanded="false" aria-haspopup="true">
+        <div class="fd-select__control" role="button" tabindex="0" aria-controls="h0GZH2325" aria-expanded="false" aria-haspopup="true">
             Select
-            <button class="fd-button fd-button--transparent sap-icon--slim-arrow-down fd-select__button"></button>
+            <span class="fd-button fd-button--transparent sap-icon--slim-arrow-down fd-select__button"></span>
         </div>
      </div>
   </div>
   <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown" aria-hidden="true" id="h0GZH2325">
      <ul class="fd-list fd-list--dropdown fd-list--compact" role="listbox">
-        <li class="fd-list__item is-selected" role="option" tabindex="0">
+        <li class="fd-list__item is-selected" aria-selected="true" role="option">
            <span class="fd-list__title fd-list__title--no-wrap">
                Very Long Text Very Long Text Very Long Text Very Long Text Very Long Text Very Long Text Very Long Text Very Long Text Very Long Text Very Long Text Very Long Text Very Long Text 
            </span>
            <span class="fd-list__secondary">A1</span>
         </li>
-        <li class="fd-list__item" role="option" tabindex="0">
+        <li class="fd-list__item" role="option">
            <span class="fd-list__title">List item 2</span>
            <span class="fd-list__secondary">A2</span>
         </li>
-        <li class="fd-list__item" role="option" tabindex="0">
+        <li class="fd-list__item" role="option">
            <span class="fd-list__title">List item 3</span>
            <span class="fd-list__secondary">A3</span>
         </li>
-        <li class="fd-list__item" role="option" tabindex="0">
+        <li class="fd-list__item" role="option">
            <span class="fd-list__title">List item 4</span>
            <span class="fd-list__secondary">A4</span>
         </li>
@@ -358,27 +358,27 @@ The length can be adjusted to match the text length by adding the `fd-popover__b
 <div class="fd-popover">
   <div class="fd-popover__control">
      <div class="fd-select">
-         <div class="fd-select__control" tabindex="0" aria-controls="h0GTKE325" aria-expanded="false" aria-haspopup="true">
+         <div class="fd-select__control" role="button" tabindex="0" aria-controls="h0GTKE325" aria-expanded="false" aria-haspopup="true">
              Much Longer than Usual
-             <button class="fd-button fd-button--transparent sap-icon--slim-arrow-down fd-select__button"></button>
+             <span class="fd-button fd-button--transparent sap-icon--slim-arrow-down fd-select__button"></span>
          </div>
       </div>
   </div>
   <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown fd-popover__body--dropdown-fill" aria-hidden="true" id="h0GTKE325">
      <ul class="fd-list fd-list--dropdown" role="listbox">
-        <li class="fd-list__item is-selected" role="option" tabindex="0">
+        <li class="fd-list__item is-selected" aria-selected="true" role="option">
            <span class="fd-list__title">List item 1</span>
            <span class="fd-list__secondary">A1</span>
         </li>
-        <li class="fd-list__item" role="option" tabindex="0">
+        <li class="fd-list__item" role="option">
            <span class="fd-list__title">List item 2</span>
            <span class="fd-list__secondary">A2</span>
        </li>
-        <li class="fd-list__item" role="option" tabindex="0">
+        <li class="fd-list__item" role="option">
            <span class="fd-list__title">List item 3</span>
            <span class="fd-list__secondary">A3</span>
         </li>
-        <li class="fd-list__item" role="option" tabindex="0">
+        <li class="fd-list__item" role="option">
            <span class="fd-list__title">List item 4</span>
            <span class="fd-list__secondary">A4</span>
         </li>
@@ -398,9 +398,9 @@ The disabled state can also be achieved by adding the `.is-disabled` class or th
 <div class="fd-popover">
     <div class="fd-popover__control" aria-disabled="true" disabled>
         <div class="fd-select">
-            <div class="fd-select__control" aria-expanded="false" aria-haspopup="false" aria-disabled="true" disabled>
+            <div class="fd-select__control" role="button" tabindex="0" aria-expanded="false" aria-haspopup="false" aria-disabled="true" disabled>
                 Select
-                <button class="fd-button sap-icon--slim-arrow-down fd-select__button"></button>
+                <span class="fd-button sap-icon--slim-arrow-down fd-select__button"></span>
             </div>
         </div>
     </div>
@@ -418,7 +418,7 @@ This can also be done by adding the `.is-readonly` class or the `aria-readonly="
 <div class="fd-popover">
     <div class="fd-popover__control" aria-expanded="false" aria-haspopup="false" aria-readonly="true" readonly>
         <div class="fd-select">
-            <div class="fd-select__control" aria-expanded="false" aria-haspopup="false" aria-readonly="true" readonly>
+            <div class="fd-select__control" role="button" tabindex="0" aria-expanded="false" aria-haspopup="false" aria-readonly="true" readonly>
                 Select
            </div>
         </div>
@@ -437,30 +437,30 @@ To add text in the body of the component, simply include your text in the `fd-li
 <div class="fd-popover">
     <div class="fd-popover__control">
         <div class="fd-select">
-            <div class="fd-select__control is-success" tabindex="0" aria-controls="h07jjhYH"  aria-expanded="false" aria-haspopup="true">
+            <div class="fd-select__control is-success" role="button" tabindex="0" aria-controls="h07jjhYH"  aria-expanded="false" aria-haspopup="true">
                 Success
-                <button class="fd-button sap-icon--slim-arrow-down fd-select__button"></button>
+                <span class="fd-button sap-icon--slim-arrow-down fd-select__button"></span>
             </div>
         </div>
     </div>
     <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown" aria-hidden="true" id="h07jjhYH">
          <ul class="fd-list fd-list--has-message fd-list--dropdown fd-list--compact" role="listbox">
             <li class="fd-list__message fd-list__message--success">Success message</li>
-            <li class="fd-list__item is-selected" role="option" tabindex="0">
+            <li class="fd-list__item is-selected" aria-selected="true" role="option">
                <span class="fd-list__title">
                    List Item 1
                </span>
                <span class="fd-list__secondary">A1</span>
             </li>
-            <li class="fd-list__item" role="option" tabindex="0">
+            <li class="fd-list__item" role="option">
                <span class="fd-list__title">List item 2</span>
                <span class="fd-list__secondary">A2</span>
             </li>
-            <li class="fd-list__item" role="option" tabindex="0">
+            <li class="fd-list__item" role="option">
                <span class="fd-list__title">List item 3</span>
                <span class="fd-list__secondary">A3</span>
             </li>
-            <li class="fd-list__item" role="option" tabindex="0">
+            <li class="fd-list__item" role="option">
                <span class="fd-list__title">List item 4</span>
                <span class="fd-list__secondary">A4</span>
             </li>
@@ -476,30 +476,30 @@ To add text in the body of the component, simply include your text in the `fd-li
 <div class="fd-popover">
    <div class="fd-popover__control">
        <div class="fd-select">
-           <div class="fd-select__control is-error" tabindex="0" aria-controls="h07j9978H"  aria-expanded="false" aria-haspopup="true">
+           <div class="fd-select__control is-error" role="button" tabindex="0" aria-controls="h07j9978H"  aria-expanded="false" aria-haspopup="true">
                Error
-               <button class="fd-button sap-icon--slim-arrow-down fd-select__button"></button>
+               <span class="fd-button sap-icon--slim-arrow-down fd-select__button"></span>
            </div>
        </div>
    </div>
    <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown" aria-hidden="true" id="h07j9978H">
         <ul class="fd-list fd-list--has-message fd-list--dropdown fd-list--compact" role="listbox">
            <li class="fd-list__message fd-list__message--error">Error message</li>
-           <li class="fd-list__item is-selected" role="option" tabindex="0">
+           <li class="fd-list__item is-selected" aria-selected="true" role="option">
               <span class="fd-list__title">
                   List Item 1
               </span>
               <span class="fd-list__secondary">A1</span>
            </li>
-           <li class="fd-list__item" role="option" tabindex="0">
+           <li class="fd-list__item" role="option">
               <span class="fd-list__title">List item 2</span>
               <span class="fd-list__secondary">A2</span>
            </li>
-           <li class="fd-list__item" role="option" tabindex="0">
+           <li class="fd-list__item" role="option">
               <span class="fd-list__title">List item 3</span>
               <span class="fd-list__secondary">A3</span>
            </li>
-           <li class="fd-list__item" role="option" tabindex="0">
+           <li class="fd-list__item" role="option">
               <span class="fd-list__title">List item 4</span>
               <span class="fd-list__secondary">A4</span>
            </li>
@@ -515,30 +515,30 @@ To add text in the body of the component, simply include your text in the `fd-li
 <div class="fd-popover">
    <div class="fd-popover__control">
        <div class="fd-select">
-           <div class="fd-select__control is-warning" tabindex="0" aria-controls="h07j998hhH"  aria-expanded="false" aria-haspopup="true">
+           <div class="fd-select__control is-warning" role="button" tabindex="0" aria-controls="h07j998hhH"  aria-expanded="false" aria-haspopup="true">
                Warning
-               <button class="fd-button sap-icon--slim-arrow-down fd-select__button"></button>
+               <span class="fd-button sap-icon--slim-arrow-down fd-select__button"></span>
            </div>
        </div>
    </div>
    <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown" aria-hidden="true" id="h07j998hhH">
         <ul class="fd-list fd-list--has-message fd-list--dropdown fd-list--compact" role="listbox">
            <li class="fd-list__message fd-list__message--warning">Warning message</li>
-           <li class="fd-list__item is-selected" role="option" tabindex="0">
+           <li class="fd-list__item is-selected" aria-selected="true" role="option">
               <span class="fd-list__title">
                   List Item 1
               </span>
               <span class="fd-list__secondary">A1</span>
            </li>
-           <li class="fd-list__item" role="option" tabindex="0">
+           <li class="fd-list__item" role="option">
               <span class="fd-list__title">List item 2</span>
               <span class="fd-list__secondary">A2</span>
            </li>
-           <li class="fd-list__item" role="option" tabindex="0">
+           <li class="fd-list__item" role="option">
               <span class="fd-list__title">List item 3</span>
               <span class="fd-list__secondary">A3</span>
            </li>
-           <li class="fd-list__item" role="option" tabindex="0">
+           <li class="fd-list__item" role="option">
               <span class="fd-list__title">List item 4</span>
               <span class="fd-list__secondary">A4</span>
            </li>
@@ -554,30 +554,30 @@ To add text in the body of the component, simply include your text in the `fd-li
 <div class="fd-popover">
    <div class="fd-popover__control">
        <div class="fd-select">
-           <div class="fd-select__control is-information" tabindex="0" aria-controls="hkhh998hhH"  aria-expanded="false" aria-haspopup="true">
+           <div class="fd-select__control is-information" role="button" tabindex="0" aria-controls="hkhh998hhH"  aria-expanded="false" aria-haspopup="true">
                Information
-               <button class="fd-button sap-icon--slim-arrow-down fd-select__button"></button>
+               <span class="fd-button sap-icon--slim-arrow-down fd-select__button"></span>
            </div>
        </div>
    </div>
    <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown" aria-hidden="true" id="hkhh998hhH">
         <ul class="fd-list fd-list--has-message fd-list--dropdown fd-list--compact" role="listbox">
            <li class="fd-list__message fd-list__message--information">Information message</li>
-           <li class="fd-list__item is-selected" role="option" tabindex="0">
+           <li class="fd-list__item is-selected" aria-selected="true" role="option">
               <span class="fd-list__title">
                   List Item 1
               </span>
               <span class="fd-list__secondary">A1</span>
            </li>
-           <li class="fd-list__item" role="option" tabindex="0">
+           <li class="fd-list__item" role="option">
               <span class="fd-list__title">List item 2</span>
               <span class="fd-list__secondary">A2</span>
            </li>
-           <li class="fd-list__item" role="option" tabindex="0">
+           <li class="fd-list__item" role="option">
               <span class="fd-list__title">List item 3</span>
               <span class="fd-list__secondary">A3</span>
            </li>
-           <li class="fd-list__item" role="option" tabindex="0">
+           <li class="fd-list__item" role="option">
               <span class="fd-list__title">List item 4</span>
               <span class="fd-list__secondary">A4</span>
            </li>
@@ -613,28 +613,28 @@ select component in `dialog` and `bar` components.
         <div class="fd-dialog__body fd-dialog__body--no-vertical-padding">
             <ul class="fd-list fd-list--has-message fd-list--dropdown fd-list--compact" role="listbox">
                 <li class="fd-list__message fd-list__message--information">Choose one item</li>
-                <li role="option" tabindex="0" class="fd-list__item is-selected">
+                <li role="option" class="fd-list__item is-selected" aria-selected="true">
                    <span class="fd-list__title">Apple</span>
                </li>
-               <li role="option" tabindex="0" class="fd-list__item">
+               <li role="option" class="fd-list__item">
                    <span class="fd-list__title">Orange</span>
                </li>
-               <li role="option" tabindex="0" class="fd-list__item">
+               <li role="option" class="fd-list__item">
                    <span class="fd-list__title">Banana</span>
                </li>
-                <li role="option" tabindex="0" class="fd-list__item">
+                <li role="option" class="fd-list__item">
                    <span class="fd-list__title">Kiwi</span>
                 </li>
-                <li role="option" tabindex="0" class="fd-list__item">
+                <li role="option" class="fd-list__item">
                     <span class="fd-list__title">Tomato</span>
                 </li>
-                <li role="option" tabindex="0" class="fd-list__item">
+                <li role="option" class="fd-list__item">
                     <span class="fd-list__title">Onion</span>
                 </li>
-                <li role="option" tabindex="0" class="fd-list__item">
+                <li role="option" class="fd-list__item">
                     <span class="fd-list__title">Spinach</span>
                 </li>
-                <li role="option" tabindex="0" class="fd-list__item">
+                <li role="option" class="fd-list__item">
                     <span class="fd-list__title">Potato</span>
                 </li>
             </ul>

--- a/docs/pages/components/select.md
+++ b/docs/pages/components/select.md
@@ -445,7 +445,7 @@ To add text in the body of the component, simply include your text in the `fd-li
     </div>
     <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown" aria-hidden="true" id="h07jjhYH">
          <ul class="fd-list fd-list--has-message fd-list--dropdown fd-list--compact" role="listbox">
-            <li class="fd-list__message fd-list__message--success">Success message</li>
+            <div aria-live="assertive" class="fd-list__message fd-list__message--success" role="alert">Success message</div>
             <li class="fd-list__item is-selected" aria-selected="true" role="option" tabindex="0">
                <span class="fd-list__title">
                    List Item 1
@@ -484,7 +484,7 @@ To add text in the body of the component, simply include your text in the `fd-li
    </div>
    <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown" aria-hidden="true" id="h07j9978H">
         <ul class="fd-list fd-list--has-message fd-list--dropdown fd-list--compact" role="listbox">
-           <li class="fd-list__message fd-list__message--error">Error message</li>
+           <div aria-live="assertive" class="fd-list__message fd-list__message--error" role="alert">Error message</div>
            <li class="fd-list__item is-selected" aria-selected="true" role="option" tabindex="0">
               <span class="fd-list__title">
                   List Item 1
@@ -523,7 +523,7 @@ To add text in the body of the component, simply include your text in the `fd-li
    </div>
    <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown" aria-hidden="true" id="h07j998hhH">
         <ul class="fd-list fd-list--has-message fd-list--dropdown fd-list--compact" role="listbox">
-           <li class="fd-list__message fd-list__message--warning">Warning message</li>
+           <div aria-live="assertive" class="fd-list__message fd-list__message--warning" role="alert">Warning message</div>
            <li class="fd-list__item is-selected" aria-selected="true" role="option" tabindex="0">
               <span class="fd-list__title">
                   List Item 1
@@ -562,7 +562,7 @@ To add text in the body of the component, simply include your text in the `fd-li
    </div>
    <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown" aria-hidden="true" id="hkhh998hhH">
         <ul class="fd-list fd-list--has-message fd-list--dropdown fd-list--compact" role="listbox">
-           <li class="fd-list__message fd-list__message--information">Information message</li>
+           <div aria-live="assertive" class="fd-list__message fd-list__message--information" role="alert">Information message</div>
            <li class="fd-list__item is-selected" aria-selected="true" role="option" tabindex="0">
               <span class="fd-list__title">
                   List Item 1
@@ -612,7 +612,7 @@ select component in `dialog` and `bar` components.
         </header>
         <div class="fd-dialog__body fd-dialog__body--no-vertical-padding">
             <ul class="fd-list fd-list--has-message fd-list--dropdown fd-list--compact" role="listbox">
-                <li class="fd-list__message fd-list__message--information">Choose one item</li>
+                <div aria-live="assertive" class="fd-list__message fd-list__message--information" role="alert">Choose one item</div>
                 <li role="option" tabindex="0" class="fd-list__item is-selected" aria-selected="true">
                    <span class="fd-list__title">Apple</span>
                </li>

--- a/docs/pages/components/select.md
+++ b/docs/pages/components/select.md
@@ -398,7 +398,7 @@ The disabled state can also be achieved by adding the `.is-disabled` class or th
 <div class="fd-popover">
     <div class="fd-popover__control" aria-disabled="true" disabled>
         <div class="fd-select">
-            <div class="fd-select__control" role="button" tabindex="0" aria-expanded="false" aria-haspopup="false" aria-disabled="true" disabled>
+            <div class="fd-select__control" role="button" aria-expanded="false" aria-haspopup="false" aria-disabled="true" disabled>
                 Select
                 <span class="fd-button sap-icon--slim-arrow-down fd-select__button"></span>
             </div>
@@ -418,7 +418,7 @@ This can also be done by adding the `.is-readonly` class or the `aria-readonly="
 <div class="fd-popover">
     <div class="fd-popover__control" aria-expanded="false" aria-haspopup="false" aria-readonly="true" readonly>
         <div class="fd-select">
-            <div class="fd-select__control" role="button" tabindex="0" aria-expanded="false" aria-haspopup="false" aria-readonly="true" readonly>
+            <div class="fd-select__control" role="button" aria-expanded="false" aria-haspopup="false" aria-readonly="true" readonly>
                 Select
            </div>
         </div>
@@ -613,28 +613,28 @@ select component in `dialog` and `bar` components.
         <div class="fd-dialog__body fd-dialog__body--no-vertical-padding">
             <ul class="fd-list fd-list--has-message fd-list--dropdown fd-list--compact" role="listbox">
                 <li class="fd-list__message fd-list__message--information">Choose one item</li>
-                <li role="option" class="fd-list__item is-selected" aria-selected="true">
+                <li role="option" tabindex="0" class="fd-list__item is-selected" aria-selected="true">
                    <span class="fd-list__title">Apple</span>
                </li>
-               <li role="option" class="fd-list__item">
+               <li role="option" tabindex="0" class="fd-list__item">
                    <span class="fd-list__title">Orange</span>
                </li>
-               <li role="option" class="fd-list__item">
+               <li role="option" tabindex="0" class="fd-list__item">
                    <span class="fd-list__title">Banana</span>
                </li>
-                <li role="option" class="fd-list__item">
+                <li role="option" tabindex="0" class="fd-list__item">
                    <span class="fd-list__title">Kiwi</span>
                 </li>
-                <li role="option" class="fd-list__item">
+                <li role="option" tabindex="0" class="fd-list__item">
                     <span class="fd-list__title">Tomato</span>
                 </li>
-                <li role="option" class="fd-list__item">
+                <li role="option" tabindex="0" class="fd-list__item">
                     <span class="fd-list__title">Onion</span>
                 </li>
-                <li role="option" class="fd-list__item">
+                <li role="option" tabindex="0" class="fd-list__item">
                     <span class="fd-list__title">Spinach</span>
                 </li>
-                <li role="option" class="fd-list__item">
+                <li role="option" tabindex="0" class="fd-list__item">
                     <span class="fd-list__title">Potato</span>
                 </li>
             </ul>

--- a/test/templates/select/component.njk
+++ b/test/templates/select/component.njk
@@ -10,9 +10,9 @@ select:
 {%- macro select(properties={}, modifier={}, state={}, aria={}) %}
     {%- set _id = utils.id() -%}
     <div class="fd-select{{ modifier.block | modifier('select') }}">
-		 <div class="fd-select__control {{ "is-expanded" if state.expanded }} {{ "is-hover" if state.hover }}" aria-controls="{{ properties.id }}" aria-expanded="false" aria-haspopup="true"{{" readonly" if state.readonly}} {{ " disabled" if state.disabled }}{{ aria | aria }}>
+		 <div class="fd-select__control {{ "is-expanded" if state.expanded }} {{ "is-hover" if state.hover }}" role="button" aria-controls="{{ properties.id }}" aria-expanded="false" aria-haspopup="true"{{" readonly" if state.readonly}} {{ " disabled" if state.disabled }}{{ aria | aria }}>
             {{ properties.label }}
-			 <button class="btn-playground fd-select__button sap-icon--slim-arrow-down"></button>
+			 <span class="btn-playground fd-select__button sap-icon--slim-arrow-down"></span>
 		 </div>
     </div>
 {%- endmacro %}


### PR DESCRIPTION
## Description
Changes to Select component markup:
- The inner `<button>` causes an extra unnecessary tab stop. Arguably, the entire select component should be a singular clickable/tabbable button.
- Each individual `<li>` option is tabbable. They should instead be navigable via arrow keys (which would be coded in the implementation libraries) and use a roving tabindex.
- Change `li` to `div` for validation messages, as they should not be part of the list, as described in https://github.com/SAP/fundamental-styles/issues/712

No visual changes.

## References
https://www.w3.org/TR/wai-aria-practices/examples/listbox/listbox-collapsible.html
Opting to use a roving tabindex vs. aria-activedescendant: https://zellwk.com/blog/element-focus-vs-aria-activedescendant/