### PR TITLE
fix: Apply icons changes to tabs

### DIFF
--- a/src/tabs.scss
+++ b/src/tabs.scss
@@ -195,6 +195,10 @@ $block: #{$fd-namespace}-tabs;
   &__icon {
     @include fd-reset();
 
+    @include fd-icon-element-base() {
+      font-size: $fd-tabs-icon-size;
+    }
+
     display: flex;
     align-items: center;
     justify-content: center;
@@ -206,10 +210,6 @@ $block: #{$fd-namespace}-tabs;
     background-color: transparent;
     position: relative;
     margin: 0 $fd-tabs-selection-padding-x;
-
-    &::before {
-      font-size: $fd-tabs-icon-size;
-    }
 
     @include tabs-selection();
   }
@@ -246,10 +246,10 @@ $block: #{$fd-namespace}-tabs;
 
   &__overflow {
     @include fd-reset();
+    @include fd-icon-element-base();
+    @include fd-flex-center();
 
     margin-left: auto;
-
-    @include fd-icon('slim-arrow-down');
   }
 
   &__process-icon {
@@ -356,10 +356,6 @@ $block: #{$fd-namespace}-tabs;
       margin: 0 $fd-tabs-active-link-line-offset-x;
     }
 
-    .#{$block}__overflow {
-      @include fd-icon('slim-arrow-right');
-    }
-
     .#{$block}__label {
       white-space: nowrap;
       max-width: 7.5rem;
@@ -377,10 +373,6 @@ $block: #{$fd-namespace}-tabs;
             padding-left: 0;
           }
         }
-      }
-
-      .#{$block}__overflow {
-        transform: rotate(180deg);
       }
     }
   }
@@ -461,7 +453,7 @@ $block: #{$fd-namespace}-tabs;
       width: $fd-tabs-compact-icon-selection-height;
       height: $fd-tabs-compact-icon-selection-height;
 
-      &::before {
+      @include fd-icon-selector() {
         font-size: $fd-tabs-compact-icon-size;
       }
     }

--- a/stories/tabs/__snapshots__/tabs.stories.storyshot
+++ b/stories/tabs/__snapshots__/tabs.stories.storyshot
@@ -72,8 +72,14 @@ exports[`Storyshots Components/Tabs Compact Filter Mode 1`] = `
         
             
         <span
-          class="fd-tabs__icon sap-icon--cart"
+          class="fd-tabs__icon"
         >
+          
+                
+          <i
+            class="sap-icon--cart"
+            role="presentation"
+          />
           
                 
           <p
@@ -114,8 +120,14 @@ exports[`Storyshots Components/Tabs Compact Filter Mode 1`] = `
         
             
         <span
-          class="fd-tabs__icon sap-icon--cart"
+          class="fd-tabs__icon"
         >
+          
+                
+          <i
+            class="sap-icon--cart"
+            role="presentation"
+          />
           
                 
           <p
@@ -156,8 +168,14 @@ exports[`Storyshots Components/Tabs Compact Filter Mode 1`] = `
         
             
         <span
-          class="fd-tabs__icon sap-icon--cart"
+          class="fd-tabs__icon"
         >
+          
+                
+          <i
+            class="sap-icon--cart"
+            role="presentation"
+          />
           
                 
           <p
@@ -186,7 +204,16 @@ exports[`Storyshots Components/Tabs Compact Filter Mode 1`] = `
     <button
       aria-label="See More"
       class="fd-button fd-button--transparent fd-button--compact fd-tabs__overflow"
-    />
+    >
+      
+        
+      <i
+        class="sap-icon--slim-arrow-down"
+        role="presentation"
+      />
+      
+    
+    </button>
     
 
   </ul>
@@ -268,8 +295,14 @@ exports[`Storyshots Components/Tabs Compact Icon Only 1`] = `
         
             
         <span
-          class="fd-tabs__icon sap-icon--cart"
+          class="fd-tabs__icon"
         >
+          
+                
+          <i
+            class="sap-icon--cart"
+            role="presentation"
+          />
           
                 
           <p
@@ -304,8 +337,14 @@ exports[`Storyshots Components/Tabs Compact Icon Only 1`] = `
         
             
         <span
-          class="fd-tabs__icon sap-icon--cart"
+          class="fd-tabs__icon"
         >
+          
+                
+          <i
+            class="sap-icon--cart"
+            role="presentation"
+          />
           
                 
           <p
