### PR TITLE
chore: Fix storybook main content overlapping

### DIFF
--- a/.storybook/custom/custom.scss
+++ b/.storybook/custom/custom.scss
@@ -4,12 +4,6 @@ body {
   padding: 0;
 }
 
-/* override storybook max width */
-.sbdocs.sbdocs-content {
-  width: 100%;
-  max-width: none;
-}
-
 /* fix bug in storybook@6 where toolbar height is hardcoded - causes scrollbar  */
 a[title='Open canvas in new tab'] {
   height: 34px;

--- a/.storybook/custom/custom.scss
+++ b/.storybook/custom/custom.scss
@@ -9,6 +9,10 @@ a[title='Open canvas in new tab'] {
   height: 34px;
 }
 
+.sbdocs.sbdocs-content {
+  max-width: 85%;
+}
+
 /* make room for TOCBot */
 @media (min-width: 1024px) {
   .sbdocs.sbdocs-content {


### PR DESCRIPTION
## Description
After update of the storybook to `6.0.5` our custom styling has started breaking storybook layout. Breaking styling has been removed.

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/17496353/90633758-e5303d80-e226-11ea-89c1-a4860d59cad4.png)

### After:
![image](https://user-images.githubusercontent.com/17496353/90633519-76eb7b00-e226-11ea-96a2-960ad7cc69bb.png)


#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
