### PR TITLE
fix: Remove double outline from side navigation expand button

### DIFF
--- a/src/_nested-list.scss
+++ b/src/_nested-list.scss
@@ -2,6 +2,7 @@
 @import "./mixins";
 
 $block: #{$fd-namespace}-nested-list;
+$button: #{$fd-namespace}-button;
 
 .#{$block} {
   @mixin fd-nested-level-padding($paddingLeft, $paddingRight) {
@@ -152,6 +153,8 @@ $block: #{$fd-namespace}-nested-list;
       }
 
       > .#{$block}__link {
+        @include fd-fiori-focus();
+
         background: transparent;
         border: none;
         height: 100%;
@@ -164,46 +167,19 @@ $block: #{$fd-namespace}-nested-list;
           }
         }
       }
-
-      > .#{$block}__link,
-      > .#{$block}__button {
-        @include fd-fiori-focus();
-      }
     }
   }
 
-  &__button.#{$fd-namespace}-button {
-    @include fd-fiori-focus();
+  &__button.#{$button} {
+    @include set-height(100%);
 
-    text-decoration: none;
-    height: 100%;
-    min-width: 2.5rem;
-    color: var(--sapContent_IconColor);
-    display: flex;
-    justify-content: center;
     border: none;
+    min-width: 2.5rem;
+    text-decoration: none;
+    color: var(--sapContent_IconColor);
 
-    @include fd-icon('navigation-right-arrow', 'after') {
-      @include fd-flex-center();
-
-      height: 100%;
-      min-height: 100%;
+    @include fd-icon-selector() {
       font-size: var(--sapFontLargeSize);
-    }
-
-    @include fd-rtl() {
-      &::after {
-        content: "\e067";
-      }
-    }
-
-    &.is-expanded,
-    &[aria-expanded="true"] {
-      border-bottom: none;
-
-      &::after {
-        content: "\e1e2";
-      }
     }
   }
 

--- a/stories/side-navigation/side-navigation.stories.js
+++ b/stories/side-navigation/side-navigation.stories.js
@@ -144,7 +144,7 @@ export const cozyMultiple = () => `
                         aria-haspopup="true" 
                         aria-expanded="false" 
                         aria-label="Expand submenu">
-                        <i class="sap-icon--navigation-right-arrow"></i>    
+                        <i class="sap-icon--navigation-right-arrow" role="presentation"></i>    
                     </button>
                 </div>
                 <ul class="fd-nested-list level-2" id="EX100L2" aria-hidden="true">
@@ -239,7 +239,7 @@ export const complexCozySideNav = () => `
                         aria-haspopup="true" 
                         aria-expanded="false" 
                         aria-label="Expand submenu">
-                        <i class="sap-icon--navigation-right-arrow"></i>    
+                        <i class="sap-icon--navigation-right-arrow" role="presentation"></i>    
                     </button>
                 </div>
                 <ul class="fd-nested-list fd-nested-list--text-only level-2" id="EX400L2" aria-hidden="true">
@@ -341,7 +341,7 @@ export const complexCompactSideNav = () => `
                         aria-haspopup="true" 
                         aria-expanded="false" 
                         aria-label="Expand submenu">
-                        <i class="sap-icon--navigation-right-arrow"></i>    
+                        <i class="sap-icon--navigation-right-arrow" role="presentation"></i>    
                     </button>
                 </div>
                 <ul class="fd-nested-list fd-nested-list--text-only level-2" id="EX500L2" aria-hidden="true">
@@ -567,7 +567,7 @@ export const nestedListWithoutIcons = () => `
                     aria-haspopup="true" 
                     aria-expanded="true" 
                     aria-label="Expand submenu">
-                    <i class="sap-icon--navigation-right-arrow"></i>    
+                    <i class="sap-icon--navigation-right-arrow" role="presentation"></i>    
             </button>
 		</div>
         <ul class="fd-nested-list level-2" id="EX100L25" aria-hidden="false">
