### PR TITLE
fix: Add spacing for list selection

### DIFF
--- a/src/_listDefinitions.scss
+++ b/src/_listDefinitions.scss
@@ -34,6 +34,7 @@ $fd-list-byline-form-item-label-top-offset: 0.375rem !default;
 
 $fd-list-selection-container-width: 2.75rem !default;
 $fd-list-selection-container-compact-width: 2rem !default;
+$fd-list-selection-form-item-compact-left-offset: 0.375rem !default;
 
 $fd-list-navigation-indicator-width: 2.5rem !default;
 $fd-list-navigation-navigator-bar-right: inset -0.1875rem 0 0 0 var(--sapSelectedColor);

--- a/src/_listDefinitions.scss
+++ b/src/_listDefinitions.scss
@@ -33,7 +33,6 @@ $fd-list-byline-form-item-left-offset: 0.375rem !default;
 $fd-list-byline-form-item-label-top-offset: 0.375rem !default;
 
 $fd-list-selection-container-width: 2.75rem !default;
-$fd-list-selection-container-compact-width: 2rem !default;
 $fd-list-selection-form-item-compact-left-offset: 0.375rem !default;
 
 $fd-list-navigation-indicator-width: 2.5rem !default;

--- a/src/_listNavigation.scss
+++ b/src/_listNavigation.scss
@@ -24,26 +24,12 @@
       }
     }
 
-    // NAVIGATION + SELECTION + Compact
-    &.#{$block}--selection.#{$block}--compact {
-      .#{$block}__link {
-        @include padding-left-right($fd-list-selection-container-compact-width, $fd-list-item-padding-x);
-      }
-    }
-
     // NAVIGATION + SELECTION + Navigation Indication
     &.#{$block}--selection.#{$block}--navigation-indication {
       @include reset-list-item-paddings();
 
       .#{$block}__link {
         @include padding-left-right($fd-list-selection-container-width, 0);
-      }
-    }
-
-    // NAVIGATION + SELECTION + NAVIGATION INDICATION + Compact
-    &.#{$block}--selection.#{$block}--navigation-indication.#{$block}--compact {
-      .#{$block}__link {
-        @include padding-left-right($fd-list-selection-container-compact-width, 0);
       }
     }
 

--- a/src/_listSelection.scss
+++ b/src/_listSelection.scss
@@ -32,8 +32,13 @@ $block: #{$fd-namespace}-list;
 
     // SELECTION + Compact
     &.#{$block}--compact {
-      .#{$block}__item {
-        @include padding-left-right($fd-list-selection-container-compact-width, $fd-list-item-padding-x);
+      .#{$block}__form-item {
+        left: $fd-list-selection-form-item-compact-left-offset;
+
+        @include fd-rtl() {
+          left: initial;
+          right: $fd-list-selection-form-item-compact-left-offset;
+        }
       }
     }
 


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/1544

## Description
There is increased padding for selection list, on compact mode.

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/26483208/92005433-c613ce80-ed43-11ea-985a-dccfb6e84050.png)


### After:
![image](https://user-images.githubusercontent.com/26483208/92005914-58b46d80-ed44-11ea-99c4-67e6f31a925e.png)

Selection + Navigation:
![image](https://user-images.githubusercontent.com/26483208/92242423-08fab100-eec0-11ea-8e06-aafe4acebae4.png)


#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
