### PR TITLE
fix: Truncation on menu button

### DIFF
--- a/src/button.scss
+++ b/src/button.scss
@@ -104,6 +104,8 @@ $block: #{$fd-namespace}-button;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+  display: inline-flex;
+  align-items: center;
 }
 
 @mixin menu-icon() {
@@ -300,6 +302,10 @@ $block: #{$fd-namespace}-button;
 
   &--menu {
     @include menu();
+
+    .#{$block}__text {
+      line-height: 1rem;
+    }
   }
 
   &--full-width {


### PR DESCRIPTION
## Related Issue

## Description
Previously there was no way to make truncation work correctly on menu buttons. With `__text` element, there is a way to fix it, adding flex/center property to button.

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/26483208/94567838-2bd47700-026c-11eb-9bc7-bb842bb941c5.png)


### After:
![image](https://user-images.githubusercontent.com/26483208/94567746-152e2000-026c-11eb-8734-a4ff9694f169.png)

#### Please check whether the PR fulfills the following requirements
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
