### PR TITLE
fix: button move focus indicator

### DIFF
--- a/src/button.scss
+++ b/src/button.scss
@@ -63,6 +63,7 @@ $block: #{$fd-namespace}-button;
   min-width: $fd-button-min-width;
   overflow: hidden;
   text-overflow: ellipsis;
+  position: relative;
 
   @include iconSize($fd-button-icon-font-size);
 

--- a/src/mixins/button/_attention.scss
+++ b/src/mixins/button/_attention.scss
@@ -23,7 +23,9 @@
 }
 
 @mixin attentionPressedFocus() {
-  outline-color: var(--sapContent_ContrastFocusColor);
+  &::after {
+    border-color: var(--sapContent_ContrastFocusColor);
+  }
 }
 
 @mixin attentionFocus() {

--- a/src/mixins/button/_button-helper.scss
+++ b/src/mixins/button/_button-helper.scss
@@ -7,10 +7,11 @@ $block: #{$fd-namespace}-button;
 }
 
 @mixin buttonFocus() {
-  $fd-focus-offset: -0.1875rem;
+  $fd-focus-offset: 0.125rem;
 
   &::after {
     content: "";
+    position: absolute;
     width: auto;
     height: auto;
     top: $fd-focus-offset;

--- a/src/mixins/button/_button-helper.scss
+++ b/src/mixins/button/_button-helper.scss
@@ -7,8 +7,16 @@ $block: #{$fd-namespace}-button;
 }
 
 @mixin buttonFocus() {
-  outline-style: dotted;
-  outline-width: var(--sapContent_FocusWidth);
-  outline-color: var(--sapContent_FocusColor);
-  outline-offset: -0.1875rem;
+  $fd-focus-offset: -0.1875rem;
+
+  &::after {
+    content: "";
+    width: auto;
+    height: auto;
+    top: $fd-focus-offset;
+    left: $fd-focus-offset;
+    right: $fd-focus-offset;
+    bottom: $fd-focus-offset;
+    border: var(--sapContent_FocusWidth) dotted var(--sapContent_FocusColor);
+  }
 }

--- a/src/mixins/button/_emphasized.scss
+++ b/src/mixins/button/_emphasized.scss
@@ -23,7 +23,9 @@
 }
 
 @mixin emphasizedPressedFocus() {
-  outline-color: var(--sapContent_ContrastFocusColor);
+  &::after {
+    border-color: var(--sapContent_ContrastFocusColor);
+  }
 }
 
 @mixin emphasizedFocus() {

--- a/src/mixins/button/_ghost.scss
+++ b/src/mixins/button/_ghost.scss
@@ -19,7 +19,9 @@
 }
 
 @mixin ghostPressedFocus() {
-  outline-color: var(--sapContent_ContrastFocusColor);
+  &::after {
+    border-color: var(--sapContent_ContrastFocusColor);
+  }
 }
 
 @mixin ghostFocus() {

--- a/src/mixins/button/_negative.scss
+++ b/src/mixins/button/_negative.scss
@@ -23,7 +23,9 @@
 }
 
 @mixin negativePressedFocus() {
-  outline-color: var(--sapContent_ContrastFocusColor);
+  &::after {
+    border-color: var(--sapContent_ContrastFocusColor);
+  }
 }
 
 @mixin negativeFocus() {

--- a/src/mixins/button/_positive.scss
+++ b/src/mixins/button/_positive.scss
@@ -23,7 +23,9 @@
 }
 
 @mixin positivePressedFocus() {
-  outline-color: var(--sapContent_ContrastFocusColor);
+  &::after {
+    border-color: var(--sapContent_ContrastFocusColor);
+  }
 }
 
 @mixin positiveFocus() {

--- a/src/mixins/button/_standard.scss
+++ b/src/mixins/button/_standard.scss
@@ -19,7 +19,9 @@
 }
 
 @mixin standardPressedFocus() {
-  outline-color: var(--sapContent_ContrastFocusColor);
+  &::after {
+    border-color: var(--sapContent_ContrastFocusColor);
+  }
 }
 
 @mixin standardFocus() {


### PR DESCRIPTION
## Description
There is moved button focus indicator. From outline to ::after pseudo element with proper offset.

#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