@@ -586,7 +586,7 @@ export const nestedListWithoutIcons = () => `
                         aria-haspopup="true" 
                         aria-expanded="true" 
                         aria-label="Expand submenu">
-                        <i class="sap-icon--navigation-right-arrow"></i>    
+                        <i class="sap-icon--navigation-right-arrow" role="presentation"></i>    
                     </button>
 				</div>
                 <ul class="fd-nested-list level-3" id="EX100L35" aria-hidden="false">
@@ -605,7 +605,7 @@ export const nestedListWithoutIcons = () => `
                                 aria-haspopup="true" 
                                 aria-expanded="true" 
                                 aria-label="Expand submenu">
-                                <i class="sap-icon--navigation-right-arrow"></i>    
+                                <i class="sap-icon--navigation-right-arrow" role="presentation"></i>    
                             </button>
 						</div>
                         <ul class="fd-nested-list level-4" id="EX100L45" aria-hidden="false">
@@ -624,7 +624,7 @@ export const nestedListWithoutIcons = () => `
                                         aria-haspopup="true" 
                                         aria-expanded="true" 
                                         aria-label="Expand submenu">
-                                        <i class="sap-icon--navigation-right-arrow"></i>    
+                                        <i class="sap-icon--navigation-right-arrow" role="presentation"></i>    
                                     </button>
 								</div>
                                 <ul class="fd-nested-list level-5" id="EX100L55" aria-hidden="false">
@@ -643,7 +643,7 @@ export const nestedListWithoutIcons = () => `
                                                 aria-haspopup="true" 
                                                 aria-expanded="true" 
                                                 aria-label="Expand submenu">
-                                                <i class="sap-icon--navigation-right-arrow"></i>
+                                                <i class="sap-icon--navigation-right-arrow" role="presentation"></i>
                                             </button>
 										</div>
                                         <ul class="fd-nested-list level-6" id="EX100L65" aria-hidden="false">
@@ -736,7 +736,7 @@ export const nestedListWithIconsOnlyInFirstLevel = () => `
                 aria-haspopup="true" 
                 aria-expanded="true" 
                 aria-label="Expand submenu">
-                <i class="sap-icon--navigation-right-arrow"></i>    
+                <i class="sap-icon--navigation-right-arrow" role="presentation"></i>    
             </button>
 		</div>
         <ul class="fd-nested-list fd-nested-list--text-only level-2" id="EX300L2" aria-hidden="false">
@@ -755,7 +755,7 @@ export const nestedListWithIconsOnlyInFirstLevel = () => `
                         aria-haspopup="true" 
                         aria-expanded="true" 
                         aria-label="Expand submenu">
-                        <i class="sap-icon--navigation-right-arrow"></i>    
+                        <i class="sap-icon--navigation-right-arrow" role="presentation"></i>    
                     </button>
 				</div>
                 <ul class="fd-nested-list fd-nested-list--text-only level-3" id="EX300L3" aria-hidden="false">
@@ -774,7 +774,7 @@ export const nestedListWithIconsOnlyInFirstLevel = () => `
                                 aria-haspopup="true" 
                                 aria-expanded="true" 
                                 aria-label="Expand submenu">
-                                <i class="sap-icon--navigation-right-arrow"></i>    
+                                <i class="sap-icon--navigation-right-arrow" role="presentation"></i>    
                             </button>
 						</div>
                         <ul class="fd-nested-list fd-nested-list--text-only level-4" id="EX300L4" aria-hidden="false">
@@ -863,7 +863,7 @@ export const nestedListWithGroupHeaders = () => `
                 aria-haspopup="true" 
                 aria-expanded="true" 
                 aria-label="Expand submenu">
-                <i class="sap-icon--navigation-right-arrow"></i>    
+                <i class="sap-icon--navigation-right-arrow" role="presentation"></i>    
             </button>
 		</div>
         <ul class="fd-nested-list fd-nested-list--text-only level-2" id="EX400L222" aria-hidden="false">
