### PR TITLE
docs: Fix header on IE11

### DIFF
--- a/docs/_sass/_docs-top-nav.scss
+++ b/docs/_sass/_docs-top-nav.scss
@@ -3,6 +3,7 @@
   align-items: center;
   background-color: $docs-home-white-color;
   min-height: 5.5rem;
+  height: 5.5rem;
   padding: 0 1.5rem;
 
   &__logo {


### PR DESCRIPTION
## Related Issue
Relates: https://github.com/SAP/fundamental-styles/issues/1060

## Description
Whenever there is `align-items: center` property, there should be `height` wiht `min-height`. To make flex work on IE11

## Screenshots

### Before:
![image](https://user-images.githubusercontent.com/26483208/83158981-c594e780-a105-11ea-938e-8adb4af6f5c0.png)


### After:
![image](https://user-images.githubusercontent.com/26483208/83158944-b7df6200-a105-11ea-9551-39d0bdcecae9.png)

#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