@@ -339,8 +378,14 @@ exports[`Storyshots Components/Tabs Compact Icon Only 1`] = `
         
             
         <span
-          class="fd-tabs__icon sap-icon--cart"
+          class="fd-tabs__icon"
         >
+          
+                
+          <i
+            class="sap-icon--cart"
+            role="presentation"
+          />
           
                 
           <p
@@ -362,7 +407,16 @@ exports[`Storyshots Components/Tabs Compact Icon Only 1`] = `
     <button
       aria-label="See More"
       class="fd-button fd-button--transparent fd-button--compact fd-tabs__overflow"
-    />
+    >
+      
+        
+      <i
+        class="sap-icon--slim-arrow-down"
+        role="presentation"
+      />
+      
+    
+    </button>
     
 
   </ul>
@@ -432,8 +486,17 @@ exports[`Storyshots Components/Tabs Compact Process Mode 1`] = `
         
             
         <span
-          class="fd-tabs__icon sap-icon--cart"
-        />
+          class="fd-tabs__icon"
+        >
+          
+                
+          <i
+            class="sap-icon--cart"
+            role="presentation"
+          />
+          
+            
+        </span>
         
             
         <div
@@ -484,8 +547,17 @@ exports[`Storyshots Components/Tabs Compact Process Mode 1`] = `
         
             
         <span
-          class="fd-tabs__icon sap-icon--cart"
-        />
+          class="fd-tabs__icon"
+        >
+          
+                
+          <i
+            class="sap-icon--cart"
+            role="presentation"
+          />
+          
+            
+        </span>
         
             
         <div
@@ -536,8 +608,17 @@ exports[`Storyshots Components/Tabs Compact Process Mode 1`] = `
         
             
         <span
-          class="fd-tabs__icon sap-icon--cart"
-        />
+          class="fd-tabs__icon"
+        >
+          
+                
+          <i
+            class="sap-icon--cart"
+            role="presentation"
+          />
+          
+            
+        </span>
         
             
         <div
@@ -571,7 +652,16 @@ exports[`Storyshots Components/Tabs Compact Process Mode 1`] = `
     <button
       aria-label="See More"
       class="fd-button fd-button--transparent fd-button--compact fd-tabs__overflow"
-    />
+    >
+      
+        
+      <i
+        class="sap-icon--slim-arrow-down"
+        role="presentation"
+      />
+      
+    
+    </button>
     
 
   </ul>
@@ -717,7 +807,16 @@ exports[`Storyshots Components/Tabs Default 1`] = `
     <button
       aria-label="See More"
       class="fd-button fd-button--transparent fd-tabs__overflow"
-    />
+    >
+      
+        
+      <i
+        class="sap-icon--slim-arrow-down"
+        role="presentation"
+      />
+      
+    
+    </button>
     
 
   </ul>
@@ -834,8 +933,14 @@ exports[`Storyshots Components/Tabs Filter Mode 1`] = `
         
             
         <span
-          class="fd-tabs__icon sap-icon--cart"
+          class="fd-tabs__icon"
         >
+          
+                
+          <i
+            class="sap-icon--cart"
+            role="presentation"
+          />
           
                 
           <p
@@ -876,8 +981,14 @@ exports[`Storyshots Components/Tabs Filter Mode 1`] = `
         
             
         <span
-          class="fd-tabs__icon sap-icon--cart"
+          class="fd-tabs__icon"
         >
+          
+                
+          <i
+            class="sap-icon--cart"
+            role="presentation"
+          />
           
                 
           <p
@@ -918,8 +1029,14 @@ exports[`Storyshots Components/Tabs Filter Mode 1`] = `
         
             
         <span
-          class="fd-tabs__icon sap-icon--cart"
+          class="fd-tabs__icon"
         >
+          
+                
+          <i
+            class="sap-icon--cart"
+            role="presentation"
+          />
           
                 
           <p
@@ -948,7 +1065,16 @@ exports[`Storyshots Components/Tabs Filter Mode 1`] = `
     <button
       aria-label="See More"
       class="fd-button fd-button--transparent fd-tabs__overflow"
-    />
+    >
+      
+        
+      <i
+        class="sap-icon--slim-arrow-down"
+        role="presentation"
+      />
+      
+    
+    </button>
     
 
   </ul>
@@ -1030,8 +1156,14 @@ exports[`Storyshots Components/Tabs Icon Only 1`] = `
         
             
         <span
-          class="fd-tabs__icon sap-icon--cart"
+          class="fd-tabs__icon"
         >
+          
+                
+          <i
+            class="sap-icon--cart"
+            role="presentation"
+          />
           
                 
           <p
