### PR TITLE
fix: add fix for Notifications examples markup and for the max-width of the footer content

### DIFF
--- a/src/notification.scss
+++ b/src/notification.scss
@@ -128,7 +128,11 @@ $block: #{$fd-namespace}-notification;
     &-content {
       @include fd-ellipsis();
 
-      flex: 1 1 auto;
+      max-width: 50%;
+
+      &:only-child {
+        max-width: 100%;
+      }
     }
   }
 

--- a/src/notification.scss
+++ b/src/notification.scss
@@ -1,9 +1,8 @@
-@import "./mixins";
+@import './mixins';
 
 $block: #{$fd-namespace}-notification;
 
 .#{$block} {
-
   // variables
   $fd-notification-max-width-m: 40rem !default;
   $fd-notification-background-color: var(--sapList_Background) !default;
@@ -36,7 +35,7 @@ $block: #{$fd-namespace}-notification;
   // mixins
 
   @mixin fd-priority-indicator($type) {
-    @include fd-icon("message-#{$type}");
+    @include fd-icon('message-#{$type}');
   }
 
   @mixin fd-hide-on-mobile {
@@ -143,7 +142,7 @@ $block: #{$fd-namespace}-notification;
     font-size: var(--sapFontSize);
 
     &::before {
-      content: "\00b7";
+      content: '\00b7';
     }
   }
 
@@ -157,7 +156,7 @@ $block: #{$fd-namespace}-notification;
     @include fd-reset();
 
     display: flex;
-    align-items: self-start;
+    align-items: flex-start;
     padding-left: $fd-notification-padding-right;
     flex: 1 0 auto; // IE11 fix for button
 

--- a/stories/notification/__snapshots__/notification.stories.storyshot
+++ b/stories/notification/__snapshots__/notification.stories.storyshot
@@ -86,7 +86,15 @@ exports[`Storyshots Components/Notifications Mobile 1`] = `
             <span
               class="fd-notification__separator"
             />
-            7 minutes ago
+            
+                
+            <span
+              class="fd-notification__footer-content"
+            >
+              7 minutes ago
+            </span>
+            
+            
           </p>
           
         
@@ -455,19 +463,19 @@ exports[`Storyshots Components/Notifications Mobile 1`] = `
             class="fd-notification__footer"
           >
             
-            
+                
             <span
               class="fd-notification__footer-content"
             >
               SAP Teamm dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor 
             </span>
             
-            
+                
             <span
               class="fd-notification__separator"
             />
             
-            
+                
             <span
               class="fd-notification__footer-content"
             >