@@ -882,7 +882,7 @@ export const nestedListWithGroupHeaders = () => `
                         aria-haspopup="true" 
                         aria-expanded="true" 
                         aria-label="Expand submenu">
-                        <i class="sap-icon--navigation-right-arrow"></i>    
+                        <i class="sap-icon--navigation-right-arrow" role="presentation"></i>    
                     </button>
 				</div>
                 <ul class="fd-nested-list fd-nested-list--text-only level-3" id="EX400L3" aria-hidden="false">
@@ -901,7 +901,7 @@ export const nestedListWithGroupHeaders = () => `
                                 aria-haspopup="true" 
                                 aria-expanded="true" 
                                 aria-label="Expand submenu">
-                                <i class="sap-icon--navigation-right-arrow"></i>    
+                                <i class="sap-icon--navigation-right-arrow" role="presentation"></i>    
                             </button>
 						</div>
                         <ul class="fd-nested-list fd-nested-list--text-only level-4" id="EX400L4" aria-hidden="false">
@@ -993,7 +993,7 @@ export const nestedListWithGroupHeadersCompactMode = () => `
                 aria-haspopup="true" 
                 aria-expanded="true" 
                 aria-label="Expand submenu">
-                <i class="sap-icon--navigation-right-arrow"></i>    
+                <i class="sap-icon--navigation-right-arrow" role="presentation"></i>    
             </button>
 		</div>
         <ul class="fd-nested-list fd-nested-list--text-only level-2" id="EX500L2" aria-hidden="false">
@@ -1012,7 +1012,7 @@ export const nestedListWithGroupHeadersCompactMode = () => `
                         aria-haspopup="true" 
                         aria-expanded="true" 
                         aria-label="Expand submenu">
-                        <i class="sap-icon--navigation-right-arrow"></i>    
+                        <i class="sap-icon--navigation-right-arrow" role="presentation"></i>    
                     </button>
 				</div>
                 <ul class="fd-nested-list fd-nested-list--text-only level-3" id="EX500L3" aria-hidden="false">
@@ -1031,7 +1031,7 @@ export const nestedListWithGroupHeadersCompactMode = () => `
                                 aria-haspopup="true" 
                                 aria-expanded="true" 
                                 aria-label="Expand submenu">
-                                <i class="sap-icon--navigation-right-arrow"></i>    
+                                <i class="sap-icon--navigation-right-arrow" role="presentation"></i>    
                             </button>
 						</div>
                         <ul class="fd-nested-list fd-nested-list--text-only level-4" id="EX500L4" aria-hidden="false">
@@ -1121,7 +1121,7 @@ export const nestedListWithoutLinks = () => `
                 aria-haspopup="true" 
                 aria-expanded="true" 
                 aria-label="Expand submenu">
-                <i class="sap-icon--navigation-right-arrow"></i>    
+                <i class="sap-icon--navigation-right-arrow" role="presentation"></i>    
             </button>
 		</div>
         <ul class="fd-nested-list fd-nested-list--text-only level-2" id="EX600L2" aria-hidden="false">
@@ -1138,7 +1138,7 @@ export const nestedListWithoutLinks = () => `
                         aria-haspopup="true" 
                         aria-expanded="true" 
                         aria-label="Expand submenu">
-                        <i class="sap-icon--navigation-right-arrow"></i>    
+                        <i class="sap-icon--navigation-right-arrow" role="presentation"></i>    
                     </button>
 				</div>
                 <ul class="fd-nested-list fd-nested-list--text-only level-3" id="EX600L3" aria-hidden="false">
@@ -1155,7 +1155,7 @@ export const nestedListWithoutLinks = () => `
                                 aria-haspopup="true" 
                                 aria-expanded="true" 
                                 aria-label="Expand submenu">
-                                <i class="sap-icon--navigation-right-arrow"></i>    
+                                <i class="sap-icon--navigation-right-arrow" role="presentation"></i>    
                             </button>
 						</div>
                         <ul class="fd-nested-list fd-nested-list--text-only level-4" id="EX600L4" aria-hidden="false">
