### PR TITLE
chore: move to jsdocs for story descriptions

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -15,6 +15,10 @@ module.exports = {
     '@storybook/addon-docs',
   ],
   webpackFinal: async (config) => {
+    config.module.rules.push({
+      test: /\.stories\.js?$/,
+      use: [{ loader: 'story-description-loader' }],
+    });
     config.plugins.push({
       // Custom plugin to add scss files to webpack watcher
       apply: (compiler) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27519,6 +27519,40 @@
       "integrity": "sha512-TQMKs+C6n9idtzLpxluikmDCYiDJrTbbIGn9LFxMg0BVTu+8JZKSlXTWYRpOFKlfKD5HlDWLVpJJyNGZ2e9l1A==",
       "dev": true
     },
+    "story-description-loader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/story-description-loader/-/story-description-loader-1.0.0.tgz",
+      "integrity": "sha512-g50SJuBIw7iPOdEa4Phk9O0LgEjuVRM9cqz5/Qiw1qnKK1fvin/LCFtylZZSoRQEy6UbPj7QKwhzLXB36frIJg==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.8.6",
+        "@babel/plugin-transform-typescript": "^7.8.3",
+        "loader-utils": "^1.4.0",
+        "schema-utils": "^2.6.4"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "loader-utils": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^1.0.1"
+          }
+        }
+      }
+    },
     "stream-browserify": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "signale": "^1.4.0",
     "standard-version": "4.2.0",
     "start-server-and-test": "^1.11.0",
+    "story-description-loader": "^1.0.0",
     "style-loader": "^1.2.1",
     "stylelint": "^13.5.0",
     "stylelint-config-standard": "^20.0.0",

--- a/stories/button/button.stories.js
+++ b/stories/button/button.stories.js
@@ -20,6 +20,17 @@ export const primary = () => `
     <button class="fd-button fd-button--emphasized ">Save</button>
 `;
 
+/**
+ *
+* - **Default Button** or Standard Button for neutral or informative (secondary) actions
+* - **Emphasized Button** Used for primary action
+* - **Ghost Button**  Used for secondary actions or primary button in cases where there is already a primary button on the page
+* - **Positive Button** Used for positive (secondary) actions
+* - **Negative Button** Used for negative (secondary) actions
+* - **Attention Button**
+* - **Transparent Button** Used for secondary or negative path actions
+ */
+
 export const types = () => `
     <div class="fddocs-container"> 
         <button class="fd-button">Default Button</button>
@@ -34,19 +45,11 @@ export const types = () => `
 
 types.storyName = 'Design Types';
 
-types.parameters = {
-    docs: {
-        storyDescription: `
-* **Default Button** or Standard Button for neutral or informative (secondary) actions
-* **Emphasized Button** Used for primary action
-* **Ghost Button**  Used for secondary actions or primary button in cases where there is already a primary button on the page
-* **Positive Button** Used for positive (secondary) actions
-* **Negative Button** Used for negative (secondary) actions
-* **Attention Button**
-* **Transparent Button** Used for secondary or negative path actions
-        `
-    }
-};
+/**
+ * Group a series of buttons together on a single line with the segmented button.
+Only one of the options can be active at a time, the others remain or become inactive.
+The option can be activated by clicking on it. This type of button is comparable to a radio button group.
+ */
 
 export const segmentedButton = () => `
     <div class="fd-segmented-button" role="group" aria-label="Group label">
@@ -64,17 +67,11 @@ export const segmentedButton = () => `
 
 segmentedButton.storyName = 'Segmented Button (previously known as Button Group)';
 
