### PR TITLE
feat: rename class fd-bar--cosy to fd-bar--cozy

### DIFF
--- a/docs/pages/components/bar.md
+++ b/docs/pages/components/bar.md
@@ -11,7 +11,7 @@ tags: [f3, a11y, theme]
 ---
 
 The Bar component is a container that holds titles, buttons and input controls. Its content is distributed in three areas - left, middle and right. <br>
-The Bar has 2 modes - `Desktop` (default) and `Tablet/Mobile` (cosy).
+The Bar has 2 modes - `Desktop` (default) and `Tablet/Mobile` (cozy).
 {: .docs-intro}
 
 <br>
@@ -93,8 +93,8 @@ The Bar has 2 modes - `Desktop` (default) and `Tablet/Mobile` (cosy).
 
 <br>
 
-## Bar - Tablet and Mobile (Cosy)
-For Tablet and Mobile (Cosy mode) apply the `fd-bar--cozy` class to the container element. 
+## Bar - Tablet and Mobile (Cozy)
+For Tablet and Mobile (Cozy mode) apply the `fd-bar--cozy` class to the container element. 
 
 {% capture bar-default-mobile %}
 
@@ -176,7 +176,7 @@ For Header in Bar Design apply the `fd-bar--header` class to the container eleme
     </div>
 </div>
 <br><br>
-<div><b>Tablet and Mobile (Cosy)</b></div>
+<div><b>Tablet and Mobile (Cozy)</b></div>
 <br>
 <div class="fd-bar fd-bar--header fd-bar--cozy">
     <div class="fd-bar__left">
@@ -278,7 +278,7 @@ SubHeader in Bar Design is achieved by adding the `fd-bar--subheader` class to t
     </div>
 </div>
 <br><br>
-<div><b>Tablet and Mobile (Cosy)</b></div>
+<div><b>Tablet and Mobile (Cozy)</b></div>
 <br>
 <div class="fd-bar fd-bar--subheader fd-bar--cozy">
     <div class="fd-bar__middle">
@@ -400,7 +400,7 @@ If a Header is followed by a SubHeader, the Header container should have the  `f
     </div>
 </div>
 <br><br>
-<div><b>Tablet and Mobile (Cosy)</b></div>
+<div><b>Tablet and Mobile (Cozy)</b></div>
 <br>
 <div class="fd-bar fd-bar--footer fd-bar--cozy">
     <div class="fd-bar__right">
@@ -447,7 +447,7 @@ If a Header is followed by a SubHeader, the Header container should have the  `f
     </div>
 </div>
 <br><br>
-<div><b>Tablet and Mobile (Cosy)</b></div>
+<div><b>Tablet and Mobile (Cozy)</b></div>
 <br>
 <div class="fd-bar fd-bar--floating-footer fd-bar--cozy">
     <div class="fd-bar__right">

--- a/docs/pages/components/bar.md
+++ b/docs/pages/components/bar.md
@@ -94,11 +94,11 @@ The Bar has 2 modes - `Desktop` (default) and `Tablet/Mobile` (cosy).
 <br>
 
 ## Bar - Tablet and Mobile (Cosy)
-For Tablet and Mobile (Cosy mode) apply the `fd-bar--cosy` class to the container element. 
+For Tablet and Mobile (Cosy mode) apply the `fd-bar--cozy` class to the container element. 
 
 {% capture bar-default-mobile %}
 
-<div class="fd-bar fd-bar--cosy">
+<div class="fd-bar fd-bar--cozy">
     <div class="fd-bar__left">
         <div class="fd-bar__element">
             <button class="fd-button fd-button--transparent sap-icon--navigation-left-arrow"></button>
@@ -178,7 +178,7 @@ For Header in Bar Design apply the `fd-bar--header` class to the container eleme
 <br><br>
 <div><b>Tablet and Mobile (Cosy)</b></div>
 <br>
-<div class="fd-bar fd-bar--header fd-bar--cosy">
+<div class="fd-bar fd-bar--header fd-bar--cozy">
     <div class="fd-bar__left">
         <div class="fd-bar__element">
             <button class="fd-button fd-button--transparent sap-icon--navigation-left-arrow"></button>
@@ -280,7 +280,7 @@ SubHeader in Bar Design is achieved by adding the `fd-bar--subheader` class to t
 <br><br>
 <div><b>Tablet and Mobile (Cosy)</b></div>
 <br>
-<div class="fd-bar fd-bar--subheader fd-bar--cosy">
+<div class="fd-bar fd-bar--subheader fd-bar--cozy">
     <div class="fd-bar__middle">
         <div class="fd-bar__element">
             <div class="fd-form-item">
@@ -296,7 +296,7 @@ SubHeader in Bar Design is achieved by adding the `fd-bar--subheader` class to t
 <br><br>
 <div><b>Full width element</b></div>
 <br>
-<div class="fd-bar fd-bar--subheader fd-bar--cosy">
+<div class="fd-bar fd-bar--subheader fd-bar--cozy">
     <div class="fd-bar__middle">
         <div class="fd-bar__element fd-bar__element--full-width">
             <input class="fd-input fd-input--compact fd-input-group__input" type="text" id="" name="" value="1234568910 ">
@@ -402,7 +402,7 @@ If a Header is followed by a SubHeader, the Header container should have the  `f
 <br><br>
 <div><b>Tablet and Mobile (Cosy)</b></div>
 <br>
-<div class="fd-bar fd-bar--footer fd-bar--cosy">
+<div class="fd-bar fd-bar--footer fd-bar--cozy">
     <div class="fd-bar__right">
         <div class="fd-bar__element">
             <button class="fd-button fd-button--emphasized">Save</button>
@@ -449,7 +449,7 @@ If a Header is followed by a SubHeader, the Header container should have the  `f
 <br><br>
 <div><b>Tablet and Mobile (Cosy)</b></div>
 <br>
-<div class="fd-bar fd-bar--floating-footer fd-bar--cosy">
+<div class="fd-bar fd-bar--floating-footer fd-bar--cozy">
     <div class="fd-bar__right">
         <div class="fd-bar__element">
             <button class="fd-button fd-button--emphasized">Save</button>

--- a/docs/pages/components/calendar.md
+++ b/docs/pages/components/calendar.md
@@ -1120,7 +1120,7 @@ Remember that if <code>.fd-calendar__close-button</code> is placed inside naviga
                 </div>
             </div>
         </div>
-        <footer class="fd-dialog__footer fd-bar fd-bar--footer fd-bar--cosy">
+        <footer class="fd-dialog__footer fd-bar fd-bar--footer fd-bar--cozy">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
                     <button class="fd-dialog__decisive-button fd-button fd-button--emphasized">
@@ -1141,7 +1141,7 @@ On mobile devices calendar is composed into Dialog window taking full width and 
 {% capture default-calendar-mobile %}
 <div class="fd-dialog-docs-static fd-calendar-mobile-docs-static--portrait fd-dialog fd-dialog--active">
     <div class="fd-dialog__content fd-dialog__content--s fd-dialog__content--mobile">
