### PR TITLE
fix: padding fix for compact radio button

### DIFF
--- a/src/mixins/_forms.scss
+++ b/src/mixins/_forms.scss
@@ -137,13 +137,6 @@
 
   outline: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
   outline-offset: $fd-radio-focus-offset - $margin;
-
-  @include fd-rtl() {
-    &::after {
-      left: $fd-radio-label-padding;
-      right: $margin - $fd-radio-focus-offset;
-    }
-  }
 }
 
 @mixin fd-form-radio-empty-focus($margin) {

--- a/src/radio.scss
+++ b/src/radio.scss
@@ -156,7 +156,7 @@ $block: #{$fd-namespace}-radio;
         min-width: $fd-radio-inner-circle-diameter-compact;
         margin-right: $fd-radio-outer-circle-margin-compact;
         margin-left: 0;
-        padding-left: 0;
+        padding-left: $fd-radio-inner-circle-padding-x;
         padding-top: 0;
       }
 
@@ -165,7 +165,7 @@ $block: #{$fd-namespace}-radio;
           margin-left: $fd-radio-outer-circle-margin-compact;
           margin-right: 0;
           padding-left: 0;
-          padding-right: 0;
+          padding-right: $fd-radio-inner-circle-padding-x;
           padding-top: 0;
         }
       }

--- a/src/radio.scss
+++ b/src/radio.scss
@@ -62,11 +62,9 @@ $block: #{$fd-namespace}-radio;
       height: $fd-radio-inner-circle-diameter;
       width: $fd-radio-inner-circle-diameter;
       min-width: $fd-radio-inner-circle-diameter;
-      font-size: 0.6875rem;
       display: inline-flex;
       justify-content: center;
       align-items: center;
-      font-family: "SAP-icons";
       background-color: var(--sapField_Background);
       margin-right: $fd-radio-outer-circle-margin;
       color: var(--sapSelectedColor);
