### PR TITLE
fix: refactor icons in switch

### DIFF
--- a/src/switch.scss
+++ b/src/switch.scss
@@ -109,12 +109,13 @@ $block: #{$fd-namespace}-switch;
 
   &__icon {
     @include fd-reset();
+    @include fd-icon-element-base();
+    @include fd-flex-center();
 
     width: $fd-switch-label-width;
     min-width: $fd-switch-label-width;
     font-size: 0.75rem;
     line-height: 1.375rem;
-    text-align: center;
     transition: $fd-switch-semantic-icon-transition;
 
     &--off {

--- a/src/switch.scss
+++ b/src/switch.scss
@@ -108,26 +108,30 @@ $block: #{$fd-namespace}-switch;
   }
 
   &__icon {
-    @include fd-reset();
-    @include fd-icon-element-base();
-    @include fd-flex-center();
+    @include fd-icon-selector() {
+      @include fd-flex-center();
 
-    width: $fd-switch-label-width;
-    min-width: $fd-switch-label-width;
-    font-size: 0.75rem;
-    line-height: 1.375rem;
-    transition: $fd-switch-semantic-icon-transition;
+      width: $fd-switch-label-width;
+      min-width: $fd-switch-label-width;
+      font-size: 0.75rem;
+      line-height: 1.375rem;
+      transition: $fd-switch-semantic-icon-transition;
+    }
 
     &--off {
-      color: var(--sapNegativeElementColor);
-      margin: 0 0.125rem 0 0;
+      @include fd-icon-selector() {
+        color: var(--sapNegativeElementColor);
+        margin: 0 0.125rem 0 0;
+      }
     }
 
     &--on {
-      color: var(--sapPositiveElementColor);
-      margin: 0 0 0 0.125rem;
-      visibility: hidden;
-      opacity: $fd-switch-off-opacity;
+      @include fd-icon-selector() {
+        color: var(--sapPositiveElementColor);
+        margin: 0 0 0 0.125rem;
+        visibility: hidden;
+        opacity: $fd-switch-off-opacity;
+      }
     }
   }
 
@@ -198,13 +202,17 @@ $block: #{$fd-namespace}-switch;
 
     .#{$block}__icon {
       &--off {
-        opacity: $fd-switch-off-opacity;
-        visibility: hidden;
+        @include fd-icon-selector() {
+          opacity: $fd-switch-off-opacity;
+          visibility: hidden;
+        }
       }
 
       &--on {
-        opacity: $fd-switch-on-opacity;
-        visibility: visible;
+        @include fd-icon-selector() {
+          opacity: $fd-switch-on-opacity;
+          visibility: visible;
+        }
       }
     }
   }

--- a/stories/switch/switch.stories.js
+++ b/stories/switch/switch.stories.js
@@ -103,13 +103,9 @@ export const semanticSwitch = () => `
                 <input class="fd-switch__input" type="checkbox" aria-labelledby="label5" name="" value="" id="y21YO3251">
                 <div class="fd-switch__wrapper">
                     <div class="fd-switch__track">
-                        <span class="fd-switch__icon--on fd-switch__icon">
-                            <i class="sap-icon--accept" role="presentation"></i>
-                        </span>
+                        <i role="presentation" class="fd-switch__icon--on fd-switch__icon sap-icon--accept"></i>
                         <span class="fd-switch__handle" role="presentation"></span>
-                        <span class="fd-switch__icon--off fd-switch__icon">
-                            <i class="sap-icon--decline" role="presentation"></i>
-                        </span>
+                        <i role="presentation" class="fd-switch__icon--off fd-switch__icon sap-icon--decline"></i>
                     </div>
                 </div>
             </span>
@@ -122,13 +118,9 @@ export const semanticSwitch = () => `
                 <input class="fd-switch__input" type="checkbox" name="" aria-labelledby="label6" value="" id="y21YO3431">
                 <div class="fd-switch__wrapper">
                     <div class="fd-switch__track">
-                        <span class="fd-switch__icon--on fd-switch__icon">
-                            <i class="sap-icon--accept" role="presentation"></i>
-                        </span>
+                        <i role="presentation" class="fd-switch__icon--on fd-switch__icon sap-icon--accept"></i>
                         <span class="fd-switch__handle" role="presentation"></span>
-                        <span class="fd-switch__icon--off fd-switch__icon">
-                            <i class="sap-icon--decline" role="presentation"></i>
-                        </span>
+                        <i role="presentation" class="fd-switch__icon--off fd-switch__icon sap-icon--decline"></i>
                     </div>
                 </div>
             </span>
@@ -150,13 +142,9 @@ export const rtl = () => `
             <input class="fd-switch__input" type="checkbox" name="" value="" id="y21YO3911" aria-label="Rtl Semantic Cozy">
             <div class="fd-switch__wrapper">
                 <div class="fd-switch__track">
-                    <span class="fd-switch__icon--on fd-switch__icon">
-                        <i class="sap-icon--accept" role="presentation"></i>
-                    </span>
+                    <i role="presentation" class="fd-switch__icon--on fd-switch__icon sap-icon--accept"></i>
                     <span class="fd-switch__handle" role="presentation"></span>
-                    <span class="fd-switch__icon--off fd-switch__icon">
-                        <i class="sap-icon--decline" role="presentation"></i>
-                    </span>
+                    <i role="presentation" class="fd-switch__icon--off fd-switch__icon sap-icon--decline"></i>
                 </div>
             </div>
         </span>
@@ -166,13 +154,9 @@ export const rtl = () => `
             <input class="fd-switch__input" type="checkbox" name="" value="" id="y21YO3912" aria-label="Rtl Semantic Compact">
             <div class="fd-switch__wrapper">
                 <div class="fd-switch__track">
-                    <span class="fd-switch__icon--on fd-switch__icon">
-                        <i class="sap-icon--accept" role="presentation"></i>
-                    </span>
-                    <span class="fd-switch__handle" role="presentation"></span>
-                    <span class="fd-switch__icon--off fd-switch__icon">
-                        <i class="sap-icon--decline" role="presentation"></i>
-                    </span>
+                   <i role="presentation" class="fd-switch__icon--on fd-switch__icon sap-icon--accept"></i>
+                   <span class="fd-switch__handle" role="presentation"></span>
+                   <i role="presentation" class="fd-switch__icon--off fd-switch__icon sap-icon--decline"></i>
                </div>
             </div>
         </span>

--- a/stories/switch/switch.stories.js
+++ b/stories/switch/switch.stories.js
@@ -103,9 +103,13 @@ export const semanticSwitch = () => `
                 <input class="fd-switch__input" type="checkbox" aria-labelledby="label5" name="" value="" id="y21YO3251">
                 <div class="fd-switch__wrapper">
                     <div class="fd-switch__track">
-                        <span class="fd-switch__icon--on fd-switch__icon sap-icon--accept"></span>
+                        <span class="fd-switch__icon--on fd-switch__icon">
+                            <i class="sap-icon--accept" role="presentation"></i>
+                        </span>
                         <span class="fd-switch__handle" role="presentation"></span>
-                        <span class="fd-switch__icon--off fd-switch__icon sap-icon--decline"></span>
+                        <span class="fd-switch__icon--off fd-switch__icon">
+                            <i class="sap-icon--decline" role="presentation"></i>
+                        </span>
                     </div>
                 </div>
             </span>
@@ -118,9 +122,13 @@ export const semanticSwitch = () => `
                 <input class="fd-switch__input" type="checkbox" name="" aria-labelledby="label6" value="" id="y21YO3431">
                 <div class="fd-switch__wrapper">
                     <div class="fd-switch__track">
-                        <span class="fd-switch__icon--on fd-switch__icon sap-icon--accept"></span>
+                        <span class="fd-switch__icon--on fd-switch__icon">
+                            <i class="sap-icon--accept" role="presentation"></i>
+                        </span>
                         <span class="fd-switch__handle" role="presentation"></span>
-                        <span class="fd-switch__icon--off fd-switch__icon sap-icon--decline"></span>
+                        <span class="fd-switch__icon--off fd-switch__icon">
+                            <i class="sap-icon--decline" role="presentation"></i>
+                        </span>
                     </div>
                 </div>
             </span>
@@ -142,9 +150,13 @@ export const rtl = () => `
             <input class="fd-switch__input" type="checkbox" name="" value="" id="y21YO3911" aria-label="Rtl Semantic Cozy">
             <div class="fd-switch__wrapper">
                 <div class="fd-switch__track">
-                    <span class="fd-switch__icon--on fd-switch__icon sap-icon--accept"></span>
+                    <span class="fd-switch__icon--on fd-switch__icon">
+                        <i class="sap-icon--accept" role="presentation"></i>
+                    </span>
                     <span class="fd-switch__handle" role="presentation"></span>
-                    <span class="fd-switch__icon--off fd-switch__icon sap-icon--decline"></span>
+                    <span class="fd-switch__icon--off fd-switch__icon">
+                        <i class="sap-icon--decline" role="presentation"></i>
+                    </span>
                 </div>
             </div>
         </span>
@@ -154,9 +166,13 @@ export const rtl = () => `
             <input class="fd-switch__input" type="checkbox" name="" value="" id="y21YO3912" aria-label="Rtl Semantic Compact">
             <div class="fd-switch__wrapper">
                 <div class="fd-switch__track">
-                   <span class="fd-switch__icon--on fd-switch__icon sap-icon--accept"></span>
-                   <span class="fd-switch__handle" role="presentation"></span>
-                   <span class="fd-switch__icon--off fd-switch__icon sap-icon--decline"></span>
+                    <span class="fd-switch__icon--on fd-switch__icon">
+                        <i class="sap-icon--accept" role="presentation"></i>
+                    </span>
+                    <span class="fd-switch__handle" role="presentation"></span>
+                    <span class="fd-switch__icon--off fd-switch__icon">
+                        <i class="sap-icon--decline" role="presentation"></i>
+                    </span>
                </div>
             </div>
         </span>


### PR DESCRIPTION
## Related Issue
Related to https://github.com/SAP/fundamental-styles/issues/1603

## Description
Breaking Changes - Only A11Y in markup:
Before:
```
<span class="fd-switch__icon--off fd-switch__icon sap-icon--decline"></span>
```
After:
```
<i class="fd-switch__icon--off fd-switch__icon sap-icon--decline" role="presentation"></i>
```



#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