-segmentedButton.parameters = {
-    docs: {
-        storyDescription: `
-Group a series of buttons together on a single line with the segmented button.
-Only one of the options can be active at a time, the others remain or become inactive.
-The option can be activated by clicking on it. This type of button is comparable to a radio button group.
-
-        `
-    }
-};
-
+/**
+ * Menu Buttons allows for multiple actions.
+There are two different types of menu buttons. Both can contain items with submenus.
+When the user activates the button, the menu opens. This is the default type.
+ */
 
 export const menuButton = () => `
 <button class="fd-button fd-button--menu">Action Button</button>
@@ -109,13 +106,23 @@ export const menuButton = () => `
 
 menuButton.parameters = {
     docs: {
-        storyDescription: `
-Menu Buttons allows for multiple actions.
-There are two different types of menu buttons. Both can contain items with submenus.
-When the user activates the button, the menu opens. This is the default type.
-        `
+        iframeHeight: 300
     }
 };
+
+/**
+ * The menu button can also be split into 2 areas: the text label and the icon. The separator between them signals that the two areas
+result in different actions. The user has two choices: 1- activating the text label on the button triggers the action or 2- activating
+the arrow opens the menu. The split button consolidates a variety of commands, especially when one of the commands is used more often.
+
+In split mode, the text label depends on the default action. If the default action is displayed as an icon only, all the menu items must contain icons.
+
+**Split Menu Button Behaviors**
+The split menu button can have two different behaviors:
+
+The button always triggers the default action set by the app developer. If no default action has been defined, the first item in the menu list becomes the default.
+The button triggers the last action chosen by the user. Initially, it also triggers the default action. However, when the user selects a different action, this user action becomes the default, and the button text label changes accordingly. The button has a fixed size and the text truncates if the menu item exceeds the available width (as with the combo box).
+ */
 
 export const splitMenuButton = () => `
 <div class="fd-button-split fd-has-margin-right-small" role="group" aria-label="button-split">
@@ -167,21 +174,11 @@ export const splitMenuButton = () => `
 
 splitMenuButton.parameters = {
     docs: {
-        storyDescription: `
-The menu button can also be split into 2 areas: the text label and the icon. The separator between them signals that the two areas
-result in different actions. The user has two choices: 1- activating the text label on the button triggers the action or 2- activating
-the arrow opens the menu. The split button consolidates a variety of commands, especially when one of the commands is used more often.
-
-In split mode, the text label depends on the default action. If the default action is displayed as an icon only, all the menu items must contain icons.
-
-**Split Menu Button Behaviors**
-The split menu button can have two different behaviors:
-
-The button always triggers the default action set by the app developer. If no default action has been defined, the first item in the menu list becomes the default.
-The button triggers the last action chosen by the user. Initially, it also triggers the default action. However, when the user selects a different action, this user action becomes the default, and the button text label changes accordingly. The button has a fixed size and the text truncates if the menu item exceeds the available width (as with the combo box).
-        `
+        iframeHeight: 300
     }
 };
+
+/** All the buttons support the cozy (default) and compact sizes. */
 
 export const sizes = () => `
 <button class="fd-button">Save</button>
@@ -205,11 +202,18 @@ export const sizes = () => `
 
 sizes.parameters = {
     docs: {
-        storyDescription: `
-All the buttons support the cozy (default) and compact sizes.
-        `
+        iframeHeight: 300
     }
 };
+
+/**
+ * The buttons can contain **icons OR text**.
+The recommendation is to use either one or the other, not both. Use icon for buttons that contain very basic standard icon metaphors
+(e.g. _Back to previous screen, Create a new item, Remove from list, Edit, ..._)
+
+All button styles can be used with an icon. You can use the `sap-icon--{icon-name}` class to attach an icon to the button.
+The full list of all the available icons can be found on the <a href="icon.html">icons page</a>.
+ */
 
 export const iconAndText = () => `
 <button class="fd-button fd-button--emphasized">Add to Cart</button>
@@ -231,16 +235,19 @@ export const iconAndText = () => `
 
 iconAndText.parameters = {
     docs: {
-        storyDescription: `
-The buttons can contain **icons OR text**.
-The recommendation is to use either one or the other, not both. Use icon for buttons that contain very basic standard icon metaphors
-(e.g. _Back to previous screen, Create a new item, Remove from list, Edit, ..._)
-
-All button styles can be used with an icon. You can use the <code>sap-icon--{icon-name}</code> class to attach an icon to the button.
-The full list of all the available icons can be found on the <a href="icon.html">icons page</a>.
-        `
+        iframeHeight: 300
     }
 };
