### PR TITLE
fix: Refactor icons and text in object marker

### DIFF
--- a/src/object-marker.scss
+++ b/src/object-marker.scss
@@ -48,8 +48,6 @@ $block: #{$fd-namespace}-object-marker;
   }
 
   &__icon {
-    @include fd-reset();
-
     @include fd-icon-selector() {
       @include fd-flex-center();
 

--- a/src/object-marker.scss
+++ b/src/object-marker.scss
@@ -15,98 +15,70 @@ $block: #{$fd-namespace}-object-marker;
   $fd-object-marker-padding-right: 0.25rem !default;
 
   @include fd-reset();
-  @include fd-ellipsis();
 
   max-width: 100%;
-  color: $fd-object-marker-text-color;
-  word-break: break-word;
-  align-items: center;
   line-height: 1;
-  display: inline-block;
   font-size: 1rem;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-
-  &::before {
-    font-size: 1rem;
-    color: $fd-object-marker-color;
-    padding: 0 $fd-object-marker-padding-right 0 0;
-    vertical-align: middle;
-  }
+  display: inline-flex;
+  align-items: center;
 
   // CLICKABLE OBJECT STATUS
   &--link {
-    display: inline-block;
+    cursor: pointer;
     text-decoration: none;
     color: $fd-object-marker-color;
-    cursor: pointer;
 
-    &::before {
-      position: relative;
-      display: inline-block;
+    .#{$block}__text {
+      color: $fd-object-marker-color;
     }
 
-    &:focus {
-      text-decoration: underline;
-    }
-
-    &:hover {
-      text-decoration: underline;
-      color: $fd-object-marker-color-hover;
-
-      &::before {
-        text-decoration: none;
+    &:focus,
+    &:hover,
+    &:visited {
+      .#{$block}__text {
+        text-decoration: underline;
       }
     }
 
-    &:visited {
-      text-decoration: none;
+    &:hover {
+      .#{$block}__text {
+        color: $fd-object-marker-color-hover;
+      }
     }
   }
 
   &__icon {
-    color: $fd-object-marker-color;
-    font-style: normal;
-    line-height: normal;
-    font-size: 1rem;
+    @include fd-reset();
 
-    &::before {
+    @include fd-icon-selector() {
+      @include fd-flex-center();
+
+      font-size: 1rem;
+      line-height: normal;
+      color: $fd-object-marker-color;
       padding-right: $fd-object-marker-padding-right;
-    }
 
-    @include fd-rtl() {
-      &::before {
+      &:only-child {
+        padding-right: 0;
+        padding-left: 0;
+      }
+
+      @include fd-rtl() {
         padding-left: $fd-object-marker-padding-right;
         padding-right: 0;
       }
     }
   }
 
-  // ICON ONLY MODE
-  @include fd-empty() {
-    justify-content: center;
-    padding-right: 0;
-    padding-left: 0;
+  &__text {
+    @include fd-reset();
+    @include fd-ellipsis();
 
-    &::before {
-      padding-right: 0;
-      padding-left: 0;
-    }
-  }
-
-  @include fd-rtl() {
-    &::before {
-      padding-left: $fd-object-marker-padding-right;
-      padding-right: 0;
-    }
-
-    @include fd-empty() {
-      &::before {
-        padding-right: 0;
-        padding-left: 0;
-      }
-    }
+    font-size: 1rem;
+    font-style: normal;
+    line-height: normal;
+    word-break: break-word;
+    color: $fd-object-marker-text-color;
   }
 
   & + .#{$block} {

--- a/src/object-marker.scss
+++ b/src/object-marker.scss
@@ -48,7 +48,7 @@ $block: #{$fd-namespace}-object-marker;
   }
 
   &__icon {
-    @include fd-icon-selector() {
+    @include fd-icon-element-base() {
       @include fd-flex-center();
 
       font-size: 1rem;

--- a/src/object-marker.scss
+++ b/src/object-marker.scss
@@ -56,7 +56,7 @@ $block: #{$fd-namespace}-object-marker;
       color: $fd-object-marker-color;
       padding-right: $fd-object-marker-padding-right;
 
-      &:only-child {
+      @include fd-only-child() {
         padding-right: 0;
         padding-left: 0;
       }
@@ -64,6 +64,11 @@ $block: #{$fd-namespace}-object-marker;
       @include fd-rtl() {
         padding-left: $fd-object-marker-padding-right;
         padding-right: 0;
+
+        @include fd-only-child() {
+          padding-right: 0;
+          padding-left: 0;
+        }
       }
     }
   }

--- a/stories/object-marker/__snapshots__/object-marker.stories.storyshot
+++ b/stories/object-marker/__snapshots__/object-marker.stories.storyshot
@@ -7,20 +7,42 @@ exports[`Storyshots Components/Object Marker Clickable Object Marker 1`] = `
   <a
     class="fd-object-marker fd-object-marker--link"
   >
+    
+    
     <i
-      class="sap-icon--private fd-object-marker__icon"
+      class="fd-object-marker__icon sap-icon--private"
+      role="presentation"
     />
-    Locked
+    
+    
+    <span
+      class="fd-object-marker__text"
+    >
+      Locked
+    </span>
+    
+
   </a>
   
 
   <a
     class="fd-object-marker fd-object-marker--link"
   >
+    
+    
     <i
-      class="sap-icon--user-edit fd-object-marker__icon"
+      class="fd-object-marker__icon sap-icon--user-edit"
+      role="presentation"
     />
-    Unsaved Changes
+    
+    
+    <span
+      class="fd-object-marker__text"
+    >
+      Unsaved Changes
+    </span>
+    
+
   </a>
   
 
@@ -29,29 +51,51 @@ exports[`Storyshots Components/Object Marker Clickable Object Marker 1`] = `
     dir="rtl"
   >
     
-
+    
     <h4>
       RTL Support
     </h4>
     
-
+    
     <a
       class="fd-object-marker fd-object-marker--link"
     >
+      
+        
       <i
-        class="sap-icon--private fd-object-marker__icon"
+        class="fd-object-marker__icon sap-icon--private"
+        role="presentation"
       />
-      Locked
+      
+        
+      <span
+        class="fd-object-marker__text"
+      >
+        Locked
+      </span>
+      
+    
     </a>
     
-
+    
     <a
       class="fd-object-marker fd-object-marker--link"
     >
+      
+        
       <i
-        class="sap-icon--user-edit fd-object-marker__icon"
+        class="fd-object-marker__icon sap-icon--user-edit"
+        role="presentation"
       />
-      Unsaved Changes
+      
+        
+      <span
+        class="fd-object-marker__text"
+      >
+        Unsaved Changes
+      </span>
+      
+    
     </a>
     
 
@@ -65,54 +109,109 @@ exports[`Storyshots Components/Object Marker Icon And Text 1`] = `
 <section>
   
 
-  <span
+  <div
     class="fd-object-marker"
   >
+    
+    
     <i
-      class="sap-icon--request fd-object-marker__icon"
+      class="fd-object-marker__icon sap-icon--request"
+      role="presentation"
     />
-    Request
-  </span>
+    
+    
+    <span
+      class="fd-object-marker__text"
+    >
+      Request
+    </span>
+    
+
+  </div>
   
 
-  <span
+  <div
     class="fd-object-marker"
   >
+    
+    
     <i
-      class="sap-icon--favorite fd-object-marker__icon"
+      class="fd-object-marker__icon sap-icon--favorite"
+      role="presentation"
     />
-    Favourite
-  </span>
+    
+    
+    <span
+      class="fd-object-marker__text"
+    >
+      Favourite
+    </span>
+    
+
+  </div>
   
 
-  <span
+  <div
     class="fd-object-marker"
   >
+    
+    
     <i
-      class="sap-icon--flag fd-object-marker__icon"
+      class="fd-object-marker__icon sap-icon--flag"
+      role="presentation"
     />
-    Flag
-  </span>
+    
+    
+    <span
+      class="fd-object-marker__text"
+    >
+      Flag
+    </span>
+    
+
+  </div>
   
 
-  <span
+  <div
     class="fd-object-marker"
   >
+    
+    
     <i
-      class="sap-icon--user-edit fd-object-marker__icon"
+      class="fd-object-marker__icon sap-icon--user-edit"
+      role="presentation"
     />
-    Draft
-  </span>
+    
+    
+    <span
+      class="fd-object-marker__text"
+    >
+      Draft
+    </span>
+    
+
+  </div>
   
 
-  <span
-    class="fd-object-marker "
+  <div
+    class="fd-object-marker"
   >
+    
+    
     <i
-      class="sap-icon--private fd-object-marker__icon"
+      class="fd-object-marker__icon sap-icon--private"
+      role="presentation"
     />
-    Locked
-  </span>
+    
+    
+    <span
+      class="fd-object-marker__text"
+    >
+      Locked
+    </span>
+    
+
+  </div>
   
 
 
@@ -120,60 +219,115 @@ exports[`Storyshots Components/Object Marker Icon And Text 1`] = `
     dir="rtl"
   >
     
-
+    
     <h4>
       RTL Support
     </h4>
     
-
-    <span
+    
+    <div
       class="fd-object-marker"
     >
+      
+        
       <i
-        class="sap-icon--request fd-object-marker__icon"
+        class="fd-object-marker__icon sap-icon--request"
+        role="presentation"
       />
-      Request
-    </span>
+      
+        
+      <span
+        class="fd-object-marker__text"
+      >
+        Request
+      </span>
+      
     
-
-    <span
+    </div>
+    
+    
+    <div
       class="fd-object-marker"
     >
+      
+        
       <i
-        class="sap-icon--favorite fd-object-marker__icon"
+        class="fd-object-marker__icon sap-icon--favorite"
+        role="presentation"
       />
-      Favourite
-    </span>
+      
+        
+      <span
+        class="fd-object-marker__text"
+      >
+        Favourite
+      </span>
+      
     
-
-    <span
+    </div>
+    
+    
+    <div
       class="fd-object-marker"
     >
+      
+        
       <i
-        class="sap-icon--flag fd-object-marker__icon"
+        class="fd-object-marker__icon sap-icon--flag"
+        role="presentation"
       />
-      Flag
-    </span>
+      
+        
+      <span
+        class="fd-object-marker__text"
+      >
+        Flag
+      </span>
+      
     
-
-    <span
+    </div>
+    
+    
+    <div
       class="fd-object-marker"
     >
+      
+        
       <i
-        class="sap-icon--user-edit fd-object-marker__icon"
+        class="fd-object-marker__icon sap-icon--user-edit"
+        role="presentation"
       />
-      Draft
-    </span>
+      
+        
+      <span
+        class="fd-object-marker__text"
+      >
+        Draft
+      </span>
+      
     
-
-    <span
-      class="fd-object-marker "
+    </div>
+    
+    
+    <div
+      class="fd-object-marker"
     >
+      
+        
       <i
-        class="sap-icon--private fd-object-marker__icon"
+        class="fd-object-marker__icon sap-icon--private"
+        role="presentation"
       />
-      Locked
-    </span>
+      
+        
+      <span
+        class="fd-object-marker__text"
+      >
+        Locked
+      </span>
+      
+    
+    </div>
     
 
   </div>
@@ -186,54 +340,74 @@ exports[`Storyshots Components/Object Marker Icon Only 1`] = `
 <section>
   
 
-  <span
-    aria-label="icon for request"
+  <div
     class="fd-object-marker"
   >
+    
+    
     <i
-      class="sap-icon--request fd-object-marker__icon"
+      aria-label="icon for request"
+      class="fd-object-marker__icon sap-icon--request"
     />
-  </span>
+    
+
+  </div>
   
 
-  <span
-    aria-label="icon for favourite"
+  <div
     class="fd-object-marker"
   >
+    
+    
     <i
-      class="sap-icon--favorite fd-object-marker__icon"
+      aria-label="icon for favourite"
+      class="fd-object-marker__icon sap-icon--favorite"
     />
-  </span>
+    
+
+  </div>
   
 
-  <span
-    aria-label="icon for flag"
+  <div
     class="fd-object-marker"
   >
+    
+    
     <i
-      class="sap-icon--flag fd-object-marker__icon"
+      aria-label="icon for flag"
+      class="fd-object-marker__icon sap-icon--flag"
     />
-  </span>
+    
+
+  </div>
   
 
-  <span
-    aria-label="icon for user edit"
+  <div
     class="fd-object-marker"
   >
+    
+    
     <i
-      class="sap-icon--user-edit fd-object-marker__icon"
+      aria-label="icon for user edit"
+      class="fd-object-marker__icon sap-icon--user-edit"
     />
-  </span>
+    
+
+  </div>
   
 
-  <span
-    aria-label="icon for private"
+  <div
     class="fd-object-marker"
   >
+    
+    
     <i
-      class="sap-icon--private fd-object-marker__icon"
+      aria-label="icon for private"
+      class="fd-object-marker__icon sap-icon--private"
     />
-  </span>
+    
+
+  </div>
   
 
 </section>
@@ -243,18 +417,34 @@ exports[`Storyshots Components/Object Marker Marker Text 1`] = `
 <section>
   
 
-  <span
+  <div
     class="fd-object-marker"
   >
-    Draft
-  </span>
+    
+    
+    <span
+      class="fd-object-marker__text"
+    >
+      Draft
+    </span>
+    
+
+  </div>
   
 
-  <span
+  <div
     class="fd-object-marker"
   >
-    Locked
-  </span>
+    
+    
+    <span
+      class="fd-object-marker__text"
+    >
+      Locked
+    </span>
+    
+
+  </div>
   
 
 </section>

--- a/stories/object-marker/object-marker.stories.js
+++ b/stories/object-marker/object-marker.stories.js
@@ -15,11 +15,21 @@ The technical status can be represented as an icon, with an icon and text, or as
  */
 
 export const iconOnly = () => `
-<span class="fd-object-marker" aria-label="icon for request"><i class="sap-icon--request fd-object-marker__icon"></i></span>
-<span class="fd-object-marker" aria-label="icon for favourite"><i class="sap-icon--favorite fd-object-marker__icon"></i></span>
-<span class="fd-object-marker" aria-label="icon for flag"><i class="sap-icon--flag fd-object-marker__icon"></i></span>
-<span class="fd-object-marker" aria-label="icon for user edit"><i class="sap-icon--user-edit fd-object-marker__icon"></i></span>
-<span class="fd-object-marker" aria-label="icon for private"><i class="sap-icon--private fd-object-marker__icon"></i></span>
+<div class="fd-object-marker">
+    <i class="fd-object-marker__icon sap-icon--request" aria-label="icon for request"></i>
+</div>
+<div class="fd-object-marker">
+    <i class="fd-object-marker__icon sap-icon--favorite" aria-label="icon for favourite"></i>
+</div>
+<div class="fd-object-marker">
+    <i class="fd-object-marker__icon sap-icon--flag" aria-label="icon for flag"></i>
+</div>
+<div class="fd-object-marker">
+    <i class="fd-object-marker__icon sap-icon--user-edit" aria-label="icon for user edit"></i>
+</div>
+<div class="fd-object-marker">
+    <i class="fd-object-marker__icon sap-icon--private" aria-label="icon for private"></i>
+</div>
 `;
 
 /**
@@ -27,8 +37,12 @@ export const iconOnly = () => `
  */
 
 export const markerText = () => `
-<span class="fd-object-marker">Draft</span>
-<span class="fd-object-marker">Locked</span>
+<div class="fd-object-marker">
+    <span class="fd-object-marker__text">Draft</span>
+</div>
+<div class="fd-object-marker">
+    <span class="fd-object-marker__text">Locked</span>
+</div>
 `;
 
 /**
@@ -36,19 +50,49 @@ export const markerText = () => `
  */
 
 export const iconAndText = () => `
-<span class="fd-object-marker"><i class="sap-icon--request fd-object-marker__icon"></i>Request</span>
-<span class="fd-object-marker"><i class="sap-icon--favorite fd-object-marker__icon"></i>Favourite</span>
-<span class="fd-object-marker"><i class="sap-icon--flag fd-object-marker__icon"></i>Flag</span>
-<span class="fd-object-marker"><i class="sap-icon--user-edit fd-object-marker__icon"></i>Draft</span>
-<span class="fd-object-marker "><i class="sap-icon--private fd-object-marker__icon"></i>Locked</span>
+<div class="fd-object-marker">
+    <i class="fd-object-marker__icon sap-icon--request" role="presentation"></i>
+    <span class="fd-object-marker__text">Request</span>
+</div>
+<div class="fd-object-marker">
+    <i class="fd-object-marker__icon sap-icon--favorite" role="presentation"></i>
+    <span class="fd-object-marker__text">Favourite</span>
+</div>
+<div class="fd-object-marker">
+    <i class="fd-object-marker__icon sap-icon--flag" role="presentation"></i>
+    <span class="fd-object-marker__text">Flag</span>
+</div>
+<div class="fd-object-marker">
+    <i class="fd-object-marker__icon sap-icon--user-edit" role="presentation"></i>
+    <span class="fd-object-marker__text">Draft</span>
+</div>
+<div class="fd-object-marker">
+    <i class="fd-object-marker__icon sap-icon--private" role="presentation"></i>
+    <span class="fd-object-marker__text">Locked</span>
+</div>
 
 <div dir="rtl">
-<h4>RTL Support</h4>
-<span class="fd-object-marker"><i class="sap-icon--request fd-object-marker__icon"></i>Request</span>
-<span class="fd-object-marker"><i class="sap-icon--favorite fd-object-marker__icon"></i>Favourite</span>
-<span class="fd-object-marker"><i class="sap-icon--flag fd-object-marker__icon"></i>Flag</span>
-<span class="fd-object-marker"><i class="sap-icon--user-edit fd-object-marker__icon"></i>Draft</span>
-<span class="fd-object-marker "><i class="sap-icon--private fd-object-marker__icon"></i>Locked</span>
+    <h4>RTL Support</h4>
+    <div class="fd-object-marker">
+        <i class="fd-object-marker__icon sap-icon--request" role="presentation"></i>
+        <span class="fd-object-marker__text">Request</span>
+    </div>
+    <div class="fd-object-marker">
+        <i class="fd-object-marker__icon sap-icon--favorite" role="presentation"></i>
+        <span class="fd-object-marker__text">Favourite</span>
+    </div>
+    <div class="fd-object-marker">
+        <i class="fd-object-marker__icon sap-icon--flag" role="presentation"></i>
+        <span class="fd-object-marker__text">Flag</span>
+    </div>
+    <div class="fd-object-marker">
+        <i class="fd-object-marker__icon sap-icon--user-edit" role="presentation"></i>
+        <span class="fd-object-marker__text">Draft</span>
+    </div>
+    <div class="fd-object-marker">
+        <i class="fd-object-marker__icon sap-icon--private" role="presentation"></i>
+        <span class="fd-object-marker__text">Locked</span>
+    </div>
 </div>
 `;
 iconAndText.parameters = {
@@ -65,13 +109,25 @@ iconAndText.parameters = {
  */
 
 export const clickableObjectMarker = () => `
-<a class="fd-object-marker fd-object-marker--link"><i class="sap-icon--private fd-object-marker__icon"></i>Locked</a>
-<a class="fd-object-marker fd-object-marker--link"><i class="sap-icon--user-edit fd-object-marker__icon"></i>Unsaved Changes</a>
+<a class="fd-object-marker fd-object-marker--link">
+    <i class="fd-object-marker__icon sap-icon--private" role="presentation"></i>
+    <span class="fd-object-marker__text">Locked</span>
+</a>
+<a class="fd-object-marker fd-object-marker--link">
+    <i class="fd-object-marker__icon sap-icon--user-edit" role="presentation"></i>
+    <span class="fd-object-marker__text">Unsaved Changes</span>
+</a>
 
 <div dir="rtl">
-<h4>RTL Support</h4>
-<a class="fd-object-marker fd-object-marker--link"><i class="sap-icon--private fd-object-marker__icon"></i>Locked</a>
-<a class="fd-object-marker fd-object-marker--link"><i class="sap-icon--user-edit fd-object-marker__icon"></i>Unsaved Changes</a>
+    <h4>RTL Support</h4>
+    <a class="fd-object-marker fd-object-marker--link">
+        <i class="fd-object-marker__icon sap-icon--private" role="presentation"></i>
+        <span class="fd-object-marker__text">Locked</span>
+    </a>
+    <a class="fd-object-marker fd-object-marker--link">
+        <i class="fd-object-marker__icon sap-icon--user-edit" role="presentation"></i>
+        <span class="fd-object-marker__text">Unsaved Changes</span>
+    </a>
 </div>
 `;
 clickableObjectMarker.parameters = {


### PR DESCRIPTION
## Related Issue
Part of: #1603 
and #1639

## Description
There is added 1 new element:
`fd-object-status__text`
And added A11Y support in markup.

Breaking Change:
Before:
```
<span class="fd-object-marker">Locked</span>
```

After:
```
<div class="fd-object-marker">
    <span class="fd-object-marker__text">Draft</span>
</div>
```

#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
