### PR TITLE
fix: focus ring on radio and checkbox

### DIFF
--- a/src/checkbox.scss
+++ b/src/checkbox.scss
@@ -42,13 +42,9 @@ $block: #{$fd-namespace}-checkbox;
     @include action-cursor();
 
     line-height: 1rem;
-    padding: $fd-checkbox-margin 0 $fd-checkbox-margin $fd-checkbox-margin;
+    padding: $fd-checkbox-margin;
     display: flex;
     align-items: center;
-
-    @include fd-rtl() {
-      padding: $fd-checkbox-margin $fd-checkbox-margin $fd-checkbox-margin 0;
-    }
 
     &::before {
       content: "";
@@ -161,11 +157,7 @@ $block: #{$fd-namespace}-checkbox;
 
   &--compact {
     + .#{$block}__label {
-      padding: $fd-checkbox-margin-compact 0 $fd-checkbox-margin-compact $fd-checkbox-margin-compact;
-
-      @include fd-rtl() {
-        padding: $fd-checkbox-margin-compact $fd-checkbox-margin-compact $fd-checkbox-margin-compact 0;
-      }
+      padding: $fd-checkbox-margin-compact;
 
       &::before {
         font-size: 0.625rem;

--- a/src/mixins/_forms.scss
+++ b/src/mixins/_forms.scss
@@ -135,16 +135,8 @@
   $fd-radio-label-padding: 0;
   $fd-radio-focus-offset: 0.125rem;
 
-  &::after {
-    content: "";
-    position: absolute;
-    border: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
-    top: $margin - $fd-radio-focus-offset;
-    left: $margin - $fd-radio-focus-offset;
-    bottom: $margin - $fd-radio-focus-offset;
-    right: $fd-radio-label-padding;
-    @content;
-  }
+  outline: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
+  outline-offset: $fd-radio-focus-offset - $margin;
 
   @include fd-rtl() {
     &::after {

--- a/src/radio.scss
+++ b/src/radio.scss
@@ -49,11 +49,7 @@ $block: #{$fd-namespace}-radio;
     display: flex;
     align-items: center;
     overflow: hidden;
-    padding: $fd-radio-outer-circle-margin 0 $fd-radio-outer-circle-margin $fd-radio-outer-circle-margin;
-
-    @include fd-rtl() {
-      padding: $fd-radio-outer-circle-margin $fd-radio-outer-circle-margin $fd-radio-outer-circle-margin 0;
-    }
+    padding: $fd-radio-outer-circle-margin;
 
     &::before {
       content: "";


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#1197

## Description
No longer use `::after` selector for focus ring on Radio and Checkbox to avoid Chrome crashes.

## Screenshots
### Before:

<img width="152" alt="Screen Shot 2020-07-21 at 10 55 35 AM" src="https://user-images.githubusercontent.com/57502177/88089882-9f0d8e80-cb41-11ea-8720-e37e12846c61.png">

<img width="119" alt="Screen Shot 2020-07-21 at 10 55 23 AM" src="https://user-images.githubusercontent.com/57502177/88089888-a2a11580-cb41-11ea-9b66-ca4ad73ba4a3.png">

### After:

<img width="132" alt="Screen Shot 2020-07-21 at 10 41 17 AM" src="https://user-images.githubusercontent.com/57502177/88089902-a6349c80-cb41-11ea-9c49-495925579182.png">

<img width="112" alt="Screen Shot 2020-07-21 at 10 41 05 AM" src="https://user-images.githubusercontent.com/57502177/88089906-a92f8d00-cb41-11ea-8567-d72b1dce9921.png">


#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
