### PR TITLE
feat: Checkbox label ellipsis overflow

### DIFF
--- a/docs/pages/components/form.md
+++ b/docs/pages/components/form.md
@@ -615,18 +615,20 @@ Do not use the checkbox control if:
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez611">
             <label class="fd-checkbox__label" for="Ai4ez611">
-                Field label
+                <span class="fd-checkbox__text">Field label</span>
             </label>
         </div>
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez612" checked>
             <label class="fd-checkbox__label" for="Ai4ez612">
-                Selected State
+                <span class="fd-checkbox__text">Selected State</span>
             </label>
         </div>
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez613">
-            <label class="fd-checkbox__label" for="Ai4ez613">TriState Text</label>
+            <label class="fd-checkbox__label" for="Ai4ez613">
+                <span class="fd-checkbox__text">TriState Text</span>
+            </label>
         </div>
     </div>
 </fieldset>
@@ -637,19 +639,19 @@ Do not use the checkbox control if:
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez614" disabled>
             <label class="fd-checkbox__label" for="Ai4ez614">
-                Field label
+                <span class="fd-checkbox__text">Field label</span>
             </label>
         </div>
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez615" disabled>
             <label class="fd-checkbox__label" for="Ai4ez615">
-                Field label
+                <span class="fd-checkbox__text">Field label</span>
             </label>
         </div>
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez616" disabled>
             <label class="fd-checkbox__label" for="Ai4ez616">
-                Field label
+                <span class="fd-checkbox__text">Field label</span>
             </label>
         </div>
     </div>
@@ -661,19 +663,19 @@ Do not use the checkbox control if:
         <div class="fd-form-group__item fd-form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez617">
             <label class="fd-checkbox__label" for="Ai4ez617">
-                Field label
+                <span class="fd-checkbox__text">Field label</span>
             </label>
         </div>
         <div class="fd-form-group__item fd-form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez618">
             <label class="fd-checkbox__label" for="Ai4ez618">
-                Field label
+                <span class="fd-checkbox__text">Field label</span>
             </label>
         </div>
         <div class="fd-form-group__item fd-form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez619">
             <label class="fd-checkbox__label" for="Ai4ez619">
-                Field label
+                <span class="fd-checkbox__text">Field label</span>
             </label>
         </div>
     </div>
@@ -685,19 +687,19 @@ Do not use the checkbox control if:
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox fd-checkbox--compact" id="Ai4ez6171">
             <label class="fd-checkbox__label fd-checkbox__label--compact" for="Ai4ez6171">
-                Field label
+                <span class="fd-checkbox__text">Field label</span>
             </label>
         </div>
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox fd-checkbox--compact" id="Ai4ez6181">
             <label class="fd-checkbox__label fd-checkbox__label--compact" for="Ai4ez6181">
-                Field label
+                <span class="fd-checkbox__text">Field label</span>
             </label>
         </div>
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox fd-checkbox--compact" id="Ai4ez6191">
             <label class="fd-checkbox__label fd-checkbox__label--compact" for="Ai4ez6191">
-                Field label
+                <span class="fd-checkbox__text">Field label</span>
             </label>
         </div>
     </div>
@@ -710,19 +712,19 @@ Do not use the checkbox control if:
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox is-error" id="Ai4ez6119">
             <label class="fd-checkbox__label" for="Ai4ez6119">
-                Text Option
+                <span class="fd-checkbox__text">Text Option</span>
             </label>
         </div>
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox is-error" id="Ai4ez6129" checked>
             <label class="fd-checkbox__label" for="Ai4ez6129">
-                Selected State
+                <span class="fd-checkbox__text">Selected State</span>
             </label>
         </div>
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox is-error" id="Ai4ez613i1">
             <label class="fd-checkbox__label" for="Ai4ez613i1">
-                TriState Text
+                <span class="fd-checkbox__text">TriState Text</span>
             </label>
         </div>
     </div>
@@ -734,19 +736,19 @@ Do not use the checkbox control if:
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox is-success" id="Ai4ez61192">
             <label class="fd-checkbox__label" for="Ai4ez61192">
-                Text Option
+                <span class="fd-checkbox__text">Text Option</span>
             </label>
         </div>
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox is-success" id="Ai4ez61292" checked>
             <label class="fd-checkbox__label" for="Ai4ez61292">
-                Selected State
+                <span class="fd-checkbox__text">Selected State</span>
             </label>
         </div>
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox is-success" id="Ai4ez613i2">
             <label class="fd-checkbox__label" for="Ai4ez613i2">
-                TriState Text
+                <span class="fd-checkbox__text">TriState Text</span>
             </label>
         </div>
     </div>
@@ -758,19 +760,19 @@ Do not use the checkbox control if:
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox is-warning" id="Ai4ez61193">
             <label class="fd-checkbox__label" for="Ai4ez61193">
-                Text Option
+                <span class="fd-checkbox__text">Text Option</span>
             </label>
         </div>
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox is-warning" id="Ai4ez61293" checked>
             <label class="fd-checkbox__label" for="Ai4ez61293">
-                Selected State
+                <span class="fd-checkbox__text">Selected State</span>
             </label>
         </div>
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox is-warning" id="Ai4ez613i3">
             <label class="fd-checkbox__label" for="Ai4ez613i3">
-                TriState Text
+                <span class="fd-checkbox__text">TriState Text</span>
             </label>
         </div>
     </div>
@@ -782,19 +784,19 @@ Do not use the checkbox control if:
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox is-information" id="Ai4ez61194">
             <label class="fd-checkbox__label" for="Ai4ez61194">
-                Text Option
+                <span class="fd-checkbox__text">Text Option</span>
             </label>
         </div>
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox is-information" id="Ai4ez61294" checked>
             <label class="fd-checkbox__label" for="Ai4ez61294">
-                Selected State
+                <span class="fd-checkbox__text">Selected State</span>
             </label>
         </div>
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox is-information" id="Ai4ez613i4">
             <label class="fd-checkbox__label" for="Ai4ez613i4">
