### PR TITLE
fix: add fix for Checkbox tristate misalignment

### DIFF
--- a/src/checkbox.scss
+++ b/src/checkbox.scss
@@ -109,6 +109,7 @@ $block: #{$fd-namespace}-checkbox;
   &:indeterminate + .#{$block}__label::before {
     content: "\e17b";
     font-size: 0.8125rem;
+    padding-top: 0.0625rem;
   }
 
   &:indeterminate + .#{$block}__label--compact::before {


### PR DESCRIPTION
## Related Issue
Part of SAP/fundamental-styles#1263

## Screenshots

### Before:
<img width="584" alt="Screen Shot 2020-07-15 at 6 32 56 PM" src="https://user-images.githubusercontent.com/39598672/87606831-f1762780-c6c9-11ea-9213-7d4c1a681b90.png">


### After:
<img width="533" alt="Screen Shot 2020-07-15 at 6 32 51 PM" src="https://user-images.githubusercontent.com/39598672/87606836-f4711800-c6c9-11ea-81a7-ea95697ad798.png">


#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
