### PR TITLE
fix: Avatar - refactor icons usage

### DIFF
--- a/src/avatar.scss
+++ b/src/avatar.scss
@@ -1,7 +1,9 @@
 @import "./mixins";
 
 /*!
-.fd-avatar+((--circle), (--thumbnail), (--xxs|--xs|--s|--m|--l|--xl|--xxl))
+.fd-avatar+((--circle), (--thumbnail), (--xxs|--xs|--s|--m|--l|--xl|--xxl), (--accent-color-{1-10}))
+  .fd-avatar__icon
+  .fd-avatar__zoom-icon
 */
 $block: #{$fd-namespace}-avatar;
 
@@ -50,9 +52,72 @@ $block: #{$fd-namespace}-avatar;
       border-radius: var(--sapElement_BorderCornerRadius);
     }
   }
-  // BLOCK MODIFIERS ************
-  // sizes
 
+  // BLOCK ELEMENTS ************
+  // zoom icon
+  &__zoom-icon {
+    @include fd-reset();
+    @include fd-flex-center();
+
+    @include fd-icon-element-base() {
+      position: absolute;
+      color: var(--sapButton_Emphasized_TextColor);
+      background-color: var(--sapButton_Emphasized_Background);
+      border-radius: $fd-avatar-border-radius;
+      border: 0.0625rem solid var(--sapButton_Emphasized_BorderColor);
+    }
+  }
+
+  &__icon {
+    @include fd-reset();
+    @include fd-icon-element-base();
+  }
+
+  // BLOCK MODIFIERS ************
+  // circle
+  &--circle {
+    border-radius: $fd-avatar-border-radius;
+
+    .#{$block}__zoom-icon {
+      bottom: 0;
+      right: 0;
+
+      @include fd-rtl() {
+        right: auto;
+        left: 0;
+      }
+    }
+  }
+
+  // background
+  &--transparent {
+    background-color: transparent;
+    color: var(--sapContent_IconColor);
+  }
+
+  // placeholder background
+  &--placeholder {
+    background-color: var(--sapContent_ImagePlaceholderBackground);
+  }
+
+  // tile background
+  &--tile {
+    background-color: var(--sapTile_IconColor);
+  }
+
+  // optional border
+  &--border {
+    border: 0.0625rem solid var(--sapGroup_ContentBorderColor);
+  }
+
+  // accent-colors
+  @each $set-name, $color-set in $fd-avatar-accent-colors {
+    &--accent-color-#{$set-name} {
+      background-color: map_get($color-set, "background-color");
+    }
+  }
+
+  // sizes
   @each $set-name, $size-set in $fd-avatar-sizes {
     &--#{$set-name} {
       @include fd-reset-spacing();
@@ -80,63 +145,10 @@ $block: #{$fd-namespace}-avatar;
           left: map_get($size-set, "offset");
         }
 
-        &::before {
+        @include fd-icon-selector() {
           font-size: map_get($size-set, "beforeFontSize");
         }
       }
-    }
-  }
-
-  // circle
-  &.#{$block}--circle {
-    border-radius: $fd-avatar-border-radius;
-
-    .#{$block}__zoom-icon {
-      bottom: 0;
-      right: 0;
-
-      @include fd-rtl() {
-        right: auto;
-        left: 0;
-      }
-    }
-  }
-
-  // background
-  &.#{$block}--transparent {
-    background-color: transparent;
-    color: var(--sapContent_IconColor);
-  }
-
-  // placeholder background
-  &.#{$block}--placeholder {
-    background-color: var(--sapContent_ImagePlaceholderBackground);
-  }
-
-  // tile background
-  &.#{$block}--tile {
-    background-color: var(--sapTile_IconColor);
-  }
-
-  // zoom icon
-  &__zoom-icon {
-    @include fd-flex-center();
-
-    background-color: var(--sapButton_Emphasized_Background);
-    color: var(--sapButton_Emphasized_TextColor);
-    position: absolute;
-    border: 0.0625rem solid var(--sapButton_Emphasized_BorderColor);
-    border-radius: $fd-avatar-border-radius;
-  }
-  // optional border
-  &.#{$block}--border {
-    border: 0.0625rem solid var(--sapGroup_ContentBorderColor);
-  }
-
-  // accent-colors
-  @each $set-name, $color-set in $fd-avatar-accent-colors {
-    &--accent-color-#{$set-name} {
-      background-color: map_get($color-set, "background-color");
     }
   }
 }