@@ -1066,8 +1198,14 @@ exports[`Storyshots Components/Tabs Icon Only 1`] = `
         
             
         <span
-          class="fd-tabs__icon sap-icon--cart"
+          class="fd-tabs__icon"
         >
+          
+                
+          <i
+            class="sap-icon--cart"
+            role="presentation"
+          />
           
                 
           <p
@@ -1101,8 +1239,14 @@ exports[`Storyshots Components/Tabs Icon Only 1`] = `
         
             
         <span
-          class="fd-tabs__icon sap-icon--cart"
+          class="fd-tabs__icon"
         >
+          
+                
+          <i
+            class="sap-icon--cart"
+            role="presentation"
+          />
           
                 
           <p
@@ -1124,7 +1268,16 @@ exports[`Storyshots Components/Tabs Icon Only 1`] = `
     <button
       aria-label="See More"
       class="fd-button fd-button--transparent fd-tabs__overflow"
-    />
+    >
+      
+        
+      <i
+        class="sap-icon--slim-arrow-down"
+        role="presentation"
+      />
+      
+    
+    </button>
     
 
   </ul>
@@ -1263,7 +1416,16 @@ exports[`Storyshots Components/Tabs Nav Tab 1`] = `
     <button
       aria-label="See More"
       class="fd-button fd-button--transparent fd-tabs__overflow"
-    />
+    >
+      
+        
+      <i
+        class="sap-icon--slim-arrow-down"
+        role="presentation"
+      />
+      
+    
+    </button>
     
 
   </nav>
@@ -1333,8 +1495,17 @@ exports[`Storyshots Components/Tabs Process Mode 1`] = `
         
             
         <span
-          class="fd-tabs__icon sap-icon--cart"
-        />
+          class="fd-tabs__icon"
+        >
+          
+                
+          <i
+            class="sap-icon--cart"
+            role="presentation"
+          />
+          
+            
+        </span>
         
             
         <div
@@ -1385,8 +1556,17 @@ exports[`Storyshots Components/Tabs Process Mode 1`] = `
         
             
         <span
-          class="fd-tabs__icon sap-icon--cart"
-        />
+          class="fd-tabs__icon"
+        >
+          
+                
+          <i
+            class="sap-icon--cart"
+            role="presentation"
+          />
+          
+            
+        </span>
         
             
         <div
@@ -1437,8 +1617,17 @@ exports[`Storyshots Components/Tabs Process Mode 1`] = `
         
             
         <span
-          class="fd-tabs__icon sap-icon--cart"
-        />
+          class="fd-tabs__icon"
+        >
+          
+                
+          <i
+            class="sap-icon--cart"
+            role="presentation"
+          />
+          
+            
+        </span>
         
             
         <div
@@ -1472,7 +1661,16 @@ exports[`Storyshots Components/Tabs Process Mode 1`] = `
     <button
       aria-label="See More"
       class="fd-button fd-button--transparent fd-tabs__overflow"
-    />
+    >
+      
+        
+      <i
+        class="sap-icon--slim-arrow-right"
+        role="presentation"
+      />
+      
+    
+    </button>
     
 
   </ul>
@@ -1589,8 +1787,14 @@ exports[`Storyshots Components/Tabs Semantic Filter Mode 1`] = `
         
             
         <span
-          class="fd-tabs__icon sap-icon--cart"
+          class="fd-tabs__icon"
         >
+          
+                
+          <i
+            class="sap-icon--cart"
+            role="presentation"
+          />
           
                 
           <p
@@ -1631,8 +1835,14 @@ exports[`Storyshots Components/Tabs Semantic Filter Mode 1`] = `
         
             
         <span
-          class="fd-tabs__icon sap-icon--cart"
+          class="fd-tabs__icon"
         >
+          
+                
+          <i
+            class="sap-icon--cart"
+            role="presentation"
+          />
           
                 
           <p
@@ -1673,8 +1883,14 @@ exports[`Storyshots Components/Tabs Semantic Filter Mode 1`] = `
         
             
         <span
-          class="fd-tabs__icon sap-icon--cart"
+          class="fd-tabs__icon"
         >
+          
+                
+          <i
+            class="sap-icon--cart"
+            role="presentation"
+          />
           
                 
           <p
@@ -1715,8 +1931,14 @@ exports[`Storyshots Components/Tabs Semantic Filter Mode 1`] = `
         
             
         <span
-          class="fd-tabs__icon sap-icon--cart"
+          class="fd-tabs__icon"
         >
+          
+                
+          <i
+            class="sap-icon--cart"
+            role="presentation"
+          />
           
                 
           <p
