### PR TITLE
fix: remove the spacing from the last page indicator

### DIFF
--- a/src/tile.scss
+++ b/src/tile.scss
@@ -532,6 +532,10 @@ $fd-tile-action-indicator-offset: 0.25rem !default;
 
         color: var(--sapContent_ContrastTextColor); // TO BE CONFIRMED
       }
+
+      &:last-child {
+        margin: 0;
+      }
     }
 
     &.#{$block}--s {


### PR DESCRIPTION
## Description
The last dot (page indicator) had a margin-right which is used as a separator for dots. Since it's the last item it does not need it.