--- a/src/avatar.scss
+++ b/src/avatar.scss
@@ -15,11 +15,11 @@ $block: #{$fd-namespace}-avatar;
   $fd-zoom-icon-xl: 1.75rem !default;
   $fd-const-ratio: 1rem;
   $fd-avatar-sizes: (
-    "xs": ("ratio": ($fd-const-ratio * 2), "font-size": 1rem, "zoomIconDimensions": $fd-zoom-icon-s, "offset":  -0.125rem, "beforeFontSize": 0.75rem, "fontStretch": condensed),
-    "s": ("ratio": ($fd-const-ratio * 3), "font-size": 1.125rem, "zoomIconDimensions": $fd-zoom-icon-s, "offset":  -0.125rem, "beforeFontSize": 0.75rem, "fontStretch": condensed),
-    "m": ("ratio": ($fd-const-ratio * 4), "font-size": 1.5rem, "zoomIconDimensions": $fd-zoom-icon-s, "offset":  -0.125rem, "beforeFontSize": 0.75rem, "fontStretch": normal),
-    "l": ("ratio": ($fd-const-ratio * 5), "font-size": 2.25rem, "zoomIconDimensions": $fd-zoom-icon-l, "offset":  -0.1875rem, "beforeFontSize": 0.875rem, "fontStretch": normal),
-    "xl": ("ratio": ($fd-const-ratio * 7), "font-size": 3rem, "zoomIconDimensions": $fd-zoom-icon-xl, "offset":  -0.25rem, "beforeFontSize": 1rem, "fontStretch": normal)
+    "xs": ("ratio": ($fd-const-ratio * 2), "font-size": 1rem, "zoomIconDimensions": $fd-zoom-icon-s, "offset": -0.125rem, "beforeFontSize": 0.75rem, "fontStretch": condensed),
+    "s": ("ratio": ($fd-const-ratio * 3), "font-size": 1.125rem, "zoomIconDimensions": $fd-zoom-icon-s, "offset": -0.125rem, "beforeFontSize": 0.75rem, "fontStretch": condensed),
+    "m": ("ratio": ($fd-const-ratio * 4), "font-size": 1.5rem, "zoomIconDimensions": $fd-zoom-icon-s, "offset": -0.125rem, "beforeFontSize": 0.75rem, "fontStretch": normal),
+    "l": ("ratio": ($fd-const-ratio * 5), "font-size": 2.25rem, "zoomIconDimensions": $fd-zoom-icon-l, "offset": -0.1875rem, "beforeFontSize": 0.875rem, "fontStretch": normal),
+    "xl": ("ratio": ($fd-const-ratio * 7), "font-size": 3rem, "zoomIconDimensions": $fd-zoom-icon-xl, "offset": -0.25rem, "beforeFontSize": 1rem, "fontStretch": normal)
   );
 
   $fd-avatar-accent-colors: (
@@ -56,10 +56,9 @@ $block: #{$fd-namespace}-avatar;
   // BLOCK ELEMENTS ************
   // zoom icon
   &__zoom-icon {
-    @include fd-reset();
-    @include fd-flex-center();
-
     @include fd-icon-element-base() {
+      @include fd-flex-center();
+
       position: absolute;
       color: var(--sapButton_Emphasized_TextColor);
       background-color: var(--sapButton_Emphasized_Background);
@@ -69,7 +68,6 @@ $block: #{$fd-namespace}-avatar;
   }
 
   &__icon {
-    @include fd-reset();
     @include fd-icon-element-base();
   }
 
@@ -79,12 +77,14 @@ $block: #{$fd-namespace}-avatar;
     border-radius: $fd-avatar-border-radius;
 
     .#{$block}__zoom-icon {
-      bottom: 0;
-      right: 0;
+      @include fd-icon-selector() {
+        bottom: 0;
+        right: 0;
 
-      @include fd-rtl() {
-        right: auto;
-        left: 0;
+        @include fd-rtl() {
+          right: auto;
+          left: 0;
+        }
       }
     }
   }
@@ -135,18 +135,17 @@ $block: #{$fd-namespace}-avatar;
       justify-content: center;
 
       .#{$block}__zoom-icon {
-        width: map_get($size-set, "zoomIconDimensions");
-        height: map_get($size-set, "zoomIconDimensions");
-        bottom: map_get($size-set, "offset");
-        right: map_get($size-set, "offset");
-
-        @include fd-rtl() {
-          right: auto;
-          left: map_get($size-set, "offset");
-        }
-
         @include fd-icon-selector() {
           font-size: map_get($size-set, "beforeFontSize");
+          width: map_get($size-set, "zoomIconDimensions");
+          height: map_get($size-set, "zoomIconDimensions");
+          bottom: map_get($size-set, "offset");
+          right: map_get($size-set, "offset");
+
+          @include fd-rtl() {
+            right: auto;
+            left: map_get($size-set, "offset");
+          }
         }
       }
     }

