### PR TITLE
fix: hover for transparent split button fixed

### DIFF
--- a/src/button-split.scss
+++ b/src/button-split.scss
@@ -22,7 +22,9 @@ $fd-button-split-margin: 0.125rem / 2;
       margin: 0;
       border-top-left-radius: 0;
       border-bottom-left-radius: 0;
-      border-left-width: 0;
+      &:not(.#{$fd-namespace}-button--transparent) {
+        border-left-width: 0;
+      }
     }
   }
 }
@@ -42,7 +44,9 @@ $fd-button-split-margin: 0.125rem / 2;
       border-top-right-radius: 0;
       border-bottom-right-radius: 0;
       border-left-width: $fd-button-split-border-width;
-      border-right-width: 0;
+      &:not(.#{$fd-namespace}-button--transparent) {
+        border-right-width: 0;
+      }
     }
   }
 }

--- a/stories/button/__snapshots__/button.stories.storyshot
+++ b/stories/button/__snapshots__/button.stories.storyshot
@@ -933,5 +933,110 @@ exports[`Storyshots Components/Button Split Menu Button 1`] = `
   </div>
   
 
+
+  <div
+    aria-label="button-split"
+    class="fd-button-split"
+    role="group"
+  >
+    
+  
+    <button
+      aria-label="button"
+      class="fd-button fd-button--transparent"
+    >
+      Button with text
+    </button>
+    
+  
+    <button
+      aria-controls="t4c0o2732"
+      aria-expanded="false"
+      aria-haspopup="true"
+      aria-label="More"
+      class="fd-button fd-button--transparent sap-icon--slim-arrow-down"
+    />
+    
+  
+    <div
+      aria-hidden="true"
+      class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right"
+      id="t4c0o2732"
+    >
+      
+    
+      <nav
+        class="fd-menu"
+      >
+        
+        
+        <ul
+          class="fd-menu__list fd-menu__list--no-shadow"
+        >
+          
+          
+          <li
+            class="fd-menu__item"
+          >
+            
+              
+            <a
+              class="fd-menu__link"
+              href="#"
+              role="button"
+            >
+              
+                  
+              <span
+                class="fd-menu__title"
+              >
+                Add to list
+              </span>
+              
+              
+            </a>
+            
+          
+          </li>
+          
+          
+          <li
+            class="fd-menu__item"
+          >
+            
+              
+            <a
+              class="fd-menu__link"
+              href="#"
+              role="button"
+            >
+              
+                  
+              <span
+                class="fd-menu__title"
+              >
+                Save for later
+              </span>
+              
+              
+            </a>
+            
+          
+          </li>
+          
+        
+        </ul>
+        
+    
+      </nav>
+      
+  
+    </div>
+    
+
+  </div>
+  
+
+
 </section>
 `;

--- a/stories/button/__snapshots__/button.stories.storyshot
+++ b/stories/button/__snapshots__/button.stories.storyshot
@@ -950,7 +950,7 @@ exports[`Storyshots Components/Button Split Menu Button 1`] = `
     
   
     <button
-      aria-controls="t4c0o2732"
+      aria-controls="t4c0o27322"
       aria-expanded="false"
       aria-haspopup="true"
       aria-label="More"
@@ -961,7 +961,7 @@ exports[`Storyshots Components/Button Split Menu Button 1`] = `
     <div
       aria-hidden="true"
       class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right"
-      id="t4c0o2732"
+      id="t4c0o27322"
     >
       
     

--- a/stories/button/button.stories.js
+++ b/stories/button/button.stories.js
@@ -170,6 +170,30 @@ export const splitMenuButton = () => `
     </nav>
   </div>
 </div>
+
+<div class="fd-button-split" role="group" aria-label="button-split">
+  <button class="fd-button fd-button--transparent" aria-label="button">Button with text</button>
+  <button class="fd-button fd-button--transparent sap-icon--slim-arrow-down" aria-controls="t4c0o2732" 
+  aria-haspopup="true" aria-expanded="false" aria-label="More"></button>
+  <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right"  aria-hidden="true" 
+    id="t4c0o2732">
+    <nav class="fd-menu">
+        <ul class="fd-menu__list fd-menu__list--no-shadow">
+          <li class="fd-menu__item">
+              <a class="fd-menu__link" role="button" href="#">
+                  <span class="fd-menu__title">Add to list</span>
+              </a>
+          </li>
+          <li class="fd-menu__item">
+              <a class="fd-menu__link" role="button" href="#">
+                  <span class="fd-menu__title">Save for later</span>
+              </a>
+          </li>
+        </ul>
+    </nav>
+  </div>
+</div>
+
 `;
 
 splitMenuButton.parameters = {

--- a/stories/button/button.stories.js
+++ b/stories/button/button.stories.js
@@ -173,10 +173,10 @@ export const splitMenuButton = () => `
 
 <div class="fd-button-split" role="group" aria-label="button-split">
   <button class="fd-button fd-button--transparent" aria-label="button">Button with text</button>
-  <button class="fd-button fd-button--transparent sap-icon--slim-arrow-down" aria-controls="t4c0o2732" 
+  <button class="fd-button fd-button--transparent sap-icon--slim-arrow-down" aria-controls="t4c0o27322"
   aria-haspopup="true" aria-expanded="false" aria-label="More"></button>
   <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right"  aria-hidden="true" 
-    id="t4c0o2732">
+    id="t4c0o27322">
     <nav class="fd-menu">
         <ul class="fd-menu__list fd-menu__list--no-shadow">
           <li class="fd-menu__item">


### PR DESCRIPTION
## Related Issue
Closes #1210

## Description
The PR brings fix for hover transparent split button

## Screenshots

### Before:
Check issue

### After:
![image](https://user-images.githubusercontent.com/10849982/86588225-9e92c680-bf8b-11ea-9c2c-248f8bab57ff.png)

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
