### PR TITLE
fix: Side Navigation - Refactor icons usage

### DIFF
--- a/src/_nested-list.scss
+++ b/src/_nested-list.scss
@@ -208,13 +208,15 @@ $block: #{$fd-namespace}-nested-list;
   }
 
   &__icon {
-    @include fd-reset();
-    @include fd-flex-center();
+    @include fd-icon-element-base() {
+      @include fd-reset();
+      @include fd-flex-center();
 
-    height: 100%;
-    min-width: 2.75rem;
-    color: var(--sapList_TextColor);
-    font-size: var(--sapFontHeader4Size);
+      height: 100%;
+      min-width: 2.75rem;
+      color: var(--sapList_TextColor);
+      font-size: var(--sapFontHeader4Size);
+    }
   }
 
   &__title {

--- a/stories/side-navigation/side-navigation.stories.js
+++ b/stories/side-navigation/side-navigation.stories.js
@@ -388,7 +388,7 @@ export const complexCompactSideNav = () => `
             </li>
             <li class="fd-nested-list__item">
                 <a class="fd-nested-list__link" href="#">
-                    <span class="fd-nested-list__icon sap-icon--chain-link"></span>
+                    <span aria-hidden="true" class="fd-nested-list__icon sap-icon--chain-link"></span>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
@@ -697,20 +697,20 @@ export const nestedListWithIconsOnlyInFirstLevel = () => `
 <ul class="fd-nested-list">
     <li class="fd-nested-list__item">
         <a class="fd-nested-list__link"href="#/">
-            <span class="fd-nested-list__icon sap-icon--home"></span>
+            <span aria-hidden="true" class="fd-nested-list__icon sap-icon--home"></span>
             <span class="fd-nested-list__title">Level 1 Item</span>
         </a>
     </li>
     <li class="fd-nested-list__item">
         <a class="fd-nested-list__link is-selected"href="#/">
-            <span class="fd-nested-list__icon sap-icon--calendar"></span>
+            <span aria-hidden="true" class="fd-nested-list__icon sap-icon--calendar"></span>
             <span class="fd-nested-list__title">Level 1 Item</span>
         </a>
     </li>
     <li class="fd-nested-list__item">
 	   <div class="fd-nested-list__content has-child is-expanded" tabindex="0">
 			<a class="fd-nested-list__link" href="#" tabindex="-1">
-				<span class="fd-nested-list__icon sap-icon--employee"></span>
+				<span aria-hidden="true" class="fd-nested-list__icon sap-icon--employee"></span>
 				<span class="fd-nested-list__title">Level 1 Item</span>
 			</a>
             <button class="fd-button fd-nested-list__button"
@@ -787,13 +787,13 @@ export const nestedListWithIconsOnlyInFirstLevel = () => `
     </li>
     <li class="fd-nested-list__item">
         <a class="fd-nested-list__link"href="#/">
-            <span class="fd-nested-list__icon sap-icon--activities"></span>
+            <span aria-hidden="true" class="fd-nested-list__icon sap-icon--activities"></span>
             <span class="fd-nested-list__title">Level 1 Item</span>
         </a>
     </li>
     <li class="fd-nested-list__item">
         <a class="fd-nested-list__link"href="#/">
-            <span class="fd-nested-list__icon sap-icon--bar-chart"></span>
+            <span aria-hidden="true" class="fd-nested-list__icon sap-icon--bar-chart"></span>
             <span class="fd-nested-list__title">Level 1 Item</span>
         </a>
     </li>
@@ -818,20 +818,20 @@ export const nestedListWithGroupHeaders = () => `
     </li>
     <li class="fd-nested-list__item">
         <a class="fd-nested-list__link"href="#/">
-            <span class="fd-nested-list__icon sap-icon--home"></span>
+            <span aria-hidden="true" class="fd-nested-list__icon sap-icon--home"></span>
             <span class="fd-nested-list__title">Level 1 Item</span>
         </a>
     </li>
     <li class="fd-nested-list__item">
         <a class="fd-nested-list__link is-selected"href="#/">
-            <span class="fd-nested-list__icon sap-icon--calendar"></span>
+            <span aria-hidden="true" class="fd-nested-list__icon sap-icon--calendar"></span>
             <span class="fd-nested-list__title">Level 1 Item</span>
         </a>
     </li>
     <li class="fd-nested-list__item">
 	   <div class="fd-nested-list__content has-child" tabindex="0">
 			<a class="fd-nested-list__link" href="#" tabindex="-1">
-				<span class="fd-nested-list__icon sap-icon--employee"></span>
+				<span aria-hidden="true" class="fd-nested-list__icon sap-icon--employee"></span>
 				<span class="fd-nested-list__title">Level 1 Item</span>
 			</a>
             <button class="fd-button fd-nested-list__button"
@@ -908,7 +908,7 @@ export const nestedListWithGroupHeaders = () => `
     </li>
     <li class="fd-nested-list__item">
         <a class="fd-nested-list__link"href="#/">
-            <span class="fd-nested-list__icon sap-icon--activities"></span>
+            <span aria-hidden="true" class="fd-nested-list__icon sap-icon--activities"></span>
             <span class="fd-nested-list__title">Level 1 Item</span>
         </a>
     </li>
@@ -917,7 +917,7 @@ export const nestedListWithGroupHeaders = () => `
     </li>
     <li class="fd-nested-list__item">
         <a class="fd-nested-list__link"href="#/">
-            <span class="fd-nested-list__icon sap-icon--bar-chart"></span>
+            <span aria-hidden="true" class="fd-nested-list__icon sap-icon--bar-chart"></span>
             <span class="fd-nested-list__title">Level 1 Item</span>
         </a>
     </li>
@@ -942,20 +942,20 @@ export const nestedListWithGroupHeadersCompactMode = () => `
     </li>
     <li class="fd-nested-list__item">
         <a class="fd-nested-list__link"href="#/">
-            <span class="fd-nested-list__icon sap-icon--home"></span>
+            <span aria-hidden="true" class="fd-nested-list__icon sap-icon--home"></span>
             <span class="fd-nested-list__title">Level 1 Item</span>
         </a>
     </li>
     <li class="fd-nested-list__item">
         <a class="fd-nested-list__link is-selected"href="#/">
-            <span class="fd-nested-list__icon sap-icon--calendar"></span>
+            <span aria-hidden="true" class="fd-nested-list__icon sap-icon--calendar"></span>
             <span class="fd-nested-list__title">Level 1 Item</span>
         </a>
     </li>
     <li class="fd-nested-list__item">
 	   <div class="fd-nested-list__content has-child" tabindex="0">
 			<a class="fd-nested-list__link" href="#" tabindex="-1">
-            	<span class="fd-nested-list__icon sap-icon--employee"></span>
+            	<span aria-hidden="true" class="fd-nested-list__icon sap-icon--employee"></span>
 				<span class="fd-nested-list__title">Level 1 Item</span>
 			</a>
             <button class="fd-button fd-nested-list__button"
@@ -1032,7 +1032,7 @@ export const nestedListWithGroupHeadersCompactMode = () => `
     </li>
     <li class="fd-nested-list__item">
         <a class="fd-nested-list__link"href="#/">
-            <span class="fd-nested-list__icon sap-icon--activities"></span>
+            <span aria-hidden="true" class="fd-nested-list__icon sap-icon--activities"></span>
             <span class="fd-nested-list__title">Level 1 Item</span>
         </a>
     </li>
@@ -1041,7 +1041,7 @@ export const nestedListWithGroupHeadersCompactMode = () => `
     </li>
     <li class="fd-nested-list__item">
         <a class="fd-nested-list__link"href="#/">
-            <span class="fd-nested-list__icon sap-icon--bar-chart"></span>
+            <span aria-hidden="true" class="fd-nested-list__icon sap-icon--bar-chart"></span>
             <span class="fd-nested-list__title">Level 1 Item</span>
         </a>
     </li>
@@ -1066,19 +1066,19 @@ export const nestedListWithoutLinks = () => `
     </li>
     <li class="fd-nested-list__item">
         <div class="fd-nested-list__content">
-            <span class="fd-nested-list__icon sap-icon--home"></span>
+            <span aria-hidden="true" class="fd-nested-list__icon sap-icon--home"></span>
             <span class="fd-nested-list__title">Level 1 Item</span>
         </div>
     </li>
     <li class="fd-nested-list__item">
         <div class="fd-nested-list__content is-selected">
-            <span class="fd-nested-list__icon sap-icon--calendar"></span>
+            <span aria-hidden="true" class="fd-nested-list__icon sap-icon--calendar"></span>
             <span class="fd-nested-list__title">Level 1 Item</span>
         </div>
     </li>
     <li class="fd-nested-list__item">
 	   <div class="fd-nested-list__content has-child" tabindex="0">
-            <span class="fd-nested-list__icon sap-icon--employee"></span>
+            <span aria-hidden="true" class="fd-nested-list__icon sap-icon--employee"></span>
 			<span class="fd-nested-list__title">Level 1 Item</span>
             <button class="fd-button fd-nested-list__button"
                 aria-controls="EX600L2"
@@ -1150,7 +1150,7 @@ export const nestedListWithoutLinks = () => `
     </li>
     <li class="fd-nested-list__item">
         <div class="fd-nested-list__content">
-            <span class="fd-nested-list__icon sap-icon--activities"></span>
+            <span aria-hidden="true" class="fd-nested-list__icon sap-icon--activities"></span>
             <span class="fd-nested-list__title">Level 1 Item</span>
         </div>
     </li>
@@ -1159,7 +1159,7 @@ export const nestedListWithoutLinks = () => `
     </li>
     <li class="fd-nested-list__item">
         <div class="fd-nested-list__content">
-            <span class="fd-nested-list__icon sap-icon--bar-chart"></span>
+            <span aria-hidden="true" class="fd-nested-list__icon sap-icon--bar-chart"></span>
             <span class="fd-nested-list__title">Level 1 Item</span>
         </div>
     </li>
@@ -1185,20 +1185,20 @@ export const rtlExample = () => `
     </li>
     <li class="fd-nested-list__item">
         <a class="fd-nested-list__link"href="#/">
-            <span class="fd-nested-list__icon sap-icon--home"></span>
+            <span aria-hidden="true" class="fd-nested-list__icon sap-icon--home" aria-hidden="true"></span>
             <span class="fd-nested-list__title">Level 1 Item</span>
         </a>
     </li>
     <li class="fd-nested-list__item">
         <a class="fd-nested-list__link is-selected"href="#/">
-            <span class="fd-nested-list__icon sap-icon--calendar"></span>
+            <span aria-hidden="true" class="fd-nested-list__icon sap-icon--calendar"></span>
             <span class="fd-nested-list__title">Level 1 Item</span>
         </a>
     </li>
     <li class="fd-nested-list__item">
 	   <div class="fd-nested-list__content has-child" tabindex="0">
 			<a class="fd-nested-list__link" href="#" tabindex="-1">
-				<span class="fd-nested-list__icon sap-icon--employee"></span>
+				<span aria-hidden="true" class="fd-nested-list__icon sap-icon--employee"></span>
 				<span class="fd-nested-list__title">Level 1 Item</span>
 			</a>
             <button class="fd-button fd-nested-list__button" 
@@ -1275,7 +1275,7 @@ export const rtlExample = () => `
     </li>
     <li class="fd-nested-list__item">
         <a class="fd-nested-list__link"href="#/">
-            <span class="fd-nested-list__icon sap-icon--activities"></span>
+            <span aria-hidden="true" class="fd-nested-list__icon sap-icon--activities"></span>
             <span class="fd-nested-list__title">Level 1 Item</span>
         </a>
     </li>
@@ -1284,7 +1284,7 @@ export const rtlExample = () => `
     </li>
     <li class="fd-nested-list__item">
         <a class="fd-nested-list__link"href="#/">
-            <span class="fd-nested-list__icon sap-icon--bar-chart"></span>
+            <span aria-hidden="true" class="fd-nested-list__icon sap-icon--bar-chart"></span>
             <span class="fd-nested-list__title">Level 1 Item</span>
         </a>
     </li>


### PR DESCRIPTION
## Related Issue
Part of: SAP/fundamental-styles#1603
and #1639

## Description
This PR:
- Styles icon element with icon mixins
- Adds aria attributes

### Before:
```
<span class="fd-nested-list__icon sap-icon--chain-link"></span>
```
### After:
```
<span aria-hidden="true" class="fd-nested-list__icon sap-icon--chain-link"></span>
```

#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