-                TriState Text
+                <span class="fd-checkbox__text">TriState Text</span>
             </label>
         </div>
     </div>
@@ -806,19 +808,19 @@ Do not use the checkbox control if:
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez61196" disabled>
             <label class="fd-checkbox__label" for="Ai4ez61196">
-                Text Option
+                <span class="fd-checkbox__text">Text Option</span>
             </label>
         </div>
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez61296" checked disabled>
             <label class="fd-checkbox__label" for="Ai4ez61296">
-                Selected State
+                <span class="fd-checkbox__text">Selected State</span>
             </label>
         </div>
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez613i6" disabled>
             <label class="fd-checkbox__label" for="Ai4ez613i6">
-                TriState Text
+                <span class="fd-checkbox__text">TriState Text</span>
             </label>
         </div>
     </div>
@@ -830,19 +832,19 @@ Do not use the checkbox control if:
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez611tt">
             <label class="fd-checkbox__label" for="Ai4ez611tt">
-                Text Option
+                <span class="fd-checkbox__text">Text Option</span>
             </label>
         </div>
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez612tt" checked>
             <label class="fd-checkbox__label" for="Ai4ez612tt">
-                Selected State
+                <span class="fd-checkbox__text">Selected State</span>
             </label>
         </div>
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez613i7">
             <label class="fd-checkbox__label" for="Ai4ez613i7">
-                TriState Text
+                <span class="fd-checkbox__text">TriState Text</span>
             </label>
         </div>
     </div>

--- a/docs/pages/patterns/multi-input.md
+++ b/docs/pages/patterns/multi-input.md
@@ -69,7 +69,7 @@ If the entries are not validated by the application, users can also enter custom
              <li class="fd-list__item is-selected" role="option">
                 <input type="checkbox" checked class="fd-checkbox fd-list__input" id="Ai4ez611">
                 <label class="fd-checkbox__label fd-list__label" for="Ai4ez611">
-                    <span class="fd-list__title">
+                    <span class="fd-checkbox__text fd-list__title">
                         Apple
                     </span>
                 </label>
@@ -77,7 +77,7 @@ If the entries are not validated by the application, users can also enter custom
              <li class="fd-list__item is-selected" role="option">
                 <input type="checkbox" checked class="fd-checkbox fd-list__input" id="Ai4ez612">
                 <label class="fd-checkbox__label fd-list__label" for="Ai4ez612">
-                    <span class="fd-list__title">
+                    <span class="fd-checkbox__text fd-list__title">
                         Orange
                     </span>
                 </label>
@@ -85,7 +85,7 @@ If the entries are not validated by the application, users can also enter custom
              <li class="fd-list__item is-selected" role="option">
                 <input type="checkbox" checked class="fd-checkbox fd-list__input" id="Ai4ez614">
                 <label class="fd-checkbox__label fd-list__label" for="Ai4ez614">
-                    <span class="fd-list__title">
+                    <span class="fd-checkbox__text fd-list__title">
                         Banana
                     </span>
                 </label>
@@ -93,7 +93,7 @@ If the entries are not validated by the application, users can also enter custom
              <li class="fd-list__item is-selected" role="option">
                 <input type="checkbox" checked class="fd-checkbox fd-list__input" id="Ai4ez615">
                 <label class="fd-checkbox__label fd-list__label" for="Ai4ez615">
-                    <span class="fd-list__title">
+                    <span class="fd-checkbox__text fd-list__title">
                         Kiwi
                     </span>
                 </label>
@@ -101,7 +101,7 @@ If the entries are not validated by the application, users can also enter custom
              <li class="fd-list__item" role="option">
                 <input type="checkbox" class="fd-checkbox fd-list__input" id="Ai4ez617">
                 <label class="fd-checkbox__label fd-list__label" for="Ai4ez617">
-                    <span class="fd-list__title">
+                    <span class="fd-checkbox__text fd-list__title">
                         Lemon
                     </span>
                 </label>
@@ -154,7 +154,7 @@ If the entries are not validated by the application, users can also enter custom
              <li class="fd-list__item is-selected" role="option">
                 <input type="checkbox" checked class="fd-checkbox fd-checkbox--compact fd-list__input" id="Ai1ez611">
                 <label class="fd-checkbox__label fd-list__label" for="Ai1ez611">
-                    <span class="fd-list__title">
+                    <span class="fd-checkbox__text fd-list__title">
                         Apple
                     </span>
                 </label>
@@ -162,7 +162,7 @@ If the entries are not validated by the application, users can also enter custom
              <li class="fd-list__item is-selected" role="option">
                 <input type="checkbox" checked class="fd-checkbox fd-checkbox--compact fd-list__input" id="Ai2ez612">
                 <label class="fd-checkbox__label fd-list__label" for="Ai2ez612">
-                    <span class="fd-list__title">
+                    <span class="fd-checkbox__text fd-list__title">
                         Orange
                     </span>
                 </label>
@@ -170,7 +170,7 @@ If the entries are not validated by the application, users can also enter custom
              <li class="fd-list__item is-selected" role="option">
                 <input type="checkbox" checked class="fd-checkbox fd-checkbox--compact fd-list__input" id="Ai3ez614">
                 <label class="fd-checkbox__label fd-list__label" for="Ai3ez614">
-                    <span class="fd-list__title">
+                    <span class="fd-checkbox__text fd-list__title">
                         Banana
                     </span>
                 </label>
@@ -178,7 +178,7 @@ If the entries are not validated by the application, users can also enter custom
              <li class="fd-list__item" role="option">
                 <input type="checkbox" class="fd-checkbox fd-checkbox--compact fd-list__input" id="Ai8ez615">
                 <label class="fd-checkbox__label fd-list__label" for="Ai8ez615">
-                    <span class="fd-list__title">
+                    <span class="fd-checkbox__text fd-list__title">
                         Kiwi
                     </span>
                 </label>
@@ -186,7 +186,7 @@ If the entries are not validated by the application, users can also enter custom
              <li class="fd-list__item" role="option">
                 <input type="checkbox" class="fd-checkbox fd-checkbox--compact fd-list__input" id="AiHez617">
                 <label class="fd-checkbox__label fd-list__label" for="AiHez617">