+
+/**
+ * The button provides feedback for "normal", "hover", "selected", "focus" and "disabled" states:
+
+- **Normal**: The default state of the button. It can be clicked/tapped to perform the corresponding action.
+- **Selected**: Used to signal that this button is selected among other buttons. This state can be rendered using
+the `is-selected` class or the `aria-selected="true"` attribute for accessibility.
+- **Disabled**: It cannot be clicked/tapped. This state can be rendered using the `is-disabled` class and the
+`aria-disabled="true"` attribute for accessibility.
+ */
 
 export const buttonStates = () => `
 <button class="fd-button fd-button--emphasized">Normal State</button>
@@ -278,17 +285,10 @@ export const buttonStates = () => `
 
 buttonStates.parameters = {
     docs: {
-        storyDescription: `
-The button provides feedback for "normal", "hover", "selected", "focus" and "disabled" states:
-
-- **Normal**: The default state of the button. It can be clicked/tapped to perform the corresponding action.
-- **Selected**: Used to signal that this button is selected among other buttons. This state can be rendered using
-the <code>is-selected</code> class or the <code>aria-selected="true"</code> attribute for accessibility.
-- **Disabled**: It cannot be clicked/tapped. This state can be rendered using the <code>is-disabled</code> class and the
-<code>aria-disabled="true"</code> attribute for accessibility.
-        `
+        iframeHeight: 300
     }
 };
+
 
 export const rtl = () => `
 <div dir="rtl">
@@ -324,3 +324,9 @@ export const rtl = () => `
   </div>
 </div>
 `;
+
+rtl.parameters = {
+    docs: {
+        iframeHeight: 300
+    }
+};

--- a/stories/panel/panel.stories.js
+++ b/stories/panel/panel.stories.js
@@ -25,6 +25,9 @@ Do not use the panel if:
     }
 };
 
+/** Expandable panels are much like fixed panels, except their content can be expanded and collapsed
+ * (including the info toolbar, if available). */
+
 export const expandable = () => `
 <div class="fd-panel">
     <div class="fd-panel__header">
@@ -55,13 +58,10 @@ export const expandable = () => `
 </div>
 `;
 
-expandable.parameters = {
-    docs: {
-        storyDescription: `
-Expandable panels are much like fixed panels, except their content can be expanded and collapsed (including the info toolbar, if available).
-        `
-    }
-};
+/**
+ * Fixed panels are useful for grouping custom content. They include headers and info toolbars.
+To create a fixed panel, add the `--fixed` modifier.
+ */
 
 export const fixed = () => `
 <div class="fd-panel fd-panel--fixed">
@@ -88,14 +88,7 @@ export const fixed = () => `
 </div>
 `;
 
-fixed.parameters = {
-    docs: {
-        storyDescription: `
-Fixed panels are useful for grouping custom content. They include headers and info toolbars.
-To create a fixed panel, add the <code>--fixed</code> modifier.
-      `
-    }
-};
+/** To use a compact panel, add the `--compact` modifier. */
 
 export const compact = () => `
 <div class="fd-panel fd-panel--compact">
@@ -125,11 +118,7 @@ export const compact = () => `
 </div>
 `;
 
-compact.parameters = {
-    docs: {
-        storyDescription: 'To use a compact panel, add the `--compact` modifier.'
-    }
-};
+/** When the height of the panel\'s content is set to a fixed size, the content area can be scrolled through. */
 
 export const fixedHeightContent = () => `
 <div class="fd-panel">
@@ -167,9 +156,3 @@ export const fixedHeightContent = () => `
     </div>
 </div>
 `;
-
-fixedHeightContent.parameters = {
-    docs: {
-        storyDescription: 'When the height of the panel\'s content is set to a fixed size, the content area can be scrolled through.'
-    }
-};

--- a/stories/step-input/step-input.stories.js
+++ b/stories/step-input/step-input.stories.js
@@ -25,6 +25,8 @@ Do not use the step input if:
     }
 };
 
+/** On smartphones and tablets, the step input is shown in cozy mode (default). */
+
 export const primary = () => `
 <div class="fd-step-input">
         <button aria-label="Step down" class="
