### PR TITLE
fix: button active outline for safari and ff

### DIFF
--- a/src/button.scss
+++ b/src/button.scss
@@ -329,22 +329,27 @@ $block: #{$fd-namespace}-button;
     @include standardPressedFocus();
 
     &.#{$block}--ghost {
+      @include ghostPressed();
       @include ghostPressedFocus();
     }
 
     &.#{$block}--positive {
+      @include positivePressed();
       @include positivePressedFocus();
     }
 
     &.#{$block}--negative {
+      @include negativePressed();
       @include negativePressedFocus();
     }
 
     &.#{$block}--attention {
+      @include attentionPressed();
       @include attentionPressedFocus();
     }
 
     &.#{$block}--emphasized {
+      @include emphasizedPressed();
       @include emphasizedPressedFocus();
     }
   }

--- a/src/button.scss
+++ b/src/button.scss
@@ -325,6 +325,7 @@ $block: #{$fd-namespace}-button;
   @include iconOverwrite() {
     box-shadow: none;
 
+    @include standardPressed();
     @include standardPressedFocus();
 
     &.#{$block}--ghost {
@@ -345,32 +346,6 @@ $block: #{$fd-namespace}-button;
 
     &.#{$block}--emphasized {
       @include emphasizedPressedFocus();
-    }
-  }
-}
-
-@mixin buttonContainerPressed() {
-  @include iconOverwrite() {
-    @include standardPressed();
-
-    &.#{$block}--ghost {
-      @include ghostPressed();
-    }
-
-    &.#{$block}--positive {
-      @include positivePressed();
-    }
-
-    &.#{$block}--negative {
-      @include negativePressed();
-    }
-
-    &.#{$block}--attention {
-      @include attentionPressed();
-    }
-
-    &.#{$block}--emphasized {
-      @include emphasizedPressed();
     }
   }
 }
@@ -436,18 +411,13 @@ $block: #{$fd-namespace}-button;
     @include buttonContainerHover();
   }
 
-  @include fd-active-pressed-selected() {
-    outline: none;
-
-    @include buttonContainerPressed();
-  }
-
   @include fd-focus() {
     @include buttonContainerFocus();
+  }
 
-    @include fd-active-pressed-selected() {
-      @include buttonContainerPressedFocus();
-    }
+  @include fd-active-pressed-selected() {
+    @include buttonContainerFocus();
+    @include buttonContainerPressedFocus();
   }
 
   @include fd-disabled() {


### PR DESCRIPTION
fixes #1055 

Problem is that when clicking a <button> on firefox or safari, specifically running OSX, :focus selector is not applied, only :active.  Previous implementation didn't apply outline unless the button was both focused and active.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus