### PR TITLE
fix: center the icon in Panel button

### DIFF
--- a/src/panel.scss
+++ b/src/panel.scss
@@ -58,6 +58,8 @@ $block: #{$fd-namespace}-panel;
       @include fd-icon('slim-arrow-left');
     }
 
+    padding-top: 0.125rem;
+
     &::before {
       font-size: 1rem;
       line-height: normal;


### PR DESCRIPTION
## Related Issue
Part of SAP/fundamental-styles#1263