### PR TITLE
fix: List footer as span

### DIFF
--- a/stories/dialog/__snapshots__/dialog.stories.storyshot
+++ b/stories/dialog/__snapshots__/dialog.stories.storyshot
@@ -375,17 +375,17 @@ exports[`Storyshots Components/Dialog Select Dialog Example 1`] = `
                 
           </li>
           
-                
-          <li
-            class="fd-list__footer"
-          >
-            
-                    2 items selected
-                
-          </li>
-          
             
         </ul>
+          
+                
+        <span
+          class="fd-list__footer"
+        >
+          
+                  2 items selected
+              
+        </span>
         
         
       </div>

--- a/stories/dialog/dialog.stories.js
+++ b/stories/dialog/dialog.stories.js
@@ -370,10 +370,10 @@ export const selectDialogExample = () => `
                 <li class="fd-list__item">
                     <span class="fd-list__title">List item 6</span>
                 </li>
-                <li class="fd-list__footer">
-                    2 items selected
-                </li>
             </ul>
+            <span class="fd-list__footer">
+                2 items selected
+            </span>
         </div>
         <footer class="fd-dialog__footer fd-bar fd-bar--footer">
             <div class="fd-bar__right">

--- a/stories/list/standard/standard-list.stories.js
+++ b/stories/list/standard/standard-list.stories.js
@@ -298,10 +298,10 @@ export const footer = () => `
   <li role="listitem" tabindex="0" class="fd-list__item">
       <span class="fd-list__title">List item 4</span>
   </li>
-  <li role="listitem" class="fd-list__footer">
-    Footer text
-  </li>
 </ul>
+<span class="fd-list__footer">
+  Footer text
+</span>
 `;
 
 footer.storyName = 'Footer';
@@ -309,7 +309,7 @@ footer.storyName = 'Footer';
 footer.parameters = {
     docs: {
         iframeHeight: 240,
-        storyDescription: 'To create list footer, create list element with `fd-list__footer` class.'
+        storyDescription: 'To create list footer, add a span element with `fd-list__footer` class, after the unordered list element'
     }
 };
 

--- a/stories/multi-input/multi-input.stories.js
+++ b/stories/multi-input/multi-input.stories.js
@@ -815,10 +815,10 @@ export const filtering = () => `
                     </span>
                 </label>
             </li>
-            <li class="fd-list__footer">
-              <a class="fd-link" href="#">Show All</a>
-            </li>
         </ul>
+        <span class="fd-list__footer">
+          <a class="fd-link" href="#">Show All</a>
+        </span>
     </div>
 </div>
 `;


### PR DESCRIPTION
## Related Issue
Closes #1396 

## Description
In this change, we update the List's markup so that the List's footer is no longer a list item. The footer appears as a span after the unordered list.

## Screenshots
No visual changes