--- a/stories/avatar/__snapshots__/avatar.stories.storyshot
+++ b/stories/avatar/__snapshots__/avatar.stories.storyshot
@@ -5,63 +5,153 @@ exports[`Storyshots Components/Avatar Accent Colors 1`] = `
   
 
   <span
-    class="fd-avatar fd-avatar--accent-color-1 fd-avatar--m sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--accent-color-1 fd-avatar--m"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-avatar fd-avatar--accent-color-2 fd-avatar--m sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--accent-color-2 fd-avatar--m"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-avatar fd-avatar--accent-color-3 fd-avatar--m sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--accent-color-3 fd-avatar--m"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-avatar fd-avatar--accent-color-4 fd-avatar--m sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--accent-color-4 fd-avatar--m"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-avatar fd-avatar--accent-color-5 fd-avatar--m sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--accent-color-5 fd-avatar--m"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-avatar fd-avatar--accent-color-6 fd-avatar--m sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--accent-color-6 fd-avatar--m"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-avatar fd-avatar--accent-color-7 fd-avatar--m sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--accent-color-7 fd-avatar--m"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-avatar fd-avatar--accent-color-8 fd-avatar--m sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--accent-color-8 fd-avatar--m"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-avatar fd-avatar--accent-color-9 fd-avatar--m sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--accent-color-9 fd-avatar--m"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-avatar fd-avatar--accent-color-10 fd-avatar--m sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--accent-color-10 fd-avatar--m"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
 </section>
@@ -119,33 +209,78 @@ exports[`Storyshots Components/Avatar Borders 1`] = `
   
 
   <span
-    class="fd-avatar fd-avatar--xs fd-avatar--transparent fd-avatar--border sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--xs fd-avatar--transparent fd-avatar--border"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-avatar fd-avatar--s fd-avatar--transparent fd-avatar--border sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--s fd-avatar--transparent fd-avatar--border"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-avatar fd-avatar--m fd-avatar--transparent fd-avatar--border sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--m fd-avatar--transparent fd-avatar--border"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-avatar fd-avatar--l fd-avatar--transparent fd-avatar--border sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--l fd-avatar--transparent fd-avatar--border"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-avatar fd-avatar--xl fd-avatar--transparent fd-avatar--border sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--xl fd-avatar--transparent fd-avatar--border"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
@@ -153,6 +288,7 @@ exports[`Storyshots Components/Avatar Borders 1`] = `
     class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--transparent fd-avatar--border"
   >
     WW
+
   </span>
   
 
@@ -161,6 +297,7 @@ exports[`Storyshots Components/Avatar Borders 1`] = `
     class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--transparent fd-avatar--border"
   >
     WW
+
   </span>
   
 
@@ -169,6 +306,7 @@ exports[`Storyshots Components/Avatar Borders 1`] = `
     class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--transparent fd-avatar--border"
   >
     WW
+
   </span>
   
 
@@ -177,6 +315,7 @@ exports[`Storyshots Components/Avatar Borders 1`] = `
     class="fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--transparent fd-avatar--border"
   >
     WW
+
   </span>
   
 
@@ -185,6 +324,7 @@ exports[`Storyshots Components/Avatar Borders 1`] = `
     class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent fd-avatar--border"
   >
     WW
+
   </span>
   
 
@@ -196,33 +336,78 @@ exports[`Storyshots Components/Avatar Circle 1`] = `
   
 
   <span