-                    <span class="fd-list__title">
+                    <span class="fd-checkbox__text fd-list__title">
                         Lemon
                     </span>
                 </label>
@@ -243,7 +243,7 @@ In cases where the list items need to be categorized into groups, it is possible
              <li class="fd-list__item is-selected" role="option">
                 <input type="checkbox" checked class="fd-checkbox fd-list__input" id="Ai1ez651">
                 <label class="fd-checkbox__label fd-list__label" for="Ai1ez651">
-                    <span class="fd-list__title">
+                    <span class="fd-checkbox__text fd-list__title">
                         Apple
                     </span>
                 </label>
@@ -251,7 +251,7 @@ In cases where the list items need to be categorized into groups, it is possible
              <li class="fd-list__item is-selected" role="option">
                 <input type="checkbox" checked class="fd-checkbox fd-list__input" id="Ai2ez652">
                 <label class="fd-checkbox__label fd-list__label" for="Ai2ez652">
-                    <span class="fd-list__title">
+                    <span class="fd-checkbox__text fd-list__title">
                         Orange
                     </span>
                 </label>
@@ -259,7 +259,7 @@ In cases where the list items need to be categorized into groups, it is possible
              <li class="fd-list__item is-selected" role="option">
                 <input type="checkbox" checked class="fd-checkbox fd-list__input" id="Ai3ez654">
                 <label class="fd-checkbox__label fd-list__label" for="Ai3ez654">
-                    <span class="fd-list__title">
+                    <span class="fd-checkbox__text fd-list__title">
                         Kiwi
                     </span>
                 </label>
@@ -267,7 +267,7 @@ In cases where the list items need to be categorized into groups, it is possible
              <li class="fd-list__item" role="option">
                 <input type="checkbox" class="fd-checkbox fd-list__input" id="Ai8ez655">
                 <label class="fd-checkbox__label fd-list__label" for="Ai8ez655">
-                    <span class="fd-list__title">
+                    <span class="fd-checkbox__text fd-list__title">
                         Banana
                     </span>
                 </label>
@@ -275,7 +275,7 @@ In cases where the list items need to be categorized into groups, it is possible
              <li class="fd-list__item" role="option">
                 <input type="checkbox" class="fd-checkbox fd-list__input" id="AiHez657">
                 <label class="fd-checkbox__label fd-list__label" for="AiHez657">
-                    <span class="fd-list__title">
+                    <span class="fd-checkbox__text fd-list__title">
                         Lemon
                     </span>
                 </label>
@@ -286,7 +286,7 @@ In cases where the list items need to be categorized into groups, it is possible
             <li class="fd-list__item is-selected" role="option">
                 <input type="checkbox" checked class="fd-checkbox fd-list__input" id="Ai8ez689">
                 <label class="fd-checkbox__label fd-list__label" for="Ai8ez689">
-                    <span class="fd-list__title">
+                    <span class="fd-checkbox__text fd-list__title">
                         Onion
                     </span>
                 </label>
@@ -294,7 +294,7 @@ In cases where the list items need to be categorized into groups, it is possible
              <li class="fd-list__item is-selected" role="option">
                 <input type="checkbox" checked class="fd-checkbox fd-list__input" id="Ai8ez685">
                 <label class="fd-checkbox__label fd-list__label" for="Ai8ez685">
-                    <span class="fd-list__title">
+                    <span class="fd-checkbox__text fd-list__title">
                         Tomato
                     </span>
                 </label>
@@ -353,7 +353,7 @@ In the example you can see how the `Multi Input` component looks without the `fd
              <li class="fd-list__item is-selected" role="option">
                 <input type="checkbox" checked class="fd-checkbox fd-list__input" id="Ai124z651">
                 <label class="fd-checkbox__label fd-list__label" for="Ai124z651">
-                    <span class="fd-list__title">
+                    <span class="fd-checkbox__text fd-list__title">
                         Apple
                     </span>
                 </label>
@@ -361,7 +361,7 @@ In the example you can see how the `Multi Input` component looks without the `fd
              <li class="fd-list__item is-selected" role="option">
                 <input type="checkbox" checked class="fd-checkbox fd-list__input" id="Ai134z651">
                 <label class="fd-checkbox__label fd-list__label" for="Ai134z651">
-                    <span class="fd-list__title">
+                    <span class="fd-checkbox__text fd-list__title">
                         Orange
                     </span>
                 </label>
@@ -369,7 +369,7 @@ In the example you can see how the `Multi Input` component looks without the `fd
              <li class="fd-list__item is-selected" role="option">
                 <input type="checkbox" checked class="fd-checkbox fd-list__input" id="Ai1366z651">
                 <label class="fd-checkbox__label fd-list__label" for="Ai1366z651">
-                    <span class="fd-list__title">
+                    <span class="fd-checkbox__text fd-list__title">
                         Kiwi
                     </span>
                 </label>
@@ -377,7 +377,7 @@ In the example you can see how the `Multi Input` component looks without the `fd
              <li class="fd-list__item" role="option">
                 <input type="checkbox" class="fd-checkbox fd-list__input" id="Ai136gf51">
                 <label class="fd-checkbox__label fd-list__label" for="Ai136gf51">
-                    <span class="fd-list__title">
+                    <span class=" fd-checkbox__text fd-list__title">
                         Banana
                     </span>
                 </label>
@@ -385,7 +385,7 @@ In the example you can see how the `Multi Input` component looks without the `fd
              <li class="fd-list__item" role="option">
                 <input type="checkbox" class="fd-checkbox fd-list__input" id="Ai136ggfd">
                 <label class="fd-checkbox__label fd-list__label" for="Ai136ggfd">
-                    <span class="fd-list__title">
+                    <span class="fd-checkbox__text fd-list__title">
                         Lemon
                     </span>
                 </label>
@@ -589,7 +589,7 @@ To add text in the `body` of the component, simply include your text in the `fd-
              <li class="fd-list__item is-selected" role="option">
                 <input type="checkbox" checked class="fd-checkbox fd-list__input" id="AGi4ez611">
                 <label class="fd-checkbox__label fd-list__label" for="AGi4ez611">
-                    <span class="fd-list__title">
+                    <span class="fd-checkbox__text fd-list__title">
                         Apple
                     </span>
                 </label>
@@ -597,25 +597,25 @@ To add text in the `body` of the component, simply include your text in the `fd-
              <li class="fd-list__item is-selected" role="option">
                 <input type="checkbox" checked class="fd-checkbox fd-list__input" id="Ai4Fez612">
                 <label class="fd-checkbox__label fd-list__label" for="Ai4Fez612">
-                    <span class="fd-list__title">Orange</span>
+                    <span class="fd-checkbox__text fd-list__title">Orange</span>
                 </label>
             </li>
              <li class="fd-list__item is-selected" role="option">
                 <input type="checkbox" checked class="fd-checkbox fd-list__input" id="Ai4eGz614">
                 <label class="fd-checkbox__label fd-list__label" for="Ai4eGz614">
-                    <span class="fd-list__title">Kiwi</span>
+                    <span class="fd-checkbox__text fd-list__title">Kiwi</span>
                 </label>
             </li>
              <li class="fd-list__item" role="option">
                 <input type="checkbox" class="fd-checkbox fd-list__input" id="Ai4egh614">
                 <label class="fd-checkbox__label fd-list__label" for="Ai4egh614">
-                    <span class="fd-list__title">Banana</span>
+                    <span class="fd-checkbox__text fd-list__title">Banana</span>
                 </label>
             </li>
              <li class="fd-list__item" role="option">
                 <input type="checkbox" class="fd-checkbox fd-list__input" id="jdFffsd3">
                 <label class="fd-checkbox__label fd-list__label" for="jdFffsd3">
-                    <span class="fd-list__title">Lemon</span>
+                    <span class="fd-checkbox__text fd-list__title">Lemon</span>
                 </label>
             </li>
         </ul>
@@ -692,7 +692,7 @@ So instead of using popover and dropdown, it should be wrapped in `dialog` and `
                 <li class="fd-list__item is-selected" role="option">
                      <input type="checkbox" checked class="fd-checkbox  fd-list__input" id="GGi4ez641">
                      <label class="fd-checkbox__label fd-list__label" for="GGi4ez641">
-                         <span class="fd-list__title">
+                         <span class="fd-checkbox__text fd-list__title">
                              Apple
                          </span>
                      </label>
@@ -700,25 +700,25 @@ So instead of using popover and dropdown, it should be wrapped in `dialog` and `
                   <li class="fd-list__item is-selected" role="option">
                      <input type="checkbox" checked class="fd-checkbox  fd-list__input" id="Ai4FGFG612">
                      <label class="fd-checkbox__label fd-list__label" for="Ai4FGFG612">
-                         <span class="fd-list__title">Orange</span>
+                         <span class="fd-checkbox__text fd-list__title">Orange</span>
                      </label>
                  </li>
                   <li class="fd-list__item is-selected" role="option">
                      <input type="checkbox" checked class="fd-checkbox  fd-list__input" id="Ai4e88614">
                      <label class="fd-checkbox__label fd-list__label" for="Ai4e88614">
-                         <span class="fd-list__title">Kiwi</span>
+                         <span class="fd-checkbox__text fd-list__title">Kiwi</span>
                      </label>
                  </li>
                   <li class="fd-list__item" role="option">
                      <input type="checkbox" class="fd-checkbox  fd-list__input" id="Ai4egh6024">
                      <label class="fd-checkbox__label fd-list__label" for="Ai4egh6024">
-                         <span class="fd-list__title">Banana</span>
+                         <span class="fd-checkbox__text fd-list__title">Banana</span>
                      </label>
                  </li>
                   <li class="fd-list__item" role="option">
                      <input type="checkbox" class="fd-checkbox  fd-list__input" id="7gJHdsad">
                      <label class="fd-checkbox__label fd-list__label" for="7gJHdsad">
-                         <span class="fd-list__title">Lemon</span>
+                         <span class="fd-checkbox__text fd-list__title">Lemon</span>
                      </label>
                  </li>
              </ul>
@@ -778,7 +778,7 @@ that when clicked, will clear the text in the input and show all options in the 
              <li class="fd-list__item is-selected" role="option">
                 <input type="checkbox" checked class="fd-checkbox fd-list__input" id="Ai4ez611A">
                 <label class="fd-checkbox__label fd-list__label" for="Ai4ez611A">
-                    <span class="fd-list__title">
+                    <span class="fd-checkbox__text fd-list__title">
                         <b>A</b>pple
                     </span>
                 </label>

--- a/src/checkbox.scss
+++ b/src/checkbox.scss
@@ -43,7 +43,6 @@ $block: #{$fd-namespace}-checkbox;
 
     line-height: 1rem;
     padding: $fd-checkbox-margin 0 $fd-checkbox-margin $fd-checkbox-margin;
-    overflow: hidden;
     display: flex;
     align-items: center;
 
@@ -97,6 +96,10 @@ $block: #{$fd-namespace}-checkbox;
         margin-left: 0;
       }
     }
+  }
+
+  &__text {
+    @include fd-ellipsis();
   }
 
   &:checked + .#{$block}__label::before {

--- a/stories/checkbox/__snapshots__/checkbox.stories.storyshot
+++ b/stories/checkbox/__snapshots__/checkbox.stories.storyshot
@@ -11,11 +11,1085 @@ exports[`Storyshots Components/Forms/Checkbox Checkboxes listed inline 1`] = `
 `;
 
 exports[`Storyshots Components/Forms/Checkbox Interaction States 1`] = `
