### PR TITLE
fix: add RTL for Panel expand button

### DIFF
--- a/src/panel.scss
+++ b/src/panel.scss
@@ -54,6 +54,10 @@ $block: #{$fd-namespace}-panel;
   &__button {
     @include fd-icon('slim-arrow-right');
 
+    @include fd-rtl() {
+      @include fd-icon('slim-arrow-left');
+    }
+
     &::before {
       font-size: 1rem;
       line-height: normal;


### PR DESCRIPTION

## Description
Panel expand button did not have RTL support

## Screenshots

### Before:
<img width="2274" alt="Screen Shot 2020-06-22 at 3 26 49 PM" src="https://user-images.githubusercontent.com/39598672/85327377-d8989e80-b49c-11ea-9e66-b5a3af0952c5.png">


### After:
<img width="2247" alt="Screen Shot 2020-06-22 at 3 26 22 PM" src="https://user-images.githubusercontent.com/39598672/85327384-dcc4bc00-b49c-11ea-9ec5-d34c4ccd470c.png">