--- a/stories/notification/__snapshots__/notification.stories.storyshot
+++ b/stories/notification/__snapshots__/notification.stories.storyshot
@@ -243,573 +243,1539 @@ exports[`Storyshots Components/Notifications Mobile 1`] = `
     style="heigt: 200px; max-width: 20rem"
   >
     
-
+    
     <div
       class="fd-notification fd-notification--mobile fd-notification--group"
     >
       
-    
+        
       <ul
         class="fd-tabs fd-tabs--l fd-notification--tabs"
         role="tablist"
       >
         
-        
+            
         <li
           class="fd-tabs__item"
           role="listitem"
         >
           
-            
+                
           <a
+            aria-controls="notifP300"
             aria-selected="true"
             class="fd-tabs__link"
+            href="#notifP300"
             role="tab"
           >
             
-                
+                    
             <span
               class="fd-tabs__tag"
             >
               
-                    By Date
-                
+                        By Date
+                    
             </span>
             
-            
+                
           </a>
           
-        
+            
         </li>
         
-        
+            
         <li
           class="fd-tabs__item"
           role="listitem"
         >
           
-            
+                
           <a
+            aria-controls="notifP301"
             class="fd-tabs__link"
+            href="#notifP301"
             role="tab"
           >
             
-                
+                    
             <span
               class="fd-tabs__tag"
             >
               
-                    By Type
-                
+                        By Type
+                    
             </span>
             
-            
+                
           </a>
           
-        
+            
         </li>
         
-        
+            
         <li
           class="fd-tabs__item"
           role="listitem"
         >
           
-            
+                
           <a
+            aria-controls="notifP302"
             class="fd-tabs__link"
+            href="#notifP302"
             role="tab"
           >
             
-                
+                    
             <span
               class="fd-tabs__tag"
             >
               
-                    By Priority
-                
+                        By Priority
+                    
             </span>
             
-            
+                
           </a>
           
-        
+            
         </li>
         
-    
+        
       </ul>
       
-    
+        
       <div
-        class="fd-notification__group-header"
+        aria-expanded="true"
+        class="fd-tabs__panel"
+        id="notifP300"
+        role="tabpanel"
       >
         
-        
-        <button
-          aria-label="arrow-down-button"
-          class="fd-button fd-button--transparent"
-          role="button"
+            
+        <div
+          class="fd-notification__group-header"
         >
           
+                
+          <button
+            aria-label="arrow-down-button"
+            class="fd-button fd-button--transparent"
+            role="button"
+          >
             
-          <i
-            class="sap-icon--slim-arrow-down"
+                    
+            <i
+              class="sap-icon--slim-arrow-down"
+            />
+            
+                
+          </button>
+          
+                
+          <div
+            class="fd-notification__content"
+          >
+            
+                    
+            <div
+              class="fd-notification__header"
+            >
+              
+                        
+              <div
+                class="fd-notification__indicator fd-notification__indicator--warning"
+              />
+              
+                        
+              <h2
+                class="fd-notification__title fd-notification__title--unread"
+              >
+                Today (5)
+              </h2>
+              
+                    
+            </div>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-notification__actions"
+          >
+            
+                    
+            <button
+              aria-label="Close"
+              class="fd-button fd-button--transparent fd-notification__actions--dismiss"
+            >
+              
+                        
+              <i
+                class="sap-icon--decline"
+              />
+              
+                    
+            </button>
+            
+                
+          </div>
+          
+            
+        </div>
+        
+            
+        <div
+          class="fd-notification__body"
+        >
+          
+                
+          <span
+            aria-label="John Doe"
+            class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail"
+            role="presentation"
+          >
+            JD
+          </span>
+          
+                
+          <div
+            class="fd-notification__content"
+          >
+            
+                    
+            <div
+              class="fd-notification__header"
+            >
+              
+                        
+              <div
+                class="fd-notification__indicator fd-notification__indicator--warning"
+              />
+              
+                        
+              <h2
+                class="fd-notification__title fd-notification__title--unread"
+              >
+                You've got new item
+              </h2>
+              
+                    
+            </div>
+            
+                    
+            <p
+              class="fd-notification__paragraph"
+            >
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            </p>
+            
+                    
+            <p
+              class="fd-notification__footer"
+            >
+              
+                        
+              <span
+                class="fd-notification__footer-content"
+              >
+                SAP Teamm dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor 
+              </span>
+              
+                        
+              <span
+                class="fd-notification__separator"
+              />
+              
+                        
+              <span
+                class="fd-notification__footer-content"
+              >
+                7 minutes ago
+              </span>
+              
+                    
+            </p>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-notification__actions"
+          >
+            
+                    
+            <div
+              class="fd-popover fd-popover--right"
+            >
+              
+                        
+              <div
+                class="fd-popover__control"
+              >
+                
+                            
+                <button
+                  aria-controls="popoverA3"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Image label"
+                  class="fd-button fd-button--transparent"
+                  onclick="onPopoverClick('popoverA3');"
+                >
+                  
+                                
+                  <i
+                    class="sap-icon--overflow"
+                  />
+                  
+                            
+                </button>
+                
+                        
+              </div>
+              
+                        
+              <div
+                aria-hidden="true"
+                class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover"
+                id="popoverA3"
+              >
+                
+                            
+                <nav
+                  class="fd-menu"
+                  id=""
+                >
+                  
+                                
+                  <ul
+                    class="fd-menu__list fd-menu__list--no-shadow"
+                  >
+                    
+                                    
+                    <li
+                      class="fd-menu__item"
+                    >
+                      
+                                        
+                      <a
+                        class="fd-menu__link"
+                      >
+                        
+                                            
+                        <span
+                          class="fd-menu__title"
+                        >
+                          Open
+                        </span>
+                        
+                                        
+                      </a>
+                      
+                                    
+                    </li>
+                    
+                                    
+                    <li
+                      class="fd-menu__item"
+                    >
+                      
+                                        
+                      <a
+                        class="fd-menu__link"
+                      >
+                        
+                                            
+                        <span
+                          class="fd-menu__title"
+                        >
+                          Decline
+                        </span>
+                        
+                                        
+                      </a>
+                      
+                                    
+                    </li>
+                    
+                                
+                  </ul>
+                  
+                            
+                </nav>
+                
+                        
+              </div>
+              
+                    
+            </div>
+            
+                    
+            <button
+              aria-label="Close"
+              class="fd-button fd-button--transparent fd-notification__actions--dismiss"
+            >
+              
+                        
+              <i
+                class="sap-icon--decline"
+              />
+              
+                    
+            </button>
+            
+                
+          </div>
+          
+            
+        </div>
+        
+            
+        <div
+          class="fd-notification__body"
+        >
+          
+                
+          <span
+            aria-label="John Doe"
+            class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail"
+            role="presentation"
+            style="background-image: url('http://lorempixel.com/400/400/nature/4/')"
           />
           
-        
-        </button>
-        
-        
-        <div
-          class="fd-notification__content"
-        >
-          
-            
+                
           <div
-            class="fd-notification__header"
+            class="fd-notification__content"
           >
             
-                
+                    
             <div
-              class="fd-notification__indicator fd-notification__indicator--warning"
-            />
-            
-                
-            <h2
-              class="fd-notification__title fd-notification__title--unread"
-            >
-              Today (5)
-            </h2>
-            
-            
-          </div>
-          
-        
-        </div>
-        
-        
-        <div
-          class="fd-notification__actions"
-        >
-          
-            
-          <button
-            aria-label="Close"
-            class="fd-button fd-button--transparent fd-notification__actions--dismiss"
-          >
-            
-                
-            <i
-              class="sap-icon--decline"
-            />
-            
-            
-          </button>
-          
-        
-        </div>
-        
-    
-      </div>
-      
-    
-      <div
-        class="fd-notification__body"
-      >
-        
-        
-        <span
-          aria-label="John Doe"
-          class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail"
-          role="presentation"
-        >
-          JD
-        </span>
-        
-        
-        <div
-          class="fd-notification__content"
-        >
-          
-            
-          <div
-            class="fd-notification__header"
-          >
-            
-                
-            <div
-              class="fd-notification__indicator fd-notification__indicator--warning"
-            />
-            
-                
-            <h2
-              class="fd-notification__title fd-notification__title--unread"
-            >
-              You've got new item
-            </h2>
-            
-            
-          </div>
-          
-            
-          <p
-            class="fd-notification__paragraph"
-          >
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-          </p>
-          
-            
-          <p
-            class="fd-notification__footer"
-          >
-            
-                
-            <span
-              class="fd-notification__footer-content"
-            >
-              SAP Teamm dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor 
-            </span>
-            
-                
-            <span
-              class="fd-notification__separator"
-            />
-            
-                
-            <span
-              class="fd-notification__footer-content"
-            >
-              7 minutes ago
-            </span>
-            
-            
-          </p>
-          
-        
-        </div>
-        
-        
-        <div
-          class="fd-notification__actions"
-        >
-          
-              
-          <div
-            class="fd-popover fd-popover--right"
-          >
-            
-                
-            <div
-              class="fd-popover__control"
+              class="fd-notification__header"
             >
               
                     
-              <button
-                aria-controls="popoverA3"
-                aria-expanded="false"
-                aria-haspopup="true"
-                aria-label="Image label"
-                class="fd-button fd-button--transparent"
-                onclick="onPopoverClick('popoverA3');"
+              <div
+                class="fd-notification__indicator fd-notification__indicator--success"
+              />
+              
+                    
+              <h2
+                class="fd-notification__title"
               >
-                
-                         
-                <i
-                  class="sap-icon--overflow"
-                />
-                
-                    
-              </button>
+                The title you've already read.
+              </h2>
               
-                
+                    
             </div>
             
-                
-            <div
-              aria-hidden="true"
-              class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover"
-              id="popoverA3"
+                    
+            <p
+              class="fd-notification__paragraph"
+            >
+              Lagna aliqua.
+            </p>
+            
+                    
+            <p
+              class="fd-notification__footer"
             >
               
+                        
+              <span
+                class="fd-notification__footer-content"
+              >
+                SAP Analytics Cloud very long author name to test truncate
+              </span>
+              
+                        
+              <span
+                class="fd-notification__separator"
+              />
+              
+                        
+              <span
+                class="fd-notification__footer-content"
+              >
+                7 minutes ago long long time ago ages ago years ago
+              </span>
+              
                     
-              <nav
-                class="fd-menu"
-                id=""
+            </p>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-notification__actions"
+          >
+            
+                    
+            <div
+              class="fd-popover fd-popover--right"
+            >
+              
+                        
+              <div
+                class="fd-popover__control"
               >
                 
-                        
-                <ul
-                  class="fd-menu__list fd-menu__list--no-shadow"
+                            
+                <button
+                  aria-controls="popoverA2"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Image label"
+                  class="fd-button fd-button--transparent"
+                  onclick="onPopoverClick('popoverA2');"
                 >
                   
-                            
-                  <li
-                    class="fd-menu__item"
-                  >
-                    
                                 
-                    <a
-                      class="fd-menu__link"
-                    >
-                      
-                                    
-                      <span
-                        class="fd-menu__title"
-                      >
-                        Open
-                      </span>
-                      
-                                
-                    </a>
-                    
-                            
-                  </li>
+                  <i
+                    class="sap-icon--overflow"
+                  />
                   
                             
-                  <li
-                    class="fd-menu__item"
-                  >
-                    
-                                
-                    <a
-                      class="fd-menu__link"
-                    >
-                      
-                                    
-                      <span
-                        class="fd-menu__title"
-                      >
-                        Decline
-                      </span>
-                      
-                                
-                    </a>
-                    
+                </button>
+                
+                        
+              </div>
+              
+                        
+              <div
+                aria-hidden="true"
+                class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover"
+                id="popoverA2"
+              >
+                
                             
-                  </li>
-                  
-                        
-                </ul>
-                
-                    
-              </nav>
-              
-                
-            </div>
-            
-            
-          </div>
-          
-
-            
-          <button
-            aria-label="Close"
-            class="fd-button fd-button--transparent fd-notification__actions--dismiss"
-          >
-            
-                
-            <i
-              class="sap-icon--decline"
-            />
-            
-            
-          </button>
-          
-        
-        </div>
-        
-    
-      </div>
-      
-    
-      <div
-        class="fd-notification__body"
-      >
-        
-        
-        <span
-          aria-label="John Doe"
-          class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail"
-          role="presentation"
-          style="background-image: url('http://lorempixel.com/400/400/nature/4/')"
-        />
-        
-        
-        <div
-          class="fd-notification__content"
-        >
-          
-            
-          <div
-            class="fd-notification__header"
-          >
-            
-            
-            <div
-              class="fd-notification__indicator fd-notification__indicator--success"
-            />
-            
-            
-            <h2
-              class="fd-notification__title"
-            >
-              The title you've already read.
-            </h2>
-            
-            
-          </div>
-          
-            
-          <p
-            class="fd-notification__paragraph"
-          >
-            Lagna aliqua.
-          </p>
-          
-            
-          <p
-            class="fd-notification__footer"
-          >
-            
-                
-            <span
-              class="fd-notification__footer-content"
-            >
-              SAP Analytics Cloud very long author name to test truncate
-            </span>
-            
-                
-            <span
-              class="fd-notification__separator"
-            />
-            
-                
-            <span
-              class="fd-notification__footer-content"
-            >
-              7 minutes ago long long time ago ages ago years ago
-            </span>
-            
-            
-          </p>
-          
-        
-        </div>
-        
-        
-        <div
-          class="fd-notification__actions"
-        >
-          
-               
-          <div
-            class="fd-popover fd-popover--right"
-          >
-            
-                
-            <div
-              class="fd-popover__control"
-            >
-              
-                    
-              <button
-                aria-controls="popoverA2"
-                aria-expanded="false"
-                aria-haspopup="true"
-                aria-label="Image label"
-                class="fd-button fd-button--transparent"
-                onclick="onPopoverClick('popoverA2');"
-              >
-                
-                         
-                <i
-                  class="sap-icon--overflow"
-                />
-                
-                    
-              </button>
-              
-                
-            </div>
-            
-                
-            <div
-              aria-hidden="true"
-              class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover"
-              id="popoverA2"
-            >
-              
-                    
-              <nav
-                class="fd-menu"
-                id=""
-              >
-                
-                        
-                <ul
-                  class="fd-menu__list fd-menu__list--no-shadow"
+                <nav
+                  class="fd-menu"
+                  id=""
                 >
                   
-                            
-                  <li
-                    class="fd-menu__item"
+                                
+                  <ul
+                    class="fd-menu__list fd-menu__list--no-shadow"
                   >
                     
-                                
-                    <a
-                      class="fd-menu__link"
+                                    
+                    <li
+                      class="fd-menu__item"
                     >
                       
-                                    
-                      <span
-                        class="fd-menu__title"
+                                        
+                      <a
+                        class="fd-menu__link"
                       >
-                        Open
-                      </span>
-                      
-                                
-                    </a>
-                    
-                            
-                  </li>
-                  
                         
-                </ul>
-                
+                                            
+                        <span
+                          class="fd-menu__title"
+                        >
+                          Open
+                        </span>
+                        
+                                        
+                      </a>
+                      
+                                    
+                    </li>
                     
-              </nav>
-              
+                                
+                  </ul>
+                  
+                            
+                </nav>
                 
+                        
+              </div>
+              
+                    
             </div>
             
-            
-          </div>
-          
-
-            
-          <button
-            aria-label="Close"
-            class="fd-button fd-button--transparent fd-notification__actions--dismiss"
-          >
+                    
+            <button
+              aria-label="Close"
+              class="fd-button fd-button--transparent fd-notification__actions--dismiss"
+            >
+              
+                        
+              <i
+                class="sap-icon--decline"
+              />
+              
+                    
+            </button>
             
                 
-            <i
-              class="sap-icon--decline"
-            />
-            
-            
-          </button>
+          </div>
           
-        
+            
         </div>
         
-    
+        
+      </div>
+      
+        
+      <div
+        aria-expanded="false"
+        class="fd-tabs__panel"
+        id="notifP301"
+        role="tabpanel"
+      >
+        
+            
+        <div
+          class="fd-notification__group-header"
+        >
+          
+                
+          <button
+            aria-label="arrow-down-button"
+            class="fd-button fd-button--transparent"
+            role="button"
+          >
+            
+                    
+            <i
+              class="sap-icon--slim-arrow-down"
+            />
+            
+                
+          </button>
+          
+                
+          <div
+            class="fd-notification__content"
+          >
+            
+                    
+            <div
+              class="fd-notification__header"
+            >
+              
+                        
+              <div
+                class="fd-notification__indicator fd-notification__indicator--warning"
+              />
+              
+                        
+              <h2
+                class="fd-notification__title fd-notification__title--unread"
+              >
+                Today (5)
+              </h2>
+              
+                    
+            </div>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-notification__actions"
+          >
+            
+                    
+            <button
+              aria-label="Close"
+              class="fd-button fd-button--transparent fd-notification__actions--dismiss"
+            >
+              
+                        
+              <i
+                class="sap-icon--decline"
+              />
+              
+                    
+            </button>
+            
+                
+          </div>
+          
+            
+        </div>
+        
+            
+        <div
+          class="fd-notification__body"
+        >
+          
+                
+          <span
+            aria-label="John Doe"
+            class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail"
+            role="presentation"
+          >
+            JD
+          </span>
+          
+                
+          <div
+            class="fd-notification__content"
+          >
+            
+                    
+            <div
+              class="fd-notification__header"
+            >
+              
+                        
+              <div
+                class="fd-notification__indicator fd-notification__indicator--warning"
+              />
+              
+                        
+              <h2
+                class="fd-notification__title fd-notification__title--unread"
+              >
+                You've got new item
+              </h2>
+              
+                    
+            </div>
+            
+                    
+            <p
+              class="fd-notification__paragraph"
+            >
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            </p>
+            
+                    
+            <p
+              class="fd-notification__footer"
+            >
+              
+                        
+              <span
+                class="fd-notification__footer-content"
+              >
+                SAP Teamm dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor 
+              </span>
+              
+                        
+              <span
+                class="fd-notification__separator"
+              />
+              
+                        
+              <span
+                class="fd-notification__footer-content"
+              >
+                7 minutes ago
+              </span>
+              
+                    
+            </p>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-notification__actions"
+          >
+            
+                    
+            <div
+              class="fd-popover fd-popover--right"
+            >
+              
+                        
+              <div
+                class="fd-popover__control"
+              >
+                
+                            
+                <button
+                  aria-controls="popoverA3"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Image label"
+                  class="fd-button fd-button--transparent"
+                  onclick="onPopoverClick('popoverA3');"
+                >
+                  
+                                
+                  <i
+                    class="sap-icon--overflow"
+                  />
+                  
+                            
+                </button>
+                
+                        
+              </div>
+              
+                        
+              <div
+                aria-hidden="true"
+                class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover"
+                id="popoverA3"
+              >
+                
+                            
+                <nav
+                  class="fd-menu"
+                  id=""
+                >
+                  
+                                
+                  <ul
+                    class="fd-menu__list fd-menu__list--no-shadow"
+                  >
+                    
+                                    
+                    <li
+                      class="fd-menu__item"
+                    >
+                      
+                                        
+                      <a
+                        class="fd-menu__link"
+                      >
+                        
+                                            
+                        <span
+                          class="fd-menu__title"
+                        >
+                          Open
+                        </span>
+                        
+                                        
+                      </a>
+                      
+                                    
+                    </li>
+                    
+                                    
+                    <li
+                      class="fd-menu__item"
+                    >
+                      
+                                        
+                      <a
+                        class="fd-menu__link"
+                      >
+                        
+                                            
+                        <span
+                          class="fd-menu__title"
+                        >
+                          Decline
+                        </span>
+                        
+                                        
+                      </a>
+                      
+                                    
+                    </li>
+                    
+                                
+                  </ul>
+                  
+                            
+                </nav>
+                
+                        
+              </div>
+              
+                    
+            </div>
+            
+                    
+            <button
+              aria-label="Close"
+              class="fd-button fd-button--transparent fd-notification__actions--dismiss"
+            >
+              
+                        
+              <i
+                class="sap-icon--decline"
+              />
+              
+                    
+            </button>
+            
+                
+          </div>
+          
+            
+        </div>
+        
+            
+        <div
+          class="fd-notification__body"
+        >
+          
+                
+          <span
+            aria-label="John Doe"
+            class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail"
+            role="presentation"
+            style="background-image: url('http://lorempixel.com/400/400/nature/4/')"
+          />
+          
+                
+          <div
+            class="fd-notification__content"
+          >
+            
+                    
+            <div
+              class="fd-notification__header"
+            >
+              
+                    
+              <div
+                class="fd-notification__indicator fd-notification__indicator--success"
+              />
+              
+                    
+              <h2
+                class="fd-notification__title"
+              >
+                The title you've already read.
+              </h2>
+              
+                    
+            </div>
+            
+                    
+            <p
+              class="fd-notification__paragraph"
+            >
+              Lagna aliqua.
+            </p>
+            
+                    
+            <p
+              class="fd-notification__footer"
+            >
+              
+                        
+              <span
+                class="fd-notification__footer-content"
+              >
+                SAP Analytics Cloud very long author name to test truncate
+              </span>
+              
+                        
+              <span
+                class="fd-notification__separator"
+              />
+              
+                        
+              <span
+                class="fd-notification__footer-content"
+              >
+                7 minutes ago long long time ago ages ago years ago
+              </span>
+              
+                    
+            </p>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-notification__actions"
+          >
+            
+                    
+            <div
+              class="fd-popover fd-popover--right"
+            >
+              
+                        
+              <div
+                class="fd-popover__control"
+              >
+                
+                            
+                <button
+                  aria-controls="popoverA2"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Image label"
+                  class="fd-button fd-button--transparent"
+                  onclick="onPopoverClick('popoverA2');"
+                >
+                  
+                                
+                  <i
+                    class="sap-icon--overflow"
+                  />
+                  
+                            
+                </button>
+                
+                        
+              </div>
+              
+                        
+              <div
+                aria-hidden="true"
+                class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover"
+                id="popoverA2"
+              >
+                
+                            
+                <nav
+                  class="fd-menu"
+                  id=""
+                >
+                  
+                                
+                  <ul
+                    class="fd-menu__list fd-menu__list--no-shadow"
+                  >
+                    
+                                    
+                    <li
+                      class="fd-menu__item"
+                    >
+                      
+                                        
+                      <a
+                        class="fd-menu__link"
+                      >
+                        
+                                            
+                        <span
+                          class="fd-menu__title"
+                        >
+                          Open
+                        </span>
+                        
+                                        
+                      </a>
+                      
+                                    
+                    </li>
+                    
+                                
+                  </ul>
+                  
+                            
+                </nav>
+                
+                        
+              </div>
+              
+                    
+            </div>
+            
+                    
+            <button
+              aria-label="Close"
+              class="fd-button fd-button--transparent fd-notification__actions--dismiss"
+            >
+              
+                        
+              <i
+                class="sap-icon--decline"
+              />
+              
+                    
+            </button>
+            
+                
+          </div>
+          
+            
+        </div>
+        
+        
+      </div>
+      
+        
+      <div
+        aria-expanded="false"
+        class="fd-tabs__panel"
+        id="notifP302"
+        role="tabpanel"
+      >
+        
+            
+        <div
+          class="fd-notification__group-header"
+        >
+          
+                
+          <button
+            aria-label="arrow-down-button"
+            class="fd-button fd-button--transparent"
+            role="button"
+          >
+            
+                    
+            <i
+              class="sap-icon--slim-arrow-down"
+            />
+            
+                
+          </button>
+          
+                
+          <div
+            class="fd-notification__content"
+          >
+            
+                    
+            <div
+              class="fd-notification__header"
+            >
+              
+                        
+              <div
+                class="fd-notification__indicator fd-notification__indicator--warning"
+              />
+              
+                        
+              <h2
+                class="fd-notification__title fd-notification__title--unread"
+              >
+                Today (5)
+              </h2>
+              
+                    
+            </div>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-notification__actions"
+          >
+            
+                    
+            <button
+              aria-label="Close"
+              class="fd-button fd-button--transparent fd-notification__actions--dismiss"
+            >
+              
+                        
+              <i
+                class="sap-icon--decline"
+              />
+              
+                    
+            </button>
+            
+                
+          </div>
+          
+            
+        </div>
+        
+            
+        <div
+          class="fd-notification__body"
+        >
+          
+                
+          <span
+            aria-label="John Doe"
+            class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail"
+            role="presentation"
+          >
+            JD
+          </span>
+          
+                
+          <div
+            class="fd-notification__content"
+          >
+            
+                    
+            <div
+              class="fd-notification__header"
+            >
+              
+                        
+              <div
+                class="fd-notification__indicator fd-notification__indicator--warning"
+              />
+              
+                        
+              <h2
+                class="fd-notification__title fd-notification__title--unread"
+              >
+                You've got new item
+              </h2>
+              
+                    
+            </div>
+            
+                    
+            <p
+              class="fd-notification__paragraph"
+            >
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            </p>
+            
+                    
+            <p
+              class="fd-notification__footer"
+            >
+              
+                        
+              <span
+                class="fd-notification__footer-content"
+              >
+                SAP Teamm dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor 
+              </span>
+              
+                        
+              <span
+                class="fd-notification__separator"
+              />
+              
+                        
+              <span
+                class="fd-notification__footer-content"
+              >
+                7 minutes ago
+              </span>
+              
+                    
+            </p>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-notification__actions"
+          >
+            
+                    
+            <div
+              class="fd-popover fd-popover--right"
+            >
+              
+                        
+              <div
+                class="fd-popover__control"
+              >
+                
+                            
+                <button
+                  aria-controls="popoverA3"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Image label"
+                  class="fd-button fd-button--transparent"
+                  onclick="onPopoverClick('popoverA3');"
+                >
+                  
+                                
+                  <i
+                    class="sap-icon--overflow"
+                  />
+                  
+                            
+                </button>
+                
+                        
+              </div>
+              
+                        
+              <div
+                aria-hidden="true"
+                class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover"
+                id="popoverA3"
+              >
+                
+                            
+                <nav
+                  class="fd-menu"
+                  id=""
+                >
+                  
+                                
+                  <ul
+                    class="fd-menu__list fd-menu__list--no-shadow"
+                  >
+                    
+                                    
+                    <li
+                      class="fd-menu__item"
+                    >
+                      
+                                        
+                      <a
+                        class="fd-menu__link"
+                      >
+                        
+                                            
+                        <span
+                          class="fd-menu__title"
+                        >
+                          Open
+                        </span>
+                        
+                                        
+                      </a>
+                      
+                                    
+                    </li>
+                    
+                                    
+                    <li
+                      class="fd-menu__item"
+                    >
+                      
+                                        
+                      <a
+                        class="fd-menu__link"
+                      >
+                        
+                                            
+                        <span
+                          class="fd-menu__title"
+                        >
+                          Decline
+                        </span>
+                        
+                                        
+                      </a>
+                      
+                                    
+                    </li>
+                    
+                                
+                  </ul>
+                  
+                            
+                </nav>
+                
+                        
+              </div>
+              
+                    
+            </div>
+            
+                    
+            <button
+              aria-label="Close"
+              class="fd-button fd-button--transparent fd-notification__actions--dismiss"
+            >
+              
+                        
+              <i
+                class="sap-icon--decline"
+              />
+              
+                    
+            </button>
+            
+                
+          </div>
+          
+            
+        </div>
+        
+            
+        <div
+          class="fd-notification__body"
+        >
+          
+                
+          <span
+            aria-label="John Doe"
+            class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail"
+            role="presentation"
+            style="background-image: url('http://lorempixel.com/400/400/nature/4/')"
+          />
+          
+                
+          <div
+            class="fd-notification__content"
+          >
+            
+                    
+            <div
+              class="fd-notification__header"
+            >
+              
+                    
+              <div
+                class="fd-notification__indicator fd-notification__indicator--success"
+              />
+              
+                    
+              <h2
+                class="fd-notification__title"
+              >
+                The title you've already read.
+              </h2>
+              
+                    
+            </div>
+            
+                    
+            <p
+              class="fd-notification__paragraph"
+            >
+              Lagna aliqua.
+            </p>
+            
+                    
+            <p
+              class="fd-notification__footer"
+            >
+              
+                        
+              <span
+                class="fd-notification__footer-content"
+              >
+                SAP Analytics Cloud very long author name to test truncate
+              </span>
+              
+                        
+              <span
+                class="fd-notification__separator"
+              />
+              
+                        
+              <span
+                class="fd-notification__footer-content"
+              >
+                7 minutes ago long long time ago ages ago years ago
+              </span>
+              
+                    
+            </p>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-notification__actions"
+          >
+            
+                    
+            <div
+              class="fd-popover fd-popover--right"
+            >
+              
+                        
+              <div
+                class="fd-popover__control"
+              >
+                
+                            
+                <button
+                  aria-controls="popoverA2"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Image label"
+                  class="fd-button fd-button--transparent"
+                  onclick="onPopoverClick('popoverA2');"
+                >
+                  
+                                
+                  <i
+                    class="sap-icon--overflow"
+                  />
+                  
+                            
+                </button>
+                
+                        
+              </div>
+              
+                        
+              <div
+                aria-hidden="true"
+                class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover"
+                id="popoverA2"
+              >
+                
+                            
+                <nav
+                  class="fd-menu"
+                  id=""
+                >
+                  
+                                
+                  <ul
+                    class="fd-menu__list fd-menu__list--no-shadow"
+                  >
+                    
+                                    
+                    <li
+                      class="fd-menu__item"
+                    >
+                      
+                                        
+                      <a
+                        class="fd-menu__link"
+                      >
+                        
+                                            
+                        <span
+                          class="fd-menu__title"
+                        >
+                          Open
+                        </span>
+                        
+                                        
+                      </a>
+                      
+                                    
+                    </li>
+                    
+                                
+                  </ul>
+                  
+                            
+                </nav>
+                
+                        
+              </div>
+              
+                    
+            </div>
+            
+                    
+            <button
+              aria-label="Close"
+              class="fd-button fd-button--transparent fd-notification__actions--dismiss"
+            >
+              
+                        
+              <i
+                class="sap-icon--decline"
+              />
+              
+                    
+            </button>
+            
+                
+          </div>
+          
+            
+        </div>
+        
+        
       </div>
       
     
     </div>
     
-
 
   </div>
   

--- a/stories/notification/notification.stories.js
+++ b/stories/notification/notification.stories.js
@@ -29,8 +29,10 @@ export const primary = () => `
             </div>
             <p class="fd-notification__paragraph">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
             <p class="fd-notification__footer">
