### PR TITLE
feat: refactor Info Label

### DIFF
--- a/src/info-label.scss
+++ b/src/info-label.scss
@@ -8,6 +8,7 @@ $fd-info-label-display-height: 1rem !default;
 $fd-info-label-icon-text-spacing: 0.1875rem !default;
 $fd-info-label-border-width: 0.063rem !default;
 $fd-info-label-border-style: solid !default;
+$fd-info-label-font-size: var(--sapFontSmallSize) !default;
 
 $color-accents: (
   "1": ("background": var(--sapLegendBackgroundColor1), "border": var(--sapLegendColor1)),
@@ -30,7 +31,7 @@ $color-accents: (
   height: $fd-info-label-height;
   min-width: $fd-info-label-height;
   max-width: 100%;
-  font-size: var(--sapFontSmallSize);
+  font-size: $fd-info-label-font-size;
   letter-spacing: 0.0125rem;
   text-transform: uppercase;
   text-align: center;
@@ -61,6 +62,7 @@ $color-accents: (
 
   &--icon {
     @include fd-icon-overwrite() {
+      font-size: $fd-info-label-font-size;
       display: inline-flex;
       align-items: center;
       padding: 0 0.3125rem;

--- a/src/info-label.scss
+++ b/src/info-label.scss
@@ -3,119 +3,95 @@
 
 $block: #{$fd-namespace}-info-label;
 
+$fd-info-label-height: 1.125rem !default;
+$fd-info-label-display-height: 1rem !default;
+$fd-info-label-icon-text-spacing: 0.1875rem !default;
+$fd-info-label-border-width: 0.063rem !default;
+$fd-info-label-border-style: solid !default;
+
+$color-accents: (
+  "1": ("background": var(--sapLegendBackgroundColor1), "border": var(--sapLegendColor1)),
+  "2": ("background": var(--sapLegendBackgroundColor2), "border": var(--sapLegendColor2)),
+  "3": ("background": var(--sapLegendBackgroundColor3), "border": var(--sapLegendColor3)),
+  "4": ("background": var(--sapLegendBackgroundColor5), "border": var(--sapLegendColor4)),
+  "5": ("background": var(--sapLegendBackgroundColor20), "border": var(--sapLegendColor5)),
+  "6": ("background": var(--sapLegendBackgroundColor6), "border": var(--sapLegendColor6)),
+  "7": ("background": var(--sapLegendBackgroundColor7), "border": var(--sapLegendColor7)),
+  "8": ("background": var(--sapLegendBackgroundColor8), "border": var(--sapLegendColor8)),
+  "9": ("background": var(--sapLegendBackgroundColor10), "border": var(--sapLegendColor9)),
+  "10": ("background": var(--sapLegendBackgroundColor9), "border": var(--sapLegendColor10))
+);
+
 .#{$block} {
-
-  // info-label DEFAULT
-  $fd-info-label-border-radius: 1.125rem !default;
-  $fd-info-label-color: var(--sapTextColor) !default;
-  $fd-info-label-fontsize: var(--sapFontSmallSize);
-  $fd-info-label-default-padding: 0 0.625rem !default;
-  $fd-info-label-default-vertical-align: middle !default;
-  $fd-info-label-default-border-width: 0.063rem !default;
-  $fd-info-label-default-border-style: solid !default;
-  $fd-info-label-default-height: 1.125rem !default;
-  $fd-info-label-default-text-transform: uppercase !default;
-  $fd-info-label-default-text-align: center !default;
-  $fd-info-label-default-letter-spacing: 0.0125rem !default;
-  $fd-info-label-default-display: inline-block !default;
-  $fd-info-label-default-text-padding-right: 0.1875rem !default;
-  $fd-info-label-default-text-padding-left: 0.3125rem !default;
-  $fd-info-label-default-overflow: hidden !default;
-  $fd-info-label-default-max-width: 100% !default;
-  $fd-info-label-default-white-space: nowrap !default;
-  $fd-info-label-default-text-overflow: ellipsis !default;
-  // INFOLABEL ICON
-  $fd-info-label-icon-size: 0.75rem !default;
-  $fd-info-label-icon-padding-left: 0.3125rem !default;
-  $fd-info-label-icon-padding-right: 0.3125rem !default;
-  $fd-info-label-icon-padding: 0 0.5rem !default;
-
-  // INFOLABEL NUMERIC PADDING
-  $fd-info-label-numeric-padding: 0 0.3125rem !default;
-
-  // COZY AND COMPACT MARGIN
-  $fd-info-label-margin-compact: 0.4375rem 0 !default;
-  $fd-info-lable-margin-cozy: 0.8125rem 0 !default;
-
-  $color-accents: (
-    "1": ("background": var(--sapLegendBackgroundColor1), "border": var(--sapLegendColor1)),
-    "2": ("background": var(--sapLegendBackgroundColor2), "border": var(--sapLegendColor2)),
-    "3": ("background": var(--sapLegendBackgroundColor3), "border": var(--sapLegendColor3)),
-    "4": ("background": var(--sapLegendBackgroundColor5), "border": var(--sapLegendColor4)),
-    "5": ("background": var(--sapLegendBackgroundColor20), "border": var(--sapLegendColor5)),
-    "6": ("background": var(--sapLegendBackgroundColor6), "border": var(--sapLegendColor6)),
-    "7": ("background": var(--sapLegendBackgroundColor7), "border": var(--sapLegendColor7)),
-    "8": ("background": var(--sapLegendBackgroundColor8), "border": var(--sapLegendColor8)),
-    "9": ("background": var(--sapLegendBackgroundColor10), "border": var(--sapLegendColor9)),
-    "10": ("background": var(--sapLegendBackgroundColor9), "border": var(--sapLegendColor10))
-  );
-
   @include fd-reset();
+  @include fd-ellipsis();
 
-  vertical-align: $fd-info-label-default-vertical-align;
-  padding: $fd-info-label-default-padding;
-  border-radius: $fd-info-label-border-radius;
-  border-width: $fd-info-label-default-border-width;
-  border-style: $fd-info-label-default-border-style;
-  height: $fd-info-label-default-height;
-  text-transform: $fd-info-label-default-text-transform;
-  text-align: $fd-info-label-default-text-align;
-  color: $fd-info-label-color;
-  font-size: $fd-info-label-fontsize;
-  letter-spacing: $fd-info-label-default-letter-spacing;
-  display: $fd-info-label-default-display;
-  max-width: $fd-info-label-default-max-width;
-  overflow: $fd-info-label-default-overflow;
-  white-space: $fd-info-label-default-white-space;
-  text-overflow: $fd-info-label-default-text-overflow;
-
-  &--numeric {
-    padding: $fd-info-label-numeric-padding;
-  }
-
-  &--icon {
-    size: $fd-info-label-icon-size;
-    padding: 0 $fd-info-label-icon-padding-right 0 $fd-info-label-icon-padding-right;
-    line-height: 1.1;
-
-    @include fd-rtl() {
-      @include fd-empty() {
-        padding: 0 $fd-info-label-icon-padding-right 0 $fd-info-label-icon-padding-right;
-      }
-
-      &::before {
-        padding-left: $fd-info-label-default-text-padding-right;
-        padding-right: 0;
-      }
-    }
-
-    &::before {
-      padding-right: $fd-info-label-default-text-padding-right;
-      position: relative;
-      top: 0.0625rem;
-    }
-
-    @include fd-empty() {
-      padding: 0 $fd-info-label-icon-padding-right 0 $fd-info-label-icon-padding-right;
-    }
-  }
-
-  &--only-icon {
-    padding: 0 $fd-info-label-icon-padding-right 0 $fd-info-label-icon-padding-left;
-  }
-
-  &--compact {
-    margin: $fd-info-label-margin-compact;
-  }
-
-  &--cozy {
-    margin: $fd-info-lable-margin-cozy;
-  }
+  border-radius: 1.125rem;
+  height: $fd-info-label-height;
+  min-width: $fd-info-label-height;
+  max-width: 100%;
+  font-size: var(--sapFontSmallSize);
+  letter-spacing: 0.0125rem;
+  text-transform: uppercase;
+  text-align: center;
+  color: var(--sapTextColor);
+  padding: 0 0.625rem;
+  border-width: $fd-info-label-border-width;
+  border-style: $fd-info-label-border-style;
 
   @each $set-name, $color-set in $color-accents {
     &--accent-color-#{$set-name} {
       background-color: map_get($color-set, "background");
       border-color: map_get($color-set, "border");
+
+      @include fd-icon-overwrite() {
+        border-color: map_get($color-set, "border");
+      }
+    }
+  }
+
+  &--display {
+    height: $fd-info-label-display-height;
+    min-width: $fd-info-label-display-height;
+  }
+
+  &--numeric {
+    padding: 0 0.3125rem;
+  }
+
+  &--icon {
+    @include fd-icon-overwrite() {
+      display: inline-flex;
+      align-items: center;
+      padding: 0 0.3125rem;
+      line-height: 1rem;
+      border-width: $fd-info-label-border-width;
+      border-style: $fd-info-label-border-style;
+    }
+
+    @include fd-icon-before-overwrite() {
+      font-size: 0.75rem;
+      color: var(--sapTextColor);
+      margin-right: $fd-info-label-icon-text-spacing;
+    }
+
+    @include fd-rtl() {
+      @include fd-icon-before-overwrite() {
+        margin-right: 0;
+        margin-left: $fd-info-label-icon-text-spacing;
+      }
+    }
+
+    @include fd-empty() {
+      @include fd-icon-before-overwrite() {
+        margin: 0;
+      }
+
+      @include fd-rtl() {
+        @include fd-icon-before-overwrite() {
+          margin: 0;
+        }
+      }
     }
   }
 }

--- a/src/mixins/_mixins.scss
+++ b/src/mixins/_mixins.scss
@@ -342,3 +342,23 @@
   color: $color;
   font-size: $fd-size;
 }
+
+@mixin fd-icon-overwrite {
+  &[class*=sap-icon] {
+    @content;
+  }
+}
+
+@mixin fd-icon-before-overwrite {
+  &[class*=sap-icon]::before,
+  &::before {
+    @content;
+  }
+}
+
+@mixin fd-icon-after-overwrite {
+  &[class*=sap-icon]::after,
+  &::after {
+    @content;
+  }
+}

--- a/stories/info-label/__snapshots__/info-label.stories.storyshot
+++ b/stories/info-label/__snapshots__/info-label.stories.storyshot
@@ -1,21 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Storyshots Components/Info Label Color Flavors 1`] = `
+
+
+`;
+
 exports[`Storyshots Components/Info Label Info Label RTL 1`] = `
 
 
 `;
 
-exports[`Storyshots Components/Info Label Info Label colors 1`] = `
+exports[`Storyshots Components/Info Label Info Label with Icon 1`] = `
 
 
 `;
 
-exports[`Storyshots Components/Info Label Info Label icons 1`] = `
-
-
-`;
-
-exports[`Storyshots Components/Info Label Info Label numeric 1`] = `
+exports[`Storyshots Components/Info Label Numeric Info Label 1`] = `
 
 
 `;

--- a/stories/info-label/info-label.stories.js
+++ b/stories/info-label/info-label.stories.js
@@ -9,21 +9,20 @@ Its primary use is to add user-defined characteristic to an object.
 Use the Info Label base class with following modifiers:
 
 - \`fd-info-label\`
+    - \`fd-info-label--accent-color-*\`
     - \`fd-info-label--icon\`
     - \`fd-info-label--numeric\`
-    - \`fd-info-label--accent-color-*\`
       `,
         tags: ['f3', 'a11y', 'theme']
     }
 };
 
