### PR TITLE
feat: Add Headers to popin mode, add fixes to selection borders

### DIFF
--- a/docs/pages/components/table.md
+++ b/docs/pages/components/table.md
@@ -836,6 +836,13 @@ modifiers. Also some cells should be merged into paragraphs.
         <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
     </div>
     <table class="fd-table fd-table--no-horizontal-borders fd-table--no-vertical-borders fd-table--pop-in">
+        <thead class="fd-table__header">
+            <tr class="fd-table__row">
+                <th class="fd-table__cell" scope="col">Description</th>
+                <th class="fd-table__cell" scope="col">Price</th>
+                <th class="fd-table__cell" scope="col"></th>
+            </tr>
+        </thead>
         <tbody class="fd-table__body">
             <tr class="fd-table__row fd-table__row--main fd-table__row--activable fd-table__row--hoverable">
                 <td class="fd-table__cell">
@@ -899,6 +906,17 @@ modifiers. Also some cells should be merged into paragraphs.
         <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
     </div>
     <table class="fd-table fd-table--no-horizontal-borders fd-table--no-vertical-borders fd-table--pop-in">
+        <thead class="fd-table__header">
+            <tr class="fd-table__row">
+                <th class="fd-table__cell fd-table__cell--checkbox">
+                    <input aria-label="checkbox" type="checkbox" class="fd-checkbox" id="CWkshBJ">
+                    <label class="fd-checkbox__label" for="CWkshBJ"></label>
+                </th>
+                <th class="fd-table__cell" scope="col">Description</th>
+                <th class="fd-table__cell" scope="col">Price</th>
+                <th class="fd-table__cell" scope="col"></th>
+            </tr>
+        </thead>
         <tbody class="fd-table__body">
             <tr class="fd-table__row fd-table__row--main">
                 <td class="fd-table__cell fd-table__cell--checkbox">

--- a/docs/pages/components/table.md
+++ b/docs/pages/components/table.md
@@ -918,9 +918,9 @@ modifiers. Also some cells should be merged into paragraphs.
             </tr>
         </thead>
         <tbody class="fd-table__body">
-            <tr class="fd-table__row fd-table__row--main">
+            <tr class="fd-table__row fd-table__row--main" aria-selected="true">
                 <td class="fd-table__cell fd-table__cell--checkbox">
-                    <input aria-label="checkbox" type="checkbox" class="fd-checkbox" id="CWkhTG">
+                    <input aria-label="checkbox" checked type="checkbox" class="fd-checkbox" id="CWkhTG">
                     <label class="fd-checkbox__label" for="CWkhTG"></label>
                 </td>
                 <td class="fd-table__cell">
@@ -934,7 +934,7 @@ modifiers. Also some cells should be merged into paragraphs.
                     <span class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"></span>
                 </td>
             </tr>
-            <tr class="fd-table__row fd-table__row--secondary">
+            <tr class="fd-table__row fd-table__row--secondary" aria-selected="true">
                 <td class="fd-table__cell fd-table__cell--checkbox"></td>
                 <td class="fd-table__cell" colspan="100%">
                     <p class="fd-table__text">

--- a/src/table.scss
+++ b/src/table.scss
@@ -340,8 +340,6 @@ $block: #{$fd-namespace}-table;
     }
 
     .#{$block}__cell {
-      height: auto;
-
       &--checkbox {
         + .#{$block}__cell {
           padding-left: 0;
@@ -351,6 +349,12 @@ $block: #{$fd-namespace}-table;
             padding-left: $fd-table-cell-padding;
           }
         }
+      }
+    }
+
+    .#{$block}__body {
+      .#{$block}__cell {
+        height: auto;
       }
     }
 

--- a/src/table.scss
+++ b/src/table.scss
@@ -397,6 +397,13 @@ $block: #{$fd-namespace}-table;
         padding-top: 0.5rem;
         padding-bottom: 0.5rem;
       }
+
+
+      @include fd-selected() {
+        .#{$block}__cell {
+          border-bottom: var(--sapList_BorderWidth) solid var(--sapList_SelectionBorderColor);
+        }
+      }
     }
   }
 

--- a/src/table.scss
+++ b/src/table.scss
@@ -261,12 +261,6 @@ $block: #{$fd-namespace}-table;
           background-color: var(--sapList_Hover_SelectionBackground);
         }
       }
-
-      @include fd-last-child() {
-        .#{$block}__cell {
-          border-bottom: none;
-        }
-      }
     }
   }
 

--- a/src/table.scss
+++ b/src/table.scss
@@ -398,7 +398,6 @@ $block: #{$fd-namespace}-table;
         padding-bottom: 0.5rem;
       }
 
-
       @include fd-selected() {
         .#{$block}__cell {
           border-bottom: var(--sapList_BorderWidth) solid var(--sapList_SelectionBorderColor);

--- a/src/table.scss
+++ b/src/table.scss
@@ -383,13 +383,21 @@ $block: #{$fd-namespace}-table;
           }
         }
       }
+
+      @include fd-selected() {
+        @include fd-hover() {
+          + .#{$block}__row--secondary {
+            background-color: var(--sapList_Hover_SelectionBackground);
+          }
+        }
+      }
     }
 
     .#{$block}__row--secondary {
       background-color: $fd-table-basic-background;
       border-bottom: $fd-table-border;
 
-      &:hover {
+      @include fd-hover() {
         background-color: $fd-table-basic-background;
       }
 
@@ -401,6 +409,10 @@ $block: #{$fd-namespace}-table;
       @include fd-selected() {
         .#{$block}__cell {
           border-bottom: var(--sapList_BorderWidth) solid var(--sapList_SelectionBorderColor);
+        }
+
+        @include fd-hover() {
+          background-color: var(--sapList_SelectionBackgroundColor);
         }
       }
     }


### PR DESCRIPTION
## Description
Our Pop in mode wasn't prepared for thead usage on it, There was a need to have some change on styles.
I also added headers to examples.
Selected border on last row is also fixed.
## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/26483208/83863928-5716e180-a724-11ea-8b54-b55e0544f97c.png)
![image](https://user-images.githubusercontent.com/26483208/83868666-9694fc00-a72b-11ea-85e7-1b4c5414e601.png)
![image](https://user-images.githubusercontent.com/26483208/83869775-60587c00-a72d-11ea-881e-c6fabd7174d2.png)


### After:
![image](https://user-images.githubusercontent.com/26483208/83863900-49f9f280-a724-11ea-8a57-77329c6ba86e.png)
![image](https://user-images.githubusercontent.com/26483208/83868644-8c72fd80-a72b-11ea-925f-4360226c835e.png)
![image](https://user-images.githubusercontent.com/26483208/83869736-4e76d900-a72d-11ea-9106-b8e9272cecee.png)

#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