-        <header class="fd-dialog__header fd-bar fd-bar--header fd-bar--cosy">
+        <header class="fd-dialog__header fd-bar fd-bar--header fd-bar--cozy">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
                     <h3 class="fd-dialog__title">
@@ -1309,7 +1309,7 @@ On mobile devices calendar is composed into Dialog window taking full width and 
                 <div aria-live="polite" class="fd-calendar__content fd-calendar__content--screen-reader-only">Use arrow keys to navigate dates</div>
             </div>
         </div>
-        <footer class="fd-dialog__footer fd-bar fd-bar--footer fd-bar--cosy">
+        <footer class="fd-dialog__footer fd-bar fd-bar--footer fd-bar--cozy">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
                     <button class="fd-dialog__decisive-button fd-button fd-button--emphasized">

--- a/docs/pages/components/dialog.md
+++ b/docs/pages/components/dialog.md
@@ -139,7 +139,7 @@ This behaviour can be changed using <code>.fd-dialog__content--no-mobile-stretch
     <li><code>.fd-dialog__content--mobile</code>: dialog takes full height and width</li>
     <li><code>.fd-dialog__content--no-mobile-stretch</code>: margin: 6% 10%</li>
 </ul>
-Please remember that on mobile devices Bar component should be used with <code>.fd-bar--cosy</code> class.
+Please remember that on mobile devices Bar component should be used with <code>.fd-bar--cozy</code> class.
 
 ### Dialog header/body/footer horizontal paddings
 {% capture dialog-size %}

--- a/docs/pages/components/generic-tile.md
+++ b/docs/pages/components/generic-tile.md
@@ -927,7 +927,7 @@ In action mode view, the close button is displayed on the top right-hand corner 
         Line Tile Container - <code>fd-tile-container</code>. The container controls the behaviour of the tiles - <strong>Floating</strong> (default) and <strong>List</strong> (<code>fd-tile-container--list</code>). For screen sizes less than 450px use the <strong>List</strong> behaviour. For bigger screens use the default <strong>Floating</strong> behaviour.
         <ul class="docs-ul">
             <li>Line Tile - apply the <code>fd-tile--line</code> modifier class to <code>fd-tile</code>.
-                Line Tiles have two modes - cosy (default) and compact (<code>fd-tile--compact</code>). *Note: the compact mode is applied only on Line Tiles. It should not be applied on the other types.
+                Line Tiles have two modes - cozy (default) and compact (<code>fd-tile--compact</code>). *Note: the compact mode is applied only on Line Tiles. It should not be applied on the other types.
                 <ul class="docs-ul">
                     <li>Line Tile Header - <code>fd-tile__header</code>
                         <ul class="docs-ul">
@@ -970,7 +970,7 @@ In action mode view, the close button is displayed on the top right-hand corner 
 The controls are wrapped in a container <code>fd-tile__action-container</code> which is right aligned within the tile. The default spacing between the header and actions container for List View in Action mode is 0.25rem. Gradient masking is also supported in edit mode. 
 
 {% capture tile-line %}
-<h4>Line Tile - Floating Behaviour, Cosy Mode</h4>
+<h4>Line Tile - Floating Behaviour, cozy Mode</h4>
 <div class="docs-section-container">
     <div class="fd-tile-container"> 
         <div role="button" tabindex="0" class="fd-tile fd-tile--line">
@@ -1012,7 +1012,7 @@ The controls are wrapped in a container <code>fd-tile__action-container</code> w
     </div>
 </div>
 <br><br><br>
-<h4>Line Tile - List Behaviour, Cosy Mode</h4>
+<h4>Line Tile - List Behaviour, cozy Mode</h4>
 <div class="docs-section-container">
     <div class="fd-tile-container fd-tile-container--list"> 
                 <div role="button" tabindex="0" class="fd-tile fd-tile--line">
@@ -1126,7 +1126,7 @@ The controls are wrapped in a container <code>fd-tile__action-container</code> w
     </div>
 </div>
 <br><br><br>
-<h4>Line Tile - Floating Behaviour, Cosy Mode, With Badge</h4>
+<h4>Line Tile - Floating Behaviour, cozy Mode, With Badge</h4>
 <div class="docs-section-container">
     <div class="fd-tile-container"> 
         <div role="button" tabindex="0" class="fd-tile fd-tile--line">
@@ -1195,7 +1195,7 @@ The controls are wrapped in a container <code>fd-tile__action-container</code> w
     </div>
 </div>
 <br><br><br>
-<h4>Line Tile - List Behaviour, Cosy Mode, With Badge</h4>
+<h4>Line Tile - List Behaviour, cozy Mode, With Badge</h4>
 <div class="docs-section-container">
     <div class="fd-tile-container fd-tile-container--list"> 
         <div role="button" tabindex="0" class="fd-tile fd-tile--line">
@@ -1255,7 +1255,7 @@ The controls are wrapped in a container <code>fd-tile__action-container</code> w
     </div>
 </div>
 <br><br><br>
-<h4>Line Tile - Floating Behaviour, Cosy and Action Mode</h4>
+<h4>Line Tile - Floating Behaviour, cozy and Action Mode</h4>
 <div class="docs-section-container">
     <div class="fd-tile-container"> 
         <div role="button" tabindex="0" class="fd-tile fd-tile--line fd-tile--action">
@@ -1321,7 +1321,7 @@ The controls are wrapped in a container <code>fd-tile__action-container</code> w
     </div>
 </div>
 <br><br><br>
-<h4>Line Tile - List Behaviour, Cosy and Action Mode</h4>
+<h4>Line Tile - List Behaviour, cozy and Action Mode</h4>
 <div class="docs-section-container">
     <div class="fd-tile-container fd-tile-container--list"> 
         <div role="button" tabindex="0" class="fd-tile fd-tile--line fd-tile--action">

--- a/docs/pages/components/menu.md
+++ b/docs/pages/components/menu.md
@@ -139,7 +139,7 @@ Example shows the parent menu's item in active state to simulate a pressed/touch
                 </ul>
             </nav>
         </div>
-       <footer class="fd-dialog__footer fd-bar fd-bar--cosy fd-bar--footer">
+       <footer class="fd-dialog__footer fd-bar fd-bar--cozy fd-bar--footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
                     <button class="fd-button fd-button--light fd-dialog__decisive-button">Cancel</button>
@@ -189,7 +189,7 @@ Example shows the parent menu's item in active state to simulate a pressed/touch
                 </ul>
             </nav>
         </div>
-       <footer class="fd-dialog__footer fd-bar fd-bar--cosy fd-bar--footer">
+       <footer class="fd-dialog__footer fd-bar fd-bar--cozy fd-bar--footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
                     <button class="fd-button fd-button--light fd-dialog__decisive-button">Cancel</button>

--- a/docs/pages/components/message-box.md
+++ b/docs/pages/components/message-box.md
@@ -325,7 +325,7 @@ To enable responsive behavior for the paddings use the following modifier classe
     <li><code>.fd-message-box__content--xl</code>: 3rem - min-width: 1440px</li>
 </ul>
 <br><br>
