### PR TITLE
fix: center Panel expand button icon

### DIFF
--- a/src/mixins/_icons.scss
+++ b/src/mixins/_icons.scss
@@ -6,8 +6,6 @@
   @include fd-icon-base($position);
   @include fd-icon-glyph($key, $position);
 
-  font-family: "SAP-icons";
-
   &::#{$position} {
     @content;
   }

--- a/src/panel.scss
+++ b/src/panel.scss
@@ -52,24 +52,16 @@ $block: #{$fd-namespace}-panel;
   }
 
   &__button {
-    @include fd-icon('slim-arrow-right');
+    @include fd-icon('slim-arrow-right') {
+      font-size: 1rem;
+    }
 
     @include fd-rtl() {
       @include fd-icon('slim-arrow-left');
     }
 
-    &::before {
-      font-size: 1rem;
-      line-height: normal;
-    }
-
     &.is-expanded {
       @include fd-icon('slim-arrow-down');
-
-      &::before {
-        font-size: 1rem;
-        line-height: normal;
-      }
     }
   }
 


### PR DESCRIPTION
## Related Issue
Part of: #1263

## Description
Alternative to #1268

Removes unnecessary styling causing icon misalignment.

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