@@ -1745,7 +1967,16 @@ exports[`Storyshots Components/Tabs Semantic Filter Mode 1`] = `
     <button
       aria-label="See More"
       class="fd-button fd-button--transparent fd-tabs__overflow"
-    />
+    >
+      
+        
+      <i
+        class="sap-icon--slim-arrow-down"
+        role="presentation"
+      />
+      
+    
+    </button>
     
 
   </ul>
@@ -2008,7 +2239,16 @@ exports[`Storyshots Components/Tabs Semantic Inline 1`] = `
     <button
       aria-label="See More"
       class="fd-button fd-button--transparent fd-tabs__overflow"
-    />
+    >
+      
+        
+      <i
+        class="sap-icon--slim-arrow-down"
+        role="presentation"
+      />
+      
+    
+    </button>
     
 
   </ul>
@@ -2102,8 +2342,14 @@ exports[`Storyshots Components/Tabs Semantic Mode 1`] = `
         
             
         <span
-          class="fd-tabs__icon sap-icon--cart"
+          class="fd-tabs__icon"
         >
+          
+                
+          <i
+            class="sap-icon--cart"
+            role="presentation"
+          />
           
                 
           <p
@@ -2138,8 +2384,14 @@ exports[`Storyshots Components/Tabs Semantic Mode 1`] = `
         
             
         <span
-          class="fd-tabs__icon sap-icon--cart"
+          class="fd-tabs__icon"
         >
+          
+                
+          <i
+            class="sap-icon--cart"
+            role="presentation"
+          />
           
                 
           <p
@@ -2173,8 +2425,14 @@ exports[`Storyshots Components/Tabs Semantic Mode 1`] = `
         
             
         <span
-          class="fd-tabs__icon sap-icon--cart"
+          class="fd-tabs__icon"
         >
+          
+                
+          <i
+            class="sap-icon--cart"
+            role="presentation"
+          />
           
                 
           <p
@@ -2208,8 +2466,14 @@ exports[`Storyshots Components/Tabs Semantic Mode 1`] = `
         
             
         <span
-          class="fd-tabs__icon sap-icon--cart"
+          class="fd-tabs__icon"
         >
+          
+                
+          <i
+            class="sap-icon--cart"
+            role="presentation"
+          />
           
                 
           <p
@@ -2243,8 +2507,14 @@ exports[`Storyshots Components/Tabs Semantic Mode 1`] = `
         
             
         <span
-          class="fd-tabs__icon sap-icon--cart"
+          class="fd-tabs__icon"
         >
+          
+                
+          <i
+            class="sap-icon--cart"
+            role="presentation"
+          />
           
                 
           <p
@@ -2266,7 +2536,16 @@ exports[`Storyshots Components/Tabs Semantic Mode 1`] = `
     <button
       aria-label="See More"
       class="fd-button fd-button--transparent fd-tabs__overflow"
-    />
+    >
+      
+        
+      <i
+        class="sap-icon--slim-arrow-down"
+        role="presentation"
+      />
+      
+    
+    </button>
     
 
   </ul>
@@ -2457,7 +2736,16 @@ exports[`Storyshots Components/Tabs Tab With Counters 1`] = `
     <button
       aria-label="See More"
       class="fd-button fd-button--transparent fd-button--compact fd-tabs__overflow"
-    />
+    >
+      
+        
+      <i
+        class="sap-icon--slim-arrow-down"
+        role="presentation"
+      />
+      
+    
+    </button>
     
 
   </ul>

--- a/stories/tabs/tabs.stories.js
+++ b/stories/tabs/tabs.stories.js
@@ -39,7 +39,9 @@ export const primary = () => `
             </span>
         </a>
     </li>
-    <button class="fd-button fd-button--transparent fd-tabs__overflow" aria-label="See More"></button>
+    <button class="fd-button fd-button--transparent fd-tabs__overflow" aria-label="See More">
+        <i class="sap-icon--slim-arrow-down" role="presentation"></i>
+    </button>
 </ul>
 <div class="fd-tabs__panel" aria-expanded="false" id="fuCwV550" role="tabpanel">
     Lorem ipsum
@@ -81,7 +83,9 @@ export const tabWithCounters = () => `
             </span>
         </a>
     </li>
-    <button class="fd-button fd-button--transparent fd-button--compact fd-tabs__overflow" aria-label="See More"></button>
+    <button class="fd-button fd-button--transparent fd-button--compact fd-tabs__overflow" aria-label="See More">
+        <i class="sap-icon--slim-arrow-down" role="presentation"></i>
+    </button>
 </ul>
 <div class="fd-tabs__panel" aria-expanded="false" id="d9vOir" role="tabpanel">
     Lorem ipsum
@@ -120,7 +124,9 @@ export const navTab = () => `
             </span>
         </a>
     </span>
