### PR TITLE
feat: shellbar button outlines should follow behavior of transparent buttons

### DIFF
--- a/docs/pages/components/shellbar.md
+++ b/docs/pages/components/shellbar.md
@@ -56,7 +56,7 @@ This example shows the minimum shellbar for a single application product with on
     <div class="fd-shellbar__action">
       <div class="fd-popover fd-popover--right">
         <div class="fd-popover__control">
-          <button class="fd-button fd-shellbar__button fd-shellbar__button--user-menu" aria-controls="WV3AY276" aria-expanded="false" aria-haspopup="true" role="button">
+          <button class="fd-button fd-shellbar__button fd-shellbar__button--user-menu" aria-controls="WV3AY276" aria-expanded="false" aria-haspopup="true">
             <span class="fd-avatar fd-avatar--xs fd-avatar--circle">WW</span>
           </button>
         </div>
@@ -150,7 +150,7 @@ This example includes the product menu for navigating to applications within the
     <div class="fd-shellbar__action">
       <div class="fd-popover fd-popover--right">
         <div class="fd-popover__control">
-          <button class="fd-button fd-shellbar__button fd-shellbar__button--user-menu" aria-controls="ZY3AY276" aria-expanded="false" aria-haspopup="true" role="button">
+          <button class="fd-button fd-shellbar__button fd-shellbar__button--user-menu" aria-controls="ZY3AY276" aria-expanded="false" aria-haspopup="true">
             <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('https://placeimg.com/400/400/nature');" aria-label="William Wallingham">WW</span>
           </button>
         </div>
@@ -247,7 +247,7 @@ When a product has multiple links, the product links should collapse into an ove
       <div class="fd-shellbar__action">
         <div class="fd-popover fd-popover--right">
           <div class="fd-popover__control">
-            <button class="fd-button fd-shellbar__button fd-shellbar__button--user-menu" aria-controls="DD35G276" aria-expanded="false" aria-haspopup="true" role="button">
+            <button class="fd-button fd-shellbar__button fd-shellbar__button--user-menu" aria-controls="DD35G276" aria-expanded="false" aria-haspopup="true">
               <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-shellbar__avatarier--circle">WW</span>
             </button>
           </div>
@@ -297,7 +297,7 @@ For more information about the Product Switch, see [Product Switch](product-swit
       <div class="fd-shellbar__action">
         <div class="fd-popover fd-popover--right">
           <div class="fd-popover__control">
-            <button class="fd-button fd-shellbar__button fd-shellbar__button--user-menu" aria-controls="MKFAY276" aria-expanded="false" aria-haspopup="true" role="button">
+            <button class="fd-button fd-shellbar__button fd-shellbar__button--user-menu" aria-controls="MKFAY276" aria-expanded="false" aria-haspopup="true">
               <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('https://placeimg.com/400/400/nature');" aria-label="William Wallingham">WW</span>
             </button>
           </div>

--- a/docs/pages/components/shellbar.md
+++ b/docs/pages/components/shellbar.md
@@ -56,9 +56,9 @@ This example shows the minimum shellbar for a single application product with on
     <div class="fd-shellbar__action">
       <div class="fd-popover fd-popover--right">
         <div class="fd-popover__control">
-          <div class="fd-button fd-shellbar__button fd-user-menu__control" aria-controls="WV3AY276" aria-expanded="false" aria-haspopup="true" role="button">
+          <button class="fd-button fd-shellbar__button fd-shellbar__button--user-menu" aria-controls="WV3AY276" aria-expanded="false" aria-haspopup="true" role="button">
             <span class="fd-avatar fd-avatar--xs fd-avatar--circle">WW</span>
-          </div>
+          </button>
         </div>
         <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right" aria-hidden="true" id="WV3AY276">
           <nav class="fd-menu">
@@ -150,9 +150,9 @@ This example includes the product menu for navigating to applications within the
     <div class="fd-shellbar__action">
       <div class="fd-popover fd-popover--right">
         <div class="fd-popover__control">
-          <div class="fd-button fd-shellbar__button fd-user-menu__control" aria-controls="ZY3AY276" aria-expanded="false" aria-haspopup="true" role="button">
+          <button class="fd-button fd-shellbar__button fd-shellbar__button--user-menu" aria-controls="ZY3AY276" aria-expanded="false" aria-haspopup="true" role="button">
             <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('https://placeimg.com/400/400/nature');" aria-label="William Wallingham">WW</span>
-          </div>
+          </button>
         </div>
         <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right" aria-hidden="true" id="ZY3AY276">
           <nav class="fd-menu">
@@ -247,9 +247,9 @@ When a product has multiple links, the product links should collapse into an ove
       <div class="fd-shellbar__action">
         <div class="fd-popover fd-popover--right">
           <div class="fd-popover__control">
-            <div class="fd-button fd-shellbar__button fd-user-menu__control" aria-controls="DD35G276" aria-expanded="false" aria-haspopup="true" role="button">
+            <button class="fd-button fd-shellbar__button fd-shellbar__button--user-menu" aria-controls="DD35G276" aria-expanded="false" aria-haspopup="true" role="button">
               <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-shellbar__avatarier--circle">WW</span>
-            </div>
+            </button>
           </div>
           <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right" aria-hidden="true" id="DD35G276">
             <nav class="fd-menu">
@@ -297,9 +297,9 @@ For more information about the Product Switch, see [Product Switch](product-swit
       <div class="fd-shellbar__action">
         <div class="fd-popover fd-popover--right">
           <div class="fd-popover__control">
-            <div class="fd-button fd-shellbar__button fd-user-menu__control" aria-controls="MKFAY276" aria-expanded="false" aria-haspopup="true" role="button">
+            <button class="fd-button fd-shellbar__button fd-shellbar__button--user-menu" aria-controls="MKFAY276" aria-expanded="false" aria-haspopup="true" role="button">
               <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('https://placeimg.com/400/400/nature');" aria-label="William Wallingham">WW</span>
-            </div>
+            </button>
           </div>
           <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right" aria-hidden="true" id="MKFAY276">
             <nav class="fd-menu">

--- a/src/shellbar.scss
+++ b/src/shellbar.scss
@@ -278,7 +278,6 @@ $block: #{$fd-namespace}-shellbar;
    is a better option than using the buttonBase() mixin from the button.scss file or using !important.
    */
   .#{$fd-namespace}-button.#{$block}__button {
-    @include fd-button-reset();
     @include fd-icon-size("m", "before");
     @include fd-icon-size("m", "after");
 
@@ -287,8 +286,7 @@ $block: #{$fd-namespace}-shellbar;
     color: $fd-shellbar-color;
     padding: 0;
 
-    &:hover,
-    &:focus {
+    &:hover {
       background: $fd-shell-hover-background;
     }
 
@@ -297,7 +295,6 @@ $block: #{$fd-namespace}-shellbar;
     }
 
     &:hover,
-    &:focus,
     &:active {
       color: $fd-shell-active-text-color;
     }
@@ -313,19 +310,21 @@ $block: #{$fd-namespace}-shellbar;
         margin-right: 0;
       }
     }
