### PR TITLE
docs: introduce tags for component doc pages

### DIFF
--- a/docs/_data/tags.yml
+++ b/docs/_data/tags.yml
@@ -1,12 +1,6 @@
-allowed-tags:
-  - getting_started
-  - content_types
-  - navigation
-  - formatting
-  - publishing
-  - single_sourcing
-  - special_layouts
-  - collaboration
-  - news
-  - troubleshooting
-  - mobile
+component-tags:
+  a11y: {name: 'a11y', title: 'Accessibility Compliant Component', color: 1}
+  f3: {name: 'fiori 3', title: 'Fiori 3 Component' , color: 2}
+  theme: {name: 'themeable', title: 'Fiori 3 Themeable Component', color: 3}
+  design: {name: 'design in progress', title: 'Design is under review', color: 4}
+  development: {name: 'in development', title: 'The component is under development', color: 5}

--- a/docs/_layouts/page.html
+++ b/docs/_layouts/page.html
@@ -37,6 +37,12 @@ layout: default
 
     {% endif %}
 
+    {% if page.tags %}
+        {% for tag in page.tags %}
+            <span title="{{site.data.tags.component-tags[tag].title}}" class="fd-info-label fd-info-label--accent-color-{{site.data.tags.component-tags[tag].color}}">{{site.data.tags.component-tags[tag].name}}</span>
+        {% endfor %}
+    {% endif%}
+
     {% unless page.toc == false %}
     {% include toc.html %}
     {% endunless %}
@@ -52,19 +58,4 @@ layout: default
     {% endif %}
 
     {{content}}
-
-    <div class="tags">
-        {% if page.tags != null %}
-        <b>Tags: </b>
-        {% assign projectTags = site.data.tags.allowed-tags %}
-        {% for tag in page.tags %}
-        {% if projectTags contains tag %}
-        <a href="{{ "tag_" | append: tag | append: ".html" }}"
-           class="btn bfd-default navbar-btn cursorNorm"
-           role="button">{{page.tagName}}{{tag}}</a>
-        {% endif %}
-        {% endfor %}
-        {% endif %}
-    </div>
-
 </div>

--- a/docs/pages/components/button.md
+++ b/docs/pages/components/button.md
@@ -6,6 +6,7 @@ sidebar: left-navigation-sidebar
 toc: false
 permalink: components/button.html
 folder: components
+tags: [f3, a11y, theme]
 ---
 {: .docs-intro}
 Buttons allow users to perform actions. All the buttons require the fd-buttonbase class and an additional modifier for each of the flavours.


### PR DESCRIPTION
Introduces tags on component doc pages
![Screen Shot 2020-05-30 at 12 56 33 PM](https://user-images.githubusercontent.com/4380815/83334510-095a2f00-a275-11ea-9555-289f9287a715.png)
