### PR TITLE
docs: fix typo in Slide Tiles example

### DIFF
--- a/docs/pages/components/tile.md
+++ b/docs/pages/components/tile.md
@@ -779,7 +779,7 @@ To create a Slide Tile, use the `fd-tile--slide` modifier class.
 <div class="docs-section-container">
     <div tabindex="0" class="fd-tile fd-tile--double fd-tile--slide">
         <div class="fd-tile__background-img" style="background-image: url('https://placeimg.com/400/200/nature')"></div>
-        <<button aria-label="toggle pause button" class="fd-tile__toggle fd-tile__toggle--pause"></button>
+        <button aria-label="toggle pause button" class="fd-tile__toggle fd-tile__toggle--pause"></button>
         <div class="fd-tile__container">
             <div class="fd-tile__header">
                 <div class="fd-tile__title">Wind Map: Monitoring Real-Time and Forecasted Wind Conditions across the Globe</div>
@@ -801,7 +801,7 @@ To create a Slide Tile, use the `fd-tile--slide` modifier class.
     </div>
     <div tabindex="0" class="fd-tile fd-tile--double fd-tile--s fd-tile--slide">
         <div class="fd-tile__background-img" style="background-image: url('https://placeimg.com/400/200/nature')"></div>
-        <<button aria-label="toggle pause button" class="fd-tile__toggle fd-tile__toggle--pause"></button>
+        <button aria-label="toggle pause button" class="fd-tile__toggle fd-tile__toggle--pause"></button>
         <div class="fd-tile__container">
             <div class="fd-tile__header">
                 <div class="fd-tile__title">Wind Map: Monitoring Real-Time and Forecasted Wind Conditions across the Globe</div>


### PR DESCRIPTION
## Description
A typo was causing some visual bugs in Slide Tile

## Screenshots
### Before:
<img width="1096" alt="Screen Shot 2020-05-22 at 10 50 53 PM" src="https://user-images.githubusercontent.com/39598672/82720155-bda8f380-9c7e-11ea-956b-9fb1f790bec5.png">

### After:
<img width="854" alt="Screen Shot 2020-05-22 at 10 51 43 PM" src="https://user-images.githubusercontent.com/39598672/82720163-d31e1d80-9c7e-11ea-97cd-a2a1e3201947.png">