-    <button class="fd-button fd-button--transparent fd-tabs__overflow" aria-label="See More"></button>
+    <button class="fd-button fd-button--transparent fd-tabs__overflow" aria-label="See More">
+        <i class="sap-icon--slim-arrow-down" role="presentation"></i>
+    </button>
 </nav>
 <div class="fd-tabs__panel" aria-expanded="false" id="kf8369" role="tabpanel">
     Lorem ipsum
@@ -145,26 +151,31 @@ export const iconOnly = () => `
 <ul class="fd-tabs fd-tabs--l fd-tabs--icon-only" role="tablist">
     <li role="listitem" class="fd-tabs__item">
         <a class="fd-tabs__link" aria-controls="pliA92" href="#pliA92" role="tab">
-            <span class="fd-tabs__icon sap-icon--cart">
+            <span class="fd-tabs__icon">
+                <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">12</p>
             </span>
         </a>
     </li>
     <li role="listitem" class="fd-tabs__item">
       <a class="fd-tabs__link" aria-controls="ZAN8Hd" aria-selected="true" href="#ZAN8Hd" role="tab">
-            <span class="fd-tabs__icon sap-icon--cart">
+            <span class="fd-tabs__icon">
+                <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">15</p>
             </span>
         </a>
     </li>
     <li role="listitem" class="fd-tabs__item">
         <a class="fd-tabs__link" aria-controls="QrQ5Cl" href="#QrQ5Cl" role="tab">
-            <span class="fd-tabs__icon sap-icon--cart">
+            <span class="fd-tabs__icon">
+                <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">1</p>
             </span>
         </a>
     </li>
-    <button class="fd-button fd-button--transparent fd-tabs__overflow" aria-label="See More"></button>
+    <button class="fd-button fd-button--transparent fd-tabs__overflow" aria-label="See More">
+        <i class="sap-icon--slim-arrow-down" role="presentation"></i>
+    </button>
 </ul>
 <div class="fd-tabs__panel" aria-expanded="false" id="pliA92" role="tabpanel">
     Lorem ipsum
@@ -189,26 +200,31 @@ export const compactIconOnly = () => `
 <ul class="fd-tabs fd-tabs--s fd-tabs--icon-only fd-tabs--compact" role="tablist">
     <li role="listitem" class="fd-tabs__item fd-tabs__item--icon-only">
         <a class="fd-tabs__link" aria-controls="0bT4aB" href="#0bT4aB" role="tab">
-            <span class="fd-tabs__icon sap-icon--cart">
+            <span class="fd-tabs__icon">
+                <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">5</p>
             </span>
         </a>
     </li>
     <li role="listitem" class="fd-tabs__item">
       <a class="fd-tabs__link" aria-controls="kzRyN3" aria-selected="true" href="#kzRyN3" role="tab">
-            <span class="fd-tabs__icon sap-icon--cart">
+            <span class="fd-tabs__icon">
+                <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">78</p>
             </span>
         </a>
     </li>
     <li role="listitem" class="fd-tabs__item">
         <a class="fd-tabs__link" aria-controls="f2epu6" href="#f2epu6" role="tab">
-            <span class="fd-tabs__icon sap-icon--cart">
+            <span class="fd-tabs__icon">
+                <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">43</p>
             </span>
         </a>
     </li>
-    <button class="fd-button fd-button--transparent fd-button--compact fd-tabs__overflow" aria-label="See More"></button>
+    <button class="fd-button fd-button--transparent fd-button--compact fd-tabs__overflow" aria-label="See More">
+        <i class="sap-icon--slim-arrow-down" role="presentation"></i>
+    </button>
 </ul>
 <div class="fd-tabs__panel" aria-expanded="false" id="0bT4aB" role="tabpanel">
     Lorem ipsum
@@ -228,7 +244,9 @@ export const processMode = () => `
 <ul class="fd-tabs fd-tabs--l fd-tabs--process" role="tablist">
     <li role="listitem" class="fd-tabs__item">
         <a class="fd-tabs__link" aria-controls="NoQLy6" href="#NoQLy6" role="tab">
-            <span class="fd-tabs__icon sap-icon--cart"></span>
+            <span class="fd-tabs__icon">
+                <i class="sap-icon--cart" role="presentation"></i>
+            </span>
             <div class="fd-tabs__process">
                 <span class="fd-tabs__label">58 of 122 items</span>
                 <span class="fd-tabs__label">Description</span>
@@ -238,7 +256,9 @@ export const processMode = () => `
     </li>
     <li role="listitem" class="fd-tabs__item">
         <a class="fd-tabs__link" aria-controls="h4yBDR" href="#h4yBDR" role="tab">
