### PR TITLE
fix: Apply icons changes to tree

### DIFF
--- a/config/bundlesize.json
+++ b/config/bundlesize.json
@@ -2,7 +2,7 @@
     "files": [
         {
             "path": "./dist/fundamental-styles.css",
-            "maxSize": "85 kB"
+            "maxSize": "90 kB"
         }
     ]
 }

--- a/config/bundlesize.json
+++ b/config/bundlesize.json
@@ -2,7 +2,7 @@
     "files": [
         {
             "path": "./dist/fundamental-styles.css",
-            "maxSize": "90 kB"
+            "maxSize": "92 kB"
         }
     ]
 }

--- a/config/bundlesize.json
+++ b/config/bundlesize.json
@@ -2,7 +2,7 @@
     "files": [
         {
             "path": "./dist/fundamental-styles.css",
-            "maxSize": "92 kB"
+            "maxSize": "94 kB"
         }
     ]
 }

--- a/src/button.scss
+++ b/src/button.scss
@@ -243,6 +243,11 @@ $block: #{$fd-namespace}-button;
       margin-right: 0;
     }
 
+    @include fd-only-child() {
+      margin-right: 0;
+      margin-left: 0;
+    }
+
     @include fd-rtl() {
       &:first-child {
         margin-left: $fd-button-icon-margin;
@@ -251,6 +256,11 @@ $block: #{$fd-namespace}-button;
 
       &:last-child {
         margin-right: $fd-button-icon-margin;
+        margin-left: 0;
+      }
+
+      @include fd-only-child() {
+        margin-right: 0;
         margin-left: 0;
       }
     }

--- a/src/tree.scss
+++ b/src/tree.scss
@@ -113,30 +113,16 @@ $fd-tree-item-selected-border-bottom: var(--sapList_BorderWidth) solid var(--sap
     .#{$button},
     .#{$block}__icon,
     .#{$block}__expander {
-      @include fd-icon-selector() {
-        color: var(--sapList_Active_TextColor);
-      }
-
-      @include fd-hover() {
-        @include fd-icon-selector() {
-          background: var(--sapList_Active_Background);
-        }
-      }
-
-      @include fd-selected() {
-        @include fd-icon-selector() {
-          background: var(--sapList_Active_Background);
-
-          @include fd-hover() {
-            background: var(--sapList_Active_Background);
-          }
-        }
-      }
-
       @include fd-focus() {
         @include fd-icon-selector() {
           outline-color: var(--sapContent_ContrastFocusColor);
         }
+      }
+    }
+
+    .#{$block}__icon {
+      @include fd-icon-selector() {
+        color: var(--sapList_Active_TextColor);
       }
     }
 
