### PR TITLE
fix: additional styles and docs for focusable disabled button

### DIFF
--- a/src/mixins/button/_emphasized.scss
+++ b/src/mixins/button/_emphasized.scss
@@ -37,6 +37,6 @@
   box-shadow: none;
 
   &:focus {
-    outline: none;
+    @include buttonFocus();
   }
 }

--- a/stories/button/__snapshots__/button.stories.storyshot
+++ b/stories/button/__snapshots__/button.stories.storyshot
@@ -29,13 +29,22 @@ exports[`Storyshots Components/Button Button States 1`] = `
   
 
   <button
-    aria-describedby="fd-ONXuqucVcF"
+    aria-describedby="fd-ONXuqucVcF1"
     aria-disabled="true"
     class="fd-button fd-button--emphasized is-disabled"
     type="button"
   >
     Disabled Focusable
   </button>
+  
+
+  <p
+    aria-live="assertive"
+    class="fd-button__instructions"
+    id="fd-ONXuqucVcF1"
+  >
+    This disabled button is focusable and this text will be read out by a screen reader and read again when there are changes to the state of the button.
+  </p>
   
 
   <br />
@@ -67,13 +76,22 @@ exports[`Storyshots Components/Button Button States 1`] = `
   
 
   <button
-    aria-describedby="fd-ONXuqucVcF"
+    aria-describedby="fd-ONXuqucVcF2"
     aria-disabled="true"
     class="fd-button is-disabled"
     type="button"
   >
     Disabled Focusable
   </button>
+  
+
+  <p
+    aria-live="assertive"
+    class="fd-button__instructions"
+    id="fd-ONXuqucVcF2"
+  >
+    This disabled button is focusable and this text will be read out by a screen reader and read again when there are changes to the state of the button.
+  </p>
   
 
   <br />
@@ -105,13 +123,22 @@ exports[`Storyshots Components/Button Button States 1`] = `
   
 
   <button
-    aria-describedby="fd-ONXuqucVcF"
+    aria-describedby="fd-ONXuqucVcF3"
     aria-disabled="true"
     class="fd-button fd-button--transparent is-disabled"
     type="button"
   >
     Disabled Focusable
   </button>
+  
+
+  <p
+    aria-live="assertive"
+    class="fd-button__instructions"
+    id="fd-ONXuqucVcF3"
+  >
+    This disabled button is focusable and this text will be read out by a screen reader and read again when there are changes to the state of the button.
+  </p>
   
 
   <br />
@@ -143,13 +170,22 @@ exports[`Storyshots Components/Button Button States 1`] = `
   
 
   <button
-    aria-describedby="fd-ONXuqucVcF"
+    aria-describedby="fd-ONXuqucVcF4"
     aria-disabled="true"
     class="fd-button fd-button is-disabled"
     type="button"
   >
     Disabled Focusable
   </button>
+  
+
+  <p
+    aria-live="assertive"
+    class="fd-button__instructions"
+    id="fd-ONXuqucVcF4"
+  >
+    This disabled button is focusable and this text will be read out by a screen reader and read again when there are changes to the state of the button.
+  </p>
   
 
   <br />
@@ -181,13 +217,22 @@ exports[`Storyshots Components/Button Button States 1`] = `
   
 
   <button
-    aria-describedby="fd-ONXuqucVcF"
+    aria-describedby="fd-ONXuqucVcF5"
     aria-disabled="true"
     class="fd-button fd-button--ghost is-disabled"
     type="button"
   >
     Disabled Focusable
   </button>
+  
+
+  <p
+    aria-live="assertive"
+    class="fd-button__instructions"
+    id="fd-ONXuqucVcF5"
+  >
+    This disabled button is focusable and this text will be read out by a screen reader and read again when there are changes to the state of the button.
+  </p>
   
 
   <br />
@@ -219,13 +264,22 @@ exports[`Storyshots Components/Button Button States 1`] = `
   
 
   <button
-    aria-describedby="fd-ONXuqucVcF"
+    aria-describedby="fd-ONXuqucVcF6"
     aria-disabled="true"
     class="fd-button fd-button--positive is-disabled"
     type="button"
   >
     Disabled Focusable
   </button>
+  
+
+  <p
+    aria-live="assertive"
+    class="fd-button__instructions"
+    id="fd-ONXuqucVcF6"
+  >
+    This disabled button is focusable and this text will be read out by a screen reader and read again when there are changes to the state of the button.
+  </p>
   
 
   <br />