-On mobile devices the component should be in `cosy` mode. Add the `fd-bar--cosy` modifier class to the header and the footer. The buttons in the footer should also be in Cosy mode. The deafult mode for Buttons is `cosy` so no modifier classes are required.
+On mobile devices the component should be in `cosy` mode. Add the `fd-bar--cozy` modifier class to the header and the footer. The buttons in the footer should also be in Cosy mode. The deafult mode for Buttons is `cosy` so no modifier classes are required.
 <br><br>
 On phone devices the content container takes 100vh and 100vw. It's achieved by applying the `fd-message-box__content--mobile` modifier class on the Message Box content container.
 <br>
@@ -333,7 +333,7 @@ On phone devices the content container takes 100vh and 100vw. It's achieved by a
 {% capture default-message-box %}
 <div class="fd-message-box-docs-static fd-message-box fd-message-box--information fd-message-box--active">
     <div class="fd-message-box__content fd-message-box__content--s">
-        <header class="fd-bar fd-bar--cosy fd-bar--header fd-message-box__header">
+        <header class="fd-bar fd-bar--cozy fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
                     <h2 class="fd-message-box__title">Information</h2>
@@ -346,7 +346,7 @@ On phone devices the content container takes 100vh and 100vw. It's achieved by a
                 <a href="#" class="fd-link" tabindex="0">Show more</a>
             </div>
         </div>
-        <footer class="fd-bar fd-bar--cosy fd-bar--footer fd-message-box__footer">
+        <footer class="fd-bar fd-bar--cozy fd-bar--footer fd-message-box__footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
                     <button class="fd-button fd-button--emphasized fd-message-box__decisive-button">
@@ -362,7 +362,7 @@ On phone devices the content container takes 100vh and 100vw. It's achieved by a
 
 <div class="fd-message-box-docs-static fd-message-box fd-message-box--error fd-message-box--active">
     <div class="fd-message-box__content fd-message-box__content--m">
-        <header class="fd-bar fd-bar--cosy fd-bar--header fd-message-box__header">
+        <header class="fd-bar fd-bar--cozy fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
                     <h2 class="fd-message-box__title">Error</h2>
@@ -372,7 +372,7 @@ On phone devices the content container takes 100vh and 100vw. It's achieved by a
         <div class="fd-message-box__body">
             Error Message Box on medium screen in Cosy mode  
         </div>
-        <footer class="fd-bar fd-bar--cosy fd-bar--footer fd-message-box__footer">
+        <footer class="fd-bar fd-bar--cozy fd-bar--footer fd-message-box__footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
                     <button class="fd-button fd-button--emphasized fd-message-box__decisive-button">

--- a/docs/pages/components/message-box.md
+++ b/docs/pages/components/message-box.md
@@ -325,7 +325,7 @@ To enable responsive behavior for the paddings use the following modifier classe
     <li><code>.fd-message-box__content--xl</code>: 3rem - min-width: 1440px</li>
 </ul>
 <br><br>
-On mobile devices the component should be in `cosy` mode. Add the `fd-bar--cozy` modifier class to the header and the footer. The buttons in the footer should also be in Cosy mode. The deafult mode for Buttons is `cosy` so no modifier classes are required.
+On mobile devices the component should be in `cozy` mode. Add the `fd-bar--cozy` modifier class to the header and the footer. The buttons in the footer should also be in Cozy mode. The deafult mode for Buttons is `cozy` so no modifier classes are required.
 <br><br>
 On phone devices the content container takes 100vh and 100vw. It's achieved by applying the `fd-message-box__content--mobile` modifier class on the Message Box content container.
 <br>
@@ -341,7 +341,7 @@ On phone devices the content container takes 100vh and 100vw. It's achieved by a
             </div>
         </header>
         <div class="fd-message-box__body">
-            Information Message Box on small screen in Cosy mode 
+            Information Message Box on small screen in Cozy mode 
             <div class="fd-message-box__more">
                 <a href="#" class="fd-link" tabindex="0">Show more</a>
             </div>
@@ -370,7 +370,7 @@ On phone devices the content container takes 100vh and 100vw. It's achieved by a
             </div>
         </header>
         <div class="fd-message-box__body">
-            Error Message Box on medium screen in Cosy mode  
+            Error Message Box on medium screen in Cozy mode  
         </div>
         <footer class="fd-bar fd-bar--cozy fd-bar--footer fd-message-box__footer">
             <div class="fd-bar__right">

--- a/docs/pages/components/popover.md
+++ b/docs/pages/components/popover.md
@@ -287,7 +287,7 @@ There are four placement options:
     </div>
     <div class="fd-popover__body fd-popover__body--no-arrow" aria-hidden="true" id="popoverHSF345">
         <div class="fd-popover__body-header">
-            <div class="fd-bar fd-bar--cosy fd-bar--header-with-subheader">
+            <div class="fd-bar fd-bar--cozy fd-bar--header-with-subheader">
                 <div class="fd-bar__left">
                     <div class="fd-bar__element">
                         <button class="fd-button fd-button--transparent sap-icon--navigation-left-arrow"></button>
@@ -298,7 +298,7 @@ There are four placement options:
                 </div>
             </div>
         </div>
-        <div class="fd-bar fd-bar--cosy fd-bar--subheader">
+        <div class="fd-bar fd-bar--cozy fd-bar--subheader">
                 <div class="fd-bar__middle">
                     <div class="fd-bar__element">
                         <div class="fd-form-item">
@@ -315,7 +315,7 @@ There are four placement options:
             <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('https://placeimg.com/400/400/nature');" role="presentation" aria-label="Nature"></span>
         </div>
         <div class="fd-popover__body-footer">
-            <div class="fd-bar fd-bar--cosy fd-bar--footer">
+            <div class="fd-bar fd-bar--cozy fd-bar--footer">
                 <div class="fd-bar__right">
                     <div class="fd-bar__element">
                         <button class="fd-button fd-button--compact fd-button--emphasized">Save</button>

--- a/docs/pages/components/popover.md
+++ b/docs/pages/components/popover.md
@@ -283,7 +283,7 @@ There are four placement options:
 
 <div class="fd-popover">
     <div class="fd-popover__control">
-        <button class="fd-button" aria-label="Image label" aria-controls="popoverHSF345" aria-expanded="false" aria-haspopup="true">All Cosy Mode</button>
+        <button class="fd-button" aria-label="Image label" aria-controls="popoverHSF345" aria-expanded="false" aria-haspopup="true">All Cozy Mode</button>
     </div>
     <div class="fd-popover__body fd-popover__body--no-arrow" aria-hidden="true" id="popoverHSF345">
         <div class="fd-popover__body-header">

--- a/docs/pages/components/switch.md
+++ b/docs/pages/components/switch.md
@@ -17,7 +17,7 @@ The Switch is meant to resemble a physical switch and allow a user to turn a set
 {% capture default %}
 <div class="fd-form-group">
     <div class="fd-form-item">
