### PR TITLE
fix: Table, List - Refactor icons usage - #2

### DIFF
--- a/src/_listBase.scss
+++ b/src/_listBase.scss
@@ -102,35 +102,33 @@
   }
 
   &__icon {
-    @include fd-reset();
-    @include ie11-active-state-fix();
-    @include fd-flex-center();
-
     @include fd-icon-element-base() {
+      @include ie11-active-state-fix();
+      @include fd-flex-center();
+
       color: var(--sapList_TextColor);
       font-size: var(--sapFontHeader4Size);
-    }
+      width: 2.75rem;
+      flex: 0 0 auto;
 
-    width: 2.75rem;
-    flex: 0 0 auto;
-
-    &:first-child {
-      margin-left: -1rem;
-    }
-
-    &:last-child {
-      margin-right: -1rem;
-    }
-
-    @include fd-rtl() {
       &:first-child {
-        margin-right: -1rem;
-        margin-left: 0;
+        margin-left: -1rem;
       }
 
       &:last-child {
-        margin-left: -1rem;
-        margin-right: 0;
+        margin-right: -1rem;
+      }
+
+      @include fd-rtl() {
+        &:first-child {
+          margin-right: -1rem;
+          margin-left: 0;
+        }
+
+        &:last-child {
+          margin-left: -1rem;
+          margin-right: 0;
+        }
       }
     }
   }

--- a/src/_listBase.scss
+++ b/src/_listBase.scss
@@ -104,14 +104,15 @@
   &__icon {
     @include fd-reset();
     @include ie11-active-state-fix();
+    @include fd-flex-center();
 
-    color: var(--sapList_TextColor);
-    flex: 0 0 auto;
+    @include fd-icon-element-base() {
+      color: var(--sapList_TextColor);
+      font-size: var(--sapFontHeader4Size);
+    }
+
     width: 2.75rem;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    font-size: var(--sapFontHeader4Size);
+    flex: 0 0 auto;
 
     &:first-child {
       margin-left: -1rem;
@@ -217,7 +218,9 @@
     }
 
     .#{$block}__icon {
-      font-size: $fd-list-large-font-size;
+      @include fd-icon-selector() {
+        font-size: $fd-list-large-font-size;
+      }
     }
   }
 

--- a/src/_listByline.scss
+++ b/src/_listByline.scss
@@ -14,7 +14,10 @@
       @include fd-reset();
       @include fd-flex-center();
       @include ie11-active-state-fix();
-      @include fd-icon-element-base();
+
+      @include fd-icon-element-base() {
+        @include fd-flex-center();
+      }
 
       width: $fd-list-byline-thumbnail-dimensions;
       height: $fd-list-byline-thumbnail-dimensions;

--- a/src/_listByline.scss
+++ b/src/_listByline.scss
@@ -14,6 +14,7 @@
       @include fd-reset();
       @include fd-flex-center();
       @include ie11-active-state-fix();
+      @include fd-icon-element-base();
 
       width: $fd-list-byline-thumbnail-dimensions;
       height: $fd-list-byline-thumbnail-dimensions;

--- a/src/table.scss
+++ b/src/table.scss
@@ -25,7 +25,9 @@ $block: #{$fd-namespace}-table;
     }
 
     .#{$block}__icon {
-      color: var(--sapContent_ContrastIconColor);
+      @include fd-icon-selector() {
+        color: var(--sapContent_ContrastIconColor);
+      }
     }
 
     .#{$fd-namespace}-link,
@@ -71,7 +73,6 @@ $block: #{$fd-namespace}-table;
   &__header,
   &__body,
   &__footer,
-  &__icon,
   &__text {
     @include fd-reset();
   }