-                <span class="fd-notification__footer-content">Long author name - SAP Analytics Cloud Cloud Cloud</span>
-                <span class="fd-notification__separator"></span>7 minutes ago</p>
+                <span class="fd-notification__footer-content">Long author name - SAP Analytics Cloud incididunt ut labore et dolore magna aliqua </span>
+                <span class="fd-notification__separator"></span>
+                <span class="fd-notification__footer-content">7 minutes ago</span>
+            </p>
         </div>
         <div class="fd-notification__actions">
             <button class="fd-button fd-button--compact">Open</button>
@@ -60,8 +62,10 @@ export const noAvatar = () => `
             </div>
             <p class="fd-notification__paragraph">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
             <p class="fd-notification__footer">
-            <span class="fd-notification__footer-content">SAP Analytics Cloud</span>
-            <span class="fd-notification__separator"></span>7 minutes ago</p>
+                <span class="fd-notification__footer-content">SAP Analytics Cloud</span>
+                <span class="fd-notification__separator"></span>
+                <span class="fd-notification__footer-content">7 minutes ago</span>
+            </p>
         </div>
         <div class="fd-notification__actions">
             <button class="fd-button fd-button--compact">Open</button>
@@ -139,8 +143,10 @@ export const warning = () => `
             </div>
             <p class="fd-notification__paragraph">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
             <p class="fd-notification__footer">