-
-/**
- * Info Label with color accents currently supports 10 semantic colors, starting from `fd-info-label--accent-color-1` to `fd-info-label--accent-color-10`.
- * */
+/** Use the `fd-info-label--accent-color-*` modifier class to apply semantic color to Info Label.
+ * Options include numbers from 1 to 10.
+ */
 
 export const colors = () => `
-<div style="display: flex; justify-content: space-around; flex-wrap: wrap;">
+<div class="fddocs-container">
     <span class="fd-info-label fd-info-label--accent-color-1">Info Label</span>
     <br><br>
     <span class="fd-info-label fd-info-label--accent-color-2">Info Label</span>
@@ -45,30 +44,23 @@ export const colors = () => `
     <span class="fd-info-label fd-info-label--accent-color-10">Info Label</span>
 </div>
 `;
+colors.storyName = 'Color Flavors';
 
-colors.storyName = 'Info Label colors';
-
-/**
- * Use `fd-info-label--icon` and icon class to create Info Label with an icon.
- * */
+/** Use the `fd-info-label--icon` modifier class and icon type to create Info Label with Icon. */
 
 export const icons = () => `
-<div style="display: flex; justify-content: space-around; flex-wrap: wrap;">
+<div class="fddocs-container">
     <span class="fd-info-label fd-info-label--accent-color-1 fd-info-label--icon sap-icon--future">Info Label</span>
     <br><br>