@@ -53,11 +55,11 @@ export const primary = () => `
 
 primary.storyName = 'Default';
 
-primary.parameters = {
-    docs: {
-        storyDescription: 'On smartphones and tablets, the step input is shown in cozy mode (default).'
-    }
-};
+/**
+ * The Step Input should be used in compact mode when using a desktop of devices with large screens.
+It can be achieved by adding the `--compact` modifier to the main element as well as the
+button and input elements.
+ */
 
 export const compact = () => `
 <div class="fd-form-item fd-form-item--horizontal">
@@ -91,15 +93,10 @@ export const compact = () => `
 </div>
 `;
 
-compact.parameters = {
-    docs: {
-        storyDescription: `
-The Step Input should be used in compact mode when using a desktop of devices with large screens. 
-It can be achieved by adding the <code>--compact</code> modifier to the main element as well as the
-button and input elements.    
-        `
-    }
-};
+/**
+ * By default there is built-in focus indicator for StepInput component, which is not supported by IE11.
+To make focus work on IE11, it should be added by putting `.is-focus` class to component
+ */
 
 export const focused = () => `
 <div class="fd-step-input is-focus">
@@ -127,15 +124,10 @@ export const focused = () => `
 </div>
 `;
 
-focused.parameters = {
-    docs: {
-        storyDescription: `
-By default there is built-in focus indicator for StepInput component, which is not supported by IE11.
-To make focus work on IE11, it should be added by putting <code>.is-focus</code> class to component  
-        `
-    }
-};
-
+/**
+ * The Step Input component also supports semantic states as does every form.
+The semantic states can be customized by adding the `is-error` | `is-success` | `is-warning` | or `is-information` into the fd-step-input element.
+ */
 
 export const states = () => `
 <h3>Success</h3>
@@ -245,12 +237,10 @@ export const states = () => `
 
 states.parameters = {
     docs: {
-        storyDescription: `
-The Step Input component also supports semantic states as does every form. 
-The semantic states can be customized by adding the <code>is-error</code> | <code>is-success</code> | <code>is-warning</code> | or <code>is-information</code> into the fd-step-input element.
-        `
+        iframeHeight: 300
     }
 };
+
 
 export const disabled = () => `
 <div class="fd-step-input is-disabled">

--- a/stories/table/table.stories.js
+++ b/stories/table/table.stories.js
@@ -10,7 +10,10 @@ import '../../dist/toolbar.css';
 export default {
     title: 'Components/Table',
     parameters: {
-        description: 'A table is a set of tabular data. Line items can support data, images and actions.'
+        description: 'A table is a set of tabular data. Line items can support data, images and actions.',
+        docs: {
+            iframeHeight: 500
+        }
     }
 };
 
@@ -51,6 +54,13 @@ export const primary = () => `
 </table>
 `;
 
+/**
+ * * `--no-vertical-borders` modifier can be applied to render a table without vertical borders.
+* `--no-horizontal-borders` modifier can be applied to render a table without horizontal borders.
+
+Both can be added to  `fd-table`, `fd-table__header`, or `fd-table__body`.
+ */
+
 export const withoutBorders = () => `
 <table class="fd-table fd-table--no-horizontal-borders fd-table--no-vertical-borders">
     <thead class="fd-table__header">
@@ -83,16 +93,6 @@ export const withoutBorders = () => `
     </tbody>
 </table>
 `;
-
-withoutBorders.parameters = {
-    docs: {
-        storyDescription: `
-* <code>--no-vertical-borders</code> modifier can be applied to render a table without vertical borders.</li>
-* <code>--no-horizontal-borders</code> modifier can be applied to render a table without horizontal borders.</li>
-
-Both can be added to  <code>fd-table</code>, <code>fd-table__header</code>, or <code>fd-table__body</code>.          `
-    }
-};
 
 export const withoutBordersOnBody = () => `
 <table class="fd-table">
