### PR TITLE
fix: rating indicator halves IE11

### DIFF
--- a/src/rating-indicator.scss
+++ b/src/rating-indicator.scss
@@ -36,7 +36,7 @@ $block: #{$fd-namespace}-rating-indicator;
 
       &:nth-child(4n+4) {
         margin-right: $spacingBetweenIcons;
-        justify-content: flex-end;
+        flex-direction: row-reverse;
 
         @include fd-rtl() {
           margin-right: 0;


### PR DESCRIPTION
## Related Issue
Part of https://github.com/SAP/fundamental-styles/issues/1433

## Description
In some cases `flex-end` doesn't work on IE11, if wrapper contains only 1 element, the reverse direction can be used instead.

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/26483208/94132051-06f09600-fe5f-11ea-9d5a-c6942526550f.png)


### After:
![image](https://user-images.githubusercontent.com/26483208/94132130-24256480-fe5f-11ea-8930-7bb483fa4851.png)

#### Please check whether the PR fulfills the following requirements

- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