@@ -165,7 +163,6 @@ $block: #{$fd-namespace}-radio;
       padding: $fd-radio-outer-circle-margin-compact;
 
       &::before {
-        font-size: 0.4375rem;
         height: $fd-radio-inner-circle-diameter-compact;
         width: $fd-radio-inner-circle-diameter-compact;
         min-width: $fd-radio-inner-circle-diameter-compact;

--- a/src/radio.scss
+++ b/src/radio.scss
@@ -143,11 +143,7 @@ $block: #{$fd-namespace}-radio;
 
   &--compact {
     + .#{$block}__label {
-      padding: $fd-radio-outer-circle-margin-compact 0 $fd-radio-outer-circle-margin-compact $fd-radio-outer-circle-margin-compact;
-
-      @include fd-rtl() {
-        padding: $fd-radio-outer-circle-margin-compact $fd-radio-outer-circle-margin-compact $fd-radio-outer-circle-margin-compact 0;
-      }
+      padding: $fd-radio-outer-circle-margin-compact;
 
       &::before {
         font-size: 0.4375rem;

--- a/src/radio.scss
+++ b/src/radio.scss
@@ -17,7 +17,10 @@ $block: #{$fd-namespace}-radio;
       &::before {
         background-color: $background-color;
         border: $border-size solid $border-color;
-        color: $text-color;
+      }
+
+      &::after {
+        background: $text-color;
       }
 
       @include fd-hover() {
@@ -53,10 +56,11 @@ $block: #{$fd-namespace}-radio;
 
     &::before {
       content: "";
+      padding-top: $fd-radio-inner-circle-padding-y;
       height: $fd-radio-inner-circle-diameter;
       width: $fd-radio-inner-circle-diameter;
       min-width: $fd-radio-inner-circle-diameter;
-      font-size: 0.625rem;
+      font-size: 0.6875rem;
       display: inline-flex;
       justify-content: center;
       align-items: center;
@@ -66,6 +70,13 @@ $block: #{$fd-namespace}-radio;
       color: var(--sapSelectedColor);
       border: var(--sapField_BorderWidth) solid var(--sapField_BorderColor);
       border-radius: 50%;
+    }
+
+    &::after {
+      height: 0.625rem;
+      width: 0.625rem;
+      top: 1.0625rem;
+      left: 1.0625rem;
     }
 
     @include fd-hover() {
@@ -79,6 +90,10 @@ $block: #{$fd-namespace}-radio;
       &::before {
         margin-left: $fd-radio-outer-circle-margin;
         margin-right: 0;
+      }
+
+      &::after {
+        right: 1.0625rem;
       }
     }
 
@@ -94,8 +109,11 @@ $block: #{$fd-namespace}-radio;
     }
   }
 
-  &:checked + .#{$block}__label::before {
-    content: "\e255";
+  &:checked + .#{$block}__label::after {
+    content: "";
+    position: absolute;
+    border-radius: 50%;
+    background: var(--sapSelectedColor);
   }
 
   // states
@@ -142,17 +160,27 @@ $block: #{$fd-namespace}-radio;
 
   &--compact {
     + .#{$block}__label {
-      padding: $fd-radio-outer-circle-margin-compact;
+      padding: $fd-radio-outer-circle-margin-compact 0 $fd-radio-outer-circle-margin-compact $fd-radio-outer-circle-margin-compact;
+
+      @include fd-rtl() {
+        padding: $fd-radio-outer-circle-margin-compact $fd-radio-outer-circle-margin-compact $fd-radio-outer-circle-margin-compact 0;
+      }
 
       &::before {
-        font-size: 0.375rem;
+        font-size: 0.4375rem;
         height: $fd-radio-inner-circle-diameter-compact;
         width: $fd-radio-inner-circle-diameter-compact;
         min-width: $fd-radio-inner-circle-diameter-compact;
         margin-right: $fd-radio-outer-circle-margin-compact;
         margin-left: 0;
         padding-left: $fd-radio-inner-circle-padding-x;
-        padding-top: 0.05rem;
+      }
+
+      &::after {
+        height: 0.375rem;
+        width: 0.375rem;
+        top: 0.8125rem;
+        left: 0.8125rem;
       }
 
       @include fd-rtl() {
@@ -161,7 +189,10 @@ $block: #{$fd-namespace}-radio;
           margin-right: 0;
           padding-left: 0;
           padding-right: $fd-radio-inner-circle-padding-x;
-          padding-top: 0.05rem;
+        }
+
+        &::after {
+          right: 0.8125px;
         }
       }
 

--- a/src/radio.scss
+++ b/src/radio.scss
@@ -37,8 +37,11 @@ $block: #{$fd-namespace}-radio;
   $fd-radio-outer-circle-margin: 0.6875rem;
   $fd-radio-outer-circle-margin-compact: 0.5rem;
 
-  $fd-radio-inner-circle-padding-y: 0.0625rem; // to align the inner circle vertically in the middle of the outer
-  $fd-radio-inner-circle-padding-x: 0.05rem; // to align the inner circle horizontally in the middle of the outer
+  $fd-radio-inner-content-size: 0.625rem; // inner circle size
+  $fd-radio-inner-content-size-compact: 0.375rem; // inner circle size for compact
+
+  $fd-radio-inner-content-padding: 1.0625rem; // aligns inner circle
+  $fd-radio-inner-content-padding-compact: 0.8125rem; // aligns inner circle for compact
 
   @include fd-form-base();
 
@@ -56,7 +59,6 @@ $block: #{$fd-namespace}-radio;
 
     &::before {
       content: "";
-      padding-top: $fd-radio-inner-circle-padding-y;
       height: $fd-radio-inner-circle-diameter;
       width: $fd-radio-inner-circle-diameter;
       min-width: $fd-radio-inner-circle-diameter;
@@ -73,10 +75,10 @@ $block: #{$fd-namespace}-radio;
     }
 
     &::after {
-      height: 0.625rem;
-      width: 0.625rem;
-      top: 1.0625rem;
-      left: 1.0625rem;
+      height: $fd-radio-inner-content-size;
+      width: $fd-radio-inner-content-size;
+      top: $fd-radio-inner-content-padding;
+      left: $fd-radio-inner-content-padding;
     }
 
     @include fd-hover() {
@@ -93,7 +95,7 @@ $block: #{$fd-namespace}-radio;
       }
 
       &::after {
-        right: 1.0625rem;
+        right: $fd-radio-inner-content-padding;
       }
     }
 
