### PR TITLE
fix: Message Page - Refactor icons usage

### DIFF
--- a/src/message-page.scss
+++ b/src/message-page.scss
@@ -17,7 +17,6 @@ $block: #{$fd-namespace}-message-page;
   &__title,
   &__subtitle,
   &__actions,
-  &__icon,
   &__more {
     @include fd-reset();
 
@@ -41,10 +40,8 @@ $block: #{$fd-namespace}-message-page;
   }
 
   &__icon {
-    font-size: 6rem;
-    color: var(--sapContent_NonInteractiveIconColor);
-
-    @include fd-icon-selector() {
+    @include fd-icon-element-base() {
+      max-width: 30rem;
       font-size: 6rem;
       color: var(--sapContent_NonInteractiveIconColor);
       opacity: 50%;

--- a/src/message-page.scss
+++ b/src/message-page.scss
@@ -17,6 +17,7 @@ $block: #{$fd-namespace}-message-page;
   &__title,
   &__subtitle,
   &__actions,
+  &__icon,
   &__more {
     @include fd-reset();
 
@@ -39,10 +40,15 @@ $block: #{$fd-namespace}-message-page;
     height: 8rem;
   }
 
-  &__icon[class*='sap-icon--'] {
+  &__icon {
     font-size: 6rem;
     color: var(--sapContent_NonInteractiveIconColor);
-    opacity: 50%;
+
+    @include fd-icon-selector() {
+      font-size: 6rem;
+      color: var(--sapContent_NonInteractiveIconColor);
+      opacity: 50%;
+    }
   }
 
   &__content {

--- a/stories/message-page/message-page.stories.js
+++ b/stories/message-page/message-page.stories.js
@@ -34,7 +34,7 @@ export const filter = () => `
     <div class="fd-message-page">
         <div class="fd-message-page__container">
             <div class="fd-message-page__icon-container">
-                <span aria-hidden="true" class="sap-icon sap-icon--filter fd-message-page__icon"></span>
+                <i role="presentation" class="sap-icon--filter fd-message-page__icon"></i>
             </div>
             <div role="status" aria-live="polite" class="fd-message-page__content">
                 <div class="fd-message-page__title">
@@ -64,7 +64,7 @@ export const search = () => `
     <div class="fd-message-page">
         <div class="fd-message-page__container">
             <div class="fd-message-page__icon-container">
-                <span aria-hidden="true" class="sap-icon sap-icon--search fd-message-page__icon"></span>
+                <i role="presentation" class="sap-icon--search fd-message-page__icon"></i>
             </div>
             <div role="status" aria-live="polite" class="fd-message-page__content">
                 <div class="fd-message-page__title">
@@ -91,7 +91,7 @@ export const noItems = () => `
     <div class="fd-message-page">
         <div class="fd-message-page__container">
             <div class="fd-message-page__icon-container">
-                <span aria-hidden="true" class="sap-icon sap-icon--product fd-message-page__icon"></span>
+                <i role="presentation" class="sap-icon--product fd-message-page__icon"></i>
             </div>
             <div role="status" aria-live="polite" class="fd-message-page__content">
                 <div class="fd-message-page__title">
@@ -118,7 +118,7 @@ export const error = () => `
     <div class="fd-message-page">
         <div class="fd-message-page__container">
             <div class="fd-message-page__icon-container">
-                <span aria-hidden="true" class="sap-icon sap-icon--document fd-message-page__icon"></span>
+                <i role="presentation" class="sap-icon--document fd-message-page__icon"></i>
             </div>
             <div role="status" aria-live="polite" class="fd-message-page__content">
                 <div class="fd-message-page__title">
@@ -151,7 +151,7 @@ export const buttons = () => `
     <div class="fd-message-page">
         <div class="fd-message-page__container">
             <div class="fd-message-page__icon-container">
-                <span aria-hidden="true" class="sap-icon sap-icon--documents fd-message-page__icon"></span>
+                <i role="presentation" class="sap-icon--documents fd-message-page__icon"></i>
             </div>
             <div role="status" aria-live="polite" class="fd-message-page__content">
                 <div class="fd-message-page__title">

--- a/stories/message-page/message-page.stories.js
+++ b/stories/message-page/message-page.stories.js
@@ -34,7 +34,7 @@ export const filter = () => `
     <div class="fd-message-page">
         <div class="fd-message-page__container">
             <div class="fd-message-page__icon-container">
-                <span class="sap-icon sap-icon--filter fd-message-page__icon"></span>
+                <span aria-hidden="true" class="sap-icon sap-icon--filter fd-message-page__icon"></span>
             </div>
             <div role="status" aria-live="polite" class="fd-message-page__content">
                 <div class="fd-message-page__title">
@@ -64,7 +64,7 @@ export const search = () => `
     <div class="fd-message-page">
         <div class="fd-message-page__container">
             <div class="fd-message-page__icon-container">
-                <span class="sap-icon sap-icon--search fd-message-page__icon"></span>
+                <span aria-hidden="true" class="sap-icon sap-icon--search fd-message-page__icon"></span>
             </div>
             <div role="status" aria-live="polite" class="fd-message-page__content">
                 <div class="fd-message-page__title">
@@ -91,7 +91,7 @@ export const noItems = () => `
     <div class="fd-message-page">
         <div class="fd-message-page__container">
             <div class="fd-message-page__icon-container">
-                <span class="sap-icon sap-icon--product fd-message-page__icon"></span>
+                <span aria-hidden="true" class="sap-icon sap-icon--product fd-message-page__icon"></span>
             </div>
             <div role="status" aria-live="polite" class="fd-message-page__content">
                 <div class="fd-message-page__title">
@@ -118,7 +118,7 @@ export const error = () => `
     <div class="fd-message-page">
         <div class="fd-message-page__container">
             <div class="fd-message-page__icon-container">
-                <span class="sap-icon sap-icon--document fd-message-page__icon"></span>
+                <span aria-hidden="true" class="sap-icon sap-icon--document fd-message-page__icon"></span>
             </div>
             <div role="status" aria-live="polite" class="fd-message-page__content">
                 <div class="fd-message-page__title">
@@ -151,7 +151,7 @@ export const buttons = () => `
     <div class="fd-message-page">
         <div class="fd-message-page__container">
             <div class="fd-message-page__icon-container">
-                <span class="sap-icon sap-icon--documents fd-message-page__icon"></span>
+                <span aria-hidden="true" class="sap-icon sap-icon--documents fd-message-page__icon"></span>
             </div>
             <div role="status" aria-live="polite" class="fd-message-page__content">
                 <div class="fd-message-page__title">
@@ -195,4 +195,3 @@ buttons.parameters = {
     `
     }
 };
-


### PR DESCRIPTION
## Related Issue
Part of: SAP/fundamental-styles#1603
and #1639

## Description
This PR: 
- Updates icon styling with icon mixins
- Adds aria attributes

### Before:
```
<span class="sap-icon sap-icon--filter fd-message-page__icon"></span>
```

### After:
```
<span aria-hidden="true" class="sap-icon sap-icon--filter fd-message-page__icon"></span>
```

#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
