### PR TITLE
fix: add shellbar button hover styles to :focus as well

### DIFF
--- a/src/shellbar.scss
+++ b/src/shellbar.scss
@@ -317,6 +317,7 @@ $block: #{$fd-namespace}-shellbar;
 
   .#{$fd-namespace}-button.#{$block}__button--menu {
     font-size: var(--sapFontSize);
+    outline: 0;
 
     &::after {
       color: $fd-shellbar-color;

--- a/src/shellbar.scss
+++ b/src/shellbar.scss
@@ -287,7 +287,8 @@ $block: #{$fd-namespace}-shellbar;
     color: $fd-shellbar-color;
     padding: 0;
 
-    &:hover {
+    &:hover,
+    &:focus {
       background: $fd-shell-hover-background;
     }
 
@@ -296,6 +297,7 @@ $block: #{$fd-namespace}-shellbar;
     }
 
     &:hover,
+    &:focus,
     &:active {
       color: $fd-shell-active-text-color;
     }
@@ -321,7 +323,8 @@ $block: #{$fd-namespace}-shellbar;
       content: "\e287";
     }
 
-    &:hover {
+    &:hover,
+    &:focus {
       background: $fd-shell-hover-background;
       border-color: transparent;
     }


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#1026 

## Description

Shellbar button hovers styles should work with focus (for tabbing).  See https://github.com/SAP/fundamental-ngx/issues/2448