-    <span class="fd-info-label fd-info-label--accent-color-2 fd-info-label--only-icon sap-icon--upload-to-cloud"></span>
+    <span class="fd-info-label fd-info-label--accent-color-2 fd-info-label--icon sap-icon--upload-to-cloud"></span>
 </div>
 `;
+icons.storyName = 'Info Label with Icon';
 
-icons.storyName = 'Info Label icons';
-
-
-/**
- * Use `fd-info-label--numeric` modifier to create Info Label with numeric content.
- * */
+/** For Numeric Info Label use the `fd-info-label--numeric` modifier class. */
 
 export const numeric = () => `
-<div style="display: flex; justify-content: space-around; flex-wrap: wrap;">
+<div class="fddocs-container">
     <span class="fd-info-label fd-info-label--numeric fd-info-label--accent-color-1">6</span>
     <br><br>
     <span class="fd-info-label fd-info-label--numeric fd-info-label--accent-color-2">6.2</span>
@@ -76,20 +68,16 @@ export const numeric = () => `
     <span class="fd-info-label fd-info-label--numeric fd-info-label--accent-color-3">42k</span>
 </div>
 `;
+numeric.storyName = 'Numeric Info Label';
 
-numeric.storyName = 'Info Label numeric';
-
-/**
- * Info Label in RTL mode.
- * */
+/** Info Label in RTL mode. */
 
 export const rtl = () => `
-<div style="display: flex; justify-content: space-around; flex-wrap: wrap;" dir="rtl">
+<div class="fddocs-container" dir="rtl">
     <span class="fd-info-label fd-info-label--accent-color-1">Info Label</span>
     <span class="fd-info-label fd-info-label--numeric fd-info-label--accent-color-1">6</span>
     <span class="fd-info-label fd-info-label--accent-color-1 fd-info-label--icon sap-icon--future">Info Label</span>
     <span class="fd-info-label fd-info-label--accent-color-2 fd-info-label--only-icon sap-icon--upload-to-cloud"></span>
 </div>
 `;