@@ -257,13 +311,22 @@ exports[`Storyshots Components/Button Button States 1`] = `
   
 
   <button
-    aria-describedby="fd-ONXuqucVcF"
+    aria-describedby="fd-ONXuqucVcF7"
     aria-disabled="true"
     class="fd-button fd-button--negative is-disabled"
     type="button"
   >
     Disabled Focusable
   </button>
+  
+
+  <p
+    aria-live="assertive"
+    class="fd-button__instructions"
+    id="fd-ONXuqucVcF7"
+  >
+    This disabled button is focusable and this text will be read out by a screen reader and read again when there are changes to the state of the button.
+  </p>
   
 
   <br />
@@ -295,13 +358,22 @@ exports[`Storyshots Components/Button Button States 1`] = `
   
 
   <button
-    aria-describedby="fd-ONXuqucVcF"
+    aria-describedby="fd-ONXuqucVcF8"
     aria-disabled="true"
     class="fd-button fd-button--attention is-disabled"
     type="button"
   >
     Disabled Focusable
   </button>
+  
+
+  <p
+    aria-live="assertive"
+    class="fd-button__instructions"
+    id="fd-ONXuqucVcF8"
+  >
+    This disabled button is focusable and this text will be read out by a screen reader and read again when there are changes to the state of the button.
+  </p>
   
 
 </section>

--- a/stories/button/__snapshots__/button.stories.storyshot
+++ b/stories/button/__snapshots__/button.stories.storyshot
@@ -28,6 +28,16 @@ exports[`Storyshots Components/Button Button States 1`] = `
   </button>
   
 
+  <button
+    aria-describedby="fd-ONXuqucVcF"
+    aria-disabled="true"
+    class="fd-button fd-button--emphasized is-disabled"
+    type="button"
+  >
+    Disabled Focusable
+  </button>
+  
+
   <br />
   <br />
   
@@ -53,6 +63,16 @@ exports[`Storyshots Components/Button Button States 1`] = `
     disabled=""
   >
     Disabled State
+  </button>
+  
+
+  <button
+    aria-describedby="fd-ONXuqucVcF"
+    aria-disabled="true"
+    class="fd-button is-disabled"
+    type="button"
+  >
+    Disabled Focusable
   </button>
   
 
@@ -84,6 +104,16 @@ exports[`Storyshots Components/Button Button States 1`] = `
   </button>
   
 
+  <button
+    aria-describedby="fd-ONXuqucVcF"
+    aria-disabled="true"
+    class="fd-button fd-button--transparent is-disabled"
+    type="button"
+  >
+    Disabled Focusable
+  </button>
+  
+
   <br />
   <br />
   
@@ -105,10 +135,20 @@ exports[`Storyshots Components/Button Button States 1`] = `
 
   <button
     aria-disabled="true"
-    class="fd-button fd-button "
+    class="fd-button fd-button"
     disabled=""
   >
     Disabled State
+  </button>
+  
+
+  <button
+    aria-describedby="fd-ONXuqucVcF"
+    aria-disabled="true"
+    class="fd-button fd-button is-disabled"
+    type="button"
+  >
+    Disabled Focusable
   </button>
   
 
@@ -140,6 +180,16 @@ exports[`Storyshots Components/Button Button States 1`] = `
   </button>
   
 
+  <button
+    aria-describedby="fd-ONXuqucVcF"
+    aria-disabled="true"
+    class="fd-button fd-button--ghost is-disabled"
+    type="button"
+  >
+    Disabled Focusable
+  </button>
+  
+
   <br />
   <br />
   
@@ -165,6 +215,16 @@ exports[`Storyshots Components/Button Button States 1`] = `
     disabled=""
   >
     Disabled State
+  </button>
+  
+
+  <button
+    aria-describedby="fd-ONXuqucVcF"
+    aria-disabled="true"
+    class="fd-button fd-button--positive is-disabled"
+    type="button"
+  >
+    Disabled Focusable
   </button>
   
 
@@ -196,6 +256,16 @@ exports[`Storyshots Components/Button Button States 1`] = `
   </button>
   
 
+  <button
+    aria-describedby="fd-ONXuqucVcF"
+    aria-disabled="true"
+    class="fd-button fd-button--negative is-disabled"
+    type="button"
+  >
+    Disabled Focusable
+  </button>
+  
+
   <br />
   <br />
   
@@ -221,6 +291,16 @@ exports[`Storyshots Components/Button Button States 1`] = `
     disabled=""
   >
     Disabled State