-            <span class="fd-notification__footer-content">Tom Norton Beam</span>
-            <span class="fd-notification__separator"></span>7 minutes ago</p>
+                <span class="fd-notification__footer-content">Tom Norton Beam</span>
+                <span class="fd-notification__separator"></span>
+                <span class="fd-notification__footer-content">7 minutes ago</span>
+            </p>
         </div>
         <div class="fd-notification__actions">
             <button class="fd-button fd-button--compact">Open</button>
@@ -179,8 +185,10 @@ export const error = () => `
           </div>
           <p class="fd-notification__paragraph">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
           <p class="fd-notification__footer">
-          <span class="fd-notification__footer-content">SAP Analytics Cloud</span>
-          <span class="fd-notification__separator"></span>7 minutes ago</p>
+            <span class="fd-notification__footer-content">SAP Analytics Cloud</span>
+            <span class="fd-notification__separator"></span>
+            <span class="fd-notification__footer-content">7 minutes ago</span>
+          </p>
         </div>
         <div class="fd-notification__actions">
             <button class="fd-button fd-button--compact">Open</button>
@@ -251,9 +259,7 @@ export const notificationGroup = () => `
             </div>
             <p class="fd-notification__paragraph">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
             <p class="fd-notification__footer">
-            <span class="fd-notification__footer-content">SAP Teamm dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor </span>
-            <span class="fd-notification__separator"></span>
-            <span class="fd-notification__footer-content">7 minutes ago</span>
+                <span class="fd-notification__footer-content">SAP Team dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor consectetur adipiscing elit </span>
             </p>
         </div>
         <div class="fd-notification__actions">
@@ -322,9 +328,9 @@ export const notificationGroup = () => `
             </div>
             <p class="fd-notification__paragraph">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
             <p class="fd-notification__footer">
-            <span class="fd-notification__footer-content">SAP Analytics Cloud</span>
-            <span class="fd-notification__separator"></span>
-            <span class="fd-notification__footer-content">7 minutes ago m dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor</span> 
+                <span class="fd-notification__footer-content">SAP Analytics Cloud</span>
+                <span class="fd-notification__separator"></span>
+                <span class="fd-notification__footer-content">7 minutes ago m dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor</span> 
             </p>
         </div>
         <div class="fd-notification__actions">
@@ -364,7 +370,9 @@ export const mobile = () => `
             <p class="fd-notification__paragraph">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
             <p class="fd-notification__footer">
                 <span class="fd-notification__footer-content">SAP Analytics Cloud</span>