-
 rtl.storyName = 'Info Label RTL';

--- a/stories/info-label/info-label.stories.js
+++ b/stories/info-label/info-label.stories.js
@@ -77,7 +77,7 @@ export const rtl = () => `
     <span class="fd-info-label fd-info-label--accent-color-1">Info Label</span>
     <span class="fd-info-label fd-info-label--numeric fd-info-label--accent-color-1">6</span>
     <span class="fd-info-label fd-info-label--accent-color-1 fd-info-label--icon sap-icon--future">Info Label</span>
-    <span class="fd-info-label fd-info-label--accent-color-2 fd-info-label--only-icon sap-icon--upload-to-cloud"></span>
+    <span class="fd-info-label fd-info-label--accent-color-2 fd-info-label--icon sap-icon--upload-to-cloud"></span>
 </div>
 `;
 rtl.storyName = 'Info Label RTL';


### PR DESCRIPTION
## Related Issue
Part of SAP/fundamental-styles#1238

## Description
This PR fixes one of the issues reported during [Defect Hunting](https://github.com/SAP/fundamental-styles/issues/1238) regarding Info Label with Icon missing border. 
- SCSS variables that were used only once in the code have been removed
- The `fd-info-label--only-icon` class has been removed. 

## Screenshots
### Before:
<img width="1218" alt="Screen Shot 2020-07-14 at 4 52 19 PM" src="https://user-images.githubusercontent.com/39598672/87475280-7aba2b00-c5f2-11ea-9e51-bbc243d7067b.png">

### After:
<img width="1207" alt="Screen Shot 2020-07-14 at 4 51 31 PM" src="https://user-images.githubusercontent.com/39598672/87475286-8148a280-c5f2-11ea-819c-114b945c0c47.png">


#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
