### PR TITLE
fix: selected segmented button should not display focus outline/border

### DIFF
--- a/src/segmented-button.scss
+++ b/src/segmented-button.scss
@@ -6,6 +6,7 @@
     .fd-button
 */
 $block: #{$fd-namespace}-segmented-button;
+$button-block: #{$fd-namespace}-button;
 
 @mixin styleButtonContent() {
   @content;
@@ -16,6 +17,14 @@ $block: #{$fd-namespace}-segmented-button;
 
   display: inline-flex;
   vertical-align: middle;
+
+  .#{$button-block} {
+    @include fd-selected() {
+      &::after {
+        border-color: transparent;
+      }
+    }
+  }
 
   & > * {
     margin: 0;


### PR DESCRIPTION
Related to this issue from defect hunting on NGX:

![Screen Shot 2020-10-22 at 7 52 42 PM](https://user-images.githubusercontent.com/2471874/96947338-27ccfb00-14a0-11eb-8526-86b771d25a26.png)

Like buttons in the shellbar, this couples segmented button code to buttons.  Open to any better alternatives