### PR TITLE
[WIP] fix: Fix compile issue for rating indicator styles

### DIFF
--- a/src/rating-indicator.scss
+++ b/src/rating-indicator.scss
@@ -5,8 +5,8 @@
 $block: #{$fd-namespace}-rating-indicator;
 
 :root {
-  --sapRating-indicator-icon-rated: url();
-  --sapRating-indicator-icon-unrated: url();
+  --sapRating-indicator-icon-rated: none;
+  --sapRating-indicator-icon-unrated: none;
 }
 
 .#{$block} {


### PR DESCRIPTION
## Related Issue
## Description
![image](https://user-images.githubusercontent.com/38053194/95965398-8e07ad00-0e12-11eb-862c-6a3117a51acd.png)

The rating indicator can't be compiled when is used in the ngx-fundamental component.

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/38053194/95963940-f5246200-0e10-11eb-9917-540b1083a3f3.png)

### After:
![image](https://user-images.githubusercontent.com/38053194/95969145-083a3080-0e17-11eb-9a86-4b9108cdabb5.png)


#### Please check whether the PR fulfills the following requirements

3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
