### PR TITLE
fix: remove storybook from precommit

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,8 +123,7 @@
   "pre-commit": {
     "colors": true,
     "run": [
-      "lint:pre-commit",
-      "storybook:visual-docker"
+      "lint:pre-commit"
     ],
     "silent": false
   },


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#

## Description
You cannot make commits with the precommit hook running storybook
