### PR TITLE
chore: update pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,5 +16,30 @@ Closes SAP/fundamental-styles#
 
 #### Please check whether the PR fulfills the following requirements
 
-- [ ] all items on the PR Review Checklist are addressed :
-https://github.com/SAP/fundamental-styles/wiki/PR-Review-Checklist
+1. The output matches the design specs
+- [ ] All values are in `rem`
+- [ ] Text elements follow the truncation rules
+- [ ] hover state of the element follow design spec
+- [ ] focus state of the element follow design spec
+- [ ] active state of the element follow design spec
+- [ ] selected state of the element follow design spec
+- [ ] selected hover state of the element follow design spec
+- [ ] pressed state of the element follow design spec
+- [ ] Responsiveness rules - the component has modifier classes for all breakpoints
+- [ ] Includes Compact/Cosy/Tablet design
+- [ ] RTL support
+2. The code follows fundamental-styles code standards and style
+- [ ] BEM naming convention is used
+- [ ] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
+- [ ] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
+- [ ] `fd-reset()` mixin is applied to all elements
+- [ ] Variables are used, if some value is used more than twice.
+- [ ] Checked if current components can be reused, instead of having new code.
+3. Testing
+- [ ] tested Storybook examples with "CSS Resources" `normalize` option 
+- [ ] tested Storybook examples with "CSS Resources" `unnormalize` option 
+- [ ] Verified all styles in IE11
+- [ ] Updated tests
+4. Documentation
+- [ ] Storybook documentation has been created/updated
+- [ ] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.


### PR DESCRIPTION
## Description
It has become pretty clear that the pr review checklist is being ignored, leading to reviews being more difficult. This pr moves the checklist to the template directly. I know this is way more wordy, but it seems necessary to prevent blindly checking "all items on the PR Review Checklist are addressed :" without having checked all of them.


