### PR TITLE
fix: update navigation buttons of Carousel

### DIFF
--- a/src/carousel.scss
+++ b/src/carousel.scss
@@ -7,6 +7,8 @@ $button: #{$fd-namespace}-button;
 .#{$block} {
   $fd-carousel-page-indicator-border: 0.0625rem solid var(--sapPageFooter_BorderColor) !default;
   $fd-carousel-button-size: 2.125rem !default;
+  $fd-carousel-touchable-button-size: 2.625rem !default;
+  $fd-carousel-button-focus-outline-offset: -0.125rem !default;
   $fd-carousel-button-content-offset: 0.5rem !default;
   $fd-carousel-dot-size: 0.25rem !default;
   $fd-carousel-dot-active-size: 0.5rem !default;
@@ -34,7 +36,7 @@ $button: #{$fd-namespace}-button;
       top: calc(50%);
       transform: translateY(-50%);
 
-      &.sap-icon--slim-arrow-left {
+      &.#{$block}__button--left {
         left: $fd-carousel-button-content-offset;
 
         @include fd-rtl() {
@@ -43,7 +45,7 @@ $button: #{$fd-namespace}-button;
         }
       }
 
-      &.sap-icon--slim-arrow-right {
+      &.#{$block}__button--right {
         right: $fd-carousel-button-content-offset;
 
         @include fd-rtl() {
@@ -132,19 +134,26 @@ $button: #{$fd-namespace}-button;
     box-shadow: none;
     margin: 0.25rem;
 
-    &[class*=sap-icon]::before {
-      display: inline-block;
-      margin: 0;
+    &::before {
+      left: -0.25rem;
+      right: -0.25rem;
+      height: $fd-carousel-touchable-button-size;
+      width: $fd-carousel-touchable-button-size;
     }
 
     @include fd-rtl() {
-      &[class*=sap-icon]::before {
+      & > [class*=sap-icon] {
         transform: rotate(180deg);
       }
     }
 
     @include fd-focus() {
-      outline-offset: 0;
+      &::after {
+        top: $fd-carousel-button-focus-outline-offset;
+        bottom: $fd-carousel-button-focus-outline-offset;
+        left: $fd-carousel-button-focus-outline-offset;
+        right: $fd-carousel-button-focus-outline-offset;
+      }
     }
   }
 

--- a/stories/carousel/carousel.stories.js
+++ b/stories/carousel/carousel.stories.js
@@ -41,9 +41,10 @@ export const carouselBottom = () => `
         <div class="fd-carousel__content" style="min-height: 15.5rem;"></div>
         <div class="fd-carousel__page-indicator-container">
             <button 
-                class="fd-button fd-carousel__button sap-icon--slim-arrow-left"
+                class="fd-button fd-carousel__button fd-carousel__button--left"
                 data-slide="prev"
                 aria-label="Go to previous item">
+                <i class="sap-icon--slim-arrow-left"></i>
             </button>
             <ol class="fd-carousel__page-indicators">
                 <li 
@@ -70,9 +71,10 @@ export const carouselBottom = () => `
                     class="fd-carousel__page-indicator"></li>
             </ol>
             <button 
-                class="fd-button fd-carousel__button sap-icon--slim-arrow-right"
+                class="fd-button fd-carousel__button fd-carousel__button--right"
                 data-slide="next"
                 aria-label="Go to next item">
+                <i class="sap-icon--slim-arrow-right"></i>
             </button>
         </div>
     </div>
@@ -87,14 +89,16 @@ export const carouselBottom = () => `
         style="margin-bottom: 3rem; max-width: 30rem;">
         <div class="fd-carousel__content" style="min-height: 15.5rem;">
             <button 
-                class="fd-button fd-carousel__button sap-icon--slim-arrow-left"
+                class="fd-button fd-carousel__button fd-carousel__button--left"
                 data-slide="prev"
                 aria-label="Go to previous item">
+                <i class="sap-icon--slim-arrow-left"></i>
             </button>
             <button 
-                class="fd-button fd-carousel__button sap-icon--slim-arrow-right"
+                class="fd-button fd-carousel__button fd-carousel__button--right"
                 data-slide="next"
                 aria-label="Go to next item">
+                <i class="sap-icon--slim-arrow-right"></i>
             </button>
         </div>
         <div class="fd-carousel__page-indicator-container">
@@ -135,17 +139,19 @@ export const carouselBottom = () => `
         <div class="fd-carousel__content" style="min-height: 15.5rem;"></div>
         <div class="fd-carousel__page-indicator-container">
             <button 
-                class="fd-button fd-carousel__button sap-icon--slim-arrow-left"
+                class="fd-button fd-carousel__button fd-carousel__button--left"
                 data-slide="prev"
                 aria-label="Go to previous item">
+                <i class="sap-icon--slim-arrow-left"></i>
             </button>
             <div class="fd-carousel__page-indicators">
                 <div class="fd-carousel__text">1 of 4</div>
             </div>
             <button 
-                class="fd-button fd-carousel__button sap-icon--slim-arrow-right"
+                class="fd-button fd-carousel__button fd-carousel__button--right"
                 data-slide="next"
                 aria-label="Go to next item">
+                <i class="sap-icon--slim-arrow-right"></i>
             </button>
         </div>
     </div>
@@ -160,14 +166,16 @@ export const carouselBottom = () => `
         style="margin-bottom: 3rem; max-width: 30rem;">
         <div class="fd-carousel__content" style="min-height: 15.5rem;">
             <button 
-                class="fd-button fd-carousel__button sap-icon--slim-arrow-left"
+                class="fd-button fd-carousel__button fd-carousel__button--left"
                 data-slide="prev"
                 aria-label="Go to previous item">
+                <i class="sap-icon--slim-arrow-left"></i>
             </button>
             <button 
-                class="fd-button fd-carousel__button sap-icon--slim-arrow-right"
+                class="fd-button fd-carousel__button fd-carousel__button--right"
                 data-slide="next"
                 aria-label="Go to next item">
+                <i class="sap-icon--slim-arrow-right"></i>
             </button>
         </div>
     </div>
@@ -195,9 +203,10 @@ export const carouselTop = () => `
         style="margin-bottom: 3rem; max-width: 30rem;">
         <div class="fd-carousel__page-indicator-container">
             <button 
-                class="fd-button fd-carousel__button sap-icon--slim-arrow-left"
+                class="fd-button fd-carousel__button fd-carousel__button--left"
                 data-slide="prev"
                 aria-label="Go to previous item">
+                <i class="sap-icon--slim-arrow-left"></i>
             </button>
             <ol class="fd-carousel__page-indicators">
                 <li 
@@ -223,9 +232,10 @@ export const carouselTop = () => `
                     class="fd-carousel__page-indicator"></li>
             </ol>
             <button 
-                class="fd-button fd-carousel__button sap-icon--slim-arrow-right"
+                class="fd-button fd-carousel__button fd-carousel__button--right"
                 data-slide="next"
                 aria-label="Go to next item">
+                <i class="sap-icon--slim-arrow-right"></i>
             </button>
         </div>
         <div class="fd-carousel__content" style="min-height: 15.5rem;"></div>
@@ -266,14 +276,16 @@ export const carouselTop = () => `
         </div>
         <div class="fd-carousel__content" style="min-height: 15.5rem;">
            <button 
-                class="fd-button fd-carousel__button sap-icon--slim-arrow-left"
+                class="fd-button fd-carousel__button fd-carousel__button--left"
                 data-slide="prev"
                 aria-label="Go to previous item">
+                <i class="sap-icon--slim-arrow-left"></i>
             </button>
            <button 
-                class="fd-button fd-carousel__button sap-icon--slim-arrow-right"
+                class="fd-button fd-carousel__button fd-carousel__button--right"
                 data-slide="next"
                 aria-label="Go to next item">
+                <i class="sap-icon--slim-arrow-right"></i>
             </button>
         </div>
     </div>
@@ -293,14 +305,16 @@ export const carouselTop = () => `
         </div>
         <div class="fd-carousel__content" style="min-height: 15.5rem;">
             <button 
-                class="fd-button fd-carousel__button sap-icon--slim-arrow-left"
+                class="fd-button fd-carousel__button fd-carousel__button--left"
                 data-slide="prev"
                 aria-label="Go to previous item">
+                <i class="sap-icon--slim-arrow-left"></i>
             </button>
             <button 
-                class="fd-button fd-carousel__button sap-icon--slim-arrow-right"
+                class="fd-button fd-carousel__button fd-carousel__button--right"
                 data-slide="next"
                 aria-label="Go to next item">
+                <i class="sap-icon--slim-arrow-right"></i>
             </button>
         </div>
     </div>
@@ -315,15 +329,17 @@ export const carouselTop = () => `
         style="margin-bottom: 3rem; max-width: 30rem;">
         <div class="fd-carousel__page-indicator-container">
             <button 
-                class="fd-button fd-carousel__button sap-icon--slim-arrow-left"
+                class="fd-button fd-carousel__button fd-carousel__button--left"
                 data-slide="prev"
                 aria-label="Go to previous item">
+                <i class="sap-icon--slim-arrow-left"></i>
             </button>
             <ol class="fd-carousel__page-indicators"></ol>
             <button 
-                class="fd-button fd-carousel__button sap-icon--slim-arrow-right"
+                class="fd-button fd-carousel__button fd-carousel__button--right"
                 data-slide="next"
                 aria-label="Go to next item">
+                <i class="sap-icon--slim-arrow-right"></i>
             </button>
         </div>
         <div class="fd-carousel__content" style="text-align: center; padding: 1rem; min-height: 15.5rem;">
@@ -367,9 +383,10 @@ export const carouselNoNavigation = () => `
         <div class="fd-carousel__content" style="min-height: 15.5rem;"></div>
         <div class="fd-carousel__page-indicator-container">
             <button 
-                class="fd-button fd-carousel__button sap-icon--slim-arrow-left"
+                class="fd-button fd-carousel__button fd-carousel__button--left"
                 data-slide="prev"
                 aria-label="Go to previous item">
+                <i class="sap-icon--slim-arrow-left"></i>
             </button>
             <ol class="fd-carousel__page-indicators">
                 <li 
@@ -396,9 +413,10 @@ export const carouselNoNavigation = () => `
                     class="fd-carousel__page-indicator"></li>
             </ol>
             <button 
-                class="fd-button fd-carousel__button sap-icon--slim-arrow-right"
+                class="fd-button fd-carousel__button fd-carousel__button--right"
                 data-slide="next"
                 aria-label="Go to next item">
+                <i class="sap-icon--slim-arrow-right"></i>
             </button>
         </div>
     </div>
@@ -438,21 +456,22 @@ export const carouselNoNavigation = () => `
         </div>
         <div class="fd-carousel__content" style="min-height: 15.5rem;">
            <button 
-                class="fd-button fd-carousel__button sap-icon--slim-arrow-left"
+                class="fd-button fd-carousel__button fd-carousel__button--left"
                 data-slide="prev"
                 aria-label="Go to previous item">
+                <i class="sap-icon--slim-arrow-left"></i>
             </button>
            <button 
-                class="fd-button fd-carousel__button sap-icon--slim-arrow-right"
+                class="fd-button fd-carousel__button fd-carousel__button--right"
                 data-slide="next"
                 aria-label="Go to next item">
+                <i class="sap-icon--slim-arrow-right"></i>
             </button>
         </div>
     </div>
     <div style="display: none;" role="region" id="carousel-6" aria-live="polite">
         Displaying item 1 of 4
     </div>
-
 </div>
 `;
 


### PR DESCRIPTION
## Description
The Button markup has changes so the Navigation buttons of the Carousel have to be updated with the latest markup. Also, additional modifier classes are introduced for the left and right button to place the buttons inside the content according to the specs.
- update the markup of the buttons to use `<i class="sap-icon--slim-arrow-left"></i>` and `<i class="sap-icon--slim-arrow-right"></i>`
- introduce additional modifier classes - `fd-carousel__button--left` and `fd-carousel__button--right`

