### PR TITLE
docs: remove Newsletter from the documentation page

### DIFF
--- a/docs/_sass/_landingPage.scss
+++ b/docs/_sass/_landingPage.scss
@@ -294,6 +294,7 @@ body {
 
     font-size: 20px;
     line-height: 1.4;
+    text-align: center;
   }
 }
 
@@ -323,6 +324,7 @@ body {
 
     font-size: 20px;
     line-height: 1.4;
+    text-align: justify;
   }
 }
 

--- a/docs/_sass/_landingPage.scss
+++ b/docs/_sass/_landingPage.scss
@@ -351,7 +351,7 @@ body {
   &__container {
     display: grid;
     grid-gap: 24px;
-    grid-template-columns: auto auto auto auto auto;
+    grid-template-columns: auto auto auto auto;
   }
 
   &__item {

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,7 +16,7 @@ footerhidden: true
         position: relative;
     }
 </style>
-<header>
+<header style="width: 100%;">
     <div class="header-section" id="headerSection">
         <div class="header-section__hamburger">
             <button id="hamburgerToggle" class="sap-icon--menu2 header-section__sap-icon--menu2" onclick="toggleHamburger()" aria-label="Open/Close Main Navigation"></button>
@@ -51,7 +51,7 @@ footerhidden: true
         </div>
     </div>
 </header>
-<main>
+<main style="width: 100%;">
     <section class="libraries-section" id="libraries">
         <h2 class="libraries-section__title">Fundamental Library</h2>
         <div class="libraries-section__container">
@@ -211,17 +211,6 @@ footerhidden: true
                     />
 
                     <span class="vh">Talk to us via</span> Slack
-                </a>
-
-            </div>
-            <div class="community-section__item">
-                <a href="https://www.sap.com/cmp/nl/fundamental-library-community-newsletter/index.html" target="_blank" class="community-section__logo">
-                    <img
-                    src="{{site.baseurl}}/images/land-page-assets/newsletterIcon.png"
-                    alt="newsletter logo"
-                    />
-
-                    <span class="vh">Visit us on</span>Newsletter
                 </a>
 
             </div>


### PR DESCRIPTION
## Description
This PR removes the Newsletter from the doc page.
Also adds width 100% to the header and the main section for big screens 
