### PR TITLE
fix: remove extra border on Input Group button

### DIFF
--- a/src/input-group.scss
+++ b/src/input-group.scss
@@ -190,6 +190,7 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
     @include fd-ellipsis();
 
     border: none;
+    outline: none;
     width: 100%;
   }
 

--- a/src/input-group.scss
+++ b/src/input-group.scss
@@ -190,8 +190,11 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
     @include fd-ellipsis();
 
     border: none;
-    outline: none;
     width: 100%;
+  }
+
+  .#{$fd-namespace}-button.#{$block}__button {
+    border-color: transparent;
   }
 
   &--control {


### PR DESCRIPTION
fixes #1195 

before: 
![Screen Shot 2020-08-06 at 8 33 16 AM](https://user-images.githubusercontent.com/2471874/89544763-be522000-d7bf-11ea-9d31-b755986ca822.png)

after:
![Screen Shot 2020-08-06 at 8 32 33 AM](https://user-images.githubusercontent.com/2471874/89544776-c14d1080-d7bf-11ea-8b98-c842f4fe2024.png)