+<section>
+  
 
 
+  <style>
+    
+    .checkbox-example-container {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-between;
+    }
+    
+    .checkbox-example-container &gt; fieldset {
+        max-width: 100%;
+    }
+
+  </style>
+  
+
+
+  <div
+    class="checkbox-example-container"
+  >
+    
+    
+    <fieldset
+      class="fd-fieldset"
+    >
+      
+        
+      <legend
+        class="fd-fieldset__legend"
+      >
+        Checkboxes Error
+      </legend>
+      
+        
+      <div
+        class="fd-form-group"
+      >
+        
+            
+        <div
+          class="fd-form-item"
+        >
+          
+                
+          <input
+            class="fd-checkbox is-error"
+            id="Ai4ez6119"
+            type="checkbox"
+          />
+          
+                
+          <label
+            class="fd-checkbox__label"
+            for="Ai4ez6119"
+          >
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              Text Option
+            </span>
+            
+                
+          </label>
+          
+            
+        </div>
+        
+            
+        <div
+          class="fd-form-item"
+        >
+          
+                
+          <input
+            checked=""
+            class="fd-checkbox is-error"
+            id="Ai4ez6129"
+            type="checkbox"
+          />
+          
+                
+          <label
+            class="fd-checkbox__label"
+            for="Ai4ez6129"
+          >
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              Selected State
+            </span>
+            
+                
+          </label>
+          
+            
+        </div>
+        
+            
+        <div
+          class="fd-form-item"
+        >
+          
+                
+          <input
+            class="fd-checkbox is-error"
+            id="Ai4ez613i1"
+            type="checkbox"
+          />
+          
+                
+          <label
+            class="fd-checkbox__label"
+            for="Ai4ez613i1"
+          >
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              TriState Text
+            </span>
+            
+                
+          </label>
+          
+            
+        </div>
+        
+        
+      </div>
+      
+    
+    </fieldset>
+    
+
+    
+    <fieldset
+      class="fd-fieldset"
+    >
+      
+        
+      <legend
+        class="fd-fieldset__legend"
+      >
+        Checkboxes Success
+      </legend>
+      
+        
+      <div
+        class="fd-form-group"
+      >
+        
+            
+        <div
+          class="fd-form-item"
+        >
+          
+                
+          <input
+            class="fd-checkbox is-success"
+            id="Ai4ez61192"
+            type="checkbox"
+          />
+          
+                
+          <label
+            class="fd-checkbox__label"
+            for="Ai4ez61192"
+          >
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              Text Option
+            </span>
+            
+                
+          </label>
+          
+            
+        </div>
+        
+            
+        <div
+          class="fd-form-item"
+        >
+          
+                
+          <input
+            checked=""
+            class="fd-checkbox is-success"
+            id="Ai4ez61292"
+            type="checkbox"
+          />
+          
+                
+          <label
+            class="fd-checkbox__label"
+            for="Ai4ez61292"
+          >
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              Selected State
+            </span>
+            
+                
+          </label>
+          
+            
+        </div>
+        
+            
+        <div
+          class="fd-form-item"
+        >
+          
+                
+          <input
+            class="fd-checkbox is-success"
+            id="Ai4ez613i2"
+            type="checkbox"
+          />
+          
+                
+          <label
+            class="fd-checkbox__label"
+            for="Ai4ez613i2"
+          >
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              TriState Text
+            </span>
+            
+                
+          </label>
+          
+            
+        </div>
+        
+        
+      </div>
+      
+    
+    </fieldset>
+    
+
+    
+    <fieldset
+      class="fd-fieldset"
+    >
+      
+        
+      <legend
+        class="fd-fieldset__legend"
+      >
+        Checkboxes Warning
+      </legend>
+      
+        
+      <div
+        class="fd-form-group"
+      >
+        
+            
+        <div
+          class="fd-form-item"
+        >
+          
+                
+          <input
+            class="fd-checkbox is-warning"
+            id="Ai4ez61193"
+            type="checkbox"
+          />
+          
+                
+          <label
+            class="fd-checkbox__label"
+            for="Ai4ez61193"
+          >
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              Text Option
+            </span>
+            
+                
+          </label>
+          
+            
+        </div>
+        
+            
+        <div
+          class="fd-form-item"
+        >
+          
+                
+          <input
+            checked=""
+            class="fd-checkbox is-warning"
+            id="Ai4ez61293"
+            type="checkbox"
+          />
+          
+                
+          <label
+            class="fd-checkbox__label"
+            for="Ai4ez61293"
+          >
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              Selected State
+            </span>
+            
+                
+          </label>
+          
+            
+        </div>
+        
+            
+        <div
+          class="fd-form-item"
+        >
+          
+                
+          <input
+            class="fd-checkbox is-warning"
+            id="Ai4ez613i3"
+            type="checkbox"
+          />
+          
+                
+          <label
+            class="fd-checkbox__label"
+            for="Ai4ez613i3"
+          >
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              TriState Text
+            </span>
+            
+                
+          </label>
+          
+            
+        </div>
+        
+        
+      </div>
+      
+    
+    </fieldset>
+    
+
+    
+    <fieldset
+      class="fd-fieldset"
+    >
+      
+        
+      <legend
+        class="fd-fieldset__legend"
+      >
+        Checkboxes Information
+      </legend>
+      
+        
+      <div
+        class="fd-form-group"
+      >
+        
+            
+        <div
+          class="fd-form-item"
+        >
+          
+                
+          <input
+            class="fd-checkbox is-information"
+            id="Ai4ez61194"
+            type="checkbox"
+          />
+          
+                
+          <label
+            class="fd-checkbox__label"
+            for="Ai4ez61194"
+          >
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              Text Option
+            </span>
+            
+                
+          </label>
+          
+            
+        </div>
+        
+            
+        <div
+          class="fd-form-item"
+        >
+          
+                
+          <input
+            checked=""
+            class="fd-checkbox is-information"
+            id="Ai4ez61294"
+            type="checkbox"
+          />
+          
+                
+          <label
+            class="fd-checkbox__label"
+            for="Ai4ez61294"
+          >
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              Selected State
+            </span>
+            
+                
+          </label>
+          
+            
+        </div>
+        
+            
+        <div
+          class="fd-form-item"
+        >
+          
+                
+          <input
+            class="fd-checkbox is-information"
+            id="Ai4ez613i4"
+            type="checkbox"
+          />
+          
+                
+          <label
+            class="fd-checkbox__label"
+            for="Ai4ez613i4"
+          >
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              TriState Text
+            </span>
+            
+                
+          </label>
+          
+            
+        </div>
+        
+        
+      </div>
+      
+    
+    </fieldset>
+    
+
+    
+    <fieldset
+      class="fd-fieldset"
+    >
+      
+        
+      <legend
+        class="fd-fieldset__legend"
+      >
+        Checkboxes Disabled
+      </legend>
+      
+        
+      <div
+        class="fd-form-group"
+      >
+        
+            
+        <div
+          class="fd-form-item"
+        >
+          
+                
+          <input
+            class="fd-checkbox"
+            disabled=""
+            id="Ai4ez61196"
+            type="checkbox"
+          />
+          
+                
+          <label
+            class="fd-checkbox__label"
+            for="Ai4ez61196"
+          >
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              Text Option
+            </span>
+            
+                
+          </label>
+          
+            
+        </div>
+        
+            
+        <div
+          class="fd-form-item"
+        >
+          
+                
+          <input
+            checked=""
+            class="fd-checkbox"
+            disabled=""
+            id="Ai4ez61296"
+            type="checkbox"
+          />
+          
+                
+          <label
+            class="fd-checkbox__label"
+            for="Ai4ez61296"
+          >
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              Selected State
+            </span>
+            
+                
+          </label>
+          
+            
+        </div>
+        
+            
+        <div
+          class="fd-form-item"
+        >
+          
+                
+          <input
+            class="fd-checkbox"
+            disabled=""
+            id="Ai4ez613i6"
+            type="checkbox"
+          />
+          
+                
+          <label
+            class="fd-checkbox__label"
+            for="Ai4ez613i6"
+          >
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              TriState Text
+            </span>
+            
+                
+          </label>
+          
+            
+        </div>
+        
+        
+      </div>
+      
+    
+    </fieldset>
+    
+
+  </div>
+  
+
+</section>
 `;
 
 exports[`Storyshots Components/Forms/Checkbox Responsiveness 1`] = `
