### PR TITLE
fix: set the correct position of the counter notification in Shellbar, RTL support

### DIFF
--- a/src/shellbar.scss
+++ b/src/shellbar.scss
@@ -33,6 +33,9 @@ $block: #{$fd-namespace}-shellbar;
   // Box shadow
   $fd-shellbar-box-shadow: var(--sapContent_HeaderShadow) !default;
 
+  // Counter Notification
+  $fd-shellbar-counter-notification-offset: -0.25rem !default;
+
   @include fd-reset();
 
   background-color: $fd-shellbar-background;
@@ -218,9 +221,17 @@ $block: #{$fd-namespace}-shellbar;
       border: $fd-content-badge-background;
       color: $fd-shellbar-color;
       line-height: 0.8;
-      top: 10px;
-      max-height: 16px;
+      max-height: 1rem;
       overflow: hidden;
+      right: $fd-shellbar-counter-notification-offset;
+      top: $fd-shellbar-counter-notification-offset;
+      transform: none;
+
+      @include fd-rtl() {
+        transform: none;
+        right: initial;
+        left: $fd-shellbar-counter-notification-offset;
+      }
     }
 
     .#{$block}__input-group__addon {
@@ -263,6 +274,7 @@ $block: #{$fd-namespace}-shellbar;
    is a better option than using the buttonBase() mixin from the button.scss file or using !important.
    */
   .#{$fd-namespace}-button.#{$block}__button {
+    position: relative;
     border-color: transparent;
     background: $fd-shellbar-background-color;
     color: $fd-shellbar-color;
@@ -292,6 +304,12 @@ $block: #{$fd-namespace}-shellbar;
     &.sap-icon--bell {
       &::before {
         margin-right: 0;
+      }
+
+      @include fd-rtl() {
+        &::before {
+          margin-left: 0;
+        }
       }
     }
 


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#1223

## Description
The position of the counter notification in Shellbar was not correct (per Fiori3 specs) and in RTL the bell icon had a margin-left.

## Screenshots

### Before:
<img width="236" alt="Screen Shot 2020-07-07 at 5 04 33 PM" src="https://user-images.githubusercontent.com/39598672/86843327-661ae780-c074-11ea-9519-dfc6fcbe5e07.png">

### After:
<img width="371" alt="Screen Shot 2020-07-07 at 4 59 54 PM" src="https://user-images.githubusercontent.com/39598672/86843362-716e1300-c074-11ea-8a9f-a87f25bc6fac.png">

<img width="365" alt="Screen Shot 2020-07-07 at 4 59 32 PM" src="https://user-images.githubusercontent.com/39598672/86843372-75019a00-c074-11ea-808f-ffce29d924f9.png">

#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
