### PR TITLE
docs: update docs to reference previous versions wiki page

### DIFF
--- a/.storybook/custom/components/Header.js
+++ b/.storybook/custom/components/Header.js
@@ -18,7 +18,7 @@ const Header = () => {
                 </a>
                 <a
                 className='fddocs-header__anchor'
-                href={`https://github.com/SAP/fundamental-styles/tree/v${packageJson.version}`}
+                href={`https://github.com/SAP/fundamental-styles/wiki/Previous-Versions`}
                 target='_blank'>
                         {`v${packageJson.version}`}
                 </a>

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ If you want to contribute, please check the [Contribution Guidelines](https://gi
 
 ## Versioning
 
+Documentation for previous versions can be found [here](https://github.com/SAP/fundamental-styles/wiki/Previous-Versions).
+
 The `fundamental-styles` library follows [Semantic Versioning](https://semver.org/). These components strictly adhere to the `[MAJOR].[MINOR].[PATCH]` numbering system (also known as `[BREAKING].[FEATURE].[FIX]`).
 
 Merges to the `master` branch will be published as a prerelease. Pre-releases will include an **rc** version (_e.g._ `[MAJOR].[MINOR].[PATCH]-rc.[RC]`).


### PR DESCRIPTION
fixes #1670 

Added a "previous versions" page to the wiki and a note about it in the readme.  Clicking the version number in the top right will no longer take you to the github page of that tag, but instead to the previous versions page