### PR TITLE
fix: wcag aaa text color contrast

### DIFF
--- a/src/_listBase.scss
+++ b/src/_listBase.scss
@@ -6,6 +6,7 @@
   position: relative;
   list-style: none;
   width: 100%;
+  text-shadow: var(--fdListBase_Text_Shadow);
 
   &__item,
   &__group-header,
@@ -49,6 +50,7 @@
         color: var(--sapButton_TextColor);
         pointer-events: all;
         cursor: pointer;
+        text-shadow: var(--fdListBase_Text_Shadow);
 
         @include fd-focus() {
           outline-style: dotted;

--- a/src/button.scss
+++ b/src/button.scss
@@ -57,6 +57,7 @@ $block: #{$fd-namespace}-button;
   padding-left: $fd-button-padding-x;
   padding-right: $fd-button-padding-x;
   text-align: center;
+  text-shadow: var(--fdButton_Text_Shadow);
 
   // look
   border-style: solid;

--- a/src/calendar.scss
+++ b/src/calendar.scss
@@ -180,11 +180,12 @@ $fd-calendar-special-days: (
 }
 
 %fd-calendar-item-current {
-  border: $fd-calendar-item-current-border;
+  border: $fd-calendar-item-current-border !important;
 }
 
 %fd-calendar-item-active {
   background-color: $fd-calendar-item-active-background;
+  border: var(--fdCalendar_Active_Item_Border);
 
   @include fd-hover() {
     background-color: $fd-calendar-item-active-background-hover;
@@ -229,6 +230,7 @@ $fd-calendar-special-days: (
   height: 100%;
   color: $fd-calendar-item-color;
   font-size: $fd-calendar-item-font-size;
+  text-shadow: var(--fdCalendar_Text_Shadow);
 }
 
 .#{$block} {

--- a/src/input-group.scss
+++ b/src/input-group.scss
@@ -28,6 +28,7 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
   background-color: var(--sapField_Background);
   width: 100%;
   overflow: hidden;
+  text-shadow: var(--fdInputGroup_Text_Shadow);
 
   // states
   @include fd-form-states();
@@ -73,6 +74,7 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
     flex: 1 1 $fd-input-width-basis;
     padding-right: 0.25rem;
     padding-left: 0.25rem;
+    text-shadow: var(--fdInputGroup_Text_Shadow);
 
     @include fd-focus() {
       outline: none;

--- a/src/input.scss
+++ b/src/input.scss
@@ -18,6 +18,7 @@ $block: #{$fd-namespace}-input;
   z-index: 1;
   cursor: text;
   overflow: hidden;
+  text-shadow: var(--fdInput_Text_Shadow);
 
   &::-ms-clear {
     display: none;

--- a/src/menu.scss
+++ b/src/menu.scss
@@ -180,6 +180,7 @@ $block: #{$fd-namespace}-menu;
     color: var(--sapList_TextColor);
     font-size: var(--sapFontSize);
     font-family: $fd-menu-title-font-family;
+    text-shadow: var(--fdMenu_Text_Shadow);
   }
 
   &__addon-before,
@@ -194,6 +195,7 @@ $block: #{$fd-namespace}-menu;
     height: 1.25rem;
     font-size: var(--sapFontLargeSize);
     background-color: transparent;
+    text-shadow: var(--fdMenu_Text_Shadow);
   }
 
   &__addon-before {

--- a/src/popover.scss
+++ b/src/popover.scss
@@ -25,6 +25,7 @@ $block: #{$fd-namespace}-popover;
 
   position: relative;
   display: inline-block;
+  text-shadow: var(--fdPopover_Text_Shadow);
 
   &__control {
     @include fd-reset();

--- a/src/product-switch.scss
+++ b/src/product-switch.scss
@@ -198,6 +198,7 @@ $block: #{$fd-namespace}-product-switch;
     width: 100%;
     overflow: hidden;
     max-height: 2.5rem;
+    text-shadow: var(--fdProductSwitch_Text_Shadow);
   }
 
   &__title {

--- a/src/select.scss
+++ b/src/select.scss
@@ -14,6 +14,7 @@ $block: #{$fd-namespace}-select;
 
   display: block;
   padding-right: 0;
+  text-shadow: var(--fdSelect_Text_Shadow);
 
   &__control {
     @include fd-form-base();

--- a/src/side-nav.scss
+++ b/src/side-nav.scss
@@ -29,6 +29,7 @@ $has-child-content-arrow-margin: 0.125rem;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  text-shadow: var(--fdSideNav_Text_Shadow);
 
   &__skip-link {
     @include fd-reset();

--- a/src/theming/sap_fiori_3.scss
+++ b/src/theming/sap_fiori_3.scss
@@ -57,4 +57,41 @@
   --fdDynamicPage_Button_Group_Background: var(--sapHighlightColor);
   --fdDynamicPage_Content_List_Background: var(--sapGroup_ContentBackground);
   --fdDynamicPage_Content_Transparent_Background: transparent;
+
+  /* Token */
+  --fdToken_Text_Shadow: none;
+
+  /* Side-Nav */
+  --fdSideNav_Text_Shadow: none;
+
+  /* Time */
+  --fdTime_Text_Shadow: none;
+
+  /* Select */
+  --fdSelect_Text_Shadow: none;
+
+  /* Popover */
+  --fdPopover_Text_Shadow: none;
+
+  /* Product Switch */
+  --fdProductSwitch_Text_Shadow: none;
+
+  /* Menu */
+  --fdMenu_Text_Shadow: none;
+
+  /* List */
+  --fdListBase_Text_Shadow: none;
+
+  /* Button */
+  --fdButton_Text_Shadow: none;
+
+  /* Input Group */
+  --fdInputGroup_Text_Shadow: none;
+
+  /* Input */
+  --fdInput_Text_Shadow: none;
+
+  /* Calendar */
+  --fdCalendar_Text_Shadow: none;
+  --fdCalendar_Active_Item_Border: none;
 }

--- a/src/theming/sap_fiori_3_dark.scss
+++ b/src/theming/sap_fiori_3_dark.scss
@@ -57,4 +57,41 @@
   --fdDynamicPage_Button_Group_Background: var(--sapHighlightColor);
   --fdDynamicPage_Content_List_Background: var(--sapGroup_ContentBackground);
   --fdDynamicPage_Content_Transparent_Background: transparent;
+
+  /* Token */
+  --fdToken_Text_Shadow: none;
+
+  /* Side-Nav */
+  --fdSideNav_Text_Shadow: none;
+
+  /* Time */
+  --fdTime_Text_Shadow: none;
+
+  /* Select */
+  --fdSelect_Text_Shadow: none;
+
+  /* Popover */
+  --fdPopover_Text_Shadow: none;
+
+  /* Product Switch */
+  --fdProductSwitch_Text_Shadow: none;
+
+  /* Menu */
+  --fdMenu_Text_Shadow: none;
+
+  /* List */
+  --fdListBase_Text_Shadow: none;
+
+  /* Button */
+  --fdButton_Text_Shadow: none;
+
+  /* Input Group */
+  --fdInputGroup_Text_Shadow: none;
+
+  /* Input */
+  --fdInput_Text_Shadow: none;
+
+  /* Calendar */
+  --fdCalendar_Text_Shadow: none;
+  --fdCalendar_Active_Item_Border: none;
 }

--- a/src/theming/sap_fiori_3_hcb.scss
+++ b/src/theming/sap_fiori_3_hcb.scss
@@ -57,4 +57,41 @@
   --fdDynamicPage_Button_Group_Background: var(--sapObjectHeader_BorderColor);
   --fdDynamicPage_Content_List_Background: var(--sapBackgroundColor);
   --fdDynamicPage_Content_Transparent_Background: var(--sapBackgroundColor);
+
+  /* Token */
+  --fdToken_Text_Shadow: 0 0 0.125rem #000;
+
+  /* Side-Nav */
+  --fdSideNav_Text_Shadow: 0 0 0.125rem #000;
+
+  /* Time */
+  --fdTime_Text_Shadow: 0 0 0.125rem #000;
+
+  /* Select */
+  --fdSelect_Text_Shadow: 0 0 0.125rem #000;
+
+  /* Popover */
+  --fdPopover_Text_Shadow: 0 0 0.125rem #000;
+
+  /* Product Switch */
+  --fdProductSwitch_Text_Shadow: 0 0 0.125rem #000;
+
+  /* Menu */
+  --fdMenu_Text_Shadow: 0 0 0.125rem #000;
+
+  /* List */
+  --fdListBase_Text_Shadow: 0 0 0.125rem #000;
+
+  /* Button */
+  --fdButton_Text_Shadow: 0 0 0.125rem #000;
+
+  /* Input Group */
+  --fdInputGroup_Text_Shadow: 0 0 0.125rem #000;
+
+  /* Input */
+  --fdInput_Text_Shadow: 0 0 0.125rem #000;
+
+  /* Calendar */
+  --fdCalendar_Text_Shadow: 0 0 0.125rem #000;
+  --fdCalendar_Active_Item_Border: solid 0.0625rem var(--sapList_SelectionBorderColor, #fff);
 }

--- a/src/theming/sap_fiori_3_hcw.scss
+++ b/src/theming/sap_fiori_3_hcw.scss
@@ -57,4 +57,41 @@
   --fdDynamicPage_Button_Group_Background: var(--sapObjectHeader_BorderColor);
   --fdDynamicPage_Content_List_Background: var(--sapBackgroundColor);
   --fdDynamicPage_Content_Transparent_Background: var(--sapBackgroundColor);
+
+  /* Token */
+  --fdToken_Text_Shadow: none;
+
+  /* Side-Nav */
+  --fdSideNav_Text_Shadow: none;
+
+  /* Time */
+  --fdTime_Text_Shadow: none;
+
+  /* Select */
+  --fdSelect_Text_Shadow: none;
+
+  /* Popover */
+  --fdPopover_Text_Shadow: none;
+
+  /* Product Switch */
+  --fdProductSwitch_Text_Shadow: none;
+
+  /* Menu */
+  --fdMenu_Text_Shadow: none;
+
+  /* List */
+  --fdListBase_Text_Shadow: none;
+
+  /* Button */
+  --fdButton_Text_Shadow: none;
+
+  /* Input Group */
+  --fdInputGroup_Text_Shadow: none;
+
+  /* Input */
+  --fdInput_Text_Shadow: none;
+
+  /* Calendar */
+  --fdCalendar_Text_Shadow: none;
+  --fdCalendar_Active_Item_Border: none;
 }

--- a/src/theming/sap_fiori_3_hcw.scss
+++ b/src/theming/sap_fiori_3_hcw.scss
@@ -101,5 +101,5 @@
 
   /* Calendar */
   --fdCalendar_Text_Shadow: none;
-  --fdCalendar_Active_Item_Border: none;
+  --fdCalendar_Active_Item_Border: solid 0.0625rem var(--sapList_SelectionBorderColor, #000);
 }

--- a/src/theming/sap_fiori_3_light_dark.scss
+++ b/src/theming/sap_fiori_3_light_dark.scss
@@ -57,4 +57,41 @@
   --fdDynamicPage_Button_Group_Background: var(--sapHighlightColor);
   --fdDynamicPage_Content_List_Background: var(--sapGroup_ContentBackground);
   --fdDynamicPage_Content_Transparent_Background: transparent;
+
+  /* Token */
+  --fdToken_Text_Shadow: none;
+
+  /* Side-Nav */
+  --fdSideNav_Text_Shadow: none;
+
+  /* Time */
+  --fdTime_Text_Shadow: none;
+
+  /* Select */
+  --fdSelect_Text_Shadow: none;
+
+  /* Popover */
+  --fdPopover_Text_Shadow: none;
+
+  /* Product Switch */
+  --fdProductSwitch_Text_Shadow: none;
+
+  /* Menu */
+  --fdMenu_Text_Shadow: none;
+
+  /* List */
+  --fdListBase_Text_Shadow: none;
+
+  /* Button */
+  --fdButton_Text_Shadow: none;
+
+  /* Input Group */
+  --fdInputGroup_Text_Shadow: none;
+
+  /* Input */
+  --fdInput_Text_Shadow: none;
+
+  /* Calendar */
+  --fdCalendar_Text_Shadow: none;
+  --fdCalendar_Active_Item_Border: none;
 }

--- a/src/time.scss
+++ b/src/time.scss
@@ -95,6 +95,7 @@ $block: #{$fd-namespace}-time;
     border-radius: var(--sapButton_BorderCornerRadius);
     background-color: var(--sapLegend_WorkingBackground);
     border: 0.0625rem solid var(--sapList_Background);
+    text-shadow: var(--fdTime_Text_Shadow);
 
     &:hover {
       background-color: var(--sapList_Hover_Background);

--- a/src/token.scss
+++ b/src/token.scss
@@ -68,6 +68,7 @@ $block: #{$fd-namespace}-token;
     min-width: auto;
     width: 100%;
     text-overflow: ellipsis;
+    text-shadow: var(--fdToken_Text_Shadow);
   }
 
   &__close {


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#1020
Closes SAP/fundamental-styles#1019
Closes SAP/fundamental-styles#1016
Closes SAP/fundamental-styles#1015
Closes SAP/fundamental-styles#1014
Closes SAP/fundamental-styles#1010
Closes SAP/fundamental-styles#1009
Closes SAP/fundamental-styles#1006
Closes SAP/fundamental-styles#1004
Closes SAP/fundamental-styles#1003
Closes SAP/fundamental-styles#996

## Description
This PR is addressing WCAG AAA Color contrast issue above which mainly pertain to the text contrast of these components against their backgrounds in Fiori **High Contrast Black** mode. The two colors used throughout are `#FFFFFF` for text, `#0F5D94` and `#7A5100` for background. This is currently failing color contrast WCAG AAA minimums.

`#FFFFFF` text color against `#7A5100` background results in 6.98:1 contrast ratio which fails WCAG AAA
https://webaim.org/resources/contrastchecker/?fcolor=FFFFFF&bcolor=7A5100
 
`#FFFFFF` text color against `#0F5D94` results in 6.96:1 contrast ratio which fails WCAG AAA
https://webaim.org/resources/contrastchecker/?fcolor=FFFFFF&bcolor=0F5D94 

Additionally for the `Calendar` component, there were no surrounding borders for items containing these colors further failing `#0F5D94` and `#7A5100` vs. `#000000` background. Borders have been added to active calendar days.
https://webaim.org/resources/contrastchecker/?fcolor=000000&bcolor=0F5D94
https://webaim.org/resources/contrastchecker/?fcolor=000000&bcolor=7A5100

In order to comply with WCAG AAA guidelines, a text shadow has been added to offending components in order to have a passing foreground/background contrast ratio.

### Contrast Ratios
- Token
   - `#FFFFFF` vs. `#0A3A5B` 11.9:1
   - `#FFFFF` vs. `#5B3C03` 10:1
- Side Nav
   - `#FFFFFF` vs. `#0A3A5B` 11.9:1
   - `#FFFFF` vs. `#5B3C03` 10:1
- Time
   - `#FFFFFF` vs. `#0A3A5B` 11.9:1
   - `#FFFFF` vs. `#5B3C03` 10:1
- Select
   - `#FFFFFF` vs. `#0A3A5B` 11.9:1
   - `#FFFFF` vs. `#5B3C03` 10:1
- Product Switch
   - `#FFFFFF` vs. `#0A3A5B` 11.9:1
   - `#FFFFF` vs. `#5B3C03` 10:1
- Menu
   - `#FFFFFF` vs. `#0A3A5B` 11.9:1
   - `#FFFFF` vs. `#5B3C03` 10:1
- List
   - `#FFFFFF` vs. `#0A3A5B` 11.9:1
   - `#FFFFF` vs. `#5B3C03` 10:1
- Input Group
   - `#FFFFFF` vs. `#0A3A5B` 11.9:1
   - `#FFFFF` vs. `#5B3C03` 10:1
- Input
   - `#FFFFFF` vs. `#0A3A5B` 11.9:1
   - `#FFFFF` vs. `#5B3C03` 10:1
- Calendar
   - `#FFFFFF` vs. `#0A3A5B` 11.9:1
   - `#FFFFF` vs. `#5B3C03` 10:1
- Button
   - `#FFFFFF` vs. `#0A3A5B` 11.9:1
   - `#FFFFF` vs. `#5B3C03` 10:1

## Screenshots

### Before:
![image](https://user-images.githubusercontent.com/21978807/96946117-51802500-1494-11eb-90fd-88fbbfe38e60.png)
![image](https://user-images.githubusercontent.com/21978807/96946125-53e27f00-1494-11eb-8e2f-f9f288df65e8.png)
![image](https://user-images.githubusercontent.com/21978807/96946129-56dd6f80-1494-11eb-86cb-ed986b7f2155.png)
![image](https://user-images.githubusercontent.com/21978807/96946134-593fc980-1494-11eb-8ab1-4efe376212d8.png)
![image](https://user-images.githubusercontent.com/21978807/96946137-5ba22380-1494-11eb-9891-25a298b33574.png)
![image](https://user-images.githubusercontent.com/21978807/96946141-5e047d80-1494-11eb-8635-04b3c3e8127a.png)
![image](https://user-images.githubusercontent.com/21978807/96946146-6066d780-1494-11eb-883d-ad73754d7e67.png)
![image](https://user-images.githubusercontent.com/21978807/96946148-62c93180-1494-11eb-900f-0e7c81c48b61.png)
![image](https://user-images.githubusercontent.com/21978807/96946153-652b8b80-1494-11eb-9e1c-ddbf952902b4.png)
![image](https://user-images.githubusercontent.com/21978807/96946160-678de580-1494-11eb-9a18-0706febaaa1f.png)
![image](https://user-images.githubusercontent.com/21978807/96946163-69f03f80-1494-11eb-8fc8-8272ae9af203.png)

### After:
#### Chrome:
![image](https://user-images.githubusercontent.com/21978807/96943208-4b864600-148c-11eb-8f5c-290731d45f9d.png)
![image](https://user-images.githubusercontent.com/21978807/96943221-517c2700-148c-11eb-9552-54a7f113e6c4.png)
![image](https://user-images.githubusercontent.com/21978807/96943217-4e813680-148c-11eb-81ed-a76dcb9993bb.png)
![image](https://user-images.githubusercontent.com/21978807/96943223-53de8100-148c-11eb-8f46-6e60a3581272.png)
![image](https://user-images.githubusercontent.com/21978807/96943230-56d97180-148c-11eb-882a-95dcb3369a0d.png)
![image](https://user-images.githubusercontent.com/21978807/96943237-593bcb80-148c-11eb-967e-3ee4e6f76bb1.png)
![image](https://user-images.githubusercontent.com/21978807/96943242-5b9e2580-148c-11eb-8c99-13a022a3db00.png)
![image](https://user-images.githubusercontent.com/21978807/96943244-5d67e900-148c-11eb-8be5-48ef41156e1e.png)
![image](https://user-images.githubusercontent.com/21978807/96943246-5fca4300-148c-11eb-9595-354d26ed2655.png)
![image](https://user-images.githubusercontent.com/21978807/96943252-622c9d00-148c-11eb-83f4-eb91c6efaaab.png)
![image](https://user-images.githubusercontent.com/21978807/96943256-648ef700-148c-11eb-8db1-9aa4e5ca41fa.png)

#### IE11:
![image](https://user-images.githubusercontent.com/21978807/96960324-f9a6e580-14b6-11eb-8dec-67ee46779a1a.png)
![image](https://user-images.githubusercontent.com/21978807/96960386-2fe46500-14b7-11eb-8548-bfe9986f4f43.png)
![image](https://user-images.githubusercontent.com/21978807/96960389-32df5580-14b7-11eb-8fd8-2f8370ea1891.png)
![image](https://user-images.githubusercontent.com/21978807/96960396-370b7300-14b7-11eb-94e4-2a4dd8b1a260.png)
![image](https://user-images.githubusercontent.com/21978807/96960402-3a066380-14b7-11eb-9948-3d4434303236.png)
![image](https://user-images.githubusercontent.com/21978807/96960412-3d015400-14b7-11eb-966f-f06471205aaa.png)
![image](https://user-images.githubusercontent.com/21978807/96960415-3f63ae00-14b7-11eb-8904-ca44f9b335ee.png)
![image](https://user-images.githubusercontent.com/21978807/96960423-44286200-14b7-11eb-91e6-2d25f53c794e.png)
![image](https://user-images.githubusercontent.com/21978807/96960429-47235280-14b7-11eb-9d10-f9063d4fceb7.png)
![image](https://user-images.githubusercontent.com/21978807/96960439-4a1e4300-14b7-11eb-8fd9-acde821870d5.png)
![image](https://user-images.githubusercontent.com/21978807/96960443-4d193380-14b7-11eb-85ee-c5ae3f20ac03.png)


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
