### PR TITLE
fix: Create base SCSS mixins for icons

### DIFF
--- a/src/mixins/_mixins.scss
+++ b/src/mixins/_mixins.scss
@@ -382,3 +382,22 @@
   min-height: $height;
   max-height: $height;
 }
+
+@mixin fd-icon-selector() {
+  [class*="sap-icon"],
+  &[class*="sap-icon"] {
+    @content;
+  }
+}
+
+@mixin fd-icon-element-base {
+  @include fd-icon-selector() {
+    color: inherit;
+    background: inherit;
+    font-size: inherit;
+    border-radius: inherit;
+    line-height: 1;
+
+    @content;
+  }
+}


### PR DESCRIPTION
This PR introduces base SCSS mixins for creating component specific icons.