### PR TITLE
fix: update icons in tile actions

### DIFF
--- a/src/mixins/button/_button-helper.scss
+++ b/src/mixins/button/_button-helper.scss
@@ -6,9 +6,7 @@ $block: #{$fd-namespace}-button;
   background-color: $backgroundColor;
 }
 
-@mixin buttonFocus() {
-  $fd-button-outline-offset: 0.0625rem;
-
+@mixin buttonFocus($fd-button-outline-offset: 0.0625rem) {
   &::after {
     content: "";
     position: absolute;

--- a/src/tile.scss
+++ b/src/tile.scss
@@ -81,11 +81,10 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
 }
 
 @mixin fake-tile-outline() {
-  &:focus,
-  &.is-focus {
+  @include fd-focus() {
     outline: none;
 
-    &::before {
+    &::after {
       content: '';
       position: absolute;
       display: block;
@@ -100,7 +99,7 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
   }
 }
 
-@mixin fake-tile-button-outline() {
+@mixin focus-close-button-outline() {
   &:focus,
   &.is-focus {
     outline: none;
@@ -109,15 +108,13 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
       content: '';
       width: 1.5rem;
       height: 1.5rem;
-      box-sizing: border-box;
-      position: absolute;
-      display: block;
-      border: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
       top: -0.0625rem;
       left: 0.4375rem;
       right: 0;
       bottom: 0;
       z-index: 3;
+
+      @content;
     }
 
     @include fd-rtl() {
@@ -624,8 +621,11 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
     .#{$block}__action-close {
       @include set-height(2rem);
       @include set-width(2rem);
-      @include fake-tile-button-outline();
+      @include focus-close-button-outline();
 
+      display: flex;
+      align-items: flex-start;
+      justify-content: flex-end;
       position: absolute;
       padding: 0;
       top: $fd-tile-close-button-position;
@@ -635,28 +635,24 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
       @include fd-rtl() {
         right: initial;
         left: $fd-tile-close-button-position;
-
-        &::before {
-          margin-left: initial;
-          margin-right: $fd-tile-close-button-offset;
-        }
       }
 
-      &::before {
+      @include fd-icon-element-base() {
         @include set-height(1.375rem);
         @include set-width(1.375rem);
         @include fd-flex-center();
 
         box-sizing: border-box;
         border-radius: 50%;
-        margin-bottom: $fd-tile-close-button-offset;
-        margin-left: $fd-tile-close-button-offset;
-        font-family: SAP-icons;
-        font-size: 0.75rem;
         background: var(--sapButton_Background);
         border: 0.0625rem solid var(--sapButton_BorderColor);
         color: var(--sapButton_IconColor);
-        content: "\e03e";
+        font-size: 0.75rem;
+
+        &::before {
+          width: auto;
+          height: auto;
+        }
       }
 
       @include fd-focus() {
@@ -683,13 +679,11 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
         margin-left: $fd-tile-action-indicator-offset;
       }
 
-      &::before {
+      @include fd-icon-element-base() {
         @include fd-flex-center();
 
-        font-family: SAP-icons;
         font-size: 1rem;
         color: var(--sapButton_IconColor);
-        content: "\e1f2";
       }
     }
 
@@ -705,14 +699,16 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
         border-color: transparent;
 
         @include fd-focus() {
-          outline-color: var(--sapContent_FocusColor);
+          &::after {
+            border-color: var(--sapContent_FocusColor);
+          }
         }
       }
     }
 
     &.#{$block}--slide {
       .#{$block}__action-indicator {
-        &::before {
+        @include fd-icon-selector() {
           color: var(--sapShell_Active_TextColor);
         }
       }
@@ -892,19 +888,17 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
       .#{$block}__action-close {
         @include set-height(1.625rem);
         @include reset-position-absolute();
+        @include fd-flex-center();
 
         padding: 0 0.25rem;
 
-        &::before {
-          margin: 0;
-        }
-
-        &::after {
-          content: none;
-        }
-
         @include fd-focus() {
-          @include buttonFocus();
+          @include buttonFocus() {
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+          }
         }
       }
     }

--- a/src/tile.scss
+++ b/src/tile.scss
@@ -84,7 +84,7 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
   @include fd-focus() {
     outline: none;
 
-    &::after {
+    &::before {
       content: '';
       position: absolute;
       display: block;
@@ -879,26 +879,24 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
         }
       }
 
-      .#{$block}__action-indicator {
-        @include reset-position-absolute();
-
-        margin: 0;
-      }
-
       .#{$block}__action-close {
         @include set-height(1.625rem);
         @include reset-position-absolute();
         @include fd-flex-center();
 
         padding: 0 0.25rem;
+      }
+
+      .#{$block}__action-indicator {
+        margin: 0;
+      }
+
+      .#{$block}__action-indicator,
+      .#{$block}__action-close {
+        @include reset-position-absolute();
 
         @include fd-focus() {
-          @include buttonFocus() {
-            top: 0;
-            left: 0;
-            right: 0;
-            bottom: 0;
-          }
+          @include buttonFocus(0);
         }
       }
     }

--- a/stories/generictile/__snapshots__/generic-tile.stories.storyshot
+++ b/stories/generictile/__snapshots__/generic-tile.stories.storyshot
@@ -3357,14 +3357,23 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             aria-label="indicator button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"
             tabindex="-1"
-          />
+          >
+            <i
+              class="sap-icon--overflow"
+            />
+          </button>
           
                 
           <button
             aria-label="close button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"
-          />
+          >
+            <i
+              class="sap-icon--decline"
+            />
+          </button>
           
+ 
             
         </div>
         
@@ -3410,13 +3419,21 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             aria-label="indicator button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"
             tabindex="-1"
-          />
+          >
+            <i
+              class="sap-icon--overflow"
+            />
+          </button>
           
                 
           <button
             aria-label="close button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"
-          />
+          >
+            <i
+              class="sap-icon--decline"
+            />
+          </button>
           
             
         </div>
@@ -3463,14 +3480,23 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             aria-label="indicator button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"
             tabindex="-1"
-          />
+          >
+            <i
+              class="sap-icon--overflow"
+            />
+          </button>
           
                 
           <button
             aria-label="close button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"
-          />
+          >
+            <i
+              class="sap-icon--decline"
+            />
+          </button>
           
+ 
             
         </div>
         
@@ -3516,14 +3542,23 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             aria-label="indicator button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"
             tabindex="-1"
-          />
+          >
+            <i
+              class="sap-icon--overflow"
+            />
+          </button>
           
                 
           <button
             aria-label="close button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"
-          />
+          >
+            <i
+              class="sap-icon--decline"
+            />
+          </button>
           
+ 
             
         </div>
         
@@ -3569,14 +3604,23 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             aria-label="indicator button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"
             tabindex="-1"
-          />
+          >
+            <i
+              class="sap-icon--overflow"
+            />
+          </button>
           
                 
           <button
             aria-label="close button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"
-          />
+          >
+            <i
+              class="sap-icon--decline"
+            />
+          </button>
           
+ 
             
         </div>
         
@@ -3622,14 +3666,23 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             aria-label="indicator button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"
             tabindex="-1"
-          />
+          >
+            <i
+              class="sap-icon--overflow"
+            />
+          </button>
           
                 
           <button
             aria-label="close button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"
-          />
+          >
+            <i
+              class="sap-icon--decline"
+            />
+          </button>
           
+ 
             
         </div>
         
@@ -3701,14 +3754,23 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             aria-label="indicator button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"
             tabindex="-1"
-          />
+          >
+            <i
+              class="sap-icon--overflow"
+            />
+          </button>
           
                 
           <button
             aria-label="close button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"
-          />
+          >
+            <i
+              class="sap-icon--decline"
+            />
+          </button>
           
+ 
             
         </div>
         
@@ -3754,14 +3816,23 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             aria-label="indicator button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"
             tabindex="-1"
-          />
+          >
+            <i
+              class="sap-icon--overflow"
+            />
+          </button>
           
                 
           <button
             aria-label="close button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"
-          />
+          >
+            <i
+              class="sap-icon--decline"
+            />
+          </button>
           
+ 
             
         </div>
         
@@ -3807,14 +3878,23 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             aria-label="indicator button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"
             tabindex="-1"
-          />
+          >
+            <i
+              class="sap-icon--overflow"
+            />
+          </button>
           
                 
           <button
             aria-label="close button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"
-          />
+          >
+            <i
+              class="sap-icon--decline"
+            />
+          </button>
           
+ 
             
         </div>
         
@@ -3860,14 +3940,23 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             aria-label="indicator button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"
             tabindex="-1"
-          />
+          >
+            <i
+              class="sap-icon--overflow"
+            />
+          </button>
           
                 
           <button
             aria-label="close button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"
-          />
+          >
+            <i
+              class="sap-icon--decline"
+            />
+          </button>
           
+ 
             
         </div>
         
@@ -3913,14 +4002,23 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             aria-label="indicator button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"
             tabindex="-1"
-          />
+          >
+            <i
+              class="sap-icon--overflow"
+            />
+          </button>
           
                 
           <button
             aria-label="close button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"
-          />
+          >
+            <i
+              class="sap-icon--decline"
+            />
+          </button>
           
+ 
             
         </div>
         
@@ -3966,14 +4064,23 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             aria-label="indicator button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"
             tabindex="-1"
-          />
+          >
+            <i
+              class="sap-icon--overflow"
+            />
+          </button>
           
                 
           <button
             aria-label="close button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"
-          />
+          >
+            <i
+              class="sap-icon--decline"
+            />
+          </button>
           
+ 
             
         </div>
         
@@ -4457,14 +4564,23 @@ exports[`Storyshots Components/Generic Tile Tile In Action Mode 1`] = `
       <button
         aria-label="close button"
         class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"
-      />
+      >
+        <i
+          class="sap-icon--decline"
+        />
+      </button>
       
+ 
         
       <button
         aria-label="indicator button"
         class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"
         tabindex="-1"
-      />
+      >
+        <i
+          class="sap-icon--overflow"
+        />
+      </button>
       
         
       <div
@@ -4538,14 +4654,23 @@ exports[`Storyshots Components/Generic Tile Tile In Action Mode 1`] = `
       <button
         aria-label="close button"
         class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"
-      />
+      >
+        <i
+          class="sap-icon--decline"
+        />
+      </button>
       
+ 
         
       <button
         aria-label="indicator button"
         class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"
         tabindex="-1"
-      />
+      >
+        <i
+          class="sap-icon--overflow"
+        />
+      </button>
       
         
       <div
@@ -4639,14 +4764,23 @@ exports[`Storyshots Components/Generic Tile Tile In Action Mode 1`] = `
       <button
         aria-label="close button"
         class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"
-      />
+      >
+        <i
+          class="sap-icon--decline"
+        />
+      </button>
       
+ 
         
       <button
         aria-label="indicator button"
         class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"
         tabindex="-1"
-      />
+      >
+        <i
+          class="sap-icon--overflow"
+        />
+      </button>
       
         
       <div
@@ -4767,14 +4901,23 @@ exports[`Storyshots Components/Generic Tile Tile In Action Mode 1`] = `
       <button
         aria-label="close button"
         class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"
-      />
+      >
+        <i
+          class="sap-icon--decline"
+        />
+      </button>
       
+ 
         
       <button
         aria-label="indicator button"
         class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"
         tabindex="-1"
-      />
+      >
+        <i
+          class="sap-icon--overflow"
+        />
+      </button>
       
         
       <div

--- a/stories/generictile/__snapshots__/generic-tile.stories.storyshot
+++ b/stories/generictile/__snapshots__/generic-tile.stories.storyshot
@@ -3358,9 +3358,13 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"
             tabindex="-1"
           >
+            
+                    
             <i
               class="sap-icon--overflow"
             />
+            
+                
           </button>
           
                 
@@ -3368,13 +3372,15 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             aria-label="close button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"
           >
+            
+                    
             <i
               class="sap-icon--decline"
+              role="presentation"
             />
-          </button>
-          
- 
             
+                
+          </button>
         </div>
         
         
@@ -3420,9 +3426,14 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"
             tabindex="-1"
           >
+            
+                    
             <i
               class="sap-icon--overflow"
+              role="presentation"
             />
+            
+                
           </button>
           
                 
@@ -3430,9 +3441,14 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             aria-label="close button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"
           >
+            
+                    
             <i
               class="sap-icon--decline"
+              role="presentation"
             />
+            
+                
           </button>
           
             
@@ -3481,9 +3497,14 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"
             tabindex="-1"
           >
+            
+                    
             <i
               class="sap-icon--overflow"
+              role="presentation"
             />
+            
+                
           </button>
           
                 
@@ -3491,13 +3512,15 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             aria-label="close button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"
           >
+            
+                    
             <i
               class="sap-icon--decline"
+              role="presentation"
             />
-          </button>
-          
- 
             
+                
+          </button>
         </div>
         
         
@@ -3543,9 +3566,14 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"
             tabindex="-1"
           >
+            
+                    
             <i
               class="sap-icon--overflow"
+              role="presentation"
             />
+            
+                
           </button>
           
                 
@@ -3553,13 +3581,15 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             aria-label="close button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"
           >
+            
+                    
             <i
               class="sap-icon--decline"
+              role="presentation"
             />
-          </button>
-          
- 
             
+                
+          </button>
         </div>
         
         
@@ -3605,9 +3635,14 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"
             tabindex="-1"
           >
+            
+                    
             <i
               class="sap-icon--overflow"
+              role="presentation"
             />
+            
+                
           </button>
           
                 
@@ -3615,13 +3650,15 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             aria-label="close button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"
           >
+            
+                    
             <i
               class="sap-icon--decline"
+              role="presentation"
             />
-          </button>
-          
- 
             
+                
+          </button>
         </div>
         
         
@@ -3667,9 +3704,14 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"
             tabindex="-1"
           >
+            
+                    
             <i
               class="sap-icon--overflow"
+              role="presentation"
             />
+            
+                
           </button>
           
                 
@@ -3677,13 +3719,15 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             aria-label="close button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"
           >
+            
+                    
             <i
               class="sap-icon--decline"
+              role="presentation"
             />
-          </button>
-          
- 
             
+                
+          </button>
         </div>
         
         
@@ -3755,9 +3799,14 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"
             tabindex="-1"
           >
+            
+                    
             <i
               class="sap-icon--overflow"
+              role="presentation"
             />
+            
+                
           </button>
           
                 
@@ -3765,13 +3814,15 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             aria-label="close button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"
           >
+            
+                    
             <i
               class="sap-icon--decline"
+              role="presentation"
             />
-          </button>
-          
- 
             
+                
+          </button>
         </div>
         
         
@@ -3817,9 +3868,14 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"
             tabindex="-1"
           >
+            
+                    
             <i
               class="sap-icon--overflow"
+              role="presentation"
             />
+            
+                
           </button>
           
                 
@@ -3827,13 +3883,15 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             aria-label="close button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"
           >
+            
+                    
             <i
               class="sap-icon--decline"
+              role="presentation"
             />
-          </button>
-          
- 
             
+                
+          </button>
         </div>
         
         
@@ -3879,9 +3937,14 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"
             tabindex="-1"
           >
+            
+                    
             <i
               class="sap-icon--overflow"
+              role="presentation"
             />
+            
+                
           </button>
           
                 
@@ -3889,13 +3952,15 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             aria-label="close button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"
           >
+            
+                    
             <i
               class="sap-icon--decline"
+              role="presentation"
             />
-          </button>
-          
- 
             
+                
+          </button>
         </div>
         
         
@@ -3941,9 +4006,14 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"
             tabindex="-1"
           >
+            
+                    
             <i
               class="sap-icon--overflow"
+              role="presentation"
             />
+            
+                
           </button>
           
                 
@@ -3951,12 +4021,16 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             aria-label="close button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"
           >
+            
+                    
             <i
               class="sap-icon--decline"
+              role="presentation"
             />
+            
+                
           </button>
           
- 
             
         </div>
         
@@ -4003,9 +4077,14 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"
             tabindex="-1"
           >
+            
+                    
             <i
               class="sap-icon--overflow"
+              role="presentation"
             />
+            
+                
           </button>
           
                 
@@ -4013,12 +4092,16 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             aria-label="close button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"
           >
+            
+                    
             <i
               class="sap-icon--decline"
+              role="presentation"
             />
+            
+                
           </button>
           
- 
             
         </div>
         
@@ -4065,9 +4148,14 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"
             tabindex="-1"
           >
+            
+                    
             <i
               class="sap-icon--overflow"
+              role="presentation"
             />
+            
+                
           </button>
           
                 
@@ -4075,12 +4163,16 @@ exports[`Storyshots Components/Generic Tile Line Tile 1`] = `
             aria-label="close button"
             class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"
           >
+            
+                    
             <i
               class="sap-icon--decline"
+              role="presentation"
             />
+            
+                
           </button>
           
- 
             
         </div>
         
@@ -4565,21 +4657,28 @@ exports[`Storyshots Components/Generic Tile Tile In Action Mode 1`] = `
         aria-label="close button"
         class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"
       >
+        
+                    
         <i
           class="sap-icon--decline"
+          role="presentation"
         />
-      </button>
-      
- 
         
+                
+      </button>
       <button
         aria-label="indicator button"
         class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"
         tabindex="-1"
       >
+        
+                    
         <i
           class="sap-icon--overflow"
+          role="presentation"
         />
+        
+                
       </button>
       
         
@@ -4655,21 +4754,28 @@ exports[`Storyshots Components/Generic Tile Tile In Action Mode 1`] = `
         aria-label="close button"
         class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"
       >
+        
+                    
         <i
           class="sap-icon--decline"
+          role="presentation"
         />
-      </button>
-      
- 
         
+                
+      </button>
       <button
         aria-label="indicator button"
         class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"
         tabindex="-1"
       >
+        
+                    
         <i
           class="sap-icon--overflow"
+          role="presentation"
         />
+        
+                
       </button>
       
         
@@ -4765,21 +4871,28 @@ exports[`Storyshots Components/Generic Tile Tile In Action Mode 1`] = `
         aria-label="close button"
         class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"
       >
+        
+                    
         <i
           class="sap-icon--decline"
+          role="presentation"
         />
-      </button>
-      
- 
         
+                
+      </button>
       <button
         aria-label="indicator button"
         class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"
         tabindex="-1"
       >
+        
+                    
         <i
           class="sap-icon--overflow"
+          role="presentation"
         />
+        
+                
       </button>
       
         
@@ -4902,21 +5015,28 @@ exports[`Storyshots Components/Generic Tile Tile In Action Mode 1`] = `
         aria-label="close button"
         class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"
       >
+        
+                    
         <i
           class="sap-icon--decline"
+          role="presentation"
         />
-      </button>
-      
- 
         
+                
+      </button>
       <button
         aria-label="indicator button"
         class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"
         tabindex="-1"
       >
+        
+                    
         <i
           class="sap-icon--overflow"
+          role="presentation"
         />
+        
+                
       </button>
       
         

--- a/stories/generictile/generic-tile.stories.mdx
+++ b/stories/generictile/generic-tile.stories.mdx
@@ -897,8 +897,9 @@ In action mode view, the close button is displayed on the top right-hand corner 
 <div class="docs-section-container">
     <div role="button" tabindex="0" class="fd-tile fd-tile--launch fd-tile--action">
         <div class="fd-tile__overlay"></div>
-        <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"></button>
-        <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"></button>
+        <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"><i class="sap-icon--decline"></i></button>
+ 
+        <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"><i class="sap-icon--overflow"></i></button>
         <div class="fd-tile__header">
             <div class="fd-tile__title">Launch Tile (Profile) Title Text</div>
             <div class="fd-tile__subtitle">Launch Tile Subtitle</div>
@@ -912,8 +913,9 @@ In action mode view, the close button is displayed on the top right-hand corner 
     </div>
     <div role="button" tabindex="0" class="fd-tile fd-tile--launch fd-tile--s fd-tile--action">
         <div class="fd-tile__overlay"></div>
-        <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"></button>
-        <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"></button>
+        <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"><i class="sap-icon--decline"></i></button>
+ 
+        <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"><i class="sap-icon--overflow"></i></button>
         <div class="fd-tile__header">
             <div class="fd-tile__title">Launch Tile (Profile) Title Text</div>
             <div class="fd-tile__subtitle">Launch Tile Subtitle</div>
@@ -931,8 +933,9 @@ In action mode view, the close button is displayed on the top right-hand corner 
         <div class="fd-tile__background-img" style="background-image: url('http://lorempixel.com/400/200/nature/10/')"></div>
         <div class="fd-tile__overlay"></div>
         <button aria-label="toggle button" class="fd-tile__toggle fd-tile__toggle--pause"></button>
-        <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"></button>
-        <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"></button>
+        <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"><i class="sap-icon--decline"></i></button>
+ 
+        <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"><i class="sap-icon--overflow"></i></button>
         <div class="fd-tile__container">
             <div class="fd-tile__header">
                 <div class="fd-tile__title">Wind Map: Monitoring Real-Time and Forecasted Wind Conditions across the Globe</div>
@@ -956,8 +959,9 @@ In action mode view, the close button is displayed on the top right-hand corner 
         <div class="fd-tile__background-img" style="background-image: url('http://lorempixel.com/400/200/nature/10/')"></div>
         <div class="fd-tile__overlay"></div>
         <button aria-label="toggle button" class="fd-tile__toggle fd-tile__toggle--pause"></button>
-        <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"></button>
-        <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"></button>
+        <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"><i class="sap-icon--decline"></i></button>
+ 
+        <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"><i class="sap-icon--overflow"></i></button>
         <div class="fd-tile__container">
             <div class="fd-tile__header">
                 <div class="fd-tile__title">Wind Map: Monitoring Real-Time and Forecasted Wind Conditions across the Globe</div>
@@ -1308,8 +1312,9 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
                 <div class="fd-tile__subtitle">Line Tile Subtitle</div>
             </div>
             <div class="fd-tile__action-container">
-                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"></button>
-                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"></button>
+                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"><i class="sap-icon--overflow"></i></button>
+                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"><i class="sap-icon--decline"></i></button>
+ 
             </div>
         </div>
         <div role="button" tabindex="0" class="fd-tile fd-tile--line fd-tile--action">
@@ -1318,8 +1323,8 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
                 <div class="fd-tile__subtitle">Line Tile Subtitle very very very very very very long text</div>
             </div>
             <div class="fd-tile__action-container">
-                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"></button>
-                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"></button>
+                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"><i class="sap-icon--overflow"></i></button>
+                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"><i class="sap-icon--decline"></i></button>
             </div>
         </div>
         <div role="button" tabindex="0" class="fd-tile fd-tile--line fd-tile--action">
@@ -1328,8 +1333,9 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
                 <div class="fd-tile__subtitle">Line Tile Subtitle</div>
             </div>
             <div class="fd-tile__action-container">
-                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"></button>
-                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"></button>
+                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"><i class="sap-icon--overflow"></i></button>
+                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"><i class="sap-icon--decline"></i></button>
+ 
             </div>
         </div>
         <div role="button" tabindex="0" class="fd-tile fd-tile--line fd-tile--action">
@@ -1338,8 +1344,9 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
                 <div class="fd-tile__subtitle">Line Tile Subtitle aute irure dolor in reprehenderit in voluptate velit esse cillum</div>
             </div>
             <div class="fd-tile__action-container">
-                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"></button>
-                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"></button>
+                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"><i class="sap-icon--overflow"></i></button>
+                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"><i class="sap-icon--decline"></i></button>
+ 
             </div>
         </div>
         <div role="button" tabindex="0" class="fd-tile fd-tile--line fd-tile--action is-disabled">
@@ -1348,8 +1355,9 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
                 <div class="fd-tile__subtitle">Line Tile Subtitle enim ipsam voluptatem quia</div>
             </div>
             <div class="fd-tile__action-container">
-                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"></button>
-                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"></button>
+                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"><i class="sap-icon--overflow"></i></button>
+                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"><i class="sap-icon--decline"></i></button>
+ 
             </div>
         </div>
         <div role="button" tabindex="0" class="fd-tile fd-tile--line fd-tile--action">
@@ -1358,8 +1366,9 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
                 <div class="fd-tile__subtitle">Line Tile Subtitle lorem ipsum dolor sit amet</div>
             </div>
             <div class="fd-tile__action-container">
-                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"></button>
-                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"></button>
+                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"><i class="sap-icon--overflow"></i></button>
+                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"><i class="sap-icon--decline"></i></button>
+ 
             </div>
         </div>
     </div>
@@ -1374,8 +1383,9 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
                 <div class="fd-tile__subtitle">Line Tile Subtitle</div>
             </div>
             <div class="fd-tile__action-container">
-                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"></button>
-                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"></button>
+                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"><i class="sap-icon--overflow"></i></button>
+                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"><i class="sap-icon--decline"></i></button>
+ 
             </div>
         </div>
         <div role="button" tabindex="0" class="fd-tile fd-tile--line fd-tile--action">
@@ -1384,8 +1394,9 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
                 <div class="fd-tile__subtitle">Line Tile Subtitle very very very very very very long text</div>
             </div>
             <div class="fd-tile__action-container">
-                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"></button>
-                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"></button>
+                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"><i class="sap-icon--overflow"></i></button>
+                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"><i class="sap-icon--decline"></i></button>
+ 
             </div>
         </div>
         <div role="button" tabindex="0" class="fd-tile fd-tile--line fd-tile--action">
@@ -1394,8 +1405,9 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
                 <div class="fd-tile__subtitle">Line Tile Subtitle</div>
             </div>
             <div class="fd-tile__action-container">
-                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"></button>
-                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"></button>
+                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"><i class="sap-icon--overflow"></i></button>
+                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"><i class="sap-icon--decline"></i></button>
+ 
             </div>
         </div>
         <div role="button" tabindex="0" class="fd-tile fd-tile--line fd-tile--action is-disabled">
@@ -1404,8 +1416,9 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
                 <div class="fd-tile__subtitle">Line Tile Subtitle aute irure dolor in reprehenderit in voluptate velit esse cillum</div>
             </div>
             <div class="fd-tile__action-container">
-                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"></button>
-                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"></button>
+                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"><i class="sap-icon--overflow"></i></button>
+                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"><i class="sap-icon--decline"></i></button>
+ 
             </div>
         </div>
         <div role="button" tabindex="0" class="fd-tile fd-tile--line fd-tile--action">
@@ -1414,8 +1427,9 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
                 <div class="fd-tile__subtitle">Line Tile Very Long Subtitle enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem</div>
             </div>
             <div class="fd-tile__action-container">
-                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"></button>
-                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"></button>
+                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"><i class="sap-icon--overflow"></i></button>
+                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"><i class="sap-icon--decline"></i></button>
+ 
             </div>
         </div>
         <div role="button" tabindex="0" class="fd-tile fd-tile--line fd-tile--action">
@@ -1424,8 +1438,9 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
                 <div class="fd-tile__subtitle">Line Tile Subtitle lorem ipsum dolor sit amet</div>
             </div>
             <div class="fd-tile__action-container">
-                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"></button>
-                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"></button>
+                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"><i class="sap-icon--overflow"></i></button>
+                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"><i class="sap-icon--decline"></i></button>
+ 
             </div>
         </div>
     </div>

--- a/stories/generictile/generic-tile.stories.mdx
+++ b/stories/generictile/generic-tile.stories.mdx
@@ -897,9 +897,11 @@ In action mode view, the close button is displayed on the top right-hand corner 
 <div class="docs-section-container">
     <div role="button" tabindex="0" class="fd-tile fd-tile--launch fd-tile--action">
         <div class="fd-tile__overlay"></div>
-        <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"><i class="sap-icon--decline"></i></button>
- 
-        <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"><i class="sap-icon--overflow"></i></button>
+        <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close">
+                    <i class="sap-icon--decline" role="presentation"></i>
+                </button><button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator">
+                    <i class="sap-icon--overflow" role="presentation"></i>
+                </button>
         <div class="fd-tile__header">
             <div class="fd-tile__title">Launch Tile (Profile) Title Text</div>
             <div class="fd-tile__subtitle">Launch Tile Subtitle</div>
@@ -913,9 +915,11 @@ In action mode view, the close button is displayed on the top right-hand corner 
     </div>
     <div role="button" tabindex="0" class="fd-tile fd-tile--launch fd-tile--s fd-tile--action">
         <div class="fd-tile__overlay"></div>
-        <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"><i class="sap-icon--decline"></i></button>
- 
-        <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"><i class="sap-icon--overflow"></i></button>
+        <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close">
+                    <i class="sap-icon--decline" role="presentation"></i>
+                </button><button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator">
+                    <i class="sap-icon--overflow" role="presentation"></i>
+                </button>
         <div class="fd-tile__header">
             <div class="fd-tile__title">Launch Tile (Profile) Title Text</div>
             <div class="fd-tile__subtitle">Launch Tile Subtitle</div>
@@ -933,9 +937,11 @@ In action mode view, the close button is displayed on the top right-hand corner 
         <div class="fd-tile__background-img" style="background-image: url('http://lorempixel.com/400/200/nature/10/')"></div>
         <div class="fd-tile__overlay"></div>
         <button aria-label="toggle button" class="fd-tile__toggle fd-tile__toggle--pause"></button>
-        <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"><i class="sap-icon--decline"></i></button>
- 
-        <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"><i class="sap-icon--overflow"></i></button>
+        <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close">
+                    <i class="sap-icon--decline" role="presentation"></i>
+                </button><button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator">
+                    <i class="sap-icon--overflow" role="presentation"></i>
+                </button>
         <div class="fd-tile__container">
             <div class="fd-tile__header">
                 <div class="fd-tile__title">Wind Map: Monitoring Real-Time and Forecasted Wind Conditions across the Globe</div>
@@ -959,9 +965,11 @@ In action mode view, the close button is displayed on the top right-hand corner 
         <div class="fd-tile__background-img" style="background-image: url('http://lorempixel.com/400/200/nature/10/')"></div>
         <div class="fd-tile__overlay"></div>
         <button aria-label="toggle button" class="fd-tile__toggle fd-tile__toggle--pause"></button>
-        <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"><i class="sap-icon--decline"></i></button>
- 
-        <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"><i class="sap-icon--overflow"></i></button>
+        <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close">
+                    <i class="sap-icon--decline" role="presentation"></i>
+                </button><button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator">
+                    <i class="sap-icon--overflow" role="presentation"></i>
+                </button>
         <div class="fd-tile__container">
             <div class="fd-tile__header">
                 <div class="fd-tile__title">Wind Map: Monitoring Real-Time and Forecasted Wind Conditions across the Globe</div>
@@ -1312,10 +1320,12 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
                 <div class="fd-tile__subtitle">Line Tile Subtitle</div>
             </div>
             <div class="fd-tile__action-container">
-                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"><i class="sap-icon--overflow"></i></button>
-                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"><i class="sap-icon--decline"></i></button>
- 
-            </div>
+                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator">
+                    <i class="sap-icon--overflow"></i>
+                </button>
+                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close">
+                    <i class="sap-icon--decline" role="presentation"></i>
+                </button></div>
         </div>
         <div role="button" tabindex="0" class="fd-tile fd-tile--line fd-tile--action">
             <div class="fd-tile__header">
@@ -1323,8 +1333,12 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
                 <div class="fd-tile__subtitle">Line Tile Subtitle very very very very very very long text</div>
             </div>
             <div class="fd-tile__action-container">
-                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"><i class="sap-icon--overflow"></i></button>
-                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"><i class="sap-icon--decline"></i></button>
+                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator">
+                    <i class="sap-icon--overflow" role="presentation"></i>
+                </button>
+                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close">
+                    <i class="sap-icon--decline" role="presentation"></i>
+                </button>
             </div>
         </div>
         <div role="button" tabindex="0" class="fd-tile fd-tile--line fd-tile--action">
@@ -1333,10 +1347,12 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
                 <div class="fd-tile__subtitle">Line Tile Subtitle</div>
             </div>
             <div class="fd-tile__action-container">
-                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"><i class="sap-icon--overflow"></i></button>
-                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"><i class="sap-icon--decline"></i></button>
- 
-            </div>
+                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator">
+                    <i class="sap-icon--overflow" role="presentation"></i>
+                </button>
+                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close">
+                    <i class="sap-icon--decline" role="presentation"></i>
+                </button></div>
         </div>
         <div role="button" tabindex="0" class="fd-tile fd-tile--line fd-tile--action">
             <div class="fd-tile__header">
@@ -1344,10 +1360,12 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
                 <div class="fd-tile__subtitle">Line Tile Subtitle aute irure dolor in reprehenderit in voluptate velit esse cillum</div>
             </div>
             <div class="fd-tile__action-container">
-                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"><i class="sap-icon--overflow"></i></button>
-                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"><i class="sap-icon--decline"></i></button>
- 
-            </div>
+                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator">
+                    <i class="sap-icon--overflow" role="presentation"></i>
+                </button>
+                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close">
+                    <i class="sap-icon--decline" role="presentation"></i>
+                </button></div>
         </div>
         <div role="button" tabindex="0" class="fd-tile fd-tile--line fd-tile--action is-disabled">
             <div class="fd-tile__header">
@@ -1355,10 +1373,12 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
                 <div class="fd-tile__subtitle">Line Tile Subtitle enim ipsam voluptatem quia</div>
             </div>
             <div class="fd-tile__action-container">
-                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"><i class="sap-icon--overflow"></i></button>
-                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"><i class="sap-icon--decline"></i></button>
- 
-            </div>
+                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator">
+                    <i class="sap-icon--overflow" role="presentation"></i>
+                </button>
+                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close">
+                    <i class="sap-icon--decline" role="presentation"></i>
+                </button></div>
         </div>
         <div role="button" tabindex="0" class="fd-tile fd-tile--line fd-tile--action">
             <div class="fd-tile__header">
@@ -1366,10 +1386,12 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
                 <div class="fd-tile__subtitle">Line Tile Subtitle lorem ipsum dolor sit amet</div>
             </div>
             <div class="fd-tile__action-container">
-                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"><i class="sap-icon--overflow"></i></button>
-                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"><i class="sap-icon--decline"></i></button>
- 
-            </div>
+                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator">
+                    <i class="sap-icon--overflow" role="presentation"></i>
+                </button>
+                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close">
+                    <i class="sap-icon--decline" role="presentation"></i>
+                </button></div>
         </div>
     </div>
 </div>
@@ -1383,10 +1405,12 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
                 <div class="fd-tile__subtitle">Line Tile Subtitle</div>
             </div>
             <div class="fd-tile__action-container">
-                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"><i class="sap-icon--overflow"></i></button>
-                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"><i class="sap-icon--decline"></i></button>
- 
-            </div>
+                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator">
+                    <i class="sap-icon--overflow" role="presentation"></i>
+                </button>
+                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close">
+                    <i class="sap-icon--decline" role="presentation"></i>
+                </button></div>
         </div>
         <div role="button" tabindex="0" class="fd-tile fd-tile--line fd-tile--action">
             <div class="fd-tile__header">
@@ -1394,10 +1418,12 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
                 <div class="fd-tile__subtitle">Line Tile Subtitle very very very very very very long text</div>
             </div>
             <div class="fd-tile__action-container">
-                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"><i class="sap-icon--overflow"></i></button>
-                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"><i class="sap-icon--decline"></i></button>
- 
-            </div>
+                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator">
+                    <i class="sap-icon--overflow" role="presentation"></i>
+                </button>
+                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close">
+                    <i class="sap-icon--decline" role="presentation"></i>
+                </button></div>
         </div>
         <div role="button" tabindex="0" class="fd-tile fd-tile--line fd-tile--action">
             <div class="fd-tile__header">
@@ -1405,10 +1431,12 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
                 <div class="fd-tile__subtitle">Line Tile Subtitle</div>
             </div>
             <div class="fd-tile__action-container">
-                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"><i class="sap-icon--overflow"></i></button>
-                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"><i class="sap-icon--decline"></i></button>
- 
-            </div>
+                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator">
+                    <i class="sap-icon--overflow" role="presentation"></i>
+                </button>
+                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close">
+                    <i class="sap-icon--decline" role="presentation"></i>
+                </button></div>
         </div>
         <div role="button" tabindex="0" class="fd-tile fd-tile--line fd-tile--action is-disabled">
             <div class="fd-tile__header">
@@ -1416,9 +1444,12 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
                 <div class="fd-tile__subtitle">Line Tile Subtitle aute irure dolor in reprehenderit in voluptate velit esse cillum</div>
             </div>
             <div class="fd-tile__action-container">
-                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"><i class="sap-icon--overflow"></i></button>
-                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"><i class="sap-icon--decline"></i></button>
- 
+                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator">
+                    <i class="sap-icon--overflow" role="presentation"></i>
+                </button>
+                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close">
+                    <i class="sap-icon--decline" role="presentation"></i>
+                </button>
             </div>
         </div>
         <div role="button" tabindex="0" class="fd-tile fd-tile--line fd-tile--action">
@@ -1427,9 +1458,12 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
                 <div class="fd-tile__subtitle">Line Tile Very Long Subtitle enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem</div>
             </div>
             <div class="fd-tile__action-container">
-                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"><i class="sap-icon--overflow"></i></button>
-                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"><i class="sap-icon--decline"></i></button>
- 
+                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator">
+                    <i class="sap-icon--overflow" role="presentation"></i>
+                </button>
+                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close">
+                    <i class="sap-icon--decline" role="presentation"></i>
+                </button>
             </div>
         </div>
         <div role="button" tabindex="0" class="fd-tile fd-tile--line fd-tile--action">
@@ -1438,9 +1472,12 @@ The controls are wrapped in a container `fd-tile__action-container` which is rig
                 <div class="fd-tile__subtitle">Line Tile Subtitle lorem ipsum dolor sit amet</div>
             </div>
             <div class="fd-tile__action-container">
-                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator"><i class="sap-icon--overflow"></i></button>
-                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close"><i class="sap-icon--decline"></i></button>
- 
+                <button aria-label="indicator button" tabindex="-1" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-indicator">
+                    <i class="sap-icon--overflow" role="presentation"></i>
+                </button>
+                <button aria-label="close button" class="fd-button fd-button--compact fd-button--transparent fd-tile__action-close">
+                    <i class="sap-icon--decline" role="presentation"></i>
+                </button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/1684
Part of https://github.com/SAP/fundamental-styles/issues/1433

## Description
In this PR:
BREAKING CHANGE
- Icons inside `fd-tile__action-close` and `fd-tile__action-indicator` are moved to separated `<i>` elements with proper roles and `sap-icon--*` classes
- Focus in such buttons is fixed - now it follows button's strategy with pseudo element.


## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/26483208/94013436-5cb73680-fdaa-11ea-8762-20c3a7eed8d9.png)

![image](https://user-images.githubusercontent.com/26483208/94013479-6c367f80-fdaa-11ea-8300-4736b03fec86.png)


### After:

Focus:
![image](https://user-images.githubusercontent.com/26483208/94013318-32657900-fdaa-11ea-848c-d5f396a144de.png)

![image](https://user-images.githubusercontent.com/26483208/94015285-f1bb2f00-fdac-11ea-8229-baf054f299d6.png)



#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
