### PR TITLE
chore: Remove page header overflow

### DIFF
--- a/.storybook/custom/custom.scss
+++ b/.storybook/custom/custom.scss
@@ -49,14 +49,6 @@ $heading-toc-spacer: $docs-hd-tp + $docs-hd-bp + $docs-hd-ch + $docs-tm;
   &:focus {
     outline: none;
   }
-
-  &::before {
-    content: '';
-    display: block;
-    height: $heading-toc-spacer;
-    margin-top: -$heading-toc-spacer;
-    visibility: hidden;
-  }
 }
 
 /* storybook iframe */


### PR DESCRIPTION
## Related Issue
Closes: #1291

## Description
Page headers had a `before` pseudo-element which was overflowing page content preventing user from interaction with covered page elements.

I'm not sure what was the purpose to introduce this styling, but I don't see a value, so my proposition is just to remove it.

#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