+  </button>
+  
+
+  <button
+    aria-describedby="fd-ONXuqucVcF"
+    aria-disabled="true"
+    class="fd-button fd-button--attention is-disabled"
+    type="button"
+  >
+    Disabled Focusable
   </button>
   
 

--- a/stories/button/button.stories.js
+++ b/stories/button/button.stories.js
@@ -274,42 +274,50 @@ export const buttonStates = () => `
 <button class="fd-button fd-button--emphasized">Normal State</button>
 <button class="fd-button fd-button--emphasized is-selected" aria-selected="true">Selected State</button>
 <button class="fd-button fd-button--emphasized" aria-disabled="true" disabled>Disabled State</button>
-<button aria-disabled="true" aria-describedby="fd-ONXuqucVcF" class="fd-button fd-button--emphasized is-disabled" type="button">Disabled Focusable</button>
+<button aria-disabled="true" aria-describedby="fd-ONXuqucVcF1" class="fd-button fd-button--emphasized is-disabled" type="button">Disabled Focusable</button>
+<p aria-live="assertive" class="fd-button__instructions" id="fd-ONXuqucVcF1">This disabled button is focusable and this text will be read out by a screen reader and read again when there are changes to the state of the button.</p>
 <br><br>
 <button class="fd-button">Normal State</button>
 <button class="fd-button is-selected" aria-selected="true">Selected State</button>
 <button class="fd-button is-disabled" aria-disabled="true" disabled>Disabled State</button>
-<button aria-disabled="true" aria-describedby="fd-ONXuqucVcF" class="fd-button is-disabled" type="button">Disabled Focusable</button>
+<button aria-disabled="true" aria-describedby="fd-ONXuqucVcF2" class="fd-button is-disabled" type="button">Disabled Focusable</button>
+<p aria-live="assertive" class="fd-button__instructions" id="fd-ONXuqucVcF2">This disabled button is focusable and this text will be read out by a screen reader and read again when there are changes to the state of the button.</p>
 <br><br>
 <button class="fd-button fd-button--transparent">Normal State</button>
 <button class="fd-button fd-button--transparent is-selected" aria-selected="true">Selected State</button>
 <button class="fd-button fd-button--transparent is-disabled" aria-disabled="true" disabled>Disabled State</button>
-<button aria-disabled="true" aria-describedby="fd-ONXuqucVcF" class="fd-button fd-button--transparent is-disabled" type="button">Disabled Focusable</button>
+<button aria-disabled="true" aria-describedby="fd-ONXuqucVcF3" class="fd-button fd-button--transparent is-disabled" type="button">Disabled Focusable</button>
+<p aria-live="assertive" class="fd-button__instructions" id="fd-ONXuqucVcF3">This disabled button is focusable and this text will be read out by a screen reader and read again when there are changes to the state of the button.</p>
 <br><br>
 <button class="fd-button fd-button">Normal State</button>
 <button class="fd-button fd-button is-selected" aria-selected="true">Selected State</button>
 <button class="fd-button fd-button" aria-disabled="true" disabled>Disabled State</button>
-<button aria-disabled="true" aria-describedby="fd-ONXuqucVcF" class="fd-button fd-button is-disabled" type="button">Disabled Focusable</button>
+<button aria-disabled="true" aria-describedby="fd-ONXuqucVcF4" class="fd-button fd-button is-disabled" type="button">Disabled Focusable</button>
+<p aria-live="assertive" class="fd-button__instructions" id="fd-ONXuqucVcF4">This disabled button is focusable and this text will be read out by a screen reader and read again when there are changes to the state of the button.</p>
 <br><br>
 <button class="fd-button fd-button--ghost">Normal State</button>
 <button class="fd-button fd-button--ghost is-selected" aria-selected="true">Selected State</button>
 <button class="fd-button fd-button--ghost" aria-disabled="true" disabled>Disabled State</button>
-<button aria-disabled="true" aria-describedby="fd-ONXuqucVcF" class="fd-button fd-button--ghost is-disabled" type="button">Disabled Focusable</button>
+<button aria-disabled="true" aria-describedby="fd-ONXuqucVcF5" class="fd-button fd-button--ghost is-disabled" type="button">Disabled Focusable</button>
+<p aria-live="assertive" class="fd-button__instructions" id="fd-ONXuqucVcF5">This disabled button is focusable and this text will be read out by a screen reader and read again when there are changes to the state of the button.</p>
 <br><br>
 <button class="fd-button fd-button--positive">Normal State</button>
 <button class="fd-button fd-button--positive is-selected" aria-selected="true">Selected State</button>
 <button class="fd-button fd-button--positive" aria-disabled="true" disabled>Disabled State</button>
-<button aria-disabled="true" aria-describedby="fd-ONXuqucVcF" class="fd-button fd-button--positive is-disabled" type="button">Disabled Focusable</button>
+<button aria-disabled="true" aria-describedby="fd-ONXuqucVcF6" class="fd-button fd-button--positive is-disabled" type="button">Disabled Focusable</button>
+<p aria-live="assertive" class="fd-button__instructions" id="fd-ONXuqucVcF6">This disabled button is focusable and this text will be read out by a screen reader and read again when there are changes to the state of the button.</p>
 <br><br>
 <button class="fd-button fd-button--negative">Normal State</button>
 <button class="fd-button fd-button--negative is-selected" aria-selected="true">Selected State</button>
 <button class="fd-button fd-button--negative" aria-disabled="true" disabled>Disabled State</button>
-<button aria-disabled="true" aria-describedby="fd-ONXuqucVcF" class="fd-button fd-button--negative is-disabled" type="button">Disabled Focusable</button>
+<button aria-disabled="true" aria-describedby="fd-ONXuqucVcF7" class="fd-button fd-button--negative is-disabled" type="button">Disabled Focusable</button>
+<p aria-live="assertive" class="fd-button__instructions" id="fd-ONXuqucVcF7">This disabled button is focusable and this text will be read out by a screen reader and read again when there are changes to the state of the button.</p>
 <br><br>
 <button class="fd-button fd-button--attention">Normal State</button>
 <button class="fd-button fd-button--attention is-selected" aria-selected="true">Selected State</button>
 <button class="fd-button fd-button--attention is-disabled" aria-disabled="true" disabled>Disabled State</button>
-<button aria-disabled="true" aria-describedby="fd-ONXuqucVcF" class="fd-button fd-button--attention is-disabled" type="button">Disabled Focusable</button>
+<button aria-disabled="true" aria-describedby="fd-ONXuqucVcF8" class="fd-button fd-button--attention is-disabled" type="button">Disabled Focusable</button>
+<p aria-live="assertive" class="fd-button__instructions" id="fd-ONXuqucVcF8">This disabled button is focusable and this text will be read out by a screen reader and read again when there are changes to the state of the button.</p>
 `;
 
 buttonStates.storyName = 'Button States';
