### PR TITLE
fix: Add fd-empty mixin, replace empty selectors

### DIFF
--- a/src/button.scss
+++ b/src/button.scss
@@ -98,7 +98,7 @@ $block: #{$fd-namespace}-button;
     }
   }
 
-  &:empty {
+  @include fd-empty() {
     &::before,
     &::after {
       margin-right: 0;
@@ -177,7 +177,7 @@ $block: #{$fd-namespace}-button;
       right: auto;
     }
 
-    &:empty {
+    @include fd-empty() {
       &::before {
         margin-left: 0;
       }

--- a/src/checkbox.scss
+++ b/src/checkbox.scss
@@ -87,7 +87,7 @@ $block: #{$fd-namespace}-checkbox;
       outline: none;
     }
 
-    &:empty {
+    @include fd-empty() {
       padding: $fd-checkbox-margin;
       margin: 0;
 
@@ -179,7 +179,7 @@ $block: #{$fd-namespace}-checkbox;
         }
       }
 
-      &:empty {
+      @include fd-empty() {
         padding: $fd-checkbox-margin-compact;
         margin: 0;
 

--- a/src/checkbox.scss
+++ b/src/checkbox.scss
@@ -139,10 +139,10 @@ $block: #{$fd-namespace}-checkbox;
   @include fd-focus() {
     + .#{$block}__label {
       @include fd-form-radio-focus($fd-checkbox-margin);
-    }
 
-    + .#{$block}__label:empty {
-      @include fd-form-radio-empty-focus($fd-checkbox-margin);
+      @include fd-empty() {
+        @include fd-form-radio-empty-focus($fd-checkbox-margin);
+      }
     }
   }
 
@@ -194,10 +194,10 @@ $block: #{$fd-namespace}-checkbox;
     @include fd-focus() {
       + .#{$block}__label {
         @include fd-form-radio-focus($fd-checkbox-margin-compact);
-      }
 
-      + .#{$block}__label:empty {
-        @include fd-form-radio-empty-focus($fd-checkbox-margin-compact);
+        @include fd-empty() {
+          @include fd-form-radio-empty-focus($fd-checkbox-margin-compact);
+        }
       }
     }
   }

--- a/src/info-label.scss
+++ b/src/info-label.scss
@@ -79,7 +79,7 @@ $block: #{$fd-namespace}-info-label;
     line-height: 1.1;
 
     @include fd-rtl() {
-      &:empty {
+      @include fd-empty() {
         padding: 0 $fd-info-label-icon-padding-right 0 $fd-info-label-icon-padding-right;
       }
 
@@ -95,7 +95,7 @@ $block: #{$fd-namespace}-info-label;
       top: 0.0625rem;
     }
 
-    &:empty {
+    @include fd-empty() {
       padding: 0 $fd-info-label-icon-padding-right 0 $fd-info-label-icon-padding-right;
     }
   }

--- a/src/mixins/_states.scss
+++ b/src/mixins/_states.scss
@@ -62,6 +62,15 @@
   }
 }
 
+// Empty state
+// `.is-empty` is when empty state can't be applied, because of some internal framework comments
+@mixin fd-empty {
+  &:empty,
+  &.is-empty {
+    @content;
+  }
+}
+
 // PRESSED state (toggle with full press-and-release)
 @mixin fd-pressed {
   &[aria-pressed="true"],

--- a/src/object-status.scss
+++ b/src/object-status.scss
@@ -135,7 +135,7 @@ $color-accents: (
   }
 
   // ICON ONLY MODE
-  &:empty {
+  @include fd-empty() {
     justify-content: center;
     padding-right: 0;
     padding-left: 0;
@@ -152,7 +152,7 @@ $color-accents: (
       padding-left: $fd-object-status-icon-padding;
     }
 
-    &:empty {
+    @include fd-empty() {
       &::before {
         padding-right: 0;
         padding-left: 0;
@@ -251,7 +251,7 @@ $color-accents: (
     }
 
     // ICON ONLY MODE
-    &:empty {
+    @include fd-empty() {
       height: $fd-object-status-inverted-height-empty;
       width: auto;
       min-width: $fd-object-status-inverted-min-width;
@@ -301,7 +301,7 @@ $color-accents: (
       }
 
       // ICON ONLY MODE
-      &:empty {
+      @include fd-empty() {
         width: auto;
         height: $fd-object-status-min-height-large-inverted-empty;
         min-width: $fd-object-status-min-width-large-inverted-empty;

--- a/src/radio.scss
+++ b/src/radio.scss
@@ -83,7 +83,7 @@ $block: #{$fd-namespace}-radio;
       }
     }
 
-    &:empty {
+    @include fd-empty() {
       padding: $fd-radio-outer-circle-margin;
       margin: 0;
 
@@ -165,7 +165,7 @@ $block: #{$fd-namespace}-radio;
         }
       }
 
-      &:empty {
+      @include fd-empty() {
         padding: $fd-radio-outer-circle-margin-compact;
         margin: 0;
 

--- a/src/radio.scss
+++ b/src/radio.scss
@@ -125,10 +125,10 @@ $block: #{$fd-namespace}-radio;
   @include fd-focus() {
     + .#{$block}__label {
       @include fd-form-radio-focus($fd-radio-outer-circle-margin);
-    }
 
-    + .#{$block}__label:empty {
-      @include fd-form-radio-empty-focus($fd-radio-outer-circle-margin);
+      @include fd-empty() {
+        @include fd-form-radio-empty-focus($fd-radio-outer-circle-margin);
+      }
     }
   }
 
@@ -180,10 +180,10 @@ $block: #{$fd-namespace}-radio;
     @include fd-focus() {
       + .#{$block}__label {
         @include fd-form-radio-focus($fd-radio-outer-circle-margin-compact);
-      }
 
-      + .#{$block}__label:empty {
-        @include fd-form-radio-empty-focus($fd-radio-outer-circle-margin-compact);
+        @include fd-empty() {
+          @include fd-form-radio-empty-focus($fd-radio-outer-circle-margin-compact);
+        }
       }
     }
   }


### PR DESCRIPTION
## Description
On Angular we had some issues, when used `&:empty` styling. Sometimes Angular under the hood puts some commented code, especially when there are `*ngIf` statements.
![image](https://user-images.githubusercontent.com/26483208/83618024-2e5ae480-a58a-11ea-8075-da819ce28f11.png)
So there is a need to be able to put empty programatically, it can be done only, by passing additional class.
