### PR TITLE
chore: Rewrite checkbox documentation helpers to ES5

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -3,15 +3,15 @@
 
 <script type="text/javascript">
 (function() {
-    document.addEventListener('DOMContentLoaded', () => {
+    document.addEventListener('DOMContentLoaded', function () {
         //set the indeterminate state of checkbox
-        const triStateCheckboxes = ['Ai4ez613', 'Ai4ez613i1', 'Ai4ez613i2', 'Ai4ez613i3', 'Ai4ez613i4', 'Ai4ez613i5', 'Ai4ez613i6', 'Ai4ez613i7', 'Ai4ez643', 'Ai4ez613c', 'Ai4ez643c'];
-        triStateCheckboxes.forEach((_id) => {
-            const triStateCheckbox = document.getElementById(_id);
+        var triStateCheckboxes = ['Ai4ez613', 'Ai4ez613i1', 'Ai4ez613i2', 'Ai4ez613i3', 'Ai4ez613i4', 'Ai4ez613i5', 'Ai4ez613i6', 'Ai4ez613i7', 'Ai4ez643', 'Ai4ez613c', 'Ai4ez643c'];
+        for (var i = 0; i < triStateCheckboxes.length; i++) {
+            const triStateCheckbox = document.getElementById(triStateCheckboxes[i]);
             if (triStateCheckbox) {
                 triStateCheckbox.indeterminate = true;
             }
-        });
+        };
 
         //climb up DOM to get block element
         function getBlock(control) {


### PR DESCRIPTION
## Related Issue
Part of: #1238

## Description
IE11 does not support ES6 features which were used to write checkbox documentation helpers.

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
