### PR TITLE
[WIP] chore: make all heights 100% for storybook

### DIFF
--- a/.storybook/custom/custom.scss
+++ b/.storybook/custom/custom.scss
@@ -259,3 +259,7 @@ body.sb-show-main {
   color: #32363a;
   color: var(--sapTextColor, #32363a);
 }
+
+.sbdocs.sbdocs-preview > :last-child > :first-child > :first-child > :first-child > :first-child {
+  height: 100% !important;
+}


### PR DESCRIPTION
## Description
This pr will allow all storybooks to take the height needed including popover heights without specifying the Iframe height. We will need to refactor the iframe heights as it is a lot of redundant code that we dont need! 

This solution is the described solution for specifying class specifics in the storybook files/documentation.

## Screenshots
### Before:
![Screen Shot 2020-06-11 at 2 36 47 PM](https://user-images.githubusercontent.com/50607147/84426310-fe968700-abf0-11ea-8397-d14fbf301864.png)

### After:
![Screen Shot 2020-06-11 at 12 12 34 PM](https://user-images.githubusercontent.com/50607147/84426187-cbec8e80-abf0-11ea-8bc9-2e6acda9cc43.png)

