### PR TITLE
feat: focusable table cells and rows

### DIFF
--- a/src/table.scss
+++ b/src/table.scss
@@ -277,6 +277,10 @@ $block: #{$fd-namespace}-table;
     &--activable {
       @include fd-trigger-element();
     }
+
+    &--focusable {
+      @include fd-fiori-focus();
+    }
   }
 
   &__footer {

--- a/stories/table/table.stories.js
+++ b/stories/table/table.stories.js
@@ -334,6 +334,98 @@ export const interactiveRowsAndColumns = () => `
 interactiveRowsAndColumns.storyName = 'Interactive Table With Hoverable and Activable Cells and Rows';
 
 /**
+ * A table can be set to have focusable rows by adding `fd-table__row--focusable` and a valid `tabindex` to the rows.
+ * It is not recommended to use focusable rows simultaneously with focusable cells.
+ */
+
+export const focusableRows = () => `
+<div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
+    <h4 style="margin: 0;">Table With Focusable Rows</h4>
+    <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
+</div>
+<table class="fd-table">
+    <thead class="fd-table__header">
+        <tr class="fd-table__row fd-table__row--focusable" tabindex="-1">
+            <th class="fd-table__cell" scope="col">Column Header</th>
+            <th class="fd-table__cell" scope="col">Column Header</th>
+            <th class="fd-table__cell" scope="col">Column Header</th>
+            <th class="fd-table__cell" scope="col">Column Header</th>
+            <th class="fd-table__cell" scope="col">Column Header</th>
+        </tr>
+    </thead>
+    <tbody class="fd-table__body">
+        <tr class="fd-table__row fd-table__row--focusable" tabindex="-1">
+            <td class="fd-table__cell"><a class="fd-link">user.name@email.com</a></td>
+            <td class="fd-table__cell">First Name</td>
+            <td class="fd-table__cell">Middle Name</td>
+            <td class="fd-table__cell">Last Name</td>
+            <td class="fd-table__cell">01/26/17</td>
+        </tr>
+        <tr class="fd-table__row fd-table__row--focusable" tabindex="-1">
+            <td class="fd-table__cell"><a class="fd-link">user.name@email.com</a></td>
+            <td class="fd-table__cell">First Name</td>
+            <td class="fd-table__cell">Middle Name</td>
+            <td class="fd-table__cell">Last Name</td>
+            <td class="fd-table__cell">01/26/17</td>
+        </tr>
+        <tr class="fd-table__row fd-table__row--focusable" tabindex="-1">
+            <td class="fd-table__cell"><a class="fd-link">user.name@email.com</a></td>
+            <td class="fd-table__cell">First Name</td>
+            <td class="fd-table__cell">Middle Name</td>
+            <td class="fd-table__cell">Last Name</td>
+            <td class="fd-table__cell">01/26/17</td>
+        </tr>
+    </tbody>
+</table>
+`;
+
+/**
+ * A table can be set to have focusable cells by adding `fd-table__row--focusable` and a valid `tabindex` to the cells.
+ * It is not recommended to use focusable cells simultaneously with focusable rows.
+ */
+
+export const focusableCells = () => `
+<div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
+    <h4 style="margin: 0;">Table With Focusable Cells</h4>
+    <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
+</div>
+<table class="fd-table">
+    <thead class="fd-table__header">
+        <tr class="fd-table__row">
+            <th class="fd-table__cell fd-table__cell--focusable" tabindex="-1" scope="col">Column Header</th>
+            <th class="fd-table__cell fd-table__cell--focusable" tabindex="-1" scope="col">Column Header</th>
+            <th class="fd-table__cell fd-table__cell--focusable" tabindex="-1" scope="col">Column Header</th>
+            <th class="fd-table__cell fd-table__cell--focusable" tabindex="-1" scope="col">Column Header</th>
+            <th class="fd-table__cell fd-table__cell--focusable" tabindex="-1" scope="col">Column Header</th>
+        </tr>
+    </thead>
+    <tbody class="fd-table__body">
+        <tr class="fd-table__row">
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1"><a class="fd-link">user.name@email.com</a></td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">First Name</td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">Middle Name</td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">Last Name</td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">01/26/17</td>
+        </tr>
+        <tr class="fd-table__row">
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1"><a class="fd-link">user.name@email.com</a></td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">First Name</td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">Middle Name</td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">Last Name</td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">01/26/17</td>
+        </tr>
+        <tr class="fd-table__row">
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1"><a class="fd-link">user.name@email.com</a></td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">First Name</td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">Middle Name</td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">Last Name</td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">01/26/17</td>
+        </tr>
+    </tbody>
+</table>
+`;
+
+/**
  * The checkbox input can be used at the beginning of each row to allow for bulk actions.
 It is recommended to add the parameter `aria-selected="true"` to the row that is selected.
 Also for cells that include a checkbox should contain the `fd-table__cell--checkbox` class.

--- a/stories/table/table.stories.js
+++ b/stories/table/table.stories.js
@@ -1476,7 +1476,7 @@ export const navigationIndicationStates = () => `
             <td class="fd-table__cell">First Name</td>
             <td class="fd-table__cell">Last Name</td>
             <td class="fd-table__cell">01/26/17</td>
-            <td class="fd-table__cell fd-table__cell--fit-content" scope="col">
+            <td class="fd-table__cell fd-table__cell--fit-content">
                 <button aria-label="navigation" class="fd-button fd-button--transparent">
                     <i class="sap-icon--navigation-right-arrow"></i>
                 </button>
@@ -1487,7 +1487,7 @@ export const navigationIndicationStates = () => `
             <td class="fd-table__cell">First Name</td>
             <td class="fd-table__cell">Last Name</td>
             <td class="fd-table__cell">01/26/17</td>
-            <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--navigated" scope="col">
+            <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--navigated">
                 <button aria-label="navigation" class="fd-button fd-button--transparent">
                     <i class="sap-icon--navigation-right-arrow"></i>
                 </button>
@@ -1498,7 +1498,7 @@ export const navigationIndicationStates = () => `
             <td class="fd-table__cell">First Name</td>
             <td class="fd-table__cell">Last Name</td>
             <td class="fd-table__cell">01/26/17</td>
-            <td class="fd-table__cell fd-table__cell--fit-content" scope="col">
+            <td class="fd-table__cell fd-table__cell--fit-content">
                 <button aria-label="navigation" class="fd-button fd-button--transparent">
                     <i class="sap-icon--navigation-right-arrow"></i>
                 </button>
@@ -1528,7 +1528,7 @@ export const navigationIndicationStates = () => `
                 <td class="fd-table__cell">First Name</td>
                 <td class="fd-table__cell">Last Name</td>
                 <td class="fd-table__cell">01/26/17</td>
-                <td class="fd-table__cell fd-table__cell--fit-content" scope="col">
+                <td class="fd-table__cell fd-table__cell--fit-content">
                     <button aria-label="navigation" class="fd-button fd-button--transparent">
                         <i class="sap-icon--navigation-left-arrow"></i>
                     </button>
@@ -1539,7 +1539,7 @@ export const navigationIndicationStates = () => `
                 <td class="fd-table__cell">First Name</td>
                 <td class="fd-table__cell">Last Name</td>
                 <td class="fd-table__cell">01/26/17</td>
-                <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--navigated" scope="col">
+                <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--navigated">
                     <button aria-label="navigation" class="fd-button fd-button--transparent">
                         <i class="sap-icon--navigation-left-arrow"></i>
                     </button>
@@ -1550,7 +1550,7 @@ export const navigationIndicationStates = () => `
                 <td class="fd-table__cell">First Name</td>
                 <td class="fd-table__cell">Last Name</td>
                 <td class="fd-table__cell">01/26/17</td>
-                <td class="fd-table__cell fd-table__cell--fit-content" scope="col">
+                <td class="fd-table__cell fd-table__cell--fit-content">
                     <button aria-label="navigation" class="fd-button fd-button--transparent">
                         <i class="sap-icon--navigation-left-arrow"></i>
                     </button>

--- a/stories/table/table.stories.js
+++ b/stories/table/table.stories.js
@@ -343,7 +343,7 @@ export const focusableRows = () => `
     <h4 style="margin: 0;">Table With Focusable Rows</h4>
     <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
 </div>
-<table class="fd-table">
+<table class="fd-table" role="grid">
     <thead class="fd-table__header">
         <tr class="fd-table__row fd-table__row--focusable" tabindex="-1">
             <th class="fd-table__cell" scope="col">Column Header</th>
@@ -355,25 +355,25 @@ export const focusableRows = () => `
     </thead>
     <tbody class="fd-table__body">
         <tr class="fd-table__row fd-table__row--focusable" tabindex="-1">
-            <td class="fd-table__cell"><a class="fd-link">user.name@email.com</a></td>
-            <td class="fd-table__cell">First Name</td>
-            <td class="fd-table__cell">Middle Name</td>
-            <td class="fd-table__cell">Last Name</td>
-            <td class="fd-table__cell">01/26/17</td>
+            <td class="fd-table__cell" role="gridcell"><a class="fd-link">user.name@email.com</a></td>
+            <td class="fd-table__cell" role="gridcell">First Name</td>
+            <td class="fd-table__cell" role="gridcell">Middle Name</td>
+            <td class="fd-table__cell" role="gridcell">Last Name</td>
+            <td class="fd-table__cell" role="gridcell">01/26/17</td>
         </tr>
         <tr class="fd-table__row fd-table__row--focusable" tabindex="-1">
-            <td class="fd-table__cell"><a class="fd-link">user.name@email.com</a></td>
-            <td class="fd-table__cell">First Name</td>
-            <td class="fd-table__cell">Middle Name</td>
-            <td class="fd-table__cell">Last Name</td>
-            <td class="fd-table__cell">01/26/17</td>
+            <td class="fd-table__cell" role="gridcell"><a class="fd-link">user.name@email.com</a></td>
+            <td class="fd-table__cell" role="gridcell">First Name</td>
+            <td class="fd-table__cell" role="gridcell">Middle Name</td>
+            <td class="fd-table__cell" role="gridcell">Last Name</td>
+            <td class="fd-table__cell" role="gridcell">01/26/17</td>
         </tr>
         <tr class="fd-table__row fd-table__row--focusable" tabindex="-1">
-            <td class="fd-table__cell"><a class="fd-link">user.name@email.com</a></td>
-            <td class="fd-table__cell">First Name</td>
-            <td class="fd-table__cell">Middle Name</td>
-            <td class="fd-table__cell">Last Name</td>
-            <td class="fd-table__cell">01/26/17</td>
+            <td class="fd-table__cell" role="gridcell"><a class="fd-link">user.name@email.com</a></td>
+            <td class="fd-table__cell" role="gridcell">First Name</td>
+            <td class="fd-table__cell" role="gridcell">Middle Name</td>
+            <td class="fd-table__cell" role="gridcell">Last Name</td>
+            <td class="fd-table__cell" role="gridcell">01/26/17</td>
         </tr>
     </tbody>
 </table>
@@ -389,37 +389,37 @@ export const focusableCells = () => `
     <h4 style="margin: 0;">Table With Focusable Cells</h4>
     <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
 </div>
-<table class="fd-table">
+<table class="fd-table" role="grid">
     <thead class="fd-table__header">
         <tr class="fd-table__row">
-            <th class="fd-table__cell fd-table__cell--focusable" tabindex="-1" scope="col">Column Header</th>
-            <th class="fd-table__cell fd-table__cell--focusable" tabindex="-1" scope="col">Column Header</th>
-            <th class="fd-table__cell fd-table__cell--focusable" tabindex="-1" scope="col">Column Header</th>
-            <th class="fd-table__cell fd-table__cell--focusable" tabindex="-1" scope="col">Column Header</th>
-            <th class="fd-table__cell fd-table__cell--focusable" tabindex="-1" scope="col">Column Header</th>
+            <th class="fd-table__cell fd-table__cell--focusable" role="gridcell" tabindex="-1" scope="col">Column Header</th>
+            <th class="fd-table__cell fd-table__cell--focusable" role="gridcell" tabindex="-1" scope="col">Column Header</th>
+            <th class="fd-table__cell fd-table__cell--focusable" role="gridcell" tabindex="-1" scope="col">Column Header</th>
+            <th class="fd-table__cell fd-table__cell--focusable" role="gridcell" tabindex="-1" scope="col">Column Header</th>
+            <th class="fd-table__cell fd-table__cell--focusable" role="gridcell" tabindex="-1" scope="col">Column Header</th>
         </tr>
     </thead>
     <tbody class="fd-table__body">
         <tr class="fd-table__row">
-            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1"><a class="fd-link">user.name@email.com</a></td>
-            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">First Name</td>
-            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">Middle Name</td>
-            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">Last Name</td>
-            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">01/26/17</td>
+            <td class="fd-table__cell fd-table__cell--focusable" role="gridcell" tabindex="-1"><a class="fd-link">user.name@email.com</a></td>
+            <td class="fd-table__cell fd-table__cell--focusable" role="gridcell" tabindex="-1">First Name</td>
+            <td class="fd-table__cell fd-table__cell--focusable" role="gridcell" tabindex="-1">Middle Name</td>
+            <td class="fd-table__cell fd-table__cell--focusable" role="gridcell" tabindex="-1">Last Name</td>
+            <td class="fd-table__cell fd-table__cell--focusable" role="gridcell" tabindex="-1">01/26/17</td>
         </tr>
         <tr class="fd-table__row">
-            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1"><a class="fd-link">user.name@email.com</a></td>
-            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">First Name</td>
-            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">Middle Name</td>
-            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">Last Name</td>
-            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">01/26/17</td>
+            <td class="fd-table__cell fd-table__cell--focusable" role="gridcell" tabindex="-1"><a class="fd-link">user.name@email.com</a></td>
+            <td class="fd-table__cell fd-table__cell--focusable" role="gridcell" tabindex="-1">First Name</td>
+            <td class="fd-table__cell fd-table__cell--focusable" role="gridcell" tabindex="-1">Middle Name</td>
+            <td class="fd-table__cell fd-table__cell--focusable" role="gridcell" tabindex="-1">Last Name</td>
+            <td class="fd-table__cell fd-table__cell--focusable" role="gridcell" tabindex="-1">01/26/17</td>
         </tr>
         <tr class="fd-table__row">
-            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1"><a class="fd-link">user.name@email.com</a></td>
-            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">First Name</td>
-            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">Middle Name</td>
-            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">Last Name</td>
-            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">01/26/17</td>
+            <td class="fd-table__cell fd-table__cell--focusable" role="gridcell" tabindex="-1"><a class="fd-link">user.name@email.com</a></td>
+            <td class="fd-table__cell fd-table__cell--focusable" role="gridcell" tabindex="-1">First Name</td>
+            <td class="fd-table__cell fd-table__cell--focusable" role="gridcell" tabindex="-1">Middle Name</td>
+            <td class="fd-table__cell fd-table__cell--focusable" role="gridcell" tabindex="-1">Last Name</td>
+            <td class="fd-table__cell fd-table__cell--focusable" role="gridcell" tabindex="-1">01/26/17</td>
         </tr>
     </tbody>
 </table>


### PR DESCRIPTION
## Description

- Add `--focusable` modifier for table cells and rows to add a focus ring when focused. This would be used when implementing [row-level](https://openui5.hana.ondemand.com/entity/sap.m.Table/sample/sap.m.sample.TableVerticalAlignment) or [cell-level](https://openui5.hana.ondemand.com/entity/sap.ui.table.Table/sample/sap.ui.table.sample.Basic) navigation.

## Screenshots
![Screen Shot 2020-09-01 at 3 20 50 PM](https://user-images.githubusercontent.com/22511993/91911845-c25e4a00-ec66-11ea-807c-dd1179942341.png)
![Screen Shot 2020-09-01 at 3 20 58 PM](https://user-images.githubusercontent.com/22511993/91911847-c38f7700-ec66-11ea-87d6-43342e432cca.png)


#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