-    class="fd-avatar fd-avatar--xs fd-avatar--circle sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--xs fd-avatar--circle"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-avatar fd-avatar--s fd-avatar--circle sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--s fd-avatar--circle"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-avatar fd-avatar--m fd-avatar--circle sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--m fd-avatar--circle"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-avatar fd-avatar--l fd-avatar--circle sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--l fd-avatar--circle"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-avatar fd-avatar--xl fd-avatar--circle sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--xl fd-avatar--circle"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
@@ -273,33 +458,78 @@ exports[`Storyshots Components/Avatar Icon 1`] = `
   
 
   <span
-    class="fd-avatar fd-avatar--xs sap-icon--washing-machine"
+    class="fd-avatar fd-avatar--xs"
     role="presentation"
-  />
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--washing-machine"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-avatar fd-avatar--s sap-icon--washing-machine"
+    class="fd-avatar fd-avatar--s"
     role="presentation"
-  />
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--washing-machine"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-avatar fd-avatar--m sap-icon--washing-machine"
+    class="fd-avatar fd-avatar--m"
     role="presentation"
-  />
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--washing-machine"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-avatar fd-avatar--l sap-icon--washing-machine"
+    class="fd-avatar fd-avatar--l"
     role="presentation"
-  />
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--washing-machine"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-avatar fd-avatar--xl sap-icon--washing-machine"
+    class="fd-avatar fd-avatar--xl"
     role="presentation"
-  />
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--washing-machine"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
 </section>
@@ -357,33 +587,78 @@ exports[`Storyshots Components/Avatar Placeholder Background 1`] = `
   
 
   <span
-    class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--placeholder sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--placeholder"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--placeholder sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--placeholder"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--placeholder sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--placeholder"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--placeholder sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--placeholder"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--placeholder sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--placeholder"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
 </section>
@@ -394,33 +669,78 @@ exports[`Storyshots Components/Avatar Tile Icon Background 1`] = `
   
 
   <span
-    class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--tile sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--tile"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--tile sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--tile"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--tile sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--tile"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--tile sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--tile"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--tile sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--tile"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
 </section>
@@ -431,33 +751,78 @@ exports[`Storyshots Components/Avatar Transparent 1`] = `
   
 
   <span
-    class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--transparent sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--transparent"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--transparent sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--transparent"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--transparent sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--transparent"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--transparent sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--transparent"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent sap-icon--money-bills"
-    role="presentation"
-  />
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent"
+  >
+    
+    
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
@@ -508,14 +873,20 @@ exports[`Storyshots Components/Avatar Zoom Icon 1`] = `
   
 
   <span
-    class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--accent-color-1 sap-icon--money-bills"
-    role="presentation"
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--accent-color-1"
   >
     
     
-    <span
-      class="fd-avatar__zoom-icon sap-icon--edit"
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
       role="presentation"
+    />
+    
+    
+    <i
+      aria-label="Edit"
+      class="fd-avatar__zoom-icon sap-icon--edit"
     />
     
 
@@ -523,14 +894,20 @@ exports[`Storyshots Components/Avatar Zoom Icon 1`] = `
   
 
   <span
-    class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--accent-color-2 sap-icon--money-bills"
-    role="presentation"
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--accent-color-2"
   >
     
     
-    <span
-      class="fd-avatar__zoom-icon sap-icon--edit"
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
       role="presentation"
+    />
+    
+    
+    <i
+      aria-label="Edit"
+      class="fd-avatar__zoom-icon sap-icon--edit"
     />
     
 
@@ -538,14 +915,20 @@ exports[`Storyshots Components/Avatar Zoom Icon 1`] = `
   
 
   <span
-    class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--accent-color-3 sap-icon--money-bills"
-    role="presentation"
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--accent-color-3"
   >
     
     
-    <span
-      class="fd-avatar__zoom-icon sap-icon--edit"
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
       role="presentation"
+    />
+    
+    
+    <i
+      aria-label="Edit"
+      class="fd-avatar__zoom-icon sap-icon--edit"
     />
     
 
@@ -553,14 +936,20 @@ exports[`Storyshots Components/Avatar Zoom Icon 1`] = `
   
 
   <span
-    class="fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--accent-color-4 sap-icon--money-bills"
-    role="presentation"
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--accent-color-4"
   >
     
     
-    <span
-      class="fd-avatar__zoom-icon sap-icon--edit"
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
       role="presentation"
+    />
+    
+    
+    <i
+      aria-label="Edit"
+      class="fd-avatar__zoom-icon sap-icon--edit"
     />
     
 
@@ -568,14 +957,20 @@ exports[`Storyshots Components/Avatar Zoom Icon 1`] = `
   
 
   <span
-    class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--accent-color-5 sap-icon--money-bills"
-    role="presentation"
+    aria-label="Avatar"
+    class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--accent-color-5"
   >
     
     
-    <span
-      class="fd-avatar__zoom-icon sap-icon--edit"
+    <i
+      class="fd-avatar__icon sap-icon--money-bills"
       role="presentation"
+    />
+    
+    
+    <i
+      aria-label="Edit"
+      class="fd-avatar__zoom-icon sap-icon--edit"
     />
     
 
@@ -588,9 +983,9 @@ exports[`Storyshots Components/Avatar Zoom Icon 1`] = `
   >
     WW
     
