### PR TITLE
fix: Remove focus on pressed button

### DIFF
--- a/src/button.scss
+++ b/src/button.scss
@@ -333,7 +333,6 @@ $block: #{$fd-namespace}-button;
   }
 
   @include fd-active-pressed-selected() {
-    @include buttonContainerFocus();
     @include buttonContainerPressedFocus();
   }
 


### PR DESCRIPTION
## Related Issue
Part of https://github.com/SAP/fundamental-ngx/issues/3641
Part of https://github.com/SAP/fundamental-styles/issues/1760

## Description
Focus outline is not needed on selected buttons, when button is not focused.

## Screenshots
### Before:
![image](https://user-images.githubusercontent.com/26483208/96993560-c488aa80-152b-11eb-9493-721549a2da4b.png)


### After:
![image](https://user-images.githubusercontent.com/26483208/96993480-a91d9f80-152b-11eb-966c-7331e032052c.png)
