### PR TITLE
fix: add fix for Pop-in Table last item border in RTL

### DIFF
--- a/src/table.scss
+++ b/src/table.scss
@@ -355,6 +355,11 @@ $block: #{$fd-namespace}-table;
       .#{$block}__cell {
         @include fd-last-child() {
           border-right: $fd-table-border;
+
+          @include fd-rtl() {
+            border-left: $fd-table-border;
+            border-right: none;
+          }
         }
       }
     }


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles##1233

## Description
In RTL Pop-in Table had issues with the border of the last item. This PR fixes this issue

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
<img width="503" alt="Screen Shot 2020-07-13 at 10 03 48 AM" src="https://user-images.githubusercontent.com/39598672/87313890-88878780-c4f0-11ea-881d-0f55096a1305.png">


### After:
<img width="518" alt="Screen Shot 2020-07-13 at 10 06 03 AM" src="https://user-images.githubusercontent.com/39598672/87313904-8d4c3b80-c4f0-11ea-9b22-448471bd8c63.png">


#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
