### PR TITLE
fix: align horizontally and vertically the inner circle of Radio Button

### DIFF
--- a/src/radio.scss
+++ b/src/radio.scss
@@ -34,6 +34,9 @@ $block: #{$fd-namespace}-radio;
   $fd-radio-outer-circle-margin: 0.6875rem;
   $fd-radio-outer-circle-margin-compact: 0.5rem;
 
+  $fd-radio-inner-circle-padding-y: 0.0625rem; // to align the inner circle vertically in the middle of the outer
+  $fd-radio-inner-circle-padding-x: 0.05rem; // to align the inner circle horizontally in the middle of the outer
+
   @include fd-form-base();
 
   @extend %fd-radio-input-hidden;
@@ -54,6 +57,7 @@ $block: #{$fd-namespace}-radio;
 
     &::before {
       content: "";
+      padding-top: $fd-radio-inner-circle-padding-y;
       height: $fd-radio-inner-circle-diameter;
       width: $fd-radio-inner-circle-diameter;
       min-width: $fd-radio-inner-circle-diameter;
@@ -156,12 +160,15 @@ $block: #{$fd-namespace}-radio;
         min-width: $fd-radio-inner-circle-diameter-compact;
         margin-right: $fd-radio-outer-circle-margin-compact;
         margin-left: 0;
+        padding-left: $fd-radio-inner-circle-padding-x;
       }
 
       @include fd-rtl() {
         &::before {
           margin-left: $fd-radio-outer-circle-margin-compact;
           margin-right: 0;
+          padding-left: 0;
+          padding-right: $fd-radio-inner-circle-padding-x;
         }
       }
 


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#1196

## Description
The inner circle (which is an icon) is not centered horizontally and vertically within the outer circle. This is due to the latest update of the icons. Paddings are added to the element to "force" the inner circle to go in the middle. 

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
Vertical alignment problem:
<img width="564" alt="Screen Shot 2020-07-06 at 2 35 14 PM" src="https://user-images.githubusercontent.com/39598672/86627287-0d751d00-bf96-11ea-870d-8181ffac1f58.png">


Horizontal alignment problem in compact mode:
<img width="633" alt="Screen Shot 2020-07-06 at 2 35 42 PM" src="https://user-images.githubusercontent.com/39598672/86627278-09e19600-bf96-11ea-803c-84fba5613179.png">


### After:
<img width="607" alt="Screen Shot 2020-07-06 at 2 34 28 PM" src="https://user-images.githubusercontent.com/39598672/86627175-de5eab80-bf95-11ea-9abc-42da4b59f946.png">
<img width="658" alt="Screen Shot 2020-07-06 at 2 34 18 PM" src="https://user-images.githubusercontent.com/39598672/86627178-def74200-bf95-11ea-857f-85298357151f.png">