@@ -82,15 +83,15 @@ $block: #{$fd-namespace}-table;
 
   // Elements
   &__icon {
-    @include fd-flex-center();
-
     @include fd-icon-element-base() {
+      @include fd-flex-center();
+
       color: var(--sapContent_NonInteractiveIconColor);
       font-size: var(--sapFontSmallSize);
     }
 
     &--navigation {
-      @include fd-icon-element-base() {
+      @include fd-icon-selector() {
         font-size: var(--sapFontSmallSize);
         width: $fd-table-navigation-icon-width;
         min-width: $fd-table-navigation-icon-width;

--- a/src/table.scss
+++ b/src/table.scss
@@ -82,16 +82,20 @@ $block: #{$fd-namespace}-table;
 
   // Elements
   &__icon {
-    color: var(--sapContent_NonInteractiveIconColor);
-    font-size: var(--sapFontSmallSize);
+    @include fd-flex-center();
+
+    @include fd-icon-element-base() {
+      color: var(--sapContent_NonInteractiveIconColor);
+      font-size: var(--sapFontSmallSize);
+    }
 
     &--navigation {
-      font-size: var(--sapFontSmallSize);
-      width: $fd-table-navigation-icon-width;
-      min-width: $fd-table-navigation-icon-width;
-      height: 100%;
-
-      @include fd-flex-center();
+      @include fd-icon-element-base() {
+        font-size: var(--sapFontSmallSize);
+        width: $fd-table-navigation-icon-width;
+        min-width: $fd-table-navigation-icon-width;
+        height: 100%;
+      }
     }
   }
 

--- a/stories/card/card.stories.js
+++ b/stories/card/card.stories.js
@@ -460,7 +460,7 @@ export const tableCard = () => `
                             <td class="fd-table__cell">5 EUR</td>
                             <td class="fd-table__cell">India</td>
                             <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
-                                <span class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"></span>
+                                <i role="presentation" class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"></i>
                             </td>
                         </tr>
                         <tr class="fd-table__row">
@@ -477,7 +477,7 @@ export const tableCard = () => `
                             <td class="fd-table__cell">2 EUR</td>
                             <td class="fd-table__cell">Mexico</td>
                             <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
-                                <span class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"></span>
+                                <i role="presentation" class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"></i>
                             </td>
                         </tr>
                         <tr class="fd-table__row">
@@ -494,7 +494,7 @@ export const tableCard = () => `
                             <td class="fd-table__cell">6 EUR</td>
                             <td class="fd-table__cell">Spain</td>
                             <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
-                                <span class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"></span>
+                                <i role="presentation" class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"></i>
                             </td>
                         </tr>
                     </tbody>
@@ -537,7 +537,7 @@ export const tableCard = () => `
                             <td class="fd-table__cell">5 EUR</td>
                             <td class="fd-table__cell">India</td>
                             <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
-                                <span class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"></span>
+                                <i role="presentation" class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"></i>
                             </td>
                         </tr>
                         <tr class="fd-table__row">
@@ -550,7 +550,7 @@ export const tableCard = () => `
                             <td class="fd-table__cell">2 EUR</td>
                             <td class="fd-table__cell">Mexico</td>
                             <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
-                                <span class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"></span>
+                                <i role="presentation" class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"></i>
                             </td>
                         </tr>
                         <tr class="fd-table__row">
@@ -563,7 +563,7 @@ export const tableCard = () => `
                             <td class="fd-table__cell">6 EUR</td>
                             <td class="fd-table__cell">Spain</td>
                             <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
-                                <span class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"></span>
+                                <i role="presentation" class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"></i>
                             </td>
                         </tr>
                     </tbody>

--- a/stories/card/card.stories.js
+++ b/stories/card/card.stories.js
@@ -338,27 +338,27 @@ export const listCard = () => `
             <div class="fd-card__content" role="group" aria-label="Card Content">
                 <ul class="fd-list fd-list--no-border" role="list">
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span class="fd-list__icon sap-icon--cart"></span>
+                        <i role="presentation" class="fd-list__icon sap-icon--cart"></i>
                         <span class="fd-list__title">List item 1</span>
                     </li>
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span class="fd-list__icon sap-icon--wrench"></span>
+                        <i role="presentation" class="fd-list__icon sap-icon--wrench"></i>
                         <span class="fd-list__title">List item 2</span>
                     </li>
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span class="fd-list__icon sap-icon--leads"></span>
+                        <i role="presentation" class="fd-list__icon sap-icon--leads"></i>
                         <span class="fd-list__title">List item 3</span>
                     </li>
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span class="fd-list__icon sap-icon--batch-payments"></span>
+                        <i role="presentation" class="fd-list__icon sap-icon--batch-payments"></i>
                         <span class="fd-list__title">List item 4</span>
                     </li>
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span class="fd-list__icon sap-icon--retail-store"></span>
+                        <i role="presentation" class="fd-list__icon sap-icon--retail-store"></i>
                         <span class="fd-list__title">List item 3</span>
                     </li>
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span class="fd-list__icon sap-icon--travel-expense"></span>
+                        <i role="presentation" class="fd-list__icon sap-icon--travel-expense"></i>
                         <span class="fd-list__title">List item 4</span>
                     </li>
                 </ul>
@@ -381,27 +381,27 @@ export const listCard = () => `
             <div class="fd-card__content" role="group" aria-label="Card Content">
                 <ul class="fd-list fd-list--no-border fd-list--compact" role="list">
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span class="fd-list__icon sap-icon--cart"></span>
+                        <i role="presentation" class="fd-list__icon sap-icon--cart"></i>
                         <span class="fd-list__title">List item 1</span>
                     </li>
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span class="fd-list__icon sap-icon--wrench"></span>
+                        <i role="presentation" class="fd-list__icon sap-icon--wrench"></i>
                         <span class="fd-list__title">List item 2</span>
                     </li>
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span class="fd-list__icon sap-icon--leads"></span>
+                        <i role="presentation" class="fd-list__icon sap-icon--leads"></i>
                         <span class="fd-list__title">List item 3</span>
                     </li>
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span class="fd-list__icon sap-icon--batch-payments"></span>
+                        <i role="presentation" class="fd-list__icon sap-icon--batch-payments"></i>
                         <span class="fd-list__title">List item 4</span>
                     </li>
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span class="fd-list__icon sap-icon--retail-store"></span>
+                        <i role="presentation" class="fd-list__icon sap-icon--retail-store"></i>
                         <span class="fd-list__title">List item 3</span>
                     </li>
                     <li role="listitem" tabindex="0" class="fd-list__item">
-                        <span class="fd-list__icon sap-icon--travel-expense"></span>
+                        <i role="presentation" class="fd-list__icon sap-icon--travel-expense"></i>
                         <span class="fd-list__title">List item 4</span>
                     </li>
                 </ul>

--- a/stories/list/byline/__snapshots__/byline-list.stories.storyshot
+++ b/stories/list/byline/__snapshots__/byline-list.stories.storyshot
@@ -70,8 +70,13 @@ exports[`Storyshots Components/List/Byline Selection 1`] = `
       
       
       <span
-        class="sap-icon--activate fd-list__thumbnail"
-      />
+        class="fd-list__thumbnail"
+      >
+        <i
+          class="sap-icon--activate"
+          role="presentation"
+        />
+      </span>
       
       
       <div
@@ -283,8 +288,13 @@ exports[`Storyshots Components/List/Byline Selection 1`] = `
       
       
       <span
-        class="sap-icon--activate fd-list__thumbnail"
-      />
+        class="fd-list__thumbnail"
+      >
+        <i
+          class="sap-icon--activate"
+          role="presentation"
+        />
+      </span>
       
       
       <div
@@ -502,8 +512,13 @@ exports[`Storyshots Components/List/Byline Selection with navigation 1`] = `
       
     
       <span
-        class="sap-icon--activate fd-list__thumbnail"
-      />
+        class="fd-list__thumbnail"
+      >
+        <i
+          class="sap-icon--activate"
+          role="presentation"
+        />
+      </span>
       
     
       <div
@@ -744,8 +759,13 @@ exports[`Storyshots Components/List/Byline Selection with navigation 1`] = `
         
       
         <span
-          class="sap-icon--activate fd-list__thumbnail"
-        />
+          class="fd-list__thumbnail"
+        >
+          <i
+            class="sap-icon--activate"
+            role="presentation"
+          />
+        </span>
         
       
         <div
@@ -951,8 +971,13 @@ exports[`Storyshots Components/List/Byline Standard 1`] = `
       
       
       <span
-        class="sap-icon--activate fd-list__thumbnail"
-      />
+        class="fd-list__thumbnail"
+      >
+        <i
+          class="sap-icon--activate"
+          role="presentation"
+        />
+      </span>
       
       
       <div
@@ -988,8 +1013,13 @@ exports[`Storyshots Components/List/Byline Standard 1`] = `
       
       
       <span
-        class="sap-icon--employee fd-list__thumbnail"
-      />
+        class="fd-list__thumbnail"
+      >
+        <i
+          class="sap-icon--employee"
+          role="presentation"
+        />
+      </span>
       
       
       <div
@@ -1119,8 +1149,13 @@ exports[`Storyshots Components/List/Byline Standard 1`] = `
       
       
       <span
-        class="sap-icon--activate fd-list__thumbnail"
-      />
+        class="fd-list__thumbnail"
+      >
+        <i
+          class="sap-icon--activate"
+          role="presentation"
+        />
+      </span>
       
       
       <div
@@ -1156,8 +1191,13 @@ exports[`Storyshots Components/List/Byline Standard 1`] = `
       
       
       <span
-        class="sap-icon--employee fd-list__thumbnail"
-      />
+        class="fd-list__thumbnail"
+      >
+        <i
+          class="sap-icon--employee"
+          role="presentation"
+        />
+      </span>
       
       
       <div

--- a/stories/list/byline/byline-list.stories.js
+++ b/stories/list/byline/byline-list.stories.js
@@ -23,14 +23,14 @@ export const standard = () => `
 <h4>Standard Size</h4>
 <ul class="fd-list fd-list--byline" role="list">
   <li role="listitem" tabindex="0" class="fd-list__item">
-      <span class="sap-icon--activate fd-list__thumbnail"></span>
+      <span class="fd-list__thumbnail"><i class="sap-icon--activate"></i></span>
       <div class="fd-list__content">
         <div class="fd-list__title">Title</div>
         <div class="fd-list__byline">Byline (description)</div>
       </div>
   </li>
   <li role="listitem" tabindex="0" class="fd-list__item">
-      <span class="sap-icon--employee fd-list__thumbnail"></span>
+      <span class="fd-list__thumbnail"><i class="sap-icon--employee"></i></span>
       <div class="fd-list__content">
         <div class="fd-list__title">List Item With No Byline</div>
       </div>
@@ -57,14 +57,14 @@ style="background-image: url('http://lorempixel.com/400/400/nature/5/');"></span
 <h4>Compact Size</h4>
 <ul class="fd-list fd-list--compact fd-list--byline" role="list">
   <li role="listitem" tabindex="0" class="fd-list__item">
-      <span class="sap-icon--activate fd-list__thumbnail"></span>
+      <span class="fd-list__thumbnail"><i class="sap-icon--activate"></i></span>
       <div class="fd-list__content">
         <div class="fd-list__title">Title</div>
         <div class="fd-list__byline">Byline (description)</div>
       </div>
   </li>
   <li role="listitem" tabindex="0" class="fd-list__item">
-      <span class="sap-icon--employee fd-list__thumbnail"></span>
+      <span class="fd-list__thumbnail"><i class="sap-icon--employee"></i></span>
       <div class="fd-list__content">
         <div class="fd-list__title">List Item With No Byline</div>
       </div>
@@ -101,7 +101,7 @@ export const navigation = () => `
 <ul class="fd-list fd-list--byline fd-list--navigation" role="list">
   <li role="listitem" tabindex="-1" class="fd-list__item fd-list__item--link">
     <a tabindex="0" class="fd-list__link" href="#"> 
-      <span class="sap-icon--activate fd-list__thumbnail"></span>
+      <span class="fd-list__thumbnail"><i class="sap-icon--activate"></i></span>
       <div class="fd-list__content">
         <div class="fd-list__title">Title</div>
         <div class="fd-list__byline">Byline (description)</div>
@@ -110,7 +110,7 @@ export const navigation = () => `
   </li>
   <li role="listitem" tabindex="-1" class="fd-list__item fd-list__item--link is-selected">
     <a tabindex="0" class="fd-list__link" href="#"> 
-      <span class="sap-icon--employee fd-list__thumbnail"></span>
+      <span class="fd-list__thumbnail"><i class="sap-icon--employee"></i></span>
       <div class="fd-list__content">
         <div class="fd-list__title">List Item With No Byline</div>
       </div>
@@ -156,7 +156,7 @@ export const navigationIndicator = () => `
 <ul class="fd-list fd-list--byline fd-list--navigation fd-list--navigation-indication" role="list">
   <li role="listitem" tabindex="-1" class="fd-list__item fd-list__item--link">
     <a tabindex="0" class="fd-list__link fd-list__link--navigation-indicator" href="#"> 
-      <span class="sap-icon--activate fd-list__thumbnail"></span>
+      <span class="fd-list__thumbnail"><i class="sap-icon--activate"></i></span>
       <div class="fd-list__content">
         <div class="fd-list__title">Title</div>
         <div class="fd-list__byline">Byline (description)</div>
@@ -165,7 +165,7 @@ export const navigationIndicator = () => `
   </li>
   <li role="listitem" tabindex="-1" class="fd-list__item fd-list__item--link is-selected">
     <a tabindex="0" class="fd-list__link fd-list__link--navigation-indicator is-navigated" href="#"> 
-      <span class="sap-icon--employee fd-list__thumbnail"></span>
+      <span class="fd-list__thumbnail"><i class="sap-icon--employee"></i></span>
       <div class="fd-list__content">
         <div class="fd-list__title">List Item With No Byline</div>
       </div>
@@ -201,14 +201,14 @@ all items are navigable. In this case use a byline list with navigation.
 export const borderless = () => `
 <ul class="fd-list fd-list--no-border fd-list--byline" role="list">
   <li role="listitem" tabindex="0" class="fd-list__item">
-      <span class="sap-icon--activate fd-list__thumbnail"></span>
+      <span class="fd-list__thumbnail"><i class="sap-icon--activate"></i></span>
       <div class="fd-list__content">
         <div class="fd-list__title">Title</div>
         <div class="fd-list__byline">Byline (description)</div>
       </div>
   </li>
   <li role="listitem" tabindex="0" class="fd-list__item">
-      <span class="sap-icon--employee fd-list__thumbnail"></span>
+      <span class="fd-list__thumbnail"><i class="sap-icon--employee"></i></span>
       <div class="fd-list__content">
         <div class="fd-list__title">List Item With No Byline</div>
       </div>
@@ -225,7 +225,7 @@ style="background-image: url('http://lorempixel.com/400/400/nature/5/');"></span
     </div>
   </li>
   <li role="listitem" tabindex="0" class="fd-list__item">
-    <span class="sap-icon--world fd-list__thumbnail"></span>
+      <span class="fd-list__thumbnail"><i class="sap-icon--world"></i></span>
     <div class="fd-list__content">
         <div class="fd-list__title">List Item With Two-Column Byline and Semantic Byline Second Item</div>
         <div class="fd-list__byline fd-list__byline--2-col">
@@ -254,7 +254,7 @@ export const selection = () => `
           <input type="checkbox" class="fd-checkbox" id="Ai4ez6111Z" checked aria-labelledby="O09lk1">
           <label tabindex="-1" class="fd-checkbox__label" for="Ai4ez6111Z"></label>
       </div>
-      <span class="sap-icon--activate fd-list__thumbnail"></span>
+      <span class="fd-list__thumbnail"><i class="sap-icon--activate"></i></span>
       <div class="fd-list__content">
         <span class="fd-list__title" id="O09lk1">Title</span>
         <span class="fd-list__byline">Byline (description)</span>
@@ -294,7 +294,7 @@ style="background-image: url('http://lorempixel.com/400/400/nature/5/');"></span
           <input type="checkbox" class="fd-checkbox fd-checkbox--compact" id="Ai4ez6115V" aria-labelledby="O09lk4">
           <label tabindex="-1" class="fd-checkbox__label fd-checkbox__label--compact" for="Ai4ez6115V"></label>
       </div>
-      <span class="sap-icon--activate fd-list__thumbnail"></span>
+      <span class="fd-list__thumbnail"><i class="sap-icon--activate"></i></span>
       <div class="fd-list__content">
         <span class="fd-list__title" id="O09lk4">Title</span>
         <span class="fd-list__byline">Byline (description)</span>
@@ -349,7 +349,7 @@ export const selectionAndNavigation = () => `
         <input type="checkbox" class="fd-checkbox" id="Ai4ez6118N" aria-labelledby="Ki81L2">
         <label tabindex="-1" class="fd-checkbox__label" for="Ai4ez6118N"></label>
     </div>
-    <span class="sap-icon--activate fd-list__thumbnail"></span>
+    <span class="fd-list__thumbnail"><i class="sap-icon--activate"></i></span>
     <div class="fd-list__content">
     <span class="fd-list__title" id="Ki81L2">Title</span>
     <span class="fd-list__byline">Byline (description)</span>
@@ -394,7 +394,7 @@ style="background-image: url('http://lorempixel.com/400/400/nature/5/');"></span
         <label tabindex="-1" class="fd-checkbox__label fd-checkbox__label--compact" for="Ai4ez6118CON"></label>
     </div>
     <a tabindex="0" class="fd-list__link fd-list__link--navigation-indicator" href="#">
-      <span class="sap-icon--activate fd-list__thumbnail"></span>
+      <span class="fd-list__thumbnail"><i class="sap-icon--activate"></i></span>
       <div class="fd-list__content">
         <span class="fd-list__title" id="Ki81L6">Title</span>
         <span class="fd-list__byline">Byline (description)</span>
@@ -447,7 +447,7 @@ export const rtl = () => `
             <input type="checkbox" class="fd-checkbox" id="Ai4ez6118N" aria-labelledby="K0921">
             <label tabindex="-1" class="fd-checkbox__label" for="Ai4ez6118N"></label>
         </div>
-        <span class="sap-icon--activate fd-list__thumbnail"></span>
+        <span class="fd-list__thumbnail"><i class="sap-icon--activate"></i></span>
         <div class="fd-list__content">
         <span class="fd-list__title" id="K0921">Title</span>
         <span class="fd-list__byline">Byline (description)</span>
@@ -488,14 +488,14 @@ export const rtl = () => `
     
     <ul class="fd-list fd-list--byline" role="list" aria-label="Byline list">
       <li role="listitem" tabindex="0" class="fd-list__item">
-          <span class="sap-icon--activate fd-list__thumbnail"></span>
+          <span class="fd-list__thumbnail"><i class="sap-icon--activate"></i></span>
           <div class="fd-list__content">
             <div class="fd-list__title">Title</div>
             <div class="fd-list__byline">Byline (description)</div>
           </div>
       </li>
       <li role="listitem" tabindex="0" class="fd-list__item">
-          <span class="sap-icon--employee fd-list__thumbnail"></span>
+          <span class="fd-list__thumbnail"><i class="sap-icon--employee"></i></span>
           <div class="fd-list__content">
             <div class="fd-list__title">List Item With No Byline</div>
           </div>

--- a/stories/list/byline/byline-list.stories.js
+++ b/stories/list/byline/byline-list.stories.js
@@ -23,14 +23,14 @@ export const standard = () => `
 <h4>Standard Size</h4>
 <ul class="fd-list fd-list--byline" role="list">
   <li role="listitem" tabindex="0" class="fd-list__item">
-      <span class="fd-list__thumbnail"><i class="sap-icon--activate"></i></span>
+      <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
       <div class="fd-list__content">
         <div class="fd-list__title">Title</div>
         <div class="fd-list__byline">Byline (description)</div>
       </div>
   </li>
   <li role="listitem" tabindex="0" class="fd-list__item">
-      <span class="fd-list__thumbnail"><i class="sap-icon--employee"></i></span>
+      <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--employee"></i></span>
       <div class="fd-list__content">
         <div class="fd-list__title">List Item With No Byline</div>
       </div>
@@ -57,14 +57,14 @@ style="background-image: url('http://lorempixel.com/400/400/nature/5/');"></span
 <h4>Compact Size</h4>
 <ul class="fd-list fd-list--compact fd-list--byline" role="list">
   <li role="listitem" tabindex="0" class="fd-list__item">
-      <span class="fd-list__thumbnail"><i class="sap-icon--activate"></i></span>
+      <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
       <div class="fd-list__content">
         <div class="fd-list__title">Title</div>
         <div class="fd-list__byline">Byline (description)</div>
       </div>
   </li>
   <li role="listitem" tabindex="0" class="fd-list__item">
-      <span class="fd-list__thumbnail"><i class="sap-icon--employee"></i></span>
+      <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--employee"></i></span>
       <div class="fd-list__content">
         <div class="fd-list__title">List Item With No Byline</div>
       </div>
@@ -101,7 +101,7 @@ export const navigation = () => `
 <ul class="fd-list fd-list--byline fd-list--navigation" role="list">
   <li role="listitem" tabindex="-1" class="fd-list__item fd-list__item--link">
     <a tabindex="0" class="fd-list__link" href="#"> 
-      <span class="fd-list__thumbnail"><i class="sap-icon--activate"></i></span>
+      <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
       <div class="fd-list__content">
         <div class="fd-list__title">Title</div>
         <div class="fd-list__byline">Byline (description)</div>
@@ -110,7 +110,7 @@ export const navigation = () => `
   </li>
   <li role="listitem" tabindex="-1" class="fd-list__item fd-list__item--link is-selected">
     <a tabindex="0" class="fd-list__link" href="#"> 
-      <span class="fd-list__thumbnail"><i class="sap-icon--employee"></i></span>
+      <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--employee"></i></span>
       <div class="fd-list__content">
         <div class="fd-list__title">List Item With No Byline</div>
       </div>
@@ -156,7 +156,7 @@ export const navigationIndicator = () => `
 <ul class="fd-list fd-list--byline fd-list--navigation fd-list--navigation-indication" role="list">
   <li role="listitem" tabindex="-1" class="fd-list__item fd-list__item--link">
     <a tabindex="0" class="fd-list__link fd-list__link--navigation-indicator" href="#"> 
-      <span class="fd-list__thumbnail"><i class="sap-icon--activate"></i></span>
+      <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
       <div class="fd-list__content">
         <div class="fd-list__title">Title</div>
         <div class="fd-list__byline">Byline (description)</div>
@@ -165,7 +165,7 @@ export const navigationIndicator = () => `
   </li>
   <li role="listitem" tabindex="-1" class="fd-list__item fd-list__item--link is-selected">
     <a tabindex="0" class="fd-list__link fd-list__link--navigation-indicator is-navigated" href="#"> 
-      <span class="fd-list__thumbnail"><i class="sap-icon--employee"></i></span>
+      <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--employee"></i></span>
       <div class="fd-list__content">
         <div class="fd-list__title">List Item With No Byline</div>
       </div>
@@ -201,14 +201,14 @@ all items are navigable. In this case use a byline list with navigation.
 export const borderless = () => `
 <ul class="fd-list fd-list--no-border fd-list--byline" role="list">
   <li role="listitem" tabindex="0" class="fd-list__item">
-      <span class="fd-list__thumbnail"><i class="sap-icon--activate"></i></span>
+      <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
       <div class="fd-list__content">
         <div class="fd-list__title">Title</div>
         <div class="fd-list__byline">Byline (description)</div>
       </div>
   </li>
   <li role="listitem" tabindex="0" class="fd-list__item">
-      <span class="fd-list__thumbnail"><i class="sap-icon--employee"></i></span>
+      <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--employee"></i></span>
       <div class="fd-list__content">
         <div class="fd-list__title">List Item With No Byline</div>
       </div>
@@ -225,7 +225,7 @@ style="background-image: url('http://lorempixel.com/400/400/nature/5/');"></span
     </div>
   </li>
   <li role="listitem" tabindex="0" class="fd-list__item">
-      <span class="fd-list__thumbnail"><i class="sap-icon--world"></i></span>
+      <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--world"></i></span>
     <div class="fd-list__content">
         <div class="fd-list__title">List Item With Two-Column Byline and Semantic Byline Second Item</div>
         <div class="fd-list__byline fd-list__byline--2-col">
@@ -254,7 +254,7 @@ export const selection = () => `
           <input type="checkbox" class="fd-checkbox" id="Ai4ez6111Z" checked aria-labelledby="O09lk1">
           <label tabindex="-1" class="fd-checkbox__label" for="Ai4ez6111Z"></label>
       </div>
-      <span class="fd-list__thumbnail"><i class="sap-icon--activate"></i></span>
+      <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
       <div class="fd-list__content">
         <span class="fd-list__title" id="O09lk1">Title</span>
         <span class="fd-list__byline">Byline (description)</span>
@@ -294,7 +294,7 @@ style="background-image: url('http://lorempixel.com/400/400/nature/5/');"></span
           <input type="checkbox" class="fd-checkbox fd-checkbox--compact" id="Ai4ez6115V" aria-labelledby="O09lk4">
           <label tabindex="-1" class="fd-checkbox__label fd-checkbox__label--compact" for="Ai4ez6115V"></label>
       </div>
-      <span class="fd-list__thumbnail"><i class="sap-icon--activate"></i></span>
+      <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
       <div class="fd-list__content">
         <span class="fd-list__title" id="O09lk4">Title</span>
         <span class="fd-list__byline">Byline (description)</span>
@@ -349,7 +349,7 @@ export const selectionAndNavigation = () => `
         <input type="checkbox" class="fd-checkbox" id="Ai4ez6118N" aria-labelledby="Ki81L2">
         <label tabindex="-1" class="fd-checkbox__label" for="Ai4ez6118N"></label>
     </div>
-    <span class="fd-list__thumbnail"><i class="sap-icon--activate"></i></span>
+    <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
     <div class="fd-list__content">
     <span class="fd-list__title" id="Ki81L2">Title</span>
     <span class="fd-list__byline">Byline (description)</span>
@@ -394,7 +394,7 @@ style="background-image: url('http://lorempixel.com/400/400/nature/5/');"></span
         <label tabindex="-1" class="fd-checkbox__label fd-checkbox__label--compact" for="Ai4ez6118CON"></label>
     </div>
     <a tabindex="0" class="fd-list__link fd-list__link--navigation-indicator" href="#">
-      <span class="fd-list__thumbnail"><i class="sap-icon--activate"></i></span>
+      <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
       <div class="fd-list__content">
         <span class="fd-list__title" id="Ki81L6">Title</span>
         <span class="fd-list__byline">Byline (description)</span>
@@ -447,7 +447,7 @@ export const rtl = () => `
             <input type="checkbox" class="fd-checkbox" id="Ai4ez6118N" aria-labelledby="K0921">
             <label tabindex="-1" class="fd-checkbox__label" for="Ai4ez6118N"></label>
         </div>
-        <span class="fd-list__thumbnail"><i class="sap-icon--activate"></i></span>
+        <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
         <div class="fd-list__content">
         <span class="fd-list__title" id="K0921">Title</span>
         <span class="fd-list__byline">Byline (description)</span>
@@ -488,14 +488,14 @@ export const rtl = () => `
     
     <ul class="fd-list fd-list--byline" role="list" aria-label="Byline list">
       <li role="listitem" tabindex="0" class="fd-list__item">
-          <span class="fd-list__thumbnail"><i class="sap-icon--activate"></i></span>
+          <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
           <div class="fd-list__content">
             <div class="fd-list__title">Title</div>
             <div class="fd-list__byline">Byline (description)</div>
           </div>
       </li>
       <li role="listitem" tabindex="0" class="fd-list__item">
-          <span class="fd-list__thumbnail"><i class="sap-icon--employee"></i></span>
+          <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--employee"></i></span>
           <div class="fd-list__content">
             <div class="fd-list__title">List Item With No Byline</div>
           </div>

--- a/stories/list/standard/standard-list.stories.js
+++ b/stories/list/standard/standard-list.stories.js
@@ -65,14 +65,14 @@ export const navigation = () => `
   </li>
   <li tabindex="-1" role="listitem" class="fd-list__item fd-list__item--link">
       <a tabindex="0" class="fd-list__link">
-        <span class="fd-list__icon sap-icon--history"></span>
+        <i role="presentation" class="fd-list__icon sap-icon--history"></i>
         <span class="fd-list__title">List item 2</span>
       </a>
   </li>
   <li tabindex="-1" role="listitem" class="fd-list__item fd-list__item--link">
       <a tabindex="0" class="fd-list__link">
         <span class="fd-list__title">List item 3</span>
-        <span class="fd-list__icon sap-icon--map"></span>
+        <i role="presentation" class="fd-list__icon sap-icon--map"></i>
       </a>
   </li>
 </ul>
@@ -99,22 +99,22 @@ export const navigationIndicator = () => `
   </li>
   <li tabindex="-1" role="listitem" class="fd-list__item fd-list__item--link">
       <a tabindex="0" class="fd-list__link fd-list__link--navigation-indicator is-selected" href="#">
-        <span class="fd-list__icon sap-icon--history"></span>
+        <i role="presentation" class="fd-list__icon sap-icon--history"></i>
         <span class="fd-list__title">List item 2</span>
       </a>
   </li>
   <li tabindex="0" role="listitem" class="fd-list__item">
-        <span class="fd-list__icon sap-icon--history"></span>
+        <i role="presentation" class="fd-list__icon sap-icon--history"></i>
         <span class="fd-list__title">List item 3</span>
   </li>
   <li tabindex="0" role="listitem" class="fd-list__item">
         <span class="fd-list__title">List item 4</span>
-        <span class="fd-list__icon sap-icon--map"></span>
+        <i role="presentation" class="fd-list__icon sap-icon--map"></i>
   </li>
   <li tabindex="-1" role="listitem" class="fd-list__item fd-list__item--link">
       <a tabindex="0" class="fd-list__link fd-list__link--navigation-indicator is-navigated" href="#">
         <span class="fd-list__title">List item 5</span>
-        <span class="fd-list__icon sap-icon--map"></span>
+        <i role="presentation" class="fd-list__icon sap-icon--map"></i>
       </a>
   </li>
 </ul>
@@ -219,20 +219,20 @@ secondaryData.parameters = {
 export const icons = () => `
 <ul class="fd-list" role="list">
   <li role="listitem" tabindex="0" class="fd-list__item">
-      <span class="fd-list__icon sap-icon--cart"></span>
+      <i role="presentation" class="fd-list__icon sap-icon--cart"></i>
       <span class="fd-list__title">List item 1</span>
   </li>
   <li role="listitem" tabindex="0" class="fd-list__item">
-      <span class="fd-list__icon sap-icon--wrench"></span>
+      <i role="presentation" class="fd-list__icon sap-icon--wrench"></i>
       <span class="fd-list__title">List item 2</span>
   </li>
   <li role="listitem" tabindex="0" class="fd-list__item">
       <span class="fd-list__title">List item 3</span>
-      <span class="fd-list__icon sap-icon--lightbulb"></span>
+      <i role="presentation" class="fd-list__icon sap-icon--lightbulb"></i>
   </li>
   <li role="listitem" tabindex="0" class="fd-list__item">
       <span class="fd-list__title">List item 4</span>
-      <span class="fd-list__icon sap-icon--history"></span>
+      <i role="presentation" class="fd-list__icon sap-icon--history"></i>
   </li>
 </ul>
 `;
@@ -416,22 +416,22 @@ export const rtl = () => `
       </li>
       <li tabindex="-1" role="listitem" class="fd-list__item fd-list__item--link">
           <a tabindex="0" class="fd-list__link fd-list__link--navigation-indicator is-selected" href="#">
-            <span class="fd-list__icon sap-icon--history"></span>
+            <i role="presentation" class="fd-list__icon sap-icon--history"></i>
             <span class="fd-list__title">List item 2</span>
           </a>
       </li>
       <li tabindex="0" role="listitem" class="fd-list__item">
-            <span class="fd-list__icon sap-icon--history"></span>
+            <i role="presentation" class="fd-list__icon sap-icon--history"></i>
             <span class="fd-list__title">List item 3</span>
       </li>
       <li tabindex="0" role="listitem" class="fd-list__item">
             <span class="fd-list__title">List item 4</span>
-            <span class="fd-list__icon sap-icon--map"></span>
+            <i role="presentation" class="fd-list__icon sap-icon--map"></i>
       </li>
       <li tabindex="-1" role="listitem" class="fd-list__item fd-list__item--link">
           <a tabindex="0" class="fd-list__link fd-list__link--navigation-indicator is-navigated" href="#">
             <span class="fd-list__title">List item 5</span>
-            <span class="fd-list__icon sap-icon--map"></span>
+            <i role="presentation" class="fd-list__icon sap-icon--map"></i>
           </a>
       </li>
     </ul>

--- a/stories/select/select.stories.js
+++ b/stories/select/select.stories.js
@@ -281,24 +281,24 @@ export const twoColumnsAndIcons = () => `
     <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown" aria-hidden="true" id="h090G325">
         <ul tabIndex="-1" aria-labelledby="g45564A50" class="fd-list fd-list--dropdown" role="listbox" id="s45GH6Y7">
             <li class="fd-list__item is-selected" aria-selected="true" role="option" tabindex="0">
-            <span class="fd-list__icon sap-icon--marketing-campaign"></span>
-            <span class="fd-list__title">Marketing</span>
-            <span class="fd-list__secondary">1000 EUR</span>
+                <i role="presentation" class="fd-list__icon sap-icon--marketing-campaign"></i>
+                <span class="fd-list__title">Marketing</span>
+                <span class="fd-list__secondary">1000 EUR</span>
             </li>
             <li class="fd-list__item" role="option" tabindex="-1">
-            <span class="fd-list__icon sap-icon--save"></span>
-            <span class="fd-list__title">Backups</span>
-            <span class="fd-list__secondary">500 EUR</span>
-        </li>
-            <li class="fd-list__item" role="option" tabindex="-1">
-            <span class="fd-list__icon sap-icon--shipping-status"></span>
-            <span class="fd-list__title">Shipping</span>
-            <span class="fd-list__secondary">125 EUR</span>
+                <i role="presentation" class="fd-list__icon sap-icon--save"></i>
+                <span class="fd-list__title">Backups</span>
+                <span class="fd-list__secondary">500 EUR</span>
             </li>
             <li class="fd-list__item" role="option" tabindex="-1">
-            <span class="fd-list__icon sap-icon--headset"></span>
-            <span class="fd-list__title">Consulting</span>
-            <span class="fd-list__secondary">200 EUR</span>
+                <i role="presentation" class="fd-list__icon sap-icon--shipping-status"></i>
+                <span class="fd-list__title">Shipping</span>
+                <span class="fd-list__secondary">125 EUR</span>
+            </li>
+            <li class="fd-list__item" role="option" tabindex="-1">
+                <i role="presentation" class="fd-list__icon sap-icon--headset"></i>
+                <span class="fd-list__title">Consulting</span>
+                <span class="fd-list__secondary">200 EUR</span>
             </li>
         </ul>
     </div>

--- a/stories/table/__snapshots__/table.stories.storyshot
+++ b/stories/table/__snapshots__/table.stories.storyshot
@@ -2378,8 +2378,9 @@ exports[`Storyshots Components/Table Responsive Table 1`] = `
         >
           
                 
-          <span
+          <i
             class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"
+            role="presentation"
           />
           
             
@@ -2459,8 +2460,9 @@ exports[`Storyshots Components/Table Responsive Table 1`] = `
         >
           
                 
-          <span
+          <i
             class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"
+            role="presentation"
           />
           
             
@@ -2540,8 +2542,9 @@ exports[`Storyshots Components/Table Responsive Table 1`] = `
         >
           
                 
-          <span
+          <i
             class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"
+            role="presentation"
           />
           
             
@@ -2638,8 +2641,9 @@ exports[`Storyshots Components/Table Responsive Table Pop In Mode 1`] = `
           >
             
                     
-            <span
+            <i
               class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"
+              role="presentation"
             />
             
                 
@@ -2747,8 +2751,9 @@ exports[`Storyshots Components/Table Responsive Table Pop In Mode 1`] = `
           >
             
                     
-            <span
+            <i
               class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"
+              role="presentation"
             />
             
                 
@@ -2925,8 +2930,9 @@ exports[`Storyshots Components/Table Responsive Table Pop In Mode 1`] = `
           >
             
                     
-            <span
+            <i
               class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"
+              role="presentation"
             />
             
                 
@@ -3061,8 +3067,9 @@ exports[`Storyshots Components/Table Responsive Table Pop In Mode 1`] = `
           >
             
                     
-            <span
+            <i
               class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"
+              role="presentation"
             />
             
                 

--- a/stories/table/table.stories.js
+++ b/stories/table/table.stories.js
@@ -60,9 +60,9 @@ export const primary = () => `
 
 /**
  * * `--no-vertical-borders` modifier can be applied to render a table without vertical borders.
-* `--no-horizontal-borders` modifier can be applied to render a table without horizontal borders.
+ * `--no-horizontal-borders` modifier can be applied to render a table without horizontal borders.
 
-Both can be added to  `fd-table`, `fd-table__header`, or `fd-table__body`.
+ Both can be added to  `fd-table`, `fd-table__header`, or `fd-table__body`.
  */
 
 export const withoutBorders = () => `
@@ -140,7 +140,7 @@ export const withoutBordersOnBody = () => `
 `;
 
 /** Footer can be added by using `fd-table__footer` class with `tfoot` element.
-It has to contain same size of columns as tbody and thead. */
+ It has to contain same size of columns as tbody and thead. */
 
 export const withFooter = () => `
 <div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
@@ -279,8 +279,8 @@ export const withFooterCondensed = () => `
 /**
  * Interactive states of columns and row can be set by adding
 
-* For active state handler `--activable` modifier
-* For hover state handler `--hoverable` modifier
+ * For active state handler `--activable` modifier
+ * For hover state handler `--hoverable` modifier
  */
 
 export const interactiveRowsAndColumns = () => `
@@ -427,8 +427,8 @@ export const focusableCells = () => `
 
 /**
  * The checkbox input can be used at the beginning of each row to allow for bulk actions.
-It is recommended to add the parameter `aria-selected="true"` to the row that is selected.
-Also for cells that include a checkbox should contain the `fd-table__cell--checkbox` class.
+ It is recommended to add the parameter `aria-selected="true"` to the row that is selected.
+ Also for cells that include a checkbox should contain the `fd-table__cell--checkbox` class.
  */
 
 export const withCheckbox = () => `
@@ -834,8 +834,8 @@ export const withAdvancedToolbar = () => `
 
 /**
  * Responsive table is not that different than basic table, there should be used some modifiers, to remove borders.
-For Pop-in example markup is changed, one row is transformed to 2 rows with `fd-table__row--main` and
-`fd-table__row--secondary`modifiers. Also some cells should be merged into paragraphs.
+ For Pop-in example markup is changed, one row is transformed to 2 rows with `fd-table__row--main` and
+ `fd-table__row--secondary`modifiers. Also some cells should be merged into paragraphs.
  */
 
 export const responsiveTable = () => `
@@ -872,7 +872,7 @@ export const responsiveTable = () => `
             <td class="fd-table__cell">5 EUR</td>
             <td class="fd-table__cell">India</td>
             <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
-                <span class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"></span>
+                <i class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow" role="presentation"></i>
             </td>
         </tr>
         <tr class="fd-table__row">
@@ -889,7 +889,7 @@ export const responsiveTable = () => `
             <td class="fd-table__cell">2 EUR</td>
             <td class="fd-table__cell">Mexico</td>
             <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
-                <span class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"></span>
+                <i class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow" role="presentation"></i>
             </td>
         </tr>
         <tr class="fd-table__row">
@@ -906,7 +906,7 @@ export const responsiveTable = () => `
             <td class="fd-table__cell">6 EUR</td>
             <td class="fd-table__cell">Spain</td>
             <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
-                <span class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"></span>
+                <i class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow" role="presentation"></i>
             </td>
         </tr>
     </tbody>
@@ -929,7 +929,7 @@ export const responsiveTablePopInMode = () => `
                     5 EUR
                 </td>
                 <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
-                    <span class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"></span>
+                    <i class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow" role="presentation"></i>
                 </td>
             </tr>
             <tr class="fd-table__row fd-table__row--secondary">
@@ -955,7 +955,7 @@ export const responsiveTablePopInMode = () => `
                     6 EUR
                 </td>
                 <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
-                    <span class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"></span>
+                    <i class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow" role="presentation"></i>
                 </td>
             </tr>
             <tr class="fd-table__row fd-table__row--secondary">
@@ -996,7 +996,7 @@ export const responsiveTablePopInMode = () => `
                     5 EUR
                 </td>
                 <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
-                    <span class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"></span>
+                    <i class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow" role="presentation"></i>
                 </td>
             </tr>
             <tr class="fd-table__row fd-table__row--secondary">
@@ -1027,7 +1027,7 @@ export const responsiveTablePopInMode = () => `
                     6 EUR
                 </td>
                 <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
-                    <span class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"></span>
+                    <i class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow" role="presentation"></i>
                 </td>
             </tr>
             <tr class="fd-table__row fd-table__row--secondary">
@@ -1052,9 +1052,9 @@ export const responsiveTablePopInMode = () => `
 
 /**
  * To show that an item needs attention, you can show a highlight indicator next to the item.
-This can be achieved by passing the `fd-table__cell--status-indicator` class to each row.
-Other indicators such as semantic states and modes can be added using the `--valid`,
-`--information`, `--error`, `--warning` modifiers.
+ This can be achieved by passing the `fd-table__cell--status-indicator` class to each row.
+ Other indicators such as semantic states and modes can be added using the `--valid`,
+ `--information`, `--error`, `--warning` modifiers.
  */
 
 export const semanticRows = () => `
@@ -1233,7 +1233,7 @@ export const mergedCells = () => `
 
 /**
  * When more than three actions exist per row and/or there isn't enough space for the required actions,
-a contextual menu can be substituted to display all actions in one menu.
+ a contextual menu can be substituted to display all actions in one menu.
  */
 
 export const tableWithContextualMenu = () => `
@@ -1362,7 +1362,7 @@ export const tableWithContextualMenu = () => `
 
 /**
  * Some customization actions can be added to headers, the options will be displayed in popover. Those popover should be
-added with `fd-table__popover` class.
+ added with `fd-table__popover` class.
  */
 
 export const withMenuInHeader = () => `
@@ -1456,9 +1456,9 @@ export const withMenuInHeader = () => `
 
 /**
  * To create fixed column, these steps need to be reproduced
-* Wrap the table with element with class `fd-table--fixed`
-* Add `fd-table__cell--fixed` class to cell elements, it should be propagated to whole row
-* Hard code the width of columns, otherwise the cells will be squashed.
+ * Wrap the table with element with class `fd-table--fixed`
+ * Add `fd-table__cell--fixed` class to cell elements, it should be propagated to whole row
+ * Hard code the width of columns, otherwise the cells will be squashed.
  */
 
 export const fixColumnHeader = () => `


### PR DESCRIPTION
## Related Issue
Successor of: #1651
Part of: #1603

## Description
This PR:
- Moves byline list thumbnail icon into separate element
- Updates table icon styling with icon mixins and adds aria labels
- Updates list icon styling with icon mixins and adds aria labels

List:
### Before:
```
 <li role="listitem" tabindex="0" class="fd-list__item">
      <span class="sap-icon--activate fd-list__thumbnail"></span>
</li>
```

### After:
```
 <li role="listitem" tabindex="0" class="fd-list__item">
      <span class="fd-list__thumbnail"><i class="sap-icon--activate" role="presentation"></i></span>
</li>
```

Table:
### Before:
```
<td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
    <span class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"></span>
</td>
```

### After:
```
<td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
    <i class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow" role="presentation"></i>
</td>
```

#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
