### PR TITLE
docs: add logo text example to bar

### DIFF
--- a/stories/bar/bar.stories.js
+++ b/stories/bar/bar.stories.js
@@ -19,7 +19,7 @@ export const desktop = () => `
             <button aria-label="button" class="fd-button fd-button--transparent sap-icon--navigation-left-arrow"></button>
         </div>
         <div class="fd-bar__element">
-            <span aria-label="logo">LOGO</span>
+            <span aria-label="text">TEXT</span>
         </div>
     </div>
     <div class="fd-bar__middle">
@@ -51,7 +51,7 @@ export const desktop = () => `
             <button aria-label="button" class="fd-button fd-button--transparent sap-icon--navigation-right-arrow"></button>
         </div>
         <div class="fd-bar__element">
-          <span aria-label="logo">LOGO</span>
+          <span aria-label="text">TEXT</span>
         </div>
     </div>
     <div class="fd-bar__middle">

--- a/stories/bar/bar.stories.js
+++ b/stories/bar/bar.stories.js
@@ -19,10 +19,7 @@ export const desktop = () => `
             <button aria-label="button" class="fd-button fd-button--transparent sap-icon--navigation-left-arrow"></button>
         </div>
         <div class="fd-bar__element">
-            <button aria-label="button" class="fd-button fd-button--transparent sap-icon--home"></button>
-        </div>
-        <div class="fd-bar__element">
-            <button aria-label="button" class="fd-button fd-button--transparent sap-icon--account"></button>
+            <span aria-label="logo">LOGO</span>
         </div>
     </div>
     <div class="fd-bar__middle">
@@ -54,10 +51,7 @@ export const desktop = () => `
             <button aria-label="button" class="fd-button fd-button--transparent sap-icon--navigation-right-arrow"></button>
         </div>
         <div class="fd-bar__element">
-            <button aria-label="button" class="fd-button fd-button--transparent sap-icon--home"></button>
-        </div>
-        <div class="fd-bar__element">
-            <button aria-label="button" class="fd-button fd-button--transparent sap-icon--account"></button>
+          <span aria-label="logo">LOGO</span>
         </div>
     </div>
     <div class="fd-bar__middle">


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#905

## Description
Add an example that shows how to add text to a bar. There are other examples using buttons alone, therefore it would be smart to have one with a text with a span

## Screenshots
### Before:
![Screen Shot 2020-06-26 at 4 32 34 PM](https://user-images.githubusercontent.com/50607147/85898692-bd929b00-b7ca-11ea-87b7-fb56d11cf323.png)

### After:
![Screen Shot 2020-06-26 at 4 31 14 PM](https://user-images.githubusercontent.com/50607147/85898702-c2574f00-b7ca-11ea-9624-85e76340dc7e.png)

#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
