### PR TITLE
fix: Tile - Refactor icons usage

### DIFF
--- a/src/tile.scss
+++ b/src/tile.scss
@@ -242,16 +242,17 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
 
   &__refresh {
     @include fd-flex-center();
-    @include fd-icon-element-base();
 
-    color: var(--sapButton_IconColor);
-    min-width: 0.875rem;
-    text-align: center;
-    margin-right: $fd-tile-refresh-icon-spacing;
+    @include fd-icon-element-base() {
+      color: var(--sapButton_IconColor);
+      min-width: 0.875rem;
+      text-align: center;
+      margin-right: $fd-tile-refresh-icon-spacing;
 
-    @include fd-rtl() {
-      margin-right: 0;
-      margin-left: $fd-tile-refresh-icon-spacing;
+      @include fd-rtl() {
+        margin-right: 0;
+        margin-left: $fd-tile-refresh-icon-spacing;
+      }
     }
   }
 

--- a/src/tile.scss
+++ b/src/tile.scss
@@ -219,8 +219,7 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
 
   &__title,
   &__subtitle,
-  &__footer-text,
-  &__refresh {
+  &__footer-text {
     @include fd-reset();
 
     font-size: var(--sapFontSize);
@@ -241,9 +240,11 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
   }
 
   &__refresh {
-    @include fd-flex-center();
-
     @include fd-icon-element-base() {
+      @include fd-flex-center();
+
+      line-height: normal;
+      font-size: var(--sapFontSize);
       color: var(--sapButton_IconColor);
       min-width: 0.875rem;
       text-align: center;

--- a/src/tile.scss
+++ b/src/tile.scss
@@ -241,6 +241,9 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
   }
 
   &__refresh {
+    @include fd-flex-center();
+    @include fd-icon-element-base();
+
     color: var(--sapButton_IconColor);
     min-width: 0.875rem;
     text-align: center;

--- a/stories/generictile/__snapshots__/generic-tile.stories.storyshot
+++ b/stories/generictile/__snapshots__/generic-tile.stories.storyshot
@@ -525,8 +525,9 @@ exports[`Storyshots Components/Generic Tile KPI Tile 1`] = `
         >
           
                 
-          <span
-            class="sap-icon--refresh fd-tile__refresh"
+          <i
+            aria-label="Refresh"
+            class="fd-tile__refresh sap-icon--refresh"
           />
           
                 
@@ -655,8 +656,9 @@ exports[`Storyshots Components/Generic Tile KPI Tile 1`] = `
         >
           
                 
-          <span
-            class="sap-icon--refresh fd-tile__refresh"
+          <i
+            aria-label="Refresh"
+            class="fd-tile__refresh sap-icon--refresh"
           />
           
                 
@@ -1227,8 +1229,9 @@ exports[`Storyshots Components/Generic Tile Launch Tile 1`] = `
         >
           
                 
-          <span
-            class="sap-icon--refresh fd-tile__refresh"
+          <i
+            aria-label="Refresh"
+            class="fd-tile__refresh sap-icon--refresh"
           />
           
                 
@@ -1411,8 +1414,9 @@ exports[`Storyshots Components/Generic Tile Launch Tile 1`] = `
         >
           
                 
-          <span
-            class="sap-icon--refresh fd-tile__refresh"
+          <i
+            aria-label="Refresh"
+            class="fd-tile__refresh sap-icon--refresh"
           />
           
                 
@@ -1482,8 +1486,9 @@ exports[`Storyshots Components/Generic Tile Launch Tile 1`] = `
         >
           
                 
-          <span
-            class="sap-icon--refresh fd-tile__refresh"
+          <i
+            aria-label="Refresh"
+            class="fd-tile__refresh sap-icon--refresh"
           />
           
                 
@@ -1833,7 +1838,7 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
     <div
       class="fd-tile-container"
     >
-       
+      
         
       <div
         class="fd-tile fd-tile--line"
@@ -2051,7 +2056,7 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
     <div
       class="fd-tile-container fd-tile-container--list"
     >
-       
+      
                 
       <div
         class="fd-tile fd-tile--line"
@@ -2269,7 +2274,7 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
     <div
       class="fd-tile-container"
     >
-       
+      
         
       <div
         class="fd-tile fd-tile--compact fd-tile--line"
@@ -2487,7 +2492,7 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
     <div
       class="fd-tile-container fd-tile-container--list"
     >
-       
+      
         
       <div
         class="fd-tile fd-tile--compact fd-tile--line"
@@ -2641,7 +2646,7 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
     <div
       class="fd-tile-container"
     >
-       
+      
         
       <div
         class="fd-tile fd-tile--line"
@@ -2996,7 +3001,7 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
     <div
       class="fd-tile-container fd-tile-container--list"
     >
-       
+      
         
       <div
         class="fd-tile fd-tile--line"
@@ -3304,7 +3309,7 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
     <div
       class="fd-tile-container"
     >
-       
+      
         
       <div
         class="fd-tile fd-tile--line fd-tile--action"
@@ -3648,7 +3653,7 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
     <div
       class="fd-tile-container fd-tile-container--list"
     >
-       
+      
         
       <div
         class="fd-tile fd-tile--line fd-tile--action"

--- a/stories/generictile/generic-tile.stories.mdx
+++ b/stories/generictile/generic-tile.stories.mdx
@@ -339,7 +339,7 @@ The header can contain a maximum of 3 lines; all 3 lines can be used for the tit
         </div>
         <div class="fd-tile__footer fd-tile__footer--2-col">
             <div class="fd-tile__section">
-                <span class="fd-tile__refresh"><i class="sap-icon--refresh"></i></span>
+                <i class="fd-tile__refresh sap-icon--refresh" aria-label="Refresh"></i>
                 <span class="fd-tile__footer-text">Now</span>
             </div>
             <div class="fd-tile__section"><span class="fd-tile__footer-text">Footer</span></div>
@@ -377,7 +377,7 @@ The header can contain a maximum of 3 lines; all 3 lines can be used for the tit
         </div>
         <div class="fd-tile__footer fd-tile__footer--2-col">
             <div class="fd-tile__section">
-                <span class="fd-tile__refresh"><i class="sap-icon--refresh"></i></span>
+                <i class="fd-tile__refresh sap-icon--refresh" aria-label="Refresh"></i>
                 <span class="fd-tile__footer-text">Now</span>
             </div>
             <div class="fd-tile__section"><span class="fd-tile__footer-text">Footer</span></div>
@@ -390,7 +390,7 @@ The header can contain a maximum of 3 lines; all 3 lines can be used for the tit
         </div>
         <div class="fd-tile__footer fd-tile__footer--2-col">
             <div class="fd-tile__section">
-                <span class="fd-tile__refresh"><i class="sap-icon--refresh"></i></span>
+                <i class="fd-tile__refresh sap-icon--refresh" aria-label="Refresh"></i>
                 <span class="fd-tile__footer-text">Now</span>
             </div>
             <div class="fd-tile__section"><span class="fd-tile__footer-text">Footer</span></div>
@@ -515,7 +515,7 @@ Structure of the Numeric Content
         </div>
         <div class="fd-tile__footer fd-tile__footer--2-col">
             <div class="fd-tile__section">
-                <span class="fd-tile__refresh"><i class="sap-icon--refresh"></i></span>
+                <i class="fd-tile__refresh sap-icon--refresh" aria-label="Refresh"></i>
                 <span class="fd-tile__footer-text">Now</span>
             </div>
             <div class="fd-tile__section"><span class="fd-tile__footer-text">Footer</span></div>
@@ -541,7 +541,7 @@ Structure of the Numeric Content
         </div>
         <div class="fd-tile__footer fd-tile__footer--2-col">
             <div class="fd-tile__section">
-                <span class="fd-tile__refresh"><i class="sap-icon--refresh"></i></span>
+                <i class="fd-tile__refresh sap-icon--refresh" aria-label="Refresh"></i>
                 <span class="fd-tile__footer-text">Now</span>
             </div>
             <div class="fd-tile__section"><span class="fd-tile__footer-text">Footer</span></div>

--- a/stories/generictile/generic-tile.stories.mdx
+++ b/stories/generictile/generic-tile.stories.mdx
@@ -339,7 +339,7 @@ The header can contain a maximum of 3 lines; all 3 lines can be used for the tit
         </div>
         <div class="fd-tile__footer fd-tile__footer--2-col">
             <div class="fd-tile__section">
-                <span class="sap-icon--refresh fd-tile__refresh"></span>
+                <span class="fd-tile__refresh"><i class="sap-icon--refresh"></i></span>
                 <span class="fd-tile__footer-text">Now</span>
             </div>
             <div class="fd-tile__section"><span class="fd-tile__footer-text">Footer</span></div>
@@ -377,7 +377,7 @@ The header can contain a maximum of 3 lines; all 3 lines can be used for the tit
         </div>
         <div class="fd-tile__footer fd-tile__footer--2-col">
             <div class="fd-tile__section">
-                <span class="sap-icon--refresh fd-tile__refresh"></span>
+                <span class="fd-tile__refresh"><i class="sap-icon--refresh"></i></span>
                 <span class="fd-tile__footer-text">Now</span>
             </div>
             <div class="fd-tile__section"><span class="fd-tile__footer-text">Footer</span></div>
@@ -390,7 +390,7 @@ The header can contain a maximum of 3 lines; all 3 lines can be used for the tit
         </div>
         <div class="fd-tile__footer fd-tile__footer--2-col">
             <div class="fd-tile__section">
-                <span class="sap-icon--refresh fd-tile__refresh"></span>
+                <span class="fd-tile__refresh"><i class="sap-icon--refresh"></i></span>
                 <span class="fd-tile__footer-text">Now</span>
             </div>
             <div class="fd-tile__section"><span class="fd-tile__footer-text">Footer</span></div>
@@ -515,7 +515,7 @@ Structure of the Numeric Content
         </div>
         <div class="fd-tile__footer fd-tile__footer--2-col">
             <div class="fd-tile__section">
-                <span class="sap-icon--refresh fd-tile__refresh"></span>
+                <span class="fd-tile__refresh"><i class="sap-icon--refresh"></i></span>
                 <span class="fd-tile__footer-text">Now</span>
             </div>
             <div class="fd-tile__section"><span class="fd-tile__footer-text">Footer</span></div>
@@ -541,7 +541,7 @@ Structure of the Numeric Content
         </div>
         <div class="fd-tile__footer fd-tile__footer--2-col">
             <div class="fd-tile__section">
-                <span class="sap-icon--refresh fd-tile__refresh"></span>
+                <span class="fd-tile__refresh"><i class="sap-icon--refresh"></i></span>
                 <span class="fd-tile__footer-text">Now</span>
             </div>
             <div class="fd-tile__section"><span class="fd-tile__footer-text">Footer</span></div>
@@ -1016,7 +1016,7 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
         {() => `
 <h4>Line Tile - Floating Behaviour, Cozy Mode</h4>
 <div class="docs-section-container">
-    <div class="fd-tile-container"> 
+    <div class="fd-tile-container">
         <div role="button" tabindex="0" class="fd-tile fd-tile--line">
             <div class="fd-tile__header">
                 <div class="fd-tile__title">Line Tile Title</div>
@@ -1058,7 +1058,7 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
 <br><br><br>
 <h4>Line Tile - List Behaviour, Cozy Mode</h4>
 <div class="docs-section-container">
-    <div class="fd-tile-container fd-tile-container--list"> 
+    <div class="fd-tile-container fd-tile-container--list">
                 <div role="button" tabindex="0" class="fd-tile fd-tile--line">
             <div class="fd-tile__header">
                 <div class="fd-tile__title">Line Tile Title</div>
@@ -1100,7 +1100,7 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
 <br><br><br>
 <h4>Line Tile - Floating Behaviour, Compact Mode</h4>
 <div class="docs-section-container">
-    <div class="fd-tile-container"> 
+    <div class="fd-tile-container">
         <div role="button" tabindex="0" class="fd-tile fd-tile--compact fd-tile--line">
             <div class="fd-tile__header">
                 <div class="fd-tile__title">Line Tile Title</div>
@@ -1142,7 +1142,7 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
 <br><br><br>
 <h4>Line Tile - List Behaviour, Compact Mode</h4>
 <div class="docs-section-container">
-    <div class="fd-tile-container fd-tile-container--list"> 
+    <div class="fd-tile-container fd-tile-container--list">
         <div role="button" tabindex="0" class="fd-tile fd-tile--compact fd-tile--line">
             <div class="fd-tile__header">
                 <div class="fd-tile__title">Line Tile Title</div>
@@ -1172,7 +1172,7 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
 <br><br><br>
 <h4>Line Tile - Floating Behaviour, Cozy Mode, With Badge</h4>
 <div class="docs-section-container">
-    <div class="fd-tile-container"> 
+    <div class="fd-tile-container">
         <div role="button" tabindex="0" class="fd-tile fd-tile--line">
             <div class="fd-tile__header">
                 <div class="fd-tile__title-container">
@@ -1241,7 +1241,7 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
 <br><br><br>
 <h4>Line Tile - List Behaviour, Cozy Mode, With Badge</h4>
 <div class="docs-section-container">
-    <div class="fd-tile-container fd-tile-container--list"> 
+    <div class="fd-tile-container fd-tile-container--list">
         <div role="button" tabindex="0" class="fd-tile fd-tile--line">
             <div class="fd-tile__header">
                 <div class="fd-tile__title-container">
@@ -1301,7 +1301,7 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
 <br><br><br>
 <h4>Line Tile - Floating Behaviour, Cozy and Action Mode</h4>
 <div class="docs-section-container">
-    <div class="fd-tile-container"> 
+    <div class="fd-tile-container">
         <div role="button" tabindex="0" class="fd-tile fd-tile--line fd-tile--action">
             <div class="fd-tile__header">
                 <div class="fd-tile__title">Line Tile Title</div>
@@ -1367,7 +1367,7 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
 <br><br><br>
 <h4>Line Tile - List Behaviour, Cozy and Action Mode</h4>
 <div class="docs-section-container">
-    <div class="fd-tile-container fd-tile-container--list"> 
+    <div class="fd-tile-container fd-tile-container--list">
         <div role="button" tabindex="0" class="fd-tile fd-tile--line fd-tile--action">
             <div class="fd-tile__header">
                 <div class="fd-tile__title">Line Tile Title</div>


### PR DESCRIPTION
## Related Issue
Part of: SAP/fundamental-styles#1603

## Description
This PR:
- Updates icon element code with icon mixins

### Before:
```
            <div class="fd-tile__section">
                <span class="sap-icon--refresh fd-tile__refresh"></span>
                <span class="fd-tile__footer-text">Now</span>
            </div>
```

### After:
```
            <div class="fd-tile__section">
                <i class="fd-tile__refresh sap-icon--refresh" aria-label="Refresh"></i>
                <span class="fd-tile__footer-text">Now</span>
            </div>
```

#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
