### PR TITLE
fix: label asterix and colon

### DIFF
--- a/src/form-item.scss
+++ b/src/form-item.scss
@@ -13,7 +13,6 @@ $block: #{$fd-namespace}-form-item;
   display: flex;
   align-content: center;
   flex-direction: column;
-  align-items: flex-start;
 
   &--horizontal {
     flex-direction: row;

--- a/src/form-item.scss
+++ b/src/form-item.scss
@@ -13,6 +13,7 @@ $block: #{$fd-namespace}-form-item;
   display: flex;
   align-content: center;
   flex-direction: column;
+  align-items: flex-start;
 
   &--horizontal {
     flex-direction: row;

--- a/src/form-label.scss
+++ b/src/form-label.scss
@@ -8,6 +8,12 @@ $block: #{$fd-namespace}-form-label;
 
 .#{$block} {
   $fd-unit-description-padding: 0.25rem;
+  $fd-require-space-padding: 0.5rem;
+  $fd-colon-space-padding: 0.25rem;
+  $fd-require-colon-space-spacing: 0.75rem;
+
+  $fd-require-colon-spacing: 0.5rem;
+  $fd-require-asterix-spacing: 0.125rem;
 
   @include fd-form-label();
 
@@ -28,23 +34,67 @@ $block: #{$fd-namespace}-form-label;
 
   &--required,
   &[aria-required="true"] {
+    padding-right: $fd-require-space-padding;
+
     &::after {
       content: "*";
       font-size: var(--sapFontSize);
       font-weight: bold;
       color: var(--sapField_RequiredColor);
-      margin-left: 0.125rem;
       position: absolute;
       right: 0;
       top: 0;
     }
 
     @include fd-rtl() {
+      padding-right: 0;
+      padding-left: $fd-require-space-padding;
+
       &::after {
-        margin-left: 0;
-        position: absolute;
         right: auto;
         left: 0;
+      }
+    }
+  }
+
+  &--colon {
+    padding-right: $fd-colon-space-padding;
+
+    &::before {
+      content: ":";
+      font-size: var(--sapFontSize);
+      color: inherit;
+      position: absolute;
+      right: 0;
+      top: 0;
+    }
+
+    @include fd-rtl() {
+      padding-left: $fd-colon-space-padding;
+      padding-right: 0;
+
+      &::before {
+        right: auto;
+        left: 0;
+      }
+    }
+
+    &.#{$block}--required,
+    &[aria-required="true"] {
+      padding-right: $fd-require-colon-space-spacing;
+
+      &::before {
+        right: $fd-require-colon-spacing;
+      }
+
+      @include fd-rtl() {
+        padding-left: $fd-require-colon-space-spacing;
+        padding-right: 0;
+
+        &::before {
+          right: auto;
+          left: $fd-require-colon-spacing;
+        }
       }
     }
   }

--- a/src/mixins/_forms.scss
+++ b/src/mixins/_forms.scss
@@ -170,6 +170,8 @@
 }
 
 @mixin fd-form-label() {
+  $fd-label-spacing: 0.5rem;
+
   @include fd-reset();
   @include fd-ellipsis();
 
@@ -178,14 +180,11 @@
   max-width: 100%;
   font-size: var(--sapFontSize);
   color: var(--sapContent_LabelColor);
-  padding-right: 6px;
-  margin-right: 8px;
+  margin-right: $fd-label-spacing;
   cursor: text;
 
   @include fd-rtl() {
-    padding-left: 6px;
-    padding-right: 0;
-    margin-left: 8px;
+    margin-left: $fd-label-spacing;
     margin-right: 0;
   }
 }

--- a/src/mixins/_forms.scss
+++ b/src/mixins/_forms.scss
@@ -182,6 +182,7 @@
   color: var(--sapContent_LabelColor);
   margin-right: $fd-label-spacing;
   cursor: text;
+  align-self: flex-start;
 
   @include fd-rtl() {
     margin-left: $fd-label-spacing;

--- a/stories/form-label/__snapshots__/form-label.stories.storyshot
+++ b/stories/form-label/__snapshots__/form-label.stories.storyshot
@@ -1,5 +1,68 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Storyshots Components/Forms/Form Label Colon 1`] = `
+<section>
+  
+    
+  <div
+    class="fd-form-item"
+  >
+    
+        
+    <label
+      class="fd-form-label fd-form-label--colon"
+      for="input-1d"
+    >
+      Input With Colon
+    </label>
+    
+        
+    <input
+      class="fd-input"
+      id="input-1d"
+      placeholder="Field placeholder text"
+      type="text"
+    />
+    
+    
+  </div>
+  
+    
+  <div
+    dir="rtl"
+  >
+    
+        
+    <div
+      class="fd-form-item"
+    >
+      
+            
+      <label
+        class="fd-form-label fd-form-label--colon"
+        for="input-1d"
+      >
+        Input With Colon
+      </label>
+      
+            
+      <input
+        class="fd-input"
+        id="input-1d"
+        placeholder="Field placeholder text"
+        type="text"
+      />
+      
+        
+    </div>
+    
+    
+  </div>
+  
+
+</section>
+`;
+
 exports[`Storyshots Components/Forms/Form Label Default 1`] = `
 
     

--- a/stories/form-label/__snapshots__/form-label.stories.storyshot
+++ b/stories/form-label/__snapshots__/form-label.stories.storyshot
@@ -40,7 +40,7 @@ exports[`Storyshots Components/Forms/Form Label Colon 1`] = `
             
       <label
         class="fd-form-label fd-form-label--colon"
-        for="input-1d"
+        for="input-2d"
       >
         Input With Colon
       </label>
@@ -48,7 +48,7 @@ exports[`Storyshots Components/Forms/Form Label Colon 1`] = `
             
       <input
         class="fd-input"
-        id="input-1d"
+        id="input-2d"
         placeholder="Field placeholder text"
         type="text"
       />

--- a/stories/form-label/form-label.stories.js
+++ b/stories/form-label/form-label.stories.js
@@ -1,5 +1,6 @@
 import '../../dist/form-item.css';
 import '../../dist/input.css';
+import { footer } from "../list/standard/standard-list.stories";
 
 export default {
     title: 'Components/Forms/Form Label',
@@ -12,7 +13,7 @@ export default {
 
 export const primary = () => `
     <div class="fd-form-item">
-        <label class="fd-form-label" for="input-1">Default input:</label>
+        <label class="fd-form-label" for="input-1">Default input</label>
         <input class="fd-input" type="text" id="input-1" placeholder="Field placeholder text">
     </div>
 `;
@@ -21,14 +22,30 @@ primary.storyName = 'Default';
 
 export const required = () => `
     <div class="fd-form-item">
-        <label class="fd-form-label fd-form-label--required" for="input-1c">Required Input:</label>
+        <label class="fd-form-label fd-form-label--required" for="input-1c">Required Input</label>
         <input class="fd-input" type="text" id="input-1c" placeholder="Field placeholder text">
     </div>
 `;
 
+export const colon = () => `
+    <div class="fd-form-item">
+        <label class="fd-form-label fd-form-label--colon" for="input-1d">Input With Colon</label>
+        <input class="fd-input" type="text" id="input-1d" placeholder="Field placeholder text">
+    </div>
+`;
+
+colon.storyName = 'Colon';
+
+colon.parameters = {
+    docs: {
+        storyDescription: 'To achieve overflow proof colon icon there should be `fd-form-label--colon` included'
+    }
+};
+
+
 export const disabled = () => `
     <div class="fd-form-item">
-        <label class="fd-form-label" for="input-05">Disabled Input:</label>
+        <label class="fd-form-label" for="input-05">Disabled Input</label>
         <input class="fd-input" type="text" id="input-05" disabled placeholder="Field placeholder text">
     </div>
 `;

--- a/stories/form-label/form-label.stories.js
+++ b/stories/form-label/form-label.stories.js
@@ -31,6 +31,12 @@ export const colon = () => `
         <label class="fd-form-label fd-form-label--colon" for="input-1d">Input With Colon</label>
         <input class="fd-input" type="text" id="input-1d" placeholder="Field placeholder text">
     </div>
+    <div dir="rtl">
+        <div class="fd-form-item">
+            <label class="fd-form-label fd-form-label--colon" for="input-2d">Input With Colon</label>
+            <input class="fd-input" type="text" id="input-2d" placeholder="Field placeholder text">
+        </div>
+    </div>
 `;
 
 colon.storyName = 'Colon';

--- a/stories/form-label/form-label.stories.js
+++ b/stories/form-label/form-label.stories.js
@@ -1,6 +1,5 @@
 import '../../dist/form-item.css';
 import '../../dist/input.css';
-import { footer } from "../list/standard/standard-list.stories";
 
 export default {
     title: 'Components/Forms/Form Label',
@@ -38,7 +37,10 @@ colon.storyName = 'Colon';
 
 colon.parameters = {
     docs: {
-        storyDescription: 'To achieve overflow proof colon icon there should be `fd-form-label--colon` included'
+        storyDescription: `
+            To achieve overflow proof colon icon there should be 'fd-form-label--colon' included. The ":" character
+            will be added at the end of a label as pseudo element. 
+        `
     }
 };
 


### PR DESCRIPTION
## Related Issue
closes: https://github.com/SAP/fundamental-styles/issues/870

## Description
There is added `--colon` modifier to every label.
Also spacing between asterix and label/colon is fixed
IE11 label is fixed


## Screenshots

### Before:
![image](https://user-images.githubusercontent.com/26483208/85857202-b1521200-b7b9-11ea-87c7-c4abebb67002.png)


### After:
![image](https://user-images.githubusercontent.com/26483208/85857147-941d4380-b7b9-11ea-9b69-b47d2a25ba20.png)

Also there is fixed required label on IE11
![image](https://user-images.githubusercontent.com/26483208/87547888-0d6ad080-c6ac-11ea-926c-dcf60459af19.png)


#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