-            <span class="fd-tabs__icon sap-icon--cart"></span>
+            <span class="fd-tabs__icon">
+                <i class="sap-icon--cart" role="presentation"></i>
+            </span>
             <div class="fd-tabs__process">
                 <span class="fd-tabs__label">22 of 122 items</span>
                 <span class="fd-tabs__label">Description</span>
@@ -248,14 +268,18 @@ export const processMode = () => `
     </li>
     <li role="listitem" class="fd-tabs__item">
         <a class="fd-tabs__link" aria-controls="nd1EMQ" href="#nd1EMQ" role="tab">
-            <span class="fd-tabs__icon sap-icon--cart"></span>
+            <span class="fd-tabs__icon">
+                <i class="sap-icon--cart" role="presentation"></i>
+            </span>
             <div class="fd-tabs__process">
                 <span class="fd-tabs__label">42 of 122 items</span>
                 <span class="fd-tabs__label">Description</span>
             </div>
         </a>
     </li>
-    <button class="fd-button fd-button--transparent fd-tabs__overflow" aria-label="See More"></button>
+    <button class="fd-button fd-button--transparent fd-tabs__overflow" aria-label="See More">
+        <i class="sap-icon--slim-arrow-right" role="presentation"></i>
+    </button>
 </ul>
 <div class="fd-tabs__panel" aria-expanded="false" id="NoQLy6" role="tabpanel">
     Lorem ipsum
@@ -276,7 +300,9 @@ export const compactProcessMode = () => `
 <ul class="fd-tabs fd-tabs--s fd-tabs--process fd-tabs--compact" role="tablist">
     <li role="listitem" class="fd-tabs__item">
         <a class="fd-tabs__link" aria-controls="LHsxsZ" href="#LHsxsZ" role="tab">
-            <span class="fd-tabs__icon sap-icon--cart"></span>
+            <span class="fd-tabs__icon">
+                <i class="sap-icon--cart" role="presentation"></i>
+            </span>
             <div class="fd-tabs__process">
                 <span class="fd-tabs__label">58 of 122 items</span>
                 <span class="fd-tabs__label">Description</span>
@@ -286,7 +312,9 @@ export const compactProcessMode = () => `
     </li>
     <li role="listitem" class="fd-tabs__item">
         <a class="fd-tabs__link" aria-controls="ZQvAjG" href="#ZQvAjG" role="tab">
-            <span class="fd-tabs__icon sap-icon--cart"></span>
+            <span class="fd-tabs__icon">
+                <i class="sap-icon--cart" role="presentation"></i>
+            </span>
             <div class="fd-tabs__process">
                 <span class="fd-tabs__label">42 of 122 items</span>
                 <span class="fd-tabs__label">Description</span>
@@ -296,14 +324,18 @@ export const compactProcessMode = () => `
     </li>
     <li role="listitem" class="fd-tabs__item">
         <a class="fd-tabs__link" aria-controls="wdqPV9" href="#wdqPV9" role="tab">
-            <span class="fd-tabs__icon sap-icon--cart"></span>
+            <span class="fd-tabs__icon">
+                <i class="sap-icon--cart" role="presentation"></i>
+            </span>
             <div class="fd-tabs__process">
                 <span class="fd-tabs__label">22 of 122 items</span>
                 <span class="fd-tabs__label">Description</span>
             </div>
         </a>
     </li>
-    <button class="fd-button fd-button--transparent fd-button--compact fd-tabs__overflow" aria-label="See More"></button>
+    <button class="fd-button fd-button--transparent fd-button--compact fd-tabs__overflow" aria-label="See More">
+        <i class="sap-icon--slim-arrow-down" role="presentation"></i>
+    </button>
 </ul>
 <div class="fd-tabs__panel" aria-expanded="false" id="LHsxsZ" role="tabpanel">
     Lorem ipsum
@@ -330,7 +362,8 @@ export const filterMode = () => `
     <div class="fd-tabs__separator"></div>
     <li role="listitem" class="fd-tabs__item">
         <a class="fd-tabs__link" aria-controls="znvnwr" href="#znvnwr" role="tab">
-            <span class="fd-tabs__icon sap-icon--cart">
+            <span class="fd-tabs__icon">
+                <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">35</p>
             </span>
             <span class="fd-tabs__label">Description</span>
@@ -338,7 +371,8 @@ export const filterMode = () => `
     </li>
     <li role="listitem" class="fd-tabs__item">
         <a class="fd-tabs__link" aria-controls="oyYpL7" href="#oyYpL7" role="tab">