-        <label class="fd-form-label">Default (Cosy) Switch</label>
+        <label class="fd-form-label">Default (Cozy) Switch</label>
         <label class="fd-switch__label">
             <span class="fd-switch">
                 <input class="fd-switch__input" type="checkbox" name="" value="" id="y21YO3251">

--- a/docs/pages/patterns/combobox-input.md
+++ b/docs/pages/patterns/combobox-input.md
@@ -360,7 +360,7 @@ So instead of using popover and dropdown, it should be wrapped in `dialog` and `
                 </div>
             </div>
         </header>
-        <div class="fd-dialog__subheader fd-bar fd-bar--cosy fd-bar--subheader">
+        <div class="fd-dialog__subheader fd-bar fd-bar--cozy fd-bar--subheader">
             <div class="fd-bar__middle">
                 <div class="fd-input-group fd-input-group--control">
                      <input type="text" class="fd-input fd-input-group__input" value="Apple" id="" placeholder="Select Ingredient">
@@ -404,7 +404,7 @@ So instead of using popover and dropdown, it should be wrapped in `dialog` and `
                  </li>
              </ul>
         </div>
-       <footer class="fd-dialog__footer fd-bar fd-bar--cosy fd-bar--footer">
+       <footer class="fd-dialog__footer fd-bar fd-bar--cozy fd-bar--footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
                     <button class="fd-button fd-button--emphasized fd-dialog__decisive-button">OK</button>

--- a/docs/pages/patterns/date-picker.md
+++ b/docs/pages/patterns/date-picker.md
@@ -566,7 +566,7 @@ The today selection button in the footer selects today's date in the system or u
 					</div>
 				</div>
 			</div>
-			<footer class="fd-dialog__footer fd-bar fd-bar--footer fd-bar--cosy">
+			<footer class="fd-dialog__footer fd-bar fd-bar--footer fd-bar--cozy">
 				<div class="fd-bar__right">
 					<div class="fd-bar__element">
 						<button class="fd-dialog__decisive-button fd-button">Today</button>
@@ -928,7 +928,7 @@ The today navigation button in the header navigates focus to today's date in the
                 </div>
             </div>
         </div>
-        <footer class="fd-dialog__footer fd-bar fd-bar--footer fd-bar--cosy">
+        <footer class="fd-dialog__footer fd-bar fd-bar--footer fd-bar--cozy">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
                     <button class="fd-dialog__decisive-button fd-button fd-button--emphasized">
@@ -946,7 +946,7 @@ The today navigation button in the header navigates focus to today's date in the
 {% capture mobile-datepicker-portrait-today-navigation %}
 <div class="fd-dialog-docs-static fd-calendar-mobile-docs-static--portrait fd-dialog fd-dialog--active">
     <div class="fd-dialog__content fd-dialog__content--s fd-dialog__content--mobile">
-        <header class="fd-dialog__header fd-bar fd-bar--header fd-bar--cosy">
+        <header class="fd-dialog__header fd-bar fd-bar--header fd-bar--cozy">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
                     <h3 class="fd-dialog__title">
@@ -1115,7 +1115,7 @@ The today navigation button in the header navigates focus to today's date in the
                 <div aria-live="polite" class="fd-calendar__content fd-calendar__content--screen-reader-only">Use arrow keys to navigate dates</div>
             </div>
         </div>
-        <footer class="fd-dialog__footer fd-bar fd-bar--footer fd-bar--cosy">
+        <footer class="fd-dialog__footer fd-bar fd-bar--footer fd-bar--cozy">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
                     <button class="fd-dialog__decisive-button fd-button fd-button--emphasized">

--- a/docs/pages/patterns/multi-input.md
+++ b/docs/pages/patterns/multi-input.md
@@ -648,7 +648,7 @@ So instead of using popover and dropdown, it should be wrapped in `dialog` and `
                 </div>
             </div>
         </header>
-        <div class="fd-dialog__subheader fd-bar fd-bar--cosy fd-bar--subheader">
+        <div class="fd-dialog__subheader fd-bar fd-bar--cozy fd-bar--subheader">
             <div class="fd-bar__middle">
                 <div class="fd-bar__element">
                     <div class="fd-input-group">
@@ -723,7 +723,7 @@ So instead of using popover and dropdown, it should be wrapped in `dialog` and `
                  </li>
              </ul>
         </div>
-       <footer class="fd-dialog__footer fd-bar fd-bar--cosy fd-bar--footer">
+       <footer class="fd-dialog__footer fd-bar fd-bar--cozy fd-bar--footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
                     <button class="fd-button fd-button--emphasized fd-dialog__decisive-button">OK</button>

--- a/docs/pages/patterns/time-picker.md
+++ b/docs/pages/patterns/time-picker.md
@@ -85,7 +85,7 @@ This component mostly relies on the CSS of other components and has no CSS of it
             </div>
         </div>
        <div class="fd-popover__body-footer">
-            <div class="fd-bar fd-bar--cosy fd-bar--footer">
+            <div class="fd-bar fd-bar--cozy fd-bar--footer">
                 <div class="fd-bar__right">
                     <div class="fd-bar__element">
                         <button class="fd-button fd-button--emphasized">OK</button>
@@ -180,7 +180,7 @@ This component mostly relies on the CSS of other components and has no CSS of it
             </div>
         </div>
        <div class="fd-popover__body-footer">
-            <div class="fd-bar fd-bar--cosy fd-bar--footer">
+            <div class="fd-bar fd-bar--cozy fd-bar--footer">
                 <div class="fd-bar__right">
                     <div class="fd-bar__element">
                         <button class="fd-button fd-button--emphasized">OK</button>
@@ -274,7 +274,7 @@ This component mostly relies on the CSS of other components and has no CSS of it
             </div>
         </div>
        <div class="fd-popover__body-footer">
-            <div class="fd-bar fd-bar--cosy fd-bar--footer">
+            <div class="fd-bar fd-bar--cozy fd-bar--footer">
                 <div class="fd-bar__right">
                     <div class="fd-bar__element">
                         <button class="fd-button fd-button--compact fd-button--emphasized">OK</button>

--- a/src/bar.scss
+++ b/src/bar.scss
@@ -129,7 +129,7 @@ $block: #{$fd-namespace}-bar;
     }
   }
 