@@ -1248,7 +1248,7 @@ export const rtlExample = () => `
                 aria-haspopup="true" 
                 aria-expanded="true" 
                 aria-label="Expand submenu">
-                <i class="sap-icon--navigation-left-arrow"></i>    
+                <i class="sap-icon--navigation-left-arrow" role="presentation"></i>    
             </button>
 		</div>
         <ul class="fd-nested-list fd-nested-list--text-only level-2" id="EX400L2122" aria-hidden="false">
@@ -1267,7 +1267,7 @@ export const rtlExample = () => `
                         aria-haspopup="true" 
                         aria-expanded="true" 
                         aria-label="Expand submenu">
-                        <i class="sap-icon--navigation-left-arrow"></i>    
+                        <i class="sap-icon--navigation-left-arrow" role="presentation"></i>    
                     </button>
 				</div>
                 <ul class="fd-nested-list fd-nested-list--text-only level-3" id="EX400L3" aria-hidden="false">
@@ -1286,7 +1286,7 @@ export const rtlExample = () => `
                                 aria-haspopup="true" 
                                 aria-expanded="true" 
                                 aria-label="Expand submenu">
-                                <i class="sap-icon--navigation-left-arrow"></i>    
+                                <i class="sap-icon--navigation-left-arrow" role="presentation"></i>    
                             </button>
 						</div>
                         <ul class="fd-nested-list fd-nested-list--text-only level-4" id="EX400L4" aria-hidden="false">
@@ -1376,7 +1376,7 @@ export const rtlCozyMultiple = () => `
                         aria-haspopup="true" 
                         aria-expanded="false" 
                         aria-label="Expand submenu">
-                        <i class="sap-icon--navigation-left-arrow"></i>    
+                        <i class="sap-icon--navigation-left-arrow" role="presentation"></i>    
                     </button>
                 </div>
                 <ul class="fd-nested-list level-2" id="EX100L233" aria-hidden="true">

--- a/stories/side-navigation/side-navigation.stories.js
+++ b/stories/side-navigation/side-navigation.stories.js
@@ -143,7 +143,9 @@ export const cozyMultiple = () => `
                         aria-controls="EX100L2" 
                         aria-haspopup="true" 
                         aria-expanded="false" 
-                        aria-label="Expand submenu"></button>
+                        aria-label="Expand submenu">
+                        <i class="sap-icon--navigation-right-arrow"></i>    
+                    </button>
                 </div>
                 <ul class="fd-nested-list level-2" id="EX100L2" aria-hidden="true">
                     <li class="fd-nested-list__item">
@@ -236,7 +238,9 @@ export const complexCozySideNav = () => `
                         aria-controls="EX400L2" 
                         aria-haspopup="true" 
                         aria-expanded="false" 
-                        aria-label="Expand submenu"></button>
+                        aria-label="Expand submenu">
+                        <i class="sap-icon--navigation-right-arrow"></i>    
+                    </button>
                 </div>
                 <ul class="fd-nested-list fd-nested-list--text-only level-2" id="EX400L2" aria-hidden="true">
                     <li class="fd-nested-list__item">
@@ -336,7 +340,9 @@ export const complexCompactSideNav = () => `
                         aria-controls="EX500L2" 
                         aria-haspopup="true" 
                         aria-expanded="false" 
-                        aria-label="Expand submenu"></button>
+                        aria-label="Expand submenu">
+                        <i class="sap-icon--navigation-right-arrow"></i>    
+                    </button>
                 </div>
                 <ul class="fd-nested-list fd-nested-list--text-only level-2" id="EX500L2" aria-hidden="true">
                     <li class="fd-nested-list__item">
@@ -560,7 +566,9 @@ export const nestedListWithoutIcons = () => `
                     aria-controls="EX100L25"
                     aria-haspopup="true" 
                     aria-expanded="true" 
-                    aria-label="Expand submenu"></button>
+                    aria-label="Expand submenu">
+                    <i class="sap-icon--navigation-right-arrow"></i>    
+            </button>
 		</div>
         <ul class="fd-nested-list level-2" id="EX100L25" aria-hidden="false">
             <li class="fd-nested-list__item">
