### PR TITLE
docs: theming followup - missing style imports in docs pages

### DIFF
--- a/stories/datepicker/datepicker.stories.js
+++ b/stories/datepicker/datepicker.stories.js
@@ -11,7 +11,7 @@ The date-picker component is an opinionated composition of the <code>input-group
 
 This component mostly relies on the CSS of other components and has very little CSS of its own.
 `,
-        components: ['calendar', 'input-group', 'popover', 'title']
+        components: ['calendar', 'input-group', 'popover', 'title', 'button', 'input', 'form-label']
     }
 };
 

--- a/stories/multi-input/multi-input.stories.js
+++ b/stories/multi-input/multi-input.stories.js
@@ -11,7 +11,7 @@ It provides an editable input field for filtering the list, and a dropdown menu 
 If the entries are not validated by the application, users can also enter custom values. 
 `,
         tags: ['f3', 'a11y', 'theme'],
-        components: ['form-label', 'popover', 'radio', 'title', 'token', 'input-group']
+        components: ['form-label', 'popover', 'radio', 'title', 'token', 'input-group', 'checkbox', 'list']
     }
 };
 

--- a/stories/object-marker/object-marker.stories.js
+++ b/stories/object-marker/object-marker.stories.js
@@ -3,10 +3,10 @@ export default {
     parameters: {
         description: `Object marker indicates the technical status of an object. It display the technical state like (draft, 
 unsaved changes, locked, favorite, flagged). Use the object marker for this unless you want to display the status of the object in the business life cycle. 
-The technical status can be represented as an icon, with an icon and text, or as text only, depending on the screen size. `
-    },
-    tags: ['f3', 'a11y', 'theme'],
-    components: ['object-marker']
+The technical status can be represented as an icon, with an icon and text, or as text only, depending on the screen size. `,
+        tags: ['f3', 'a11y', 'theme'],
+        components: ['object-marker', 'icon']
+    }
 };
 
 /**

--- a/stories/object-number/object-number.stories.js
+++ b/stories/object-number/object-number.stories.js
@@ -22,10 +22,10 @@ Make sure that the object number is properly described and semantically understa
 
 - You want to display system messages.
 - They are for decorative purposes only.
-        `
-    },
-    tags: ['f3', 'theme'],
-    components: ['object-number']
+        `,
+        tags: ['f3', 'theme'],
+        components: ['object-number']
+    }
 };
 
 /**

--- a/stories/object-status/object-status.stories.js
+++ b/stories/object-status/object-status.stories.js
@@ -3,10 +3,10 @@ export default {
     parameters: {
         description: `Object Status is a short text that represents the semantic status of an object. It has a semantic 
 color and an optional icon. Typically, the object status is used in the dynamic page header and as a status 
-attribute of a line item in a table. `
-    },
-    tags: ['f3', 'a11y', 'theme'],
-    components: ['object-status']
+attribute of a line item in a table. `,
+        tags: ['f3', 'a11y', 'theme'],
+        components: ['object-status', 'icon']
+    }
 };
 
 /**


### PR DESCRIPTION
Docs fixes as part of https://github.com/SAP/fundamental-styles/pull/1752 followup.