@@ -160,11 +162,7 @@ $block: #{$fd-namespace}-radio;
 
   &--compact {
     + .#{$block}__label {
-      padding: $fd-radio-outer-circle-margin-compact 0 $fd-radio-outer-circle-margin-compact $fd-radio-outer-circle-margin-compact;
-
-      @include fd-rtl() {
-        padding: $fd-radio-outer-circle-margin-compact $fd-radio-outer-circle-margin-compact $fd-radio-outer-circle-margin-compact 0;
-      }
+      padding: $fd-radio-outer-circle-margin-compact;
 
       &::before {
         font-size: 0.4375rem;
@@ -173,14 +171,13 @@ $block: #{$fd-namespace}-radio;
         min-width: $fd-radio-inner-circle-diameter-compact;
         margin-right: $fd-radio-outer-circle-margin-compact;
         margin-left: 0;
-        padding-left: $fd-radio-inner-circle-padding-x;
       }
 
       &::after {
-        height: 0.375rem;
-        width: 0.375rem;
-        top: 0.8125rem;
-        left: 0.8125rem;
+        height: $fd-radio-inner-content-size-compact;
+        width: $fd-radio-inner-content-size-compact;
+        top: $fd-radio-inner-content-padding-compact;
+        left: $fd-radio-inner-content-padding-compact;
       }
 
       @include fd-rtl() {
@@ -188,11 +185,10 @@ $block: #{$fd-namespace}-radio;
           margin-left: $fd-radio-outer-circle-margin-compact;
           margin-right: 0;
           padding-left: 0;
-          padding-right: $fd-radio-inner-circle-padding-x;
         }
 
         &::after {
-          right: 0.8125px;
+          right: $fd-radio-inner-content-padding-compact;
         }
       }
 

--- a/src/radio.scss
+++ b/src/radio.scss
@@ -156,7 +156,8 @@ $block: #{$fd-namespace}-radio;
         min-width: $fd-radio-inner-circle-diameter-compact;
         margin-right: $fd-radio-outer-circle-margin-compact;
         margin-left: 0;
-        padding-left: $fd-radio-inner-circle-padding-x;
+        padding-left: 0;
+        padding-top: 0;
       }
 
       @include fd-rtl() {
@@ -164,7 +165,8 @@ $block: #{$fd-namespace}-radio;
           margin-left: $fd-radio-outer-circle-margin-compact;
           margin-right: 0;
           padding-left: 0;
-          padding-right: $fd-radio-inner-circle-padding-x;
+          padding-right: 0;
+          padding-top: 0;
         }
       }
 

--- a/src/radio.scss
+++ b/src/radio.scss
@@ -53,11 +53,10 @@ $block: #{$fd-namespace}-radio;
 
     &::before {
       content: "";
-      padding-top: $fd-radio-inner-circle-padding-y;
       height: $fd-radio-inner-circle-diameter;
       width: $fd-radio-inner-circle-diameter;
       min-width: $fd-radio-inner-circle-diameter;
-      font-size: 0.6875rem;
+      font-size: 0.625rem;
       display: inline-flex;
       justify-content: center;
       align-items: center;
@@ -146,14 +145,14 @@ $block: #{$fd-namespace}-radio;
       padding: $fd-radio-outer-circle-margin-compact;
 
       &::before {
-        font-size: 0.4375rem;
+        font-size: 0.375rem;
         height: $fd-radio-inner-circle-diameter-compact;
         width: $fd-radio-inner-circle-diameter-compact;
         min-width: $fd-radio-inner-circle-diameter-compact;
         margin-right: $fd-radio-outer-circle-margin-compact;
         margin-left: 0;
         padding-left: $fd-radio-inner-circle-padding-x;
-        padding-top: 0;
+        padding-top: 0.05rem;
       }
 
       @include fd-rtl() {
@@ -162,7 +161,7 @@ $block: #{$fd-namespace}-radio;
           margin-right: 0;
           padding-left: 0;
           padding-right: $fd-radio-inner-circle-padding-x;
-          padding-top: 0;
+          padding-top: 0.05rem;
         }
       }
 

