### PR TITLE
fix: Remove reset from icons

### DIFF
--- a/src/icon.scss
+++ b/src/icon.scss
@@ -3,10 +3,7 @@
 $block: sap-icon;
 
 [class*="#{$block}"] {
-  @include fd-reset();
   @include fd-icon-base();
-
-  display: inline-block;
 }
 
 .#{$block} {


### PR DESCRIPTION
## Description
There is a need form NGX to remove `fd-reset()` mixin from icons. Due to different order of imports styles from reset are more important than other styles, which breaks most of components.

#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
