### PR TITLE
fix: Remove redundant focus on empty forms

### DIFF
--- a/src/checkbox.scss
+++ b/src/checkbox.scss
@@ -139,10 +139,6 @@ $block: #{$fd-namespace}-checkbox;
   @include fd-focus() {
     + .#{$block}__label {
       @include fd-form-radio-focus($fd-checkbox-margin);
-
-      @include fd-empty() {
-        @include fd-form-radio-empty-focus($fd-checkbox-margin);
-      }
     }
   }
 
@@ -190,10 +186,6 @@ $block: #{$fd-namespace}-checkbox;
     @include fd-focus() {
       + .#{$block}__label {
         @include fd-form-radio-focus($fd-checkbox-margin-compact);
-
-        @include fd-empty() {
-          @include fd-form-radio-empty-focus($fd-checkbox-margin-compact);
-        }
       }
     }
   }

--- a/src/mixins/_forms.scss
+++ b/src/mixins/_forms.scss
@@ -146,21 +146,6 @@
   }
 }
 
-@mixin fd-form-radio-empty-focus($margin) {
-  $fd-radio-focus-offset: 0.125rem;
-
-  &::after {
-    content: "";
-    position: absolute;
-    border: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
-    top: $margin - $fd-radio-focus-offset;
-    left: $margin - $fd-radio-focus-offset;
-    bottom: $margin - $fd-radio-focus-offset;
-    right: $margin - $fd-radio-focus-offset;
-    @content;
-  }
-}
-
 @mixin fd-form-label() {
   $fd-label-spacing: 0.5rem;
 

--- a/src/radio.scss
+++ b/src/radio.scss
@@ -125,10 +125,6 @@ $block: #{$fd-namespace}-radio;
   @include fd-focus() {
     + .#{$block}__label {
       @include fd-form-radio-focus($fd-radio-outer-circle-margin);
-
-      @include fd-empty() {
-        @include fd-form-radio-empty-focus($fd-radio-outer-circle-margin);
-      }
     }
   }
 
@@ -183,10 +179,6 @@ $block: #{$fd-namespace}-radio;
     @include fd-focus() {
       + .#{$block}__label {
         @include fd-form-radio-focus($fd-radio-outer-circle-margin-compact);
-
-        @include fd-empty() {
-          @include fd-form-radio-empty-focus($fd-radio-outer-circle-margin-compact);
-        }
       }
     }
   }


### PR DESCRIPTION
## Related Issue
Part of https://github.com/SAP/fundamental-styles/issues/1433

## Description
There was missed leftover after old focus indicator. So the focus ring appeared twice on empty checkboxes and radio buttons
Focus pseudo elements were removed in https://github.com/SAP/fundamental-styles/pull/1283 .

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/26483208/93597692-c1921b80-f9bb-11ea-8c7f-a7d3acf1b6ed.png)


### After:
![image](https://user-images.githubusercontent.com/26483208/93597669-b7701d00-f9bb-11ea-86e3-96e7449d3ba8.png)

#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