@@ -257,10 +243,13 @@ $fd-tree-item-selected-border-bottom: var(--sapList_BorderWidth) solid var(--sap
   &__expander {
     @include fd-reset();
 
-    @include fd-icon-element-base() {
-      font-size: var(--sapFontLargeSize);
+    .#{$block}__icon {
+      @include fd-icon-selector() {
+        font-size: var(--sapFontLargeSize);
+        color: var(--sapButton_IconColor);
 
-      @include fd-flex-center();
+        @include fd-flex-center();
+      }
     }
 
     @include fd-focus() {
@@ -268,8 +257,8 @@ $fd-tree-item-selected-border-bottom: var(--sapList_BorderWidth) solid var(--sap
     }
 
     cursor: pointer;
-    background: transparent;
     color: var(--sapButton_IconColor);
+    background: transparent;
     min-width: $fd-tree-expander-size;
     min-height: $fd-tree-expander-size;
     margin-left: $fd-tree-expander-size-negative;
@@ -306,7 +295,6 @@ $fd-tree-item-selected-border-bottom: var(--sapList_BorderWidth) solid var(--sap
   }
 
   &__icon {
-    @include fd-reset();
     @include fd-flex-center();
 
     min-width: $fd-tree-icon-size;

--- a/src/tree.scss
+++ b/src/tree.scss
@@ -111,12 +111,9 @@ $fd-tree-item-selected-border-bottom: var(--sapList_BorderWidth) solid var(--sap
     background: var(--sapList_Active_Background);
 
     .#{$button},
-    .#{$block}__icon,
     .#{$block}__expander {
       @include fd-focus() {
-        @include fd-icon-selector() {
-          outline-color: var(--sapContent_ContrastFocusColor);
-        }
+        outline-color: var(--sapContent_ContrastFocusColor);
       }
     }
 

--- a/src/tree.scss
+++ b/src/tree.scss
@@ -2,6 +2,7 @@
 
 // VARIABLES
 $block: #{$fd-namespace}-tree;
+$button: #{$fd-namespace}-button;
 $first-level-item-container: '.#{$block}__item[aria-level="1"] > .#{$block}__item-container';
 $active-item-container: '.#{$block}__item-container.#{$block}__item-container--active';
 
@@ -109,11 +110,37 @@ $fd-tree-item-selected-border-bottom: var(--sapList_BorderWidth) solid var(--sap
   @include fd-active() {
     background: var(--sapList_Active_Background);
 
-    .#{$block}__expander,
-    .#{$block}__text,
+    .#{$button},
     .#{$block}__icon,
-    .has-navigation-indicator::after,
-    button::before {
+    .#{$block}__expander {
+      @include fd-icon-selector() {
+        color: var(--sapList_Active_TextColor);
+      }
+
+      @include fd-hover() {
+        @include fd-icon-selector() {
+          background: var(--sapList_Active_Background);
+        }
+      }
+
+      @include fd-selected() {
+        @include fd-icon-selector() {
+          background: var(--sapList_Active_Background);
+
+          @include fd-hover() {
+            background: var(--sapList_Active_Background);
+          }
+        }
+      }
+
+      @include fd-focus() {
+        @include fd-icon-selector() {
+          outline-color: var(--sapContent_ContrastFocusColor);
+        }
+      }
+    }
+
+    .#{$block}__text {
       color: var(--sapList_Active_TextColor);
     }
 
@@ -230,37 +257,29 @@ $fd-tree-item-selected-border-bottom: var(--sapList_BorderWidth) solid var(--sap
   &__expander {
     @include fd-reset();
 
+    @include fd-icon-contain() {
+      font-size: var(--sapFontLargeSize);
+    }
+
     @include fd-focus() {
       @include tree-focus();
     }
 
-    @include fd-icon('navigation-right-arrow', 'after') {
-      font-size: var(--sapFontLargeSize);
-    }
-
-    @include fd-rtl() {
-      &::after {
-        content: "\e067";
-      }
-
-      margin-left: 0;
-      margin-right: $fd-tree-expander-size-negative;
-      cursor: pointer;
-    }
-
-    margin-left: $fd-tree-expander-size-negative;
-    min-width: $fd-tree-expander-size;
-    min-height: $fd-tree-expander-size;
+    cursor: pointer;
     background: transparent;
     color: var(--sapButton_IconColor);
+    min-width: $fd-tree-expander-size;
+    min-height: $fd-tree-expander-size;
+    margin-left: $fd-tree-expander-size-negative;
+
+    @include fd-rtl() {
+      margin-left: 0;
+      margin-right: $fd-tree-expander-size-negative;
+    }
 
     &.is-expanded,
     &[aria-expanded="true"] {
       border-bottom: none;
-
-      &::after {
-        content: "\e1e2";
-      }
     }
   }
 
@@ -285,14 +304,34 @@ $fd-tree-item-selected-border-bottom: var(--sapList_BorderWidth) solid var(--sap
   }
 
   &__icon {
+    @include fd-reset();
     @include fd-flex-center();
 
-    min-width: $fd-tree-icon-size;
-    min-height: $fd-tree-icon-size;
-    line-height: $fd-tree-icon-size; // IE11 fix for vertical alignment
-    font-size: 1.125rem;
-    text-align: center;
-    color: var(--sapContent_NonInteractiveIconColor);
+    @include fd-icon-contain() {
+      font-size: 1.125rem;
+      color: var(--sapContent_NonInteractiveIconColor);
+      min-width: $fd-tree-icon-size;
+      min-height: $fd-tree-icon-size;
+      line-height: $fd-tree-icon-size; // IE11 fix for vertical alignment
+    }
+
+    &--navigation {
+      @include fd-icon-selector() {
+        min-width: 2.5rem;
+        font-size: 0.75rem;
+      }
+
+      &:last-child {
+        margin-right: $fd-tree-item-padding-right-negative;
+      }
+
+      @include fd-rtl() {
+        &:last-child {
+          margin-right: 0;
+          margin-left: $fd-tree-item-padding-right-negative;
+        }
+      }
+    }
   }
 
   &__text {
@@ -340,13 +379,13 @@ $fd-tree-item-selected-border-bottom: var(--sapList_BorderWidth) solid var(--sap
       min-width: $fd-tree-expander-size-compact;
       margin-left: $fd-tree-expander-size-negative-compact;
 
+      @include fd-icon-selector() {
+        font-size: var(--sapFontSmallSize);
+      }
+
       @include fd-rtl() {
         margin-left: 0;
         margin-right: $fd-tree-expander-size-negative-compact;
-      }
-
-      &::after {
-        font-size: var(--sapFontSmallSize);
       }
     }
 
@@ -393,39 +432,6 @@ $fd-tree-item-selected-border-bottom: var(--sapList_BorderWidth) solid var(--sap
 
     &--success {
       @include set-highlight(var(--sapSuccessBorderColor));
-    }
-  }
-
-  .has-navigation-indicator {
-    &::after {
-      min-width: 2.5rem;
-      font-size: 0.75rem;
-      height: 100%;
-      font-family: "SAP-icons";
-      content: '\e1ed';
-      color: var(--sapContent_NonInteractiveIconColor);
-      text-align: center;
-      text-decoration: none;
-      text-transform: none;
-    }
-
-    &:last-child {
-      &::after {
-        margin-right: $fd-tree-item-padding-right-negative;
-      }
-    }
-
-    @include fd-rtl() {
-      &::after {
-        content: '\e1ee';
-      }
-
-      &:last-child {
-        &::after {
-          margin-right: 0;
-          margin-left: $fd-tree-item-padding-right-negative;
-        }
-      }
     }
   }
 }

--- a/src/tree.scss
+++ b/src/tree.scss
@@ -257,8 +257,10 @@ $fd-tree-item-selected-border-bottom: var(--sapList_BorderWidth) solid var(--sap
   &__expander {
     @include fd-reset();
 
-    @include fd-icon-contain() {
+    @include fd-icon-element-base() {
       font-size: var(--sapFontLargeSize);
+
+      @include fd-flex-center();
     }
 
     @include fd-focus() {
@@ -307,12 +309,15 @@ $fd-tree-item-selected-border-bottom: var(--sapList_BorderWidth) solid var(--sap
     @include fd-reset();
     @include fd-flex-center();
 
-    @include fd-icon-contain() {
+    min-width: $fd-tree-icon-size;
+    min-height: $fd-tree-icon-size;
+    line-height: $fd-tree-icon-size; // IE11 fix for vertical alignment
+
+    @include fd-icon-selector() {
       font-size: 1.125rem;
       color: var(--sapContent_NonInteractiveIconColor);
-      min-width: $fd-tree-icon-size;
-      min-height: $fd-tree-icon-size;
-      line-height: $fd-tree-icon-size; // IE11 fix for vertical alignment
+
+      @include fd-flex-center();
     }
 
     &--navigation {

--- a/src/tree.scss
+++ b/src/tree.scss
@@ -123,7 +123,8 @@ $fd-tree-item-selected-border-bottom: var(--sapList_BorderWidth) solid var(--sap
       }
     }
 
-    .#{$block}__text {
+    .#{$block}__text,
+    .#{$button} {
       color: var(--sapList_Active_TextColor);
     }
 

--- a/stories/tree/__snapshots__/tree.stories.storyshot
+++ b/stories/tree/__snapshots__/tree.stories.storyshot
@@ -41,7 +41,7 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 1 1`] = `
           
                 
           <i
-            class="sap-icon--navigation-down-arrow"
+            class="fd-tree__icon sap-icon--navigation-down-arrow"
             role="presentation"
           />
           
@@ -95,7 +95,7 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 1 1`] = `
               
                         
               <i
-                class="sap-icon--navigation-right-arrow"
+                class="fd-tree__icon sap-icon--navigation-right-arrow"
                 role="presentation"
               />
               
@@ -342,7 +342,7 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 1 1`] = `
           
                 
           <i
-            class="sap-icon--navigation-down-arrow"
+            class="fd-tree__icon sap-icon--navigation-down-arrow"
             role="presentation"
           />
           
@@ -396,7 +396,7 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 1 1`] = `
               
                         
               <i
-                class="sap-icon--navigation-right-arrow"
+                class="fd-tree__icon sap-icon--navigation-right-arrow"
                 role="presentation"
               />
               
@@ -647,7 +647,7 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
           
                 
           <i
-            class="sap-icon--navigation-down-arrow"
+            class="fd-tree__icon sap-icon--navigation-down-arrow"
             role="presentation"
           />
           
@@ -671,18 +671,10 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
         </a>
         
             
-        <span
-          class="fd-tree__icon fd-tree__icon--navigation"
-        >
-          
-                
-          <i
-            class="sap-icon--slim-arrow-right"
-            role="presentation"
-          />
-          
-            
-        </span>
+        <i
+          class="fd-tree__icon fd-tree__icon--navigation sap-icon--slim-arrow-right"
+          role="presentation"
+        />
         
         
       </div>
@@ -719,7 +711,7 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
               
                         
               <i
-                class="sap-icon--navigation-down-arrow"
+                class="fd-tree__icon sap-icon--navigation-down-arrow"
                 role="presentation"
               />
               
@@ -776,7 +768,7 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                   
                                 
                   <i
-                    class="sap-icon--navigation-down-arrow"
+                    class="fd-tree__icon sap-icon--navigation-down-arrow"
                     role="presentation"
                   />
                   
@@ -800,18 +792,10 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                 </a>
                 
                             
-                <span
-                  class="fd-tree__icon fd-tree__icon--navigation"
-                >
-                  
-                                
-                  <i
-                    class="sap-icon--slim-arrow-right"
-                    role="presentation"
-                  />
-                  
-                            
-                </span>
+                <i
+                  class="fd-tree__icon fd-tree__icon--navigation sap-icon--slim-arrow-right"
+                  role="presentation"
+                />
                 
                         
               </div>
@@ -848,7 +832,7 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                       
                                         
                       <i
-                        class="sap-icon--navigation-down-arrow"
+                        class="fd-tree__icon sap-icon--navigation-down-arrow"
                         role="presentation"
                       />
                       
@@ -905,7 +889,7 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                           
                                                 
                           <i
-                            class="sap-icon--navigation-down-arrow"
+                            class="fd-tree__icon sap-icon--navigation-down-arrow"
                             role="presentation"
                           />
                           
@@ -962,7 +946,7 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                               
                                                         
                               <i
-                                class="sap-icon--navigation-down-arrow"
+                                class="fd-tree__icon sap-icon--navigation-down-arrow"
                                 role="presentation"
                               />
                               
@@ -1015,7 +999,7 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                                   
                                                                 
                                   <i
-                                    class="sap-icon--navigation-right-arrow"
+                                    class="fd-tree__icon sap-icon--navigation-right-arrow"
                                     role="presentation"
                                   />
                                   
@@ -1189,18 +1173,10 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                     </a>
                     
                                     
-                    <span
-                      class="fd-tree__icon fd-tree__icon--navigation"
-                    >
-                      
-                                        
-                      <i
-                        class="sap-icon--slim-arrow-right"
-                        role="presentation"
-                      />
-                      
-                                    
-                    </span>
+                    <i
+                      class="fd-tree__icon fd-tree__icon--navigation sap-icon--slim-arrow-right"
+                      role="presentation"
+                    />
                     
                                 
                   </div>
@@ -1243,18 +1219,10 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                 </a>
                 
                             
-                <span
-                  class="fd-tree__icon fd-tree__icon--navigation"
-                >
-                  
-                                
-                  <i
-                    class="sap-icon--slim-arrow-right"
-                    role="presentation"
-                  />
-                  
-                            
-                </span>
+                <i
+                  class="fd-tree__icon fd-tree__icon--navigation sap-icon--slim-arrow-right"
+                  role="presentation"
+                />
                 
                         
               </div>
@@ -1336,18 +1304,10 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
         </a>
         
             
-        <span
-          class="fd-tree__icon fd-tree__icon--navigation"
-        >
-          
-                
-          <i
-            class="sap-icon--slim-arrow-right"
-            role="presentation"
-          />
-          
-            
-        </span>
+        <i
+          class="fd-tree__icon fd-tree__icon--navigation sap-icon--slim-arrow-right"
+          role="presentation"
+        />
         
         
       </div>
@@ -1384,18 +1344,10 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
         </a>
         
             
-        <span
-          class="fd-tree__icon fd-tree__icon--navigation"
-        >
-          
-                
-          <i
-            class="sap-icon--slim-arrow-right"
-            role="presentation"
-          />
-          
-            
-        </span>
+        <i
+          class="fd-tree__icon fd-tree__icon--navigation sap-icon--slim-arrow-right"
+          role="presentation"
+        />
         
         
       </div>
@@ -1449,7 +1401,7 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
           
                 
           <i
-            class="sap-icon--navigation-down-arrow"
+            class="fd-tree__icon sap-icon--navigation-down-arrow"
             role="presentation"
           />
           
@@ -1473,18 +1425,10 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
         </a>
         
             
-        <span
-          class="fd-tree__icon fd-tree__icon--navigation"
-        >
-          
-                
-          <i
-            class="sap-icon--slim-arrow-right"
-            role="presentation"
-          />
-          
-            
-        </span>
+        <i
+          class="fd-tree__icon fd-tree__icon--navigation sap-icon--slim-arrow-right"
+          role="presentation"
+        />
         
         
       </div>
@@ -1521,7 +1465,7 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
               
                         
               <i
-                class="sap-icon--navigation-down-arrow"
+                class="fd-tree__icon sap-icon--navigation-down-arrow"
                 role="presentation"
               />
               
@@ -1578,7 +1522,7 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                   
                                 
                   <i
-                    class="sap-icon--navigation-down-arrow"
+                    class="fd-tree__icon sap-icon--navigation-down-arrow"
                     role="presentation"
                   />
                   
@@ -1602,18 +1546,10 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                 </a>
                 
                             
-                <span
-                  class="fd-tree__icon fd-tree__icon--navigation"
-                >
-                  
-                                
-                  <i
-                    class="sap-icon--slim-arrow-right"
-                    role="presentation"
-                  />
-                  
-                            
-                </span>
+                <i
+                  class="fd-tree__icon fd-tree__icon--navigation sap-icon--slim-arrow-right"
+                  role="presentation"
+                />
                 
                         
               </div>
@@ -1650,7 +1586,7 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                       
                                         
                       <i
-                        class="sap-icon--navigation-down-arrow"
+                        class="fd-tree__icon sap-icon--navigation-down-arrow"
                         role="presentation"
                       />
                       
@@ -1707,7 +1643,7 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                           
                                                 
                           <i
-                            class="sap-icon--navigation-down-arrow"
+                            class="fd-tree__icon sap-icon--navigation-down-arrow"
                             role="presentation"
                           />
                           
@@ -1764,7 +1700,7 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                               
                                                         
                               <i
-                                class="sap-icon--navigation-down-arrow"
+                                class="fd-tree__icon sap-icon--navigation-down-arrow"
                                 role="presentation"
                               />
                               
@@ -1817,7 +1753,7 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                                   
                                                                 
                                   <i
-                                    class="sap-icon--navigation-right-arrow"
+                                    class="fd-tree__icon sap-icon--navigation-right-arrow"
                                     role="presentation"
                                   />
                                   
@@ -1991,18 +1927,10 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                     </a>
                     
                                     
-                    <span
-                      class="fd-tree__icon fd-tree__icon--navigation"
-                    >
-                      
-                                        
-                      <i
-                        class="sap-icon--slim-arrow-right"
-                        role="presentation"
-                      />
-                      
-                                    
-                    </span>
+                    <i
+                      class="fd-tree__icon fd-tree__icon--navigation sap-icon--slim-arrow-right"
+                      role="presentation"
+                    />
                     
                                 
                   </div>
@@ -2045,18 +1973,10 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                 </a>
                 
                             
-                <span
-                  class="fd-tree__icon fd-tree__icon--navigation"
-                >
-                  
-                                
-                  <i
-                    class="sap-icon--slim-arrow-right"
-                    role="presentation"
-                  />
-                  
-                            
-                </span>
+                <i
+                  class="fd-tree__icon fd-tree__icon--navigation sap-icon--slim-arrow-right"
+                  role="presentation"
+                />
                 
                         
               </div>
@@ -2138,18 +2058,10 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
         </a>
         
             
-        <span
-          class="fd-tree__icon fd-tree__icon--navigation"
-        >
-          
-                
-          <i
-            class="sap-icon--slim-arrow-right"
-            role="presentation"
-          />
-          
-            
-        </span>
+        <i
+          class="fd-tree__icon fd-tree__icon--navigation sap-icon--slim-arrow-right"
+          role="presentation"
+        />
         
         
       </div>
@@ -2186,18 +2098,10 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
         </a>
         
             
-        <span
-          class="fd-tree__icon fd-tree__icon--navigation"
-        >
-          
-                
-          <i
-            class="sap-icon--slim-arrow-right"
-            role="presentation"
-          />
-          
-            
-        </span>
+        <i
+          class="fd-tree__icon fd-tree__icon--navigation sap-icon--slim-arrow-right"
+          role="presentation"
+        />
         
         
       </div>
@@ -2258,7 +2162,7 @@ exports[`Storyshots Components/Tree Tree With Selection 1`] = `
           
                 
           <i
-            class="sap-icon--navigation-down-arrow"
+            class="fd-tree__icon sap-icon--navigation-down-arrow"
             role="presentation"
           />
           
@@ -2336,7 +2240,7 @@ exports[`Storyshots Components/Tree Tree With Selection 1`] = `
               
                         
               <i
-                class="sap-icon--navigation-right-arrow"
+                class="fd-tree__icon sap-icon--navigation-right-arrow"
                 role="presentation"
               />
               
@@ -2666,7 +2570,7 @@ exports[`Storyshots Components/Tree Tree With Selection 1`] = `
           
                 
           <i
-            class="sap-icon--navigation-down-arrow"
+            class="fd-tree__icon sap-icon--navigation-down-arrow"
             role="presentation"
           />
           
@@ -2744,7 +2648,7 @@ exports[`Storyshots Components/Tree Tree With Selection 1`] = `
               
                         
               <i
-                class="sap-icon--navigation-right-arrow"
+                class="fd-tree__icon sap-icon--navigation-right-arrow"
                 role="presentation"
               />
               
@@ -3074,7 +2978,7 @@ exports[`Storyshots Components/Tree Tree With Selection 1`] = `
           
                 
           <i
-            class="sap-icon--navigation-down-arrow"
+            class="fd-tree__icon sap-icon--navigation-down-arrow"
             role="presentation"
           />
           
@@ -3152,7 +3056,7 @@ exports[`Storyshots Components/Tree Tree With Selection 1`] = `
               
                         
               <i
-                class="sap-icon--navigation-right-arrow"
+                class="fd-tree__icon sap-icon--navigation-right-arrow"
                 role="presentation"
               />
               

--- a/stories/tree/__snapshots__/tree.stories.storyshot
+++ b/stories/tree/__snapshots__/tree.stories.storyshot
@@ -37,7 +37,16 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 1 1`] = `
           aria-label="Expand level 2"
           class="fd-tree__expander is-expanded"
           tabindex="0"
-        />
+        >
+          
+                
+          <i
+            class="sap-icon--navigation-down-arrow"
+            role="presentation"
+          />
+          
+            
+        </button>
         
             
         <div
@@ -82,7 +91,16 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 1 1`] = `
               aria-label="Expander"
               class="fd-tree__expander"
               tabindex="0"
-            />
+            >
+              
+                        
+              <i
+                class="sap-icon--navigation-right-arrow"
+                role="presentation"
+              />
+              
+                    
+            </button>
             
                     
             <div
@@ -204,8 +222,10 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 1 1`] = `
             
         </div>
         
-    
+        
       </div>
+      
+    
     </li>
     
     
@@ -318,7 +338,16 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 1 1`] = `
           aria-label="Expand level 2"
           class="fd-tree__expander is-expanded"
           tabindex="0"
-        />
+        >
+          
+                
+          <i
+            class="sap-icon--navigation-down-arrow"
+            role="presentation"
+          />
+          
+            
+        </button>
         
             
         <div
@@ -363,7 +392,16 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 1 1`] = `
               aria-label="Expander"
               class="fd-tree__expander"
               tabindex="0"
-            />
+            >
+              
+                        
+              <i
+                class="sap-icon--navigation-right-arrow"
+                role="presentation"
+              />
+              
+                    
+            </button>
             
                     
             <div
@@ -485,8 +523,10 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 1 1`] = `
             
         </div>
         
-    
+        
       </div>
+      
+    
     </li>
     
     
@@ -603,11 +643,20 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
           aria-haspopup="true"
           aria-label="Expand level 2"
           class="fd-tree__expander is-expanded"
-        />
+        >
+          
+                
+          <i
+            class="sap-icon--navigation-down-arrow"
+            role="presentation"
+          />
+          
+            
+        </button>
         
             
         <a
-          class="fd-tree__content has-navigation-indicator"
+          class="fd-tree__content"
           href="https://sap.github.io/fundamental/"
         >
           
@@ -620,6 +669,20 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
           
             
         </a>
+        
+            
+        <span
+          class="fd-tree__icon fd-tree__icon--navigation"
+        >
+          
+                
+          <i
+            class="sap-icon--slim-arrow-right"
+            role="presentation"
+          />
+          
+            
+        </span>
         
         
       </div>
@@ -652,7 +715,16 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
               aria-haspopup="true"
               aria-label="Expand level 3"
               class="fd-tree__expander is-expanded"
-            />
+            >
+              
+                        
+              <i
+                class="sap-icon--navigation-down-arrow"
+                role="presentation"
+              />
+              
+                    
+            </button>
             
                     
             <div
@@ -700,11 +772,20 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                   aria-haspopup="true"
                   aria-label="Expand level 4"
                   class="fd-tree__expander is-expanded"
-                />
+                >
+                  
+                                
+                  <i
+                    class="sap-icon--navigation-down-arrow"
+                    role="presentation"
+                  />
+                  
+                            
+                </button>
                 
                             
                 <a
-                  class="fd-tree__content has-navigation-indicator"
+                  class="fd-tree__content"
                   href="https://sap.github.io/fundamental/"
                 >
                   
@@ -717,6 +798,20 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                   
                             
                 </a>
+                
+                            
+                <span
+                  class="fd-tree__icon fd-tree__icon--navigation"
+                >
+                  
+                                
+                  <i
+                    class="sap-icon--slim-arrow-right"
+                    role="presentation"
+                  />
+                  
+                            
+                </span>
                 
                         
               </div>
@@ -749,7 +844,16 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                       aria-haspopup="true"
                       aria-label="Expand level 5"
                       class="fd-tree__expander is-expanded"
-                    />
+                    >
+                      
+                                        
+                      <i
+                        class="sap-icon--navigation-down-arrow"
+                        role="presentation"
+                      />
+                      
+                                    
+                    </button>
                     
                                     
                     <div
@@ -797,7 +901,16 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                           aria-haspopup="true"
                           aria-label="Expand level 6"
                           class="fd-tree__expander is-expanded"
-                        />
+                        >
+                          
+                                                
+                          <i
+                            class="sap-icon--navigation-down-arrow"
+                            role="presentation"
+                          />
+                          
+                                            
+                        </button>
                         
                                             
                         <div
@@ -845,7 +958,16 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                               aria-haspopup="true"
                               aria-label="Expand level 7"
                               class="fd-tree__expander is-expanded"
-                            />
+                            >
+                              
+                                                        
+                              <i
+                                class="sap-icon--navigation-down-arrow"
+                                role="presentation"
+                              />
+                              
+                                                    
+                            </button>
                             
                                                     
                             <div
@@ -889,7 +1011,16 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                                 <button
                                   aria-label="Expander"
                                   class="fd-tree__expander"
-                                />
+                                >
+                                  
+                                                                
+                                  <i
+                                    class="sap-icon--navigation-right-arrow"
+                                    role="presentation"
+                                  />
+                                  
+                                                            
+                                </button>
                                 
                                                             
                                 <div
@@ -1043,7 +1174,7 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                     
                                     
                     <a
-                      class="fd-tree__content has-navigation-indicator"
+                      class="fd-tree__content"
                       href="https://sap.github.io/fundamental/"
                     >
                       
@@ -1056,6 +1187,20 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                       
                                     
                     </a>
+                    
+                                    
+                    <span
+                      class="fd-tree__icon fd-tree__icon--navigation"
+                    >
+                      
+                                        
+                      <i
+                        class="sap-icon--slim-arrow-right"
+                        role="presentation"
+                      />
+                      
+                                    
+                    </span>
                     
                                 
                   </div>
@@ -1083,7 +1228,7 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                 
                             
                 <a
-                  class="fd-tree__content has-navigation-indicator"
+                  class="fd-tree__content"
                   href="https://sap.github.io/fundamental/"
                 >
                   
@@ -1096,6 +1241,20 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                   
                             
                 </a>
+                
+                            
+                <span
+                  class="fd-tree__icon fd-tree__icon--navigation"
+                >
+                  
+                                
+                  <i
+                    class="sap-icon--slim-arrow-right"
+                    role="presentation"
+                  />
+                  
+                            
+                </span>
                 
                         
               </div>
@@ -1162,7 +1321,7 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
         
             
         <a
-          class="fd-tree__content has-navigation-indicator"
+          class="fd-tree__content"
           href="https://sap.github.io/fundamental/"
         >
           
@@ -1175,6 +1334,20 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
           
             
         </a>
+        
+            
+        <span
+          class="fd-tree__icon fd-tree__icon--navigation"
+        >
+          
+                
+          <i
+            class="sap-icon--slim-arrow-right"
+            role="presentation"
+          />
+          
+            
+        </span>
         
         
       </div>
@@ -1194,21 +1367,35 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
         class="fd-tree__item-container has-highlight-indicator--success"
       >
         
-        
+            
         <a
-          class="fd-tree__content has-navigation-indicator"
+          class="fd-tree__content"
           href="https://sap.github.io/fundamental/"
         >
           
-            
+                
           <span
             class="fd-tree__text"
           >
             Level 1
           </span>
           
-        
+            
         </a>
+        
+            
+        <span
+          class="fd-tree__icon fd-tree__icon--navigation"
+        >
+          
+                
+          <i
+            class="sap-icon--slim-arrow-right"
+            role="presentation"
+          />
+          
+            
+        </span>
         
         
       </div>
@@ -1258,11 +1445,20 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
           aria-haspopup="true"
           aria-label="Expand level 2"
           class="fd-tree__expander is-expanded"
-        />
+        >
+          
+                
+          <i
+            class="sap-icon--navigation-down-arrow"
+            role="presentation"
+          />
+          
+            
+        </button>
         
             
         <a
-          class="fd-tree__content has-navigation-indicator"
+          class="fd-tree__content"
           href="https://sap.github.io/fundamental/"
         >
           
@@ -1275,6 +1471,20 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
           
             
         </a>
+        
+            
+        <span
+          class="fd-tree__icon fd-tree__icon--navigation"
+        >
+          
+                
+          <i
+            class="sap-icon--slim-arrow-right"
+            role="presentation"
+          />
+          
+            
+        </span>
         
         
       </div>
@@ -1307,7 +1517,16 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
               aria-haspopup="true"
               aria-label="Expand level 3"
               class="fd-tree__expander is-expanded"
-            />
+            >
+              
+                        
+              <i
+                class="sap-icon--navigation-down-arrow"
+                role="presentation"
+              />
+              
+                    
+            </button>
             
                     
             <div
@@ -1355,11 +1574,20 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                   aria-haspopup="true"
                   aria-label="Expand level 4"
                   class="fd-tree__expander is-expanded"
-                />
+                >
+                  
+                                
+                  <i
+                    class="sap-icon--navigation-down-arrow"
+                    role="presentation"
+                  />
+                  
+                            
+                </button>
                 
                             
                 <a
-                  class="fd-tree__content has-navigation-indicator"
+                  class="fd-tree__content"
                   href="https://sap.github.io/fundamental/"
                 >
                   
@@ -1372,6 +1600,20 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                   
                             
                 </a>
+                
+                            
+                <span
+                  class="fd-tree__icon fd-tree__icon--navigation"
+                >
+                  
+                                
+                  <i
+                    class="sap-icon--slim-arrow-right"
+                    role="presentation"
+                  />
+                  
+                            
+                </span>
                 
                         
               </div>
@@ -1404,7 +1646,16 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                       aria-haspopup="true"
                       aria-label="Expand level 5"
                       class="fd-tree__expander is-expanded"
-                    />
+                    >
+                      
+                                        
+                      <i
+                        class="sap-icon--navigation-down-arrow"
+                        role="presentation"
+                      />
+                      
+                                    
+                    </button>
                     
                                     
                     <div
@@ -1452,7 +1703,16 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                           aria-haspopup="true"
                           aria-label="Expand level 6"
                           class="fd-tree__expander is-expanded"
-                        />
+                        >
+                          
+                                                
+                          <i
+                            class="sap-icon--navigation-down-arrow"
+                            role="presentation"
+                          />
+                          
+                                            
+                        </button>
                         
                                             
                         <div
@@ -1500,7 +1760,16 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                               aria-haspopup="true"
                               aria-label="Expand level 7"
                               class="fd-tree__expander is-expanded"
-                            />
+                            >
+                              
+                                                        
+                              <i
+                                class="sap-icon--navigation-down-arrow"
+                                role="presentation"
+                              />
+                              
+                                                    
+                            </button>
                             
                                                     
                             <div
@@ -1544,7 +1813,16 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                                 <button
                                   aria-label="Expander"
                                   class="fd-tree__expander"
-                                />
+                                >
+                                  
+                                                                
+                                  <i
+                                    class="sap-icon--navigation-right-arrow"
+                                    role="presentation"
+                                  />
+                                  
+                                                            
+                                </button>
                                 
                                                             
                                 <div
@@ -1698,7 +1976,7 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                     
                                     
                     <a
-                      class="fd-tree__content has-navigation-indicator"
+                      class="fd-tree__content"
                       href="https://sap.github.io/fundamental/"
                     >
                       
@@ -1711,6 +1989,20 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                       
                                     
                     </a>
+                    
+                                    
+                    <span
+                      class="fd-tree__icon fd-tree__icon--navigation"
+                    >
+                      
+                                        
+                      <i
+                        class="sap-icon--slim-arrow-right"
+                        role="presentation"
+                      />
+                      
+                                    
+                    </span>
                     
                                 
                   </div>
@@ -1738,7 +2030,7 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                 
                             
                 <a
-                  class="fd-tree__content has-navigation-indicator"
+                  class="fd-tree__content"
                   href="https://sap.github.io/fundamental/"
                 >
                   
@@ -1751,6 +2043,20 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
                   
                             
                 </a>
+                
+                            
+                <span
+                  class="fd-tree__icon fd-tree__icon--navigation"
+                >
+                  
+                                
+                  <i
+                    class="sap-icon--slim-arrow-right"
+                    role="presentation"
+                  />
+                  
+                            
+                </span>
                 
                         
               </div>
@@ -1817,7 +2123,7 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
         
             
         <a
-          class="fd-tree__content has-navigation-indicator"
+          class="fd-tree__content"
           href="https://sap.github.io/fundamental/"
         >
           
@@ -1830,6 +2136,20 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
           
             
         </a>
+        
+            
+        <span
+          class="fd-tree__icon fd-tree__icon--navigation"
+        >
+          
+                
+          <i
+            class="sap-icon--slim-arrow-right"
+            role="presentation"
+          />
+          
+            
+        </span>
         
         
       </div>
@@ -1849,21 +2169,35 @@ exports[`Storyshots Components/Tree Tree With Expanded Level 6 And Navigation Li
         class="fd-tree__item-container has-highlight-indicator--success"
       >
         
-        
+            
         <a
-          class="fd-tree__content has-navigation-indicator"
+          class="fd-tree__content"
           href="https://sap.github.io/fundamental/"
         >
           
-            
+                
           <span
             class="fd-tree__text"
           >
             Level 1
           </span>
           
-        
+            
         </a>
+        
+            
+        <span
+          class="fd-tree__icon fd-tree__icon--navigation"
+        >
+          
+                
+          <i
+            class="sap-icon--slim-arrow-right"
+            role="presentation"
+          />
+          
+            
+        </span>
         
         
       </div>
@@ -1920,7 +2254,16 @@ exports[`Storyshots Components/Tree Tree With Selection 1`] = `
           aria-label="Expand level 2"
           class="fd-tree__expander is-expanded"
           tabindex="0"
-        />
+        >
+          
+                
+          <i
+            class="sap-icon--navigation-down-arrow"
+            role="presentation"
+          />
+          
+            
+        </button>
         
             
         <div
@@ -1989,7 +2332,16 @@ exports[`Storyshots Components/Tree Tree With Selection 1`] = `
               aria-label="Expander"
               class="fd-tree__expander"
               tabindex="0"
-            />
+            >
+              
+                        
+              <i
+                class="sap-icon--navigation-right-arrow"
+                role="presentation"
+              />
+              
+                    
+            </button>
             
                     
             <div
@@ -2204,8 +2556,10 @@ exports[`Storyshots Components/Tree Tree With Selection 1`] = `
             
         </div>
         
-    
+        
       </div>
+      
+    
     </li>
     
     
@@ -2308,7 +2662,16 @@ exports[`Storyshots Components/Tree Tree With Selection 1`] = `
           aria-label="Expand level 2"
           class="fd-tree__expander is-expanded"
           tabindex="0"
-        />
+        >
+          
+                
+          <i
+            class="sap-icon--navigation-down-arrow"
+            role="presentation"
+          />
+          
+            
+        </button>
         
             
         <div
@@ -2377,7 +2740,16 @@ exports[`Storyshots Components/Tree Tree With Selection 1`] = `
               aria-label="Expander"
               class="fd-tree__expander"
               tabindex="0"
-            />
+            >
+              
+                        
+              <i
+                class="sap-icon--navigation-right-arrow"
+                role="presentation"
+              />
+              
+                    
+            </button>
             
                     
             <div
@@ -2568,26 +2940,33 @@ exports[`Storyshots Components/Tree Tree With Selection 1`] = `
             
         </div>
         
-                
-        <input
-          checked=""
-          class="fd-checkbox fd-checkbox--compact"
-          id="Ai4ezEE"
-          type="checkbox"
-        />
-        
-                
-        <label
-          aria-label="checkbox"
-          class="fd-checkbox__label fd-checkbox__label--compact"
-          for="Ai4ezEE"
-          tabindex="-1"
-        />
-        
             
+        <div
+          class="fd-form-item"
+        >
+          
+                
+          <input
+            checked=""
+            class="fd-checkbox fd-checkbox--compact"
+            id="Ai4ezEE"
+            type="checkbox"
+          />
+          
+                
+          <label
+            aria-label="checkbox"
+            class="fd-checkbox__label fd-checkbox__label--compact"
+            for="Ai4ezEE"
+            tabindex="-1"
+          />
+          
+            
+        </div>
+        
+        
       </div>
       
-        
     
     </li>
     
@@ -2691,7 +3070,16 @@ exports[`Storyshots Components/Tree Tree With Selection 1`] = `
           aria-label="Expand level 2"
           class="fd-tree__expander is-expanded"
           tabindex="0"
-        />
+        >
+          
+                
+          <i
+            class="sap-icon--navigation-down-arrow"
+            role="presentation"
+          />
+          
+            
+        </button>
         
             
         <div
@@ -2760,7 +3148,16 @@ exports[`Storyshots Components/Tree Tree With Selection 1`] = `
               aria-label="Expander"
               class="fd-tree__expander"
               tabindex="0"
-            />
+            >
+              
+                        
+              <i
+                class="sap-icon--navigation-right-arrow"
+                role="presentation"
+              />
+              
+                    
+            </button>
             
                     
             <div
@@ -2975,8 +3372,10 @@ exports[`Storyshots Components/Tree Tree With Selection 1`] = `
             
         </div>
         
-    
+        
       </div>
+      
+    
     </li>
     
     

--- a/stories/tree/tree.stories.js
+++ b/stories/tree/tree.stories.js
@@ -60,7 +60,9 @@ export const treeWithExpandedLevel1 = () => `
 <ul role="tree" aria-label="Root Tree" id="TREE1L1" class="fd-tree expanded-level-1">
     <li role="treeitem" aria-level="1" aria-expanded="true" class="fd-tree__item">
         <div class="fd-tree__item-container">
-            <button tabindex="0" class="fd-tree__expander is-expanded" aria-controls="TREE1L2" aria-haspopup="true" aria-label="Expand level 2" aria-expanded="true"></button>
+            <button tabindex="0" class="fd-tree__expander is-expanded" aria-controls="TREE1L2" aria-haspopup="true" aria-label="Expand level 2" aria-expanded="true">
+                <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+            </button>
             <div class="fd-tree__content">
                 <span class="fd-tree__text">Level 1</span>
             </div>
@@ -68,7 +70,9 @@ export const treeWithExpandedLevel1 = () => `
         <ul role="group" class="fd-tree" id="TREE1L2" aria-hidden="false">
             <li role="treeitem" aria-level="2" class="fd-tree__item">
                 <div class="fd-tree__item-container">
-                    <button tabindex="0" class="fd-tree__expander" aria-label="Expander"></button>
+                    <button tabindex="0" class="fd-tree__expander" aria-label="Expander">
+                        <i class="sap-icon--navigation-right-arrow" role="presentation"></i>
+                    </button>
                     <div class="fd-tree__content">
                         <span class="fd-tree__text">Level 2</span>
                     </div>
@@ -94,7 +98,7 @@ export const treeWithExpandedLevel1 = () => `
         <div class="fd-tree__item-container">
             <div class="fd-tree__content">
                 <span class="fd-tree__text">Level 1</span>
-            </div
+            </div>
         </div>
     </li>
     <li role="treeitem" aria-level="1" class="fd-tree__item">
@@ -120,7 +124,9 @@ export const treeWithExpandedLevel1 = () => `
 <ul role="tree" aria-label="Root Tree" id="TREE1CL1" class="fd-tree fd-tree--compact expanded-level-1">
     <li role="treeitem" aria-level="1" aria-expanded="true" class="fd-tree__item">
         <div class="fd-tree__item-container">
-            <button tabindex="0" class="fd-tree__expander is-expanded" aria-controls="TREE1CL2" aria-haspopup="true" aria-label="Expand level 2" aria-expanded="true"></button>
+            <button tabindex="0" class="fd-tree__expander is-expanded" aria-controls="TREE1CL2" aria-haspopup="true" aria-label="Expand level 2" aria-expanded="true">
+                <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+            </button>
             <div class="fd-tree__content">
                 <span class="fd-tree__text">Level 1</span>
             </div>
@@ -128,7 +134,9 @@ export const treeWithExpandedLevel1 = () => `
         <ul role="group" class="fd-tree" id="TREE1CL2" aria-hidden="false">
             <li role="treeitem" aria-level="2" class="fd-tree__item">
                 <div class="fd-tree__item-container">
-                    <button tabindex="0" class="fd-tree__expander" aria-label="Expander"></button>
+                    <button tabindex="0" class="fd-tree__expander" aria-label="Expander">
+                        <i class="sap-icon--navigation-right-arrow" role="presentation"></i>
+                    </button>
                     <div class="fd-tree__content">
                         <span class="fd-tree__text">Level 2</span>
                     </div>
@@ -154,7 +162,7 @@ export const treeWithExpandedLevel1 = () => `
         <div class="fd-tree__item-container">
             <div class="fd-tree__content">
                 <span class="fd-tree__text">Level 1</span>
-            </div
+            </div>
         </div>
     </li>
     <li role="treeitem" aria-level="1" class="fd-tree__item">
@@ -188,45 +196,75 @@ export const treeWithExpandedLevel2AndNoBorders = () => `
 <ul role="tree" aria-label="Root Tree" id="TREE2L1" class="fd-tree fd-tree--no-border expanded-level-2">
     <li role="treeitem" aria-level="1" aria-expanded="true" class="fd-tree__item">
         <div class="fd-tree__item-container">
-            <button tabindex="0" class="fd-tree__expander is-expanded" aria-controls="TREE2L2" aria-haspopup="true" aria-label="Expand level 2" aria-expanded="true"></button>
+            <button tabindex="0" class="fd-tree__expander is-expanded" aria-controls="TREE2L2" aria-haspopup="true" aria-label="Expand level 2" aria-expanded="true">
+                <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+            </button>
             <div class="fd-tree__content">
-                <span class="sap-icon--e-care sap-icon--l fd-tree__icon"></span>
+                <span class="fd-tree__icon">
+                    <i class="sap-icon--e-care sap-icon--l" role="presentation"></i>
+                </span>
                 <span class="fd-tree__text">Level 1</span>
             </div>
-            <button aria-label="Edit button" class="fd-button fd-button--transparent sap-icon--edit"></button>
-            <button aria-label="Delete button" class="fd-button fd-button--transparent sap-icon--decline"></button>
+            <button aria-label="Edit button" class="fd-button fd-button--transparent">
+                <i class="sap-icon--edit" role="presentation"></i>
+            </button>
+            <button aria-label="Delete button" class="fd-button fd-button--transparent">
+                <i class="sap-icon--decline" role="presentation"></i>
+            </button>
         </div>
         <ul role="group" class="fd-tree" id="TREE2L2" aria-hidden="false">
             <li role="treeitem" aria-level="2" aria-expanded="true" class="fd-tree__item">
                 <div class="fd-tree__item-container">
-                    <button tabindex="0" class="fd-tree__expander is-expanded" aria-controls="TREE2L3" aria-haspopup="true" aria-label="Expand level 3" aria-expanded="true"></button>
+                    <button tabindex="0" class="fd-tree__expander is-expanded" aria-controls="TREE2L3" aria-haspopup="true" aria-label="Expand level 3" aria-expanded="true">
+                        <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                    </button>
                     <div class="fd-tree__content">
-                        <span class="sap-icon--account sap-icon--l fd-tree__icon"></span>
+                        <span class="fd-tree__icon">
+                            <i class="sap-icon--account sap-icon--l" role="presentation"></i>
+                        </span>
                         <span class="fd-tree__text">Level 2</span>
                     </div>
-                    <button aria-label="Edit button" class="fd-button fd-button--transparent sap-icon--edit"></button>
-                    <button aria-label="Delete button" class="fd-button fd-button--transparent sap-icon--decline"></button>
+                    <button aria-label="Edit button" class="fd-button fd-button--transparent">
+                        <i class="sap-icon--edit" role="presentation"></i>
+                    </button>
+                    <button aria-label="Delete button" class="fd-button fd-button--transparent">
+                        <i class="sap-icon--decline" role="presentation"></i>
+                    </button>
                 </div>
                 <ul role="group" class="fd-tree" id="TREE2L3" aria-hidden="false">
                     <li role="treeitem" aria-level="3" class="fd-tree__item">
                         <div class="fd-tree__item-container">
-                            <button tabindex="0" class="fd-tree__expander" aria-label="Expander"></button>
+                            <button tabindex="0" class="fd-tree__expander" aria-label="Expander">
+                                <i class="sap-icon--navigation-right-arrow" role="presentation"></i>
+                            </button>
                             <div class="fd-tree__content">
-                                <span class="sap-icon--product sap-icon--l fd-tree__icon"></span>
+                                <span class="fd-tree__icon">
+                                    <i class="sap-icon--product sap-icon--l" role="presentation"></i>
+                                </span>
                                 <span class="fd-tree__text">Level 3</span>
                             </div>
-                            <button aria-label="Edit button" class="fd-button fd-button--transparent sap-icon--edit"></button>
-                            <button aria-label="Delete button" class="fd-button fd-button--transparent sap-icon--decline"></button>
+                            <button aria-label="Edit button" class="fd-button fd-button--transparent">
+                                <i class="sap-icon--edit" role="presentation"></i>
+                            </button>
+                            <button aria-label="Delete button" class="fd-button fd-button--transparent">
+                                <i class="sap-icon--decline" role="presentation"></i>
+                            </button>
                         </div>
                     </li>
                     <li role="treeitem" aria-level="3" class="fd-tree__item">
                         <div class="fd-tree__item-container">
                             <div class="fd-tree__content">
-                                <span class="sap-icon--history sap-icon--l fd-tree__icon"></span>
+                                <span class="fd-tree__icon">
+                                    <i class="sap-icon--history sap-icon--l" role="presentation"></i>
+                                </span>
                                 <span class="fd-tree__text">Level 3</span>
                             </div>
-                            <button aria-label="Edit button" class="fd-button fd-button--transparent sap-icon--edit"></button>
-                            <button aria-label="Delete button" class="fd-button fd-button--transparent sap-icon--decline"></button>
+                            <button aria-label="Edit button" class="fd-button fd-button--transparent">
+                                <i class="sap-icon--edit" role="presentation"></i>
+                            </button>
+                            <button aria-label="Delete button" class="fd-button fd-button--transparent">
+                                <i class="sap-icon--decline" role="presentation"></i>
+                            </button>
                         </div>
                     </li>
                 </ul>
@@ -234,11 +272,17 @@ export const treeWithExpandedLevel2AndNoBorders = () => `
             <li role="treeitem" aria-level="2" class="fd-tree__item">
                 <div class="fd-tree__item-container">
                     <div class="fd-tree__content">
-                        <span class="sap-icon--competitor sap-icon--l fd-tree__icon"></span>
+                        <span class="fd-tree__icon">
+                            <i class="sap-icon--competitor sap-icon--l" role="presentation"></i>
+                        </span>
                         <span class="fd-tree__text">Level 2</span>
                     </div>
-                    <button aria-label="Edit button" class="fd-button fd-button--transparent sap-icon--edit"></button>
-                    <button aria-label="Delete button" class="fd-button fd-button--transparent sap-icon--decline"></button>
+                    <button aria-label="Edit button" class="fd-button fd-button--transparent">
+                        <i class="sap-icon--edit" role="presentation"></i>
+                    </button>
+                    <button aria-label="Delete button" class="fd-button fd-button--transparent">
+                        <i class="sap-icon--decline" role="presentation"></i>
+                    </button>
                 </div>
             </li>
         </ul>
@@ -246,21 +290,33 @@ export const treeWithExpandedLevel2AndNoBorders = () => `
     <li role="treeitem" aria-level="1" class="fd-tree__item">
         <div class="fd-tree__item-container">
             <div class="fd-tree__content">
-                <span class="sap-icon--batch-payments sap-icon--l fd-tree__icon"></span>
+                <span class="fd-tree__icon">
+                    <i class="sap-icon--batch-payments sap-icon--l" role="presentation"></i>
+                </span>
                 <span class="fd-tree__text">Level 1</span>
             </div>
-            <button aria-label="Edit button" class="fd-button fd-button--transparent sap-icon--edit"></button>
-            <button aria-label="Delete button" class="fd-button fd-button--transparent sap-icon--decline"></button>
+            <button aria-label="Edit button" class="fd-button fd-button--transparent">
+                <i class="sap-icon--edit" role="presentation"></i>
+            </button>
+            <button aria-label="Delete button" class="fd-button fd-button--transparent">
+                <i class="sap-icon--decline" role="presentation"></i>
+            </button>
         </div>
     </li>
     <li role="treeitem" aria-level="1" class="fd-tree__item">
         <div class="fd-tree__item-container">
             <div class="fd-tree__content">
-                <span class="sap-icon--favorite sap-icon--l fd-tree__icon"></span>
+                <span class="fd-tree__icon">
+                    <i class="sap-icon--favorite sap-icon--l" role="presentation"></i>
+                </span>
                 <span class="fd-tree__text">Level 1</span>
             </div>
-            <button aria-label="Edit button" class="fd-button fd-button--transparent sap-icon--edit"></button>
-            <button aria-label="Delete button" class="fd-button fd-button--transparent sap-icon--decline"></button>
+            <button aria-label="Edit button" class="fd-button fd-button--transparent">
+                <i class="sap-icon--edit" role="presentation"></i>
+            </button>
+            <button aria-label="Delete button" class="fd-button fd-button--transparent">
+                <i class="sap-icon--decline" role="presentation"></i>
+            </button>
         </div>
     </li>
 </ul>
@@ -283,7 +339,9 @@ export const treeWithExpandedLevel3AndHighlightIndicators = () => `
 <ul role="tree" aria-label="Root Tree" id="TREE3L1" class="fd-tree expanded-level-3">
     <li role="treeitem" aria-level="1" aria-expanded="true" class="fd-tree__item">
         <div class="fd-tree__item-container has-highlight-indicator">
-            <button class="fd-tree__expander is-expanded" aria-controls="TREE3L2" aria-haspopup="true" aria-label="Expand level 2" aria-expanded="true"></button>
+            <button class="fd-tree__expander is-expanded" aria-controls="TREE3L2" aria-haspopup="true" aria-label="Expand level 2" aria-expanded="true">
+                <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+            </button>
             <div class="fd-tree__content">
                 <span class="fd-tree__text">Level 1</span>
             </div>
@@ -291,7 +349,9 @@ export const treeWithExpandedLevel3AndHighlightIndicators = () => `
         <ul role="group" class="fd-tree" id="TREE3L2" aria-hidden="false">
             <li role="treeitem" aria-level="2" aria-expanded="true" class="fd-tree__item">
                 <div class="fd-tree__item-container has-highlight-indicator--warning">
-                    <button class="fd-tree__expander is-expanded" aria-controls="TREE3L3" aria-haspopup="true" aria-label="Expand level 3" aria-expanded="true"></button>
+                    <button class="fd-tree__expander is-expanded" aria-controls="TREE3L3" aria-haspopup="true" aria-label="Expand level 3" aria-expanded="true">
+                        <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                    </button>
                     <div class="fd-tree__content">
                         <span class="fd-tree__text">Level 2</span>
                     </div>
@@ -299,7 +359,9 @@ export const treeWithExpandedLevel3AndHighlightIndicators = () => `
                 <ul role="group" class="fd-tree" id="TREE3L3" aria-hidden="false">
                     <li role="treeitem" aria-level="3" aria-expanded="true" class="fd-tree__item">
                         <div class="fd-tree__item-container has-highlight-indicator--error">
-                            <button class="fd-tree__expander is-expanded" aria-controls="TREE3L4" aria-haspopup="true" aria-label="Expand level 4" aria-expanded="true"></button>
+                            <button class="fd-tree__expander is-expanded" aria-controls="TREE3L4" aria-haspopup="true" aria-label="Expand level 4" aria-expanded="true">
+                                <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                            </button>
                             <div class="fd-tree__content">
                                 <span class="fd-tree__text">Level 3</span>
                             </div>
@@ -307,7 +369,9 @@ export const treeWithExpandedLevel3AndHighlightIndicators = () => `
                         <ul role="group" class="fd-tree" id="TREE3L4" aria-hidden="false">
                             <li role="treeitem" aria-level="4" class="fd-tree__item">
                                 <div class="fd-tree__item-container has-highlight-indicator--success">
-                                    <button class="fd-tree__expander" aria-label="Expander"></button>
+                                    <button class="fd-tree__expander" aria-label="Expander">
+                                        <i class="sap-icon--navigation-right-arrow" role="presentation"></i>
+                                    </button>
                                     <div class="fd-tree__content">
                                         <span class="fd-tree__text">Level 4</span>
                                     </div>
@@ -390,15 +454,22 @@ export const treeWithExpandedLevel6AndNavigationLinks = () => `
 <ul role="tree" aria-label="Root Tree" id="TREE6CL1" class="fd-tree expanded-level-6">
     <li role="treeitem" aria-level="1" aria-expanded="true" class="fd-tree__item">
         <div class="fd-tree__item-container fd-tree__item-container--active has-highlight-indicator--success">
-            <button class="fd-tree__expander is-expanded" aria-controls="TREE6CL2" aria-haspopup="true" aria-label="Expand level 2" aria-expanded="true"></button>
-            <a href="https://sap.github.io/fundamental/" class="fd-tree__content has-navigation-indicator">
+            <button class="fd-tree__expander is-expanded" aria-controls="TREE6CL2" aria-haspopup="true" aria-label="Expand level 2" aria-expanded="true">
+                <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+            </button>
+            <a href="https://sap.github.io/fundamental/" class="fd-tree__content">
                 <span class="fd-tree__text">Level 1</span>
             </a>
+            <span class="fd-tree__icon fd-tree__icon--navigation">
+                <i class="sap-icon--slim-arrow-right" role="presentation"></i>
+            </span>
         </div>
         <ul role="group" class="fd-tree" id="TREE6CL2" aria-hidden="false">
             <li role="treeitem" aria-level="2" aria-expanded="true" class="fd-tree__item">
                 <div class="fd-tree__item-container has-highlight-indicator--warning">
-                    <button class="fd-tree__expander is-expanded" aria-controls="TREE6CL3" aria-haspopup="true" aria-label="Expand level 3" aria-expanded="true"></button>
+                    <button class="fd-tree__expander is-expanded" aria-controls="TREE6CL3" aria-haspopup="true" aria-label="Expand level 3" aria-expanded="true">
+                        <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                    </button>
                     <div class="fd-tree__content">
                         <span class="fd-tree__text">Level 2</span>
                     </div>
@@ -406,15 +477,22 @@ export const treeWithExpandedLevel6AndNavigationLinks = () => `
                 <ul role="group" class="fd-tree" id="TREE6CL3" aria-hidden="false">
                     <li role="treeitem" aria-level="3" aria-expanded="true" class="fd-tree__item">
                         <div class="fd-tree__item-container fd-tree__item-container--active has-highlight-indicator--error">
-                            <button class="fd-tree__expander is-expanded" aria-controls="TREE6CL4" aria-haspopup="true" aria-label="Expand level 4" aria-expanded="true"></button>
-                            <a href="https://sap.github.io/fundamental/" class="fd-tree__content has-navigation-indicator">
+                            <button class="fd-tree__expander is-expanded" aria-controls="TREE6CL4" aria-haspopup="true" aria-label="Expand level 4" aria-expanded="true">
+                                <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                            </button>
+                            <a href="https://sap.github.io/fundamental/" class="fd-tree__content">
                                 <span class="fd-tree__text">Level 3</span>
                             </a>
+                            <span class="fd-tree__icon fd-tree__icon--navigation">
+                                <i class="sap-icon--slim-arrow-right" role="presentation"></i>
+                            </span>
                         </div>
                         <ul role="group" class="fd-tree" id="TREE6CL4" aria-hidden="false">
                             <li role="treeitem" aria-level="4" aria-expanded="true" class="fd-tree__item">
                                 <div class="fd-tree__item-container has-highlight-indicator">
-                                    <button class="fd-tree__expander is-expanded" aria-controls="TREE6CL5" aria-haspopup="true" aria-label="Expand level 5" aria-expanded="true"></button>
+                                    <button class="fd-tree__expander is-expanded" aria-controls="TREE6CL5" aria-haspopup="true" aria-label="Expand level 5" aria-expanded="true">
+                                        <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                                    </button>
                                     <div class="fd-tree__content">
                                         <span class="fd-tree__text">Level 4</span>
                                     </div>
@@ -422,7 +500,9 @@ export const treeWithExpandedLevel6AndNavigationLinks = () => `
                                 <ul role="group" class="fd-tree" id="TREE6CL5" aria-hidden="false">
                                     <li role="treeitem" aria-level="5" aria-expanded="true"  class="fd-tree__item">
                                         <div class="fd-tree__item-container">
-                                            <button class="fd-tree__expander is-expanded" aria-controls="TREE6CL6" aria-haspopup="true" aria-label="Expand level 6" aria-expanded="true"></button>
+                                            <button class="fd-tree__expander is-expanded" aria-controls="TREE6CL6" aria-haspopup="true" aria-label="Expand level 6" aria-expanded="true">
+                                                <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                                            </button>
                                             <div class="fd-tree__content">
                                                 <span class="fd-tree__text">Level 5</span>
                                             </div>
@@ -430,7 +510,9 @@ export const treeWithExpandedLevel6AndNavigationLinks = () => `
                                         <ul role="group" class="fd-tree" id="TREE6CL6" aria-hidden="false">
                                             <li role="treeitem" aria-level="6" aria-expanded="true" class="fd-tree__item">
                                                 <div class="fd-tree__item-container">
-                                                    <button class="fd-tree__expander is-expanded" aria-controls="TREE6CL7" aria-haspopup="true" aria-label="Expand level 7" aria-expanded="true"></button>
+                                                    <button class="fd-tree__expander is-expanded" aria-controls="TREE6CL7" aria-haspopup="true" aria-label="Expand level 7" aria-expanded="true">
+                                                        <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                                                    </button>
                                                     <div class="fd-tree__content">
                                                         <span class="fd-tree__text">Level 6</span>
                                                     </div>
@@ -438,7 +520,9 @@ export const treeWithExpandedLevel6AndNavigationLinks = () => `
                                                 <ul role="group" class="fd-tree" id="TREE6CL7" aria-hidden="false">
                                                     <li role="treeitem" aria-level="7" class="fd-tree__item">
                                                         <div class="fd-tree__item-container">
-                                                            <button class="fd-tree__expander" aria-label="Expander"></button>
+                                                            <button class="fd-tree__expander" aria-label="Expander">
+                                                                <i class="sap-icon--navigation-right-arrow" role="presentation"></i>
+                                                            </button>
                                                             <div class="fd-tree__content">
                                                                 <span class="fd-tree__text">Level 7</span>
                                                             </div>
@@ -473,18 +557,24 @@ export const treeWithExpandedLevel6AndNavigationLinks = () => `
                             </li>
                             <li role="treeitem" aria-level="4" class="fd-tree__item">
                                 <div class="fd-tree__item-container fd-tree__item-container--active">
-                                    <a href="https://sap.github.io/fundamental/" class="fd-tree__content has-navigation-indicator">
+                                    <a href="https://sap.github.io/fundamental/" class="fd-tree__content">
                                         <span class="fd-tree__text">Level 4</span>
                                     </a>
+                                    <span class="fd-tree__icon fd-tree__icon--navigation">
+                                        <i class="sap-icon--slim-arrow-right" role="presentation"></i>
+                                    </span>
                                 </div>
                             </li>
                         </ul>
                     </li>
                     <li role="treeitem" aria-level="3" class="fd-tree__item">
                         <div class="fd-tree__item-container fd-tree__item-container--active">
-                            <a href="https://sap.github.io/fundamental/" class="fd-tree__content has-navigation-indicator">
+                            <a href="https://sap.github.io/fundamental/" class="fd-tree__content">
                                 <span class="fd-tree__text">Level 3</span>
                             </a>
+                            <span class="fd-tree__icon fd-tree__icon--navigation">
+                                <i class="sap-icon--slim-arrow-right" role="presentation"></i>
+                            </span>
                         </div>
                     </li>
                 </ul>
@@ -500,16 +590,22 @@ export const treeWithExpandedLevel6AndNavigationLinks = () => `
     </li>
     <li role="treeitem" aria-level="1" class="fd-tree__item">
         <div class="fd-tree__item-container fd-tree__item-container--active has-highlight-indicator--success is-navigated">
-            <a href="https://sap.github.io/fundamental/" class="fd-tree__content has-navigation-indicator">
+            <a href="https://sap.github.io/fundamental/" class="fd-tree__content">
                 <span class="fd-tree__text">Level 1</span>
             </a>
+            <span class="fd-tree__icon fd-tree__icon--navigation">
+                <i class="sap-icon--slim-arrow-right" role="presentation"></i>
+            </span>
         </div>
     </li>
     <li role="treeitem" aria-level="1" class="fd-tree__item">
         <div class="fd-tree__item-container has-highlight-indicator--success">
-        <a href="https://sap.github.io/fundamental/" class="fd-tree__content has-navigation-indicator">
-            <span class="fd-tree__text">Level 1</span>
-        </a>
+            <a href="https://sap.github.io/fundamental/" class="fd-tree__content">
+                <span class="fd-tree__text">Level 1</span>
+            </a>
+            <span class="fd-tree__icon fd-tree__icon--navigation">
+                <i class="sap-icon--slim-arrow-right" role="presentation"></i>
+            </span>
         </div>
     </li>
 </ul>
@@ -520,15 +616,22 @@ export const treeWithExpandedLevel6AndNavigationLinks = () => `
 <ul role="tree" aria-label="Root Tree" id="TREE6L1" class="fd-tree fd-tree--active fd-tree--compact expanded-level-6">
     <li role="treeitem" aria-level="1" aria-expanded="true" class="fd-tree__item">
         <div class="fd-tree__item-container has-highlight-indicator--success">
-            <button class="fd-tree__expander is-expanded" aria-controls="TREE6L2" aria-haspopup="true" aria-label="Expand level 2" aria-expanded="true"></button>
-            <a href="https://sap.github.io/fundamental/" class="fd-tree__content has-navigation-indicator">
+            <button class="fd-tree__expander is-expanded" aria-controls="TREE6L2" aria-haspopup="true" aria-label="Expand level 2" aria-expanded="true">
+                <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+            </button>
+            <a href="https://sap.github.io/fundamental/" class="fd-tree__content">
                 <span class="fd-tree__text">Level 1</span>
             </a>
+            <span class="fd-tree__icon fd-tree__icon--navigation">
+                <i class="sap-icon--slim-arrow-right" role="presentation"></i>
+            </span>
         </div>
         <ul role="group" class="fd-tree" id="TREE6L2" aria-hidden="false">
             <li role="treeitem" aria-level="2" aria-expanded="true" class="fd-tree__item">
                 <div class="fd-tree__item-container has-highlight-indicator--warning">
-                    <button class="fd-tree__expander is-expanded" aria-controls="TREE6L3" aria-haspopup="true" aria-label="Expand level 3" aria-expanded="true"></button>
+                    <button class="fd-tree__expander is-expanded" aria-controls="TREE6L3" aria-haspopup="true" aria-label="Expand level 3" aria-expanded="true">
+                        <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                    </button>
                     <div class="fd-tree__content">
                         <span class="fd-tree__text">Level 2</span>
                     </div>
@@ -536,15 +639,22 @@ export const treeWithExpandedLevel6AndNavigationLinks = () => `
                 <ul role="group" class="fd-tree" id="TREE6L3" aria-hidden="false">
                     <li role="treeitem" aria-level="3" aria-expanded="true" class="fd-tree__item">
                         <div class="fd-tree__item-container has-highlight-indicator--error">
-                            <button class="fd-tree__expander is-expanded" aria-controls="TREE6L4" aria-haspopup="true" aria-label="Expand level 4" aria-expanded="true"></button>
-                            <a href="https://sap.github.io/fundamental/" class="fd-tree__content has-navigation-indicator">
+                            <button class="fd-tree__expander is-expanded" aria-controls="TREE6L4" aria-haspopup="true" aria-label="Expand level 4" aria-expanded="true">
+                                <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                            </button>
+                            <a href="https://sap.github.io/fundamental/" class="fd-tree__content">
                                 <span class="fd-tree__text">Level 3</span>
                             </a>
+                            <span class="fd-tree__icon fd-tree__icon--navigation">
+                                <i class="sap-icon--slim-arrow-right" role="presentation"></i>
+                            </span>
                         </div>
                         <ul role="group" class="fd-tree" id="TREE6L4" aria-hidden="false">
                             <li role="treeitem" aria-level="4" aria-expanded="true" class="fd-tree__item">
                                 <div class="fd-tree__item-container has-highlight-indicator">
-                                    <button class="fd-tree__expander is-expanded" aria-controls="TREE6L5" aria-haspopup="true" aria-label="Expand level 5" aria-expanded="true"></button>
+                                    <button class="fd-tree__expander is-expanded" aria-controls="TREE6L5" aria-haspopup="true" aria-label="Expand level 5" aria-expanded="true">
+                                        <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                                    </button>
                                     <div class="fd-tree__content">
                                         <span class="fd-tree__text">Level 4</span>
                                     </div>
@@ -552,7 +662,9 @@ export const treeWithExpandedLevel6AndNavigationLinks = () => `
                                 <ul role="group" class="fd-tree" id="TREE6L5" aria-hidden="false">
                                     <li role="treeitem" aria-level="5" aria-expanded="true"  class="fd-tree__item">
                                         <div class="fd-tree__item-container">
-                                            <button class="fd-tree__expander is-expanded" aria-controls="TREE6L6" aria-haspopup="true" aria-label="Expand level 6" aria-expanded="true"></button>
+                                            <button class="fd-tree__expander is-expanded" aria-controls="TREE6L6" aria-haspopup="true" aria-label="Expand level 6" aria-expanded="true">
+                                                <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                                            </button>
                                             <div class="fd-tree__content">
                                                 <span class="fd-tree__text">Level 5</span>
                                             </div>
@@ -560,7 +672,9 @@ export const treeWithExpandedLevel6AndNavigationLinks = () => `
                                         <ul role="group" class="fd-tree" id="TREE6L6" aria-hidden="false">
                                             <li role="treeitem" aria-level="6" aria-expanded="true" class="fd-tree__item">
                                                 <div class="fd-tree__item-container">
-                                                    <button class="fd-tree__expander is-expanded" aria-controls="TREE6L7" aria-haspopup="true" aria-label="Expand level 7" aria-expanded="true"></button>
+                                                    <button class="fd-tree__expander is-expanded" aria-controls="TREE6L7" aria-haspopup="true" aria-label="Expand level 7" aria-expanded="true">
+                                                        <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                                                    </button>
                                                     <div class="fd-tree__content">
                                                         <span class="fd-tree__text">Level 6</span>
                                                     </div>
@@ -568,7 +682,9 @@ export const treeWithExpandedLevel6AndNavigationLinks = () => `
                                                 <ul role="group" class="fd-tree" id="TREE6L7" aria-hidden="false">
                                                     <li role="treeitem" aria-level="7" class="fd-tree__item">
                                                         <div class="fd-tree__item-container">
-                                                            <button class="fd-tree__expander" aria-label="Expander"></button>
+                                                            <button class="fd-tree__expander" aria-label="Expander">
+                                                                <i class="sap-icon--navigation-right-arrow" role="presentation"></i>
+                                                            </button>
                                                             <div class="fd-tree__content">
                                                                 <span class="fd-tree__text">Level 7</span>
                                                             </div>
@@ -603,18 +719,24 @@ export const treeWithExpandedLevel6AndNavigationLinks = () => `
                             </li>
                             <li role="treeitem" aria-level="4" class="fd-tree__item">
                                 <div class="fd-tree__item-container">
-                                    <a href="https://sap.github.io/fundamental/" class="fd-tree__content has-navigation-indicator">
+                                    <a href="https://sap.github.io/fundamental/" class="fd-tree__content">
                                         <span class="fd-tree__text">Level 4</span>
                                     </a>
+                                    <span class="fd-tree__icon fd-tree__icon--navigation">
+                                        <i class="sap-icon--slim-arrow-right" role="presentation"></i>
+                                    </span>
                                 </div>
                             </li>
                         </ul>
                     </li>
                     <li role="treeitem" aria-level="3" class="fd-tree__item">
                         <div class="fd-tree__item-container">
-                            <a href="https://sap.github.io/fundamental/" class="fd-tree__content has-navigation-indicator">
+                            <a href="https://sap.github.io/fundamental/" class="fd-tree__content">
                                 <span class="fd-tree__text">Level 3</span>
                             </a>
+                            <span class="fd-tree__icon fd-tree__icon--navigation">
+                                <i class="sap-icon--slim-arrow-right" role="presentation"></i>
+                            </span>
                         </div>
                     </li>
                 </ul>
@@ -630,16 +752,22 @@ export const treeWithExpandedLevel6AndNavigationLinks = () => `
     </li>
     <li role="treeitem" aria-level="1" class="fd-tree__item">
         <div class="fd-tree__item-container has-highlight-indicator--success is-navigated">
-            <a href="https://sap.github.io/fundamental/" class="fd-tree__content has-navigation-indicator">
+            <a href="https://sap.github.io/fundamental/" class="fd-tree__content">
                 <span class="fd-tree__text">Level 1</span>
             </a>
+            <span class="fd-tree__icon fd-tree__icon--navigation">
+                <i class="sap-icon--slim-arrow-right" role="presentation"></i>
+            </span>
         </div>
     </li>
     <li role="treeitem" aria-level="1" class="fd-tree__item">
         <div class="fd-tree__item-container has-highlight-indicator--success">
-        <a href="https://sap.github.io/fundamental/" class="fd-tree__content has-navigation-indicator">
-            <span class="fd-tree__text">Level 1</span>
-        </a>
+            <a href="https://sap.github.io/fundamental/" class="fd-tree__content">
+                <span class="fd-tree__text">Level 1</span>
+            </a>
+            <span class="fd-tree__icon fd-tree__icon--navigation">
+                <i class="sap-icon--slim-arrow-right" role="presentation"></i>
+            </span>
         </div>
     </li>
 </ul>
@@ -661,7 +789,7 @@ Indentations are calculated with 0.25rem
 
 0.25rem is added to each indentation up to level 12.
 
-If only a subset of the tree items are navigable (contain links) you should indicate those by displaying a navigation arrow. This is achieved by applying the <code class="docs-code">.has-navigation-indicator</code> class to the <code class="docs-code">.fd-tree\\_\\_content</code> element and <code class="docs-code">.fd-tree\\_\\_item-container--active</code> modifier class to the <code class="docs-code">.fd-tree\\_\\_item-container</code>. 
+If only a subset of the tree items are navigable (contain links) you should indicate those by displaying a navigation arrow. This is achieved by creating an element with <code class="docs-code">.fd-tree\\_\\_icon</code> and <code class="docs-code">.fd-tree\\_\\_icon--navigation</code> classes inside <code class="docs-code">.fd-tree\\_\\_item-container</code> element and adding <code class="docs-code">.fd-tree\\_\\_item-container--active</code> modifier class. 
 
 Do not show arrows if all items are navigable. In this case apply the <code class="docs-code">.fd-tree--active</code> modifier class to the root tree. This will add states (hover, selected, active) to all tree items.
 
@@ -678,7 +806,9 @@ export const treeWithSelection = () => `
 <ul role="tree" aria-label="Root Tree" id="TREESELL1" class="fd-tree expanded-level-1">
     <li role="treeitem" aria-level="1" aria-expanded="true" class="fd-tree__item">
         <div class="fd-tree__item-container is-selected">
-            <button tabindex="0" class="fd-tree__expander is-expanded" aria-controls="TREESELL2" aria-haspopup="true" aria-label="Expand level 2" aria-expanded="true"></button>
+            <button tabindex="0" class="fd-tree__expander is-expanded" aria-controls="TREESELL2" aria-haspopup="true" aria-label="Expand level 2" aria-expanded="true">
+                <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+            </button>
             <div class="fd-form-item">
                 <input type="checkbox" checked class="fd-checkbox" id="Ai4ez1">
                 <label tabindex="-1" aria-label="checkbox" class="fd-checkbox__label" for="Ai4ez1"></label>
@@ -690,7 +820,9 @@ export const treeWithSelection = () => `
         <ul role="group" class="fd-tree" id="TREESELL2" aria-hidden="false">
             <li role="treeitem" aria-level="2" class="fd-tree__item">
                 <div class="fd-tree__item-container">
-                    <button tabindex="0" class="fd-tree__expander" aria-label="Expander"></button>
+                    <button tabindex="0" class="fd-tree__expander" aria-label="Expander">
+                        <i class="sap-icon--navigation-right-arrow" role="presentation"></i>
+                    </button>
                     <div class="fd-form-item">
                         <input type="checkbox" class="fd-checkbox" id="Ai4ez2">
                         <label tabindex="-1" aria-label="checkbox" class="fd-checkbox__label" for="Ai4ez2"></label>
@@ -732,7 +864,7 @@ export const treeWithSelection = () => `
             </div>
             <div class="fd-tree__content">
                 <span class="fd-tree__text">Level 1</span>
-            </div
+            </div>
         </div>
     </li>
     <li role="treeitem" aria-level="1" class="fd-tree__item">
@@ -755,7 +887,9 @@ export const treeWithSelection = () => `
 <ul role="tree" aria-label="Root Tree" id="TREESELCL1" class="fd-tree fd-tree--compact fd-tree--no-border expanded-level-1">
     <li role="treeitem" aria-level="1" aria-expanded="true" class="fd-tree__item">
         <div class="fd-tree__item-container is-selected">
-            <button tabindex="0" class="fd-tree__expander is-expanded" aria-controls="TREESELCL2" aria-haspopup="true" aria-label="Expand level 2" aria-expanded="true"></button>
+            <button tabindex="0" class="fd-tree__expander is-expanded" aria-controls="TREESELCL2" aria-haspopup="true" aria-label="Expand level 2" aria-expanded="true">
+                <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+            </button>
             <div class="fd-tree__content">
                 <span class="fd-tree__text">Level 1</span>
             </div>
@@ -767,7 +901,9 @@ export const treeWithSelection = () => `
         <ul role="group" class="fd-tree" id="TREESELCL2" aria-hidden="false">
             <li role="treeitem" aria-level="2" class="fd-tree__item">
                 <div class="fd-tree__item-container">
-                    <button tabindex="0" class="fd-tree__expander" aria-label="Expander"></button>
+                    <button tabindex="0" class="fd-tree__expander" aria-label="Expander">
+                        <i class="sap-icon--navigation-right-arrow" role="presentation"></i>
+                    </button>
                     <div class="fd-tree__content">
                         <span class="fd-tree__text">Level 2</span>
                     </div>
@@ -805,7 +941,7 @@ export const treeWithSelection = () => `
         <div class="fd-tree__item-container is-selected">
             <div class="fd-tree__content">
                 <span class="fd-tree__text">Level 1</span>
-            </div
+            </div>
             <div class="fd-form-item">
                 <input type="checkbox" checked class="fd-checkbox fd-checkbox--compact" id="Ai4ezEE">
                 <label tabindex="-1" aria-label="checkbox" class="fd-checkbox__label fd-checkbox__label--compact" for="Ai4ezEE"></label>
@@ -832,7 +968,9 @@ export const treeWithSelection = () => `
 <ul role="tree" aria-label="Root Tree" id="TREESESSLL1" class="fd-tree expanded-level-1">
     <li role="treeitem" aria-level="1" aria-expanded="true" class="fd-tree__item">
         <div class="fd-tree__item-container is-selected">
-            <button tabindex="0" class="fd-tree__expander is-expanded" aria-controls="TREESESSLL2" aria-haspopup="true" aria-label="Expand level 2" aria-expanded="true"></button>
+            <button tabindex="0" class="fd-tree__expander is-expanded" aria-controls="TREESESSLL2" aria-haspopup="true" aria-label="Expand level 2" aria-expanded="true">
+                <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+            </button>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio" id="pDidh761" name="radio1" checked>
                 <label class="fd-radio__label" aria-label="radio button" for="pDidh761"></label>
@@ -844,7 +982,9 @@ export const treeWithSelection = () => `
         <ul role="group" class="fd-tree" id="TREESESSLL2" aria-hidden="false">
             <li role="treeitem" aria-level="2" class="fd-tree__item">
                 <div class="fd-tree__item-container">
-                    <button tabindex="0" class="fd-tree__expander" aria-label="Expander"></button>
+                    <button tabindex="0" class="fd-tree__expander" aria-label="Expander">
+                        <i class="sap-icon--navigation-right-arrow" role="presentation"></i>
+                    </button>
                     <div class="fd-form-item">
                         <input type="radio" class="fd-radio" id="pDidh7612" name="radio1">
                         <label class="fd-radio__label" aria-label="radio button" for="pDidh7612"></label>
@@ -886,7 +1026,7 @@ export const treeWithSelection = () => `
             </div>
             <div class="fd-tree__content">
                 <span class="fd-tree__text">Level 1</span>
-            </div
+            </div>
         </div>
     </li>
     <li role="treeitem" aria-level="1" class="fd-tree__item">
@@ -938,45 +1078,78 @@ export const RTL = () => `
     <ul role="tree" aria-label="Root Tree" id="TREE1RTLL1" class="fd-tree fd-tree--active expanded-level-1">
         <li role="treeitem" aria-level="1" aria-expanded="true" class="fd-tree__item">
             <div class="fd-tree__item-container  has-highlight-indicator--success is-navigated">
-                <button class="fd-tree__expander is-expanded" aria-controls="TREE1RTLL2" aria-haspopup="true" aria-label="Expand level 2" aria-expanded="true"></button>
-                <a href="https://sap.github.io/fundamental/" class="fd-tree__content has-navigation-indicator">
-                    <span class="sap-icon--pie-chart sap-icon--l fd-tree__icon"></span>
+                <button class="fd-tree__expander is-expanded" aria-controls="TREE1RTLL2" aria-haspopup="true" aria-label="Expand level 2" aria-expanded="true">
+                    <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                </button>
+                <a href="https://sap.github.io/fundamental/" class="fd-tree__content">
+                    <span class="fd-tree__icon">
+                        <i class="sap-icon--pie-chart sap-icon--l" role="presentation"></i>
+                    </span>
                     <span class="fd-tree__text">Level 1</span>
                 </a>
-                <button aria-label="Edit button" class="fd-button fd-button--transparent sap-icon--edit"></button>
-                <button aria-label="Delete button" class="fd-button fd-button--transparent sap-icon--decline"></button>
+                <span class="fd-tree__icon fd-tree__icon--navigation">
+                    <i class="sap-icon--slim-arrow-left" role="presentation"></i>
+                </span>
+                <button aria-label="Edit button" class="fd-button fd-button--transparent">
+                    <i class="sap-icon--edit" role="presentation"></i>
+                </button>
+                <button aria-label="Delete button" class="fd-button fd-button--transparent">
+                    <i class="sap-icon--decline" role="presentation"></i>
+                </button>
             </div>
             <ul role="group" class="fd-tree" id="TREE1RTLL2" aria-hidden="false">
                 <li role="treeitem" aria-level="2" class="fd-tree__item">
                     <div class="fd-tree__item-container has-highlight-indicator--warning">
-                        <button class="fd-tree__expander" aria-label="Expander"></button>
+                        <button class="fd-tree__expander" aria-label="Expander">
+                            <i class="sap-icon--navigation-left-arrow" role="presentation"></i>
+                        </button>
                         <div class="fd-tree__content">
-                            <span class="sap-icon--money-bills sap-icon--l fd-tree__icon"></span>
+                            <span class="fd-tree__icon">
+                                <i class="sap-icon--money-bills sap-icon--l" role="presentation"></i>
+                            </span>
                             <span class="fd-tree__text">Level 2</span>
                         </div>
-                        <button aria-label="Edit button" class="fd-button fd-button--transparent sap-icon--edit"></button>
-                        <button aria-label="Delete button" class="fd-button fd-button--transparent sap-icon--decline"></button>
+                        <button aria-label="Edit button" class="fd-button fd-button--transparent">
+                            <i class="sap-icon--edit" role="presentation"></i>
+                        </button>
+                        <button aria-label="Delete button" class="fd-button fd-button--transparent">
+                            <i class="sap-icon--decline" role="presentation"></i>
+                        </button>
                     </div>
                 </li>
                 <li role="treeitem" aria-level="2" class="fd-tree__item">
                     <div class="fd-tree__item-container">
                         <div class="fd-tree__content">
-                            <span class="sap-icon--marketing-campaign sap-icon--l fd-tree__icon"></span>
+                            <span class="fd-tree__icon">
+                                <i class="sap-icon--marketing-campaign sap-icon--l" role="presentation"></i>
+                            </span>
                             <span class="fd-tree__text">Level 2</span>
                         </div>
-                        <button aria-label="Edit button" class="fd-button fd-button--transparent sap-icon--edit"></button>
-                        <button aria-label="Delete button" class="fd-button fd-button--transparent sap-icon--decline"></button>
+                        <button aria-label="Edit button" class="fd-button fd-button--transparent">
+                            <i class="sap-icon--edit" role="presentation"></i>
+                        </button>
+                        <button aria-label="Delete button" class="fd-button fd-button--transparent">
+                            <i class="sap-icon--decline" role="presentation"></i>
+                        </button>
                     </div>
                 </li>
                 <li role="treeitem" aria-level="2" class="fd-tree__item">
                     <div class="fd-tree__item-container">
                         <div class="fd-tree__content">
-                            <span class="sap-icon--waiver sap-icon--l fd-tree__icon"></span>
+                            <span class="fd-tree__icon">
+                                <i class="sap-icon--waiver sap-icon--l" role="presentation"></i>
+                            </span>
                             <span class="fd-tree__text">Level 2</span>
-                            <span class="sap-icon--e-learning sap-icon--l fd-tree__icon"></span>
+                            <span class="fd-tree__icon">
+                                <i class="sap-icon--e-learning sap-icon--l" role="presentation"></i>
+                            </span>
                         </div>
-                        <button aria-label="Edit button" class="fd-button fd-button--transparent sap-icon--edit"></button>
-                        <button aria-label="Delete button" class="fd-button fd-button--transparent sap-icon--decline"></button>
+                        <button aria-label="Edit button" class="fd-button fd-button--transparent">
+                            <i class="sap-icon--edit" role="presentation"></i>
+                        </button>
+                        <button aria-label="Delete button" class="fd-button fd-button--transparent">
+                            <i class="sap-icon--decline" role="presentation"></i>
+                        </button>
                     </div>
                 </li>
             </ul>
@@ -984,30 +1157,49 @@ export const RTL = () => `
         <li role="treeitem" aria-level="1" class="fd-tree__item">
             <div class="fd-tree__item-container">
                 <div class="fd-tree__content">
-                    <span class="sap-icon--home-share sap-icon--l fd-tree__icon"></span>
+                    <span class="fd-tree__icon">
+                        <i class="sap-icon--home-share sap-icon--l" role="presentation"></i>
+                    </span>
                     <span class="fd-tree__text">Level 1</span>
-                    <span class="sap-icon--puzzle sap-icon--l fd-tree__icon"></span>
+                    <span class="fd-tree__icon">
+                        <i class="sap-icon--puzzle sap-icon--l" role="presentation"></i>
+                    </span>
                 </div>
-                <button aria-label="Edit button" class="fd-button fd-button--transparent sap-icon--edit"></button>
-                <button aria-label="Delete button" class="fd-button fd-button--transparent sap-icon--decline"></button>
+                <button aria-label="Edit button" class="fd-button fd-button--transparent">
+                    <i class="sap-icon--edit" role="presentation"></i>
+                </button>
+                <button aria-label="Delete button" class="fd-button fd-button--transparent">
+                    <i class="sap-icon--decline" role="presentation"></i>
+                </button>
             </div>
         </li>
         <li role="treeitem" aria-level="1" class="fd-tree__item">
             <div class="fd-tree__item-container is-navigated has-highlight-indicator--error">
-                <a href="https://sap.github.io/fundamental/" class="fd-tree__content has-navigation-indicator">
-                    <span class="sap-icon--overview-chart sap-icon--l fd-tree__icon"></span>
+                <a href="https://sap.github.io/fundamental/" class="fd-tree__content">
+                    <span class="fd-tree__icon">
+                        <i class="sap-icon--overview-chart sap-icon--l" role="presentation"></i>
+                    </span>
                     <span class="fd-tree__text">Very long text that does not wrap ... perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem.</span>
                 </a>
+                <span class="fd-tree__icon fd-tree__icon--navigation">
+                    <i class="sap-icon--slim-arrow-left" role="presentation"></i>
+                </span>
             </div>
         </li>
         <li role="treeitem" aria-level="1" class="fd-tree__item">
             <div class="fd-tree__item-container has-highlight-indicator">
                 <div class="fd-tree__content fd-tree__content--wrap">
-                    <span class="sap-icon--e-care sap-icon--l fd-tree__icon"></span>
+                    <span class="fd-tree__icon">
+                        <i class="sap-icon--e-care sap-icon--l" role="presentation"></i>
+                    </span>
                     <span class="fd-tree__text">Very long text with wrapping behaviour ... perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem.</span>
                 </div>
-                <button aria-label="Edit button" class="fd-button fd-button--transparent sap-icon--edit"></button>
-                <button aria-label="Delete button" class="fd-button fd-button--transparent sap-icon--decline"></button>
+                <button aria-label="Edit button" class="fd-button fd-button--transparent">
+                    <i class="sap-icon--edit" role="presentation"></i>
+                </button>
+                <button aria-label="Delete button" class="fd-button fd-button--transparent">
+                    <i class="sap-icon--decline" role="presentation"></i>
+                </button>
             </div>
         </li>
     </ul>

--- a/stories/tree/tree.stories.js
+++ b/stories/tree/tree.stories.js
@@ -197,7 +197,7 @@ export const treeWithExpandedLevel2AndNoBorders = () => `
     <li role="treeitem" aria-level="1" aria-expanded="true" class="fd-tree__item">
         <div class="fd-tree__item-container">
             <button tabindex="0" class="fd-tree__expander is-expanded" aria-controls="TREE2L2" aria-haspopup="true" aria-label="Expand level 2" aria-expanded="true">
-                <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                <i class="fd-tree__icon sap-icon--navigation-down-arrow" role="presentation"></i>
             </button>
             <div class="fd-tree__content">
                 <i class="fd-tree__icon sap-icon--e-care" role="presentation"></i>

--- a/stories/tree/tree.stories.js
+++ b/stories/tree/tree.stories.js
@@ -493,7 +493,7 @@ export const treeWithExpandedLevel6AndNavigationLinks = () => `
                                             <li role="treeitem" aria-level="6" aria-expanded="true" class="fd-tree__item">
                                                 <div class="fd-tree__item-container">
                                                     <button class="fd-tree__expander is-expanded" aria-controls="TREE6CL7" aria-haspopup="true" aria-label="Expand level 7" aria-expanded="true">
-                                                        <i class=fd-tree__icon "sap-icon--navigation-down-arrow" role="presentation"></i>
+                                                        <i class="fd-tree__icon sap-icon--navigation-down-arrow" role="presentation"></i>
                                                     </button>
                                                     <div class="fd-tree__content">
                                                         <span class="fd-tree__text">Level 6</span>

--- a/stories/tree/tree.stories.js
+++ b/stories/tree/tree.stories.js
@@ -61,7 +61,7 @@ export const treeWithExpandedLevel1 = () => `
     <li role="treeitem" aria-level="1" aria-expanded="true" class="fd-tree__item">
         <div class="fd-tree__item-container">
             <button tabindex="0" class="fd-tree__expander is-expanded" aria-controls="TREE1L2" aria-haspopup="true" aria-label="Expand level 2" aria-expanded="true">
-                <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                <i class="fd-tree__icon sap-icon--navigation-down-arrow" role="presentation"></i>
             </button>
             <div class="fd-tree__content">
                 <span class="fd-tree__text">Level 1</span>
@@ -71,7 +71,7 @@ export const treeWithExpandedLevel1 = () => `
             <li role="treeitem" aria-level="2" class="fd-tree__item">
                 <div class="fd-tree__item-container">
                     <button tabindex="0" class="fd-tree__expander" aria-label="Expander">
-                        <i class="sap-icon--navigation-right-arrow" role="presentation"></i>
+                        <i class="fd-tree__icon sap-icon--navigation-right-arrow" role="presentation"></i>
                     </button>
                     <div class="fd-tree__content">
                         <span class="fd-tree__text">Level 2</span>
@@ -125,7 +125,7 @@ export const treeWithExpandedLevel1 = () => `
     <li role="treeitem" aria-level="1" aria-expanded="true" class="fd-tree__item">
         <div class="fd-tree__item-container">
             <button tabindex="0" class="fd-tree__expander is-expanded" aria-controls="TREE1CL2" aria-haspopup="true" aria-label="Expand level 2" aria-expanded="true">
-                <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                <i class="fd-tree__icon sap-icon--navigation-down-arrow" role="presentation"></i>
             </button>
             <div class="fd-tree__content">
                 <span class="fd-tree__text">Level 1</span>
@@ -135,7 +135,7 @@ export const treeWithExpandedLevel1 = () => `
             <li role="treeitem" aria-level="2" class="fd-tree__item">
                 <div class="fd-tree__item-container">
                     <button tabindex="0" class="fd-tree__expander" aria-label="Expander">
-                        <i class="sap-icon--navigation-right-arrow" role="presentation"></i>
+                        <i class="fd-tree__icon sap-icon--navigation-right-arrow" role="presentation"></i>
                     </button>
                     <div class="fd-tree__content">
                         <span class="fd-tree__text">Level 2</span>
@@ -200,9 +200,7 @@ export const treeWithExpandedLevel2AndNoBorders = () => `
                 <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
             </button>
             <div class="fd-tree__content">
-                <span class="fd-tree__icon">
-                    <i class="sap-icon--e-care sap-icon--l" role="presentation"></i>
-                </span>
+                <i class="fd-tree__icon sap-icon--e-care" role="presentation"></i>
                 <span class="fd-tree__text">Level 1</span>
             </div>
             <button aria-label="Edit button" class="fd-button fd-button--transparent">
@@ -216,12 +214,10 @@ export const treeWithExpandedLevel2AndNoBorders = () => `
             <li role="treeitem" aria-level="2" aria-expanded="true" class="fd-tree__item">
                 <div class="fd-tree__item-container">
                     <button tabindex="0" class="fd-tree__expander is-expanded" aria-controls="TREE2L3" aria-haspopup="true" aria-label="Expand level 3" aria-expanded="true">
-                        <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                        <i class="fd-tree__icon sap-icon--navigation-down-arrow" role="presentation"></i>
                     </button>
                     <div class="fd-tree__content">
-                        <span class="fd-tree__icon">
-                            <i class="sap-icon--account sap-icon--l" role="presentation"></i>
-                        </span>
+                        <i class="fd-tree__icon sap-icon--account" role="presentation"></i>
                         <span class="fd-tree__text">Level 2</span>
                     </div>
                     <button aria-label="Edit button" class="fd-button fd-button--transparent">
@@ -235,12 +231,10 @@ export const treeWithExpandedLevel2AndNoBorders = () => `
                     <li role="treeitem" aria-level="3" class="fd-tree__item">
                         <div class="fd-tree__item-container">
                             <button tabindex="0" class="fd-tree__expander" aria-label="Expander">
-                                <i class="sap-icon--navigation-right-arrow" role="presentation"></i>
+                                <i class="fd-tree__icon sap-icon--navigation-right-arrow" role="presentation"></i>
                             </button>
                             <div class="fd-tree__content">
-                                <span class="fd-tree__icon">
-                                    <i class="sap-icon--product sap-icon--l" role="presentation"></i>
-                                </span>
+                                <i class="fd-tree__icon sap-icon--product" role="presentation"></i>
                                 <span class="fd-tree__text">Level 3</span>
                             </div>
                             <button aria-label="Edit button" class="fd-button fd-button--transparent">
@@ -254,9 +248,7 @@ export const treeWithExpandedLevel2AndNoBorders = () => `
                     <li role="treeitem" aria-level="3" class="fd-tree__item">
                         <div class="fd-tree__item-container">
                             <div class="fd-tree__content">
-                                <span class="fd-tree__icon">
-                                    <i class="sap-icon--history sap-icon--l" role="presentation"></i>
-                                </span>
+                                <i class="fd-tree__icon sap-icon--history" role="presentation"></i>
                                 <span class="fd-tree__text">Level 3</span>
                             </div>
                             <button aria-label="Edit button" class="fd-button fd-button--transparent">
@@ -272,9 +264,7 @@ export const treeWithExpandedLevel2AndNoBorders = () => `
             <li role="treeitem" aria-level="2" class="fd-tree__item">
                 <div class="fd-tree__item-container">
                     <div class="fd-tree__content">
-                        <span class="fd-tree__icon">
-                            <i class="sap-icon--competitor sap-icon--l" role="presentation"></i>
-                        </span>
+                        <i class="fd-tree__icon sap-icon--competitor" role="presentation"></i>
                         <span class="fd-tree__text">Level 2</span>
                     </div>
                     <button aria-label="Edit button" class="fd-button fd-button--transparent">
@@ -290,9 +280,7 @@ export const treeWithExpandedLevel2AndNoBorders = () => `
     <li role="treeitem" aria-level="1" class="fd-tree__item">
         <div class="fd-tree__item-container">
             <div class="fd-tree__content">
-                <span class="fd-tree__icon">
-                    <i class="sap-icon--batch-payments sap-icon--l" role="presentation"></i>
-                </span>
+                <i class="fd-tree__icon sap-icon--batch-payments" role="presentation"></i>
                 <span class="fd-tree__text">Level 1</span>
             </div>
             <button aria-label="Edit button" class="fd-button fd-button--transparent">
@@ -306,9 +294,7 @@ export const treeWithExpandedLevel2AndNoBorders = () => `
     <li role="treeitem" aria-level="1" class="fd-tree__item">
         <div class="fd-tree__item-container">
             <div class="fd-tree__content">
-                <span class="fd-tree__icon">
-                    <i class="sap-icon--favorite sap-icon--l" role="presentation"></i>
-                </span>
+                <i class="fd-tree__icon sap-icon--favorite" role="presentation"></i>
                 <span class="fd-tree__text">Level 1</span>
             </div>
             <button aria-label="Edit button" class="fd-button fd-button--transparent">
@@ -340,7 +326,7 @@ export const treeWithExpandedLevel3AndHighlightIndicators = () => `
     <li role="treeitem" aria-level="1" aria-expanded="true" class="fd-tree__item">
         <div class="fd-tree__item-container has-highlight-indicator">
             <button class="fd-tree__expander is-expanded" aria-controls="TREE3L2" aria-haspopup="true" aria-label="Expand level 2" aria-expanded="true">
-                <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                <i class="fd-tree__icon sap-icon--navigation-down-arrow" role="presentation"></i>
             </button>
             <div class="fd-tree__content">
                 <span class="fd-tree__text">Level 1</span>
@@ -350,7 +336,7 @@ export const treeWithExpandedLevel3AndHighlightIndicators = () => `
             <li role="treeitem" aria-level="2" aria-expanded="true" class="fd-tree__item">
                 <div class="fd-tree__item-container has-highlight-indicator--warning">
                     <button class="fd-tree__expander is-expanded" aria-controls="TREE3L3" aria-haspopup="true" aria-label="Expand level 3" aria-expanded="true">
-                        <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                        <i class="fd-tree__icon sap-icon--navigation-down-arrow" role="presentation"></i>
                     </button>
                     <div class="fd-tree__content">
                         <span class="fd-tree__text">Level 2</span>
@@ -360,7 +346,7 @@ export const treeWithExpandedLevel3AndHighlightIndicators = () => `
                     <li role="treeitem" aria-level="3" aria-expanded="true" class="fd-tree__item">
                         <div class="fd-tree__item-container has-highlight-indicator--error">
                             <button class="fd-tree__expander is-expanded" aria-controls="TREE3L4" aria-haspopup="true" aria-label="Expand level 4" aria-expanded="true">
-                                <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                                <i class="fd-tree__icon sap-icon--navigation-down-arrow" role="presentation"></i>
                             </button>
                             <div class="fd-tree__content">
                                 <span class="fd-tree__text">Level 3</span>
@@ -370,7 +356,7 @@ export const treeWithExpandedLevel3AndHighlightIndicators = () => `
                             <li role="treeitem" aria-level="4" class="fd-tree__item">
                                 <div class="fd-tree__item-container has-highlight-indicator--success">
                                     <button class="fd-tree__expander" aria-label="Expander">
-                                        <i class="sap-icon--navigation-right-arrow" role="presentation"></i>
+                                        <i class="fd-tree__icon sap-icon--navigation-right-arrow" role="presentation"></i>
                                     </button>
                                     <div class="fd-tree__content">
                                         <span class="fd-tree__text">Level 4</span>
@@ -455,20 +441,18 @@ export const treeWithExpandedLevel6AndNavigationLinks = () => `
     <li role="treeitem" aria-level="1" aria-expanded="true" class="fd-tree__item">
         <div class="fd-tree__item-container fd-tree__item-container--active has-highlight-indicator--success">
             <button class="fd-tree__expander is-expanded" aria-controls="TREE6CL2" aria-haspopup="true" aria-label="Expand level 2" aria-expanded="true">
-                <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                <i class="fd-tree__icon sap-icon--navigation-down-arrow" role="presentation"></i>
             </button>
             <a href="https://sap.github.io/fundamental/" class="fd-tree__content">
                 <span class="fd-tree__text">Level 1</span>
             </a>
-            <span class="fd-tree__icon fd-tree__icon--navigation">
-                <i class="sap-icon--slim-arrow-right" role="presentation"></i>
-            </span>
+            <i class="fd-tree__icon fd-tree__icon--navigation sap-icon--slim-arrow-right" role="presentation"></i>
         </div>
         <ul role="group" class="fd-tree" id="TREE6CL2" aria-hidden="false">
             <li role="treeitem" aria-level="2" aria-expanded="true" class="fd-tree__item">
                 <div class="fd-tree__item-container has-highlight-indicator--warning">
                     <button class="fd-tree__expander is-expanded" aria-controls="TREE6CL3" aria-haspopup="true" aria-label="Expand level 3" aria-expanded="true">
-                        <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                        <i class="fd-tree__icon sap-icon--navigation-down-arrow" role="presentation"></i>
                     </button>
                     <div class="fd-tree__content">
                         <span class="fd-tree__text">Level 2</span>
@@ -478,20 +462,18 @@ export const treeWithExpandedLevel6AndNavigationLinks = () => `
                     <li role="treeitem" aria-level="3" aria-expanded="true" class="fd-tree__item">
                         <div class="fd-tree__item-container fd-tree__item-container--active has-highlight-indicator--error">
                             <button class="fd-tree__expander is-expanded" aria-controls="TREE6CL4" aria-haspopup="true" aria-label="Expand level 4" aria-expanded="true">
-                                <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                                <i class="fd-tree__icon sap-icon--navigation-down-arrow" role="presentation"></i>
                             </button>
                             <a href="https://sap.github.io/fundamental/" class="fd-tree__content">
                                 <span class="fd-tree__text">Level 3</span>
                             </a>
-                            <span class="fd-tree__icon fd-tree__icon--navigation">
-                                <i class="sap-icon--slim-arrow-right" role="presentation"></i>
-                            </span>
+                            <i class="fd-tree__icon fd-tree__icon--navigation sap-icon--slim-arrow-right" role="presentation"></i>
                         </div>
                         <ul role="group" class="fd-tree" id="TREE6CL4" aria-hidden="false">
                             <li role="treeitem" aria-level="4" aria-expanded="true" class="fd-tree__item">
                                 <div class="fd-tree__item-container has-highlight-indicator">
                                     <button class="fd-tree__expander is-expanded" aria-controls="TREE6CL5" aria-haspopup="true" aria-label="Expand level 5" aria-expanded="true">
-                                        <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                                        <i class="fd-tree__icon sap-icon--navigation-down-arrow" role="presentation"></i>
                                     </button>
                                     <div class="fd-tree__content">
                                         <span class="fd-tree__text">Level 4</span>
@@ -501,7 +483,7 @@ export const treeWithExpandedLevel6AndNavigationLinks = () => `
                                     <li role="treeitem" aria-level="5" aria-expanded="true"  class="fd-tree__item">
                                         <div class="fd-tree__item-container">
                                             <button class="fd-tree__expander is-expanded" aria-controls="TREE6CL6" aria-haspopup="true" aria-label="Expand level 6" aria-expanded="true">
-                                                <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                                                <i class="fd-tree__icon sap-icon--navigation-down-arrow" role="presentation"></i>
                                             </button>
                                             <div class="fd-tree__content">
                                                 <span class="fd-tree__text">Level 5</span>
@@ -511,7 +493,7 @@ export const treeWithExpandedLevel6AndNavigationLinks = () => `
                                             <li role="treeitem" aria-level="6" aria-expanded="true" class="fd-tree__item">
                                                 <div class="fd-tree__item-container">
                                                     <button class="fd-tree__expander is-expanded" aria-controls="TREE6CL7" aria-haspopup="true" aria-label="Expand level 7" aria-expanded="true">
-                                                        <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                                                        <i class=fd-tree__icon "sap-icon--navigation-down-arrow" role="presentation"></i>
                                                     </button>
                                                     <div class="fd-tree__content">
                                                         <span class="fd-tree__text">Level 6</span>
@@ -521,7 +503,7 @@ export const treeWithExpandedLevel6AndNavigationLinks = () => `
                                                     <li role="treeitem" aria-level="7" class="fd-tree__item">
                                                         <div class="fd-tree__item-container">
                                                             <button class="fd-tree__expander" aria-label="Expander">
-                                                                <i class="sap-icon--navigation-right-arrow" role="presentation"></i>
+                                                                <i class="fd-tree__icon sap-icon--navigation-right-arrow" role="presentation"></i>
                                                             </button>
                                                             <div class="fd-tree__content">
                                                                 <span class="fd-tree__text">Level 7</span>
@@ -560,9 +542,7 @@ export const treeWithExpandedLevel6AndNavigationLinks = () => `
                                     <a href="https://sap.github.io/fundamental/" class="fd-tree__content">
                                         <span class="fd-tree__text">Level 4</span>
                                     </a>
-                                    <span class="fd-tree__icon fd-tree__icon--navigation">
-                                        <i class="sap-icon--slim-arrow-right" role="presentation"></i>
-                                    </span>
+                                    <i class="fd-tree__icon fd-tree__icon--navigation sap-icon--slim-arrow-right" role="presentation"></i>
                                 </div>
                             </li>
                         </ul>
@@ -572,9 +552,7 @@ export const treeWithExpandedLevel6AndNavigationLinks = () => `
                             <a href="https://sap.github.io/fundamental/" class="fd-tree__content">
                                 <span class="fd-tree__text">Level 3</span>
                             </a>
-                            <span class="fd-tree__icon fd-tree__icon--navigation">
-                                <i class="sap-icon--slim-arrow-right" role="presentation"></i>
-                            </span>
+                            <i class="fd-tree__icon fd-tree__icon--navigation sap-icon--slim-arrow-right" role="presentation"></i>
                         </div>
                     </li>
                 </ul>
@@ -593,9 +571,7 @@ export const treeWithExpandedLevel6AndNavigationLinks = () => `
             <a href="https://sap.github.io/fundamental/" class="fd-tree__content">
                 <span class="fd-tree__text">Level 1</span>
             </a>
-            <span class="fd-tree__icon fd-tree__icon--navigation">
-                <i class="sap-icon--slim-arrow-right" role="presentation"></i>
-            </span>
+            <i class="fd-tree__icon fd-tree__icon--navigation sap-icon--slim-arrow-right" role="presentation"></i>
         </div>
     </li>
     <li role="treeitem" aria-level="1" class="fd-tree__item">
@@ -603,9 +579,7 @@ export const treeWithExpandedLevel6AndNavigationLinks = () => `
             <a href="https://sap.github.io/fundamental/" class="fd-tree__content">
                 <span class="fd-tree__text">Level 1</span>
             </a>
-            <span class="fd-tree__icon fd-tree__icon--navigation">
-                <i class="sap-icon--slim-arrow-right" role="presentation"></i>
-            </span>
+            <i class="fd-tree__icon fd-tree__icon--navigation sap-icon--slim-arrow-right" role="presentation"></i>
         </div>
     </li>
 </ul>
@@ -617,20 +591,18 @@ export const treeWithExpandedLevel6AndNavigationLinks = () => `
     <li role="treeitem" aria-level="1" aria-expanded="true" class="fd-tree__item">
         <div class="fd-tree__item-container has-highlight-indicator--success">
             <button class="fd-tree__expander is-expanded" aria-controls="TREE6L2" aria-haspopup="true" aria-label="Expand level 2" aria-expanded="true">
-                <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                <i class="fd-tree__icon sap-icon--navigation-down-arrow" role="presentation"></i>
             </button>
             <a href="https://sap.github.io/fundamental/" class="fd-tree__content">
                 <span class="fd-tree__text">Level 1</span>
             </a>
-            <span class="fd-tree__icon fd-tree__icon--navigation">
-                <i class="sap-icon--slim-arrow-right" role="presentation"></i>
-            </span>
+            <i class="fd-tree__icon fd-tree__icon--navigation sap-icon--slim-arrow-right" role="presentation"></i>
         </div>
         <ul role="group" class="fd-tree" id="TREE6L2" aria-hidden="false">
             <li role="treeitem" aria-level="2" aria-expanded="true" class="fd-tree__item">
                 <div class="fd-tree__item-container has-highlight-indicator--warning">
                     <button class="fd-tree__expander is-expanded" aria-controls="TREE6L3" aria-haspopup="true" aria-label="Expand level 3" aria-expanded="true">
-                        <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                        <i class="fd-tree__icon sap-icon--navigation-down-arrow" role="presentation"></i>
                     </button>
                     <div class="fd-tree__content">
                         <span class="fd-tree__text">Level 2</span>
@@ -640,20 +612,18 @@ export const treeWithExpandedLevel6AndNavigationLinks = () => `
                     <li role="treeitem" aria-level="3" aria-expanded="true" class="fd-tree__item">
                         <div class="fd-tree__item-container has-highlight-indicator--error">
                             <button class="fd-tree__expander is-expanded" aria-controls="TREE6L4" aria-haspopup="true" aria-label="Expand level 4" aria-expanded="true">
-                                <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                                <i class="fd-tree__icon sap-icon--navigation-down-arrow" role="presentation"></i>
                             </button>
                             <a href="https://sap.github.io/fundamental/" class="fd-tree__content">
                                 <span class="fd-tree__text">Level 3</span>
                             </a>
-                            <span class="fd-tree__icon fd-tree__icon--navigation">
-                                <i class="sap-icon--slim-arrow-right" role="presentation"></i>
-                            </span>
+                            <i class="fd-tree__icon fd-tree__icon--navigation sap-icon--slim-arrow-right" role="presentation"></i>
                         </div>
                         <ul role="group" class="fd-tree" id="TREE6L4" aria-hidden="false">
                             <li role="treeitem" aria-level="4" aria-expanded="true" class="fd-tree__item">
                                 <div class="fd-tree__item-container has-highlight-indicator">
                                     <button class="fd-tree__expander is-expanded" aria-controls="TREE6L5" aria-haspopup="true" aria-label="Expand level 5" aria-expanded="true">
-                                        <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                                        <i class="fd-tree__icon sap-icon--navigation-down-arrow" role="presentation"></i>
                                     </button>
                                     <div class="fd-tree__content">
                                         <span class="fd-tree__text">Level 4</span>
@@ -663,7 +633,7 @@ export const treeWithExpandedLevel6AndNavigationLinks = () => `
                                     <li role="treeitem" aria-level="5" aria-expanded="true"  class="fd-tree__item">
                                         <div class="fd-tree__item-container">
                                             <button class="fd-tree__expander is-expanded" aria-controls="TREE6L6" aria-haspopup="true" aria-label="Expand level 6" aria-expanded="true">
-                                                <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                                                <i class="fd-tree__icon sap-icon--navigation-down-arrow" role="presentation"></i>
                                             </button>
                                             <div class="fd-tree__content">
                                                 <span class="fd-tree__text">Level 5</span>
@@ -673,7 +643,7 @@ export const treeWithExpandedLevel6AndNavigationLinks = () => `
                                             <li role="treeitem" aria-level="6" aria-expanded="true" class="fd-tree__item">
                                                 <div class="fd-tree__item-container">
                                                     <button class="fd-tree__expander is-expanded" aria-controls="TREE6L7" aria-haspopup="true" aria-label="Expand level 7" aria-expanded="true">
-                                                        <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                                                        <i class="fd-tree__icon sap-icon--navigation-down-arrow" role="presentation"></i>
                                                     </button>
                                                     <div class="fd-tree__content">
                                                         <span class="fd-tree__text">Level 6</span>
@@ -683,7 +653,7 @@ export const treeWithExpandedLevel6AndNavigationLinks = () => `
                                                     <li role="treeitem" aria-level="7" class="fd-tree__item">
                                                         <div class="fd-tree__item-container">
                                                             <button class="fd-tree__expander" aria-label="Expander">
-                                                                <i class="sap-icon--navigation-right-arrow" role="presentation"></i>
+                                                                <i class="fd-tree__icon sap-icon--navigation-right-arrow" role="presentation"></i>
                                                             </button>
                                                             <div class="fd-tree__content">
                                                                 <span class="fd-tree__text">Level 7</span>
@@ -722,9 +692,7 @@ export const treeWithExpandedLevel6AndNavigationLinks = () => `
                                     <a href="https://sap.github.io/fundamental/" class="fd-tree__content">
                                         <span class="fd-tree__text">Level 4</span>
                                     </a>
-                                    <span class="fd-tree__icon fd-tree__icon--navigation">
-                                        <i class="sap-icon--slim-arrow-right" role="presentation"></i>
-                                    </span>
+                                    <i class="fd-tree__icon fd-tree__icon--navigation sap-icon--slim-arrow-right" role="presentation"></i>
                                 </div>
                             </li>
                         </ul>
@@ -734,9 +702,7 @@ export const treeWithExpandedLevel6AndNavigationLinks = () => `
                             <a href="https://sap.github.io/fundamental/" class="fd-tree__content">
                                 <span class="fd-tree__text">Level 3</span>
                             </a>
-                            <span class="fd-tree__icon fd-tree__icon--navigation">
-                                <i class="sap-icon--slim-arrow-right" role="presentation"></i>
-                            </span>
+                            <i class="fd-tree__icon fd-tree__icon--navigation sap-icon--slim-arrow-right" role="presentation"></i>
                         </div>
                     </li>
                 </ul>
@@ -755,9 +721,7 @@ export const treeWithExpandedLevel6AndNavigationLinks = () => `
             <a href="https://sap.github.io/fundamental/" class="fd-tree__content">
                 <span class="fd-tree__text">Level 1</span>
             </a>
-            <span class="fd-tree__icon fd-tree__icon--navigation">
-                <i class="sap-icon--slim-arrow-right" role="presentation"></i>
-            </span>
+            <i class="fd-tree__icon fd-tree__icon--navigation sap-icon--slim-arrow-right" role="presentation"></i>
         </div>
     </li>
     <li role="treeitem" aria-level="1" class="fd-tree__item">
@@ -765,9 +729,7 @@ export const treeWithExpandedLevel6AndNavigationLinks = () => `
             <a href="https://sap.github.io/fundamental/" class="fd-tree__content">
                 <span class="fd-tree__text">Level 1</span>
             </a>
-            <span class="fd-tree__icon fd-tree__icon--navigation">
-                <i class="sap-icon--slim-arrow-right" role="presentation"></i>
-            </span>
+            <i class="fd-tree__icon fd-tree__icon--navigation sap-icon--slim-arrow-right" role="presentation"></i>
         </div>
     </li>
 </ul>
@@ -807,7 +769,7 @@ export const treeWithSelection = () => `
     <li role="treeitem" aria-level="1" aria-expanded="true" class="fd-tree__item">
         <div class="fd-tree__item-container is-selected">
             <button tabindex="0" class="fd-tree__expander is-expanded" aria-controls="TREESELL2" aria-haspopup="true" aria-label="Expand level 2" aria-expanded="true">
-                <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                <i class="fd-tree__icon sap-icon--navigation-down-arrow" role="presentation"></i>
             </button>
             <div class="fd-form-item">
                 <input type="checkbox" checked class="fd-checkbox" id="Ai4ez1">
@@ -821,7 +783,7 @@ export const treeWithSelection = () => `
             <li role="treeitem" aria-level="2" class="fd-tree__item">
                 <div class="fd-tree__item-container">
                     <button tabindex="0" class="fd-tree__expander" aria-label="Expander">
-                        <i class="sap-icon--navigation-right-arrow" role="presentation"></i>
+                        <i class="fd-tree__icon sap-icon--navigation-right-arrow" role="presentation"></i>
                     </button>
                     <div class="fd-form-item">
                         <input type="checkbox" class="fd-checkbox" id="Ai4ez2">
@@ -888,7 +850,7 @@ export const treeWithSelection = () => `
     <li role="treeitem" aria-level="1" aria-expanded="true" class="fd-tree__item">
         <div class="fd-tree__item-container is-selected">
             <button tabindex="0" class="fd-tree__expander is-expanded" aria-controls="TREESELCL2" aria-haspopup="true" aria-label="Expand level 2" aria-expanded="true">
-                <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                <i class="fd-tree__icon sap-icon--navigation-down-arrow" role="presentation"></i>
             </button>
             <div class="fd-tree__content">
                 <span class="fd-tree__text">Level 1</span>
@@ -902,7 +864,7 @@ export const treeWithSelection = () => `
             <li role="treeitem" aria-level="2" class="fd-tree__item">
                 <div class="fd-tree__item-container">
                     <button tabindex="0" class="fd-tree__expander" aria-label="Expander">
-                        <i class="sap-icon--navigation-right-arrow" role="presentation"></i>
+                        <i class="fd-tree__icon sap-icon--navigation-right-arrow" role="presentation"></i>
                     </button>
                     <div class="fd-tree__content">
                         <span class="fd-tree__text">Level 2</span>
@@ -969,7 +931,7 @@ export const treeWithSelection = () => `
     <li role="treeitem" aria-level="1" aria-expanded="true" class="fd-tree__item">
         <div class="fd-tree__item-container is-selected">
             <button tabindex="0" class="fd-tree__expander is-expanded" aria-controls="TREESESSLL2" aria-haspopup="true" aria-label="Expand level 2" aria-expanded="true">
-                <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                <i class="fd-tree__icon sap-icon--navigation-down-arrow" role="presentation"></i>
             </button>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio" id="pDidh761" name="radio1" checked>
@@ -983,7 +945,7 @@ export const treeWithSelection = () => `
             <li role="treeitem" aria-level="2" class="fd-tree__item">
                 <div class="fd-tree__item-container">
                     <button tabindex="0" class="fd-tree__expander" aria-label="Expander">
-                        <i class="sap-icon--navigation-right-arrow" role="presentation"></i>
+                        <i class="fd-tree__icon sap-icon--navigation-right-arrow" role="presentation"></i>
                     </button>
                     <div class="fd-form-item">
                         <input type="radio" class="fd-radio" id="pDidh7612" name="radio1">
@@ -1079,17 +1041,13 @@ export const RTL = () => `
         <li role="treeitem" aria-level="1" aria-expanded="true" class="fd-tree__item">
             <div class="fd-tree__item-container  has-highlight-indicator--success is-navigated">
                 <button class="fd-tree__expander is-expanded" aria-controls="TREE1RTLL2" aria-haspopup="true" aria-label="Expand level 2" aria-expanded="true">
-                    <i class="sap-icon--navigation-down-arrow" role="presentation"></i>
+                    <i class="fd-tree__icon sap-icon--navigation-down-arrow" role="presentation"></i>
                 </button>
                 <a href="https://sap.github.io/fundamental/" class="fd-tree__content">
-                    <span class="fd-tree__icon">
-                        <i class="sap-icon--pie-chart sap-icon--l" role="presentation"></i>
-                    </span>
+                    <i class="fd-tree__icon sap-icon--pie-chart" role="presentation"></i>
                     <span class="fd-tree__text">Level 1</span>
                 </a>
-                <span class="fd-tree__icon fd-tree__icon--navigation">
-                    <i class="sap-icon--slim-arrow-left" role="presentation"></i>
-                </span>
+                <i class="fd-tree__icon fd-tree__icon--navigation sap-icon--slim-arrow-left" role="presentation"></i>
                 <button aria-label="Edit button" class="fd-button fd-button--transparent">
                     <i class="sap-icon--edit" role="presentation"></i>
                 </button>
@@ -1101,12 +1059,10 @@ export const RTL = () => `
                 <li role="treeitem" aria-level="2" class="fd-tree__item">
                     <div class="fd-tree__item-container has-highlight-indicator--warning">
                         <button class="fd-tree__expander" aria-label="Expander">
-                            <i class="sap-icon--navigation-left-arrow" role="presentation"></i>
+                            <i class="fd-tree__icon sap-icon--navigation-left-arrow" role="presentation"></i>
                         </button>
                         <div class="fd-tree__content">
-                            <span class="fd-tree__icon">
-                                <i class="sap-icon--money-bills sap-icon--l" role="presentation"></i>
-                            </span>
+                            <i class="fd-tree__icon sap-icon--money-bills" role="presentation"></i>
                             <span class="fd-tree__text">Level 2</span>
                         </div>
                         <button aria-label="Edit button" class="fd-button fd-button--transparent">
@@ -1120,9 +1076,7 @@ export const RTL = () => `
                 <li role="treeitem" aria-level="2" class="fd-tree__item">
                     <div class="fd-tree__item-container">
                         <div class="fd-tree__content">
-                            <span class="fd-tree__icon">
-                                <i class="sap-icon--marketing-campaign sap-icon--l" role="presentation"></i>
-                            </span>
+                            <i class="fd-tree__icon sap-icon--marketing-campaign" role="presentation"></i>
                             <span class="fd-tree__text">Level 2</span>
                         </div>
                         <button aria-label="Edit button" class="fd-button fd-button--transparent">
@@ -1136,13 +1090,9 @@ export const RTL = () => `
                 <li role="treeitem" aria-level="2" class="fd-tree__item">
                     <div class="fd-tree__item-container">
                         <div class="fd-tree__content">
-                            <span class="fd-tree__icon">
-                                <i class="sap-icon--waiver sap-icon--l" role="presentation"></i>
-                            </span>
+                            <i class="fd-tree__icon sap-icon--waiver" role="presentation"></i>
                             <span class="fd-tree__text">Level 2</span>
-                            <span class="fd-tree__icon">
-                                <i class="sap-icon--e-learning sap-icon--l" role="presentation"></i>
-                            </span>
+                            <i class="fd-tree__icon sap-icon--e-learning" role="presentation"></i>
                         </div>
                         <button aria-label="Edit button" class="fd-button fd-button--transparent">
                             <i class="sap-icon--edit" role="presentation"></i>
@@ -1157,13 +1107,9 @@ export const RTL = () => `
         <li role="treeitem" aria-level="1" class="fd-tree__item">
             <div class="fd-tree__item-container">
                 <div class="fd-tree__content">
-                    <span class="fd-tree__icon">
-                        <i class="sap-icon--home-share sap-icon--l" role="presentation"></i>
-                    </span>
+                    <i class="fd-tree__icon sap-icon--home-share" role="presentation"></i>
                     <span class="fd-tree__text">Level 1</span>
-                    <span class="fd-tree__icon">
-                        <i class="sap-icon--puzzle sap-icon--l" role="presentation"></i>
-                    </span>
+                    <i class="fd-tree__icon sap-icon--puzzle" role="presentation"></i>
                 </div>
                 <button aria-label="Edit button" class="fd-button fd-button--transparent">
                     <i class="sap-icon--edit" role="presentation"></i>
@@ -1176,22 +1122,16 @@ export const RTL = () => `
         <li role="treeitem" aria-level="1" class="fd-tree__item">
             <div class="fd-tree__item-container is-navigated has-highlight-indicator--error">
                 <a href="https://sap.github.io/fundamental/" class="fd-tree__content">
-                    <span class="fd-tree__icon">
-                        <i class="sap-icon--overview-chart sap-icon--l" role="presentation"></i>
-                    </span>
+                    <i class="fd-tree__icon sap-icon--overview-chart" role="presentation"></i>
                     <span class="fd-tree__text">Very long text that does not wrap ... perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem.</span>
                 </a>
-                <span class="fd-tree__icon fd-tree__icon--navigation">
-                    <i class="sap-icon--slim-arrow-left" role="presentation"></i>
-                </span>
+                <i class="fd-tree__icon fd-tree__icon--navigation sap-icon--slim-arrow-left" role="presentation"></i>
             </div>
         </li>
         <li role="treeitem" aria-level="1" class="fd-tree__item">
             <div class="fd-tree__item-container has-highlight-indicator">
                 <div class="fd-tree__content fd-tree__content--wrap">
-                    <span class="fd-tree__icon">
-                        <i class="sap-icon--e-care sap-icon--l" role="presentation"></i>
-                    </span>
+                    <i class="fd-tree__icon sap-icon--e-care" role="presentation"></i>
                     <span class="fd-tree__text">Very long text with wrapping behaviour ... perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem.</span>
                 </div>
                 <button aria-label="Edit button" class="fd-button fd-button--transparent">


### PR DESCRIPTION
## Related Issue
Related to https://github.com/SAP/fundamental-styles/issues/1603

## Description
Breaking Change:
- Now Tree expander requires navigation icon
Before:
```
<button tabindex="0" class="fd-tree__expander" aria-label="Expander"></button>
```

After:
```
<button tabindex="0" class="fd-tree__expander" aria-label="Expander">
     <i class="fd-tree__icon sap-icon--navigation-right-arrow" role="presentation"></i>
</button> 
```

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
