### PR TITLE
fix: uicomp-1102 change standard-version commit message format

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "release": "./scripts/publish-release.sh",
     "size": "bundlesize --config config/bundlesize.json",
     "start": "npm run storybook",
-    "std-version": "standard-version -m \"chore(release): version %s build ${TRAVIS_BUILD_NUMBER} [ci skip]\"",
+    "std-version": "standard-version --releaseCommitMessageFormat \"chore(release): version {{currentTag}} build ${TRAVIS_BUILD_NUMBER} [ci skip]\"",
     "style:assets": "./scripts/copy-assets.sh",
     "style:compile": "node-sass -q --output-style expanded --precision 5 src/ --output dist/",
     "style:postCSS": "postcss --config config/postcss.config.js  --replace dist/*.css",


### PR DESCRIPTION
## Jira ID [UICOMP-1102](https://jira.concur.com/jira/browse/UICOMP-1102)

### Description
`-m` or `--message` is deprecated https://github.com/conventional-changelog/standard-version/blob/master/command.js#L33

Instead of using `%s` we can use `{{currentTag}}` -- https://github.com/conventional-changelog/standard-version/blob/ae032bfa9268a0a14351b0d78b6deedee7891e3a/test.js#L1244