-            <span class="fd-tabs__icon sap-icon--cart">
+            <span class="fd-tabs__icon">
+                <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">5</p>
             </span>
             <span class="fd-tabs__label">Description</span>
@@ -346,13 +380,16 @@ export const filterMode = () => `
     </li>
     <li role="listitem" class="fd-tabs__item">
         <a class="fd-tabs__link" aria-controls="gRpu9H" href="#gRpu9H" role="tab">
-            <span class="fd-tabs__icon sap-icon--cart">
+            <span class="fd-tabs__icon">
+                <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">60</p>
             </span>
             <span class="fd-tabs__label">Description</span>
         </a>
     </li>
-    <button class="fd-button fd-button--transparent fd-tabs__overflow" aria-label="See More"></button>
+    <button class="fd-button fd-button--transparent fd-tabs__overflow" aria-label="See More">
+        <i class="sap-icon--slim-arrow-down" role="presentation"></i>
+    </button>
 </ul>
 <div class="fd-tabs__panel" aria-expanded="false" id="5ZkDVE" role="tabpanel">
     Lorem ipsum
@@ -382,7 +419,8 @@ export const compactFilterMode = () => `
     <div class="fd-tabs__separator"></div>
     <li role="listitem" class="fd-tabs__item">
         <a class="fd-tabs__link" aria-controls="eu3WeD" href="#eu3WeD" role="tab">
-            <span class="fd-tabs__icon sap-icon--cart">
+            <span class="fd-tabs__icon">
+                <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">3</p>
             </span>
             <span class="fd-tabs__label">Description</span>
@@ -390,7 +428,8 @@ export const compactFilterMode = () => `
     </li>
     <li role="listitem" class="fd-tabs__item">
         <a class="fd-tabs__link" aria-controls="VqJcYO" href="#VqJcYO" role="tab">
-            <span class="fd-tabs__icon sap-icon--cart">
+            <span class="fd-tabs__icon">
+                <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">40</p>
             </span>
             <span class="fd-tabs__label">Description</span>
@@ -398,13 +437,16 @@ export const compactFilterMode = () => `
     </li>
     <li role="listitem" class="fd-tabs__item">
         <a class="fd-tabs__link" aria-controls="ceoDu7" href="#ceoDu7" role="tab">
-            <span class="fd-tabs__icon sap-icon--cart">
+            <span class="fd-tabs__icon">
+                <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">107</p>
             </span>
             <span class="fd-tabs__label">Description</span>
         </a>
     </li>
-    <button class="fd-button fd-button--transparent fd-button--compact fd-tabs__overflow" aria-label="See More"></button>
+    <button class="fd-button fd-button--transparent fd-button--compact fd-tabs__overflow" aria-label="See More">
+        <i class="sap-icon--slim-arrow-down" role="presentation"></i>
+    </button>
 </ul>
 <div class="fd-tabs__panel" aria-expanded="false" id="YETAv8" role="tabpanel">
     Lorem ipsum
@@ -425,40 +467,47 @@ export const semanticMode = () => `
 <ul class="fd-tabs fd-tabs--s fd-tabs--icon-only fd-tabs--compact" role="tablist">
     <li role="listitem" class="fd-tabs__item fd-tabs__item--success">
         <a class="fd-tabs__link" aria-controls="XTsSDD" href="#XTsSDD" role="tab">
-            <span class="fd-tabs__icon sap-icon--cart">
+            <span class="fd-tabs__icon">
+                <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">54</p>
             </span>
         </a>
     </li>
     <li role="listitem" class="fd-tabs__item fd-tabs__item--warning">
       <a class="fd-tabs__link" aria-controls="DomvG6" aria-selected="true" href="#DomvG6" role="tab">
-            <span class="fd-tabs__icon sap-icon--cart">
+            <span class="fd-tabs__icon">
+                <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">71</p>
             </span>
         </a>
     </li>
     <li role="listitem" class="fd-tabs__item fd-tabs__item--information">
         <a class="fd-tabs__link" aria-controls="DqIStt" href="#DqIStt" role="tab">
-            <span class="fd-tabs__icon sap-icon--cart">
+            <span class="fd-tabs__icon">
+                <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">23</p>
             </span>
         </a>
     </li>
     <li role="listitem" class="fd-tabs__item fd-tabs__item--error">
         <a class="fd-tabs__link" aria-controls="bRCSzS" href="#bRCSzS" role="tab">
-            <span class="fd-tabs__icon sap-icon--cart">
+            <span class="fd-tabs__icon">
+                <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">4</p>
             </span>
         </a>
     </li>
     <li role="listitem" class="fd-tabs__item fd-tabs__item--neutral">
         <a class="fd-tabs__link" aria-controls="xMN6I9" href="#xMN6I9" role="tab">
-            <span class="fd-tabs__icon sap-icon--cart">
+            <span class="fd-tabs__icon">
+                <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">100</p>
             </span>
         </a>
     </li>
-    <button class="fd-button fd-button--transparent fd-tabs__overflow" aria-label="See More"></button>
+    <button class="fd-button fd-button--transparent fd-tabs__overflow" aria-label="See More">
+        <i class="sap-icon--slim-arrow-down" role="presentation"></i>
+    </button>
 </ul>
 <div class="fd-tabs__panel" aria-expanded="false" id="XTsSDD" role="tabpanel">
     Lorem ipsum
@@ -491,7 +540,8 @@ export const semanticFilterMode = () => `
     <div class="fd-tabs__separator"></div>
     <li role="listitem" class="fd-tabs__item fd-tabs__item--success">
         <a class="fd-tabs__link" aria-controls="znvnwr" href="#znvnwr" role="tab">
