### PR TITLE
fix: remove transparent color from disabled text area placeholder

### DIFF
--- a/src/mixins/_forms.scss
+++ b/src/mixins/_forms.scss
@@ -78,10 +78,6 @@
   @include fd-disabled() {
     pointer-events: none;
     opacity: var(--sapContent_DisabledOpacity);
-
-    &::placeholder {
-      color: transparent;
-    }
   }
 
   @include fd-readonly() {
@@ -113,6 +109,7 @@
   &::placeholder {
     font-style: italic;
     color: var(--sapField_PlaceholderTextColor);
+    opacity: 100%;
   }
 
   &::selection {


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#907

## Description
This PR will remove the transparent property applied on disabled text area place holders

## Screenshots
### Before:
![Screen Shot 2020-06-26 at 4 06 03 PM](https://user-images.githubusercontent.com/50607147/85896901-4c051d80-b7c7-11ea-89d4-c52997f1956f.png)

### After:
![Screen Shot 2020-06-26 at 4 05 47 PM](https://user-images.githubusercontent.com/50607147/85896912-4f98a480-b7c7-11ea-8edc-639f516b3da8.png)

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