-  &--cosy {
+  &--cozy {
     height: 2.75rem;
 
     &.#{$block}--header,

--- a/stories/bar/__snapshots__/bar.stories.storyshot
+++ b/stories/bar/__snapshots__/bar.stories.storyshot
@@ -77,7 +77,7 @@ exports[`Storyshots Components/Bar Bar As Floating Footer 1`] = `
   
 
   <div
-    class="fd-bar fd-bar--floating-footer fd-bar--cosy"
+    class="fd-bar fd-bar--floating-footer fd-bar--cozy"
   >
     
     
@@ -267,7 +267,7 @@ exports[`Storyshots Components/Bar Bar As Footer 1`] = `
   
 
   <div
-    class="fd-bar fd-bar--footer fd-bar--cosy"
+    class="fd-bar fd-bar--footer fd-bar--cozy"
   >
     
     
@@ -552,7 +552,7 @@ exports[`Storyshots Components/Bar Bar As Header 1`] = `
   
 
   <div
-    class="fd-bar fd-bar--header fd-bar--cosy"
+    class="fd-bar fd-bar--header fd-bar--cozy"
   >
     
     
@@ -968,7 +968,7 @@ exports[`Storyshots Components/Bar Bar As Subheader 1`] = `
   
 
   <div
-    class="fd-bar fd-bar--subheader fd-bar--cosy"
+    class="fd-bar fd-bar--subheader fd-bar--cozy"
   >
     
     
@@ -1043,7 +1043,7 @@ exports[`Storyshots Components/Bar Bar As Subheader 1`] = `
   
 
   <div
-    class="fd-bar fd-bar--subheader fd-bar--cosy"
+    class="fd-bar fd-bar--subheader fd-bar--cozy"
   >
     
     

--- a/stories/bar/__snapshots__/bar.stories.storyshot
+++ b/stories/bar/__snapshots__/bar.stories.storyshot
@@ -68,7 +68,7 @@ exports[`Storyshots Components/Bar Bar As Floating Footer 1`] = `
 
   <div>
     <b>
-      Tablet and Mobile (Cosy)
+      Tablet and Mobile (Cozy)
     </b>
   </div>
   
@@ -258,7 +258,7 @@ exports[`Storyshots Components/Bar Bar As Footer 1`] = `
 
   <div>
     <b>
-      Tablet and Mobile (Cosy)
+      Tablet and Mobile (Cozy)
     </b>
   </div>
   
@@ -543,7 +543,7 @@ exports[`Storyshots Components/Bar Bar As Header 1`] = `
 
   <div>
     <b>
-      Tablet and Mobile (Cosy)
+      Tablet and Mobile (Cozy)
     </b>
   </div>
   
@@ -959,7 +959,7 @@ exports[`Storyshots Components/Bar Bar As Subheader 1`] = `
 
   <div>
     <b>
-      Tablet and Mobile (Cosy)
+      Tablet and Mobile (Cozy)
     </b>
   </div>
   

--- a/stories/bar/bar.stories.js
+++ b/stories/bar/bar.stories.js
@@ -89,7 +89,7 @@ desktop.parameters = {
 };
 
 export const tabletAndMobile = () => `
-<div class="fd-bar fd-bar--cosy">
+<div class="fd-bar fd-bar--cozy">
     <div class="fd-bar__left">
         <div class="fd-bar__element">
             <button aria-label="button" class="fd-button fd-button--transparent sap-icon--navigation-left-arrow"></button>
@@ -126,7 +126,7 @@ export const tabletAndMobile = () => `
 tabletAndMobile.parameters = {
     docs: {
         iframeHeight: 100,
-        storyDescription: 'For Tablet and Mobile (Cosy mode) apply the <code>fd-bar--cosy</code> class to the container element.'
+        storyDescription: 'For Tablet and Mobile (Cosy mode) apply the <code>fd-bar--cozy</code> class to the container element.'
     }
 };
 
@@ -168,7 +168,7 @@ export const barAsHeader = () => `
 <br><br>
 <div><b>Tablet and Mobile (Cosy)</b></div>
 <br>
-<div class="fd-bar fd-bar--header fd-bar--cosy">
+<div class="fd-bar fd-bar--header fd-bar--cozy">
     <div class="fd-bar__left">
         <div class="fd-bar__element">
             <button aria-label="button" class="fd-button fd-button--transparent sap-icon--navigation-left-arrow"></button>
@@ -271,7 +271,7 @@ export const barAsSubheader = () => `
 <br><br>
 <div><b>Tablet and Mobile (Cosy)</b></div>
 <br>
-<div class="fd-bar fd-bar--subheader fd-bar--cosy">
+<div class="fd-bar fd-bar--subheader fd-bar--cozy">
     <div class="fd-bar__middle">
         <div class="fd-bar__element">
             <div class="fd-form-item">
@@ -287,7 +287,7 @@ export const barAsSubheader = () => `
 <br><br>
 <div><b>Full width element</b></div>
 <br>
-<div class="fd-bar fd-bar--subheader fd-bar--cosy">
+<div class="fd-bar fd-bar--subheader fd-bar--cozy">
     <div class="fd-bar__middle">
         <div class="fd-bar__element fd-bar__element--full-width">
             <input class="fd-input fd-input--compact fd-input-group__input" type="text" id="" name="" value="1234568910" aria-label="input">
@@ -394,7 +394,7 @@ export const barAsFooter = () => `
 <br><br>
 <div><b>Tablet and Mobile (Cosy)</b></div>
 <br>
-<div class="fd-bar fd-bar--footer fd-bar--cosy">
+<div class="fd-bar fd-bar--footer fd-bar--cozy">
     <div class="fd-bar__right">
         <div class="fd-bar__element">
             <button aria-label="button" class="fd-button fd-button--emphasized">Save</button>
@@ -441,7 +441,7 @@ export const barAsFloatingFooter = () => `
 <br><br>
 <div><b>Tablet and Mobile (Cosy)</b></div>
 <br>
-<div class="fd-bar fd-bar--floating-footer fd-bar--cosy">
+<div class="fd-bar fd-bar--floating-footer fd-bar--cozy">
     <div class="fd-bar__right">
         <div class="fd-bar__element">
             <button aria-label="button" class="fd-button fd-button--emphasized">Save</button>

--- a/stories/bar/bar.stories.js
+++ b/stories/bar/bar.stories.js
@@ -7,7 +7,7 @@ export default {
     title: 'Components/Bar',
     parameters: {
         description: `The Bar component is a container that holds titles, buttons and input controls. Its content is distributed in three areas - left, middle and right.
-The Bar has 2 modes - Desktop (default) and Tablet/Mobile (cosy).`,
+The Bar has 2 modes - Desktop (default) and Tablet/Mobile (cozy).`,
         tags: ['f3', 'a11y', 'theme']
     }
 };
@@ -126,7 +126,7 @@ export const tabletAndMobile = () => `
 tabletAndMobile.parameters = {
     docs: {
         iframeHeight: 100,
-        storyDescription: 'For Tablet and Mobile (Cosy mode) apply the <code>fd-bar--cozy</code> class to the container element.'
+        storyDescription: 'For Tablet and Mobile (Cozy mode) apply the <code>fd-bar--cozy</code> class to the container element.'
     }
 };
 
@@ -166,7 +166,7 @@ export const barAsHeader = () => `
     </div>
 </div>
 <br><br>
-<div><b>Tablet and Mobile (Cosy)</b></div>
+<div><b>Tablet and Mobile (Cozy)</b></div>
 <br>
 <div class="fd-bar fd-bar--header fd-bar--cozy">
     <div class="fd-bar__left">
@@ -269,7 +269,7 @@ export const barAsSubheader = () => `
     </div>
 </div>
 <br><br>
-<div><b>Tablet and Mobile (Cosy)</b></div>
+<div><b>Tablet and Mobile (Cozy)</b></div>
 <br>
 <div class="fd-bar fd-bar--subheader fd-bar--cozy">
     <div class="fd-bar__middle">
@@ -392,7 +392,7 @@ export const barAsFooter = () => `
     </div>
 </div>
 <br><br>
-<div><b>Tablet and Mobile (Cosy)</b></div>
+<div><b>Tablet and Mobile (Cozy)</b></div>
 <br>
 <div class="fd-bar fd-bar--footer fd-bar--cozy">
     <div class="fd-bar__right">
@@ -439,7 +439,7 @@ export const barAsFloatingFooter = () => `
     </div>
 </div>
 <br><br>
-<div><b>Tablet and Mobile (Cosy)</b></div>
+<div><b>Tablet and Mobile (Cozy)</b></div>
 <br>
 <div class="fd-bar fd-bar--floating-footer fd-bar--cozy">
     <div class="fd-bar__right">

--- a/stories/calendar/calendar.stories.js
+++ b/stories/calendar/calendar.stories.js
@@ -917,7 +917,7 @@ export const mobileModeLandscapeOrientation = () => `
                 </div>
             </div>
         </div>
-        <footer class="fd-dialog__footer fd-bar fd-bar--footer fd-bar--cosy">
+        <footer class="fd-dialog__footer fd-bar fd-bar--footer fd-bar--cozy">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
                     <button class="fd-dialog__decisive-button fd-button fd-button--emphasized">
@@ -947,7 +947,7 @@ Dialog footer element is optional. Remember that if <code class="docs-code">.fd-
 export const mobileModePortraitOrientation = () => `
 <div class="fd-dialog-docs-static fd-calendar-mobile-docs-static--portrait fd-dialog fd-dialog--active">
     <div class="fd-dialog__content fd-dialog__content--s fd-dialog__content--mobile">
-        <header class="fd-dialog__header fd-bar fd-bar--header fd-bar--cosy">
+        <header class="fd-dialog__header fd-bar fd-bar--header fd-bar--cozy">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
                     <h3 class="fd-dialog__title">
@@ -1115,7 +1115,7 @@ export const mobileModePortraitOrientation = () => `
                 <div aria-live="polite" class="fd-calendar__content fd-calendar__content--screen-reader-only">Use arrow keys to navigate dates</div>
             </div>
         </div>
-        <footer class="fd-dialog__footer fd-bar fd-bar--footer fd-bar--cosy">
+        <footer class="fd-dialog__footer fd-bar fd-bar--footer fd-bar--cozy">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
                     <button class="fd-dialog__decisive-button fd-button fd-button--emphasized">

--- a/stories/dialog/dialog.stories.js
+++ b/stories/dialog/dialog.stories.js
@@ -234,7 +234,7 @@ By default dialog on mobile devices should take full height and width of the scr
 
 - \`.fd-dialog__content--mobile\`: dialog takes full height and width
 - \`.fd-dialog__content--no-mobile-stretch\`: margin: 6% 10%
-Please remember that on mobile devices Bar component should be used with \`.fd-bar--cosy\` class.
+Please remember that on mobile devices Bar component should be used with \`.fd-bar--cozy\` class.
 
 **DIALOG HEADER/BODY/FOOTER HORIZONTAL PADDINGS**
 `

--- a/stories/generictile/__snapshots__/generic-tile.stories.storyshot
+++ b/stories/generictile/__snapshots__/generic-tile.stories.storyshot
@@ -1821,7 +1821,7 @@ exports[`Storyshots Components/GenericTile Line Tile 1`] = `
   
 
   <h4>
-    Line Tile - Floating Behaviour, Cosy Mode
+    Line Tile - Floating Behaviour, Cozy Mode
   </h4>
   
 
@@ -2039,7 +2039,7 @@ exports[`Storyshots Components/GenericTile Line Tile 1`] = `
   
 
   <h4>
-    Line Tile - List Behaviour, Cosy Mode
+    Line Tile - List Behaviour, Cozy Mode
   </h4>
   
 
@@ -2629,7 +2629,7 @@ exports[`Storyshots Components/GenericTile Line Tile 1`] = `
   
 
   <h4>
-    Line Tile - Floating Behaviour, Cosy Mode, With Badge
+    Line Tile - Floating Behaviour, Cozy Mode, With Badge
   </h4>
   
 
@@ -2984,7 +2984,7 @@ exports[`Storyshots Components/GenericTile Line Tile 1`] = `
   
 
   <h4>
-    Line Tile - List Behaviour, Cosy Mode, With Badge
+    Line Tile - List Behaviour, Cozy Mode, With Badge
   </h4>
   
 
@@ -3292,7 +3292,7 @@ exports[`Storyshots Components/GenericTile Line Tile 1`] = `
   
 
   <h4>
-    Line Tile - Floating Behaviour, Cosy and Action Mode
+    Line Tile - Floating Behaviour, Cozy and Action Mode
   </h4>
   
 
@@ -3636,7 +3636,7 @@ exports[`Storyshots Components/GenericTile Line Tile 1`] = `
   
 
   <h4>
-    Line Tile - List Behaviour, Cosy and Action Mode
+    Line Tile - List Behaviour, Cozy and Action Mode
   </h4>
   
 

--- a/stories/generictile/generic-tile.stories.mdx
+++ b/stories/generictile/generic-tile.stories.mdx
@@ -985,7 +985,7 @@ In action mode view, the close button is displayed on the top right-hand corner 
 ## Line Tile
 
 -   Line Tile Container - `fd-tile-container`. The container controls the behaviour of the tiles - **Floating** (default) and **List** (`fd-tile-container--list`). For screen sizes less than 450px use the **List** behaviour. For bigger screens use the default **Floating** behaviour.
-    -   Line Tile - apply the `fd-tile--line` modifier class to `fd-tile`. Line Tiles have two modes - cosy (default) and compact (`fd-tile--compact`). \*Note: the compact mode is applied only on Line Tiles. It should not be applied on the other types.
+    -   Line Tile - apply the `fd-tile--line` modifier class to `fd-tile`. Line Tiles have two modes - cozy (default) and compact (`fd-tile--compact`). \*Note: the compact mode is applied only on Line Tiles. It should not be applied on the other types.
         -   Line Tile Header - `fd-tile__header`
             -   Title `fd-tile__title` - **required**. For a Line Tile with a badge the title and the badge must be wrapped in a container `fd-tile__title-container`.
             -   Subtitle `fd-tile__subtitle` **optional**.
@@ -1014,7 +1014,7 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
 <Preview>
     <Story name="Line Tile">
         {() => `
-<h4>Line Tile - Floating Behaviour, Cosy Mode</h4>
+<h4>Line Tile - Floating Behaviour, Cozy Mode</h4>
 <div class="docs-section-container">
     <div class="fd-tile-container"> 
         <div role="button" tabindex="0" class="fd-tile fd-tile--line">
@@ -1056,7 +1056,7 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
     </div>
 </div>
 <br><br><br>
-<h4>Line Tile - List Behaviour, Cosy Mode</h4>
+<h4>Line Tile - List Behaviour, Cozy Mode</h4>
 <div class="docs-section-container">
     <div class="fd-tile-container fd-tile-container--list"> 
                 <div role="button" tabindex="0" class="fd-tile fd-tile--line">
@@ -1170,7 +1170,7 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
     </div>
 </div>
 <br><br><br>
-<h4>Line Tile - Floating Behaviour, Cosy Mode, With Badge</h4>
+<h4>Line Tile - Floating Behaviour, Cozy Mode, With Badge</h4>
 <div class="docs-section-container">
     <div class="fd-tile-container"> 
         <div role="button" tabindex="0" class="fd-tile fd-tile--line">
@@ -1239,7 +1239,7 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
     </div>
 </div>
 <br><br><br>
-<h4>Line Tile - List Behaviour, Cosy Mode, With Badge</h4>
+<h4>Line Tile - List Behaviour, Cozy Mode, With Badge</h4>
 <div class="docs-section-container">
     <div class="fd-tile-container fd-tile-container--list"> 
         <div role="button" tabindex="0" class="fd-tile fd-tile--line">
@@ -1299,7 +1299,7 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
     </div>
 </div>
 <br><br><br>
-<h4>Line Tile - Floating Behaviour, Cosy and Action Mode</h4>
+<h4>Line Tile - Floating Behaviour, Cozy and Action Mode</h4>
 <div class="docs-section-container">
     <div class="fd-tile-container"> 
         <div role="button" tabindex="0" class="fd-tile fd-tile--line fd-tile--action">
@@ -1365,7 +1365,7 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
     </div>
 </div>
 <br><br><br>
-<h4>Line Tile - List Behaviour, Cosy and Action Mode</h4>
+<h4>Line Tile - List Behaviour, Cozy and Action Mode</h4>
 <div class="docs-section-container">
     <div class="fd-tile-container fd-tile-container--list"> 
         <div role="button" tabindex="0" class="fd-tile fd-tile--line fd-tile--action">

--- a/stories/menu/__snapshots__/menu.stories.storyshot
+++ b/stories/menu/__snapshots__/menu.stories.storyshot
@@ -892,7 +892,7 @@ exports[`Storyshots Components/Menu Mobile Cozy Mode 1`] = `
        
       <footer
         aria-label="bar-footer"
-        class="fd-dialog__footer fd-bar fd-bar--cosy fd-bar--footer"
+        class="fd-dialog__footer fd-bar fd-bar--cozy fd-bar--footer"
       >
         
             
@@ -1121,7 +1121,7 @@ exports[`Storyshots Components/Menu Mobile Cozy Mode 1`] = `
       
        
       <footer
-        class="fd-dialog__footer fd-bar fd-bar--cosy fd-bar--footer"
+        class="fd-dialog__footer fd-bar fd-bar--cozy fd-bar--footer"
       >
         
             

--- a/stories/menu/menu.stories.js
+++ b/stories/menu/menu.stories.js
@@ -129,7 +129,7 @@ export const mobileCozyMode = () => `
                 </ul>
             </nav>
         </div>
-       <footer aria-label="bar-footer" class="fd-dialog__footer fd-bar fd-bar--cosy fd-bar--footer">
+       <footer aria-label="bar-footer" class="fd-dialog__footer fd-bar fd-bar--cozy fd-bar--footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
                     <button aria-label="fd-button" role="button" class="fd-button fd-button--light fd-dialog__decisive-button">Cancel</button>
@@ -179,7 +179,7 @@ export const mobileCozyMode = () => `
                 </ul>
             </nav>
         </div>
-       <footer class="fd-dialog__footer fd-bar fd-bar--cosy fd-bar--footer">
+       <footer class="fd-dialog__footer fd-bar fd-bar--cozy fd-bar--footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
                     <button aria-label="fd-button" role="button" class="fd-button fd-button--light fd-dialog__decisive-button">Cancel</button>

--- a/stories/message-box/__snapshots__/message-box.stories.storyshot
+++ b/stories/message-box/__snapshots__/message-box.stories.storyshot
@@ -224,7 +224,7 @@ exports[`Storyshots Components/Message Box Responsive 1`] = `
       
         
       <header
-        class="fd-bar fd-bar--cosy fd-bar--header fd-message-box__header"
+        class="fd-bar fd-bar--cozy fd-bar--header fd-message-box__header"
       >
         
             
@@ -281,7 +281,7 @@ exports[`Storyshots Components/Message Box Responsive 1`] = `
       
         
       <footer
-        class="fd-bar fd-bar--cosy fd-bar--footer fd-message-box__footer"
+        class="fd-bar fd-bar--cozy fd-bar--footer fd-message-box__footer"
       >
         
             
@@ -337,7 +337,7 @@ exports[`Storyshots Components/Message Box Responsive 1`] = `
       
         
       <header
-        class="fd-bar fd-bar--cosy fd-bar--header fd-message-box__header"
+        class="fd-bar fd-bar--cozy fd-bar--header fd-message-box__header"
       >
         
             
@@ -377,7 +377,7 @@ exports[`Storyshots Components/Message Box Responsive 1`] = `
       
         
       <footer
-        class="fd-bar fd-bar--cosy fd-bar--footer fd-message-box__footer"
+        class="fd-bar fd-bar--cozy fd-bar--footer fd-message-box__footer"
       >
         
             

--- a/stories/message-box/__snapshots__/message-box.stories.storyshot
+++ b/stories/message-box/__snapshots__/message-box.stories.storyshot
@@ -258,7 +258,7 @@ exports[`Storyshots Components/Message Box Responsive 1`] = `
         class="fd-message-box__body"
       >
         
-            Information Message Box on small screen in Cosy mode 
+            Information Message Box on small screen in Cozy mode 
             
         <div
           class="fd-message-box__more"
@@ -371,7 +371,7 @@ exports[`Storyshots Components/Message Box Responsive 1`] = `
         class="fd-message-box__body"
       >
         
-            Error Message Box on medium screen in Cosy mode  
+            Error Message Box on medium screen in Cozy mode  
         
       </div>
       

--- a/stories/message-box/message-box.stories.js
+++ b/stories/message-box/message-box.stories.js
@@ -314,7 +314,7 @@ export const responsive = () =>
             </div>
         </header>
         <div class="fd-message-box__body">
-            Information Message Box on small screen in Cosy mode 
+            Information Message Box on small screen in Cozy mode 
             <div class="fd-message-box__more">
                 <a href="#" class="fd-link" tabindex="0">Show more</a>
             </div>
@@ -343,7 +343,7 @@ export const responsive = () =>
             </div>
         </header>
         <div class="fd-message-box__body">
-            Error Message Box on medium screen in Cosy mode  
+            Error Message Box on medium screen in Cozy mode  
         </div>
         <footer class="fd-bar fd-bar--cozy fd-bar--footer fd-message-box__footer">
             <div class="fd-bar__right">
@@ -426,7 +426,7 @@ To enable responsive behavior for the paddings use the following modifier classe
 - \`.fd-message-box__content--l\`: 2rem - min-width: 1024px and max-width: 1439px
 - \`.fd-message-box__content--xl\`: 3rem - min-width: 1440px
 
-On mobile devices the component should be in \`cosy\` mode. Add the \`fd-bar--cozy\` modifier class to the header and the footer. The buttons in the footer should also be in Cosy mode. The deafult mode for Buttons is \`cosy\` so no modifier classes are required.
+On mobile devices the component should be in \`cozy\` mode. Add the \`fd-bar--cozy\` modifier class to the header and the footer. The buttons in the footer should also be in Cozy mode. The deafult mode for Buttons is \`cozy\` so no modifier classes are required.
 
 On phone devices the content container takes 100vh and 100vw. It's achieved by applying the \`fd-message-box__content--mobile\` modifier class on the Message Box content container.
         `

--- a/stories/message-box/message-box.stories.js
+++ b/stories/message-box/message-box.stories.js
@@ -306,7 +306,7 @@ export const responsive = () =>
     `
 <div class="fd-message-box-docs-static fd-message-box fd-message-box--information fd-message-box--active">
     <div class="fd-message-box__content fd-message-box__content--s">
-        <header class="fd-bar fd-bar--cosy fd-bar--header fd-message-box__header">
+        <header class="fd-bar fd-bar--cozy fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
                     <h2 class="fd-message-box__title">Information</h2>
@@ -319,7 +319,7 @@ export const responsive = () =>
                 <a href="#" class="fd-link" tabindex="0">Show more</a>
             </div>
         </div>
-        <footer class="fd-bar fd-bar--cosy fd-bar--footer fd-message-box__footer">
+        <footer class="fd-bar fd-bar--cozy fd-bar--footer fd-message-box__footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
                     <button class="fd-button fd-button--emphasized fd-message-box__decisive-button">
@@ -335,7 +335,7 @@ export const responsive = () =>
 
 <div class="fd-message-box-docs-static fd-message-box fd-message-box--error fd-message-box--active">
     <div class="fd-message-box__content fd-message-box__content--m">
-        <header class="fd-bar fd-bar--cosy fd-bar--header fd-message-box__header">
+        <header class="fd-bar fd-bar--cozy fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
                     <h2 class="fd-message-box__title">Error</h2>
@@ -345,7 +345,7 @@ export const responsive = () =>
         <div class="fd-message-box__body">
             Error Message Box on medium screen in Cosy mode  
         </div>
-        <footer class="fd-bar fd-bar--cosy fd-bar--footer fd-message-box__footer">
+        <footer class="fd-bar fd-bar--cozy fd-bar--footer fd-message-box__footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
                     <button class="fd-button fd-button--emphasized fd-message-box__decisive-button">
@@ -426,7 +426,7 @@ To enable responsive behavior for the paddings use the following modifier classe
 - \`.fd-message-box__content--l\`: 2rem - min-width: 1024px and max-width: 1439px
 - \`.fd-message-box__content--xl\`: 3rem - min-width: 1440px
 
-On mobile devices the component should be in \`cosy\` mode. Add the \`fd-bar--cosy\` modifier class to the header and the footer. The buttons in the footer should also be in Cosy mode. The deafult mode for Buttons is \`cosy\` so no modifier classes are required.
+On mobile devices the component should be in \`cosy\` mode. Add the \`fd-bar--cozy\` modifier class to the header and the footer. The buttons in the footer should also be in Cosy mode. The deafult mode for Buttons is \`cosy\` so no modifier classes are required.
 
 On phone devices the content container takes 100vh and 100vw. It's achieved by applying the \`fd-message-box__content--mobile\` modifier class on the Message Box content container.
         `

--- a/stories/popover/popover.stories.js
+++ b/stories/popover/popover.stories.js
@@ -268,7 +268,7 @@ export const layoutOptions = () => `
         </div>
         <div class="fd-popover__body fd-popover__body--no-arrow" aria-hidden="true" id="popoverHSF345">
             <div class="fd-popover__body-header">
-                <div class="fd-bar fd-bar--cosy fd-bar--header-with-subheader">
+                <div class="fd-bar fd-bar--cozy fd-bar--header-with-subheader">
                     <div class="fd-bar__left">
                         <div class="fd-bar__element">
                             <button class="fd-button fd-button--transparent sap-icon--navigation-left-arrow"></button>
@@ -279,7 +279,7 @@ export const layoutOptions = () => `
                     </div>
                 </div>
             </div>
-            <div class="fd-bar fd-bar--cosy fd-bar--subheader">
+            <div class="fd-bar fd-bar--cozy fd-bar--subheader">
                     <div class="fd-bar__middle">
                         <div class="fd-bar__element">
                             <div class="fd-form-item">
@@ -296,7 +296,7 @@ export const layoutOptions = () => `
                 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('https://placeimg.com/400/400/nature');" role="presentation" aria-label="Nature"></span>
             </div>
             <div class="fd-popover__body-footer">
-                <div class="fd-bar fd-bar--cosy fd-bar--footer">
+                <div class="fd-bar fd-bar--cozy fd-bar--footer">
                     <div class="fd-bar__right">
                         <div class="fd-bar__element">
                             <button class="fd-button fd-button--compact fd-button--emphasized">Save</button>

--- a/stories/popover/popover.stories.js
+++ b/stories/popover/popover.stories.js
@@ -264,7 +264,7 @@ export const layoutOptions = () => `
 
     <div class="fd-popover">
         <div class="fd-popover__control">
-            <button class="fd-button" aria-label="Image label" aria-controls="popoverHSF345" aria-expanded="false" aria-haspopup="true" onclick="onPopoverClick('popoverHSF345');">All Cosy Mode</button>
+            <button class="fd-button" aria-label="Image label" aria-controls="popoverHSF345" aria-expanded="false" aria-haspopup="true" onclick="onPopoverClick('popoverHSF345');">All Cozy Mode</button>
         </div>
         <div class="fd-popover__body fd-popover__body--no-arrow" aria-hidden="true" id="popoverHSF345">
             <div class="fd-popover__body-header">

--- a/stories/switch/switch.stories.js
+++ b/stories/switch/switch.stories.js
@@ -20,7 +20,7 @@ export default {
 export const basic = () => `
 <div class="fd-form-group">
     <div class="fd-form-item">
-        <div class="fd-form-label" id="label1">Default (Cosy) Switch</div>
+        <div class="fd-form-label" id="label1">Default (Cozy) Switch</div>
         <label class="fd-switch__label">
             <span class="fd-switch">
                 <input class="fd-switch__input" type="checkbox" name="" value="" aria-labelledby="label1" id="y21YO3251">


### PR DESCRIPTION
## Related Issue
fixes: #1114 

Renamed class `fd-bar--cosy` to `fd-bar--cozy`
Affected components:

- bar.md
- calendar.md
- dialog.md
- menu.md
- message-box.md
- popover.md
- switch.md
- combobox-input.md
- date-picker.md
- multi-input.md
- time-picker.md