+
+    &.#{$block}__button--user-menu {
+      outline-offset: 0.1px;
+    }
   }
 
   .#{$fd-namespace}-button.#{$block}__button--menu {
     font-size: var(--sapFontSize);
-    outline: 0;
 
     &::after {
       color: $fd-shellbar-color;
       content: "\e287";
     }
 
-    &:hover,
-    &:focus {
+    &:hover {
       background: $fd-shell-hover-background;
       border-color: transparent;
     }

--- a/src/shellbar.scss
+++ b/src/shellbar.scss
@@ -285,6 +285,7 @@ $block: #{$fd-namespace}-shellbar;
     background: $fd-shellbar-background-color;
     color: $fd-shellbar-color;
     padding: 0;
+    outline-color: var(--sapContent_ContrastFocusColor);
 
     &:hover {
       background: $fd-shell-hover-background;
@@ -318,6 +319,7 @@ $block: #{$fd-namespace}-shellbar;
 
   .#{$fd-namespace}-button.#{$block}__button--menu {
     font-size: var(--sapFontSize);
+    outline-color: var(--sapContent_ContrastFocusColor);
 
     &::after {
       color: $fd-shellbar-color;

--- a/src/shellbar.scss
+++ b/src/shellbar.scss
@@ -293,6 +293,7 @@ $block: #{$fd-namespace}-shellbar;
 
     &:active {
       background: $fd-shell-active-background;
+      outline-color: var(--sapContent_ContrastFocusColor);
     }
 
     &:hover,
@@ -335,6 +336,7 @@ $block: #{$fd-namespace}-shellbar;
     &:focus {
       background: $fd-shell-active-background;
       color: $fd-shell-active-text-color;
+      outline-color: var(--sapContent_ContrastFocusColor);
     }
   }
 


### PR DESCRIPTION
## Related Issue

part of #1060 

## Description
According to the shellbar designer, shellbar buttons should behave the same as transparent buttons, other than what is specifically mentioned in the shellbar specs.  This PR makes the button outline the same as transparent buttons

Worth noting that the outline was, by default, smaller than the user menu button circle, so I used outline-offset to slightly expand that.  Which is what they are doing in sapui5 for the same problem.  Maybe we can discuss alternative solutions

### Before:
![Screen Shot 2020-05-29 at 2 42 01 PM](https://user-images.githubusercontent.com/2471874/83303639-a7d58a00-a1ba-11ea-9c4e-ac4e2b7d6a50.png)

### After:
![Screen Shot 2020-05-29 at 2 43 06 PM](https://user-images.githubusercontent.com/2471874/83303690-bde34a80-a1ba-11ea-9464-0c3cbc06c66b.png)

