### PR TITLE
fix: Numeric Content - Refactor icons usage #2

### DIFF
--- a/src/numeric-content.scss
+++ b/src/numeric-content.scss
@@ -13,6 +13,18 @@ $fd-numeric-content-elements-spacing-s: 0.5rem !default;
   max-width: $width;
 }
 
+@mixin scale-color($color) {
+  .#{$block}__scale-arrow {
+    @include fd-icon-selector() {
+      color: $color;
+    }
+  }
+
+  .#{$block}__scale-text {
+    color: $color;
+  }
+}
+
 @mixin small-tile-values() {
   height: 2.375rem;
 
@@ -37,7 +49,9 @@ $fd-numeric-content-elements-spacing-s: 0.5rem !default;
   }
 
   .#{$block}__launch-icon {
-    font-size: 1.5rem;
+    @include fd-icon-selector() {
+      font-size: 1.5rem;
+    }
   }
 
   .#{$block}__kpi {
@@ -53,10 +67,6 @@ $fd-numeric-content-elements-spacing-s: 0.5rem !default;
   display: flex;
   height: 3rem;
   width: 100%;
-
-  @include fd-icon-element-base() {
-    @include fd-flex-center();
-  }
 
   &__launch-icon-container,
   &__kpi-container {
@@ -98,11 +108,11 @@ $fd-numeric-content-elements-spacing-s: 0.5rem !default;
   }
 
   &__launch-icon {
-    @include fd-reset();
-
-    line-height: normal;
-    font-size: 1.75rem;
-    color: var(--sapTile_IconColor);
+    @include fd-icon-element-base() {
+      line-height: normal;
+      font-size: 1.75rem;
+      color: var(--sapTile_IconColor);
+    }
   }
 
   &__kpi {
@@ -133,12 +143,19 @@ $fd-numeric-content-elements-spacing-s: 0.5rem !default;
   &__scale {
     @include fd-reset();
 
-    @include fd-flex-vertical-center () {
+    @include fd-flex-vertical-center() {
       flex-direction: column;
       justify-content: space-between;
     }
 
-    &-arrow,
+    &-arrow {
+      @include fd-icon-element-base() {
+        font-size: 0.875rem;
+        line-height: normal;
+        color: var(--sapNeutralTextColor);
+      }
+    }
+
     &-text {
       @include fd-reset();
 
@@ -148,31 +165,19 @@ $fd-numeric-content-elements-spacing-s: 0.5rem !default;
     }
 
     &--positive {
-      .#{$block}__scale-arrow,
-      .#{$block}__scale-text {
-        color: var(--sapPositiveTextColor);
-      }
+      @include scale-color(var(--sapPositiveTextColor));
     }
 
     &--critical {
-      .#{$block}__scale-arrow,
-      .#{$block}__scale-text {
-        color: var(--sapCriticalTextColor);
-      }
+      @include scale-color(var(--sapCriticalTextColor));
     }
 
     &--negative {
-      .#{$block}__scale-arrow,
-      .#{$block}__scale-text {
-        color: var(--sapNegativeTextColor);
-      }
+      @include scale-color(var(--sapNegativeTextColor));
     }
 
     &--informative {
-      .#{$block}__scale-arrow,
-      .#{$block}__scale-text {
-        color: var(--sapInformativeTextColor);
-      }
+      @include scale-color(var(--sapInformativeTextColor));
     }
   }
 
@@ -236,7 +241,7 @@ $fd-numeric-content-elements-spacing-s: 0.5rem !default;
         .#{$block}__launch-icon-container {
           align-items: flex-end;
         }
-      };
+      }
     }
 
     &.#{$block}--s {
@@ -244,7 +249,7 @@ $fd-numeric-content-elements-spacing-s: 0.5rem !default;
         .#{$block}__scale-container {
           padding-top: 0;
         }
-      };
+      }
     }
   }
 }

--- a/src/numeric-content.scss
+++ b/src/numeric-content.scss
@@ -54,6 +54,10 @@ $fd-numeric-content-elements-spacing-s: 0.5rem !default;
   height: 3rem;
   width: 100%;
 