-    <span
+    <i
+      aria-label="Edit"
       class="fd-avatar__zoom-icon sap-icon--edit"
-      role="presentation"
     />
     
 
@@ -603,9 +998,9 @@ exports[`Storyshots Components/Avatar Zoom Icon 1`] = `
   >
     WW
     
-    <span
+    <i
+      aria-label="Edit"
       class="fd-avatar__zoom-icon sap-icon--edit"
-      role="presentation"
     />
     
 
@@ -618,9 +1013,9 @@ exports[`Storyshots Components/Avatar Zoom Icon 1`] = `
   >
     WW
     
-    <span
+    <i
+      aria-label="Edit"
       class="fd-avatar__zoom-icon sap-icon--edit"
-      role="presentation"
     />
     
 
@@ -633,9 +1028,9 @@ exports[`Storyshots Components/Avatar Zoom Icon 1`] = `
   >
     WW
     
-    <span
+    <i
+      aria-label="Edit"
       class="fd-avatar__zoom-icon sap-icon--edit"
-      role="presentation"
     />
     
 
@@ -648,9 +1043,9 @@ exports[`Storyshots Components/Avatar Zoom Icon 1`] = `
   >
     WW
     
-    <span
+    <i
+      aria-label="Edit"
       class="fd-avatar__zoom-icon sap-icon--edit"
-      role="presentation"
     />
     
 