@@ -577,7 +585,9 @@ export const nestedListWithoutIcons = () => `
                         aria-controls="EX100L35"
                         aria-haspopup="true" 
                         aria-expanded="true" 
-                        aria-label="Expand submenu"></button>
+                        aria-label="Expand submenu">
+                        <i class="sap-icon--navigation-right-arrow"></i>    
+                    </button>
 				</div>
                 <ul class="fd-nested-list level-3" id="EX100L35" aria-hidden="false">
                     <li class="fd-nested-list__item">
@@ -594,7 +604,9 @@ export const nestedListWithoutIcons = () => `
                                 aria-controls="EX100L45"
                                 aria-haspopup="true" 
                                 aria-expanded="true" 
-                                aria-label="Expand submenu"></button>
+                                aria-label="Expand submenu">
+                                <i class="sap-icon--navigation-right-arrow"></i>    
+                            </button>
 						</div>
                         <ul class="fd-nested-list level-4" id="EX100L45" aria-hidden="false">
                             <li class="fd-nested-list__item">
@@ -611,7 +623,9 @@ export const nestedListWithoutIcons = () => `
                                         aria-controls="EX100L55"
                                         aria-haspopup="true" 
                                         aria-expanded="true" 
-                                        aria-label="Expand submenu"></button>
+                                        aria-label="Expand submenu">
+                                        <i class="sap-icon--navigation-right-arrow"></i>    
+                                    </button>
 								</div>
                                 <ul class="fd-nested-list level-5" id="EX100L55" aria-hidden="false">
                                     <li class="fd-nested-list__item">
@@ -625,10 +639,12 @@ export const nestedListWithoutIcons = () => `
 												<span class="fd-nested-list__title">Level 5 Item</span>
 											</a>
                                             <button class="fd-button fd-nested-list__button"
-                                            aria-controls="EX100L65"
-                                            aria-haspopup="true" 
-                                            aria-expanded="true" 
-                                            aria-label="Expand submenu"></button>
+                                                aria-controls="EX100L65"
+                                                aria-haspopup="true" 
+                                                aria-expanded="true" 
+                                                aria-label="Expand submenu">
+                                                <i class="sap-icon--navigation-right-arrow"></i>
+                                            </button>
 										</div>
                                         <ul class="fd-nested-list level-6" id="EX100L65" aria-hidden="false">
                                             <li class="fd-nested-list__item">
@@ -719,7 +735,9 @@ export const nestedListWithIconsOnlyInFirstLevel = () => `
                 aria-controls="EX300L2"
                 aria-haspopup="true" 
                 aria-expanded="true" 
-                aria-label="Expand submenu"></button>
+                aria-label="Expand submenu">
+                <i class="sap-icon--navigation-right-arrow"></i>    
+            </button>
 		</div>
         <ul class="fd-nested-list fd-nested-list--text-only level-2" id="EX300L2" aria-hidden="false">
             <li class="fd-nested-list__item">
@@ -736,7 +754,9 @@ export const nestedListWithIconsOnlyInFirstLevel = () => `
                         aria-controls="EX300L3"
                         aria-haspopup="true" 
                         aria-expanded="true" 
-                        aria-label="Expand submenu"></button>
+                        aria-label="Expand submenu">
+                        <i class="sap-icon--navigation-right-arrow"></i>    
+                    </button>
 				</div>
                 <ul class="fd-nested-list fd-nested-list--text-only level-3" id="EX300L3" aria-hidden="false">
                     <li class="fd-nested-list__item">
@@ -753,7 +773,9 @@ export const nestedListWithIconsOnlyInFirstLevel = () => `
                                 aria-controls="EX300L4"
                                 aria-haspopup="true" 
                                 aria-expanded="true" 
-                                aria-label="Expand submenu"></button>
+                                aria-label="Expand submenu">
+                                <i class="sap-icon--navigation-right-arrow"></i>    
+                            </button>
 						</div>
                         <ul class="fd-nested-list fd-nested-list--text-only level-4" id="EX300L4" aria-hidden="false">
                             <li class="fd-nested-list__item">
@@ -840,7 +862,9 @@ export const nestedListWithGroupHeaders = () => `
                 aria-controls="EX400L222"
                 aria-haspopup="true" 
                 aria-expanded="true" 
