### PR TITLE
fix: remove input group button outline

### DIFF
--- a/src/input-group.scss
+++ b/src/input-group.scss
@@ -190,6 +190,7 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
     @include fd-ellipsis();
 
     border: none;
+    outline: none;
     width: 100%;
   }
 


### PR DESCRIPTION
fixes #1195 

removes the browser's default stylesheet button outline on focus

before:
![Screen Shot 2020-08-05 at 12 29 07 PM](https://user-images.githubusercontent.com/2471874/89450334-9c04c780-d717-11ea-9bc9-8136add320b2.png)

after:
![Screen Shot 2020-08-05 at 12 29 53 PM](https://user-images.githubusercontent.com/2471874/89450350-a1621200-d717-11ea-8aaf-642e5a93d9dd.png)