-                <span class="fd-notification__separator"></span>7 minutes ago</p>
+                <span class="fd-notification__separator"></span>
+                <span class="fd-notification__footer-content">7 minutes ago</span>
+            </p>
         </div>
         <div class="fd-notification__actions">
                <div class="fd-popover fd-popover--right">
@@ -447,9 +455,9 @@ export const mobile = () => `
             </div>
             <p class="fd-notification__paragraph">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
             <p class="fd-notification__footer">
-            <span class="fd-notification__footer-content">SAP Teamm dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor </span>
-            <span class="fd-notification__separator"></span>
-            <span class="fd-notification__footer-content">7 minutes ago</span>
+                <span class="fd-notification__footer-content">SAP Teamm dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor </span>
+                <span class="fd-notification__separator"></span>
+                <span class="fd-notification__footer-content">7 minutes ago</span>
             </p>
         </div>
         <div class="fd-notification__actions">

--- a/stories/notification/notification.stories.js
+++ b/stories/notification/notification.stories.js
@@ -166,7 +166,6 @@ Notifications can display warning alerts by adding the <code>fd-message-strip fd
     }
 };
 
-
 export const error = () => `
 <div class="fd-notification">
     <div class="fd-message-strip fd-message-strip--error fd-message-strip--dismissible" role="alert">
@@ -212,137 +211,234 @@ export const notificationGroup = () => `
 <div class="fd-notification fd-notification--group">
     <ul class="fd-tabs fd-tabs--l fd-notification--tabs" role="tablist">
         <li role="listitem" class="fd-tabs__item">
-            <a class="fd-tabs__link" aria-selected="true" role="tab">
+            <a 
+                class="fd-tabs__link" 
+                aria-controls="notifV550" 
+                href="#notifV550" 
+                aria-selected="true" 
+                role="tab">
                 <span class="fd-tabs__tag">
                     By Date
                 </span>
             </a>
         </li>
         <li role="listitem" class="fd-tabs__item">
-            <a class="fd-tabs__link" role="tab">
+            <a 
+                class="fd-tabs__link" 
+                aria-controls="notifV551" 
+                href="#notifV551"
+                role="tab">
                 <span class="fd-tabs__tag">
                     By Type
                 </span>
             </a>
         </li>
         <li role="listitem" class="fd-tabs__item">
-            <a class="fd-tabs__link" role="tab">
+            <a 
+                class="fd-tabs__link" 
+                aria-controls="notifV552" 
+                href="#notifV552" 
+                role="tab">
                 <span class="fd-tabs__tag">
                     By Priority
                 </span>
             </a>
         </li>
     </ul>
-    <div class="fd-notification__group-header">
-        <button role="button" aria-label="arrow-down-button" class="fd-button fd-button--compact fd-button--transparent">
-            <i class="sap-icon--slim-arrow-down"></i>
-        </button>
-        <div class="fd-notification__content">
-            <div class="fd-notification__header">
-                <div class="fd-notification__indicator fd-notification__indicator--warning"></div>
-                <h2 class="fd-notification__title fd-notification__title--unread">Today (5)</h2>
-            </div>
-        </div>
-        <div class="fd-notification__actions">
-            <button class="fd-button fd-button--compact">Accept All</button>
-            <button class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss" aria-label="Close">
-                <i class="sap-icon--decline"></i>
+    <div class="fd-tabs__panel" aria-expanded="true" id="notifV550" role="tabpanel">
+        <div class="fd-notification__group-header">
+            <button role="button" aria-label="arrow-down-button" class="fd-button fd-button--compact fd-button--transparent">
+                <i class="sap-icon--slim-arrow-down"></i>
             </button>
-        </div>
-    </div>
-    <div class="fd-notification__body">
-        <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" role="presentation" aria-label="John Doe">JD</span>
-        <div class="fd-notification__content">
-            <div class="fd-notification__header">
-                <div class="fd-notification__indicator fd-notification__indicator--warning"></div>
-                <h2 class="fd-notification__title fd-notification__title--unread">You've got new item</h2>
-            </div>
-            <p class="fd-notification__paragraph">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
-            <p class="fd-notification__footer">
-                <span class="fd-notification__footer-content">SAP Team dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor consectetur adipiscing elit </span>
-            </p>
-        </div>
-        <div class="fd-notification__actions">
-              <div class="fd-popover fd-popover--right">
-                <div class="fd-popover__control">
-                    <button class="fd-button fd-button--transparent" aria-label="Image label" aria-controls="popoverA4" aria-expanded="false" aria-haspopup="true" onclick="onPopoverClick('popoverA4');">
-                         <i class="sap-icon--overflow"></i>
-                    </button>
-                </div>
-                <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover" aria-hidden="true" id="popoverA5">
-                    <nav class="fd-menu" id="">
-                        <ul class="fd-menu__list fd-menu__list--no-shadow">
-                            <li class="fd-menu__item">
-                                <a class="fd-menu__link">
-                                    <span class="fd-menu__title">Accept</span>
-                                </a>
-                            </li>
-                            <li class="fd-menu__item">
-                                <a class="fd-menu__link">
-                                    <span class="fd-menu__title">Decline</span>
-                                </a>
-                            </li>
-                            <li class="fd-menu__item">
-                                <a class="fd-menu__link">
-                                    <span class="fd-menu__title">Forward</span>
-                                </a>
-                            </li>
-                        </ul>
-                    </nav>
+            <div class="fd-notification__content">
+                <div class="fd-notification__header">
+                    <div class="fd-notification__indicator fd-notification__indicator--warning"></div>
+                    <h2 class="fd-notification__title fd-notification__title--unread">Today (5)</h2>
                 </div>
             </div>
-
-            <button class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss" aria-label="Close">
-                <i class="sap-icon--decline"></i>
-            </button>
-        </div>
-    </div>
-    <div class="fd-notification__body">
-        <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('http://lorempixel.com/400/400/nature/4/')" role="presentation" aria-label="John Doe"></span>
-        <div class="fd-notification__content">
-            <div class="fd-notification__header">
-            <div class="fd-notification__indicator fd-notification__indicator--success"></div>
-            <h2 class="fd-notification__title">The title you've already read.</h2>
+            <div class="fd-notification__actions">
+                <button class="fd-button fd-button--compact">Accept All</button>
+                <button class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss" aria-label="Close">
+                    <i class="sap-icon--decline"></i>
+                </button>
             </div>
-            <p class="fd-notification__paragraph">Lagna aliqua.</p>
-            <p class="fd-notification__footer">
-                <span class="fd-notification__footer-content">SAP Analytics Cloud very long author name to test truncate</span>
-                <span class="fd-notification__separator"></span>
-                <span class="fd-notification__footer-content">7 minutes ago long long time ago ages ago years ago</span>
-            </p>
         </div>
-        <div class="fd-notification__actions">
-            <button class="fd-button fd-button--compact">Open</button>
-
-            <button class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss" aria-label="Close">
-                <i class="sap-icon--decline"></i>
-            </button>
-        </div>
-    </div>
-     <div class="fd-notification__body">
-        <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('http://lorempixel.com/400/400/nature/4/')" role="presentation" aria-label="John Doe"></span>
-        <div class="fd-notification__content">
-            <div class="fd-notification__header">
-            <div class="fd-notification__indicator fd-notification__indicator--error"></div>
-            <h2 class="fd-notification__title fd-notification__title--unread">Your leave request has been rejected. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</h2>
+        <div class="fd-notification__body">
+            <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" role="presentation" aria-label="John Doe">JD</span>
+            <div class="fd-notification__content">
+                <div class="fd-notification__header">
+                    <div class="fd-notification__indicator fd-notification__indicator--warning"></div>
+                    <h2 class="fd-notification__title fd-notification__title--unread">You've got new item</h2>
+                </div>
+                <p class="fd-notification__paragraph">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+                <p class="fd-notification__footer">
+                    <span class="fd-notification__footer-content">SAP Team dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor consectetur adipiscing elit </span>
+                </p>
             </div>
-            <p class="fd-notification__paragraph">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
-            <p class="fd-notification__footer">
-                <span class="fd-notification__footer-content">SAP Analytics Cloud</span>
-                <span class="fd-notification__separator"></span>
-                <span class="fd-notification__footer-content">7 minutes ago m dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor</span> 
-            </p>
+            <div class="fd-notification__actions">
+                <div class="fd-popover fd-popover--right">
+                    <div class="fd-popover__control">
+                        <button class="fd-button fd-button--transparent" aria-label="Image label" aria-controls="popoverA5" aria-expanded="false" aria-haspopup="true" onclick="onPopoverClick('popoverA5');">
+                            <i class="sap-icon--overflow"></i>
+                        </button>
+                    </div>
+                    <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover" aria-hidden="true" id="popoverA5">
+                        <nav class="fd-menu" id="">
+                            <ul class="fd-menu__list fd-menu__list--no-shadow">
+                                <li class="fd-menu__item">
+                                    <a class="fd-menu__link">
+                                        <span class="fd-menu__title">Accept</span>
+                                    </a>
+                                </li>
+                                <li class="fd-menu__item">
+                                    <a class="fd-menu__link">
+                                        <span class="fd-menu__title">Decline</span>
+                                    </a>
+                                </li>
+                                <li class="fd-menu__item">
+                                    <a class="fd-menu__link">
+                                        <span class="fd-menu__title">Forward</span>
+                                    </a>
+                                </li>
+                            </ul>
+                        </nav>
+                    </div>
+                </div>
+
+                <button class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss" aria-label="Close">
+                    <i class="sap-icon--decline"></i>
+                </button>
+            </div>
         </div>
-        <div class="fd-notification__actions">
-            <button class="fd-button fd-button--compact">Open</button>
-            <button class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss" aria-label="Close">
-                <i class="sap-icon--decline"></i>
-            </button>
+        <div class="fd-notification__body">
+            <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('http://lorempixel.com/400/400/nature/4/')" role="presentation" aria-label="John Doe"></span>
+            <div class="fd-notification__content">
+                <div class="fd-notification__header">
+                <div class="fd-notification__indicator fd-notification__indicator--success"></div>
+                <h2 class="fd-notification__title">The title you've already read.</h2>
+                </div>
+                <p class="fd-notification__paragraph">Lagna aliqua.</p>
+                <p class="fd-notification__footer">
+                    <span class="fd-notification__footer-content">SAP Analytics Cloud very long author name to test truncate</span>
+                    <span class="fd-notification__separator"></span>
+                    <span class="fd-notification__footer-content">7 minutes ago long long time ago ages ago years ago</span>
+                </p>
+            </div>
+            <div class="fd-notification__actions">
+                <button class="fd-button fd-button--compact">Open</button>
+
+                <button class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss" aria-label="Close">
+                    <i class="sap-icon--decline"></i>
+                </button>
+            </div>
+        </div>
+        <div class="fd-notification__body">
+            <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('http://lorempixel.com/400/400/nature/4/')" role="presentation" aria-label="John Doe"></span>
+            <div class="fd-notification__content">
+                <div class="fd-notification__header">
+                <div class="fd-notification__indicator fd-notification__indicator--error"></div>
+                <h2 class="fd-notification__title fd-notification__title--unread">Your leave request has been rejected. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</h2>
+                </div>
+                <p class="fd-notification__paragraph">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+                <p class="fd-notification__footer">
+                    <span class="fd-notification__footer-content">SAP Analytics Cloud</span>
+                    <span class="fd-notification__separator"></span>
+                    <span class="fd-notification__footer-content">7 minutes ago m dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor</span> 
+                </p>
+            </div>
+            <div class="fd-notification__actions">
+                <button class="fd-button fd-button--compact">Open</button>
+                <button class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss" aria-label="Close">
+                    <i class="sap-icon--decline"></i>
+                </button>
+            </div>
+        </div>
+        <div class="fd-notification__limit">
+            <h1 class="fd-notification__limit--title">There are 30 more notifications</h1>
+            <p class="fd-notification__limit--description">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
         </div>
     </div>
-    <div class="fd-notification__limit">
-        <h1 class="fd-notification__limit--title">There are 30 more notifications</h1>
-        <p class="fd-notification__limit--description">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    <div class="fd-tabs__panel" aria-expanded="false" id="notifV551" role="tabpanel">
+        <div class="fd-notification__group-header">
+            <button role="button" aria-label="arrow-down-button" class="fd-button fd-button--compact fd-button--transparent">
+                <i class="sap-icon--slim-arrow-down"></i>
+            </button>
+            <div class="fd-notification__content">
+                <div class="fd-notification__header">
+                    <div class="fd-notification__indicator fd-notification__indicator--warning"></div>
+                    <h2 class="fd-notification__title fd-notification__title--unread">Today (5)</h2>
+                </div>
+            </div>
+            <div class="fd-notification__actions">
+                <button class="fd-button fd-button--compact">Accept All</button>
+                <button class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss" aria-label="Close">
+                    <i class="sap-icon--decline"></i>
+                </button>
+            </div>
+        </div>
+        <div class="fd-notification__body">
+            <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('http://lorempixel.com/400/400/nature/4/')" role="presentation" aria-label="John Doe"></span>
+            <div class="fd-notification__content">
+                <div class="fd-notification__header">
+                <div class="fd-notification__indicator fd-notification__indicator--success"></div>
+                <h2 class="fd-notification__title">The title you've already read.</h2>
+                </div>
+                <p class="fd-notification__paragraph">Lagna aliqua.</p>
+                <p class="fd-notification__footer">
+                    <span class="fd-notification__footer-content">SAP Analytics Cloud very long author name to test truncate</span>
+                    <span class="fd-notification__separator"></span>
+                    <span class="fd-notification__footer-content">7 minutes ago long long time ago ages ago years ago</span>
+                </p>
+            </div>
+            <div class="fd-notification__actions">
+                <button class="fd-button fd-button--compact">Open</button>
+
+                <button class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss" aria-label="Close">
+                    <i class="sap-icon--decline"></i>
+                </button>
+            </div>
+        </div>
+    </div>
+    <div class="fd-tabs__panel" aria-expanded="false" id="notifV552" role="tabpanel">
+        <div class="fd-notification__group-header">
+            <button role="button" aria-label="arrow-down-button" class="fd-button fd-button--compact fd-button--transparent">
+                <i class="sap-icon--slim-arrow-down"></i>
+            </button>
+            <div class="fd-notification__content">
+                <div class="fd-notification__header">
+                    <div class="fd-notification__indicator fd-notification__indicator--warning"></div>
+                    <h2 class="fd-notification__title fd-notification__title--unread">Today (5)</h2>
+                </div>
+            </div>
+            <div class="fd-notification__actions">
+                <button class="fd-button fd-button--compact">Accept All</button>
+                <button class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss" aria-label="Close">
+                    <i class="sap-icon--decline"></i>
+                </button>
+            </div>
+        </div>
+        <div class="fd-notification__body">
+            <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('http://lorempixel.com/400/400/nature/4/')" role="presentation" aria-label="John Doe"></span>
+            <div class="fd-notification__content">
+                <div class="fd-notification__header">
+                <div class="fd-notification__indicator fd-notification__indicator--success"></div>
+                <h2 class="fd-notification__title">The title you've already read.</h2>
+                </div>
+                <p class="fd-notification__paragraph">Lagna aliqua.</p>
+                <p class="fd-notification__footer">
+                    <span class="fd-notification__footer-content">SAP Analytics Cloud very long author name to test truncate</span>
+                    <span class="fd-notification__separator"></span>
+                    <span class="fd-notification__footer-content">7 minutes ago long long time ago ages ago years ago</span>
+                </p>
+            </div>
+            <div class="fd-notification__actions">
+                <button class="fd-button fd-button--compact">Open</button>
+
+                <button class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss" aria-label="Close">
+                    <i class="sap-icon--decline"></i>
+                </button>
+            </div>
+        </div>
     </div>
 </div>
 `;