@@ -326,7 +334,9 @@ the \`is-selected\` class or the \`aria-selected="true"\` attribute for accessib
 \`aria-disabled="true"\` attribute for accessibility.
 - **Focusable Disabled**: It cannot be clicked/tapped. The button is tabbable and focusable. A focus ring will appear when clicking or tabbing into the button.
  This state can be rendered using the \`is-disabled\` class and the
-\`aria-disabled="true"\` attribute for accessibility without the use of the \`disabled\` property.
+\`aria-disabled="true"\` attribute for accessibility without the use of the \`disabled\` property. With the addition of the hidden \`__instructions\` 
+element, the user will be notified of further instructions to enable the button, and will be notified when the button is enabled
+by use of the \`aria-live\` property.
 `
     }
 };

--- a/stories/button/button.stories.js
+++ b/stories/button/button.stories.js
@@ -324,6 +324,9 @@ The button provides feedback for "normal", "hover", "selected", "focus" and "dis
 the \`is-selected\` class or the \`aria-selected="true"\` attribute for accessibility.
 - **Disabled**: It cannot be clicked/tapped. This state can be rendered using the \`is-disabled\` class and the
 \`aria-disabled="true"\` attribute for accessibility.
+- **Focusable Disabled**: It cannot be clicked/tapped. The button is tabbable and focusable. A focus ring will appear when clicking or tabbing into the button.
+ This state can be rendered using the \`is-disabled\` class and the
+\`aria-disabled="true"\` attribute for accessibility without the use of the \`disabled\` property.
 `
     }
 };

--- a/stories/button/button.stories.js
+++ b/stories/button/button.stories.js
@@ -274,34 +274,42 @@ export const buttonStates = () => `
 <button class="fd-button fd-button--emphasized">Normal State</button>
 <button class="fd-button fd-button--emphasized is-selected" aria-selected="true">Selected State</button>
 <button class="fd-button fd-button--emphasized" aria-disabled="true" disabled>Disabled State</button>
+<button aria-disabled="true" aria-describedby="fd-ONXuqucVcF" class="fd-button fd-button--emphasized is-disabled" type="button">Disabled Focusable</button>
 <br><br>
 <button class="fd-button">Normal State</button>
 <button class="fd-button is-selected" aria-selected="true">Selected State</button>
 <button class="fd-button is-disabled" aria-disabled="true" disabled>Disabled State</button>
+<button aria-disabled="true" aria-describedby="fd-ONXuqucVcF" class="fd-button is-disabled" type="button">Disabled Focusable</button>
 <br><br>
 <button class="fd-button fd-button--transparent">Normal State</button>
 <button class="fd-button fd-button--transparent is-selected" aria-selected="true">Selected State</button>
 <button class="fd-button fd-button--transparent is-disabled" aria-disabled="true" disabled>Disabled State</button>
+<button aria-disabled="true" aria-describedby="fd-ONXuqucVcF" class="fd-button fd-button--transparent is-disabled" type="button">Disabled Focusable</button>
 <br><br>
 <button class="fd-button fd-button">Normal State</button>
 <button class="fd-button fd-button is-selected" aria-selected="true">Selected State</button>
-<button class="fd-button fd-button " aria-disabled="true" disabled>Disabled State</button>
+<button class="fd-button fd-button" aria-disabled="true" disabled>Disabled State</button>
+<button aria-disabled="true" aria-describedby="fd-ONXuqucVcF" class="fd-button fd-button is-disabled" type="button">Disabled Focusable</button>
 <br><br>
 <button class="fd-button fd-button--ghost">Normal State</button>
 <button class="fd-button fd-button--ghost is-selected" aria-selected="true">Selected State</button>
 <button class="fd-button fd-button--ghost" aria-disabled="true" disabled>Disabled State</button>
+<button aria-disabled="true" aria-describedby="fd-ONXuqucVcF" class="fd-button fd-button--ghost is-disabled" type="button">Disabled Focusable</button>
 <br><br>
 <button class="fd-button fd-button--positive">Normal State</button>
 <button class="fd-button fd-button--positive is-selected" aria-selected="true">Selected State</button>
 <button class="fd-button fd-button--positive" aria-disabled="true" disabled>Disabled State</button>
+<button aria-disabled="true" aria-describedby="fd-ONXuqucVcF" class="fd-button fd-button--positive is-disabled" type="button">Disabled Focusable</button>
 <br><br>
 <button class="fd-button fd-button--negative">Normal State</button>
 <button class="fd-button fd-button--negative is-selected" aria-selected="true">Selected State</button>
 <button class="fd-button fd-button--negative" aria-disabled="true" disabled>Disabled State</button>
+<button aria-disabled="true" aria-describedby="fd-ONXuqucVcF" class="fd-button fd-button--negative is-disabled" type="button">Disabled Focusable</button>
 <br><br>
 <button class="fd-button fd-button--attention">Normal State</button>
 <button class="fd-button fd-button--attention is-selected" aria-selected="true">Selected State</button>
 <button class="fd-button fd-button--attention is-disabled" aria-disabled="true" disabled>Disabled State</button>
+<button aria-disabled="true" aria-describedby="fd-ONXuqucVcF" class="fd-button fd-button--attention is-disabled" type="button">Disabled Focusable</button>
 `;
 
 buttonStates.storyName = 'Button States';


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#756
Related to https://github.com/SAP/fundamental-styles/pull/1293

## Description
Add more examples to Button States to include Focusable Disabled Buttons.
Fix focus ring for focusable disabled emphasized buttons. Previously no focus ring for this button, now focus ring follows the same style as other button states.

### Before:
![B9C1D18B-CB3F-40CD-8D4B-653F4A47C22C](https://user-images.githubusercontent.com/21978807/88866737-695f4a00-d1c0-11ea-9621-cc8abe7b8c17.jpeg)

### After:
![A22EB906-73DE-4BB8-981A-A99DDCCBB1B3](https://user-images.githubusercontent.com/21978807/88866749-6fedc180-d1c0-11ea-933b-bc38f6e0c454.jpeg)

![F768A285-DB43-4CCD-A249-6DB4CC32A48D_4_5005_c](https://user-images.githubusercontent.com/21978807/88866752-72501b80-d1c0-11ea-917e-2ed236a3fe0a.jpeg)


#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
