### PR TITLE
fix: border cutting off bottom of product switch item subtitles

### DIFF
--- a/src/product-switch.scss
+++ b/src/product-switch.scss
@@ -83,8 +83,7 @@ $block: #{$fd-namespace}-product-switch;
 
     &.selected {
       background-color: var(--sapList_SelectionBackgroundColor);
-      border: 0.125rem solid;
-      border-color: var(--sapList_SelectionBorderColor);
+      box-shadow: inset 0 0 0 0.125rem var(--sapList_SelectionBorderColor);
 
       @include fd-product-pseudo-element-background(var(--sapList_SelectionBackgroundColor));
 
@@ -98,6 +97,10 @@ $block: #{$fd-namespace}-product-switch;
         background-color: var(--sapList_Active_Background);
 
         @include fd-product-pseudo-element-background(var(--sapList_Active_Background));
+      }
+
+      &:focus {
+        box-shadow: none;
       }
     }
 

--- a/src/product-switch.scss
+++ b/src/product-switch.scss
@@ -83,7 +83,7 @@ $block: #{$fd-namespace}-product-switch;
 
     &.selected {
       background-color: var(--sapList_SelectionBackgroundColor);
-      box-shadow: inset 0 0 0 0.125rem var(--sapList_SelectionBorderColor);
+      box-shadow: 0 0 0 0.125rem var(--sapList_SelectionBorderColor);
 
       @include fd-product-pseudo-element-background(var(--sapList_SelectionBackgroundColor));
 

--- a/src/product-switch.scss
+++ b/src/product-switch.scss
@@ -292,6 +292,7 @@ $block: #{$fd-namespace}-product-switch;
 
       &.selected {
         border-bottom-color: var(--sapList_SelectionBorderColor);
+        box-shadow: none;
 
         @include fd-product-pseudo-element-background(var(--sapList_SelectionBorderColor));
 

--- a/stories/product-switch/product-switch.stories.js
+++ b/stories/product-switch/product-switch.stories.js
@@ -23,7 +23,7 @@ export const productSwitchInShellbar = () => `
             <div class="fd-popover__body fd-popover__body--right" aria-hidden="false" id="product-switch-body">
                 <div class="fd-product-switch__body">
                     <ul class="fd-product-switch__list">
-                        <li class="fd-product-switch__item" tabindex="0">
+                        <li class="fd-product-switch__item selected" tabindex="0">
                             <div class="fd-product-switch__icon sap-icon--home"></div>
                             <div class="fd-product-switch__text">
                                 <div class="fd-product-switch__title">Home</div>


### PR DESCRIPTION
fixes #1336 

before (look at the "g"):
![Screen Shot 2020-08-06 at 9 55 52 AM](https://user-images.githubusercontent.com/2471874/89566181-ed2abf00-d7dc-11ea-806d-8305dd414f6c.png)

after:
![Screen Shot 2020-08-06 at 9 56 40 AM](https://user-images.githubusercontent.com/2471874/89566188-f025af80-d7dc-11ea-8009-1ee9065927ce.png)