@@ -127,6 +127,8 @@ export const withoutBordersOnBody = () => `
 </table>
 `;
 
+/** Footer can be added by using `fd-table__footer` class with `tfoot` element.
+It has to contain same size of columns as tbody and thead. */
 
 export const withFooter = () => `
 <table class="fd-table">
@@ -167,15 +169,6 @@ export const withFooter = () => `
         </tr>
     </tfoot>
 </table>`;
-
-withFooter.parameters = {
-    docs: {
-        storyDescription: `
-Footer can be added by using <code>fd-table__footer</code> class with <code>tfoot</code> element.
-It has to contain same size of columns as tbody and thead
-`
-    }
-};
 
 export const withFooterCompact = () => `
 <table class="fd-table fd-table--compact">
@@ -259,6 +252,12 @@ export const withFooterCondensed = () => `
 </table>
 `;
 
+/**
+ * Interactive states of columns and row can be set by adding
+
+* For active state handler `--activable` modifier
+* For hover state handler `--hoverable` modifier
+ */
 
 export const interactiveRowsAndColumns = () => `
 <table class="fd-table">
@@ -306,17 +305,11 @@ export const interactiveRowsAndColumns = () => `
 
 interactiveRowsAndColumns.storyName = 'Interactive Table With Hoverable and Activable Cells and Rows';
 
-interactiveRowsAndColumns.parameters = {
-    docs: {
-        storyDescription: `
-Interactive states of columns and row can be set by adding
-
-* For active state handler <code>--activable</code> modifier
-* For hover state handler <code>--hoverable</code> modifier
-      `
-    }
-};
-
+/**
+ * The checkbox input can be used at the beginning of each row to allow for bulk actions.
+It is recommended to add the parameter `aria-selected="true"` to the row that is selected.
+Also for cells that include a checkbox should contain the `fd-table__cell--checkbox` class.
+ */
 
 export const withCheckbox = () => `
 <table class="fd-table">
@@ -366,16 +359,6 @@ export const withCheckbox = () => `
     </tbody>
 </table>
 `;
-
-withCheckbox.parameters = {
-    docs: {
-        storyDescription: `
-The checkbox input can be used at the beginning of each row to allow for bulk actions.
-It is recommended to add the parameter <code>aria-selected="true"</code> to the row that is selected.
-Also for cells that include a checkbox should contain the <code>fd-table__cell--checkbox</code> class.
-      `
-    }
-};
 
 export const withCheckboxCompact = () => `
 <table class="fd-table fd-table--compact">
@@ -532,6 +515,8 @@ export const withPagination = () => `
     </nav>
 </div>
 `;
+
+/** Advanced Toolbar can be used to customize table. Certain buttons trigger dialogs, where user can set some data. */
 
 export const withAdvancedToolbar = () => `
 <div class="fd-dialog" id="filter-dialog-example">
@@ -701,13 +686,11 @@ export const withAdvancedToolbar = () => `
 </table>
 `;
 
-withAdvancedToolbar.parameters = {
-    docs: {
-        storyDescription: `
-Advanced Toolbar can be used to customize table. Certain buttons trigger dialogs, where user can set some data.
-      `
-    }
-};
+/**
+ * Responsive table is not that different than basic table, there should be used some modifiers, to remove borders.
+For Pop-in example markup is changed, one row is transformed to 2 rows with `fd-table__row--main` and
+`fd-table__row--secondary`modifiers. Also some cells should be merged into paragraphs.
+ */
 
 export const responsiveTable = () => `
 <table class="fd-table fd-table--no-horizontal-borders">
@@ -779,16 +762,6 @@ export const responsiveTable = () => `
     </tbody>
 </table>`;
 