--- a/stories/avatar/avatar.stories.js
+++ b/stories/avatar/avatar.stories.js
@@ -36,11 +36,21 @@ Do not use avatar if:
 };
 
 export const icon = () => `
-<span class="fd-avatar fd-avatar--xs sap-icon--washing-machine" role="presentation"></span>
-<span class="fd-avatar fd-avatar--s sap-icon--washing-machine" role="presentation"></span>
-<span class="fd-avatar fd-avatar--m sap-icon--washing-machine" role="presentation"></span>
-<span class="fd-avatar fd-avatar--l sap-icon--washing-machine" role="presentation"></span>
-<span class="fd-avatar fd-avatar--xl sap-icon--washing-machine" role="presentation"></span>
+<span class="fd-avatar fd-avatar--xs" role="presentation">
+    <i class="fd-avatar__icon sap-icon--washing-machine"></i>
+</span>
+<span class="fd-avatar fd-avatar--s" role="presentation">
+    <i class="fd-avatar__icon sap-icon--washing-machine"></i>
+</span>
+<span class="fd-avatar fd-avatar--m" role="presentation">
+    <i class="fd-avatar__icon sap-icon--washing-machine"></i>
+</span>
+<span class="fd-avatar fd-avatar--l" role="presentation">
+    <i class="fd-avatar__icon sap-icon--washing-machine"></i>
+</span>
+<span class="fd-avatar fd-avatar--xl" role="presentation">
+    <i class="fd-avatar__icon sap-icon--washing-machine"></i>
+</span>
 `;
 
 icon.parameters = {
@@ -71,11 +81,21 @@ initials.parameters = {
 
 
 export const circle = () => `
-<span class="fd-avatar fd-avatar--xs fd-avatar--circle sap-icon--money-bills" role="presentation"></span>
-<span class="fd-avatar fd-avatar--s fd-avatar--circle sap-icon--money-bills" role="presentation"></span>
-<span class="fd-avatar fd-avatar--m fd-avatar--circle sap-icon--money-bills" role="presentation"></span>
-<span class="fd-avatar fd-avatar--l fd-avatar--circle sap-icon--money-bills" role="presentation"></span>
-<span class="fd-avatar fd-avatar--xl fd-avatar--circle sap-icon--money-bills" role="presentation"></span>
+<span class="fd-avatar fd-avatar--xs fd-avatar--circle" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
+<span class="fd-avatar fd-avatar--s fd-avatar--circle" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
+<span class="fd-avatar fd-avatar--m fd-avatar--circle" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
+<span class="fd-avatar fd-avatar--l fd-avatar--circle" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
+<span class="fd-avatar fd-avatar--xl fd-avatar--circle" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
 <span class="fd-avatar fd-avatar--xs fd-avatar--circle" aria-label="Wendy Wallace">WW</span>
 <span class="fd-avatar fd-avatar--s fd-avatar--circle" aria-label="Wendy Wallace">WW</span>
 <span class="fd-avatar fd-avatar--m fd-avatar--circle" aria-label="Wendy Wallace">WW</span>
@@ -106,11 +126,21 @@ backgroundImage.parameters = {
 };
 
 export const transparent = () => `
-<span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--transparent sap-icon--money-bills" role="presentation"></span>
-<span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--transparent sap-icon--money-bills" role="presentation"></span>
-<span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--transparent sap-icon--money-bills" role="presentation"></span>
-<span class="fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--transparent sap-icon--money-bills" role="presentation"></span>
-<span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent sap-icon--money-bills" role="presentation"></span>
+<span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--transparent" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
+<span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--transparent" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
+<span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--transparent" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
+<span class="fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--transparent" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
+<span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
 <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--transparent" aria-label="Wendy Wallace">WW</span>
 <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--transparent" aria-label="Wendy Wallace">WW</span>
 <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--transparent" aria-label="Wendy Wallace">WW</span>
@@ -127,11 +157,21 @@ transparent.parameters = {
 
 
 export const placeholderBackground = () => `
-<span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--placeholder sap-icon--money-bills" role="presentation"></span>
-<span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--placeholder sap-icon--money-bills" role="presentation"></span>
-<span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--placeholder sap-icon--money-bills" role="presentation"></span>
-<span class="fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--placeholder sap-icon--money-bills" role="presentation"></span>
-<span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--placeholder sap-icon--money-bills" role="presentation"></span>
+<span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--placeholder" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
+<span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--placeholder" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
+<span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--placeholder" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
+<span class="fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--placeholder" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
+<span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--placeholder" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
 `;
 
 placeholderBackground.parameters = {
@@ -143,12 +183,23 @@ placeholderBackground.parameters = {
 
 
 export const tileIconBackground = () => `
-<span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--tile sap-icon--money-bills" role="presentation"></span>
-<span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--tile sap-icon--money-bills" role="presentation"></span>
-<span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--tile sap-icon--money-bills" role="presentation"></span>
-<span class="fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--tile sap-icon--money-bills" role="presentation"></span>
-<span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--tile sap-icon--money-bills" role="presentation"></span>
+<span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--tile" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
+<span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--tile" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
+<span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--tile" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
+<span class="fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--tile" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
+<span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--tile" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
 `;
+
 
 tileIconBackground.parameters = {
     docs: {
@@ -159,16 +210,36 @@ tileIconBackground.parameters = {
 
 
 export const accentColors = () => `
-<span class="fd-avatar fd-avatar--accent-color-1 fd-avatar--m sap-icon--money-bills" role="presentation"></span>
-<span class="fd-avatar fd-avatar--accent-color-2 fd-avatar--m sap-icon--money-bills" role="presentation"></span>
-<span class="fd-avatar fd-avatar--accent-color-3 fd-avatar--m sap-icon--money-bills" role="presentation"></span>
-<span class="fd-avatar fd-avatar--accent-color-4 fd-avatar--m sap-icon--money-bills" role="presentation"></span>
-<span class="fd-avatar fd-avatar--accent-color-5 fd-avatar--m sap-icon--money-bills" role="presentation"></span>
-<span class="fd-avatar fd-avatar--accent-color-6 fd-avatar--m sap-icon--money-bills" role="presentation"></span>
-<span class="fd-avatar fd-avatar--accent-color-7 fd-avatar--m sap-icon--money-bills" role="presentation"></span>
-<span class="fd-avatar fd-avatar--accent-color-8 fd-avatar--m sap-icon--money-bills" role="presentation"></span>
-<span class="fd-avatar fd-avatar--accent-color-9 fd-avatar--m sap-icon--money-bills" role="presentation"></span>
-<span class="fd-avatar fd-avatar--accent-color-10 fd-avatar--m sap-icon--money-bills" role="presentation"></span>
+<span class="fd-avatar fd-avatar--accent-color-1 fd-avatar--m" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
+<span class="fd-avatar fd-avatar--accent-color-2 fd-avatar--m" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
+<span class="fd-avatar fd-avatar--accent-color-3 fd-avatar--m" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
+<span class="fd-avatar fd-avatar--accent-color-4 fd-avatar--m" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
+<span class="fd-avatar fd-avatar--accent-color-5 fd-avatar--m" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
+<span class="fd-avatar fd-avatar--accent-color-6 fd-avatar--m" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
+<span class="fd-avatar fd-avatar--accent-color-7 fd-avatar--m" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
+<span class="fd-avatar fd-avatar--accent-color-8 fd-avatar--m" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
+<span class="fd-avatar fd-avatar--accent-color-9 fd-avatar--m" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
+<span class="fd-avatar fd-avatar--accent-color-10 fd-avatar--m" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
 `;
 
 accentColors.parameters = {
@@ -180,57 +251,77 @@ accentColors.parameters = {
 
 
 export const zoomIcon = () => `
-<span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--accent-color-1 sap-icon--money-bills" role="presentation">
-    <span class="fd-avatar__zoom-icon sap-icon--edit" role="presentation"></span>
+<span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--accent-color-1" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+    <i class="fd-avatar__zoom-icon sap-icon--edit" aria-label="Edit"></i>
 </span>
-<span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--accent-color-2 sap-icon--money-bills" role="presentation">
-    <span class="fd-avatar__zoom-icon sap-icon--edit" role="presentation"></span>
+<span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--accent-color-2" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+    <i class="fd-avatar__zoom-icon sap-icon--edit" aria-label="Edit"></i>
 </span>
-<span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--accent-color-3 sap-icon--money-bills" role="presentation">
-    <span class="fd-avatar__zoom-icon sap-icon--edit" role="presentation"></span>
+<span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--accent-color-3" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+    <i class="fd-avatar__zoom-icon sap-icon--edit" aria-label="Edit"></i>
 </span>
-<span class="fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--accent-color-4 sap-icon--money-bills" role="presentation">
-    <span class="fd-avatar__zoom-icon sap-icon--edit" role="presentation"></span>
+<span class="fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--accent-color-4" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+    <i class="fd-avatar__zoom-icon sap-icon--edit" aria-label="Edit"></i>
 </span>
-<span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--accent-color-5 sap-icon--money-bills" role="presentation">
-    <span class="fd-avatar__zoom-icon sap-icon--edit" role="presentation"></span>
+<span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--accent-color-5" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+    <i class="fd-avatar__zoom-icon sap-icon--edit" aria-label="Edit"></i>
 </span>
 <span class="fd-avatar fd-avatar--accent-color-6 fd-avatar--xs" aria-label="Wendy Wallace">WW
-    <span class="fd-avatar__zoom-icon sap-icon--edit" role="presentation"></span>
+    <i class="fd-avatar__zoom-icon sap-icon--edit" aria-label="Edit"></i>
 </span>
 <span class="fd-avatar fd-avatar--accent-color-7 fd-avatar--s" aria-label="Wendy Wallace">WW
-    <span class="fd-avatar__zoom-icon sap-icon--edit" role="presentation"></span>
+    <i class="fd-avatar__zoom-icon sap-icon--edit" aria-label="Edit"></i>
 </span>
 <span class="fd-avatar fd-avatar--accent-color-8 fd-avatar--m" aria-label="Wendy Wallace">WW
-    <span class="fd-avatar__zoom-icon sap-icon--edit" role="presentation"></span>
+    <i class="fd-avatar__zoom-icon sap-icon--edit" aria-label="Edit"></i>
 </span>
 <span class="fd-avatar fd-avatar--accent-color-9 fd-avatar--l" aria-label="Wendy Wallace">WW
-    <span class="fd-avatar__zoom-icon sap-icon--edit" role="presentation"></span>
+    <i class="fd-avatar__zoom-icon sap-icon--edit" aria-label="Edit"></i>
 </span>
 <span class="fd-avatar fd-avatar--accent-color-10 fd-avatar--xl" aria-label="Wendy Wallace">WW
-    <span class="fd-avatar__zoom-icon sap-icon--edit" role="presentation"></span>
+    <i class="fd-avatar__zoom-icon sap-icon--edit" aria-label="Edit"></i>
 </span>
 `;
 
 zoomIcon.parameters = {
     docs: {
         iframeHeight: 200,
-        storyDescription: 'Any avatar can display a zoom icon by adding the <code>fd-avatar\\_\\_zoom-icon</code> class to the element.'
+        storyDescription: 'Any avatar can display a zoom icon by creating an element with <code>fd-avatar\\_\\_zoom-icon</code> class.'
     }
 };
 
 
 export const borders = () => `
-<span class="fd-avatar fd-avatar--xs fd-avatar--transparent fd-avatar--border sap-icon--money-bills" role="presentation"></span>
-<span class="fd-avatar fd-avatar--s fd-avatar--transparent fd-avatar--border sap-icon--money-bills" role="presentation"></span>
-<span class="fd-avatar fd-avatar--m fd-avatar--transparent fd-avatar--border sap-icon--money-bills" role="presentation"></span>
-<span class="fd-avatar fd-avatar--l fd-avatar--transparent fd-avatar--border sap-icon--money-bills" role="presentation"></span>
-<span class="fd-avatar fd-avatar--xl fd-avatar--transparent fd-avatar--border sap-icon--money-bills" role="presentation"></span>
-<span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--transparent fd-avatar--border" aria-label="Wendy Wallace">WW</span>
-<span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--transparent fd-avatar--border" aria-label="Wendy Wallace">WW</span>
-<span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--transparent fd-avatar--border" aria-label="Wendy Wallace">WW</span>
-<span class="fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--transparent fd-avatar--border" aria-label="Wendy Wallace">WW</span>
-<span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent fd-avatar--border" aria-label="Wendy Wallace">WW</span>
+<span class="fd-avatar fd-avatar--xs fd-avatar--transparent fd-avatar--border" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
+<span class="fd-avatar fd-avatar--s fd-avatar--transparent fd-avatar--border" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
+<span class="fd-avatar fd-avatar--m fd-avatar--transparent fd-avatar--border" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
+<span class="fd-avatar fd-avatar--l fd-avatar--transparent fd-avatar--border" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
+<span class="fd-avatar fd-avatar--xl fd-avatar--transparent fd-avatar--border" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
+</span>
+<span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--transparent fd-avatar--border" aria-label="Wendy Wallace">WW
+</span>
+<span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--transparent fd-avatar--border" aria-label="Wendy Wallace">WW
+</span>
+<span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--transparent fd-avatar--border" aria-label="Wendy Wallace">WW
+</span>
+<span class="fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--transparent fd-avatar--border" aria-label="Wendy Wallace">WW
+</span>
+<span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent fd-avatar--border" aria-label="Wendy Wallace">WW
+</span>
 `;
 
 borders.parameters = {

--- a/stories/avatar/avatar.stories.js
+++ b/stories/avatar/avatar.stories.js
@@ -37,19 +37,19 @@ Do not use avatar if:
 
 export const icon = () => `
 <span class="fd-avatar fd-avatar--xs" role="presentation">
-    <i class="fd-avatar__icon sap-icon--washing-machine"></i>
+    <i role="presentation" class="fd-avatar__icon sap-icon--washing-machine"></i>
 </span>
 <span class="fd-avatar fd-avatar--s" role="presentation">
-    <i class="fd-avatar__icon sap-icon--washing-machine"></i>
+    <i role="presentation" class="fd-avatar__icon sap-icon--washing-machine"></i>
 </span>
 <span class="fd-avatar fd-avatar--m" role="presentation">
-    <i class="fd-avatar__icon sap-icon--washing-machine"></i>
+    <i role="presentation" class="fd-avatar__icon sap-icon--washing-machine"></i>
 </span>
 <span class="fd-avatar fd-avatar--l" role="presentation">
-    <i class="fd-avatar__icon sap-icon--washing-machine"></i>
+    <i role="presentation" class="fd-avatar__icon sap-icon--washing-machine"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl" role="presentation">
-    <i class="fd-avatar__icon sap-icon--washing-machine"></i>
+    <i role="presentation" class="fd-avatar__icon sap-icon--washing-machine"></i>
 </span>
 `;
 


### PR DESCRIPTION
## Related Issue
Part of: SAP/fundamental-styles#1603

## Description
This PR:
- Introduces new class `fd-avatar__icon`
- Introduces avatar icon as separate HTML element
- Updates aria role and label attributes

## Before
Avatar with icon
```
<span class="fd-avatar fd-avatar--xl fd-avatar--circle sap-icon--money-bills" role="presentation"></span>
```
Avatar with icon and zoom icon
```
<span class="fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--accent-color-4 sap-icon--money-bills" role="presentation">
    <span class="fd-avatar__zoom-icon sap-icon--edit" role="presentation"></span>
</span>
```

## After
Avatar with icon
```
<span class="fd-avatar fd-avatar--xs fd-avatar--circle" aria-label="Avatar">
    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
</span>
```
Avatar with icon and zoom icon
```
<span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--accent-color-5" aria-label="Avatar">
    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
    <i class="fd-avatar__zoom-icon sap-icon--edit" aria-label="Edit"></i>
</span>
```

#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist