### PR TITLE
fix: Menu - Refactor icons usage

### DIFF
--- a/src/menu.scss
+++ b/src/menu.scss
@@ -186,6 +186,7 @@ $block: #{$fd-namespace}-menu;
   &__addon-after {
     @include fd-reset();
     @include fd-flex-center();
+    @include fd-icon-element-base();
 
     color: $fd-menu-icon-color;
     width: $fd-menu-icon-width;
@@ -198,22 +199,17 @@ $block: #{$fd-namespace}-menu;
   &__addon-before {
     margin: $fd-menu-icon-before-margin;
 
-    @include fd-icon-element-base();
-
     @include fd-rtl() {
       margin: $fd-menu-icon-after-margin;
     }
   }
 
   &__addon-after {
-    @include fd-flex-center();
-    @include fd-icon-element-base();
+    margin: $fd-menu-icon-after-margin;
 
     @include fd-rtl() {
       margin: $fd-menu-icon-before-margin;
     }
-
-    margin: $fd-menu-icon-after-margin;
 
     &--submenu {
       @include fd-icon("navigation-right-arrow");

--- a/src/menu.scss
+++ b/src/menu.scss
@@ -198,18 +198,22 @@ $block: #{$fd-namespace}-menu;
   &__addon-before {
     margin: $fd-menu-icon-before-margin;
 
+    @include fd-icon-element-base();
+
     @include fd-rtl() {
       margin: $fd-menu-icon-after-margin;
     }
   }
 
   &__addon-after {
-    flex: 0 0 auto;
-    margin: $fd-menu-icon-after-margin;
+    @include fd-flex-center();
+    @include fd-icon-element-base();
 
     @include fd-rtl() {
       margin: $fd-menu-icon-before-margin;
     }
+
+    margin: $fd-menu-icon-after-margin;
 
     &--submenu {
       @include fd-icon("navigation-right-arrow");

--- a/stories/menu/__snapshots__/menu.stories.storyshot
+++ b/stories/menu/__snapshots__/menu.stories.storyshot
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots Components/Menu Default (tablet) 1`] = `
+exports[`Storyshots Components/Menu Desktop and Tablet Modes 1`] = `
 <section>
      
 
   <label
     class="fd-form-label"
   >
-    Default menu (tablet)
+    Combobox Tablet Cozy Mode - default mode
   </label>
   <br />
   <br />
@@ -136,17 +136,14 @@ exports[`Storyshots Components/Menu Default (tablet) 1`] = `
   </nav>
   
 
-</section>
-`;
 
-exports[`Storyshots Components/Menu Desktop 1`] = `
-<section>
-     
+  <br />
+   
 
   <label
     class="fd-form-label"
   >
-    Desktop menu (compact)
+    Combobox Desktop Compact Mode
   </label>
   <br />
   <br />
@@ -277,524 +274,7 @@ exports[`Storyshots Components/Menu Desktop 1`] = `
 </section>
 `;
 
-exports[`Storyshots Components/Menu Icons 1`] = `
-
-
-`;
-
-exports[`Storyshots Components/Menu Mobile 1`] = `
-<section>
-  
-
-  <div
-    class="fd-dialog fd-dialog-docs-static fd-select-docs-max-height fd-dialog--active"
-    id="select-dialog-example"
-    style="width: 50%; display: inline-block"
-  >
-    
-    
-    <div
-      class="fd-dialog__content fd-dialog__content--mobile"
-    >
-      
-        
-      <header
-        aria-label="bar-header"
-        class="fd-dialog__header fd-bar fd-bar--header"
-      >
-        
-            
-        <div
-          class="fd-bar__left"
-        >
-          
-                
-          <div
-            class="fd-bar__element"
-          >
-            
-                    
-            <h3
-              class="fd-title fd-title--h5"
-            >
-              
-                        Example Submenu
-                    
-            </h3>
-            
-                
-          </div>
-          
-            
-        </div>
-        
-        
-      </header>
-      
-        
-      <div
-        class="fd-dialog__body fd-dialog__body--no-vertical-padding"
-      >
-        
-             
-        <nav
-          aria-hidden="true"
-          class="fd-menu fd-menu--mobile"
-          id="parent-menu"
-          tabindex="-1"
-        >
-          
-                
-          <ul
-            class="fd-menu__list"
-            role="menu"
-          >
-            
-                    
-            <li
-              class="fd-menu__item"
-              role="presentation"
-            >
-              
-                        
-              <a
-                class="fd-menu__link"
-                href="#"
-                role="menuitem"
-              >
-                
-                            
-                <span
-                  class="fd-menu__addon-before sap-icon--grid"
-                />
-                
-                            
-                <span
-                  class="fd-menu__title"
-                >
-                  Option 1
-                </span>
-                
-                            
-                <span
-                  class="fd-menu__addon-after sap-icon--wrench"
-                />
-                 
-                        
-              </a>
-              
-                    
-            </li>
-            
-                    
-            <li
-              class="fd-menu__item"
-              role="presentation"
-            >
-              
-                        
-              <a
-                class="fd-menu__link is-active"
-                href="#"
-                role="menuitem"
-              >
-                
-                            
-                <span
-                  class="fd-menu__addon-before sap-icon--accept"
-                />
-                
-                            
-                <span
-                  class="fd-menu__title"
-                >
-                  Option 2
-                </span>
-                
-                            
-                <span
-                  class="fd-menu__addon-after fd-menu__addon-after--submenu"
-                />
-                
-                        
-              </a>
-              
-                    
-            </li>
-            
-                    
-            <li
-              class="fd-menu__item"
-              role="presentation"
-            >
-              
-                        
-              <a
-                class="fd-menu__link"
-                href="#"
-                role="menuitem"
-              >
-                
-                            
-                <span
-                  class="fd-menu__addon-before sap-icon--history"
-                />
-                
-                            
-                <span
-                  class="fd-menu__title"
-                >
-                  Option 3
-                </span>
-                
-                            
-                <span
-                  class="fd-menu__addon-after sap-icon--lightbulb"
-                />
-                
-                        
-              </a>
-              
-                    
-            </li>
-            
-                    
-            <li
-              class="fd-menu__item"
-              role="presentation"
-            >
-              
-                        
-              <a
-                class="fd-menu__link"
-                href="#"
-                role="menuitem"
-              >
-                
-                            
-                <span
-                  class="fd-menu__addon-before sap-icon--grid"
-                />
-                
-                            
-                <span
-                  class="fd-menu__title"
-                >
-                  Option 4
-                </span>
-                
-                            
-                <span
-                  class="fd-menu__addon-after sap-icon--history"
-                />
-                
-                        
-              </a>
-              
-                    
-            </li>
-            
-                
-          </ul>
-          
-            
-        </nav>
-        
-        
-      </div>
-      
-       
-      <footer
-        aria-label="bar-footer"
-        class="fd-dialog__footer fd-bar fd-bar--cozy fd-bar--footer"
-      >
-        
-            
-        <div
-          class="fd-bar__right"
-        >
-          
-                
-          <div
-            class="fd-bar__element"
-          >
-            
-                    
-            <button
-              aria-label="fd-button"
-              class="fd-button fd-button--light fd-dialog__decisive-button"
-              role="button"
-            >
-              Cancel
-            </button>
-            
-                
-          </div>
-          
-            
-        </div>
-        
-        
-      </footer>
-      
-    
-    </div>
-    
-
-  </div>
-  
-
-
-  <div
-    class="fd-dialog fd-dialog-docs-static fd-select-docs-max-height fd-dialog--active"
-    id="select-dialog-example-inner"
-    style="display: inline-block; width: auto;"
-  >
-    
-    
-    <div
-      class="fd-dialog__content fd-dialog__content--mobile"
-    >
-      
-        
-      <header
-        class="fd-dialog__header fd-bar fd-bar--header"
-      >
-        
-            
-        <div
-          class="fd-bar__left"
-        >
-          
-                
-          <div
-            class="fd-bar__element"
-          >
-            
-                
-            <button
-              aria-label="fd-button"
-              class="fd-button fd-button--transparent"
-              role="button"
-            >
-              
-                    
-              <i
-                class="sap-icon--navigation-left-arrow"
-              />
-              
-                
-            </button>
-            
-            
-          </div>
-          
-            
-          <div
-            class="fd-bar__element"
-          >
-            
-                    
-            <h3
-              class="fd-title fd-title--h5"
-            >
-              
-                        Option 2
-                    
-            </h3>
-            
-                
-          </div>
-          
-            
-        </div>
-        
-        
-      </header>
-      
-        
-      <div
-        class="fd-dialog__body fd-dialog__body--no-vertical-padding"
-      >
-        
-             
-        <nav
-          class="fd-menu fd-menu--mobile"
-        >
-          
-                
-          <ul
-            class="fd-menu__sublist"
-            role="menu"
-          >
-            
-                    
-            <li
-              class="fd-menu__item"
-              role="presentation"
-            >
-              
-                        
-              <a
-                class="fd-menu__link"
-                href="#"
-                role="menuitem"
-              >
-                
-                            
-                <span
-                  class="fd-menu__title"
-                >
-                  Sub-option 1
-                </span>
-                
-                        
-              </a>
-                                  
-                    
-            </li>
-            
-                    
-            <li
-              class="fd-menu__item"
-              role="presentation"
-            >
-                                  
-                        
-              <a
-                class="fd-menu__link"
-                href="#"
-                role="menuitem"
-              >
-                
-                            
-                <span
-                  class="fd-menu__title"
-                >
-                  Sub-option 2
-                </span>
-                
-                        
-              </a>
-              
-                    
-            </li>
-            
-                    
-            <li
-              class="fd-menu__item"
-              role="presentation"
-            >
-                                  
-                        
-              <a
-                class="fd-menu__link"
-                href="#"
-                role="menuitem"
-              >
-                
-                            
-                <span
-                  class="fd-menu__title"
-                >
-                  Sub-option 3
-                </span>
-                
-                        
-              </a>
-              
-                    
-            </li>
-            
-                    
-            <li
-              class="fd-menu__item"
-              role="presentation"
-            >
-                                  
-                        
-              <a
-                class="fd-menu__link"
-                href="#"
-                role="menuitem"
-              >
-                
-                            
-                <span
-                  class="fd-menu__title"
-                >
-                  Sub-option 4
-                </span>
-                
-                        
-              </a>
-              
-                    
-            </li>
-            
-                
-          </ul>
-          
-            
-        </nav>
-        
-        
-      </div>
-      
-       
-      <footer
-        class="fd-dialog__footer fd-bar fd-bar--cozy fd-bar--footer"
-      >
-        
-            
-        <div
-          class="fd-bar__right"
-        >
-          
-                
-          <div
-            class="fd-bar__element"
-          >
-            
-                    
-            <button
-              aria-label="fd-button"
-              class="fd-button fd-button--light fd-dialog__decisive-button"
-              role="button"
-            >
-              Cancel
-            </button>
-            
-                
-          </div>
-          
-            
-        </div>
-        
-        
-      </footer>
-      
-    
-    </div>
-    
-
-  </div>
-  
-
-</section>
-`;
-
-exports[`Storyshots Components/Menu RTL 1`] = `
-
-
-`;
-
-exports[`Storyshots Components/Menu Separators 1`] = `
-
-
-`;
-
-exports[`Storyshots Components/Menu States 1`] = `
+exports[`Storyshots Components/Menu List different states 1`] = `
 <section>
   
 
@@ -1165,7 +645,560 @@ exports[`Storyshots Components/Menu States 1`] = `
 </section>
 `;
 
-exports[`Storyshots Components/Menu Submenu 1`] = `
+exports[`Storyshots Components/Menu List with Icon 1`] = `
+
+
+`;
+
+exports[`Storyshots Components/Menu List with separated items 1`] = `
+
+
+`;
+
+exports[`Storyshots Components/Menu Mobile Cozy Mode 1`] = `
+<section>
+  
+
+  <div
+    class="fd-dialog fd-dialog-docs-static fd-select-docs-max-height fd-dialog--active"
+    id="select-dialog-example"
+    style="width: 50%; display: inline-block"
+  >
+    
+    
+    <div
+      class="fd-dialog__content fd-dialog__content--mobile"
+    >
+      
+        
+      <header
+        aria-label="bar-header"
+        class="fd-dialog__header fd-bar fd-bar--header"
+      >
+        
+            
+        <div
+          class="fd-bar__left"
+        >
+          
+                
+          <div
+            class="fd-bar__element"
+          >
+            
+                    
+            <h3
+              class="fd-title fd-title--h5"
+            >
+              
+                        Example Submenu
+                    
+            </h3>
+            
+                
+          </div>
+          
+            
+        </div>
+        
+        
+      </header>
+      
+        
+      <div
+        class="fd-dialog__body fd-dialog__body--no-vertical-padding"
+      >
+        
+             
+        <nav
+          aria-hidden="true"
+          class="fd-menu fd-menu--mobile"
+          id="parent-menu"
+          tabindex="-1"
+        >
+          
+                
+          <ul
+            class="fd-menu__list"
+            role="menu"
+          >
+            
+                    
+            <li
+              class="fd-menu__item"
+              role="presentation"
+            >
+              
+                        
+              <a
+                class="fd-menu__link"
+                href="#"
+                role="menuitem"
+              >
+                
+                            
+                <span
+                  class="fd-menu__addon-before"
+                >
+                  <i
+                    class="sap-icon--grid"
+                    role="presentation"
+                  />
+                </span>
+                
+                            
+                <span
+                  class="fd-menu__title"
+                >
+                  Option 1
+                </span>
+                
+                            
+                <span
+                  class="fd-menu__addon-after"
+                >
+                  <i
+                    class="sap-icon--wrench"
+                    role="presentation"
+                  />
+                </span>
+                 
+                        
+              </a>
+              
+                    
+            </li>
+            
+                    
+            <li
+              class="fd-menu__item"
+              role="presentation"
+            >
+              
+                        
+              <a
+                class="fd-menu__link is-active"
+                href="#"
+                role="menuitem"
+              >
+                
+                            
+                <span
+                  class="fd-menu__addon-before"
+                >
+                  <i
+                    class="sap-icon--accept"
+                    role="presentation"
+                  />
+                </span>
+                
+                            
+                <span
+                  class="fd-menu__title"
+                >
+                  Option 2
+                </span>
+                
+                            
+                <span
+                  class="fd-menu__addon-after fd-menu__addon-after--submenu"
+                />
+                
+                        
+              </a>
+              
+                    
+            </li>
+            
+                    
+            <li
+              class="fd-menu__item"
+              role="presentation"
+            >
+              
+                        
+              <a
+                class="fd-menu__link"
+                href="#"
+                role="menuitem"
+              >
+                
+                            
+                <span
+                  class="fd-menu__addon-before"
+                >
+                  <i
+                    class="sap-icon--history"
+                    role="presentation"
+                  />
+                </span>
+                
+                            
+                <span
+                  class="fd-menu__title"
+                >
+                  Option 3
+                </span>
+                
+                            
+                <span
+                  class="fd-menu__addon-after"
+                >
+                  <i
+                    class="sap-icon--lightbulb"
+                    role="presentation"
+                  />
+                </span>
+                
+                        
+              </a>
+              
+                    
+            </li>
+            
+                    
+            <li
+              class="fd-menu__item"
+              role="presentation"
+            >
+              
+                        
+              <a
+                class="fd-menu__link"
+                href="#"
+                role="menuitem"
+              >
+                
+                            
+                <span
+                  class="fd-menu__addon-before"
+                >
+                  <i
+                    class="sap-icon--grid"
+                    role="presentation"
+                  />
+                </span>
+                
+                            
+                <span
+                  class="fd-menu__title"
+                >
+                  Option 4
+                </span>
+                
+                            
+                <span
+                  class="fd-menu__addon-after"
+                >
+                  <i
+                    class="sap-icon--history"
+                    role="presentation"
+                  />
+                </span>
+                
+                        
+              </a>
+              
+                    
+            </li>
+            
+                
+          </ul>
+          
+            
+        </nav>
+        
+        
+      </div>
+      
+       
+      <footer
+        aria-label="bar-footer"
+        class="fd-dialog__footer fd-bar fd-bar--cozy fd-bar--footer"
+      >
+        
+            
+        <div
+          class="fd-bar__right"
+        >
+          
+                
+          <div
+            class="fd-bar__element"
+          >
+            
+                    
+            <button
+              aria-label="fd-button"
+              class="fd-button fd-button--light fd-dialog__decisive-button"
+              role="button"
+            >
+              Cancel
+            </button>
+            
+                
+          </div>
+          
+            
+        </div>
+        
+        
+      </footer>
+      
+    
+    </div>
+    
+
+  </div>
+  
+
+
+  <div
+    class="fd-dialog fd-dialog-docs-static fd-select-docs-max-height fd-dialog--active"
+    id="select-dialog-example-inner"
+    style="display: inline-block; width: auto;"
+  >
+    
+    
+    <div
+      class="fd-dialog__content fd-dialog__content--mobile"
+    >
+      
+        
+      <header
+        class="fd-dialog__header fd-bar fd-bar--header"
+      >
+        
+            
+        <div
+          class="fd-bar__left"
+        >
+          
+                
+          <div
+            class="fd-bar__element"
+          >
+            
+                
+            <button
+              aria-label="fd-button"
+              class="fd-button fd-button--transparent"
+              role="button"
+            >
+              
+                    
+              <i
+                class="sap-icon--navigation-left-arrow"
+                role="presentation"
+              />
+              
+                
+            </button>
+            
+            
+          </div>
+          
+            
+          <div
+            class="fd-bar__element"
+          >
+            
+                    
+            <h3
+              class="fd-title fd-title--h5"
+            >
+              
+                        Option 2
+                    
+            </h3>
+            
+                
+          </div>
+          
+            
+        </div>
+        
+        
+      </header>
+      
+        
+      <div
+        class="fd-dialog__body fd-dialog__body--no-vertical-padding"
+      >
+        
+             
+        <nav
+          class="fd-menu fd-menu--mobile"
+        >
+          
+                
+          <ul
+            class="fd-menu__sublist"
+            role="menu"
+          >
+            
+                    
+            <li
+              class="fd-menu__item"
+              role="presentation"
+            >
+              
+                        
+              <a
+                class="fd-menu__link"
+                href="#"
+                role="menuitem"
+              >
+                
+                            
+                <span
+                  class="fd-menu__title"
+                >
+                  Sub-option 1
+                </span>
+                
+                        
+              </a>
+                                  
+                    
+            </li>
+            
+                    
+            <li
+              class="fd-menu__item"
+              role="presentation"
+            >
+                                  
+                        
+              <a
+                class="fd-menu__link"
+                href="#"
+                role="menuitem"
+              >
+                
+                            
+                <span
+                  class="fd-menu__title"
+                >
+                  Sub-option 2
+                </span>
+                
+                        
+              </a>
+              
+                    
+            </li>
+            
+                    
+            <li
+              class="fd-menu__item"
+              role="presentation"
+            >
+                                  
+                        
+              <a
+                class="fd-menu__link"
+                href="#"
+                role="menuitem"
+              >
+                
+                            
+                <span
+                  class="fd-menu__title"
+                >
+                  Sub-option 3
+                </span>
+                
+                        
+              </a>
+              
+                    
+            </li>
+            
+                    
+            <li
+              class="fd-menu__item"
+              role="presentation"
+            >
+                                  
+                        
+              <a
+                class="fd-menu__link"
+                href="#"
+                role="menuitem"
+              >
+                
+                            
+                <span
+                  class="fd-menu__title"
+                >
+                  Sub-option 4
+                </span>
+                
+                        
+              </a>
+              
+                    
+            </li>
+            
+                
+          </ul>
+          
+            
+        </nav>
+        
+        
+      </div>
+      
+       
+      <footer
+        class="fd-dialog__footer fd-bar fd-bar--cozy fd-bar--footer"
+      >
+        
+            
+        <div
+          class="fd-bar__right"
+        >
+          
+                
+          <div
+            class="fd-bar__element"
+          >
+            
+                    
+            <button
+              aria-label="fd-button"
+              class="fd-button fd-button--light fd-dialog__decisive-button"
+              role="button"
+            >
+              Cancel
+            </button>
+            
+                
+          </div>
+          
+            
+        </div>
+        
+        
+      </footer>
+      
+    
+    </div>
+    
+
+  </div>
+  
+
+</section>
+`;
+
+exports[`Storyshots Components/Menu RTL 1`] = `
+
+
+`;
+
+exports[`Storyshots Components/Menu With Submenu 1`] = `
 
 
 `;

--- a/stories/menu/menu.stories.js
+++ b/stories/menu/menu.stories.js
@@ -98,30 +98,30 @@ export const mobileCozyMode = () => `
                 <ul class="fd-menu__list" role="menu">
                     <li class="fd-menu__item" role="presentation">
                         <a class="fd-menu__link" href="#" role="menuitem">
-                            <span class="fd-menu__addon-before"><i class="sap-icon--grid"></i></span>
+                            <span class="fd-menu__addon-before"><i class="sap-icon--grid" role="presentation"></i></span>
                             <span class="fd-menu__title">Option 1</span>
-                            <span class="fd-menu__addon-after"><i class="sap-icon--wrench"></i></span> 
+                            <span class="fd-menu__addon-after"><i class="sap-icon--wrench" role="presentation"></i></span> 
                         </a>
                     </li>
                     <li class="fd-menu__item" role="presentation">
                         <a class="fd-menu__link is-active" href="#" role="menuitem">
-                            <span class="fd-menu__addon-before"><i class="sap-icon--accept"></i></span>
+                            <span class="fd-menu__addon-before"><i class="sap-icon--accept" role="presentation"></i></span>
                             <span class="fd-menu__title">Option 2</span>
                             <span class="fd-menu__addon-after fd-menu__addon-after--submenu"></span>
                         </a>
                     </li>
                     <li class="fd-menu__item" role="presentation">
                         <a class="fd-menu__link" href="#" role="menuitem">
-                            <span class="fd-menu__addon-before"><i class="sap-icon--history"></i></span>
+                            <span class="fd-menu__addon-before"><i class="sap-icon--history" role="presentation"></i></span>
                             <span class="fd-menu__title">Option 3</span>
-                            <span class="fd-menu__addon-after"><i class="sap-icon--lightbulb"></i></span>
+                            <span class="fd-menu__addon-after"><i class="sap-icon--lightbulb" role="presentation"></i></span>
                         </a>
                     </li>
                     <li class="fd-menu__item" role="presentation">
                         <a class="fd-menu__link" href="#" role="menuitem">
-                            <span class="fd-menu__addon-before"><i class="sap-icon--grid"></i></span>
+                            <span class="fd-menu__addon-before"><i class="sap-icon--grid" role="presentation"></i></span>
                             <span class="fd-menu__title">Option 4</span>
-                            <span class="fd-menu__addon-after"><i class="sap-icon--history"></i></span>
+                            <span class="fd-menu__addon-after"><i class="sap-icon--history" role="presentation"></i></span>
                         </a>
                     </li>
                 </ul>
@@ -143,7 +143,7 @@ export const mobileCozyMode = () => `
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
                 <button aria-label="fd-button" role="button" class="fd-button fd-button--transparent">
-                    <i class="sap-icon--navigation-left-arrow"></i>
+                    <i class="sap-icon--navigation-left-arrow" role="presentation"></i>
                 </button>
             </div>
             <div class="fd-bar__element">
@@ -338,31 +338,31 @@ export const menuIcon = () => `
     <ul class="fd-menu__list" role="menu">
         <li class="fd-menu__item" role="presentation">
                 <a class="fd-menu__link" href="#" role="menuitem">
-                    <span class="fd-menu__addon-before"><i class="sap-icon--grid"></i></span>
+                    <span class="fd-menu__addon-before"><i class="sap-icon--grid" role="presentation"></i></span>
                     <span class="fd-menu__title">Option 1</span>
-                    <span class="fd-menu__addon-after"><i class="sap-icon--wrench"></i></span>
+                    <span class="fd-menu__addon-after"><i class="sap-icon--wrench" role="presentation"></i></span>
                 </a>
         </li>
         <li class="fd-menu__item" role="presentation">
                 <a class="fd-menu__link" href="#" role="menuitem">
-                    <span class="fd-menu__addon-before"><i class="sap-icon--accept"></i></span>
+                    <span class="fd-menu__addon-before"><i class="sap-icon--accept" role="presentation"></i></span>
                     <span class="fd-menu__title">Option 2</span>
-                    <span class="fd-menu__addon-after"><i class="sap-icon--history"></i></span>
+                    <span class="fd-menu__addon-after"><i class="sap-icon--history" role="presentation"></i></span>
                 </a>            
         </li>
         <li class="fd-menu__item" role="presentation">
                 <a class="fd-menu__link" href="#" role="menuitem">
-                    <span class="fd-menu__addon-before"><i class="sap-icon--wrench"></i></span>
+                    <span class="fd-menu__addon-before"><i class="sap-icon--wrench" role="presentation"></i></span>
                     <span class="fd-menu__title">Option 3</span>
-                    <span class="fd-menu__addon-after"><i class="sap-icon--lightbulb"></i></span>
+                    <span class="fd-menu__addon-after"><i class="sap-icon--lightbulb" role="presentation"></i></span>
                 </a>
         </li>
         <li class="fd-menu__item" role="presentation">            
                 <a class="fd-menu__link" href="#" role="menuitem">
-                    <span class="fd-menu__addon-before"><i class="sap-icon--cart"></i></span>
+                    <span class="fd-menu__addon-before"><i class="sap-icon--cart" role="presentation"></i></span>
                     <span class="fd-menu__title">Option 4</span>
                     <span class="fd-menu__shortcut">Ctrl + A</span>
-                    <span class="fd-menu__addon-after"><i class="sap-icon--history"></i></span>
+                    <span class="fd-menu__addon-after"><i class="sap-icon--history" role="presentation"></i></span>
                 </a>
         </li>
     </ul>
@@ -453,30 +453,30 @@ export const RTL = () => `
     <ul class="fd-menu__list" role="menu">
         <li class="fd-menu__item" role="presentation">
             <a class="fd-menu__link" href="#" role="menuitem">
-                <span class="fd-menu__addon-before"><i class="sap-icon--grid"></i></span>
+                <span class="fd-menu__addon-before"><i class="sap-icon--grid" role="presentation"></i></span>
                 <span class="fd-menu__title">Option 1</span>
-                <span class="fd-menu__addon-after"><i class="sap-icon--history"></i></span>
+                <span class="fd-menu__addon-after"><i class="sap-icon--history" role="presentation"></i></span>
             </a>
         </li>
         <li class="fd-menu__item" role="presentation">
             <a class="fd-menu__link" href="#" role="menuitem">
-                <span class="fd-menu__addon-before"><i class="sap-icon--accept"></i></span>
+                <span class="fd-menu__addon-before"><i class="sap-icon--accept" role="presentation"></i></span>
                 <span class="fd-menu__title">Option 2</span>
-                <span class="fd-menu__addon-after"><i class="sap-icon--grid"></i></span>
+                <span class="fd-menu__addon-after"><i class="sap-icon--grid" role="presentation"></i></span>
             </a>
         </li>
         <li class="fd-menu__item" role="presentation">
             <a class="fd-menu__link" href="#" role="menuitem">
-                <span class="fd-menu__addon-before"><i class="sap-icon--history"></i></span>
+                <span class="fd-menu__addon-before"><i class="sap-icon--history" role="presentation"></i></span>
                 <span class="fd-menu__title">Option 3</span>
-                <span class="fd-menu__addon-after"><i class="sap-icon--cart"></i></span>
+                <span class="fd-menu__addon-after"><i class="sap-icon--cart" role="presentation"></i></span>
             </a>
         </li>
         <li class="fd-menu__item" role="presentation">
             <a class="fd-menu__link" href="#" role="menuitem">
-                <span class="fd-menu__addon-before"><i class="sap-icon--grid"></i></span>
+                <span class="fd-menu__addon-before"><i class="sap-icon--grid" role="presentation"></i></span>
                 <span class="fd-menu__title">Option 4</span>
-                <span class="fd-menu__addon-after"><i class="sap-icon--lightbulb"></i></span>
+                <span class="fd-menu__addon-after"><i class="sap-icon--lightbulb" role="presentation"></i></span>
             </a>
         </li>
     </ul>

--- a/stories/menu/menu.stories.js
+++ b/stories/menu/menu.stories.js
@@ -7,14 +7,17 @@ export default {
     title: 'Components/Menu',
     parameters: {
         tags: ['f3', 'a11y', 'theme', 'development'],
-        description: `The menu component displays a dropdown menu with multiple actions, which is usually triggered by a menu button. Visually, actions can be either divided by a separator or grouped together in a submenu. Menu is commonly used with the **Popover** component.
+        description: `
+The menu component is the listing structure with optional headers to create menus.
+
+Commonly used as the contents when composing "dropdowns", "contextual menus", etc, when paired with the popover component.
 `
     }
 };
 
 
-export const tablet = () => `   
-<label class="fd-form-label">Default menu (tablet)</label><br/><br/>
+export const desktopAndTablet = () => `   
+<label class="fd-form-label">Combobox Tablet Cozy Mode - default mode</label><br/><br/>
 
 <nav aria-label="fd-menu-nav" class="fd-menu">
     <ul class="fd-menu__list" role="menu">
@@ -40,18 +43,9 @@ export const tablet = () => `
         </li>
     </ul>
 </nav>
-`;
 
-tablet.storyName = 'Default (tablet)';
-tablet.parameters = {
-    docs: {
-        iframeHeight: 300,
-        storyDescription: 'The default menu is optimized for tablet. To display a default menu, add the <code>fd-menu\\_\\_list</code> class to the main element. To display options or actions, wrap the <code>fd-menu\\_\\_title</code> in the <code>fd-menu\\_\\_link</code> and <code>fd-menu\\_\\_item</code> classes.'
-    }
-};
-
-export const desktop = () => `   
-<label class="fd-form-label">Desktop menu (compact)</label><br/><br/>
+<br> 
+<label class="fd-form-label">Combobox Desktop Compact Mode</label><br/><br/>
 
 <nav class="fd-menu fd-menu--compact">
     <ul class="fd-menu__list" role="menu">
@@ -79,11 +73,11 @@ export const desktop = () => `
 </nav>
 `;
 
-desktop.storyName = 'Desktop';
-desktop.parameters = {
+desktopAndTablet.storyName = 'Desktop and Tablet Modes';
+desktopAndTablet.parameters = {
     docs: {
         iframeHeight: 300,
-        storyDescription: 'To display the compact menu for desktop, add the <code>fd-menu--compact</code> modifier class to the main element.'
+        storyDescription: 'The basic stucture of a menu. Place the menu item title in a `<span>` tag using class `fd-menu__title` and wrap it in the `fd-menu__link` and `fd-menu__item` classes as shown. Default mode is the cozy tablet mode, no class has to be added for this. Use class modifier`fd-menu--compact` on menu container level for desktop mode.'
     }
 };
 
@@ -104,30 +98,30 @@ export const mobileCozyMode = () => `
                 <ul class="fd-menu__list" role="menu">
                     <li class="fd-menu__item" role="presentation">
                         <a class="fd-menu__link" href="#" role="menuitem">
-                            <span class="fd-menu__addon-before sap-icon--grid"></span>
+                            <span class="fd-menu__addon-before"><i class="sap-icon--grid"></i></span>
                             <span class="fd-menu__title">Option 1</span>
-                            <span class="fd-menu__addon-after sap-icon--wrench"></span> 
+                            <span class="fd-menu__addon-after"><i class="sap-icon--wrench"></i></span> 
                         </a>
                     </li>
                     <li class="fd-menu__item" role="presentation">
                         <a class="fd-menu__link is-active" href="#" role="menuitem">
-                            <span class="fd-menu__addon-before sap-icon--accept"></span>
+                            <span class="fd-menu__addon-before"><i class="sap-icon--accept"></i></span>
                             <span class="fd-menu__title">Option 2</span>
                             <span class="fd-menu__addon-after fd-menu__addon-after--submenu"></span>
                         </a>
                     </li>
                     <li class="fd-menu__item" role="presentation">
                         <a class="fd-menu__link" href="#" role="menuitem">
-                            <span class="fd-menu__addon-before sap-icon--history"></span>
+                            <span class="fd-menu__addon-before"><i class="sap-icon--history"></i></span>
                             <span class="fd-menu__title">Option 3</span>
-                            <span class="fd-menu__addon-after sap-icon--lightbulb"></span>
+                            <span class="fd-menu__addon-after"><i class="sap-icon--lightbulb"></i></span>
                         </a>
                     </li>
                     <li class="fd-menu__item" role="presentation">
                         <a class="fd-menu__link" href="#" role="menuitem">
-                            <span class="fd-menu__addon-before sap-icon--grid"></span>
+                            <span class="fd-menu__addon-before"><i class="sap-icon--grid"></i></span>
                             <span class="fd-menu__title">Option 4</span>
-                            <span class="fd-menu__addon-after sap-icon--history"></span>
+                            <span class="fd-menu__addon-after"><i class="sap-icon--history"></i></span>
                         </a>
                     </li>
                 </ul>
@@ -196,11 +190,11 @@ export const mobileCozyMode = () => `
 </div>
 `;
 
-mobileCozyMode.storyName = 'Mobile';
+mobileCozyMode.storyName = 'Mobile Cozy Mode';
 mobileCozyMode.parameters = {
     docs: {
         iframeHeight: 300,
-        storyDescription: 'On a mobile screen, menu is displayed within a **Dialog** and uses its structure. However, you can add the <code>fd menu fd-menu--mobile</code> modifier class to dialog\'s body container to display a menu.'
+        storyDescription: 'The basic stucture of a menu in mobile where it opens as a dialog. Use class <code>fd-menu--mobile</code> on menu container level. Example shows the parent menu\'s item in active state to simulate a pressed/touched event. Submenu appears in its own fullscreen dialog in mobile devices. The device\'s back button takes one back to the parent menu fullscreen dialog.'
     }
 };
 
@@ -238,12 +232,11 @@ export const seperatedItems = () => `
 </nav>
 `;
 
-seperatedItems.storyName = 'Separators';
+seperatedItems.storyName = 'List with separated items';
 seperatedItems.parameters = {
     docs: {
         iframeHeight: 300,
-        storyDescription: `Menu can display separators between menu items. To display a separator, add the <code>fd-menu\\_\\_separator</code> wrapped in <code>span</code> tags after the list item where you want the separation.
-        `
+        storyDescription: 'To add separators between the items, use the class `fd-menu__separator` in its own `<span>` after the `<li>` item where you want the separation.'
     }
 };
 
@@ -323,21 +316,20 @@ export const differentStates = () => `
 </div>
 `;
 
-differentStates.storyName = 'States';
+differentStates.storyName = 'List different states';
 differentStates.parameters = {
     docs: {
         iframeHeight: 300,
-        storyDescription: `The list items in a menu can display different state behaviours by adding certain classes to the menu items. You can also remove the default box shadow from menu containers by using either <code>fd-menu\\_\\_list—no-shadow</code> or <code>fd-menu\\_\\_sublist—no-shadow</code>.
+        storyDescription: `
+Simulate different states to show state behaviour between the items.
 
-| **States** | **Class** |
-| ------: | :------ |
-| Regular | _n/a_ |
-| Hover | <code>is-hover</code> |
-| Active | <code>is-active</code> |
-| Selected | <code>is-selected</code> |
-| Selected (Hover) | <code>is-selected is-hover</code> |
-| Disabled | <code>is-disabled</code> |
-        `
+- For simulating hover state, use class <code>is-hover</code> on the menu item.
+- For simulating active state, use class <code>is-active</code> on the menu item.
+- For simulating selected state, use class <code>is-selected</code> on the menu item.
+- For simulating selected-hover state, use classes <code>is-selected is-hover</code> on the menu item.
+- For simulating disabled state, use class <code>is-disabled</code> on the menu item.
+
+To remove default box shadow from menu containers use <code>fd-menu__list--no-shadow</code> or <code>fd-menu__sublist--no-shadow</code>.`
     }
 };
 
@@ -346,48 +338,47 @@ export const menuIcon = () => `
     <ul class="fd-menu__list" role="menu">
         <li class="fd-menu__item" role="presentation">
                 <a class="fd-menu__link" href="#" role="menuitem">
-                    <span class="fd-menu__addon-before sap-icon--grid"></span>
+                    <span class="fd-menu__addon-before"><i class="sap-icon--grid"></i></span>
                     <span class="fd-menu__title">Option 1</span>
-                    <span class="fd-menu__addon-after sap-icon--wrench"></span>
+                    <span class="fd-menu__addon-after"><i class="sap-icon--wrench"></i></span>
                 </a>
         </li>
         <li class="fd-menu__item" role="presentation">
                 <a class="fd-menu__link" href="#" role="menuitem">
-                    <span class="fd-menu__addon-before sap-icon--accept"></span>
+                    <span class="fd-menu__addon-before"><i class="sap-icon--accept"></i></span>
                     <span class="fd-menu__title">Option 2</span>
-                    <span class="fd-menu__addon-after sap-icon--history"></span>
+                    <span class="fd-menu__addon-after"><i class="sap-icon--history"></i></span>
                 </a>            
         </li>
         <li class="fd-menu__item" role="presentation">
                 <a class="fd-menu__link" href="#" role="menuitem">
-                    <span class="fd-menu__addon-before sap-icon--wrench"></span>
+                    <span class="fd-menu__addon-before"><i class="sap-icon--wrench"></i></span>
                     <span class="fd-menu__title">Option 3</span>
-                    <span class="fd-menu__addon-after sap-icon--lightbulb"></span>
+                    <span class="fd-menu__addon-after"><i class="sap-icon--lightbulb"></i></span>
                 </a>
         </li>
         <li class="fd-menu__item" role="presentation">            
                 <a class="fd-menu__link" href="#" role="menuitem">
-                    <span class="fd-menu__addon-before sap-icon--cart"></span>
+                    <span class="fd-menu__addon-before"><i class="sap-icon--cart"></i></span>
                     <span class="fd-menu__title">Option 4</span>
                     <span class="fd-menu__shortcut">Ctrl + A</span>
-                    <span class="fd-menu__addon-after sap-icon--history"></span>
+                    <span class="fd-menu__addon-after"><i class="sap-icon--history"></i></span>
                 </a>
         </li>
     </ul>
 </nav>
 `;
 
-menuIcon.storyName = 'Icons';
+menuIcon.storyName = 'List with Icon';
 menuIcon.parameters = {
     docs: {
         iframeHeight: 220,
-        storyDescription: `Menu can display icons on either side of the menu items. To display icons, place the addon class before or after the <code>fd-menu\\_\\_title</code> class. In the case that you want the icon to display before the text in the menu item, add the <code>fd-menu\\_\\_addon-before</code>.
-
-| Displays addon… | Class |
-| -------------------: | :---------------------- |
-| Before text | <code>fd-menu\\_\\_addon-before</code> |
-| After text | <code>fd-menu\\_\\_addon-after</code> |
-        `
+        storyDescription: `
+To create an addon before or after <code>fd-menu__title</code> element, use elements with folowing classes inside <code>fd-menu__link<code>:
+- <code>fd-menu__addon-before</code>   - styles addon befotre <code>fd-menu__title</code>
+- <code>fd-menu__addon-after</code>    - styles addon after <code>fd-menu__title</code>
+- <code>fd-menu__shortcut</code>       - styles shortcut placed after <code>fd-menu__title</code>
+According to Fiori3 design shortcuts should be on desktop devices.`
     }
 };
 
@@ -442,22 +433,17 @@ export const withSubmenu = () => `
     </ul>
 </nav>
 `;
-withSubmenu.storyName = 'Submenu';
 withSubmenu.parameters = {
     docs: {
         iframeHeight: 220,
         storyDescription: `
-Menu can display an additional submenu that further groups the list items into a secondary level that is not visible until selected. 
+Menu with an additional submenu that can be used for items that can be further grouped under a level but not necessarily visible to user always.
 
-**To display a submenu:**
-
--	Add the <code>has-child</code> class to the <code>fd-menu\\_\\_link</code> container.
--	Then add a <code>fd-menu\\_\\_addon-after--submenu</code> class (with an icon) after the title of the menu item where you want the submenu.
--	On the next line, add the <code>fd-menu\\_\\_sublist</code> with its own unordered list (where the submenu items will be).
-
-
-Note: The same <code>fd-menu\\_\\_item</code> and <code>fd-menu\\_\\_link</code> classes can be used for submenu items too.
-        
+For a submenu, do the following:
+- Specify <code>fd-menu__link</code> class normally like other items. Use <code>has-child</code> class to apply styles for parent containing the submenu.
+- Create an addon indicating submenu level using <code>fd-menu__addon-after--submenu</code> class and an icon.
+- After the end of the <code>fd-menu__link</code> container, use <code>fd-menu__sublist</code> class in its own <code><ul><code>
+- Follow the same template for submenu as you would for a normal menu. The same <code>fd-menu__item</code> and <code>fd-menu__link</code> works for the subitems too.
 `
     }
 };
@@ -467,30 +453,30 @@ export const RTL = () => `
     <ul class="fd-menu__list" role="menu">
         <li class="fd-menu__item" role="presentation">
             <a class="fd-menu__link" href="#" role="menuitem">
-                <span class="fd-menu__addon-before sap-icon--grid"></span>
+                <span class="fd-menu__addon-before"><i class="sap-icon--grid"></i></span>
                 <span class="fd-menu__title">Option 1</span>
-                <span class="fd-menu__addon-after sap-icon--history"></span>
+                <span class="fd-menu__addon-after"><i class="sap-icon--history"></i></span>
             </a>
         </li>
         <li class="fd-menu__item" role="presentation">
             <a class="fd-menu__link" href="#" role="menuitem">
-                <span class="fd-menu__addon-before sap-icon--accept"></span>
+                <span class="fd-menu__addon-before"><i class="sap-icon--accept"></i></span>
                 <span class="fd-menu__title">Option 2</span>
-                <span class="fd-menu__addon-after sap-icon--grid"></span>
+                <span class="fd-menu__addon-after"><i class="sap-icon--grid"></i></span>
             </a>
         </li>
         <li class="fd-menu__item" role="presentation">
             <a class="fd-menu__link" href="#" role="menuitem">
-                <span class="fd-menu__addon-before sap-icon--history"></span>
+                <span class="fd-menu__addon-before"><i class="sap-icon--history"></i></span>
                 <span class="fd-menu__title">Option 3</span>
-                <span class="fd-menu__addon-after sap-icon--cart"></span>
+                <span class="fd-menu__addon-after"><i class="sap-icon--cart"></i></span>
             </a>
         </li>
         <li class="fd-menu__item" role="presentation">
             <a class="fd-menu__link" href="#" role="menuitem">
-                <span class="fd-menu__addon-before sap-icon--grid"></span>
+                <span class="fd-menu__addon-before"><i class="sap-icon--grid"></i></span>
                 <span class="fd-menu__title">Option 4</span>
-                <span class="fd-menu__addon-after sap-icon--lightbulb"></span>
+                <span class="fd-menu__addon-after"><i class="sap-icon--lightbulb"></i></span>
             </a>
         </li>
     </ul>
@@ -500,6 +486,6 @@ export const RTL = () => `
 RTL.parameters = {
     docs: {
         iframeHeight: 220,
-        storyDescription: 'The menu can be displayed from right to left so it may be used internationally.'
+        storyDescription: 'The basic stucture of a menu in RTL simulated mode.'
     }
 };


### PR DESCRIPTION
## Related Issue
Part of: SAP/fundamental-styles#1603

## Description
This PR:
- Moves icons to separate HTML tags
- Updates aria labels/roles

### Before:
```
<a class="fd-menu__link" href="#" role="menuitem">
    <span class="fd-menu__addon-before sap-icon--wrench"></span>
    ...
    <span class="fd-menu__addon-after sap-icon--wrench"></span>
</a>
```

### After:
```
<a class="fd-menu__link" href="#" role="menuitem">
    <span class="fd-menu__addon-before"><i class="sap-icon--wrench" role="presentation"></i></span>
    ...
    <span class="fd-menu__addon-after"><i class="sap-icon--wrench" role="presentation"></i></span>
</a>
```

#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