-responsiveTable.parameters = {
-    docs: {
-        storyDescription: `
-Responsive table is not that different than basic table, there should be used some modifiers, to remove borders.
-For Pop-in example markup is changed, one row is transformed to 2 rows with <code>fd-table__row--main</code> and 
-<code>fd-table__row--secondary</code>modifiers. Also some cells should be merged into paragraphs.
-      `
-    }
-};
-
 export const responsiveTablePopInMode = () => `
     <table class="fd-table fd-table--no-horizontal-borders fd-table--no-vertical-borders fd-table--pop-in">
         <tbody class="fd-table__body">
@@ -847,6 +820,13 @@ export const responsiveTablePopInMode = () => `
         </tbody>
     </table>
 `;
+
+/**
+ * To show that an item needs attention, you can show a highlight indicator next to the item.
+This can be achieved by passing the `fd-table__cell--status-indicator` class to each row.
+Other indicators such as semantic states and modes can be added using the `--valid`,
+`--information`, `--error`, `--warning` modifiers.
+ */
 
 export const semanticRows = () => `
 <table class="fd-table">
@@ -967,16 +947,7 @@ export const semanticRows = () => `
 </table>
 `;
 
-semanticRows.parameters = {
-    docs: {
-        storyDescription: `
-To show that an item needs attention, you can show a highlight indicator next to the item.
-This can be achieved by passing the <code>fd-table__cell--status-indicator</code> class to each row.
-Other indicators such as semantic states and modes can be added using the <code>--valid</code>,
-<code>--information</code>, <code>--error</code>, <code>--warning</code> modifiers.     
-      `
-    }
-};
+/** To merge cells, the `--no-horizontal-border` or `--no-vertical-border` modifier should be added. */
 
 export const mergedCells = () => `
 <div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
@@ -1027,12 +998,10 @@ export const mergedCells = () => `
 </table>
 `;
 
-mergedCells.parameters = {
-    docs: {
-        storyDescription: `
-To merge cells, the <code>--no-horizontal-border</code> or <code>--no-vertical-border</code> modifier should be added.        `
-    }
-};
+/**
+ * Some customization actions can be added to headers, the options will be displayed in popover. Those popover should be
+added with `fd-table__popover` class.
+ */
 
 export const withMenuInHeader = () => `
 <table class="fd-table" >
@@ -1073,15 +1042,12 @@ export const withMenuInHeader = () => `
 </table>
 `;
 
-withMenuInHeader.parameters = {
-    docs: {
-        storyDescription: `
-Some customization actions can be added to headers, the options will be displayed in popover. Those popover should be 
-added with <code>fd-table__popover</code> class.
-        `
-    }
-};
-
+/**
+ * To create fixed column, these steps need to be reproduced
+* Wrap the table with element with class `fd-table--fixed`
+* Add `fd-table__cell--fixed` class to cell elements, it should be propagated to whole row
+* Hard code the width of columns, otherwise the cells will be squashed.
+ */
 
 export const fixColumnHeader = () => `
 <style>
@@ -1162,17 +1128,7 @@ export const fixColumnHeader = () => `
 </div>
 `;
 
-fixColumnHeader.parameters = {
-    docs: {
-        storyDescription: `
-To create fixed column, these steps need to be reproduced
-* Wrap the table with element with class <code>fd-table--fixed</code>
-* Add <code>fd-table__cell--fixed</code> class to cell elements, it should be propagated to whole row
-* Hard code the width of columns, otherwise the cells will be squashed 
-        `
-    }
-};
-
+/** Navigation can be indicated on a row in the final column using the `.fd-table__cell--navigated` class. */
 
 export const navigationIndicationStates = () => `
 <table class="fd-table">
@@ -1216,10 +1172,3 @@ export const navigationIndicationStates = () => `
     </tbody>
 </table>
 `;
-
-
-navigationIndicationStates.parameters = {
-    docs: {
-        storyDescription: 'Navigation can be indicated on a row in the final column using the `.fd-table__cell--navigated` class.'
-    }
-};


### PR DESCRIPTION
Now story descriptions can be added like this:
```
/** Story description here **/
export const basic = () => (`<button>Test</button`);
```
instead of:
```
export const basic = () => (`<button>Test</button`);
basic.parameters = {
    docs: {
       storyDescription: 'Story description here'
     }
};
```