+<section>
+  
 
 
+  <style>
+    
+    .checkbox-example-container {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-between;
+    }
+    
+    .checkbox-example-container &gt; fieldset {
+        max-width: 100%;
+    }
+
+  </style>
+  
+
+
+  <div
+    class="checkbox-example-container"
+  >
+    
+    
+    <fieldset
+      class="fd-fieldset"
+    >
+      
+        
+      <legend
+        class="fd-fieldset__legend"
+      >
+        Cozy Checkboxes
+      </legend>
+      
+        
+      <div
+        class="fd-form-group"
+      >
+        
+            
+        <div
+          class="fd-form-item"
+        >
+          
+                
+          <input
+            class="fd-checkbox"
+            id="Ai4ez611"
+            type="checkbox"
+          />
+          
+                
+          <label
+            class="fd-checkbox__label"
+            for="Ai4ez611"
+          >
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              Apple
+            </span>
+            
+                
+          </label>
+          
+            
+        </div>
+        
+            
+        <div
+          class="fd-form-item"
+        >
+          
+                
+          <input
+            checked=""
+            class="fd-checkbox"
+            id="Ai4ez612"
+            type="checkbox"
+          />
+          
+                
+          <label
+            class="fd-checkbox__label"
+            for="Ai4ez612"
+          >
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              Banana
+            </span>
+            
+                
+          </label>
+          
+            
+        </div>
+        
+            
+        <div
+          class="fd-form-item"
+        >
+          
+                
+          <input
+            class="fd-checkbox"
+            disabled=""
+            id="Ai4ez622"
+            type="checkbox"
+          />
+          
+                
+          <label
+            class="fd-checkbox__label"
+            for="Ai4ez622"
+          >
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              Kiwi
+            </span>
+            
+                
+          </label>
+          
+            
+        </div>
+        
+            
+        <div
+          class="fd-form-item"
+        >
+          
+                
+          <input
+            checked=""
+            class="fd-checkbox"
+            disabled=""
+            id="Ai4ez632"
+            type="checkbox"
+          />
+          
+                
+          <label
+            class="fd-checkbox__label"
+            for="Ai4ez632"
+          >
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              Lemon
+            </span>
+            
+                
+          </label>
+          
+            
+        </div>
+        
+            
+        <div
+          class="fd-form-item"
+        >
+          
+                
+          <input
+            class="fd-checkbox"
+            id="Ai4ez613"
+            type="checkbox"
+          />
+          
+                
+          <label
+            class="fd-checkbox__label"
+            for="Ai4ez613"
+          >
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              All Fruits (TriState)
+            </span>
+            
+                
+          </label>
+          
+            
+        </div>
+        
+            
+        <div
+          class="fd-form-item"
+        >
+          
+                
+          <input
+            class="fd-checkbox"
+            disabled=""
+            id="Ai4ez643"
+            type="checkbox"
+          />
+          
+                
+          <label
+            class="fd-checkbox__label"
+            for="Ai4ez643"
+          >
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              All Fruits (TriState)
+            </span>
+            
+                
+          </label>
+          
+            
+        </div>
+        
+        
+      </div>
+      
+    
+    </fieldset>
+    
+    
+    <fieldset
+      class="fd-fieldset"
+    >
+      
+        
+      <legend
+        class="fd-fieldset__legend"
+      >
+        Compact Checkboxes
+      </legend>
+      
+        
+      <div
+        class="fd-form-group"
+      >
+        
+            
+        <div
+          class="fd-form-item"
+        >
+          
+                
+          <input
+            class="fd-checkbox fd-checkbox--compact"
+            id="Ai4ez611c"
+            type="checkbox"
+          />
+          
+                
+          <label
+            class="fd-checkbox__label fd-checkbox__label--compact"
+            for="Ai4ez611c"
+          >
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              Apple
+            </span>
+            
+                
+          </label>
+          
+            
+        </div>
+        
+            
+        <div
+          class="fd-form-item"
+        >
+          
+                
+          <input
+            checked=""
+            class="fd-checkbox fd-checkbox--compact"
+            id="Ai4ez612c"
+            type="checkbox"
+          />
+          
+                
+          <label
+            class="fd-checkbox__label fd-checkbox__label--compact"
+            for="Ai4ez612c"
+          >
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              Banana
+            </span>
+            
+                
+          </label>
+          
+            
+        </div>
+        
+            
+        <div
+          class="fd-form-item"
+        >
+          
+                
+          <input
+            class="fd-checkbox fd-checkbox--compact"
+            disabled=""
+            id="Ai4ez622c"
+            type="checkbox"
+          />
+          
+                
+          <label
+            class="fd-checkbox__label fd-checkbox__label--compact"
+            for="Ai4ez622c"
+          >
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              Kiwi
+            </span>
+            
+                
+          </label>
+          
+            
+        </div>
+        
+            
+        <div
+          class="fd-form-item"
+        >
+          
+                
+          <input
+            checked=""
+            class="fd-checkbox fd-checkbox--compact"
+            disabled=""
+            id="Ai4ez632c"
+            type="checkbox"
+          />
+          
+                
+          <label
+            class="fd-checkbox__label fd-checkbox__label--compact"
+            for="Ai4ez632c"
+          >
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              Lemon
+            </span>
+            
+                
+          </label>
+          
+            
+        </div>
+        
+            
+        <div
+          class="fd-form-item"
+        >
+          
+                
+          <input
+            class="fd-checkbox fd-checkbox--compact"
+            id="Ai4ez613c"
+            type="checkbox"
+          />
+          
+                
+          <label
+            class="fd-checkbox__label fd-checkbox__label--compact"
+            for="Ai4ez613c"
+          >
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              All Fruits (TriState)
+            </span>
+            
+                
+          </label>
+          
+            
+        </div>
+        
+            
+        <div
+          class="fd-form-item"
+        >
+          
+                
+          <input
+            class="fd-checkbox fd-checkbox--compact"
+            disabled=""
+            id="Ai4ez643c"
+            type="checkbox"
+          />
+          
+                
+          <label
+            class="fd-checkbox__label fd-checkbox__label--compact"
+            for="Ai4ez643c"
+          >
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              All Fruits (TriState)
+            </span>
+            
+                
+          </label>
+          
+            
+        </div>
+        
+        
+      </div>
+      
+    
+    </fieldset>
+    
+
+  </div>
+  
+
+</section>
 `;

--- a/stories/checkbox/checkbox.stories.js
+++ b/stories/checkbox/checkbox.stories.js
@@ -25,8 +25,23 @@ Do not use the checkbox control if:
         tags: ['f3', 'a11y', 'theme'] }
 };
 
+const localStyles = `
+<style>
+    .checkbox-example-container {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-between;
+    }
+    
+    .checkbox-example-container > fieldset {
+        max-width: 100%;
+    }
+</style>
+`;
+
 export const primary = () => `