-            <span class="fd-tabs__icon sap-icon--cart">
+            <span class="fd-tabs__icon">
+                <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">35</p>
             </span>
             <span class="fd-tabs__label">Success</span>
@@ -499,7 +549,8 @@ export const semanticFilterMode = () => `
     </li>
     <li role="listitem" class="fd-tabs__item fd-tabs__item--warning">
         <a class="fd-tabs__link" aria-controls="oyYpL7" href="#oyYpL7" role="tab">
-            <span class="fd-tabs__icon sap-icon--cart">
+            <span class="fd-tabs__icon">
+                <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">5</p>
             </span>
             <span class="fd-tabs__label">Warning</span>
@@ -507,7 +558,8 @@ export const semanticFilterMode = () => `
     </li>
     <li role="listitem" class="fd-tabs__item fd-tabs__item--information">
         <a class="fd-tabs__link" aria-controls="gRpu9H" href="#gRpu9H" role="tab">
-            <span class="fd-tabs__icon sap-icon--cart">
+            <span class="fd-tabs__icon">
+                <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">60</p>
             </span>
             <span class="fd-tabs__label">Information</span>
@@ -515,13 +567,16 @@ export const semanticFilterMode = () => `
     </li>
     <li role="listitem" class="fd-tabs__item fd-tabs__item--error">
         <a class="fd-tabs__link" aria-controls="gRpu1A" href="#gRpu1A" role="tab">
-            <span class="fd-tabs__icon sap-icon--cart">
+            <span class="fd-tabs__icon">
+                <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">50</p>
             </span>
             <span class="fd-tabs__label">Error</span>
         </a>
     </li>
-    <button class="fd-button fd-button--transparent fd-tabs__overflow" aria-label="See More"></button>
+    <button class="fd-button fd-button--transparent fd-tabs__overflow" aria-label="See More">
+        <i class="sap-icon--slim-arrow-down" role="presentation"></i>
+    </button>
 </ul>
 <div class="fd-tabs__panel" aria-expanded="false" id="5ZkDVE" role="tabpanel">
     Lorem ipsum
@@ -583,7 +638,9 @@ export const semanticInline = () => `
             </span>
         </a>
     </li>
-    <button class="fd-button fd-button--transparent fd-tabs__overflow" aria-label="See More"></button>
+    <button class="fd-button fd-button--transparent fd-tabs__overflow" aria-label="See More">
+        <i class="sap-icon--slim-arrow-down" role="presentation"></i>
+    </button>
 </ul>
 <div class="fd-tabs__panel" aria-expanded="false" id="5abyKZ" role="tabpanel">
     Lorem ipsum


### PR DESCRIPTION
## Related Issue
Related to #1603 

## Description

Breaking Changes in 2 places:
- overflow button

Before:
```
<button class="fd-button fd-button--transparent fd-button--compact fd-tabs__overflow" aria-label="See More"></button>
```    
After:
```
<button class="fd-button fd-button--transparent fd-button--compact fd-tabs__overflow" aria-label="See More">
        <i class="sap-icon--slim-arrow-down" role="presentation"></i>
</button>
```

-icons

Before:
```
<span class="fd-tabs__icon sap-icon--cart">
    <p class="fd-tabs__count">15</p>
</span>    
```

After:
```
            <span class="fd-tabs__icon">
                <i class="sap-icon--cart" role="presentation"></i>
                <p class="fd-tabs__count">15</p>
            </span>
```


#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