+  @include fd-icon-element-base() {
+    @include fd-flex-center();
+  }
+
   &__launch-icon-container,
   &__kpi-container {
     @include fd-reset();

--- a/stories/card/card.stories.js
+++ b/stories/card/card.stories.js
@@ -338,27 +338,27 @@ export const listCard = () => `
             <div class="fd-card__content" role="group" aria-label="Card Content">
                 <ul class="fd-list fd-list--no-border" role="list">
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span aria-hidden="true" class="fd-list__icon sap-icon--cart"></span>
+                        <span class="fd-list__icon sap-icon--cart"></span>
                         <span class="fd-list__title">List item 1</span>
                     </li>
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span aria-hidden="true" class="fd-list__icon sap-icon--wrench"></span>
+                        <span class="fd-list__icon sap-icon--wrench"></span>
                         <span class="fd-list__title">List item 2</span>
                     </li>
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span aria-hidden="true" class="fd-list__icon sap-icon--leads"></span>
+                        <span class="fd-list__icon sap-icon--leads"></span>
                         <span class="fd-list__title">List item 3</span>
                     </li>
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span aria-hidden="true" class="fd-list__icon sap-icon--batch-payments"></span>
+                        <span class="fd-list__icon sap-icon--batch-payments"></span>
                         <span class="fd-list__title">List item 4</span>
                     </li>
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span aria-hidden="true" class="fd-list__icon sap-icon--retail-store"></span>
+                        <span class="fd-list__icon sap-icon--retail-store"></span>
                         <span class="fd-list__title">List item 3</span>
                     </li>
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span aria-hidden="true" class="fd-list__icon sap-icon--travel-expense"></span>
+                        <span class="fd-list__icon sap-icon--travel-expense"></span>
                         <span class="fd-list__title">List item 4</span>
                     </li>
                 </ul>
@@ -381,27 +381,27 @@ export const listCard = () => `
             <div class="fd-card__content" role="group" aria-label="Card Content">
                 <ul class="fd-list fd-list--no-border fd-list--compact" role="list">
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span aria-hidden="true" class="fd-list__icon sap-icon--cart"></span>
+                        <span class="fd-list__icon sap-icon--cart"></span>
                         <span class="fd-list__title">List item 1</span>
                     </li>
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span aria-hidden="true" class="fd-list__icon sap-icon--wrench"></span>
+                        <span class="fd-list__icon sap-icon--wrench"></span>
                         <span class="fd-list__title">List item 2</span>
                     </li>
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span aria-hidden="true" class="fd-list__icon sap-icon--leads"></span>
+                        <span class="fd-list__icon sap-icon--leads"></span>
                         <span class="fd-list__title">List item 3</span>
                     </li>
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span aria-hidden="true" class="fd-list__icon sap-icon--batch-payments"></span>
+                        <span class="fd-list__icon sap-icon--batch-payments"></span>
                         <span class="fd-list__title">List item 4</span>
                     </li>
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span aria-hidden="true" class="fd-list__icon sap-icon--retail-store"></span>
-                        <span class="fd-list__title">List item 5</span>
+                        <span class="fd-list__icon sap-icon--retail-store"></span>
+                        <span class="fd-list__title">List item 3</span>
                     </li>
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span aria-hidden="true" class="fd-list__icon sap-icon--travel-expense"></span>
+                        <span class="fd-list__icon sap-icon--travel-expense"></span>
                         <span class="fd-list__title">List item 4</span>
                     </li>
                 </ul>
@@ -460,9 +460,7 @@ export const tableCard = () => `
                             <td class="fd-table__cell">5 EUR</td>
                             <td class="fd-table__cell">India</td>
                             <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
-                                <span class="fd-table__icon fd-table__icon--navigation" aria-label="Navigate">
-                                    <i class="sap-icon--navigation-right-arrow"></i>
-                                </span>
+                                <span class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"></span>
                             </td>
                         </tr>
                         <tr class="fd-table__row">
@@ -479,9 +477,7 @@ export const tableCard = () => `
                             <td class="fd-table__cell">2 EUR</td>
                             <td class="fd-table__cell">Mexico</td>
                             <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
-                                <span class="fd-table__icon fd-table__icon--navigation" aria-label="Navigate">
-                                    <i class="sap-icon--navigation-right-arrow"></i>
-                                </span>
+                                <span class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"></span>
                             </td>
                         </tr>
                         <tr class="fd-table__row">
@@ -498,9 +494,7 @@ export const tableCard = () => `
                             <td class="fd-table__cell">6 EUR</td>
                             <td class="fd-table__cell">Spain</td>
                             <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
-                                <span class="fd-table__icon fd-table__icon--navigation" aria-label="Navigate">
-                                    <i class="sap-icon--navigation-right-arrow"></i>
-                                </span>
+                                <span class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"></span>
                             </td>
                         </tr>
                     </tbody>
@@ -543,9 +537,7 @@ export const tableCard = () => `
                             <td class="fd-table__cell">5 EUR</td>
                             <td class="fd-table__cell">India</td>
                             <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
-                                <span class="fd-table__icon fd-table__icon--navigation" aria-label="Navigate">
-                                    <i class="sap-icon--navigation-right-arrow"></i>
-                                </span>
+                                <span class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"></span>
                             </td>
                         </tr>
                         <tr class="fd-table__row">
@@ -558,9 +550,7 @@ export const tableCard = () => `
                             <td class="fd-table__cell">2 EUR</td>
                             <td class="fd-table__cell">Mexico</td>
                             <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
-                                <span class="fd-table__icon fd-table__icon--navigation" aria-label="Navigate">
-                                    <i class="sap-icon--navigation-right-arrow"></i>
-                                </span>
+                                <span class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"></span>
                             </td>
                         </tr>
                         <tr class="fd-table__row">
@@ -573,9 +563,7 @@ export const tableCard = () => `
                             <td class="fd-table__cell">6 EUR</td>
                             <td class="fd-table__cell">Spain</td>
                             <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
-                                <span class="fd-table__icon fd-table__icon--navigation" aria-label="Navigate">
-                                    <i class="sap-icon--navigation-right-arrow"></i>
-                                </span>
+                                <span class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"></span>
                             </td>
                         </tr>
                     </tbody>
@@ -685,8 +673,8 @@ export const objectCard = () => `
                         </div>
                         <div class="fd-card__content-group">
                             <span 
-                                class="fd-avatar fd-avatar--xs fd-avatar--circle" 
-                                role="presentation"><i class="sap-icon--person-placeholder"></i></span>
+                                class="fd-avatar fd-avatar--xs fd-avatar--circle sap-icon--person-placeholder" 
+                                role="presentation"></span>
                             <div class="fd-card__content-group-text">
                                 <span style="color: green;">Label</span>
                                 <a href="#" class="fd-link" tabindex="0">Link Text</a>
@@ -711,8 +699,8 @@ export const objectCard = () => `
                         </div>
                         <div class="fd-card__content-group">
                             <span 
-                                class="fd-avatar fd-avatar--xs fd-avatar--circle" 
-                                role="presentation"><i class="sap-icon--person-placeholder"></span>
+                                class="fd-avatar fd-avatar--xs fd-avatar--circle sap-icon--person-placeholder" 
+                                role="presentation"></span>
                             <div class="fd-card__content-group-text">
                                 <span style="color: blue">Label</span>
                             </div>

--- a/stories/card/card.stories.js
+++ b/stories/card/card.stories.js
@@ -221,7 +221,9 @@ export const analyticalCard = () => `
                             </div>
                             <div class="fd-numeric-content__scale-container">
                                 <div class="fd-numeric-content__scale">
-                                    <span class="fd-numeric-content__scale-arrow sap-icon--down"></span>
+                                    <span class="fd-numeric-content__scale-arrow" aria-label="decrease">
+                                        <i class="sap-icon--down"></i>
+                                    </span>
                                     <span class="fd-numeric-content__scale-text">M</span>
                                 </div>
                             </div>
@@ -263,8 +265,10 @@ export const analyticalCard = () => `
                                 <div class="fd-numeric-content__kpi">1Ñç</div>
                             </div>
                             <div class="fd-numeric-content__scale-container">
-                                <div class="fd-numeric-content__scale">
-                                    <span class="fd-numeric-content__scale-arrow sap-icon--down"></span>
+                                <div class="fd-numeric-content__scale">                                
+                                    <span class="fd-numeric-content__scale-arrow" aria-label="decrease">
+                                        <i class="sap-icon--down"></i>
+                                    </span>
                                     <span class="fd-numeric-content__scale-text">M</span>
                                 </div>
                             </div>
@@ -338,27 +342,27 @@ export const listCard = () => `
             <div class="fd-card__content" role="group" aria-label="Card Content">
                 <ul class="fd-list fd-list--no-border" role="list">
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span class="fd-list__icon sap-icon--cart"></span>
+                        <span aria-hidden="true" aria-hidden="true" class="fd-list__icon sap-icon--cart"></span>
                         <span class="fd-list__title">List item 1</span>
                     </li>
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span class="fd-list__icon sap-icon--wrench"></span>
+                        <span aria-hidden="true" class="fd-list__icon sap-icon--wrench"></span>
                         <span class="fd-list__title">List item 2</span>
                     </li>
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span class="fd-list__icon sap-icon--leads"></span>
+                        <span aria-hidden="true" class="fd-list__icon sap-icon--leads"></span>
                         <span class="fd-list__title">List item 3</span>
                     </li>
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span class="fd-list__icon sap-icon--batch-payments"></span>
+                        <span aria-hidden="true" class="fd-list__icon sap-icon--batch-payments"></span>
                         <span class="fd-list__title">List item 4</span>
                     </li>
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span class="fd-list__icon sap-icon--retail-store"></span>
+                        <span aria-hidden="true" class="fd-list__icon sap-icon--retail-store"></span>
                         <span class="fd-list__title">List item 3</span>
                     </li>
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span class="fd-list__icon sap-icon--travel-expense"></span>
+                        <span aria-hidden="true" class="fd-list__icon sap-icon--travel-expense"></span>
                         <span class="fd-list__title">List item 4</span>
                     </li>
                 </ul>
@@ -381,27 +385,27 @@ export const listCard = () => `
             <div class="fd-card__content" role="group" aria-label="Card Content">
                 <ul class="fd-list fd-list--no-border fd-list--compact" role="list">
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span class="fd-list__icon sap-icon--cart"></span>
+                        <span aria-hidden="true" class="fd-list__icon sap-icon--cart"></span>
                         <span class="fd-list__title">List item 1</span>
                     </li>
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span class="fd-list__icon sap-icon--wrench"></span>
+                        <span aria-hidden="true" class="fd-list__icon sap-icon--wrench"></span>
                         <span class="fd-list__title">List item 2</span>
                     </li>
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span class="fd-list__icon sap-icon--leads"></span>
+                        <span aria-hidden="true" class="fd-list__icon sap-icon--leads"></span>
                         <span class="fd-list__title">List item 3</span>
                     </li>
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span class="fd-list__icon sap-icon--batch-payments"></span>
+                        <span aria-hidden="true" class="fd-list__icon sap-icon--batch-payments"></span>
                         <span class="fd-list__title">List item 4</span>
                     </li>
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span class="fd-list__icon sap-icon--retail-store"></span>
-                        <span class="fd-list__title">List item 3</span>
+                        <span aria-hidden="true" class="fd-list__icon sap-icon--retail-store"></span>
+                        <span class="fd-list__title">List item 5</span>
                     </li>
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span class="fd-list__icon sap-icon--travel-expense"></span>
+                        <span aria-hidden="true" class="fd-list__icon sap-icon--travel-expense"></span>
                         <span class="fd-list__title">List item 4</span>
                     </li>
                 </ul>
@@ -460,7 +464,9 @@ export const tableCard = () => `
                             <td class="fd-table__cell">5 EUR</td>
                             <td class="fd-table__cell">India</td>
                             <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
-                                <span class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"></span>
+                                <span class="fd-table__icon fd-table__icon--navigation" aria-label="Navigate">
+                                    <i class="sap-icon--navigation-right-arrow"></i>
+                                </span>
                             </td>
                         </tr>
                         <tr class="fd-table__row">
@@ -477,7 +483,9 @@ export const tableCard = () => `
                             <td class="fd-table__cell">2 EUR</td>
                             <td class="fd-table__cell">Mexico</td>
                             <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
-                                <span class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"></span>
+                                <span class="fd-table__icon fd-table__icon--navigation" aria-label="Navigate">
+                                    <i class="sap-icon--navigation-right-arrow"></i>
+                                </span>
                             </td>
                         </tr>
                         <tr class="fd-table__row">
@@ -494,7 +502,9 @@ export const tableCard = () => `
                             <td class="fd-table__cell">6 EUR</td>
                             <td class="fd-table__cell">Spain</td>
                             <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
-                                <span class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"></span>
+                                <span class="fd-table__icon fd-table__icon--navigation" aria-label="Navigate">
+                                    <i class="sap-icon--navigation-right-arrow"></i>
+                                </span>
                             </td>
                         </tr>
                     </tbody>
@@ -537,7 +547,9 @@ export const tableCard = () => `
                             <td class="fd-table__cell">5 EUR</td>
                             <td class="fd-table__cell">India</td>
                             <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
-                                <span class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"></span>
+                                <span class="fd-table__icon fd-table__icon--navigation" aria-label="Navigate">
+                                    <i class="sap-icon--navigation-right-arrow"></i>
+                                </span>
                             </td>
                         </tr>
                         <tr class="fd-table__row">
@@ -550,7 +562,9 @@ export const tableCard = () => `
                             <td class="fd-table__cell">2 EUR</td>
                             <td class="fd-table__cell">Mexico</td>
                             <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
-                                <span class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"></span>
+                                <span class="fd-table__icon fd-table__icon--navigation" aria-label="Navigate">
+                                    <i class="sap-icon--navigation-right-arrow"></i>
+                                </span>
                             </td>
                         </tr>
                         <tr class="fd-table__row">
@@ -563,7 +577,9 @@ export const tableCard = () => `
                             <td class="fd-table__cell">6 EUR</td>
                             <td class="fd-table__cell">Spain</td>
                             <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
-                                <span class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"></span>
+                                <span class="fd-table__icon fd-table__icon--navigation" aria-label="Navigate">
+                                    <i class="sap-icon--navigation-right-arrow"></i>
+                                </span>
                             </td>
                         </tr>
                     </tbody>
@@ -673,8 +689,8 @@ export const objectCard = () => `
                         </div>
                         <div class="fd-card__content-group">
                             <span 
-                                class="fd-avatar fd-avatar--xs fd-avatar--circle sap-icon--person-placeholder" 
-                                role="presentation"></span>
+                                class="fd-avatar fd-avatar--xs fd-avatar--circle" 
+                                role="presentation"><i class="sap-icon--person-placeholder"></i></span>
                             <div class="fd-card__content-group-text">
                                 <span style="color: green;">Label</span>
                                 <a href="#" class="fd-link" tabindex="0">Link Text</a>
@@ -699,8 +715,8 @@ export const objectCard = () => `
                         </div>
                         <div class="fd-card__content-group">
                             <span 
-                                class="fd-avatar fd-avatar--xs fd-avatar--circle sap-icon--person-placeholder" 
-                                role="presentation"></span>
+                                class="fd-avatar fd-avatar--xs fd-avatar--circle" 
+                                role="presentation"><i class="sap-icon--person-placeholder"></span>
                             <div class="fd-card__content-group-text">
                                 <span style="color: blue">Label</span>
                             </div>

--- a/stories/card/card.stories.js
+++ b/stories/card/card.stories.js
@@ -342,7 +342,7 @@ export const listCard = () => `
             <div class="fd-card__content" role="group" aria-label="Card Content">
                 <ul class="fd-list fd-list--no-border" role="list">
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span aria-hidden="true" aria-hidden="true" class="fd-list__icon sap-icon--cart"></span>
+                        <span aria-hidden="true" class="fd-list__icon sap-icon--cart"></span>
                         <span class="fd-list__title">List item 1</span>
                     </li>
                     <li role="listitem" tabindex="0" class="fd-list__item">

--- a/stories/card/card.stories.js
+++ b/stories/card/card.stories.js
@@ -221,9 +221,7 @@ export const analyticalCard = () => `
                             </div>
                             <div class="fd-numeric-content__scale-container">
                                 <div class="fd-numeric-content__scale">
-                                    <span class="fd-numeric-content__scale-arrow" aria-label="decrease">
-                                        <i class="sap-icon--down"></i>
-                                    </span>
+                                    <i class="fd-numeric-content__scale-arrow sap-icon--down" aria-label="decrease"></i>
                                     <span class="fd-numeric-content__scale-text">M</span>
                                 </div>
                             </div>
@@ -266,9 +264,7 @@ export const analyticalCard = () => `
                             </div>
                             <div class="fd-numeric-content__scale-container">
                                 <div class="fd-numeric-content__scale">                                
-                                    <span class="fd-numeric-content__scale-arrow" aria-label="decrease">
-                                        <i class="sap-icon--down"></i>
-                                    </span>
+                                    <i class="fd-numeric-content__scale-arrow sap-icon--down" aria-label="decrease"></i>
                                     <span class="fd-numeric-content__scale-text">M</span>
                                 </div>
                             </div>

--- a/stories/generictile/__snapshots__/generic-tile.stories.storyshot
+++ b/stories/generictile/__snapshots__/generic-tile.stories.storyshot
@@ -491,8 +491,9 @@ exports[`Storyshots Components/Generic Tile KPI Tile 1`] = `
             >
               
                         
-              <span
+              <i
                 class="fd-numeric-content__scale-arrow sap-icon--down"
+                role="presentation"
               />
               
                         
@@ -621,8 +622,9 @@ exports[`Storyshots Components/Generic Tile KPI Tile 1`] = `
             >
               
                         
-              <span
+              <i
                 class="fd-numeric-content__scale-arrow sap-icon--down"
+                role="presentation"
               />
               
                         
@@ -763,8 +765,9 @@ exports[`Storyshots Components/Generic Tile KPI Tile 1`] = `
             >
               
                         
-              <span
+              <i
                 class="fd-numeric-content__scale-arrow sap-icon--down"
+                role="presentation"
               />
               
                     
@@ -862,8 +865,9 @@ exports[`Storyshots Components/Generic Tile KPI Tile 1`] = `
             >
               
                         
-              <span
+              <i
                 class="fd-numeric-content__scale-arrow sap-icon--up"
+                role="presentation"
               />
               
                     
@@ -973,8 +977,9 @@ exports[`Storyshots Components/Generic Tile KPI Tile 1`] = `
             >
               
                         
-              <span
+              <i
                 class="fd-numeric-content__scale-arrow sap-icon--down"
+                role="presentation"
               />
               
                         
@@ -1160,8 +1165,9 @@ exports[`Storyshots Components/Generic Tile Launch Tile 1`] = `
           >
             
                     
-            <span
+            <i
               class="fd-numeric-content__launch-icon sap-icon--line-charts"
+              role="presentation"
             />
             
                 
@@ -1193,8 +1199,9 @@ exports[`Storyshots Components/Generic Tile Launch Tile 1`] = `
             >
               
                         
-              <span
+              <i
                 class="fd-numeric-content__scale-arrow sap-icon--down"
+                role="presentation"
               />
               
                         
@@ -1303,8 +1310,9 @@ exports[`Storyshots Components/Generic Tile Launch Tile 1`] = `
           >
             
                     
-            <span
+            <i
               class="fd-numeric-content__launch-icon sap-icon--line-charts"
+              role="presentation"
             />
             
                 

--- a/stories/generictile/generic-tile.stories.mdx
+++ b/stories/generictile/generic-tile.stories.mdx
@@ -324,14 +324,14 @@ The header can contain a maximum of 3 lines; all 3 lines can be used for the tit
         <div class="fd-tile__content">
             <div class="fd-numeric-content">
                 <div class="fd-numeric-content__launch-icon-container">
-                    <span class="fd-numeric-content__launch-icon sap-icon--line-charts"></span>
+                    <i role="presentation" class="fd-numeric-content__launch-icon sap-icon--line-charts"></i>
                 </div>
                 <div class="fd-numeric-content__kpi-container">
                     <div class="fd-numeric-content__kpi fd-numeric-content__kpi--negative">1Ñç</div>
                 </div>
                 <div class="fd-numeric-content__scale-container">
                     <div class="fd-numeric-content__scale fd-numeric-content__scale--negative">
-                        <span class="fd-numeric-content__scale-arrow sap-icon--down"></span>
+                        <i role="presentation" class="fd-numeric-content__scale-arrow sap-icon--down"></i>
                         <span class="fd-numeric-content__scale-text">M</span>
                     </div>
                 </div>
@@ -353,7 +353,7 @@ The header can contain a maximum of 3 lines; all 3 lines can be used for the tit
         <div class="fd-tile__content">
             <div class="fd-numeric-content fd-numeric-content--small-tile">
                 <div class="fd-numeric-content__launch-icon-container">
-                    <span class="fd-numeric-content__launch-icon sap-icon--line-charts"></span>
+                    <i role="presentation" class="fd-numeric-content__launch-icon sap-icon--line-charts"></i>
                 </div>
                 <div class="fd-numeric-content__kpi-container">
                     <div class="fd-numeric-content__kpi fd-numeric-content__kpi--positive">1234</div>
@@ -507,7 +507,7 @@ Structure of the Numeric Content
                 </div>
                 <div class="fd-numeric-content__scale-container">
                     <div class="fd-numeric-content__scale">
-                        <span class="fd-numeric-content__scale-arrow sap-icon--down"></span>
+                        <i role="presentation" class="fd-numeric-content__scale-arrow sap-icon--down"></i>
                         <span class="fd-numeric-content__scale-text">M</span>
                     </div>
                 </div>
@@ -533,7 +533,7 @@ Structure of the Numeric Content
                 </div>
                 <div class="fd-numeric-content__scale-container">
                     <div class="fd-numeric-content__scale">
-                        <span class="fd-numeric-content__scale-arrow sap-icon--down"></span>
+                        <i role="presentation" class="fd-numeric-content__scale-arrow sap-icon--down"></i>
                         <span class="fd-numeric-content__scale-text">milçM</span>
                     </div>
                 </div>
@@ -563,7 +563,7 @@ Structure of the Numeric Content
                 </div>
                 <div class="fd-numeric-content__scale-container">
                     <div class="fd-numeric-content__scale fd-numeric-content__scale--positive">
-                        <span class="fd-numeric-content__scale-arrow sap-icon--down"></span>
+                        <i role="presentation" class="fd-numeric-content__scale-arrow sap-icon--down"></i>
                     </div>
                 </div>
             </div>
@@ -584,7 +584,7 @@ Structure of the Numeric Content
                 </div>
                 <div class="fd-numeric-content__scale-container">
                     <div class="fd-numeric-content__scale fd-numeric-content__scale--negative">
-                        <span class="fd-numeric-content__scale-arrow sap-icon--up"></span>
+                        <i role="presentation" class="fd-numeric-content__scale-arrow sap-icon--up"></i>
                     </div>
                 </div>
             </div>
@@ -609,7 +609,7 @@ Structure of the Numeric Content
                 </div>
                 <div class="fd-numeric-content__scale-container">
                     <div class="fd-numeric-content__scale fd-numeric-content__scale--critical">
-                        <span class="fd-numeric-content__scale-arrow sap-icon--down"></span>
+                        <i role="presentation" class="fd-numeric-content__scale-arrow sap-icon--down"></i>
                         <span class="fd-numeric-content__scale-text">%</span>
                     </div>
                 </div>

--- a/stories/numeric-content/__snapshots__/numeric-content.stories.storyshot
+++ b/stories/numeric-content/__snapshots__/numeric-content.stories.storyshot
@@ -39,7 +39,8 @@ exports[`Storyshots Dev/Numeric Content Large 1`] = `
         >
           
                         
-          <span
+          <i
+            aria-label="decrease"
             class="fd-numeric-content__scale-arrow sap-icon--down"
           />
           
@@ -95,13 +96,14 @@ exports[`Storyshots Dev/Numeric Content Large 1`] = `
         class="fd-numeric-content__scale-container"
       >
         
-                        
+                    
         <div
           class="fd-numeric-content__scale"
         >
           
                         
-          <span
+          <i
+            aria-label="decrease"
             class="fd-numeric-content__scale-arrow sap-icon--down"
           />
           
@@ -112,7 +114,7 @@ exports[`Storyshots Dev/Numeric Content Large 1`] = `
             milçM
           </span>
           
-                        
+                    
         </div>
         
                 
@@ -147,8 +149,9 @@ exports[`Storyshots Dev/Numeric Content Launch Icon Large 1`] = `
       >
         
                     
-        <span
+        <i
           class="fd-numeric-content__launch-icon sap-icon--line-charts"
+          role="presentation"
         />
         
                 
@@ -180,7 +183,8 @@ exports[`Storyshots Dev/Numeric Content Launch Icon Large 1`] = `
         >
           
                         
-          <span
+          <i
+            aria-label="decrease"
             class="fd-numeric-content__scale-arrow sap-icon--down"
           />
           
@@ -222,8 +226,9 @@ exports[`Storyshots Dev/Numeric Content Launch Icon Large 1`] = `
       >
         
                     
-        <span
+        <i
           class="fd-numeric-content__launch-icon sap-icon--line-charts"
+          role="presentation"
         />
         
                 
@@ -273,8 +278,9 @@ exports[`Storyshots Dev/Numeric Content Launch Icon Medium 1`] = `
       >
         
                     
-        <span
+        <i
           class="fd-numeric-content__launch-icon sap-icon--line-charts"
+          role="presentation"
         />
         
                 
@@ -306,7 +312,8 @@ exports[`Storyshots Dev/Numeric Content Launch Icon Medium 1`] = `
         >
           
                         
-          <span
+          <i
+            aria-label="decrease"
             class="fd-numeric-content__scale-arrow sap-icon--down"
           />
           
@@ -348,8 +355,9 @@ exports[`Storyshots Dev/Numeric Content Launch Icon Medium 1`] = `
       >
         
                     
-        <span
+        <i
           class="fd-numeric-content__launch-icon sap-icon--line-charts"
+          role="presentation"
         />
         
                 
@@ -381,7 +389,8 @@ exports[`Storyshots Dev/Numeric Content Launch Icon Medium 1`] = `
         >
           
                         
-          <span
+          <i
+            aria-label="decrease"
             class="fd-numeric-content__scale-arrow sap-icon--down"
           />
           
@@ -427,8 +436,9 @@ exports[`Storyshots Dev/Numeric Content Launch Icon Small 1`] = `
       >
         
                     
-        <span
+        <i
           class="fd-numeric-content__launch-icon sap-icon--line-charts"
+          role="presentation"
         />
         
                 
@@ -460,7 +470,8 @@ exports[`Storyshots Dev/Numeric Content Launch Icon Small 1`] = `
         >
           
                         
-          <span
+          <i
+            aria-label="increase"
             class="fd-numeric-content__scale-arrow sap-icon--up"
           />
           
@@ -502,8 +513,9 @@ exports[`Storyshots Dev/Numeric Content Launch Icon Small 1`] = `
       >
         
                     
-        <span
+        <i
           class="fd-numeric-content__launch-icon sap-icon--line-charts"
+          role="presentation"
         />
         
                 
@@ -535,7 +547,8 @@ exports[`Storyshots Dev/Numeric Content Launch Icon Small 1`] = `
         >
           
                         
-          <span
+          <i
+            aria-label="decrease"
             class="fd-numeric-content__scale-arrow sap-icon--down"
           />
           
@@ -601,7 +614,8 @@ exports[`Storyshots Dev/Numeric Content Medium 1`] = `
         >
           
                         
-          <span
+          <i
+            aria-label="decrease"
             class="fd-numeric-content__scale-arrow sap-icon--down"
           />
           
@@ -656,8 +670,9 @@ exports[`Storyshots Dev/Numeric Content Medium 1`] = `
         >
           
                         
-          <span
-            class="fd-numeric-content__scale-arrow sap-icon--up"
+          <i
+            aria-label="decrease"
+            class="fd-numeric-content__scale-arrow sap-icon--down"
           />
           
                     
@@ -715,7 +730,8 @@ exports[`Storyshots Dev/Numeric Content Small 1`] = `
         >
           
                         
-          <span
+          <i
+            aria-label="decrease"
             class="fd-numeric-content__scale-arrow sap-icon--down"
           />
           

--- a/stories/numeric-content/numeric-content.stories.js
+++ b/stories/numeric-content/numeric-content.stories.js
@@ -15,9 +15,7 @@ export const large = () => `
                 </div>
                 <div class="fd-numeric-content__scale-container">
                     <div class="fd-numeric-content__scale">
-                        <span class="fd-numeric-content__scale-arrow" aria-label="decrease">
-                            <i class="sap-icon--down"></i>
-                        </span>
+                        <i class="fd-numeric-content__scale-arrow sap-icon--down" aria-label="decrease"></i>
                         <span class="fd-numeric-content__scale-text">M</span>
                     </div>
                 </div>

--- a/stories/numeric-content/numeric-content.stories.js
+++ b/stories/numeric-content/numeric-content.stories.js
@@ -15,7 +15,9 @@ export const large = () => `
                 </div>
                 <div class="fd-numeric-content__scale-container">
                     <div class="fd-numeric-content__scale">
-                        <span class="fd-numeric-content__scale-arrow sap-icon--down"></span>
+                        <span class="fd-numeric-content__scale-arrow" aria-label="decrease">
+                            <i class="sap-icon--down"></i>
+                        </span>
                         <span class="fd-numeric-content__scale-text">M</span>
                     </div>
                 </div>
@@ -28,10 +30,12 @@ export const large = () => `
                         <div class="fd-numeric-content__kpi">1Ñç</div>
                 </div>
                 <div class="fd-numeric-content__scale-container">
-                        <div class="fd-numeric-content__scale">
-                        <span class="fd-numeric-content__scale-arrow sap-icon--down"></span>
+                    <div class="fd-numeric-content__scale">
+                        <span class="fd-numeric-content__scale-arrow" aria-label="decrease">
+                            <i class="sap-icon--down"></i>
+                        </span>
                         <span class="fd-numeric-content__scale-text">milçM</span>
-                        </div>
+                    </div>
                 </div>
         </div>
 </div>
@@ -48,7 +52,9 @@ export const medium = () => `
                 </div>
                 <div class="fd-numeric-content__scale-container">
                     <div class="fd-numeric-content__scale fd-numeric-content__scale--positive">
-                        <span class="fd-numeric-content__scale-arrow sap-icon--down"></span>
+                        <span class="fd-numeric-content__scale-arrow" aria-label="decrease">
+                            <i class="sap-icon--down"></i>
+                        </span>
                     </div>
                 </div>
         </div>
@@ -61,7 +67,9 @@ export const medium = () => `
                 </div>
                 <div class="fd-numeric-content__scale-container">
                     <div class="fd-numeric-content__scale fd-numeric-content__scale--negative">
-                        <span class="fd-numeric-content__scale-arrow sap-icon--up"></span>
+                        <span class="fd-numeric-content__scale-arrow" aria-label="decrease">
+                            <i class="sap-icon--down"></i>
+                        </span>
                     </div>
                 </div>
         </div>
@@ -79,7 +87,9 @@ export const small = () => `
                 </div>
                 <div class="fd-numeric-content__scale-container">
                     <div class="fd-numeric-content__scale fd-numeric-content__scale--critical">
-                        <span class="fd-numeric-content__scale-arrow sap-icon--down"></span>
+                        <span class="fd-numeric-content__scale-arrow" aria-label="decrease">
+                            <i class="sap-icon--down"></i>
+                        </span>
                         <span class="fd-numeric-content__scale-text">%</span>
                     </div>
                 </div>
@@ -102,14 +112,18 @@ export const launchIconLarge = () => `
 <div class="tile-content-playground">
         <div class="fd-numeric-content">
                 <div class="fd-numeric-content__launch-icon-container">
-                    <span class="fd-numeric-content__launch-icon sap-icon--line-charts"></span>
+                    <span class="fd-numeric-content__launch-icon">
+                        <i class="sap-icon--line-charts"></i>
+                    </span>
                 </div>
                 <div class="fd-numeric-content__kpi-container">
                     <div class="fd-numeric-content__kpi">123</div>
                 </div>
                 <div class="fd-numeric-content__scale-container">
                     <div class="fd-numeric-content__scale">
-                        <span class="fd-numeric-content__scale-arrow sap-icon--down"></span>
+                        <span class="fd-numeric-content__scale-arrow" aria-label="decrease">
+                            <i class="sap-icon--down"></i>
+                        </span>
                         <span class="fd-numeric-content__scale-text">milçM</span>
                     </div>
                 </div>
@@ -119,7 +133,9 @@ export const launchIconLarge = () => `
 <div class="tile-content-small-playground">
         <div class="fd-numeric-content fd-numeric-content--small-tile">
                 <div class="fd-numeric-content__launch-icon-container">
-                    <span class="fd-numeric-content__launch-icon sap-icon--line-charts"></span>
+                    <span class="fd-numeric-content__launch-icon" role="presentation">
+                        <i class="sap-icon--line-charts"></i>
+                    </span>
                 </div>
                 <div class="fd-numeric-content__kpi-container">
                     <div class="fd-numeric-content__kpi fd-numeric-content__kpi--positive">1234</div>
@@ -135,14 +151,18 @@ export const launchIconMedium = () => `
 <div class="tile-content-playground">
         <div class="fd-numeric-content fd-numeric-content--m">
                 <div class="fd-numeric-content__launch-icon-container">
-                    <span class="fd-numeric-content__launch-icon sap-icon--line-charts"></span>
+                    <span class="fd-numeric-content__launch-icon" role="presentation">
+                        <i class="sap-icon--line-charts"></i>
+                    </span>
                 </div>
                 <div class="fd-numeric-content__kpi-container">
                     <div class="fd-numeric-content__kpi fd-numeric-content__kpi--negative">-889</div>
                 </div>
                 <div class="fd-numeric-content__scale-container">
                     <div class="fd-numeric-content__scale fd-numeric-content__scale--negative">
-                        <span class="fd-numeric-content__scale-arrow sap-icon--down"></span>
+                        <span class="fd-numeric-content__scale-arrow" aria-label="decrease">
+                            <i class="sap-icon--down"></i>
+                        </span>
                         <span class="fd-numeric-content__scale-text">M</span>
                     </div>
                 </div>
@@ -152,14 +172,18 @@ export const launchIconMedium = () => `
 <div class="tile-content-small-playground">
         <div class="fd-numeric-content fd-numeric-content--m fd-numeric-content--small-tile">
                 <div class="fd-numeric-content__launch-icon-container">
-                    <span class="fd-numeric-content__launch-icon sap-icon--line-charts"></span>
+                    <span class="fd-numeric-content__launch-icon" role="presentation">
+                        <i class="sap-icon--line-charts"></i>
+                    </span>
                 </div>
                 <div class="fd-numeric-content__kpi-container">
                     <div class="fd-numeric-content__kpi fd-numeric-content__kpi--informative">-88 88</div>
                 </div>
                 <div class="fd-numeric-content__scale-container">
                     <div class="fd-numeric-content__scale fd-numeric-content__scale--informative">
-                        <span class="fd-numeric-content__scale-arrow sap-icon--down"></span>
+                        <span class="fd-numeric-content__scale-arrow" aria-label="decrease">
+                            <i class="sap-icon--down"></i>
+                        </span>
                         <span class="fd-numeric-content__scale-text">milÇ</span>
                     </div>
                 </div>
@@ -174,14 +198,18 @@ export const launchIconSmall = () => `
 <div class="tile-content-playground">
         <div class="fd-numeric-content fd-numeric-content--s">
                 <div class="fd-numeric-content__launch-icon-container">
-                    <span class="fd-numeric-content__launch-icon sap-icon--line-charts"></span>
+                    <span class="fd-numeric-content__launch-icon" role="presentation">
+                        <i class="sap-icon--line-charts"></i>
+                    </span>
                 </div>
                 <div class="fd-numeric-content__kpi-container">
                     <div class="fd-numeric-content__kpi fd-numeric-content__kpi--critical">123</div>
                 </div>
                 <div class="fd-numeric-content__scale-container">
                     <div class="fd-numeric-content__scale fd-numeric-content__scale--critical">
-                        <span class="fd-numeric-content__scale-arrow sap-icon--up"></span>
+                        <span class="fd-numeric-content__scale-arrow" aria-label="decrease">
+                            <i class="sap-icon--up"></i>
+                        </span>
                         <span class="fd-numeric-content__scale-text">ÑÇmlč</span>
                     </div>
                 </div>
@@ -191,14 +219,18 @@ export const launchIconSmall = () => `
 <div class="tile-content-small-playground">
         <div class="fd-numeric-content fd-numeric-content--s fd-numeric-content--small-tile">
                 <div class="fd-numeric-content__launch-icon-container">
-                    <span class="fd-numeric-content__launch-icon sap-icon--line-charts"></span>
+                    <span class="fd-numeric-content__launch-icon" role="presentation">
+                        <i class="sap-icon--line-charts"></i>
+                    </span>
                 </div>
                 <div class="fd-numeric-content__kpi-container">
                     <div class="fd-numeric-content__kpi fd-numeric-content__kpi--positive">123</div>
                 </div>
                 <div class="fd-numeric-content__scale-container">
                     <div class="fd-numeric-content__scale fd-numeric-content__scale--positive">
-                        <span class="fd-numeric-content__scale-arrow sap-icon--down"></span>
+                        <span class="fd-numeric-content__scale-arrow" aria-label="decrease">
+                            <i class="sap-icon--down"></i>
+                        </span>
                         <span class="fd-numeric-content__scale-text">ÑÇmlč</span>
                     </div>
                 </div>

--- a/stories/numeric-content/numeric-content.stories.js
+++ b/stories/numeric-content/numeric-content.stories.js
@@ -31,9 +31,7 @@ export const large = () => `
                 </div>
                 <div class="fd-numeric-content__scale-container">
                     <div class="fd-numeric-content__scale">
-                        <span class="fd-numeric-content__scale-arrow" aria-label="decrease">
-                            <i class="sap-icon--down"></i>
-                        </span>
+                        <i class="fd-numeric-content__scale-arrow sap-icon--down" aria-label="decrease"></i>
                         <span class="fd-numeric-content__scale-text">milçM</span>
                     </div>
                 </div>
@@ -52,9 +50,7 @@ export const medium = () => `
                 </div>
                 <div class="fd-numeric-content__scale-container">
                     <div class="fd-numeric-content__scale fd-numeric-content__scale--positive">
-                        <span class="fd-numeric-content__scale-arrow" aria-label="decrease">
-                            <i class="sap-icon--down"></i>
-                        </span>
+                        <i class="fd-numeric-content__scale-arrow sap-icon--down" aria-label="decrease"></i>
                     </div>
                 </div>
         </div>
@@ -67,9 +63,7 @@ export const medium = () => `
                 </div>
                 <div class="fd-numeric-content__scale-container">
                     <div class="fd-numeric-content__scale fd-numeric-content__scale--negative">
-                        <span class="fd-numeric-content__scale-arrow" aria-label="decrease">
-                            <i class="sap-icon--down"></i>
-                        </span>
+                        <i class="fd-numeric-content__scale-arrow sap-icon--down" aria-label="decrease"></i>
                     </div>
                 </div>
         </div>
@@ -87,9 +81,7 @@ export const small = () => `
                 </div>
                 <div class="fd-numeric-content__scale-container">
                     <div class="fd-numeric-content__scale fd-numeric-content__scale--critical">
-                        <span class="fd-numeric-content__scale-arrow" aria-label="decrease">
-                            <i class="sap-icon--down"></i>
-                        </span>
+                        <i class="fd-numeric-content__scale-arrow sap-icon--down" aria-label="decrease"></i>
                         <span class="fd-numeric-content__scale-text">%</span>
                     </div>
                 </div>
@@ -112,18 +104,14 @@ export const launchIconLarge = () => `
 <div class="tile-content-playground">
         <div class="fd-numeric-content">
                 <div class="fd-numeric-content__launch-icon-container">
-                    <span class="fd-numeric-content__launch-icon">
-                        <i class="sap-icon--line-charts"></i>
-                    </span>
+                    <i class="fd-numeric-content__launch-icon sap-icon--line-charts" role="presentation"></i>
                 </div>
                 <div class="fd-numeric-content__kpi-container">
                     <div class="fd-numeric-content__kpi">123</div>
                 </div>
                 <div class="fd-numeric-content__scale-container">
                     <div class="fd-numeric-content__scale">
-                        <span class="fd-numeric-content__scale-arrow" aria-label="decrease">
-                            <i class="sap-icon--down"></i>
-                        </span>
+                        <i class="fd-numeric-content__scale-arrow sap-icon--down" aria-label="decrease"></i>
                         <span class="fd-numeric-content__scale-text">milçM</span>
                     </div>
                 </div>
@@ -133,9 +121,7 @@ export const launchIconLarge = () => `
 <div class="tile-content-small-playground">
         <div class="fd-numeric-content fd-numeric-content--small-tile">
                 <div class="fd-numeric-content__launch-icon-container">
-                    <span class="fd-numeric-content__launch-icon" role="presentation">
-                        <i class="sap-icon--line-charts"></i>
-                    </span>
+                    <i class="fd-numeric-content__launch-icon sap-icon--line-charts" role="presentation"></i>
                 </div>
                 <div class="fd-numeric-content__kpi-container">
                     <div class="fd-numeric-content__kpi fd-numeric-content__kpi--positive">1234</div>
@@ -151,18 +137,14 @@ export const launchIconMedium = () => `
 <div class="tile-content-playground">
         <div class="fd-numeric-content fd-numeric-content--m">
                 <div class="fd-numeric-content__launch-icon-container">
-                    <span class="fd-numeric-content__launch-icon" role="presentation">
-                        <i class="sap-icon--line-charts"></i>
-                    </span>
+                    <i class="fd-numeric-content__launch-icon sap-icon--line-charts" role="presentation"></i>
                 </div>
                 <div class="fd-numeric-content__kpi-container">
                     <div class="fd-numeric-content__kpi fd-numeric-content__kpi--negative">-889</div>
                 </div>
                 <div class="fd-numeric-content__scale-container">
                     <div class="fd-numeric-content__scale fd-numeric-content__scale--negative">
-                        <span class="fd-numeric-content__scale-arrow" aria-label="decrease">
-                            <i class="sap-icon--down"></i>
-                        </span>
+                        <i class="fd-numeric-content__scale-arrow sap-icon--down" aria-label="decrease"></i>
                         <span class="fd-numeric-content__scale-text">M</span>
                     </div>
                 </div>
@@ -172,18 +154,14 @@ export const launchIconMedium = () => `
 <div class="tile-content-small-playground">
         <div class="fd-numeric-content fd-numeric-content--m fd-numeric-content--small-tile">
                 <div class="fd-numeric-content__launch-icon-container">
-                    <span class="fd-numeric-content__launch-icon" role="presentation">
-                        <i class="sap-icon--line-charts"></i>
-                    </span>
+                    <i class="fd-numeric-content__launch-icon sap-icon--line-charts" role="presentation"></i>
                 </div>
                 <div class="fd-numeric-content__kpi-container">
                     <div class="fd-numeric-content__kpi fd-numeric-content__kpi--informative">-88 88</div>
                 </div>
                 <div class="fd-numeric-content__scale-container">
                     <div class="fd-numeric-content__scale fd-numeric-content__scale--informative">
-                        <span class="fd-numeric-content__scale-arrow" aria-label="decrease">
-                            <i class="sap-icon--down"></i>
-                        </span>
+                        <i class="fd-numeric-content__scale-arrow sap-icon--down" aria-label="decrease"></i>
                         <span class="fd-numeric-content__scale-text">milÇ</span>
                     </div>
                 </div>
@@ -198,18 +176,14 @@ export const launchIconSmall = () => `
 <div class="tile-content-playground">
         <div class="fd-numeric-content fd-numeric-content--s">
                 <div class="fd-numeric-content__launch-icon-container">
-                    <span class="fd-numeric-content__launch-icon" role="presentation">
-                        <i class="sap-icon--line-charts"></i>
-                    </span>
+                    <i class="fd-numeric-content__launch-icon sap-icon--line-charts" role="presentation"></i>
                 </div>
                 <div class="fd-numeric-content__kpi-container">
                     <div class="fd-numeric-content__kpi fd-numeric-content__kpi--critical">123</div>
                 </div>
                 <div class="fd-numeric-content__scale-container">
                     <div class="fd-numeric-content__scale fd-numeric-content__scale--critical">
-                        <span class="fd-numeric-content__scale-arrow" aria-label="decrease">
-                            <i class="sap-icon--up"></i>
-                        </span>
+                        <i class="fd-numeric-content__scale-arrow sap-icon--up" aria-label="increase"></i>
                         <span class="fd-numeric-content__scale-text">ÑÇmlč</span>
                     </div>
                 </div>
@@ -219,18 +193,14 @@ export const launchIconSmall = () => `
 <div class="tile-content-small-playground">
         <div class="fd-numeric-content fd-numeric-content--s fd-numeric-content--small-tile">
                 <div class="fd-numeric-content__launch-icon-container">
-                    <span class="fd-numeric-content__launch-icon" role="presentation">
-                        <i class="sap-icon--line-charts"></i>
-                    </span>
+                    <i class="fd-numeric-content__launch-icon sap-icon--line-charts" role="presentation"></i>
                 </div>
                 <div class="fd-numeric-content__kpi-container">
                     <div class="fd-numeric-content__kpi fd-numeric-content__kpi--positive">123</div>
                 </div>
                 <div class="fd-numeric-content__scale-container">
                     <div class="fd-numeric-content__scale fd-numeric-content__scale--positive">
-                        <span class="fd-numeric-content__scale-arrow" aria-label="decrease">
-                            <i class="sap-icon--down"></i>
-                        </span>
+                        <i class="fd-numeric-content__scale-arrow sap-icon--down" aria-label="decrease"></i>
                         <span class="fd-numeric-content__scale-text">ÑÇmlč</span>
                     </div>
                 </div>


### PR DESCRIPTION
## Related Issue
Successor of: #1659
Part of: #1603

## Description
This PR:
- Updates Numeric Content styling with icon mixins
- Updates Numeric Content markup to use `<i>` element
- Adds aria attributes

### Before:
```
<span class="fd-numeric-content__scale-arrow sap-icon--down"></span>
```
```
<div class="fd-numeric-content__scale">
    <span class="fd-numeric-content__scale-arrow sap-icon--down"></span>
</div>
```
### After:
```
<i class="fd-numeric-content__scale-arrow sap-icon--down" aria-label="decrease"></i>
```
```
<div class="fd-numeric-content__scale">
    <i class="fd-numeric-content__scale-arrow sap-icon--down" aria-label="decrease"></i>
</div>
```

#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