-<div style="display:flex;justify-content:space-between">
+${localStyles}
+<div class="checkbox-example-container">
     <fieldset class="fd-fieldset">
         <legend class="fd-fieldset__legend">Cozy Checkboxes</legend>
         <div class="fd-form-group">
@@ -148,7 +163,8 @@ export const inline = () => `
 inline.storyName = 'Checkboxes listed inline';
 
 export const states = () => `
-<div style="display:flex;justify-content:space-between;flex-wrap:wrap">
+${localStyles}
+<div class="checkbox-example-container">
     <fieldset class="fd-fieldset">
         <legend class="fd-fieldset__legend">Checkboxes Error</legend>
         <div class="fd-form-group">

--- a/stories/checkbox/checkbox.stories.js
+++ b/stories/checkbox/checkbox.stories.js
@@ -33,34 +33,38 @@ export const primary = () => `
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox" id="Ai4ez611">
                 <label class="fd-checkbox__label" for="Ai4ez611">
-                    Apple
+                    <span class="fd-checkbox__text">Apple</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox" id="Ai4ez612" checked>
                 <label class="fd-checkbox__label" for="Ai4ez612">
-                    Banana
+                    <span class="fd-checkbox__text">Banana</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox" id="Ai4ez622" disabled>
                 <label class="fd-checkbox__label" for="Ai4ez622">
-                    Kiwi
+                    <span class="fd-checkbox__text">Kiwi</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox" id="Ai4ez632"  checked disabled>
                 <label class="fd-checkbox__label" for="Ai4ez632">
-                    Lemon
+                    <span class="fd-checkbox__text">Lemon</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox" id="Ai4ez613">
-                <label class="fd-checkbox__label" for="Ai4ez613">All Fruits (TriState)</label>
+                <label class="fd-checkbox__label" for="Ai4ez613">
+                    <span class="fd-checkbox__text">All Fruits (TriState)</span>
+                </label>
             </div>
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox" id="Ai4ez643" disabled>
-                <label class="fd-checkbox__label" for="Ai4ez643">All Fruits (TriState)</label>
+                <label class="fd-checkbox__label" for="Ai4ez643">
+                    <span class="fd-checkbox__text">All Fruits (TriState)</span>
+                </label>
             </div>
         </div>
     </fieldset>
@@ -70,34 +74,38 @@ export const primary = () => `
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox fd-checkbox--compact" id="Ai4ez611c">
                 <label class="fd-checkbox__label fd-checkbox__label--compact" for="Ai4ez611c">
-                    Apple
+                    <span class="fd-checkbox__text">Apple</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox fd-checkbox--compact" id="Ai4ez612c" checked>
                 <label class="fd-checkbox__label fd-checkbox__label--compact" for="Ai4ez612c">
-                    Banana
+                    <span class="fd-checkbox__text">Banana</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox fd-checkbox--compact" id="Ai4ez622c" disabled>
                 <label class="fd-checkbox__label fd-checkbox__label--compact" for="Ai4ez622c">
-                    Kiwi
+                    <span class="fd-checkbox__text">Kiwi</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox fd-checkbox--compact" id="Ai4ez632c"  checked disabled>
                 <label class="fd-checkbox__label fd-checkbox__label--compact" for="Ai4ez632c">
