### PR TITLE
fix: Refactor object status icons and text

### DIFF
--- a/src/object-status.scss
+++ b/src/object-status.scss
@@ -230,8 +230,6 @@ $inverted-color-accents: (
   }
 
   &__icon {
-    @include fd-reset();
-
     @include fd-icon-element-base() {
       @include fd-flex-center();
 

--- a/src/object-status.scss
+++ b/src/object-status.scss
@@ -109,12 +109,20 @@ $inverted-color-accents: (
   ),
 );
 
+@mixin fd-object-status-icon-selector() {
+  .#{$block}__icon {
+    @include fd-icon-selector() {
+      @content;
+    }
+  }
+}
+
 // STATES FOR INVERTED OBJECT STATUS
 @mixin inverted-object-states($variablesSet) {
   color: map_deep_get($variablesSet, "regular", "color");
   background-color: map_deep_get($variablesSet, "regular", "background");
 
-  &::before {
+  @include fd-object-status-icon-selector() {
     color: map_deep_get($variablesSet, "regular", "color");
   }
 
@@ -124,7 +132,7 @@ $inverted-color-accents: (
     color: map_deep_get($variablesSet, "regular", "color");
     background-color: map_deep_get($variablesSet, "regular", "background");
 
-    &::before {
+    @include fd-object-status-icon-selector() {
       color: map_deep_get($variablesSet, "regular", "color");
     }
   }
@@ -140,7 +148,7 @@ $inverted-color-accents: (
     color: map_deep_get($variablesSet, "visited", "color");
     background-color: map_deep_get($variablesSet, "visited", "background");
 
-    &::before {
+    @include fd-object-status-icon-selector() {
       color: map_deep_get($variablesSet, "visited", "color");
     }
   }
@@ -149,7 +157,7 @@ $inverted-color-accents: (
     color: map_deep_get($variablesSet, "hover", "color");
     background-color: map_deep_get($variablesSet, "hover", "background");
 
-    &::before {
+    @include fd-object-status-icon-selector() {
       color: map_deep_get($variablesSet, "hover", "color");
     }
   }
@@ -158,16 +166,27 @@ $inverted-color-accents: (
     color: map_deep_get($variablesSet, "active", "color");
     background-color: map_deep_get($variablesSet, "active", "background");
 
-    &::before {
+    @include fd-object-status-icon-selector() {
       color: map_deep_get($variablesSet, "active", "color");
     }
   }
 }
 
 .#{$block} {
+  @mixin fd-object-status-text-inherit() {
+    font-size: inherit;
+    font-weight: inherit;
+    word-break: inherit;
+    color: inherit;
+    font-family: inherit;
+    line-height: 1;
+
+    @content;
+  }
+
   // ICON VARIABLES
   $fd-object-status-icon-font-size: 1rem;
-  $fd-object-status-icon-padding: 0.5rem !default;
+  $fd-object-status-icon-padding: 0.25rem !default;
   $fd-object-status-icon-neutral: var(--sapNeutralElementColor);
 
   // TEXT VARIABLES
@@ -180,7 +199,6 @@ $inverted-color-accents: (
   $fd-object-status-inverted-padding: 0.0625rem 0.25rem !default;
   $fd-object-status-inverted-padding-empty: 0 0.25rem !default;
   $fd-object-status-inverted-min-height: 1rem !default;
-  $fd-object-status-inverted-height-empty: 1rem !default;
   $fd-object-status-inverted-min-width: 1.25rem !default;
   $fd-object-status-inverted-text-font-weight: bold !default;
   $fd-object-status-inverted-icon-font-size: 0.75rem !default;
@@ -206,35 +224,34 @@ $inverted-color-accents: (
   align-items: center;
   line-height: 1;
 
-  &::before {
-    font-size: $fd-object-status-icon-font-size;
-    padding-right: $fd-object-status-icon-padding;
-    color: $fd-object-status-icon-neutral;
+  &__text {
+    @include fd-reset();
+    @include fd-object-status-text-inherit();
   }
 
-  // ICON ONLY MODE
-  @include fd-empty() {
-    justify-content: center;
-    padding-right: 0;
-    padding-left: 0;
+  &__icon {
+    @include fd-reset();
 
-    &::before {
-      padding-right: 0;
-      padding-left: 0;
+    @include fd-icon-element-base() {
+      @include fd-flex-center();
+
+      font-size: $fd-object-status-icon-font-size;
+      padding-right: $fd-object-status-icon-padding;
+      color: $fd-object-status-icon-neutral;
+
+      // ICON ONLY MODE
+      @include fd-only-child() {
+        justify-content: center;
+        padding-right: 0;
+        padding-left: 0;
+      }
     }
   }
 
   @include fd-rtl() {
-    &::before {
+    @include fd-object-status-icon-selector() {
       padding-right: 0;
       padding-left: $fd-object-status-icon-padding;
-    }
-
-    @include fd-empty() {
-      &::before {
-        padding-right: 0;
-        padding-left: 0;
-      }
     }
   }
 
@@ -242,13 +259,16 @@ $inverted-color-accents: (
     &--#{$set-name} {
       color: map_get($color-set, "color");
 
-      &::before {
+      @include fd-object-status-icon-selector() {
         color: map_get($color-set, "iconColor");
       }
 
-      &:visited,
-      &:visited::before {
+      &:visited {
         color: map_get($color-set, "visited");
+
+        @include fd-object-status-icon-selector() {
+          color: map_get($color-set, "visited");
+        }
       }
     }
   }
@@ -257,33 +277,28 @@ $inverted-color-accents: (
     &--indication-#{$set-name} {
       color: map_get($color-set, "color");
 
-      &::before {
+      @include fd-object-status-icon-selector() {
         color: map_get($color-set, "iconColor");
       }
 
-      &:visited,
-      &:visited::before {
+      &:visited {
         color: map_get($color-set, "visited");
+
+        @include fd-object-status-icon-selector() {
+          color: map_get($color-set, "visited");
+        }
       }
     }
   }
 
   // CLICKABLE OBJECT STATUS
   &--link {
-    display: inline-block;
     text-decoration: none;
     cursor: pointer;
 
-    &::before {
-      position: relative;
-      top: 0.125rem;
-    }
-
     &:hover {
-      text-decoration: underline;
-
-      &::before {
-        text-decoration: none;
+      .#{$block}__text {
+        text-decoration: underline;
       }
     }
 
@@ -296,7 +311,7 @@ $inverted-color-accents: (
   &--large {
     font-size: $fd-object-status-icon-text-font-size-large;
 
-    &::before {
+    @include fd-object-status-icon-selector() {
       font-size: $fd-object-status-icon-text-font-size-large;
     }
   }
@@ -315,22 +330,21 @@ $inverted-color-accents: (
     border-style: solid;
     text-shadow: none;
 
-    &::before {
+    @include fd-object-status-icon-selector() {
       font-size: $fd-object-status-inverted-icon-font-size;
       padding-right: $fd-object-status-inverted-icon-spacing;
-    }
 
-    @include fd-rtl() {
-      &::before {
-        padding-right: 0;
-        padding-left: $fd-object-status-inverted-icon-spacing;
+      // ICON ONLY MODE
+      @include fd-only-child() {
+        padding: $fd-object-status-inverted-padding-empty;
       }
     }
 
-    // ICON ONLY MODE
-    @include fd-empty() {
-      height: $fd-object-status-inverted-height-empty;
-      padding: $fd-object-status-inverted-padding-empty;
+    @include fd-rtl() {
+      @include fd-object-status-icon-selector() {
+        padding-right: 0;
+        padding-left: $fd-object-status-inverted-icon-spacing;
+      }
     }
 
     // TEXT AND BACKGROUND COLOR FOR INVERTED OBJECT STATUS STATES
@@ -356,34 +370,28 @@ $inverted-color-accents: (
       font-size: $fd-object-status-icon-text-font-size-large-inverted;
       padding: $fd-object-status-padding-large-inverted;
 
-      &::before {
+      @include fd-object-status-icon-selector() {
         font-size: $fd-object-status-icon-text-font-size-large-inverted;
-      }
 
-      // ICON ONLY MODE
-      @include fd-empty() {
-        height: $fd-object-status-min-height-large-inverted-empty;
-        min-width: $fd-object-status-min-width-large-inverted-empty;
-        padding: $fd-object-status-padding-large-inverted-empty;
+        // ICON ONLY MODE
+        @include fd-empty() {
+          height: $fd-object-status-min-height-large-inverted-empty;
+          min-width: $fd-object-status-min-width-large-inverted-empty;
+          padding: $fd-object-status-padding-large-inverted-empty;
+        }
       }
     }
 
     // CLICKABLE INVERTED OBJECT STATUS
     &.#{$block}--link {
-      text-decoration: none;
-      display: inline-flex;
-      align-items: center;
       cursor: pointer;
-
-      &::before {
-        position: initial;
-        top: initial;
-      }
 
       &:hover,
       &:active,
       &:visited {
-        text-decoration: none;
+        .#{$block}__text {
+          text-decoration: none;
+        }
       }
 
       // INTERACTION STATES FOR CLICKABLE INVERTED OBJECT STATUS

--- a/stories/object-status/__snapshots__/object-status.stories.storyshot
+++ b/stories/object-status/__snapshots__/object-status.stories.storyshot
@@ -388,8 +388,8 @@ exports[`Storyshots Components/Object Status Icon 1`] = `
     
     
     <i
+      aria-label="Negative"
       class="fd-object-status__icon sap-icon--status-negative"
-      role="presentation"
     />
     
 
@@ -402,8 +402,8 @@ exports[`Storyshots Components/Object Status Icon 1`] = `
     
     
     <i
+      aria-label="Warning"
       class="fd-object-status__icon sap-icon--status-critical"
-      role="presentation"
     />
     
 
@@ -416,8 +416,8 @@ exports[`Storyshots Components/Object Status Icon 1`] = `
     
     
     <i
+      aria-label="Correct"
       class="fd-object-status__icon sap-icon--status-positive"
-      role="presentation"
     />
     
 
@@ -430,8 +430,8 @@ exports[`Storyshots Components/Object Status Icon 1`] = `
     
     
     <i
+      aria-label="More information"
       class="fd-object-status__icon sap-icon--hint"
-      role="presentation"
     />
     
 
@@ -444,8 +444,8 @@ exports[`Storyshots Components/Object Status Icon 1`] = `
     
     
     <i
+      aria-label="To be reviewed"
       class="fd-object-status__icon sap-icon--to-be-reviewed"
-      role="presentation"
     />
     
 
@@ -1022,8 +1022,8 @@ exports[`Storyshots Components/Object Status Inverted 1`] = `
       
         
       <i
+        aria-label="Error"
         class="fd-object-status__icon sap-icon--status-negative"
-        role="presentation"
       />
       
     
@@ -1148,56 +1148,120 @@ exports[`Storyshots Components/Object Status Inverted Indication 1`] = `
   <span
     class="fd-object-status fd-object-status--inverted fd-object-status--indication-1"
   >
-    Indication1
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Indication1
+    </span>
+    
+
   </span>
   
 
   <span
     class="fd-object-status fd-object-status--inverted fd-object-status--indication-2"
   >
-    Indication2
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Indication2
+    </span>
+    
+
   </span>
   
 
   <span
     class="fd-object-status fd-object-status--inverted fd-object-status--indication-3"
   >
-    Indication3
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Indication3
+    </span>
+    
+
   </span>
   
 
   <span
     class="fd-object-status fd-object-status--inverted fd-object-status--indication-4"
   >
-    Indication4
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Indication4
+    </span>
+    
+
   </span>
   
 
   <span
     class="fd-object-status fd-object-status--inverted fd-object-status--indication-5"
   >
-    Indication5
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Indication5
+    </span>
+    
+
   </span>
   
 
   <span
     class="fd-object-status fd-object-status--inverted fd-object-status--indication-6"
   >
-    Indication6
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Indication6
+    </span>
+    
+
   </span>
   
 
   <span
     class="fd-object-status fd-object-status--inverted fd-object-status--indication-7"
   >
-    Indication7
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Indication7
+    </span>
+    
+
   </span>
   
 
   <span
     class="fd-object-status fd-object-status--inverted fd-object-status--indication-8"
   >
-    Indication8
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Indication8
+    </span>
+    
+
   </span>
   
 
@@ -1214,68 +1278,124 @@ exports[`Storyshots Components/Object Status Inverted Indication 1`] = `
   </h4>
   
 
-  <a
-    class="fd-object-status fd-object-status--link fd-object-status--inverted fd-object-status--indication-1"
-    href="#"
+  <span
+    class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-1"
   >
-    Indication1
-  </a>
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Indication1
+    </span>
+    
+
+  </span>
   
 
-  <a
-    class="fd-object-status fd-object-status--link fd-object-status--inverted fd-object-status--indication-2"
-    href="#"
+  <span
+    class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-2"
   >
-    Indication2
-  </a>
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Indication2
+    </span>
+    
+
+  </span>
   
 
-  <a
-    class="fd-object-status fd-object-status--link fd-object-status--inverted fd-object-status--indication-3"
-    href="#"
+  <span
+    class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-3"
   >
-    Indication3
-  </a>
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Indication3
+    </span>
+    
+
+  </span>
   
 
-  <a
-    class="fd-object-status fd-object-status--link fd-object-status--inverted fd-object-status--indication-4"
-    href="#"
+  <span
+    class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-4"
   >
-    Indication4
-  </a>
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Indication4
+    </span>
+    
+
+  </span>
   
 
-  <a
-    class="fd-object-status fd-object-status--link fd-object-status--inverted fd-object-status--indication-5"
-    href="#"
+  <span
+    class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-5"
   >
-    Indication5
-  </a>
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Indication5
+    </span>
+    
+
+  </span>
   
 
-  <a
-    class="fd-object-status fd-object-status--link fd-object-status--inverted fd-object-status--indication-6"
-    href="#"
+  <span
+    class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-6"
   >
-    Indication6
-  </a>
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Indication6
+    </span>
+    
+
+  </span>
   
 
-  <a
-    class="fd-object-status fd-object-status--link fd-object-status--inverted fd-object-status--indication-7"
-    href="#"
+  <span
+    class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-7"
   >
-    Indication7
-  </a>
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Indication7
+    </span>
+    
+
+  </span>
   
 
-  <a
-    class="fd-object-status fd-object-status--link fd-object-status--inverted fd-object-status--indication-8"
-    href="#"
+  <span
+    class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-8"
   >
-    Indication8
-  </a>
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Indication8
+    </span>
+    
+
+  </span>
   
 
 </section>

--- a/stories/object-status/__snapshots__/object-status.stories.storyshot
+++ b/stories/object-status/__snapshots__/object-status.stories.storyshot
@@ -5,18 +5,46 @@ exports[`Storyshots Components/Object Status Clickable Object Status 1`] = `
   
 
   <a
-    class="fd-object-status fd-object-status--link"
+    class="fd-object-status fd-object-status--negative fd-object-status--link"
     href="#"
   >
-    Neutral
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--status-negative"
+      role="presentation"
+    />
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Negative
+    </span>
+    
+
   </a>
   
 
   <a
-    class="fd-object-status fd-object-status--negative fd-object-status--link"
+    class="fd-object-status fd-object-status--critical fd-object-status--link"
     href="#"
   >
-    Negative
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--status-critical"
+      role="presentation"
+    />
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Critical
+    </span>
+    
+
   </a>
   
 
@@ -24,23 +52,65 @@ exports[`Storyshots Components/Object Status Clickable Object Status 1`] = `
     class="fd-object-status fd-object-status--positive fd-object-status--link"
     href="#"
   >
-    Positive
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--status-positive"
+      role="presentation"
+    />
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Positive
+    </span>
+    
+
   </a>
   
 
   <span
-    class="fd-object-status fd-object-status--critical fd-object-status--link sap-icon--status-critical"
+    class="fd-object-status fd-object-status--informative fd-object-status--link"
     role="button"
   >
-    Critical
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--hint"
+      role="presentation"
+    />
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Info
+    </span>
+    
+
   </span>
   
 
   <span
-    class="fd-object-status fd-object-status--informative fd-object-status--link sap-icon--hint"
+    class="fd-object-status fd-object-status--link"
     role="button"
   >
-    Informative
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--to-be-reviewed"
+      role="presentation"
+    />
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Neutral
+    </span>
+    
+
   </span>
   
 
@@ -54,7 +124,15 @@ exports[`Storyshots Components/Object Status Clickable Object Status 1`] = `
     class="fd-object-status fd-object-status--link fd-object-status--indication-1"
     href="#"
   >
-    Dark Red
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Dark Red
+    </span>
+    
+
   </a>
   
 
@@ -62,7 +140,15 @@ exports[`Storyshots Components/Object Status Clickable Object Status 1`] = `
     class="fd-object-status fd-object-status--link fd-object-status--indication-2"
     href="#"
   >
-    Red
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Red
+    </span>
+    
+
   </a>
   
 
@@ -70,7 +156,15 @@ exports[`Storyshots Components/Object Status Clickable Object Status 1`] = `
     class="fd-object-status fd-object-status--link fd-object-status--indication-3"
     href="#"
   >
-    Yellow
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Yellow
+    </span>
+    
+
   </a>
   
 
@@ -78,7 +172,15 @@ exports[`Storyshots Components/Object Status Clickable Object Status 1`] = `
     class="fd-object-status fd-object-status--link fd-object-status--indication-4"
     href="#"
   >
-    Green
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Green
+    </span>
+    
+
   </a>
   
 
@@ -86,7 +188,15 @@ exports[`Storyshots Components/Object Status Clickable Object Status 1`] = `
     class="fd-object-status fd-object-status--link fd-object-status--indication-5"
     href="#"
   >
-    Blue
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Blue
+    </span>
+    
+
   </a>
   
 
@@ -94,7 +204,15 @@ exports[`Storyshots Components/Object Status Clickable Object Status 1`] = `
     class="fd-object-status fd-object-status--link fd-object-status--indication-6"
     role="button"
   >
-    Teal
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Teal
+    </span>
+    
+
   </span>
   
 
@@ -102,7 +220,15 @@ exports[`Storyshots Components/Object Status Clickable Object Status 1`] = `
     class="fd-object-status fd-object-status--link fd-object-status--indication-7"
     role="button"
   >
-    Purple
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Purple
+    </span>
+    
+
   </span>
   
 
@@ -110,7 +236,15 @@ exports[`Storyshots Components/Object Status Clickable Object Status 1`] = `
     class="fd-object-status fd-object-status--link fd-object-status--indication-8"
     role="button"
   >
-    Pink
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Pink
+    </span>
+    
+
   </span>
   
 
@@ -124,56 +258,120 @@ exports[`Storyshots Components/Object Status Generic Indication Colors 1`] = `
   <span
     class="fd-object-status fd-object-status--indication-1"
   >
-    Dark Red
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Dark Red
+    </span>
+    
+
   </span>
   
 
   <span
     class="fd-object-status fd-object-status--indication-2"
   >
-    Red
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Red
+    </span>
+    
+
   </span>
   
 
   <span
     class="fd-object-status fd-object-status--indication-3"
   >
-    Yellow
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Yellow
+    </span>
+    
+
   </span>
   
 
   <span
     class="fd-object-status fd-object-status--indication-4"
   >
-    Green
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Green
+    </span>
+    
+
   </span>
   
 
   <span
     class="fd-object-status fd-object-status--indication-5"
   >
-    Blue
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Blue
+    </span>
+    
+
   </span>
   
 
   <span
     class="fd-object-status fd-object-status--indication-6"
   >
-    Teal
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Teal
+    </span>
+    
+
   </span>
   
 
   <span
     class="fd-object-status fd-object-status--indication-7"
   >
-    Purple
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Purple
+    </span>
+    
+
   </span>
   
 
   <span
     class="fd-object-status fd-object-status--indication-8"
   >
-    Pink
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Pink
+    </span>
+    
+
   </span>
   
 
@@ -185,28 +383,73 @@ exports[`Storyshots Components/Object Status Icon 1`] = `
   
 
   <span
-    class="fd-object-status fd-object-status--negative sap-icon--status-negative"
-  />
+    class="fd-object-status fd-object-status--negative"
+  >
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--status-negative"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-object-status fd-object-status--critical sap-icon--status-critical"
-  />
+    class="fd-object-status fd-object-status--critical"
+  >
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--status-critical"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-object-status fd-object-status--positive sap-icon--status-positive"
-  />
+    class="fd-object-status fd-object-status--positive"
+  >
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--status-positive"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-object-status fd-object-status--informative sap-icon--hint"
-  />
+    class="fd-object-status fd-object-status--informative"
+  >
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--hint"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
   <span
-    class="fd-object-status sap-icon--to-be-reviewed"
-  />
+    class="fd-object-status"
+  >
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--to-be-reviewed"
+      role="presentation"
+    />
+    
+
+  </span>
   
 
 </section>
@@ -217,37 +460,107 @@ exports[`Storyshots Components/Object Status Icon And Text 1`] = `
   
 
   <span
-    class="fd-object-status fd-object-status--negative sap-icon--status-negative"
+    class="fd-object-status fd-object-status--negative"
   >
-    Negative
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--status-negative"
+      role="presentation"
+    />
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Negative
+    </span>
+    
+
   </span>
   
 
   <span
-    class="fd-object-status fd-object-status--critical sap-icon--status-critical"
+    class="fd-object-status fd-object-status--critical"
   >
-    Critical
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--status-critical"
+      role="presentation"
+    />
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Critical
+    </span>
+    
+
   </span>
   
 
   <span
-    class="fd-object-status fd-object-status--positive sap-icon--status-positive"
+    class="fd-object-status fd-object-status--positive"
   >
-    Positive
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--status-positive"
+      role="presentation"
+    />
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Positive
+    </span>
+    
+
   </span>
   
 
   <span
-    class="fd-object-status fd-object-status--informative sap-icon--hint"
+    class="fd-object-status fd-object-status--informative"
   >
-    Informative
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--hint"
+      role="presentation"
+    />
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Info
+    </span>
+    
+
   </span>
   
 
   <span
-    class="fd-object-status sap-icon--to-be-reviewed"
+    class="fd-object-status"
   >
-    Neutral
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--to-be-reviewed"
+      role="presentation"
+    />
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Neutral
+    </span>
+    
+
   </span>
   
 
@@ -259,46 +572,80 @@ exports[`Storyshots Components/Object Status Inverted 1`] = `
   
 
   <span
-    class="fd-object-status fd-object-status--inverted fd-object-status--negative"
+    class="fd-object-status fd-object-status--negative fd-object-status--inverted"
   >
-    Inverted Negative
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Inverted Negative
+    </span>
+    
+
   </span>
   
 
   <span
-    class="fd-object-status fd-object-status--inverted fd-object-status--critical"
+    class="fd-object-status fd-object-status--critical fd-object-status--inverted"
   >
-    Inverted Warning
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Inverted Warning
+    </span>
+    
+
   </span>
   
 
   <span
-    class="fd-object-status fd-object-status--inverted fd-object-status--positive"
+    class="fd-object-status fd-object-status--positive fd-object-status--inverted"
   >
-    Inverted Success
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Inverted Success
+    </span>
+    
+
   </span>
   
 
   <span
-    class="fd-object-status fd-object-status--inverted fd-object-status--informative"
+    class="fd-object-status fd-object-status--informative fd-object-status--inverted"
   >
-    Inverted informative
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Inverted informative
+    </span>
+    
+
   </span>
   
 
   <span
-    class="fd-object-status fd-object-status--inverted fd-object-status--positive"
+    class="fd-object-status fd-object-status--inverted"
   >
-    3
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Inverted Neutral
+    </span>
+    
+
   </span>
   
 
-  <span
-    class="fd-object-status fd-object-status--inverted fd-object-status--informative"
-  >
-    2.99
-  </span>
-  
 
 
   <br />
@@ -309,47 +656,134 @@ exports[`Storyshots Components/Object Status Inverted 1`] = `
   <span
     class="fd-object-status fd-object-status--inverted"
   >
-    Inverted Neutral
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Inverted Neutral
+    </span>
+    
+
   </span>
   
 
   <span
-    class="fd-object-status fd-object-status--inverted fd-object-status--negative sap-icon--status-negative"
-  />
-  
-
-  <span
-    class="fd-object-status fd-object-status--inverted fd-object-status--negative sap-icon--status-negative"
+    class="fd-object-status fd-object-status--inverted fd-object-status--negative"
   >
-    Negative
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--status-negative"
+      role="presentation"
+    />
+    
+
   </span>
   
 
   <span
-    class="fd-object-status fd-object-status--inverted fd-object-status--critical sap-icon--status-critical"
+    class="fd-object-status fd-object-status--inverted fd-object-status--negative"
   >
-    Critical
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--status-negative"
+      role="presentation"
+    />
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Negative
+    </span>
+    
+
   </span>
   
 
   <span
-    class="fd-object-status fd-object-status--inverted fd-object-status--positive sap-icon--status-positive"
+    class="fd-object-status fd-object-status--inverted fd-object-status--critical"
   >
-    Positive
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--status-critical"
+      role="presentation"
+    />
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Critical
+    </span>
+    
+
   </span>
   
 
   <span
-    class="fd-object-status fd-object-status--inverted fd-object-status--informative sap-icon--hint"
+    class="fd-object-status fd-object-status--inverted fd-object-status--positive"
   >
-    Informative
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--status-positive"
+      role="presentation"
+    />
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Positive
+    </span>
+    
+
   </span>
   
 
   <span
-    class="fd-object-status fd-object-status--inverted sap-icon--to-be-reviewed"
+    class="fd-object-status fd-object-status--inverted fd-object-status--informative"
   >
-    Neutral
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--hint"
+      role="presentation"
+    />
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Informative
+    </span>
+    
+
+  </span>
+  
+
+  <span
+    class="fd-object-status fd-object-status--inverted"
+  >
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--to-be-reviewed"
+      role="presentation"
+    />
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Neutral
+    </span>
+    
+
   </span>
   
 
@@ -366,37 +800,107 @@ exports[`Storyshots Components/Object Status Inverted 1`] = `
   
 
   <a
-    class="fd-object-status fd-object-status--link fd-object-status--inverted fd-object-status--negative sap-icon--status-negative"
+    class="fd-object-status fd-object-status--link fd-object-status--negative fd-object-status--inverted"
   >
-    Negative
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--status-negative"
+      role="presentation"
+    />
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Inverted Negative
+    </span>
+    
+
   </a>
   
 
   <a
-    class="fd-object-status fd-object-status--link fd-object-status--inverted fd-object-status--critical sap-icon--status-critical"
+    class="fd-object-status fd-object-status--link fd-object-status--critical fd-object-status--inverted"
   >
-    Critical
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--status-critical"
+      role="presentation"
+    />
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Inverted Warning
+    </span>
+    
+
   </a>
   
 
   <a
-    class="fd-object-status fd-object-status--link fd-object-status--inverted fd-object-status--positive sap-icon--status-positive"
+    class="fd-object-status fd-object-status--link fd-object-status--positive fd-object-status--inverted"
   >
-    Positive
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--status-positive"
+      role="presentation"
+    />
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Inverted Success
+    </span>
+    
+
   </a>
   
 
   <a
-    class="fd-object-status fd-object-status--link fd-object-status--inverted fd-object-status--informative sap-icon--hint"
+    class="fd-object-status fd-object-status--link fd-object-status--informative fd-object-status--inverted"
   >
-    Informative
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--hint"
+      role="presentation"
+    />
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Inverted informative
+    </span>
+    
+
   </a>
   
 
   <a
-    class="fd-object-status fd-object-status--link fd-object-status--inverted sap-icon--to-be-reviewed"
+    class="fd-object-status fd-object-status--link fd-object-status--inverted"
   >
-    Neutral
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--to-be-reviewed"
+      role="presentation"
+    />
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Inverted Neutral
+    </span>
+    
+
   </a>
   
 
@@ -410,104 +914,224 @@ exports[`Storyshots Components/Object Status Inverted 1`] = `
     dir="rtl"
   >
     
-
+    
     <h4>
       RTL Support
     </h4>
     
-
+    
     <span
-      class="fd-object-status fd-object-status--inverted fd-object-status--negative"
+      class="fd-object-status fd-object-status--negative fd-object-status--inverted"
     >
-      Inverted Negative
+      
+        
+      <span
+        class="fd-object-status__text"
+      >
+        Inverted Negative
+      </span>
+      
+    
     </span>
     
-
+    
     <span
-      class="fd-object-status fd-object-status--inverted fd-object-status--critical"
+      class="fd-object-status fd-object-status--critical fd-object-status--inverted"
     >
-      Inverted Warning
+      
+        
+      <span
+        class="fd-object-status__text"
+      >
+        Inverted Warning
+      </span>
+      
+    
     </span>
     
-
+    
     <span
-      class="fd-object-status fd-object-status--inverted fd-object-status--positive"
+      class="fd-object-status fd-object-status--positive fd-object-status--inverted"
     >
-      Inverted Success
+      
+        
+      <span
+        class="fd-object-status__text"
+      >
+        Inverted Success
+      </span>
+      
+    
     </span>
     
-
+    
     <span
-      class="fd-object-status fd-object-status--inverted fd-object-status--informative"
+      class="fd-object-status fd-object-status--informative fd-object-status--inverted"
     >
-      Inverted informative
+      
+        
+      <span
+        class="fd-object-status__text"
+      >
+        Inverted informative
+      </span>
+      
+    
     </span>
     
-
-    <span
-      class="fd-object-status fd-object-status--inverted fd-object-status--positive"
-    >
-      3
-    </span>
     
-
-    <span
-      class="fd-object-status fd-object-status--inverted fd-object-status--informative"
-    >
-      2.99
-    </span>
-    
-
-
-    <br />
-    <br />
-    
-
-
     <span
       class="fd-object-status fd-object-status--inverted"
     >
-      Inverted Neutral
+      
+        
+      <span
+        class="fd-object-status__text"
+      >
+        Inverted Neutral
+      </span>
+      
+    
     </span>
     
 
-    <span
-      class="fd-object-status fd-object-status--inverted fd-object-status--negative sap-icon--status-negative"
-    />
+    
+    <br />
+    <br />
     
 
+    
     <span
-      class="fd-object-status fd-object-status--inverted fd-object-status--negative sap-icon--status-negative"
+      class="fd-object-status fd-object-status--inverted"
     >
-      Negative
+      
+        
+      <span
+        class="fd-object-status__text"
+      >
+        Inverted Neutral
+      </span>
+      
+    
     </span>
     
-
+    
     <span
-      class="fd-object-status fd-object-status--inverted fd-object-status--critical sap-icon--status-critical"
+      class="fd-object-status fd-object-status--inverted fd-object-status--negative"
     >
-      Critical
+      
+        
+      <i
+        class="fd-object-status__icon sap-icon--status-negative"
+        role="presentation"
+      />
+      
+    
     </span>
     
-
+    
     <span
-      class="fd-object-status fd-object-status--inverted fd-object-status--positive sap-icon--status-positive"
+      class="fd-object-status fd-object-status--inverted fd-object-status--negative"
     >
-      Positive
+      
+        
+      <i
+        class="fd-object-status__icon sap-icon--status-negative"
+        role="presentation"
+      />
+      
+        
+      <span
+        class="fd-object-status__text"
+      >
+        Negative
+      </span>
+      
+    
     </span>
     
-
+    
     <span
-      class="fd-object-status fd-object-status--inverted fd-object-status--informative sap-icon--hint"
+      class="fd-object-status fd-object-status--inverted fd-object-status--critical"
     >
-      Informative
+      
+        
+      <i
+        class="fd-object-status__icon sap-icon--status-critical"
+        role="presentation"
+      />
+      
+        
+      <span
+        class="fd-object-status__text"
+      >
+        Critical
+      </span>
+      
+    
     </span>
     
-
+    
     <span
-      class="fd-object-status fd-object-status--inverted sap-icon--to-be-reviewed"
+      class="fd-object-status fd-object-status--inverted fd-object-status--positive"
     >
-      Neutral
+      
+        
+      <i
+        class="fd-object-status__icon sap-icon--status-positive"
+        role="presentation"
+      />
+      
+        
+      <span
+        class="fd-object-status__text"
+      >
+        Positive
+      </span>
+      
+    
+    </span>
+    
+    
+    <span
+      class="fd-object-status fd-object-status--inverted fd-object-status--informative"
+    >
+      
+        
+      <i
+        class="fd-object-status__icon sap-icon--hint"
+        role="presentation"
+      />
+      
+        
+      <span
+        class="fd-object-status__text"
+      >
+        Informative
+      </span>
+      
+    
+    </span>
+    
+    
+    <span
+      class="fd-object-status fd-object-status--inverted"
+    >
+      
+        
+      <i
+        class="fd-object-status__icon sap-icon--to-be-reviewed"
+        role="presentation"
+      />
+      
+        
+      <span
+        class="fd-object-status__text"
+      >
+        Neutral
+      </span>
+      
+    
     </span>
     
 
@@ -657,42 +1281,224 @@ exports[`Storyshots Components/Object Status Inverted Indication 1`] = `
 </section>
 `;
 
+exports[`Storyshots Components/Object Status Large Object Status 1`] = `
+<section>
+  
+
+  <span
+    class="fd-object-status fd-object-status--large fd-object-status--negative"
+  >
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--status-negative"
+      role="presentation"
+    />
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Negative
+    </span>
+    
+
+  </span>
+  
+
+  <span
+    class="fd-object-status fd-object-status--large fd-object-status--critical"
+  >
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--status-critical"
+      role="presentation"
+    />
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Critical
+    </span>
+    
+
+  </span>
+  
+
+  <span
+    class="fd-object-status fd-object-status--large fd-object-status--positive"
+  >
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--status-positive"
+      role="presentation"
+    />
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Positive
+    </span>
+    
+
+  </span>
+  
+
+  <span
+    class="fd-object-status fd-object-status--large fd-object-status--informative"
+  >
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--hint"
+      role="presentation"
+    />
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Info
+    </span>
+    
+
+  </span>
+  
+
+  <span
+    class="fd-object-status fd-object-status--large"
+  >
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--to-be-reviewed"
+      role="presentation"
+    />
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Neutral
+    </span>
+    
+
+  </span>
+  
+
+</section>
+`;
+
 exports[`Storyshots Components/Object Status Primary 1`] = `
 <section>
   
 
   <span
-    class="fd-object-status fd-object-status--negative sap-icon--status-negative"
+    class="fd-object-status fd-object-status--negative"
   >
-    Negative
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--status-negative"
+      role="presentation"
+    />
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Negative
+    </span>
+    
+
   </span>
   
 
   <span
-    class="fd-object-status fd-object-status--critical sap-icon--status-critical"
+    class="fd-object-status fd-object-status--critical"
   >
-    Critical
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--status-critical"
+      role="presentation"
+    />
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Critical
+    </span>
+    
+
   </span>
   
 
   <span
-    class="fd-object-status fd-object-status--positive sap-icon--status-positive"
+    class="fd-object-status fd-object-status--positive"
   >
-    Positive
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--status-positive"
+      role="presentation"
+    />
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Positive
+    </span>
+    
+
   </span>
   
 
   <span
-    class="fd-object-status fd-object-status--informative sap-icon--hint"
+    class="fd-object-status fd-object-status--informative"
   >
-    Info
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--hint"
+      role="presentation"
+    />
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Info
+    </span>
+    
+
   </span>
   
 
   <span
-    class="fd-object-status sap-icon--to-be-reviewed"
+    class="fd-object-status"
   >
-    Neutral
+    
+    
+    <i
+      class="fd-object-status__icon sap-icon--to-be-reviewed"
+      role="presentation"
+    />
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Neutral
+    </span>
+    
+
   </span>
   
 
@@ -703,38 +1509,79 @@ exports[`Storyshots Components/Object Status Text 1`] = `
 <section>
   
 
+
   <span
     class="fd-object-status fd-object-status--negative"
   >
-    Negative
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Negative
+    </span>
+    
+
   </span>
   
 
   <span
     class="fd-object-status fd-object-status--critical"
   >
-    Critical
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Critical
+    </span>
+    
+
   </span>
   
 
   <span
     class="fd-object-status fd-object-status--positive"
   >
-    Positive
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Positive
+    </span>
+    
+
   </span>
   
 
   <span
     class="fd-object-status fd-object-status--informative"
   >
-    Informative
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Info
+    </span>
+    
+
   </span>
   
 
   <span
     class="fd-object-status"
   >
-    Neutral
+    
+    
+    <span
+      class="fd-object-status__text"
+    >
+      Neutral
+    </span>
+    
+
   </span>
   
 

--- a/stories/object-status/object-status.stories.js
+++ b/stories/object-status/object-status.stories.js
@@ -18,11 +18,26 @@ attribute of a line item in a table. `
  */
 
 export const primary = () => `
-<span class="fd-object-status fd-object-status--negative sap-icon--status-negative">Negative</span>
-<span class="fd-object-status fd-object-status--critical sap-icon--status-critical">Critical</span>
-<span class="fd-object-status fd-object-status--positive sap-icon--status-positive">Positive</span>
-<span class="fd-object-status fd-object-status--informative sap-icon--hint">Info</span>
-<span class="fd-object-status sap-icon--to-be-reviewed">Neutral</span>
+<span class="fd-object-status fd-object-status--negative">
+    <i class="fd-object-status__icon sap-icon--status-negative" role="presentation"></i>
+    <span class="fd-object-status__text">Negative</span>
+</span>
+<span class="fd-object-status fd-object-status--critical">
+    <i class="fd-object-status__icon sap-icon--status-critical" role="presentation"></i>
+    <span class="fd-object-status__text">Critical</span>
+</span>
+<span class="fd-object-status fd-object-status--positive">
+    <i class="fd-object-status__icon sap-icon--status-positive" role="presentation"></i>
+    <span class="fd-object-status__text">Positive</span>
+</span>
+<span class="fd-object-status fd-object-status--informative">
+    <i class="fd-object-status__icon sap-icon--hint" role="presentation"></i>
+    <span class="fd-object-status__text">Info</span>
+</span>
+<span class="fd-object-status">
+    <i class="fd-object-status__icon sap-icon--to-be-reviewed" role="presentation"></i>
+    <span class="fd-object-status__text">Neutral</span>
+</span>
 `;
 
 /**
@@ -30,11 +45,21 @@ export const primary = () => `
  */
 
 export const icon = () => `
-<span class="fd-object-status fd-object-status--negative sap-icon--status-negative"></span>
-<span class="fd-object-status fd-object-status--critical sap-icon--status-critical"></span>
-<span class="fd-object-status fd-object-status--positive sap-icon--status-positive"></span>
-<span class="fd-object-status fd-object-status--informative sap-icon--hint"></span>
-<span class="fd-object-status sap-icon--to-be-reviewed"></span>
+<span class="fd-object-status fd-object-status--negative">
+    <i class="fd-object-status__icon sap-icon--status-negative" role="presentation"></i>
+</span>
+<span class="fd-object-status fd-object-status--critical">
+    <i class="fd-object-status__icon sap-icon--status-critical" role="presentation"></i>
+</span>
+<span class="fd-object-status fd-object-status--positive">
+    <i class="fd-object-status__icon sap-icon--status-positive" role="presentation"></i>
+</span>
+<span class="fd-object-status fd-object-status--informative">
+    <i class="fd-object-status__icon sap-icon--hint" role="presentation"></i>
+</span>
+<span class="fd-object-status">
+    <i class="fd-object-status__icon sap-icon--to-be-reviewed" role="presentation"></i>
+</span>
 `;
 
 /**
@@ -42,11 +67,22 @@ export const icon = () => `
  */
 
 export const text = () => `
-<span class="fd-object-status fd-object-status--negative">Negative</span>
-<span class="fd-object-status fd-object-status--critical">Critical</span>
-<span class="fd-object-status fd-object-status--positive">Positive</span>
-<span class="fd-object-status fd-object-status--informative">Informative</span>
-<span class="fd-object-status">Neutral</span>
+
+<span class="fd-object-status fd-object-status--negative">
+    <span class="fd-object-status__text">Negative</span>
+</span>
+<span class="fd-object-status fd-object-status--critical">
+    <span class="fd-object-status__text">Critical</span>
+</span>
+<span class="fd-object-status fd-object-status--positive">
+    <span class="fd-object-status__text">Positive</span>
+</span>
+<span class="fd-object-status fd-object-status--informative">
+    <span class="fd-object-status__text">Info</span>
+</span>
+<span class="fd-object-status">
+    <span class="fd-object-status__text">Neutral</span>
+</span>
 `;
 
 /**
@@ -54,11 +90,26 @@ export const text = () => `
  */
 
 export const iconAndText = () => `
-<span class="fd-object-status fd-object-status--negative sap-icon--status-negative">Negative</span>
-<span class="fd-object-status fd-object-status--critical sap-icon--status-critical">Critical</span>
-<span class="fd-object-status fd-object-status--positive sap-icon--status-positive">Positive</span>
-<span class="fd-object-status fd-object-status--informative sap-icon--hint">Informative</span>
-<span class="fd-object-status sap-icon--to-be-reviewed">Neutral</span>
+<span class="fd-object-status fd-object-status--negative">
+    <i class="fd-object-status__icon sap-icon--status-negative" role="presentation"></i>
+    <span class="fd-object-status__text">Negative</span>
+</span>
+<span class="fd-object-status fd-object-status--critical">
+    <i class="fd-object-status__icon sap-icon--status-critical" role="presentation"></i>
+    <span class="fd-object-status__text">Critical</span>
+</span>
+<span class="fd-object-status fd-object-status--positive">
+    <i class="fd-object-status__icon sap-icon--status-positive" role="presentation"></i>
+    <span class="fd-object-status__text">Positive</span>
+</span>
+<span class="fd-object-status fd-object-status--informative">
+    <i class="fd-object-status__icon sap-icon--hint" role="presentation"></i>
+    <span class="fd-object-status__text">Info</span>
+</span>
+<span class="fd-object-status">
+    <i class="fd-object-status__icon sap-icon--to-be-reviewed" role="presentation"></i>
+    <span class="fd-object-status__text">Neutral</span>
+</span>
 `;
 
 /**
@@ -66,14 +117,30 @@ export const iconAndText = () => `
  */
 
 export const genericIndicationColors = () => `
-<span class="fd-object-status fd-object-status--indication-1">Dark Red</span>
-<span class="fd-object-status fd-object-status--indication-2">Red</span>
-<span class="fd-object-status fd-object-status--indication-3">Yellow</span>
-<span class="fd-object-status fd-object-status--indication-4">Green</span>
-<span class="fd-object-status fd-object-status--indication-5">Blue</span>
-<span class="fd-object-status fd-object-status--indication-6">Teal</span>
-<span class="fd-object-status fd-object-status--indication-7">Purple</span>
-<span class="fd-object-status fd-object-status--indication-8">Pink</span>
+<span class="fd-object-status fd-object-status--indication-1">
+    <span class="fd-object-status__text">Dark Red</span>
+</span>
+<span class="fd-object-status fd-object-status--indication-2">
+    <span class="fd-object-status__text">Red</span>
+</span>
+<span class="fd-object-status fd-object-status--indication-3">
+    <span class="fd-object-status__text">Yellow</span>
+</span>
+<span class="fd-object-status fd-object-status--indication-4">
+    <span class="fd-object-status__text">Green</span>
+</span>
+<span class="fd-object-status fd-object-status--indication-5">
+    <span class="fd-object-status__text">Blue</span>
+</span>
+<span class="fd-object-status fd-object-status--indication-6">
+    <span class="fd-object-status__text">Teal</span>
+</span>
+<span class="fd-object-status fd-object-status--indication-7">
+    <span class="fd-object-status__text">Purple</span>
+</span>
+<span class="fd-object-status fd-object-status--indication-8">
+    <span class="fd-object-status__text">Pink</span>
+</span>
 `;
 
 /**
@@ -83,22 +150,77 @@ export const genericIndicationColors = () => `
  */
 
 export const clickableObjectStatus = () => `
-<a href="#" class="fd-object-status fd-object-status--link">Neutral</a>
-<a href="#" class="fd-object-status fd-object-status--negative fd-object-status--link">Negative</a>
-<a href="#" class="fd-object-status fd-object-status--positive fd-object-status--link">Positive</a>
-<span role="button" class="fd-object-status fd-object-status--critical fd-object-status--link sap-icon--status-critical">Critical</span>
-<span role="button" class="fd-object-status fd-object-status--informative fd-object-status--link sap-icon--hint">Informative</span>
+<a href="#"  class="fd-object-status fd-object-status--negative fd-object-status--link">
+    <i class="fd-object-status__icon sap-icon--status-negative" role="presentation"></i>
+    <span class="fd-object-status__text">Negative</span>
+</a>
+<a href="#"  class="fd-object-status fd-object-status--critical fd-object-status--link">
+    <i class="fd-object-status__icon sap-icon--status-critical" role="presentation"></i>
+    <span class="fd-object-status__text">Critical</span>
+</a>
+<a href="#"class="fd-object-status fd-object-status--positive fd-object-status--link">
+    <i class="fd-object-status__icon sap-icon--status-positive" role="presentation"></i>
+    <span class="fd-object-status__text">Positive</span>
+</a>
+<span role="button" class="fd-object-status fd-object-status--informative fd-object-status--link">
+    <i class="fd-object-status__icon sap-icon--hint" role="presentation"></i>
+    <span class="fd-object-status__text">Info</span>
+</span>
+<span role="button" class="fd-object-status fd-object-status--link">
+    <i class="fd-object-status__icon sap-icon--to-be-reviewed" role="presentation"></i>
+    <span class="fd-object-status__text">Neutral</span>
+</span>
 
 <br><br>
 
-<a href="#" class="fd-object-status fd-object-status--link fd-object-status--indication-1">Dark Red</a>
-<a href="#" class="fd-object-status fd-object-status--link fd-object-status--indication-2">Red</a>
-<a href="#" class="fd-object-status fd-object-status--link fd-object-status--indication-3">Yellow</a>
-<a href="#" class="fd-object-status fd-object-status--link fd-object-status--indication-4">Green</a>
-<a href="#" class="fd-object-status fd-object-status--link fd-object-status--indication-5">Blue</a>
-<span role="button" class="fd-object-status fd-object-status--link fd-object-status--indication-6">Teal</span>
-<span role="button" class="fd-object-status fd-object-status--link fd-object-status--indication-7">Purple</span>
-<span role="button" class="fd-object-status fd-object-status--link fd-object-status--indication-8">Pink</span>
+<a href="#"  class="fd-object-status fd-object-status--link fd-object-status--indication-1">
+    <span class="fd-object-status__text">Dark Red</span>
+</a>
+<a href="#"  class="fd-object-status fd-object-status--link fd-object-status--indication-2">
+    <span class="fd-object-status__text">Red</span>
+</a>
+<a href="#"  class="fd-object-status fd-object-status--link fd-object-status--indication-3">
+    <span class="fd-object-status__text">Yellow</span>
+</a>
+<a href="#"  class="fd-object-status fd-object-status--link fd-object-status--indication-4">
+    <span class="fd-object-status__text">Green</span>
+</a>
+<a href="#"  class="fd-object-status fd-object-status--link fd-object-status--indication-5">
+    <span class="fd-object-status__text">Blue</span>
+</a>
+<span role="button" class="fd-object-status fd-object-status--link fd-object-status--indication-6">
+    <span class="fd-object-status__text">Teal</span>
+</span>
+<span role="button" class="fd-object-status fd-object-status--link fd-object-status--indication-7">
+    <span class="fd-object-status__text">Purple</span>
+</span>
+<span role="button" class="fd-object-status fd-object-status--link fd-object-status--indication-8">
+    <span class="fd-object-status__text">Pink</span>
+</span>
+`;
+
+
+export const largeObjectStatus = () => `
+<span class="fd-object-status fd-object-status--large fd-object-status--negative">
+    <i class="fd-object-status__icon sap-icon--status-negative" role="presentation"></i>
+    <span class="fd-object-status__text">Negative</span>
+</span>
+<span class="fd-object-status fd-object-status--large fd-object-status--critical">
+    <i class="fd-object-status__icon sap-icon--status-critical" role="presentation"></i>
+    <span class="fd-object-status__text">Critical</span>
+</span>
+<span class="fd-object-status fd-object-status--large fd-object-status--positive">
+    <i class="fd-object-status__icon sap-icon--status-positive" role="presentation"></i>
+    <span class="fd-object-status__text">Positive</span>
+</span>
+<span class="fd-object-status fd-object-status--large fd-object-status--informative">
+    <i class="fd-object-status__icon sap-icon--hint" role="presentation"></i>
+    <span class="fd-object-status__text">Info</span>
+</span>
+<span class="fd-object-status fd-object-status--large">
+    <i class="fd-object-status__icon sap-icon--to-be-reviewed" role="presentation"></i>
+    <span class="fd-object-status__text">Neutral</span>
+</span>
 `;
 
 /**
@@ -108,52 +230,124 @@ export const clickableObjectStatus = () => `
  */
 
 export const inverted = () => `
-<span class="fd-object-status fd-object-status--inverted fd-object-status--negative">Inverted Negative</span>
-<span class="fd-object-status fd-object-status--inverted fd-object-status--critical">Inverted Warning</span>
-<span class="fd-object-status fd-object-status--inverted fd-object-status--positive">Inverted Success</span>
-<span class="fd-object-status fd-object-status--inverted fd-object-status--informative">Inverted informative</span>
-<span class="fd-object-status fd-object-status--inverted fd-object-status--positive">3</span>
-<span class="fd-object-status fd-object-status--inverted fd-object-status--informative">2.99</span>
+<span class="fd-object-status fd-object-status--negative fd-object-status--inverted">
+    <span class="fd-object-status__text">Inverted Negative</span>
+</span>
+<span class="fd-object-status fd-object-status--critical fd-object-status--inverted">
+    <span class="fd-object-status__text">Inverted Warning</span>
+</span>
+<span class="fd-object-status fd-object-status--positive fd-object-status--inverted">
+    <span class="fd-object-status__text">Inverted Success</span>
+</span>
+<span class="fd-object-status fd-object-status--informative fd-object-status--inverted">
+    <span class="fd-object-status__text">Inverted informative</span>
+</span>
+<span class="fd-object-status fd-object-status--inverted">
+    <span class="fd-object-status__text">Inverted Neutral</span>
+</span>
+
 
 <br><br>
 
-<span class="fd-object-status fd-object-status--inverted">Inverted Neutral</span>
-<span class="fd-object-status fd-object-status--inverted fd-object-status--negative sap-icon--status-negative"></span>
-<span class="fd-object-status fd-object-status--inverted fd-object-status--negative sap-icon--status-negative">Negative</span>
-<span class="fd-object-status fd-object-status--inverted fd-object-status--critical sap-icon--status-critical">Critical</span>
-<span class="fd-object-status fd-object-status--inverted fd-object-status--positive sap-icon--status-positive">Positive</span>
-<span class="fd-object-status fd-object-status--inverted fd-object-status--informative sap-icon--hint">Informative</span>
-<span class="fd-object-status fd-object-status--inverted sap-icon--to-be-reviewed">Neutral</span>
+<span class="fd-object-status fd-object-status--inverted">
+    <span class="fd-object-status__text">Inverted Neutral</span>
+</span>
+<span class="fd-object-status fd-object-status--inverted fd-object-status--negative">
+    <i class="fd-object-status__icon sap-icon--status-negative" role="presentation"></i>
+</span>
+<span class="fd-object-status fd-object-status--inverted fd-object-status--negative">
+    <i class="fd-object-status__icon sap-icon--status-negative" role="presentation"></i>
+    <span class="fd-object-status__text">Negative</span>
+</span>
+<span class="fd-object-status fd-object-status--inverted fd-object-status--critical">
+    <i class="fd-object-status__icon sap-icon--status-critical" role="presentation"></i>
+    <span class="fd-object-status__text">Critical</span>
+</span>
+<span class="fd-object-status fd-object-status--inverted fd-object-status--positive">
+    <i class="fd-object-status__icon sap-icon--status-positive" role="presentation"></i>
+    <span class="fd-object-status__text">Positive</span>
+</span>
+<span class="fd-object-status fd-object-status--inverted fd-object-status--informative">
+    <i class="fd-object-status__icon sap-icon--hint" role="presentation"></i>
+    <span class="fd-object-status__text">Informative</span>
+</span>
+<span class="fd-object-status fd-object-status--inverted">
+    <i class="fd-object-status__icon sap-icon--to-be-reviewed" role="presentation"></i>
+    <span class="fd-object-status__text">Neutral</span>
+</span>
 
 <br>
 <br>
 <h4>Clickable Inverted Object Status</h4>
-<a class="fd-object-status fd-object-status--link fd-object-status--inverted fd-object-status--negative sap-icon--status-negative">Negative</a>
-<a class="fd-object-status fd-object-status--link fd-object-status--inverted fd-object-status--critical sap-icon--status-critical">Critical</a>
-<a class="fd-object-status fd-object-status--link fd-object-status--inverted fd-object-status--positive sap-icon--status-positive">Positive</a>
-<a class="fd-object-status fd-object-status--link fd-object-status--inverted fd-object-status--informative sap-icon--hint">Informative</a>
-<a class="fd-object-status fd-object-status--link fd-object-status--inverted sap-icon--to-be-reviewed">Neutral</a>
+<a class="fd-object-status fd-object-status--link fd-object-status--negative fd-object-status--inverted">
+    <i class="fd-object-status__icon sap-icon--status-negative" role="presentation"></i>
+    <span class="fd-object-status__text">Inverted Negative</span>
+</a>
+<a class="fd-object-status fd-object-status--link fd-object-status--critical fd-object-status--inverted">
+    <i class="fd-object-status__icon sap-icon--status-critical" role="presentation"></i>
+    <span class="fd-object-status__text">Inverted Warning</span>
+</a>
+<a class="fd-object-status fd-object-status--link fd-object-status--positive fd-object-status--inverted">
+    <i class="fd-object-status__icon sap-icon--status-positive" role="presentation"></i>
+    <span class="fd-object-status__text">Inverted Success</span>
+</a>
+<a class="fd-object-status fd-object-status--link fd-object-status--informative fd-object-status--inverted">
+    <i class="fd-object-status__icon sap-icon--hint" role="presentation"></i>
+    <span class="fd-object-status__text">Inverted informative</span>
+</a>
+<a class="fd-object-status fd-object-status--link fd-object-status--inverted">
+    <i class="fd-object-status__icon sap-icon--to-be-reviewed" role="presentation"></i>
+    <span class="fd-object-status__text">Inverted Neutral</span>
+</a>
 
 <br><br>
 
 <div dir="rtl">
-<h4>RTL Support</h4>
-<span class="fd-object-status fd-object-status--inverted fd-object-status--negative">Inverted Negative</span>
-<span class="fd-object-status fd-object-status--inverted fd-object-status--critical">Inverted Warning</span>
-<span class="fd-object-status fd-object-status--inverted fd-object-status--positive">Inverted Success</span>
-<span class="fd-object-status fd-object-status--inverted fd-object-status--informative">Inverted informative</span>
-<span class="fd-object-status fd-object-status--inverted fd-object-status--positive">3</span>
-<span class="fd-object-status fd-object-status--inverted fd-object-status--informative">2.99</span>
+    <h4>RTL Support</h4>
+    <span class="fd-object-status fd-object-status--negative fd-object-status--inverted">
+        <span class="fd-object-status__text">Inverted Negative</span>
+    </span>
+    <span class="fd-object-status fd-object-status--critical fd-object-status--inverted">
+        <span class="fd-object-status__text">Inverted Warning</span>
+    </span>
+    <span class="fd-object-status fd-object-status--positive fd-object-status--inverted">
+        <span class="fd-object-status__text">Inverted Success</span>
+    </span>
+    <span class="fd-object-status fd-object-status--informative fd-object-status--inverted">
+        <span class="fd-object-status__text">Inverted informative</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted">
+        <span class="fd-object-status__text">Inverted Neutral</span>
+    </span>
 
-<br><br>
+    <br><br>
 
-<span class="fd-object-status fd-object-status--inverted">Inverted Neutral</span>
-<span class="fd-object-status fd-object-status--inverted fd-object-status--negative sap-icon--status-negative"></span>
-<span class="fd-object-status fd-object-status--inverted fd-object-status--negative sap-icon--status-negative">Negative</span>
-<span class="fd-object-status fd-object-status--inverted fd-object-status--critical sap-icon--status-critical">Critical</span>
-<span class="fd-object-status fd-object-status--inverted fd-object-status--positive sap-icon--status-positive">Positive</span>
-<span class="fd-object-status fd-object-status--inverted fd-object-status--informative sap-icon--hint">Informative</span>
-<span class="fd-object-status fd-object-status--inverted sap-icon--to-be-reviewed">Neutral</span>
+    <span class="fd-object-status fd-object-status--inverted">
+        <span class="fd-object-status__text">Inverted Neutral</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--negative">
+        <i class="fd-object-status__icon sap-icon--status-negative" role="presentation"></i>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--negative">
+        <i class="fd-object-status__icon sap-icon--status-negative" role="presentation"></i>
+        <span class="fd-object-status__text">Negative</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--critical">
+        <i class="fd-object-status__icon sap-icon--status-critical" role="presentation"></i>
+        <span class="fd-object-status__text">Critical</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--positive">
+        <i class="fd-object-status__icon sap-icon--status-positive" role="presentation"></i>
+        <span class="fd-object-status__text">Positive</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--informative">
+        <i class="fd-object-status__icon sap-icon--hint" role="presentation"></i>
+        <span class="fd-object-status__text">Informative</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted">
+        <i class="fd-object-status__icon sap-icon--to-be-reviewed" role="presentation"></i>
+        <span class="fd-object-status__text">Neutral</span>
+    </span>
 </div>
 `;
 

--- a/stories/object-status/object-status.stories.js
+++ b/stories/object-status/object-status.stories.js
@@ -46,19 +46,19 @@ export const primary = () => `
 
 export const icon = () => `
 <span class="fd-object-status fd-object-status--negative">
-    <i class="fd-object-status__icon sap-icon--status-negative" role="presentation"></i>
+    <i class="fd-object-status__icon sap-icon--status-negative" aria-label="Negative"></i>
 </span>
 <span class="fd-object-status fd-object-status--critical">
-    <i class="fd-object-status__icon sap-icon--status-critical" role="presentation"></i>
+    <i class="fd-object-status__icon sap-icon--status-critical" aria-label="Warning"></i>
 </span>
 <span class="fd-object-status fd-object-status--positive">
-    <i class="fd-object-status__icon sap-icon--status-positive" role="presentation"></i>
+    <i class="fd-object-status__icon sap-icon--status-positive" aria-label="Correct"></i>
 </span>
 <span class="fd-object-status fd-object-status--informative">
-    <i class="fd-object-status__icon sap-icon--hint" role="presentation"></i>
+    <i class="fd-object-status__icon sap-icon--hint" aria-label="More information"></i>
 </span>
 <span class="fd-object-status">
-    <i class="fd-object-status__icon sap-icon--to-be-reviewed" role="presentation"></i>
+    <i class="fd-object-status__icon sap-icon--to-be-reviewed" aria-label="To be reviewed"></i>
 </span>
 `;
 
@@ -326,7 +326,7 @@ export const inverted = () => `
         <span class="fd-object-status__text">Inverted Neutral</span>
     </span>
     <span class="fd-object-status fd-object-status--inverted fd-object-status--negative">
-        <i class="fd-object-status__icon sap-icon--status-negative" role="presentation"></i>
+        <i class="fd-object-status__icon sap-icon--status-negative" aria-label="Error"></i>
     </span>
     <span class="fd-object-status fd-object-status--inverted fd-object-status--negative">
         <i class="fd-object-status__icon sap-icon--status-negative" role="presentation"></i>
@@ -356,25 +356,57 @@ export const inverted = () => `
  */
 
 export const invertedIndication = () => `
-<span class="fd-object-status fd-object-status--inverted fd-object-status--indication-1">Indication1</span>
-<span class="fd-object-status fd-object-status--inverted fd-object-status--indication-2">Indication2</span>
-<span class="fd-object-status fd-object-status--inverted fd-object-status--indication-3">Indication3</span>
-<span class="fd-object-status fd-object-status--inverted fd-object-status--indication-4">Indication4</span>
-<span class="fd-object-status fd-object-status--inverted fd-object-status--indication-5">Indication5</span>
-<span class="fd-object-status fd-object-status--inverted fd-object-status--indication-6">Indication6</span>
-<span class="fd-object-status fd-object-status--inverted fd-object-status--indication-7">Indication7</span>
-<span class="fd-object-status fd-object-status--inverted fd-object-status--indication-8">Indication8</span>
+<span class="fd-object-status fd-object-status--inverted fd-object-status--indication-1">
+    <span class="fd-object-status__text">Indication1</span>
+</span>
+<span class="fd-object-status fd-object-status--inverted fd-object-status--indication-2">
+    <span class="fd-object-status__text">Indication2</span>
+</span>
+<span class="fd-object-status fd-object-status--inverted fd-object-status--indication-3">
+    <span class="fd-object-status__text">Indication3</span>
+</span>
+<span class="fd-object-status fd-object-status--inverted fd-object-status--indication-4">
+    <span class="fd-object-status__text">Indication4</span>
+</span>
+<span class="fd-object-status fd-object-status--inverted fd-object-status--indication-5">
+    <span class="fd-object-status__text">Indication5</span>
+</span>
+<span class="fd-object-status fd-object-status--inverted fd-object-status--indication-6">
+    <span class="fd-object-status__text">Indication6</span>
+</span>
+<span class="fd-object-status fd-object-status--inverted fd-object-status--indication-7">
+    <span class="fd-object-status__text">Indication7</span>
+</span>
+<span class="fd-object-status fd-object-status--inverted fd-object-status--indication-8">
+    <span class="fd-object-status__text">Indication8</span>
+</span>
 
 <br>
 <br>
 
 <h4>Clickable Inverted Object Status</h4>
-<a href="#" class="fd-object-status fd-object-status--link fd-object-status--inverted fd-object-status--indication-1">Indication1</a>
-<a href="#" class="fd-object-status fd-object-status--link fd-object-status--inverted fd-object-status--indication-2">Indication2</a>
-<a href="#" class="fd-object-status fd-object-status--link fd-object-status--inverted fd-object-status--indication-3">Indication3</a>
-<a href="#" class="fd-object-status fd-object-status--link fd-object-status--inverted fd-object-status--indication-4">Indication4</a>
-<a href="#" class="fd-object-status fd-object-status--link fd-object-status--inverted fd-object-status--indication-5">Indication5</a>
-<a href="#" class="fd-object-status fd-object-status--link fd-object-status--inverted fd-object-status--indication-6">Indication6</a>
-<a href="#" class="fd-object-status fd-object-status--link fd-object-status--inverted fd-object-status--indication-7">Indication7</a>
-<a href="#" class="fd-object-status fd-object-status--link fd-object-status--inverted fd-object-status--indication-8">Indication8</a>
+<span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-1">
+    <span class="fd-object-status__text">Indication1</span>
+</span>
+<span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-2">
+    <span class="fd-object-status__text">Indication2</span>
+</span>
+<span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-3">
+    <span class="fd-object-status__text">Indication3</span>
+</span>
+<span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-4">
+    <span class="fd-object-status__text">Indication4</span>
+</span>
+<span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-5">
+    <span class="fd-object-status__text">Indication5</span>
+</span>
+<span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-6">
+    <span class="fd-object-status__text">Indication6</span>
+</span>
+<span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-7">
+    <span class="fd-object-status__text">Indication7</span>
+</span>
+<span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-8">
+    <span class="fd-object-status__text">Indication8</span>
+</span>
 `;


### PR DESCRIPTION
## Related Issue
related to https://github.com/SAP/fundamental-styles/issues/1603
and #1639
## Description
There are added 2 new elements:
`fd-object-status__icon` and `fd-object-status__text`

Breaking change:
Object status icon and text are extracted in separate `<i>` and `<span>`  elements and new classes have been introduced: `fd-object-status__icon` and `fd-object-status__text`

Before:
```
<span class="fd-object-status sap-icon--to-be-negative">Negative</span>
```

After:
```
<span class="fd-object-status fd-object-status--negative">
    <i class="fd-object-status__icon sap-icon--status-negative" role="presentation"></i>
    <span class="fd-object-status__text">Negative</span>
</span>
```

#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