--- a/stories/radio/__snapshots__/radio.stories.storyshot
+++ b/stories/radio/__snapshots__/radio.stories.storyshot
@@ -16,6 +16,323 @@ exports[`Storyshots Components/Forms/Radio Responsiveness 1`] = `
 `;
 
 exports[`Storyshots Components/Forms/Radio Right-to-Left Example 1`] = `
+<section>
+  
 
+  <fieldset
+    class="fd-fieldset"
+    dir="rtl"
+    id="radiortl"
+  >
+    
+    
+    <legend
+      class="fd-fieldset__legend"
+    >
+      Interaction States RTL
+    </legend>
+    
+    
+    <div
+      class="fd-form-group"
+    >
+      
+        
+      <div
+        class="fd-form-item"
+      >
+        
+            
+        <input
+          checked=""
+          class="fd-radio"
+          id="radioRtl1"
+          name="radiortl"
+          type="radio"
+        />
+        
+            
+        <label
+          class="fd-radio__label"
+          for="radioRtl1"
+        >
+          
+                Field label
+            
+        </label>
+        
+        
+      </div>
+      
+        
+      <div
+        class="fd-form-item"
+      >
+        
+            
+        <input
+          class="fd-radio is-success"
+          id="radioRtl2"
+          name="radiortl"
+          type="radio"
+        />
+        
+            
+        <label
+          class="fd-radio__label"
+          for="radioRtl2"
+        >
+          
+                Field label
+            
+        </label>
+        
+        
+      </div>
+      
+        
+      <div
+        class="fd-form-item"
+      >
+        
+            
+        <input
+          class="fd-radio is-error"
+          id="radioRtl3"
+          name="radiortl"
+          type="radio"
+        />
+        
+            
+        <label
+          class="fd-radio__label"
+          for="radioRtl3"
+        >
+          
+                Field label
+            
+        </label>
+        
+        
+      </div>
+      
+        
+      <div
+        class="fd-form-item"
+      >
+        
+            
+        <input
+          class="fd-radio is-warning"
+          id="radioRtl4"
+          name="radiortl"
+          type="radio"
+        />
+        
+            
+        <label
+          class="fd-radio__label"
+          for="radioRtl4"
+        >
+          
+                Field label
+            
+        </label>
+        
+        
+      </div>
+      
+        
+      <div
+        class="fd-form-item"
+      >
+        
+            
+        <input
+          class="fd-radio is-information"
+          id="radioRtl5"
+          name="radiortl"
+          type="radio"
+        />
+        
+            
+        <label
+          class="fd-radio__label"
+          for="radioRtl5"
+        >
+          
+                Field label
+            
+        </label>
+        
+        
+      </div>
+      
+    
+    </div>
+    
 
+  </fieldset>
+  
+
+  <br />
+  
+
+  <fieldset
+    class="fd-fieldset"
+    dir="rtl"
+    id="radiortlcompact"
+  >
+    
+    
+    <legend
+      class="fd-fieldset__legend"
+    >
+      Interaction States RTL Compact Mode
+    </legend>
+    
+    
+    <div
+      class="fd-form-group"
+    >
+      
+        
+      <div
+        class="fd-form-item"
+      >
+        
+            
+        <input
+          checked=""
+          class="fd-radio fd-radio--compact"
+          id="radioRtl6"
+          name="radiortlcompact"
+          type="radio"
+        />
+        
+            
+        <label
+          class="fd-radio__label"
+          for="radioRtl6"
+        >
+          
+                Field label
+            
+        </label>
+        
+        
+      </div>
+      
+        
+      <div
+        class="fd-form-item"
+      >
+        
+            
+        <input
+          class="fd-radio is-success fd-radio--compact"
+          id="radioRtl7"
+          name="radiortlcompact"
+          type="radio"
+        />
+        
+            
+        <label
+          class="fd-radio__label"
+          for="radioRtl7"
+        >
+          
+                Field label
+            
+        </label>
+        
+        
+      </div>
+      
+        
+      <div
+        class="fd-form-item"
+      >
+        
+            
+        <input
+          class="fd-radio is-error fd-radio--compact"
+          id="radioRtl8"
+          name="radiortlcompact"
+          type="radio"
+        />
+        
+            
+        <label
+          class="fd-radio__label"
+          for="radioRtl8"
+        >
+          
+                Field label
+            
+        </label>
+        
+        
+      </div>
+      
+        
+      <div
+        class="fd-form-item"
+      >
+        
+            
+        <input
+          class="fd-radio is-warning fd-radio--compact"
+          id="radioRtl9"
+          name="radiortlcompact"
+          type="radio"
+        />
+        
+            
+        <label
+          class="fd-radio__label"
+          for="radioRtl9"
+        >
+          
+                Field label
+            
+        </label>
+        
+        
+      </div>
+      
+        
+      <div
+        class="fd-form-item"
+      >
+        
+            
+        <input
+          class="fd-radio is-information fd-radio--compact"
+          id="radioRtl10"
+          name="radiortlcompact"
+          type="radio"
+        />
+        
+            
+        <label
+          class="fd-radio__label"
+          for="radioRtl10"
+        >
+          
+                Field label
+            
+        </label>
+        
+        
+      </div>
+      
+    
+    </div>
+    
+
+  </fieldset>
+  
+
+</section>
 `;