-                    Lemon
+                    <span class="fd-checkbox__text">Lemon</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox fd-checkbox--compact" id="Ai4ez613c">
-                <label class="fd-checkbox__label fd-checkbox__label--compact" for="Ai4ez613c">All Fruits (TriState)</label>
+                <label class="fd-checkbox__label fd-checkbox__label--compact" for="Ai4ez613c">
+                    <span class="fd-checkbox__text">All Fruits (TriState)</span>
+                </label>
             </div>
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox fd-checkbox--compact" id="Ai4ez643c" disabled>
-                <label class="fd-checkbox__label fd-checkbox__label--compact" for="Ai4ez643c">All Fruits (TriState)</label>
+                <label class="fd-checkbox__label fd-checkbox__label--compact" for="Ai4ez643c">
+                    <span class="fd-checkbox__text">All Fruits (TriState)</span>
+                </label>
             </div>
         </div>
     </fieldset>
@@ -119,19 +127,19 @@ export const inline = () => `
         <div class="fd-form-group__item fd-form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez617">
             <label class="fd-checkbox__label" for="Ai4ez617">
-                Potatos
+                <span class="fd-checkbox__text">Potatoes</span>
             </label>
         </div>
         <div class="fd-form-group__item fd-form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez618" checked>
             <label class="fd-checkbox__label" for="Ai4ez618">
-                Tomatos
+                <span class="fd-checkbox__text">Tomatoes</span>
             </label>
         </div>
         <div class="fd-form-group__item fd-form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez619" disabled checked>
             <label class="fd-checkbox__label" for="Ai4ez619">
-                Carrots
+                <span class="fd-checkbox__text">Carrots</span>
             </label>
         </div>
     </div>
@@ -147,19 +155,19 @@ export const states = () => `
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox is-error" id="Ai4ez6119">
                 <label class="fd-checkbox__label" for="Ai4ez6119">
-                    Text Option
+                    <span class="fd-checkbox__text">Text Option</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox is-error" id="Ai4ez6129" checked>
                 <label class="fd-checkbox__label" for="Ai4ez6129">
-                    Selected State
+                    <span class="fd-checkbox__text">Selected State</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox is-error" id="Ai4ez613i1">
                 <label class="fd-checkbox__label" for="Ai4ez613i1">
-                    TriState Text
+                    <span class="fd-checkbox__text">TriState Text</span>
                 </label>
             </div>
         </div>
@@ -171,19 +179,19 @@ export const states = () => `
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox is-success" id="Ai4ez61192">
                 <label class="fd-checkbox__label" for="Ai4ez61192">
-                    Text Option
+                    <span class="fd-checkbox__text">Text Option</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox is-success" id="Ai4ez61292" checked>
                 <label class="fd-checkbox__label" for="Ai4ez61292">
-                    Selected State
+                    <span class="fd-checkbox__text">Selected State</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox is-success" id="Ai4ez613i2">
                 <label class="fd-checkbox__label" for="Ai4ez613i2">
-                    TriState Text
+                    <span class="fd-checkbox__text">TriState Text</span>
                 </label>
             </div>
         </div>
@@ -195,19 +203,19 @@ export const states = () => `
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox is-warning" id="Ai4ez61193">
                 <label class="fd-checkbox__label" for="Ai4ez61193">
-                    Text Option
+                    <span class="fd-checkbox__text">Text Option</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox is-warning" id="Ai4ez61293" checked>
                 <label class="fd-checkbox__label" for="Ai4ez61293">
-                    Selected State
+                    <span class="fd-checkbox__text">Selected State</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox is-warning" id="Ai4ez613i3">
                 <label class="fd-checkbox__label" for="Ai4ez613i3">
-                    TriState Text
+                    <span class="fd-checkbox__text">TriState Text</span>
                 </label>
             </div>
         </div>
@@ -219,19 +227,19 @@ export const states = () => `
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox is-information" id="Ai4ez61194">
                 <label class="fd-checkbox__label" for="Ai4ez61194">
-                    Text Option
+                    <span class="fd-checkbox__text">Text Option</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox is-information" id="Ai4ez61294" checked>
                 <label class="fd-checkbox__label" for="Ai4ez61294">
-                    Selected State
+                    <span class="fd-checkbox__text">Selected State</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox is-information" id="Ai4ez613i4">
                 <label class="fd-checkbox__label" for="Ai4ez613i4">
-                    TriState Text
+                    <span class="fd-checkbox__text">TriState Text</span>
                 </label>
             </div>
         </div>
@@ -243,19 +251,19 @@ export const states = () => `
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox" id="Ai4ez61196" disabled>
                 <label class="fd-checkbox__label" for="Ai4ez61196">
-                    Text Option
+                    <span class="fd-checkbox__text">Text Option</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox" id="Ai4ez61296" checked disabled>
                 <label class="fd-checkbox__label" for="Ai4ez61296">
-                    Selected State
+                    <span class="fd-checkbox__text">Selected State</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox" id="Ai4ez613i6" disabled>
                 <label class="fd-checkbox__label" for="Ai4ez613i6">
-                    TriState Text
+                    <span class="fd-checkbox__text">TriState Text</span>
                 </label>
             </div>
         </div>
@@ -277,19 +285,19 @@ export const rtl = () => `
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez611tt">
             <label class="fd-checkbox__label" for="Ai4ez611tt">
-                Text Option
+                <span class="fd-checkbox__text">Text Option</span>
             </label>
         </div>
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez612tt" checked>
             <label class="fd-checkbox__label" for="Ai4ez612tt">
-                Selected State
+                <span class="fd-checkbox__text">Selected State</span>
             </label>
         </div>
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez613i7">
             <label class="fd-checkbox__label" for="Ai4ez613i7">
-                TriState Text
+                <span class="fd-checkbox__text">TriState Text</span>
             </label>
         </div>
     </div>


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#610

## Description
In previous implementation text inside `.fd-checkbox__label` was not able to properly overflow with ellipsis, because of `display: flex`;

This PR introduces new wrapper which should be used inside `.fd-checkbox__label` to provide proper overflow for the text values.

#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