-                aria-label="Expand submenu"></button>
+                aria-label="Expand submenu">
+                <i class="sap-icon--navigation-right-arrow"></i>    
+            </button>
 		</div>
         <ul class="fd-nested-list fd-nested-list--text-only level-2" id="EX400L222" aria-hidden="false">
             <li class="fd-nested-list__item">
@@ -857,7 +881,9 @@ export const nestedListWithGroupHeaders = () => `
                         aria-controls="EX400L3"
                         aria-haspopup="true" 
                         aria-expanded="true" 
-                        aria-label="Expand submenu"></button>
+                        aria-label="Expand submenu">
+                        <i class="sap-icon--navigation-right-arrow"></i>    
+                    </button>
 				</div>
                 <ul class="fd-nested-list fd-nested-list--text-only level-3" id="EX400L3" aria-hidden="false">
                     <li class="fd-nested-list__item">
@@ -874,7 +900,9 @@ export const nestedListWithGroupHeaders = () => `
                                 aria-controls="EX400L4"
                                 aria-haspopup="true" 
                                 aria-expanded="true" 
-                                aria-label="Expand submenu"></button>
+                                aria-label="Expand submenu">
+                                <i class="sap-icon--navigation-right-arrow"></i>    
+                            </button>
 						</div>
                         <ul class="fd-nested-list fd-nested-list--text-only level-4" id="EX400L4" aria-hidden="false">
                             <li class="fd-nested-list__item">
@@ -964,7 +992,9 @@ export const nestedListWithGroupHeadersCompactMode = () => `
                 aria-controls="EX500L2"
                 aria-haspopup="true" 
                 aria-expanded="true" 
-                aria-label="Expand submenu"></button>
+                aria-label="Expand submenu">
+                <i class="sap-icon--navigation-right-arrow"></i>    
+            </button>
 		</div>
         <ul class="fd-nested-list fd-nested-list--text-only level-2" id="EX500L2" aria-hidden="false">
             <li class="fd-nested-list__item">
@@ -981,7 +1011,9 @@ export const nestedListWithGroupHeadersCompactMode = () => `
                         aria-controls="EX500L3"
                         aria-haspopup="true" 
                         aria-expanded="true" 
-                        aria-label="Expand submenu"></button>
+                        aria-label="Expand submenu">
+                        <i class="sap-icon--navigation-right-arrow"></i>    
+                    </button>
 				</div>
                 <ul class="fd-nested-list fd-nested-list--text-only level-3" id="EX500L3" aria-hidden="false">
                     <li class="fd-nested-list__item">
@@ -998,7 +1030,9 @@ export const nestedListWithGroupHeadersCompactMode = () => `
                                 aria-controls="EX500L4"
                                 aria-haspopup="true" 
                                 aria-expanded="true" 
-                                aria-label="Expand submenu"></button>
+                                aria-label="Expand submenu">
+                                <i class="sap-icon--navigation-right-arrow"></i>    
+                            </button>
 						</div>
                         <ul class="fd-nested-list fd-nested-list--text-only level-4" id="EX500L4" aria-hidden="false">
                             <li class="fd-nested-list__item">
@@ -1086,7 +1120,9 @@ export const nestedListWithoutLinks = () => `
                 aria-controls="EX600L2"
                 aria-haspopup="true" 
                 aria-expanded="true" 
-                aria-label="Expand submenu"></button>
+                aria-label="Expand submenu">
+                <i class="sap-icon--navigation-right-arrow"></i>    
+            </button>
 		</div>
         <ul class="fd-nested-list fd-nested-list--text-only level-2" id="EX600L2" aria-hidden="false">
             <li class="fd-nested-list__item">