--- a/stories/radio/radio.stories.js
+++ b/stories/radio/radio.stories.js
@@ -310,6 +310,42 @@ export const rtl = () => `
         </div>
     </div>
 </fieldset>
+<br />
+<fieldset class="fd-fieldset" id="radiortlcompact" dir="rtl">
+    <legend class="fd-fieldset__legend">Interaction States RTL Compact Mode</legend>
+    <div class="fd-form-group">
+        <div class="fd-form-item">
+            <input type="radio" class="fd-radio fd-radio--compact" id="radioRtl6" name="radiortlcompact" checked>
+            <label class="fd-radio__label" for="radioRtl6">
+                Field label
+            </label>
+        </div>
+        <div class="fd-form-item">
+            <input type="radio" class="fd-radio is-success fd-radio--compact" id="radioRtl7" name="radiortlcompact">
+            <label class="fd-radio__label" for="radioRtl7">
+                Field label
+            </label>
+        </div>
+        <div class="fd-form-item">
+            <input type="radio" class="fd-radio is-error fd-radio--compact" id="radioRtl8" name="radiortlcompact">
+            <label class="fd-radio__label" for="radioRtl8">
+                Field label
+            </label>
+        </div>
+        <div class="fd-form-item">
+            <input type="radio" class="fd-radio is-warning fd-radio--compact" id="radioRtl9" name="radiortlcompact">
+            <label class="fd-radio__label" for="radioRtl9">
+                Field label
+            </label>
+        </div>
+        <div class="fd-form-item">
+            <input type="radio" class="fd-radio is-information fd-radio--compact" id="radioRtl10" name="radiortlcompact">
+            <label class="fd-radio__label" for="radioRtl10">
+                Field label
+            </label>
+        </div>
+    </div>
+</fieldset>
 `;
 
 rtl.storyName = 'Right-to-Left Example';


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/1589
https://github.com/SAP/fundamental-ngx/issues/3086

## Description
Compact radio filling is not centre aligned. fixed padding for compact radio.

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
<img width="195" alt="Screenshot 2020-09-09 at 10 05 55 PM" src="https://user-images.githubusercontent.com/57661487/92627458-04cbfa80-f2e9-11ea-8ab5-f653ec8da70f.png">


### After:
<img width="160" alt="Screenshot 2020-09-10 at 12 28 16 PM" src="https://user-images.githubusercontent.com/57661487/92692011-2bc61300-f361-11ea-9644-e3d5042f8bd4.png">


#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
