### PR TITLE
feat: Basic Grid Table example, caption element

### DIFF
--- a/src/table.scss
+++ b/src/table.scss
@@ -304,6 +304,10 @@ $block: #{$fd-namespace}-table;
     justify-content: space-between;
   }
 
+  &__instructions {
+    @include fd-screen-reader-only();
+  }
+
   &__popover.#{$fd-namespace}-popover {
     height: 100%;
     display: block;

--- a/src/table.scss
+++ b/src/table.scss
@@ -304,7 +304,7 @@ $block: #{$fd-namespace}-table;
     justify-content: space-between;
   }
 
-  &__instructions {
+  &__caption {
     @include fd-screen-reader-only();
   }
 

--- a/stories/table/__snapshots__/table.stories.storyshot
+++ b/stories/table/__snapshots__/table.stories.storyshot
@@ -6977,6 +6977,11 @@ exports[`Storyshots Components/Table With Footer Condensed 1`] = `
 </section>
 `;
 
+exports[`Storyshots Components/Table With Inputs 1`] = `
+
+
+`;
+
 exports[`Storyshots Components/Table With Menu In Header 1`] = `
 <section>
   

--- a/stories/table/__snapshots__/table.stories.storyshot
+++ b/stories/table/__snapshots__/table.stories.storyshot
@@ -891,6 +891,11 @@ exports[`Storyshots Components/Table Focusable Rows 1`] = `
 </section>
 `;
 
+exports[`Storyshots Components/Table Grid Table 1`] = `
+
+
+`;
+
 exports[`Storyshots Components/Table Interactive Table With Hoverable and Activable Cells and Rows 1`] = `
 <section>
   
@@ -6975,11 +6980,6 @@ exports[`Storyshots Components/Table With Footer Condensed 1`] = `
   
 
 </section>
-`;
-
-exports[`Storyshots Components/Table With Inputs 1`] = `
-
-
 `;
 
 exports[`Storyshots Components/Table With Menu In Header 1`] = `

--- a/stories/table/table.stories.js
+++ b/stories/table/table.stories.js
@@ -1653,12 +1653,12 @@ export const navigationIndicationStates = () => `
 </div>
 `;
 
-/** Grid tables can contain various input elements inside of cells. Provide information about the table for screen readers (such as a title and / or keyboard navigation instructions) using the `fd-table__caption` class. */
+/** Grid tables can contain various input elements inside of cells. Provide information about the table for screen readers (such as a title, summary, and / or keyboard navigation instructions) using the `fd-table__caption` class. */
 
 export const gridTable = () => `
-<table class="fd-table">
-    <caption class="fd-table__caption" id="FU4EwF6st">
-        <div aria-live="polite">Use arrow keys to navigate between cells</div>
+<table class="fd-table" aria-describedby="FU4EwF6st">
+    <caption class="fd-table__caption" id="FU4EwF6st" aria-live="polite">
+        Inventory Status. Use arrow keys to navigate between cells.
     </caption>
     <thead class="fd-table__header">
         <tr class="fd-table__row">

--- a/stories/table/table.stories.js
+++ b/stories/table/table.stories.js
@@ -1652,3 +1652,280 @@ export const navigationIndicationStates = () => `
     </table>
 </div>
 `;
+
+/** Various input elements can be used inside of cells. Provide information about the table for screen readers (such as a title and / or keyboard navigation instructions) using the `fd-table__caption` class */
+
+export const withInputs = () => `
+<table class="fd-table">
+    <caption class="fd-table__caption" id="FU4EwF6st">
+        <div aria-live="polite">Use arrow keys to navigate between cells</div>
+    </caption>
+    <thead class="fd-table__header">
+        <tr class="fd-table__row">
+            <th class="fd-table__cell fd-table__cell--checkbox" tabindex="-1">
+                <div class="fd-form-item">
+                    <input aria-checked="false" aria-label="Select all rows" class="fd-checkbox" id="fd-gEAc87vXrAR" type="checkbox" value="" tabindex="-1" /><label for="fd-gEAc87vXrAR" class="fd-form-label fd-checkbox__label"></label>
+                </div>
+            </th>
+            <th class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                Product Name
+            </th>
+            <th class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                Product ID
+            </th>
+            <th class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                Quantity
+            </th>
+            <th class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                Status
+            </th>
+            <th class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                Supplier
+            </th>
+            <th class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                Image
+            </th>
+            <th class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                Heavy Weight
+            </th>
+            <th class="fd-table__cell fd-table__cell--focusable" tabindex="0">
+                Categories
+            </th>
+            <th class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                Delivery Date
+            </th>
+        </tr>
+    </thead>
+    <tbody class="fd-table__body">
+        <tr class="fd-table__row" aria-selected="false">
+            <td class="fd-table__cell fd-table__cell--checkbox" tabindex="-1">
+                <div class="fd-form-item">
+                    <input aria-checked="false" aria-label="Select row" class="fd-checkbox" id="fd-7EMZOUrG2eK" name="Notebook Basic 15" type="checkbox" value="" tabindex="-1" />
+                    <label for="fd-7EMZOUrG2eK" class="fd-form-label fd-checkbox__label"></label>
+                </div>
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <span>Notebook Basic 15</span>
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <input class="fd-input" name="Notebook Basic 15" type="text" value="HT-1000" tabindex="-1" />
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <span>10</span>
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <span class="fd-object-status fd-object-status--positive">Available</span>
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <div class="fd-popover">
+                    <div class="fd-popover__control">
+                        <div class="fd-select" role="combobox" tabindex="-1" aria-controls="fd-tdEfCXd9Rt5" aria-expanded="false" aria-haspopup="listbox">
+                            <div class="fd-select__control">
+                                <span class="fd-select__text-content">Very Best Screens</span>
+                                <span class="fd-button fd-button--transparent fd-select__button"><i aria-hidden="true" class="sap-icon--slim-arrow-down" role="img"></i></span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <a href="https://openui5.hana.ondemand.com/test-resources/sap/ui/documentation/sdk/images/HT-1000.jpg" class="fd-link" tabindex="-1">Show image</a>
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <div class="fd-form-item">
+                    <input aria-checked="false" aria-label="Heavy Weight" class="fd-checkbox" id="fd-tF03y4hjeLT" type="checkbox" value="" tabindex="-1" /><label for="fd-tF03y4hjeLT" class="fd-form-label fd-checkbox__label"></label>
+                </div>
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <input class="fd-input" type="text" value="" tabindex="-1" />
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <div class="fd-popover">
+                    <div class="fd-popover__control">
+                        <div aria-expanded="false" aria-haspopup="true" class="fd-input-group--control fd-input-group">
+                            <input class="fd-input fd-input-group__input" placeholder="MM/DD/YYYY" type="text" value="" tabindex="-1" />
+                            <span class="fd-input-group__addon fd-input-group__addon--button">
+                                <button aria-label="Choose date" class="fd-button fd-button--transparent fd-input-group__button" type="button" tabindex="-1">
+                                    <i aria-hidden="true" class="sap-icon--appointment-2" role="img"></i>
+                                </button>
+                            </span>
+                        </div>
+                    </div>
+                </div>
+            </td>
+        </tr>
+        <tr class="fd-table__row" aria-selected="false">
+            <td class="fd-table__cell fd-table__cell--checkbox" tabindex="-1">
+                <div class="fd-form-item">
+                    <input aria-checked="false" aria-label="Select row" class="fd-checkbox" id="fd-LbUmEre6JKj" name="Notebook Basic 17" type="checkbox" value="" tabindex="-1" />
+                    <label for="fd-LbUmEre6JKj" class="fd-form-label fd-checkbox__label"></label>
+                </div>
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <span>Notebook Basic 17</span>
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <input class="fd-input" name="Notebook Basic 17" type="text" value="HT-1001" tabindex="-1" />
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <span>0</span>
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <span class="fd-object-status fd-object-status--negative">Unavailable</span>
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <div class="fd-popover">
+                    <div class="fd-popover__control">
+                        <div class="fd-select" role="combobox" tabindex="-1" aria-controls="fd-WUd6z4F7gPr" aria-expanded="false" aria-haspopup="listbox">
+                            <div class="fd-select__control">
+                                <span class="fd-select__text-content">Fasttech</span>
+                                <span class="fd-button fd-button--transparent fd-select__button"><i aria-hidden="true" class="sap-icon--slim-arrow-down" role="img"></i></span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <a href="https://openui5.hana.ondemand.com/test-resources/sap/ui/documentation/sdk/images/HT-1001.jpg" class="fd-link" tabindex="-1">Show image</a>
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <div class="fd-form-item">
+                    <input aria-checked="false" aria-label="Heavy Weight" class="fd-checkbox" id="fd-9WXDOs3SBLH" type="checkbox" value="" tabindex="-1" /><label for="fd-9WXDOs3SBLH" class="fd-form-label fd-checkbox__label"></label>
+                </div>
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <input class="fd-input" type="text" value="" tabindex="-1" />
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <div class="fd-popover">
+                    <div class="fd-popover__control">
+                        <div aria-expanded="false" aria-haspopup="true" class="fd-input-group--control fd-input-group">
+                            <input class="fd-input fd-input-group__input" placeholder="MM/DD/YYYY" type="text" value="" tabindex="-1" />
+                            <span class="fd-input-group__addon fd-input-group__addon--button">
+                                <button aria-label="Choose date" class="fd-button fd-button--transparent fd-input-group__button" type="button" tabindex="-1">
+                                    <i aria-hidden="true" class="sap-icon--appointment-2" role="img"></i>
+                                </button>
+                            </span>
+                        </div>
+                    </div>
+                </div>
+            </td>
+        </tr>
+        <tr class="fd-table__row" aria-selected="false">
+            <td class="fd-table__cell fd-table__cell--checkbox" tabindex="-1">
+                <div class="fd-form-item">
+                    <input aria-checked="false" aria-label="Select row" class="fd-checkbox" id="fd-Cmvc_Hc7N3_" name="Notebook Basic 18" type="checkbox" value="" tabindex="-1" />
+                    <label for="fd-Cmvc_Hc7N3_" class="fd-form-label fd-checkbox__label"></label>
+                </div>
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <span>Notebook Basic 18</span>
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <input class="fd-input" name="Notebook Basic 18" type="text" value="HT-1002" tabindex="-1" />
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <span>13</span>
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <span class="fd-object-status fd-object-status--positive">Available</span>
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <div class="fd-popover">
+                    <div class="fd-popover__control">
+                        <div class="fd-select" role="combobox" tabindex="-1" aria-controls="fd-sYJBE7tEBss" aria-expanded="false" aria-haspopup="listbox">
+                            <div class="fd-select__control">
+                                <span class="fd-select__text-content">Printers for All</span>
+                                <span class="fd-button fd-button--transparent fd-select__button"><i aria-hidden="true" class="sap-icon--slim-arrow-down" role="img"></i></span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <a href="https://openui5.hana.ondemand.com/test-resources/sap/ui/documentation/sdk/images/HT-1002.jpg" class="fd-link" tabindex="-1">Show image</a>
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <div class="fd-form-item">
+                    <input aria-checked="false" aria-label="Heavy Weight" class="fd-checkbox" id="fd-Rzaro06MMoH" type="checkbox" value="" tabindex="-1" /><label for="fd-Rzaro06MMoH" class="fd-form-label fd-checkbox__label"></label>
+                </div>
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <input class="fd-input" type="text" value="" tabindex="-1" />
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <div class="fd-popover">
+                    <div class="fd-popover__control">
+                        <div aria-expanded="false" aria-haspopup="true" class="fd-input-group--control fd-input-group">
+                                <input class="fd-input fd-input-group__input" placeholder="MM/DD/YYYY" type="text" value="" tabindex="-1" />
+                                <span class="fd-input-group__addon fd-input-group__addon--button">
+                                    <button aria-label="Choose date" class="fd-button fd-button--transparent fd-input-group__button" type="button" tabindex="-1">
+                                        <i aria-hidden="true" class="sap-icon--appointment-2" role="img"></i>
+                                    </button>
+                                </span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </td>
+        </tr>
+        <tr class="fd-table__row" aria-selected="false">
+            <td class="fd-table__cell fd-table__cell--checkbox" tabindex="-1">
+                <div class="fd-form-item">
+                    <input aria-checked="false" aria-label="Select row" class="fd-checkbox" id="fd-kgZvkuwUtB-" name="Notebook Basic 19" type="checkbox" value="" tabindex="-1" />
+                    <label for="fd-kgZvkuwUtB-" class="fd-form-label fd-checkbox__label"></label>
+                </div>
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <span>Notebook Basic 19</span>
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <input class="fd-input" name="Notebook Basic 19" type="text" value="HT-1003" tabindex="-1" />
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <span>15</span>
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <span class="fd-object-status fd-object-status--positive">Available</span>
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <div class="fd-popover">
+                    <div class="fd-popover__control">
+                        <div class="fd-select" role="combobox" tabindex="-1" aria-controls="fd-NvmIKgyb4ZV" aria-expanded="false" aria-haspopup="listbox">
+                            <div class="fd-select__control">
+                                <span class="fd-select__text-content">Technocom</span>
+                                <span class="fd-button fd-button--transparent fd-select__button"><i aria-hidden="true" class="sap-icon--slim-arrow-down" role="img"></i></span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <a href="https://openui5.hana.ondemand.com/test-resources/sap/ui/documentation/sdk/images/HT-1003.jpg" class="fd-link" tabindex="-1">Show image</a>
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <div class="fd-form-item">
+                    <input aria-checked="false" aria-label="Heavy Weight" class="fd-checkbox" id="fd-LHL3aUwc6pZ" type="checkbox" value="" tabindex="-1" /><label for="fd-LHL3aUwc6pZ" class="fd-form-label fd-checkbox__label"></label>
+                </div>
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <input class="fd-input" type="text" value="" tabindex="-1" />
+            </td>
+            <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+                <div class="fd-popover">
+                    <div class="fd-popover__control">
+                        <div aria-expanded="false" aria-haspopup="true" class="fd-input-group--control fd-input-group">
+                            <input class="fd-input fd-input-group__input" placeholder="MM/DD/YYYY" type="text" value="" tabindex="-1" />
+                            <span class="fd-input-group__addon fd-input-group__addon--button">
+                                <button aria-label="Choose date" class="fd-button fd-button--transparent fd-input-group__button" type="button" tabindex="-1">
+                                    <i aria-hidden="true" class="sap-icon--appointment-2" role="img"></i>
+                                </button>
+                            </span>
+                        </div>
+                    </div>
+                </div>
+            </td>
+        </tr>
+    </tbody>
+</table>
+`;

--- a/stories/table/table.stories.js
+++ b/stories/table/table.stories.js
@@ -1653,7 +1653,7 @@ export const navigationIndicationStates = () => `
 </div>
 `;
 
-/** Various input elements can be used inside of cells. Provide information about the table for screen readers (such as a title and / or keyboard navigation instructions) using the `fd-table__caption` class */
+/** Various input elements can be used inside of cells. Provide information about the table for screen readers (such as a title and / or keyboard navigation instructions) using the `fd-table__caption` class. */
 
 export const withInputs = () => `
 <table class="fd-table">
@@ -1717,12 +1717,14 @@ export const withInputs = () => `
                 <span class="fd-object-status fd-object-status--positive">Available</span>
             </td>
             <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
-                <div class="fd-popover">
-                    <div class="fd-popover__control">
-                        <div class="fd-select" role="combobox" tabindex="-1" aria-controls="fd-tdEfCXd9Rt5" aria-expanded="false" aria-haspopup="listbox">
-                            <div class="fd-select__control">
-                                <span class="fd-select__text-content">Very Best Screens</span>
-                                <span class="fd-button fd-button--transparent fd-select__button"><i aria-hidden="true" class="sap-icon--slim-arrow-down" role="img"></i></span>
+                <div class="fd-form-item">
+                    <div class="fd-popover">
+                        <div class="fd-popover__control">
+                            <div class="fd-select" role="combobox" tabindex="-1" aria-controls="fd-tdEfCXd9Rt5" aria-expanded="false" aria-haspopup="listbox">
+                                <div class="fd-select__control">
+                                    <span class="fd-select__text-content">Very Best Screens</span>
+                                    <span class="fd-button fd-button--transparent fd-select__button"><i aria-hidden="true" class="sap-icon--slim-arrow-down" role="img"></i></span>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -1774,12 +1776,14 @@ export const withInputs = () => `
                 <span class="fd-object-status fd-object-status--negative">Unavailable</span>
             </td>
             <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
-                <div class="fd-popover">
-                    <div class="fd-popover__control">
-                        <div class="fd-select" role="combobox" tabindex="-1" aria-controls="fd-WUd6z4F7gPr" aria-expanded="false" aria-haspopup="listbox">
-                            <div class="fd-select__control">
-                                <span class="fd-select__text-content">Fasttech</span>
-                                <span class="fd-button fd-button--transparent fd-select__button"><i aria-hidden="true" class="sap-icon--slim-arrow-down" role="img"></i></span>
+                <div class="fd-form-item">
+                    <div class="fd-popover">
+                        <div class="fd-popover__control">
+                            <div class="fd-select" role="combobox" tabindex="-1" aria-controls="fd-WUd6z4F7gPr" aria-expanded="false" aria-haspopup="listbox">
+                                <div class="fd-select__control">
+                                    <span class="fd-select__text-content">Fasttech</span>
+                                    <span class="fd-button fd-button--transparent fd-select__button"><i aria-hidden="true" class="sap-icon--slim-arrow-down" role="img"></i></span>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -1831,12 +1835,14 @@ export const withInputs = () => `
                 <span class="fd-object-status fd-object-status--positive">Available</span>
             </td>
             <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
-                <div class="fd-popover">
-                    <div class="fd-popover__control">
-                        <div class="fd-select" role="combobox" tabindex="-1" aria-controls="fd-sYJBE7tEBss" aria-expanded="false" aria-haspopup="listbox">
-                            <div class="fd-select__control">
-                                <span class="fd-select__text-content">Printers for All</span>
-                                <span class="fd-button fd-button--transparent fd-select__button"><i aria-hidden="true" class="sap-icon--slim-arrow-down" role="img"></i></span>
+                <div class="fd-form-item">
+                    <div class="fd-popover">
+                        <div class="fd-popover__control">
+                            <div class="fd-select" role="combobox" tabindex="-1" aria-controls="fd-sYJBE7tEBss" aria-expanded="false" aria-haspopup="listbox">
+                                <div class="fd-select__control">
+                                    <span class="fd-select__text-content">Printers for All</span>
+                                    <span class="fd-button fd-button--transparent fd-select__button"><i aria-hidden="true" class="sap-icon--slim-arrow-down" role="img"></i></span>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -1889,12 +1895,14 @@ export const withInputs = () => `
                 <span class="fd-object-status fd-object-status--positive">Available</span>
             </td>
             <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
-                <div class="fd-popover">
-                    <div class="fd-popover__control">
-                        <div class="fd-select" role="combobox" tabindex="-1" aria-controls="fd-NvmIKgyb4ZV" aria-expanded="false" aria-haspopup="listbox">
-                            <div class="fd-select__control">
-                                <span class="fd-select__text-content">Technocom</span>
-                                <span class="fd-button fd-button--transparent fd-select__button"><i aria-hidden="true" class="sap-icon--slim-arrow-down" role="img"></i></span>
+                <div class="fd-form-item">
+                    <div class="fd-popover">
+                        <div class="fd-popover__control">
+                            <div class="fd-select" role="combobox" tabindex="-1" aria-controls="fd-NvmIKgyb4ZV" aria-expanded="false" aria-haspopup="listbox">
+                                <div class="fd-select__control">
+                                    <span class="fd-select__text-content">Technocom</span>
+                                    <span class="fd-button fd-button--transparent fd-select__button"><i aria-hidden="true" class="sap-icon--slim-arrow-down" role="img"></i></span>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/stories/table/table.stories.js
+++ b/stories/table/table.stories.js
@@ -1662,36 +1662,36 @@ export const gridTable = () => `
     </caption>
     <thead class="fd-table__header">
         <tr class="fd-table__row">
-            <th class="fd-table__cell fd-table__cell--checkbox" tabindex="-1">
+            <th id="fd-4C0WYEyPqUS" class="fd-table__cell fd-table__cell--checkbox" tabindex="-1">
                 <div class="fd-form-item">
                     <input aria-checked="false" aria-label="Select all rows" class="fd-checkbox" id="fd-gEAc87vXrAR" type="checkbox" value="" tabindex="-1" /><label for="fd-gEAc87vXrAR" class="fd-form-label fd-checkbox__label"></label>
                 </div>
             </th>
-            <th class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+            <th id="fd-KWRjZC5EqkW" class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
                 Product Name
             </th>
-            <th class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+            <th id="fd-NPWFoAxBzUa" class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
                 Product ID
             </th>
-            <th class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+            <th id="fd-jtbiFXSC7Uy" class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
                 Quantity
             </th>
-            <th class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+            <th id="fd-mQuRgWM6D0u" class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
                 Status
             </th>
-            <th class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+            <th id="fd-hEzpEm5PMU2" class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
                 Supplier
             </th>
-            <th class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+            <th id="fd-NujEpyB6EkG" class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
                 Image
             </th>
-            <th class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+            <th id="fd-NMFoRAVbFky" class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
                 Heavy Weight
             </th>
-            <th class="fd-table__cell fd-table__cell--focusable" tabindex="0">
+            <th id="fd-OspcU6H7F0q" class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
                 Categories
             </th>
-            <th class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
+            <th id="fd-nEac1Ko5K0e" class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
                 Delivery Date
             </th>
         </tr>
@@ -1708,7 +1708,7 @@ export const gridTable = () => `
                 <span>Notebook Basic 15</span>
             </td>
             <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
-                <input class="fd-input" name="Notebook Basic 15" type="text" value="HT-1000" tabindex="-1" />
+                <input aria-labelledby="fd-NPWFoAxBzUa" class="fd-input" name="Notebook Basic 15" type="text" value="HT-1000" tabindex="-1" />
             </td>
             <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
                 <span>10</span>
@@ -1720,7 +1720,7 @@ export const gridTable = () => `
                 <div class="fd-form-item">
                     <div class="fd-popover">
                         <div class="fd-popover__control">
-                            <div class="fd-select" role="combobox" tabindex="-1" aria-controls="fd-tdEfCXd9Rt5" aria-expanded="false" aria-haspopup="listbox">
+                            <div class="fd-select" role="combobox" tabindex="-1" aria-labelledby="fd-hEzpEm5PMU2" aria-expanded="false" aria-haspopup="listbox">
                                 <div class="fd-select__control">
                                     <span class="fd-select__text-content">Very Best Screens</span>
                                     <span class="fd-button fd-button--transparent fd-select__button"><i aria-hidden="true" class="sap-icon--slim-arrow-down" role="img"></i></span>
@@ -1739,13 +1739,13 @@ export const gridTable = () => `
                 </div>
             </td>
             <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
-                <input class="fd-input" type="text" value="" tabindex="-1" />
+                <input aria-labelledby="fd-OspcU6H7F0q" class="fd-input" type="text" value="" tabindex="-1" />
             </td>
             <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
                 <div class="fd-popover">
                     <div class="fd-popover__control">
                         <div aria-expanded="false" aria-haspopup="true" class="fd-input-group--control fd-input-group">
-                            <input class="fd-input fd-input-group__input" placeholder="MM/DD/YYYY" type="text" value="" tabindex="-1" />
+                            <input aria-labelledby="fd-nEac1Ko5K0e" class="fd-input fd-input-group__input" placeholder="MM/DD/YYYY" type="text" value="" tabindex="-1" />
                             <span class="fd-input-group__addon fd-input-group__addon--button">
                                 <button aria-label="Choose date" class="fd-button fd-button--transparent fd-input-group__button" type="button" tabindex="-1">
                                     <i aria-hidden="true" class="sap-icon--appointment-2" role="img"></i>
@@ -1767,7 +1767,7 @@ export const gridTable = () => `
                 <span>Notebook Basic 17</span>
             </td>
             <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
-                <input class="fd-input" name="Notebook Basic 17" type="text" value="HT-1001" tabindex="-1" />
+                <input aria-labelledby="fd-NPWFoAxBzUa" class="fd-input" name="Notebook Basic 17" type="text" value="HT-1001" tabindex="-1" />
             </td>
             <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
                 <span>0</span>
@@ -1779,7 +1779,7 @@ export const gridTable = () => `
                 <div class="fd-form-item">
                     <div class="fd-popover">
                         <div class="fd-popover__control">
-                            <div class="fd-select" role="combobox" tabindex="-1" aria-controls="fd-WUd6z4F7gPr" aria-expanded="false" aria-haspopup="listbox">
+                            <div class="fd-select" role="combobox" tabindex="-1" aria-labelledby="fd-hEzpEm5PMU2" aria-expanded="false" aria-haspopup="listbox">
                                 <div class="fd-select__control">
                                     <span class="fd-select__text-content">Fasttech</span>
                                     <span class="fd-button fd-button--transparent fd-select__button"><i aria-hidden="true" class="sap-icon--slim-arrow-down" role="img"></i></span>
@@ -1798,13 +1798,13 @@ export const gridTable = () => `
                 </div>
             </td>
             <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
-                <input class="fd-input" type="text" value="" tabindex="-1" />
+                <input aria-labelledby="fd-OspcU6H7F0q" class="fd-input" type="text" value="" tabindex="-1" />
             </td>
             <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
                 <div class="fd-popover">
                     <div class="fd-popover__control">
                         <div aria-expanded="false" aria-haspopup="true" class="fd-input-group--control fd-input-group">
-                            <input class="fd-input fd-input-group__input" placeholder="MM/DD/YYYY" type="text" value="" tabindex="-1" />
+                            <input aria-labelledby="fd-nEac1Ko5K0e" class="fd-input fd-input-group__input" placeholder="MM/DD/YYYY" type="text" value="" tabindex="-1" />
                             <span class="fd-input-group__addon fd-input-group__addon--button">
                                 <button aria-label="Choose date" class="fd-button fd-button--transparent fd-input-group__button" type="button" tabindex="-1">
                                     <i aria-hidden="true" class="sap-icon--appointment-2" role="img"></i>
@@ -1826,7 +1826,7 @@ export const gridTable = () => `
                 <span>Notebook Basic 18</span>
             </td>
             <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
-                <input class="fd-input" name="Notebook Basic 18" type="text" value="HT-1002" tabindex="-1" />
+                <input aria-labelledby="fd-NPWFoAxBzUa" class="fd-input" name="Notebook Basic 18" type="text" value="HT-1002" tabindex="-1" />
             </td>
             <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
                 <span>13</span>
@@ -1838,7 +1838,7 @@ export const gridTable = () => `
                 <div class="fd-form-item">
                     <div class="fd-popover">
                         <div class="fd-popover__control">
-                            <div class="fd-select" role="combobox" tabindex="-1" aria-controls="fd-sYJBE7tEBss" aria-expanded="false" aria-haspopup="listbox">
+                            <div class="fd-select" role="combobox" tabindex="-1" aria-labelledby="fd-hEzpEm5PMU2" aria-expanded="false" aria-haspopup="listbox">
                                 <div class="fd-select__control">
                                     <span class="fd-select__text-content">Printers for All</span>
                                     <span class="fd-button fd-button--transparent fd-select__button"><i aria-hidden="true" class="sap-icon--slim-arrow-down" role="img"></i></span>
@@ -1857,13 +1857,13 @@ export const gridTable = () => `
                 </div>
             </td>
             <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
-                <input class="fd-input" type="text" value="" tabindex="-1" />
+                <input aria-labelledby="fd-OspcU6H7F0q" class="fd-input" type="text" value="" tabindex="-1" />
             </td>
             <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
                 <div class="fd-popover">
                     <div class="fd-popover__control">
                         <div aria-expanded="false" aria-haspopup="true" class="fd-input-group--control fd-input-group">
-                                <input class="fd-input fd-input-group__input" placeholder="MM/DD/YYYY" type="text" value="" tabindex="-1" />
+                                <input aria-labelledby="fd-nEac1Ko5K0e" class="fd-input fd-input-group__input" placeholder="MM/DD/YYYY" type="text" value="" tabindex="-1" />
                                 <span class="fd-input-group__addon fd-input-group__addon--button">
                                     <button aria-label="Choose date" class="fd-button fd-button--transparent fd-input-group__button" type="button" tabindex="-1">
                                         <i aria-hidden="true" class="sap-icon--appointment-2" role="img"></i>
@@ -1886,7 +1886,7 @@ export const gridTable = () => `
                 <span>Notebook Basic 19</span>
             </td>
             <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
-                <input class="fd-input" name="Notebook Basic 19" type="text" value="HT-1003" tabindex="-1" />
+                <input aria-labelledby="fd-NPWFoAxBzUa" class="fd-input" name="Notebook Basic 19" type="text" value="HT-1003" tabindex="-1" />
             </td>
             <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
                 <span>15</span>
@@ -1898,7 +1898,7 @@ export const gridTable = () => `
                 <div class="fd-form-item">
                     <div class="fd-popover">
                         <div class="fd-popover__control">
-                            <div class="fd-select" role="combobox" tabindex="-1" aria-controls="fd-NvmIKgyb4ZV" aria-expanded="false" aria-haspopup="listbox">
+                            <div class="fd-select" role="combobox" tabindex="-1" aria-labelledby="fd-hEzpEm5PMU2" aria-expanded="false" aria-haspopup="listbox">
                                 <div class="fd-select__control">
                                     <span class="fd-select__text-content">Technocom</span>
                                     <span class="fd-button fd-button--transparent fd-select__button"><i aria-hidden="true" class="sap-icon--slim-arrow-down" role="img"></i></span>
@@ -1917,13 +1917,13 @@ export const gridTable = () => `
                 </div>
             </td>
             <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
-                <input class="fd-input" type="text" value="" tabindex="-1" />
+                <input aria-labelledby="fd-OspcU6H7F0q" class="fd-input" type="text" value="" tabindex="-1" />
             </td>
             <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
                 <div class="fd-popover">
                     <div class="fd-popover__control">
                         <div aria-expanded="false" aria-haspopup="true" class="fd-input-group--control fd-input-group">
-                            <input class="fd-input fd-input-group__input" placeholder="MM/DD/YYYY" type="text" value="" tabindex="-1" />
+                            <input aria-labelledby="fd-nEac1Ko5K0e" class="fd-input fd-input-group__input" placeholder="MM/DD/YYYY" type="text" value="" tabindex="-1" />
                             <span class="fd-input-group__addon fd-input-group__addon--button">
                                 <button aria-label="Choose date" class="fd-button fd-button--transparent fd-input-group__button" type="button" tabindex="-1">
                                     <i aria-hidden="true" class="sap-icon--appointment-2" role="img"></i>

--- a/stories/table/table.stories.js
+++ b/stories/table/table.stories.js
@@ -1653,9 +1653,9 @@ export const navigationIndicationStates = () => `
 </div>
 `;
 
-/** Various input elements can be used inside of cells. Provide information about the table for screen readers (such as a title and / or keyboard navigation instructions) using the `fd-table__caption` class. */
+/** Grid tables can contain various input elements inside of cells. Provide information about the table for screen readers (such as a title and / or keyboard navigation instructions) using the `fd-table__caption` class. */
 
-export const withInputs = () => `
+export const gridTable = () => `
 <table class="fd-table">
     <caption class="fd-table__caption" id="FU4EwF6st">
         <div aria-live="polite">Use arrow keys to navigate between cells</div>
@@ -1773,7 +1773,7 @@ export const withInputs = () => `
                 <span>0</span>
             </td>
             <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
-                <span class="fd-object-status fd-object-status--negative">Unavailable</span>
+                <span class="fd-object-status fd-object-status--negative">Out of stock</span>
             </td>
             <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
                 <div class="fd-form-item">


### PR DESCRIPTION
## Description

- Create basic Grid Table example inspired by https://openui5.hana.ondemand.com/entity/sap.ui.table.Table/sample/sap.ui.table.sample.Basic
- Create `fd-table__caption` element

This is an initial Grid Table example meant to show what the Table looks like with inputs inside of it. No huge changes to the component itself other than adding a `<caption>` for screen reader users.

## Screenshots
![Screen Shot 2020-09-17 at 6 04 51 PM](https://user-images.githubusercontent.com/22511993/93543398-54757c00-f910-11ea-90fc-90544e6f45c4.png)

#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