@@ -1101,7 +1137,9 @@ export const nestedListWithoutLinks = () => `
                         aria-controls="EX600L3"
                         aria-haspopup="true" 
                         aria-expanded="true" 
-                        aria-label="Expand submenu"></button>
+                        aria-label="Expand submenu">
+                        <i class="sap-icon--navigation-right-arrow"></i>    
+                    </button>
 				</div>
                 <ul class="fd-nested-list fd-nested-list--text-only level-3" id="EX600L3" aria-hidden="false">
                     <li class="fd-nested-list__item">
@@ -1116,7 +1154,9 @@ export const nestedListWithoutLinks = () => `
                                 aria-controls="EX600L4"
                                 aria-haspopup="true" 
                                 aria-expanded="true" 
-                                aria-label="Expand submenu"></button>
+                                aria-label="Expand submenu">
+                                <i class="sap-icon--navigation-right-arrow"></i>    
+                            </button>
 						</div>
                         <ul class="fd-nested-list fd-nested-list--text-only level-4" id="EX600L4" aria-hidden="false">
                             <li class="fd-nested-list__item">
@@ -1207,7 +1247,9 @@ export const rtlExample = () => `
                 aria-controls="EX400L2122" 
                 aria-haspopup="true" 
                 aria-expanded="true" 
-                aria-label="Expand submenu"></button>
+                aria-label="Expand submenu">
+                <i class="sap-icon--navigation-left-arrow"></i>    
+            </button>
 		</div>
         <ul class="fd-nested-list fd-nested-list--text-only level-2" id="EX400L2122" aria-hidden="false">
             <li class="fd-nested-list__item">
@@ -1224,7 +1266,9 @@ export const rtlExample = () => `
                         aria-controls="EX400L3"
                         aria-haspopup="true" 
                         aria-expanded="true" 
-                        aria-label="Expand submenu"></button>
+                        aria-label="Expand submenu">
+                        <i class="sap-icon--navigation-left-arrow"></i>    
+                    </button>
 				</div>
                 <ul class="fd-nested-list fd-nested-list--text-only level-3" id="EX400L3" aria-hidden="false">
                     <li class="fd-nested-list__item">
@@ -1241,7 +1285,9 @@ export const rtlExample = () => `
                                 aria-controls="EX400L4"
                                 aria-haspopup="true" 
                                 aria-expanded="true" 
-                                aria-label="Expand submenu"></button>
+                                aria-label="Expand submenu">
+                                <i class="sap-icon--navigation-left-arrow"></i>    
+                            </button>
 						</div>
                         <ul class="fd-nested-list fd-nested-list--text-only level-4" id="EX400L4" aria-hidden="false">
                             <li class="fd-nested-list__item">
@@ -1329,7 +1375,9 @@ export const rtlCozyMultiple = () => `
                         aria-controls="EX100L233" 
                         aria-haspopup="true" 
                         aria-expanded="false" 
-                        aria-label="Expand submenu"></button>
+                        aria-label="Expand submenu">
+                        <i class="sap-icon--navigation-left-arrow"></i>    
+                    </button>
                 </div>
                 <ul class="fd-nested-list level-2" id="EX100L233" aria-hidden="true">
                     <li class="fd-nested-list__item">


### PR DESCRIPTION
## Related Issue
Part of: #1433

## Description
This PR:
- Moves expand icon to separate `<i>` tag.
- Cleans up styling

### Before:
![image](https://user-images.githubusercontent.com/17496353/93985722-bce7b180-fd85-11ea-9077-d32dbd75880b.png)
BREAKING CHANGE:
```
<button class="fd-button fd-nested-list__button"></button>
```
### After:
![image](https://user-images.githubusercontent.com/17496353/93985244-14d1e880-fd85-11ea-8ec9-fd31502a52dd.png)
BREAKING CHANGE:
```
<button class="fd-button fd-nested-list__button">
    <i class="sap-icon--navigation-right-arrow"></i>
</button>
```
#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