@@ -353,8 +449,6 @@ notificationGroup.parameters = {
     `
     }
 };
-
-
 
 export const mobile = () => `
 <div style="heigt: 200px; max-width: 20rem">
@@ -406,131 +500,341 @@ export const mobile = () => `
 </div>
 </div>
 <div style="heigt: 200px; max-width: 20rem">
-<div class="fd-notification fd-notification--mobile fd-notification--group">
-    <ul class="fd-tabs fd-tabs--l fd-notification--tabs" role="tablist">
-        <li role="listitem" class="fd-tabs__item">
-            <a class="fd-tabs__link" aria-selected="true" role="tab">
-                <span class="fd-tabs__tag">
-                    By Date
-                </span>
-            </a>
-        </li>
-        <li role="listitem" class="fd-tabs__item">
-            <a class="fd-tabs__link" role="tab">
-                <span class="fd-tabs__tag">
-                    By Type
-                </span>
-            </a>
-        </li>
-        <li role="listitem" class="fd-tabs__item">
-            <a class="fd-tabs__link" role="tab">
-                <span class="fd-tabs__tag">
-                    By Priority
-                </span>
-            </a>
-        </li>
-    </ul>
-    <div class="fd-notification__group-header">
-        <button role="button" aria-label="arrow-down-button" class="fd-button fd-button--transparent">
-            <i class="sap-icon--slim-arrow-down"></i>
-        </button>
-        <div class="fd-notification__content">
-            <div class="fd-notification__header">
-                <div class="fd-notification__indicator fd-notification__indicator--warning"></div>
-                <h2 class="fd-notification__title fd-notification__title--unread">Today (5)</h2>
-            </div>
-        </div>
-        <div class="fd-notification__actions">
-            <button class="fd-button fd-button--transparent fd-notification__actions--dismiss" aria-label="Close">
-                <i class="sap-icon--decline"></i>
-            </button>
-        </div>
-    </div>
-    <div class="fd-notification__body">
-        <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" role="presentation" aria-label="John Doe">JD</span>
-        <div class="fd-notification__content">
-            <div class="fd-notification__header">
-                <div class="fd-notification__indicator fd-notification__indicator--warning"></div>
-                <h2 class="fd-notification__title fd-notification__title--unread">You've got new item</h2>
-            </div>
-            <p class="fd-notification__paragraph">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
-            <p class="fd-notification__footer">
-                <span class="fd-notification__footer-content">SAP Teamm dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor </span>
-                <span class="fd-notification__separator"></span>
-                <span class="fd-notification__footer-content">7 minutes ago</span>
-            </p>
-        </div>
-        <div class="fd-notification__actions">
-              <div class="fd-popover fd-popover--right">
-                <div class="fd-popover__control">
-                    <button class="fd-button fd-button--transparent" aria-label="Image label" aria-controls="popoverA3" aria-expanded="false" aria-haspopup="true" onclick="onPopoverClick('popoverA3');">
-                         <i class="sap-icon--overflow"></i>
+    <div class="fd-notification fd-notification--mobile fd-notification--group">
+        <ul class="fd-tabs fd-tabs--l fd-notification--tabs" role="tablist">
+            <li role="listitem" class="fd-tabs__item">
+                <a 
+                    class="fd-tabs__link" 
+                    aria-selected="true"
+                    aria-controls="notifP300" 
+                    href="#notifP300"  
+                    role="tab">
+                    <span class="fd-tabs__tag">
+                        By Date
+                    </span>
+                </a>
+            </li>
+            <li role="listitem" class="fd-tabs__item">
+                <a 
+                    class="fd-tabs__link" 
+                    aria-controls="notifP301" 
+                    href="#notifP301"  
+                    role="tab">
+                    <span class="fd-tabs__tag">
+                        By Type
+                    </span>
+                </a>
+            </li>
+            <li role="listitem" class="fd-tabs__item">
+                <a 
+                    class="fd-tabs__link"
+                    aria-controls="notifP302" 
+                    href="#notifP302"  
+                    role="tab">
+                    <span class="fd-tabs__tag">
+                        By Priority
+                    </span>
+                </a>
+            </li>
+        </ul>
+        <div class="fd-tabs__panel" aria-expanded="true" id="notifP300" role="tabpanel">
+            <div class="fd-notification__group-header">
+                <button role="button" aria-label="arrow-down-button" class="fd-button fd-button--transparent">
+                    <i class="sap-icon--slim-arrow-down"></i>
+                </button>
+                <div class="fd-notification__content">
+                    <div class="fd-notification__header">
+                        <div class="fd-notification__indicator fd-notification__indicator--warning"></div>
+                        <h2 class="fd-notification__title fd-notification__title--unread">Today (5)</h2>
+                    </div>
+                </div>
+                <div class="fd-notification__actions">
+                    <button class="fd-button fd-button--transparent fd-notification__actions--dismiss" aria-label="Close">
+                        <i class="sap-icon--decline"></i>
                     </button>
                 </div>
-                <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover" aria-hidden="true" id="popoverA3">
-                    <nav class="fd-menu" id="">
-                        <ul class="fd-menu__list fd-menu__list--no-shadow">
-                            <li class="fd-menu__item">
-                                <a class="fd-menu__link">
-                                    <span class="fd-menu__title">Open</span>
-                                </a>
-                            </li>
-                            <li class="fd-menu__item">
-                                <a class="fd-menu__link">
-                                    <span class="fd-menu__title">Decline</span>
-                                </a>
-                            </li>
-                        </ul>
-                    </nav>
+            </div>
+            <div class="fd-notification__body">
+                <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" role="presentation" aria-label="John Doe">JD</span>
+                <div class="fd-notification__content">
+                    <div class="fd-notification__header">
+                        <div class="fd-notification__indicator fd-notification__indicator--warning"></div>
+                        <h2 class="fd-notification__title fd-notification__title--unread">You've got new item</h2>
+                    </div>
+                    <p class="fd-notification__paragraph">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+                    <p class="fd-notification__footer">
+                        <span class="fd-notification__footer-content">SAP Teamm dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor </span>
+                        <span class="fd-notification__separator"></span>
+                        <span class="fd-notification__footer-content">7 minutes ago</span>
+                    </p>
                 </div>
-            </div>
-
-            <button class="fd-button fd-button--transparent fd-notification__actions--dismiss" aria-label="Close">
-                <i class="sap-icon--decline"></i>
-            </button>
-        </div>
-    </div>
-    <div class="fd-notification__body">
-        <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('http://lorempixel.com/400/400/nature/4/')" role="presentation" aria-label="John Doe"></span>
-        <div class="fd-notification__content">
-            <div class="fd-notification__header">
-            <div class="fd-notification__indicator fd-notification__indicator--success"></div>
-            <h2 class="fd-notification__title">The title you've already read.</h2>
-            </div>
-            <p class="fd-notification__paragraph">Lagna aliqua.</p>
-            <p class="fd-notification__footer">
-                <span class="fd-notification__footer-content">SAP Analytics Cloud very long author name to test truncate</span>
-                <span class="fd-notification__separator"></span>
-                <span class="fd-notification__footer-content">7 minutes ago long long time ago ages ago years ago</span>
-            </p>
-        </div>
-        <div class="fd-notification__actions">
-               <div class="fd-popover fd-popover--right">
-                <div class="fd-popover__control">
-                    <button class="fd-button fd-button--transparent" aria-label="Image label" aria-controls="popoverA2" aria-expanded="false" aria-haspopup="true" onclick="onPopoverClick('popoverA2');">
-                         <i class="sap-icon--overflow"></i>
+                <div class="fd-notification__actions">
+                    <div class="fd-popover fd-popover--right">
+                        <div class="fd-popover__control">
+                            <button class="fd-button fd-button--transparent" aria-label="Image label" aria-controls="popoverA3" aria-expanded="false" aria-haspopup="true" onclick="onPopoverClick('popoverA3');">
+                                <i class="sap-icon--overflow"></i>
+                            </button>
+                        </div>
+                        <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover" aria-hidden="true" id="popoverA3">
+                            <nav class="fd-menu" id="">
+                                <ul class="fd-menu__list fd-menu__list--no-shadow">
+                                    <li class="fd-menu__item">
+                                        <a class="fd-menu__link">
+                                            <span class="fd-menu__title">Open</span>
+                                        </a>
+                                    </li>
+                                    <li class="fd-menu__item">
+                                        <a class="fd-menu__link">
+                                            <span class="fd-menu__title">Decline</span>
+                                        </a>
+                                    </li>
+                                </ul>
+                            </nav>
+                        </div>
+                    </div>
+                    <button class="fd-button fd-button--transparent fd-notification__actions--dismiss" aria-label="Close">
+                        <i class="sap-icon--decline"></i>
                     </button>
                 </div>
-                <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover" aria-hidden="true" id="popoverA2">
-                    <nav class="fd-menu" id="">
-                        <ul class="fd-menu__list fd-menu__list--no-shadow">
-                            <li class="fd-menu__item">
-                                <a class="fd-menu__link">
-                                    <span class="fd-menu__title">Open</span>
-                                </a>
-                            </li>
-                        </ul>
-                    </nav>
+            </div>
+            <div class="fd-notification__body">
+                <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('http://lorempixel.com/400/400/nature/4/')" role="presentation" aria-label="John Doe"></span>
+                <div class="fd-notification__content">
+                    <div class="fd-notification__header">
+                    <div class="fd-notification__indicator fd-notification__indicator--success"></div>
+                    <h2 class="fd-notification__title">The title you've already read.</h2>
+                    </div>
+                    <p class="fd-notification__paragraph">Lagna aliqua.</p>
+                    <p class="fd-notification__footer">
+                        <span class="fd-notification__footer-content">SAP Analytics Cloud very long author name to test truncate</span>
+                        <span class="fd-notification__separator"></span>
+                        <span class="fd-notification__footer-content">7 minutes ago long long time ago ages ago years ago</span>
+                    </p>
+                </div>
+                <div class="fd-notification__actions">
+                    <div class="fd-popover fd-popover--right">
+                        <div class="fd-popover__control">
+                            <button class="fd-button fd-button--transparent" aria-label="Image label" aria-controls="popoverA2" aria-expanded="false" aria-haspopup="true" onclick="onPopoverClick('popoverA2');">
+                                <i class="sap-icon--overflow"></i>
+                            </button>
+                        </div>
+                        <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover" aria-hidden="true" id="popoverA2">
+                            <nav class="fd-menu" id="">
+                                <ul class="fd-menu__list fd-menu__list--no-shadow">
+                                    <li class="fd-menu__item">
+                                        <a class="fd-menu__link">
+                                            <span class="fd-menu__title">Open</span>
+                                        </a>
+                                    </li>
+                                </ul>
+                            </nav>
+                        </div>
+                    </div>
+                    <button class="fd-button fd-button--transparent fd-notification__actions--dismiss" aria-label="Close">
+                        <i class="sap-icon--decline"></i>
+                    </button>
                 </div>
             </div>
-
-            <button class="fd-button fd-button--transparent fd-notification__actions--dismiss" aria-label="Close">
-                <i class="sap-icon--decline"></i>
-            </button>
+        </div>
+        <div class="fd-tabs__panel" aria-expanded="false" id="notifP301" role="tabpanel">
+            <div class="fd-notification__group-header">
+                <button role="button" aria-label="arrow-down-button" class="fd-button fd-button--transparent">
+                    <i class="sap-icon--slim-arrow-down"></i>
+                </button>
+                <div class="fd-notification__content">
+                    <div class="fd-notification__header">
+                        <div class="fd-notification__indicator fd-notification__indicator--warning"></div>
+                        <h2 class="fd-notification__title fd-notification__title--unread">Today (5)</h2>
+                    </div>
+                </div>
+                <div class="fd-notification__actions">
+                    <button class="fd-button fd-button--transparent fd-notification__actions--dismiss" aria-label="Close">
+                        <i class="sap-icon--decline"></i>
+                    </button>
+                </div>
+            </div>
+            <div class="fd-notification__body">
+                <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" role="presentation" aria-label="John Doe">JD</span>
+                <div class="fd-notification__content">
+                    <div class="fd-notification__header">
+                        <div class="fd-notification__indicator fd-notification__indicator--warning"></div>
+                        <h2 class="fd-notification__title fd-notification__title--unread">You've got new item</h2>
+                    </div>
+                    <p class="fd-notification__paragraph">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+                    <p class="fd-notification__footer">
+                        <span class="fd-notification__footer-content">SAP Teamm dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor </span>
+                        <span class="fd-notification__separator"></span>
+                        <span class="fd-notification__footer-content">7 minutes ago</span>
+                    </p>
+                </div>
+                <div class="fd-notification__actions">
+                    <div class="fd-popover fd-popover--right">
+                        <div class="fd-popover__control">
+                            <button class="fd-button fd-button--transparent" aria-label="Image label" aria-controls="popoverA3" aria-expanded="false" aria-haspopup="true" onclick="onPopoverClick('popoverA3');">
+                                <i class="sap-icon--overflow"></i>
+                            </button>
+                        </div>
+                        <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover" aria-hidden="true" id="popoverA3">
+                            <nav class="fd-menu" id="">
+                                <ul class="fd-menu__list fd-menu__list--no-shadow">
+                                    <li class="fd-menu__item">
+                                        <a class="fd-menu__link">
+                                            <span class="fd-menu__title">Open</span>
+                                        </a>
+                                    </li>
+                                    <li class="fd-menu__item">
+                                        <a class="fd-menu__link">
+                                            <span class="fd-menu__title">Decline</span>
+                                        </a>
+                                    </li>
+                                </ul>
+                            </nav>
+                        </div>
+                    </div>
+                    <button class="fd-button fd-button--transparent fd-notification__actions--dismiss" aria-label="Close">
+                        <i class="sap-icon--decline"></i>
+                    </button>
+                </div>
+            </div>
+            <div class="fd-notification__body">
+                <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('http://lorempixel.com/400/400/nature/4/')" role="presentation" aria-label="John Doe"></span>
+                <div class="fd-notification__content">
+                    <div class="fd-notification__header">
+                    <div class="fd-notification__indicator fd-notification__indicator--success"></div>
+                    <h2 class="fd-notification__title">The title you've already read.</h2>
+                    </div>
+                    <p class="fd-notification__paragraph">Lagna aliqua.</p>
+                    <p class="fd-notification__footer">
+                        <span class="fd-notification__footer-content">SAP Analytics Cloud very long author name to test truncate</span>
+                        <span class="fd-notification__separator"></span>
+                        <span class="fd-notification__footer-content">7 minutes ago long long time ago ages ago years ago</span>
+                    </p>
+                </div>
+                <div class="fd-notification__actions">
+                    <div class="fd-popover fd-popover--right">
+                        <div class="fd-popover__control">
+                            <button class="fd-button fd-button--transparent" aria-label="Image label" aria-controls="popoverA2" aria-expanded="false" aria-haspopup="true" onclick="onPopoverClick('popoverA2');">
+                                <i class="sap-icon--overflow"></i>
+                            </button>
+                        </div>
+                        <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover" aria-hidden="true" id="popoverA2">
+                            <nav class="fd-menu" id="">
+                                <ul class="fd-menu__list fd-menu__list--no-shadow">
+                                    <li class="fd-menu__item">
+                                        <a class="fd-menu__link">
+                                            <span class="fd-menu__title">Open</span>
+                                        </a>
+                                    </li>
+                                </ul>
+                            </nav>
+                        </div>
+                    </div>
+                    <button class="fd-button fd-button--transparent fd-notification__actions--dismiss" aria-label="Close">
+                        <i class="sap-icon--decline"></i>
+                    </button>
+                </div>
+            </div>
+        </div>
+        <div class="fd-tabs__panel" aria-expanded="false" id="notifP302" role="tabpanel">
+            <div class="fd-notification__group-header">
+                <button role="button" aria-label="arrow-down-button" class="fd-button fd-button--transparent">
+                    <i class="sap-icon--slim-arrow-down"></i>
+                </button>
+                <div class="fd-notification__content">
+                    <div class="fd-notification__header">
+                        <div class="fd-notification__indicator fd-notification__indicator--warning"></div>
+                        <h2 class="fd-notification__title fd-notification__title--unread">Today (5)</h2>
+                    </div>
+                </div>
+                <div class="fd-notification__actions">
+                    <button class="fd-button fd-button--transparent fd-notification__actions--dismiss" aria-label="Close">
+                        <i class="sap-icon--decline"></i>
+                    </button>
+                </div>
+            </div>
+            <div class="fd-notification__body">
+                <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" role="presentation" aria-label="John Doe">JD</span>
+                <div class="fd-notification__content">
+                    <div class="fd-notification__header">
+                        <div class="fd-notification__indicator fd-notification__indicator--warning"></div>
+                        <h2 class="fd-notification__title fd-notification__title--unread">You've got new item</h2>
+                    </div>
+                    <p class="fd-notification__paragraph">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+                    <p class="fd-notification__footer">
+                        <span class="fd-notification__footer-content">SAP Teamm dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor </span>
+                        <span class="fd-notification__separator"></span>
+                        <span class="fd-notification__footer-content">7 minutes ago</span>
+                    </p>
+                </div>
+                <div class="fd-notification__actions">
+                    <div class="fd-popover fd-popover--right">
+                        <div class="fd-popover__control">
+                            <button class="fd-button fd-button--transparent" aria-label="Image label" aria-controls="popoverA3" aria-expanded="false" aria-haspopup="true" onclick="onPopoverClick('popoverA3');">
+                                <i class="sap-icon--overflow"></i>
+                            </button>
+                        </div>
+                        <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover" aria-hidden="true" id="popoverA3">
+                            <nav class="fd-menu" id="">
+                                <ul class="fd-menu__list fd-menu__list--no-shadow">
+                                    <li class="fd-menu__item">
+                                        <a class="fd-menu__link">
+                                            <span class="fd-menu__title">Open</span>
+                                        </a>
+                                    </li>
+                                    <li class="fd-menu__item">
+                                        <a class="fd-menu__link">
+                                            <span class="fd-menu__title">Decline</span>
+                                        </a>
+                                    </li>
+                                </ul>
+                            </nav>
+                        </div>
+                    </div>
+                    <button class="fd-button fd-button--transparent fd-notification__actions--dismiss" aria-label="Close">
+                        <i class="sap-icon--decline"></i>
+                    </button>
+                </div>
+            </div>
+            <div class="fd-notification__body">
+                <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('http://lorempixel.com/400/400/nature/4/')" role="presentation" aria-label="John Doe"></span>
+                <div class="fd-notification__content">
+                    <div class="fd-notification__header">
+                    <div class="fd-notification__indicator fd-notification__indicator--success"></div>
+                    <h2 class="fd-notification__title">The title you've already read.</h2>
+                    </div>
+                    <p class="fd-notification__paragraph">Lagna aliqua.</p>
+                    <p class="fd-notification__footer">
+                        <span class="fd-notification__footer-content">SAP Analytics Cloud very long author name to test truncate</span>
+                        <span class="fd-notification__separator"></span>
+                        <span class="fd-notification__footer-content">7 minutes ago long long time ago ages ago years ago</span>
+                    </p>
+                </div>
+                <div class="fd-notification__actions">
+                    <div class="fd-popover fd-popover--right">
+                        <div class="fd-popover__control">
+                            <button class="fd-button fd-button--transparent" aria-label="Image label" aria-controls="popoverA2" aria-expanded="false" aria-haspopup="true" onclick="onPopoverClick('popoverA2');">
+                                <i class="sap-icon--overflow"></i>
+                            </button>
+                        </div>
+                        <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover" aria-hidden="true" id="popoverA2">
+                            <nav class="fd-menu" id="">
+                                <ul class="fd-menu__list fd-menu__list--no-shadow">
+                                    <li class="fd-menu__item">
+                                        <a class="fd-menu__link">
+                                            <span class="fd-menu__title">Open</span>
+                                        </a>
+                                    </li>
+                                </ul>
+                            </nav>
+                        </div>
+                    </div>
+                    <button class="fd-button fd-button--transparent fd-notification__actions--dismiss" aria-label="Close">
+                        <i class="sap-icon--decline"></i>
+                    </button>
+                </div>
+            </div>
         </div>
     </div>
-    </div>
-
 </div>
 `;
 error.mobile = {


### PR DESCRIPTION

## Description
The last item of the footer (7 minutes ago) was wrapped with a span and `fd-notification__footer-content` class in all examples. The footer items were always the same size, changed the max-width to be 50%, positioning the second item close to the first one.

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
<img width="790" alt="Screen Shot 2020-09-25 at 3 44 36 PM" src="https://user-images.githubusercontent.com/39598672/94309414-0a128180-ff46-11ea-89b1-731a6761fdf4.png">


### After:
<img width="820" alt="Screen Shot 2020-09-25 at 3 38 50 PM" src="https://user-images.githubusercontent.com/39598672/94309456-1e567e80-ff46-11ea-9dea-420410457e33.png">
<img width="835" alt="Screen Shot 2020-09-25 at 3 38 41 PM" src="https://user-images.githubusercontent.com/39598672/94309470-231b3280-ff46-11ea-957d-4ac8638cadcf.png">
<img width="445" alt="Screen Shot 2020-09-25 at 3 38 33 PM" src="https://user-images.githubusercontent.com/39598672/94309475-257d8c80-ff46-11ea-91a5-bf1730f146fc.png">


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] Text elements follow the truncation rules

2. Documentation
- [x] Storybook documentation has been created/updated
