### PR TITLE
fix: Improve Dialog documentation examples

### DIFF
--- a/.storybook/custom/custom.scss
+++ b/.storybook/custom/custom.scss
@@ -277,6 +277,11 @@ code.docs-code-grey {
   background-color: #f8f8f8;
 }
 
+.fd-dialog,
+.fd-message-box {
+  z-index: 100;
+}
+
 .fd-dialog-docs-static,
 .fd-message-box-docs-static {
   &.fd-dialog,

--- a/.storybook/static/preview-head.js
+++ b/.storybook/static/preview-head.js
@@ -176,19 +176,6 @@
     }
 })();
 
-function toggleDialog(dialogId, show) {
-    let dialog = document.getElementById(dialogId);
-    if(!dialog){
-        console.warn('No dialog with id', dialogId);
-        return;
-    }
-    if (show) {
-        dialog.classList.add('fd-dialog--active');
-    } else {
-        dialog.classList.remove('fd-dialog--active');
-    }
-}
-
 function onControlClick(controlId) {
     let ref = document.getElementById(controlId);
 

--- a/stories/dialog/__snapshots__/dialog.stories.storyshot
+++ b/stories/dialog/__snapshots__/dialog.stories.storyshot
@@ -285,7 +285,7 @@ exports[`Storyshots Components/Dialog Loading 1`] = `
 
   <button
     class="fd-button"
-    onclick="toggleDialog('loading-dialog-example', true)"
+    onclick="toggleClass('loading-dialog-example', 'fd-dialog--active')"
   >
     Open example
   </button>
@@ -394,7 +394,7 @@ exports[`Storyshots Components/Dialog Loading 1`] = `
                     
             <button
               class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact"
-              onclick="toggleDialog('loading-dialog-example', false)"
+              onclick="toggleClass('loading-dialog-example', 'fd-dialog--active')"
             >
               Cancel
             </button>
@@ -538,7 +538,7 @@ exports[`Storyshots Components/Dialog Selectable 1`] = `
 
   <button
     class="fd-button"
-    onclick="toggleDialog('select-dialog-example', true)"
+    onclick="toggleClass('select-dialog-example', 'fd-dialog--active')"
   >
     Open example
   </button>
@@ -631,6 +631,7 @@ exports[`Storyshots Components/Dialog Selectable 1`] = `
             
                     
             <input
+              aria-label="search"
               class="fd-input fd-input-group__input fd-input--compact"
               placeholder="Search..."
               type="text"
@@ -643,12 +644,14 @@ exports[`Storyshots Components/Dialog Selectable 1`] = `
               
                         
               <button
+                aria-label="perform search"
                 class="fd-button fd-input-group__button fd-button--icon fd-button--transparent fd-button--compact"
               >
                 
                             
                 <i
                   class="sap-icon--search"
+                  role="presentation"
                 />
                 
                         
@@ -673,17 +676,45 @@ exports[`Storyshots Components/Dialog Selectable 1`] = `
         
             
         <ul
-          class="fd-list fd-list--compact"
+          aria-label="selection list"
+          class="fd-list fd-list--selection fd-list--compact fd-list--no-border"
+          role="listbox"
         >
           
                 
           <li
             class="fd-list__item"
+            role="option"
+            tabindex="0"
           >
+            
+                    
+            <div
+              class="fd-form-item fd-list__form-item"
+            >
+              
+                        
+              <input
+                aria-labelledby="Az0bg4"
+                class="fd-checkbox fd-checkbox--compact"
+                id="Ai4ez4"
+                type="checkbox"
+              />
+              
+                        
+              <label
+                class="fd-checkbox__label fd-checkbox__label--compact"
+                for="Ai4ez4"
+                tabindex="-1"
+              />
+              
+                    
+            </div>
             
                     
             <span
               class="fd-list__title"
+              id="Az0bg4"
             >
               List item 1
             </span>
@@ -693,12 +724,40 @@ exports[`Storyshots Components/Dialog Selectable 1`] = `
           
                 
           <li
-            class="fd-list__item"
+            aria-selected="true"
+            class="fd-list__item is-selected"
+            role="option"
+            tabindex="0"
           >
+            
+                    
+            <div
+              class="fd-form-item fd-list__form-item"
+            >
+              
+                        
+              <input
+                aria-labelledby="Az0bg5"
+                checked=""
+                class="fd-checkbox fd-checkbox--compact"
+                id="Ai4ez5"
+                type="checkbox"
+              />
+              
+                        
+              <label
+                class="fd-checkbox__label fd-checkbox__label--compact"
+                for="Ai4ez5"
+                tabindex="-1"
+              />
+              
+                    
+            </div>
             
                     
             <span
               class="fd-list__title"
+              id="Az0bg5"
             >
               List item 2
             </span>
@@ -708,12 +767,39 @@ exports[`Storyshots Components/Dialog Selectable 1`] = `
           
                 
           <li
-            class="fd-list__item is-active"
+            class="fd-list__item is-selected"
+            role="option"
+            tabindex="0"
           >
+            
+                    
+            <div
+              class="fd-form-item fd-list__form-item"
+            >
+              
+                        
+              <input
+                aria-labelledby="Az0bg6"
+                checked=""
+                class="fd-checkbox fd-checkbox--compact"
+                id="Ai4ez6"
+                type="checkbox"
+              />
+              
+                        
+              <label
+                class="fd-checkbox__label fd-checkbox__label--compact"
+                for="Ai4ez6"
+                tabindex="-1"
+              />
+              
+                    
+            </div>
             
                     
             <span
               class="fd-list__title"
+              id="Az0bg6"
             >
               List item 3
             </span>
@@ -723,12 +809,38 @@ exports[`Storyshots Components/Dialog Selectable 1`] = `
           
                 
           <li
-            class="fd-list__item is-active"
+            class="fd-list__item"
+            role="option"
+            tabindex="0"
           >
+            
+                    
+            <div
+              class="fd-form-item fd-list__form-item"
+            >
+              
+                        
+              <input
+                aria-labelledby="440bg6"
+                class="fd-checkbox fd-checkbox--compact"
+                id="Ai4e44"
+                type="checkbox"
+              />
+              
+                        
+              <label
+                class="fd-checkbox__label fd-checkbox__label--compact"
+                for="Ai4e44"
+                tabindex="-1"
+              />
+              
+                    
+            </div>
             
                     
             <span
               class="fd-list__title"
+              id="440bg6"
             >
               List item 4
             </span>
@@ -739,11 +851,37 @@ exports[`Storyshots Components/Dialog Selectable 1`] = `
                 
           <li
             class="fd-list__item"
+            role="option"
+            tabindex="0"
           >
+            
+                    
+            <div
+              class="fd-form-item fd-list__form-item"
+            >
+              
+                        
+              <input
+                aria-labelledby="550bg6"
+                class="fd-checkbox fd-checkbox--compact"
+                id="Ai4e55"
+                type="checkbox"
+              />
+              
+                        
+              <label
+                class="fd-checkbox__label fd-checkbox__label--compact"
+                for="Ai4e55"
+                tabindex="-1"
+              />
+              
+                    
+            </div>
             
                     
             <span
               class="fd-list__title"
+              id="550bg6"
             >
               List item 5
             </span>
@@ -754,11 +892,37 @@ exports[`Storyshots Components/Dialog Selectable 1`] = `
                 
           <li
             class="fd-list__item"
+            role="option"
+            tabindex="0"
           >
+            
+                    
+            <div
+              class="fd-form-item fd-list__form-item"
+            >
+              
+                        
+              <input
+                aria-labelledby="660bg6"
+                class="fd-checkbox fd-checkbox--compact"
+                id="Ai4e66"
+                type="checkbox"
+              />
+              
+                        
+              <label
+                class="fd-checkbox__label fd-checkbox__label--compact"
+                for="Ai4e66"
+                tabindex="-1"
+              />
+              
+                    
+            </div>
             
                     
             <span
               class="fd-list__title"
+              id="660bg6"
             >
               List item 6
             </span>
@@ -814,7 +978,7 @@ exports[`Storyshots Components/Dialog Selectable 1`] = `
                     
             <button
               class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact"
-              onclick="toggleDialog('select-dialog-example', false)"
+              onclick="toggleClass('select-dialog-example', 'fd-dialog--active')"
             >
               Cancel
             </button>

--- a/stories/dialog/__snapshots__/dialog.stories.storyshot
+++ b/stories/dialog/__snapshots__/dialog.stories.storyshot
@@ -1,1420 +1,473 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Components/Dialog Default 1`] = `
-<div
-  class="fd-dialog-docs-static fd-dialog fd-dialog--active"
->
-  
-    
-  <section
-    aria-labelledby="dialog-title-1"
-    aria-modal="true"
-    class="fd-dialog__content"
-    role="dialog"
-  >
-    
-        
-    <span
-      class="fd-dialog__resize-handle"
-    />
-    
-        
-    <header
-      class="fd-dialog__header fd-bar fd-bar--header-with-subheader"
-    >
-      
-            
-      <div
-        class="fd-bar__left"
-      >
-        
-                
-        <div
-          class="fd-bar__element"
-        >
-          
-                    Dialog header
-                
-        </div>
-        
-                
-        <div
-          class="fd-bar__element"
-        >
-          
-                    
-          <h2
-            class="fd-title fd-title--h5"
-            id="dialog-title-1"
-          >
-            
-                        Dialog title
-                    
-          </h2>
-          
-                
-        </div>
-        
-            
-      </div>
-      
-        
-    </header>
-    
-        
-    <div
-      class="fd-dialog__subheader fd-bar fd-bar--subheader"
-    >
-      
-            
-      <div
-        class="fd-bar__left"
-      >
-        
-                
-        <div
-          class="fd-bar__element"
-        >
-          
-                    Dialog subheader
-                
-        </div>
-        
-            
-      </div>
-      
-        
-    </div>
-    
-        
-    <div
-      class="fd-dialog__body"
-    >
-      
-            Dialog body
-            
-      <div
-        class="fd-dialog__loader"
-      >
-        
-                Dialog loader
-            
-      </div>
-      
-        
-    </div>
-    
-        
-    <footer
-      class="fd-dialog__footer fd-bar fd-bar--footer"
-    >
-      
-            
-      <div
-        class="fd-bar__right"
-      >
-        
-                
-        <div
-          class="fd-bar__element"
-        >
-          
-                    Dialog footer
-                
-        </div>
-        
-                
-        <div
-          class="fd-bar__element"
-        >
-          
-                    
-          <button
-            class="fd-dialog__decisive-button fd-button fd-button--compact"
-          >
-            
-                        Begin button
-                    
-          </button>
-          
-                
-        </div>
-        
-                
-        <div
-          class="fd-bar__element"
-        >
-          
-                    
-          <button
-            class="fd-dialog__decisive-button fd-button fd-button--compact"
-          >
-            
-                        End button
-                    
-          </button>
-          
-                
-        </div>
-        
-            
-      </div>
-      
-        
-    </footer>
-    
-    
-  </section>
-  
 
-</div>
+
 `;
 
 exports[`Storyshots Components/Dialog Draggable 1`] = `
-<div
-  class="fd-dialog-docs-static fd-dialog fd-dialog--active"
->
-  
-    
-  <section
-    aria-labelledby="dialog-title-7"
-    aria-modal="true"
-    class="fd-dialog__content fd-dialog__content--draggable-grab fd-dialog__content--s"
-    role="dialog"
-  >
-    
-        
-    <header
-      class="fd-dialog__header fd-bar fd-bar--header"
-    >
-      
-            
-      <div
-        class="fd-bar__left"
-      >
-        
-                
-        <div
-          class="fd-bar__element"
-        >
-          
-                    
-          <h2
-            class="fd-title fd-title--h5"
-            id="dialog-title-7"
-          >
-            
-                        Lorem ipsum
-                    
-          </h2>
-          
-                
-        </div>
-        
-            
-      </div>
-      
-        
-    </header>
-    
-        
-    <div
-      class="fd-dialog__body"
-    >
-      
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
-        
-    </div>
-    
-        
-    <footer
-      class="fd-dialog__footer fd-bar fd-bar--footer"
-    >
-      
-            
-      <div
-        class="fd-bar__right"
-      >
-        
-                
-        <div
-          class="fd-bar__element"
-        >
-          
-                    
-          <button
-            class="fd-dialog__decisive-button fd-button fd-button--emphasized fd-button--compact"
-          >
-            Save
-          </button>
-          
-                
-        </div>
-        
-                
-        <div
-          class="fd-bar__element"
-        >
-          
-                    
-          <button
-            class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact"
-          >
-            Cancel
-          </button>
-          
-                
-        </div>
-        
-            
-      </div>
-      
-        
-    </footer>
-    
-    
-  </section>
-  
 
-</div>
+
 `;
 
 exports[`Storyshots Components/Dialog Loading 1`] = `
-<div
-  class="fd-dialog-docs-static fd-dialog fd-dialog--active"
-  id="loading-dialog-example"
->
-  
-    
-  <section
-    aria-labelledby="dialog-title-9"
-    aria-modal="true"
-    class="fd-dialog__content fd-dialog__content--s"
-    role="dialog"
-  >
-    
-        
-    <header
-      class="fd-dialog__header fd-bar fd-bar--header"
-    >
-      
-            
-      <div
-        class="fd-bar__left"
-      >
-        
-                
-        <div
-          class="fd-bar__element"
-        >
-          
-                    
-          <h2
-            class="fd-title fd-title--h5"
-            id="dialog-title-9"
-          >
-            
-                        Loading Data...
-                    
-          </h2>
-          
-                
-        </div>
-        
-            
-      </div>
-      
-        
-    </header>
-    
-        
-    <div
-      class="fd-dialog__body"
-    >
-      
-            
-      <strong>
-        Status:
-      </strong>
-       Connecting 127.0.0.1
-            
-      <div
-        aria-hidden="false"
-        aria-label="Loading"
-        class="fd-dialog__loader fd-busy-indicator--l"
-      >
-        
-                
-        <div
-          class="fd-busy-indicator--circle-0"
-        />
-        
-                
-        <div
-          class="fd-busy-indicator--circle-1"
-        />
-        
-                
-        <div
-          class="fd-busy-indicator--circle-2"
-        />
-        
-            
-      </div>
-      
-        
-    </div>
-    
-        
-    <footer
-      class="fd-dialog__footer fd-bar fd-bar--footer"
-    >
-      
-            
-      <div
-        class="fd-bar__right"
-      >
-        
-                
-        <div
-          class="fd-bar__element"
-        >
-          
-                    
-          <button
-            class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact"
-          >
-            Cancel
-          </button>
-          
-                
-        </div>
-        
-            
-      </div>
-      
-        
-    </footer>
-    
-    
-  </section>
-  
 
-</div>
+
 `;
 
 exports[`Storyshots Components/Dialog Resizable 1`] = `
-<div
-  class="fd-dialog-docs-static fd-dialog fd-dialog--active"
->
-  
-        
-  <section
-    aria-labelledby="dialog-title-6"
-    aria-modal="true"
-    class="fd-dialog__content fd-dialog__content--s"
-    role="dialog"
-  >
-    
-            
-    <span
-      class="fd-dialog__resize-handle"
-    />
-    
-            
-    <header
-      class="fd-dialog__header fd-bar fd-bar--header"
-    >
-      
-                
-      <div
-        class="fd-bar__left"
-      >
-        
-                    
-        <div
-          class="fd-bar__element"
-        >
-          
-                        
-          <h2
-            class="fd-title fd-title--h5"
-            id="dialog-title-6"
-          >
-            
-                            Lorem ipsum
-                        
-          </h2>
-          
-                    
-        </div>
-        
-                
-      </div>
-      
-            
-    </header>
-    
-            
-    <div
-      class="fd-dialog__body"
-    >
-      
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
-            
-    </div>
-    
-            
-    <footer
-      class="fd-dialog__footer fd-bar fd-bar--footer"
-    >
-      
-                
-      <div
-        class="fd-bar__right"
-      >
-        
-                    
-        <div
-          class="fd-bar__element"
-        >
-          
-                        
-          <button
-            class="fd-dialog__decisive-button fd-button fd-button--emphasized fd-button--compact"
-          >
-            Save
-          </button>
-          
-                    
-        </div>
-        
-                    
-        <div
-          class="fd-bar__element"
-        >
-          
-                        
-          <button
-            class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact"
-          >
-            Cancel
-          </button>
-          
-                    
-        </div>
-        
-                
-      </div>
-      
-            
-    </footer>
-    
-        
-  </section>
-  
-    
-</div>
+
+
 `;
 
 exports[`Storyshots Components/Dialog Selectable 1`] = `
-<div
-  class="fd-dialog-docs-static fd-dialog fd-dialog--active"
-  id="select-dialog-example"
->
-  
-    
-  <section
-    aria-labelledby="dialog-title-8"
-    aria-modal="true"
-    class="fd-dialog__content"
-    role="dialog"
-  >
-    
-        
-    <header
-      class="fd-dialog__header fd-bar fd-bar--header-with-subheader"
-    >
-      
-            
-      <div
-        class="fd-bar__left"
-      >
-        
-                
-        <div
-          class="fd-bar__element"
-        >
-          
-                    
-          <h2
-            class="fd-title fd-title--h5"
-            id="dialog-title-8"
-          >
-            
-                        Select Dialog
-                    
-          </h2>
-          
-                
-        </div>
-        
-            
-      </div>
-      
-            
-      <div
-        class="fd-bar__right"
-      >
-        
-                
-        <div
-          class="fd-bar__element"
-        >
-          
-                    
-          <button
-            class="fd-button fd-button--transparent fd-button--compact"
-          >
-            Clear
-          </button>
-          
-                
-        </div>
-        
-            
-      </div>
-      
-        
-    </header>
-    
-        
-    <div
-      class="fd-dialog__subheader fd-bar fd-bar--subheader"
-    >
-      
-            
-      <div
-        class="fd-bar__middle"
-      >
-        
-                
-        <div
-          class="fd-input-group"
-        >
-          
-                    
-          <input
-            aria-label="search"
-            class="fd-input fd-input-group__input fd-input--compact"
-            placeholder="Search..."
-            type="text"
-          />
-          
-                    
-          <span
-            class="fd-input-group__addon fd-input-group__addon--button fd-input-group__addon--compact"
-          >
-            
-                        
-            <button
-              aria-label="perform search"
-              class="fd-button fd-input-group__button fd-button--icon fd-button--transparent fd-button--compact"
-            >
-              
-                            
-              <i
-                class="sap-icon--search"
-                role="presentation"
-              />
-              
-                        
-            </button>
-            
-                    
-          </span>
-          
-                
-        </div>
-        
-            
-      </div>
-      
-        
-    </div>
-    
-        
-    <div
-      class="fd-dialog__body fd-dialog__body--no-vertical-padding"
-    >
-      
-            
-      <ul
-        aria-label="selection list"
-        class="fd-list fd-list--selection fd-list--compact fd-list--no-border"
-        role="listbox"
-      >
-        
-                
-        <li
-          class="fd-list__item"
-          role="option"
-          tabindex="0"
-        >
-          
-                    
-          <div
-            class="fd-form-item fd-list__form-item"
-          >
-            
-                        
-            <input
-              aria-labelledby="Az0bg4"
-              class="fd-checkbox fd-checkbox--compact"
-              id="Ai4ez4"
-              type="checkbox"
-            />
-            
-                        
-            <label
-              class="fd-checkbox__label fd-checkbox__label--compact"
-              for="Ai4ez4"
-              tabindex="-1"
-            />
-            
-                    
-          </div>
-          
-                    
-          <span
-            class="fd-list__title"
-            id="Az0bg4"
-          >
-            List item 1
-          </span>
-          
-                
-        </li>
-        
-                
-        <li
-          aria-selected="true"
-          class="fd-list__item is-selected"
-          role="option"
-          tabindex="0"
-        >
-          
-                    
-          <div
-            class="fd-form-item fd-list__form-item"
-          >
-            
-                        
-            <input
-              aria-labelledby="Az0bg5"
-              checked=""
-              class="fd-checkbox fd-checkbox--compact"
-              id="Ai4ez5"
-              type="checkbox"
-            />
-            
-                        
-            <label
-              class="fd-checkbox__label fd-checkbox__label--compact"
-              for="Ai4ez5"
-              tabindex="-1"
-            />
-            
-                    
-          </div>
-          
-                    
-          <span
-            class="fd-list__title"
-            id="Az0bg5"
-          >
-            List item 2
-          </span>
-          
-                
-        </li>
-        
-                
-        <li
-          class="fd-list__item is-selected"
-          role="option"
-          tabindex="0"
-        >
-          
-                    
-          <div
-            class="fd-form-item fd-list__form-item"
-          >
-            
-                        
-            <input
-              aria-labelledby="Az0bg6"
-              checked=""
-              class="fd-checkbox fd-checkbox--compact"
-              id="Ai4ez6"
-              type="checkbox"
-            />
-            
-                        
-            <label
-              class="fd-checkbox__label fd-checkbox__label--compact"
-              for="Ai4ez6"
-              tabindex="-1"
-            />
-            
-                    
-          </div>
-          
-                    
-          <span
-            class="fd-list__title"
-            id="Az0bg6"
-          >
-            List item 3
-          </span>
-          
-                
-        </li>
-        
-                
-        <li
-          class="fd-list__item"
-          role="option"
-          tabindex="0"
-        >
-          
-                    
-          <div
-            class="fd-form-item fd-list__form-item"
-          >
-            
-                        
-            <input
-              aria-labelledby="440bg6"
-              class="fd-checkbox fd-checkbox--compact"
-              id="Ai4e44"
-              type="checkbox"
-            />
-            
-                        
-            <label
-              class="fd-checkbox__label fd-checkbox__label--compact"
-              for="Ai4e44"
-              tabindex="-1"
-            />
-            
-                    
-          </div>
-          
-                    
-          <span
-            class="fd-list__title"
-            id="440bg6"
-          >
-            List item 4
-          </span>
-          
-                
-        </li>
-        
-                
-        <li
-          class="fd-list__item"
-          role="option"
-          tabindex="0"
-        >
-          
-                    
-          <div
-            class="fd-form-item fd-list__form-item"
-          >
-            
-                        
-            <input
-              aria-labelledby="550bg6"
-              class="fd-checkbox fd-checkbox--compact"
-              id="Ai4e55"
-              type="checkbox"
-            />
-            
-                        
-            <label
-              class="fd-checkbox__label fd-checkbox__label--compact"
-              for="Ai4e55"
-              tabindex="-1"
-            />
-            
-                    
-          </div>
-          
-                    
-          <span
-            class="fd-list__title"
-            id="550bg6"
-          >
-            List item 5
-          </span>
-          
-                
-        </li>
-        
-                
-        <li
-          class="fd-list__item"
-          role="option"
-          tabindex="0"
-        >
-          
-                    
-          <div
-            class="fd-form-item fd-list__form-item"
-          >
-            
-                        
-            <input
-              aria-labelledby="660bg6"
-              class="fd-checkbox fd-checkbox--compact"
-              id="Ai4e66"
-              type="checkbox"
-            />
-            
-                        
-            <label
-              class="fd-checkbox__label fd-checkbox__label--compact"
-              for="Ai4e66"
-              tabindex="-1"
-            />
-            
-                    
-          </div>
-          
-                    
-          <span
-            class="fd-list__title"
-            id="660bg6"
-          >
-            List item 6
-          </span>
-          
-                
-        </li>
-        
-            
-      </ul>
-      
-            
-      <span
-        class="fd-list__footer"
-      >
-        
-                2 items selected
-            
-      </span>
-      
-        
-    </div>
-    
-        
-    <footer
-      class="fd-dialog__footer fd-bar fd-bar--footer"
-    >
-      
-            
-      <div
-        class="fd-bar__right"
-      >
-        
-                
-        <div
-          class="fd-bar__element"
-        >
-          
-                    
-          <button
-            class="fd-dialog__decisive-button fd-button fd-button--emphasized fd-button--compact"
-          >
-            Select
-          </button>
-          
-                
-        </div>
-        
-                
-        <div
-          class="fd-bar__element"
-        >
-          
-                    
-          <button
-            class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact"
-          >
-            Cancel
-          </button>
-          
-                
-        </div>
-        
-            
-      </div>
-      
-        
-    </footer>
-    
-    
-  </section>
-  
 
-</div>
+
 `;
 
 exports[`Storyshots Components/Dialog Sizes 1`] = `
 <section>
   
 
-  <div
+  <section
     class="fd-dialog-docs-static fd-dialog fd-dialog--active"
   >
     
-
-    <section
+    
+    <div
       aria-labelledby="dialog-title-2"
       aria-modal="true"
       class="fd-dialog__content fd-dialog__content--s"
       role="dialog"
     >
       
-    
+        
       <header
         class="fd-dialog__header fd-bar fd-bar--header"
       >
         
-        
+            
         <div
           class="fd-bar__left"
         >
           
-            
+                
           <div
             class="fd-bar__element"
           >
             
-                
+                    
             <h2
               class="fd-title fd-title--h5"
               id="dialog-title-2"
             >
               
-                    Small Dialog
-                
+                        Small Dialog
+                    
             </h2>
             
-            
+                
           </div>
           
-        
+            
         </div>
         
-    
+        
       </header>
       
-    
+        
       <div
         class="fd-dialog__body"
       >
         
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
-    
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
+        
       </div>
       
-    
+        
       <footer
         class="fd-dialog__footer fd-bar fd-bar--footer"
       >
         
-        
+            
         <div
           class="fd-bar__right"
         >
           
-            
+                
           <div
             class="fd-bar__element"
           >
             
-                
+                    
             <button
               class="fd-dialog__decisive-button fd-button fd-button--emphasized fd-button--compact"
             >
               Save
             </button>
             
-            
+                
           </div>
           
-            
+                
           <div
             class="fd-bar__element"
           >
             
-                
+                    
             <button
               class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact"
             >
               Cancel
             </button>
             
-            
+                
           </div>
           
-        
+            
         </div>
         
-    
+        
       </footer>
       
-
-    </section>
+    
+    </div>
     
 
-  </div>
+  </section>
   
 
   <br />
   
 
-  <div
+  <section
     class="fd-dialog-docs-static fd-dialog fd-dialog--active"
   >
     
-
-    <section
+    
+    <div
       aria-labelledby="dialog-title-3"
       aria-modal="true"
       class="fd-dialog__content fd-dialog__content--m"
       role="dialog"
     >
       
-    
+        
       <header
         class="fd-dialog__header fd-bar fd-bar--header"
       >
         
-        
+            
         <div
           class="fd-bar__left"
         >
           
-            
+                
           <div
             class="fd-bar__element"
           >
             
-                
+                    
             <h2
               class="fd-title fd-title--h5"
               id="dialog-title-3"
             >
               
-                    Medium Dialog
-                
+                        Medium Dialog
+                    
             </h2>
             
-            
+                
           </div>
           
-        
+            
         </div>
         
-    
+        
       </header>
       
-    
+        
       <div
         class="fd-dialog__body"
       >
         
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
-    
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
+        
       </div>
       
-    
+        
       <footer
         class="fd-dialog__footer fd-bar fd-bar--footer"
       >
         
-        
+            
         <div
           class="fd-bar__right"
         >
           
-            
+                
           <div
             class="fd-bar__element"
           >
             
-                
+                    
             <button
               class="fd-dialog__decisive-button fd-button fd-button--emphasized fd-button--compact"
             >
               Save
             </button>
             
-            
+                
           </div>
           
-            
+                
           <div
             class="fd-bar__element"
           >
             
-                
+                    
             <button
               class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact"
             >
               Cancel
             </button>
             
-            
+                
           </div>
           
-        
+            
         </div>
         
-    
+        
       </footer>
       
-
-    </section>
+    
+    </div>
      
 
-  </div>
+  </section>
   
 
   <br />
   
 
-  <div
+  <section
     class="fd-dialog-docs-static fd-dialog fd-dialog--active"
   >
     
-
-    <section
+    
+    <div
       aria-labelledby="dialog-title-4"
       aria-modal="true"
       class="fd-dialog__content fd-dialog__content--l"
       role="dialog"
     >
       
-    
+        
       <header
         class="fd-dialog__header fd-bar fd-bar--header"
       >
         
-        
+            
         <div
           class="fd-bar__left"
         >
           
-            
+                
           <div
             class="fd-bar__element"
           >
             
-                
+                    
             <h2
               class="fd-title fd-title--h5"
               id="dialog-title-4"
             >
               
-                    Large Dialog
-                
+                        Large Dialog
+                    
             </h2>
             
-            
+                
           </div>
           
-        
+            
         </div>
         
-    
+        
       </header>
       
-    
+        
       <div
         class="fd-dialog__body"
       >
         
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
-    
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
+        
       </div>
       
-    
+        
       <footer
         class="fd-dialog__footer fd-bar fd-bar--footer"
       >
         
-        
+            
         <div
           class="fd-bar__right"
         >
           
-            
+                
           <div
             class="fd-bar__element"
           >
             
-                
+                    
             <button
               class="fd-dialog__decisive-button fd-button fd-button--emphasized fd-button--compact"
             >
               Save
             </button>
             
-            
+                
           </div>
           
-            
+                
           <div
             class="fd-bar__element"
           >
             
-                
+                    
             <button
               class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact"
             >
               Cancel
             </button>
             
-            
+                
           </div>
           
-        
+            
         </div>
         
-    
+        
       </footer>
       
-
-    </section>
+    
+    </div>
     
 
-  </div>
+  </section>
   
 
   <br />
   
 
-  <div
+  <section
     class="fd-dialog-docs-static fd-dialog fd-dialog--active"
   >
     
-
-    <section
+    
+    <div
       aria-labelledby="dialog-title-5"
       aria-modal="true"
       class="fd-dialog__content fd-dialog__content--xl"
       role="dialog"
     >
       
-    
+        
       <header
         class="fd-dialog__header fd-bar fd-bar--header"
       >
         
-        
+            
         <div
           class="fd-bar__left"
         >
           
-            
+                
           <div
             class="fd-bar__element"
           >
             
-                
+                    
             <h2
               class="fd-title fd-title--h5"
               id="dialog-title-5"
             >
               
-                    Extra Large Dialog
-                
+                        Extra Large Dialog
+                    
             </h2>
             
-            
+                
           </div>
           
-        
+            
         </div>
         
-    
+        
       </header>
       
-    
+        
       <div
         class="fd-dialog__body"
       >
         
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
-    
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
+        
       </div>
       
-    
+        
       <footer
         class="fd-dialog__footer fd-bar fd-bar--footer"
       >
         
-        
+            
         <div
           class="fd-bar__right"
         >
           
-            
+                
           <div
             class="fd-bar__element"
           >
             
-                
+                    
             <button
               class="fd-dialog__decisive-button fd-button fd-button--emphasized fd-button--compact"
             >
               Save
             </button>
             
-            
+                
           </div>
           
-            
+                
           <div
             class="fd-bar__element"
           >
             
-                
+                    
             <button
               class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact"
             >
               Cancel
             </button>
             
-            
+                
           </div>
           
-        
+            
         </div>
         
-    
+        
       </footer>
       
-
-    </section>
+    
+    </div>
     
 
-  </div>
+  </section>
   
 
 </section>

--- a/stories/dialog/__snapshots__/dialog.stories.storyshot
+++ b/stories/dialog/__snapshots__/dialog.stories.storyshot
@@ -6,7 +6,7 @@ exports[`Storyshots Components/Dialog Default 1`] = `
 >
   
     
-  <div
+  <section
     aria-labelledby="dialog-title-1"
     aria-modal="true"
     class="fd-dialog__content"
@@ -164,7 +164,7 @@ exports[`Storyshots Components/Dialog Default 1`] = `
     </footer>
     
     
-  </div>
+  </section>
   
 
 </div>
@@ -176,7 +176,7 @@ exports[`Storyshots Components/Dialog Draggable 1`] = `
 >
   
     
-  <div
+  <section
     aria-labelledby="dialog-title-7"
     aria-modal="true"
     class="fd-dialog__content fd-dialog__content--draggable-grab fd-dialog__content--s"
@@ -273,149 +273,134 @@ exports[`Storyshots Components/Dialog Draggable 1`] = `
     </footer>
     
     
-  </div>
+  </section>
   
 
 </div>
 `;
 
 exports[`Storyshots Components/Dialog Loading 1`] = `
-<section>
+<div
+  class="fd-dialog-docs-static fd-dialog fd-dialog--active"
+  id="loading-dialog-example"
+>
   
-
-  <button
-    class="fd-button"
-    onclick="toggleClass('loading-dialog-example', 'fd-dialog--active')"
-  >
-    Open example
-  </button>
-  
-
-  <div
-    class="fd-dialog"
-    id="loading-dialog-example"
+    
+  <section
+    aria-labelledby="dialog-title-9"
+    aria-modal="true"
+    class="fd-dialog__content fd-dialog__content--s"
+    role="dialog"
   >
     
-    
-    <div
-      aria-labelledby="dialog-title-9"
-      aria-modal="true"
-      class="fd-dialog__content fd-dialog__content--s"
-      role="dialog"
+        
+    <header
+      class="fd-dialog__header fd-bar fd-bar--header"
     >
       
-        
-      <header
-        class="fd-dialog__header fd-bar fd-bar--header"
+            
+      <div
+        class="fd-bar__left"
       >
         
-            
+                
         <div
-          class="fd-bar__left"
+          class="fd-bar__element"
         >
           
-                
-          <div
-            class="fd-bar__element"
+                    
+          <h2
+            class="fd-title fd-title--h5"
+            id="dialog-title-9"
           >
             
-                    
-            <h2
-              class="fd-title fd-title--h5"
-              id="dialog-title-9"
-            >
-              
                         Loading Data...
                     
-            </h2>
-            
-                
-          </div>
+          </h2>
           
-            
+                
         </div>
         
-        
-      </header>
-      
-        
-      <div
-        class="fd-dialog__body"
-      >
-        
             
-        <strong>
-          Status:
-        </strong>
-         Connecting 127.0.0.1
-            
-        <div
-          aria-hidden="false"
-          aria-label="Loading"
-          class="fd-dialog__loader fd-busy-indicator--l"
-        >
-          
-                
-          <div
-            class="fd-busy-indicator--circle-0"
-          />
-          
-                
-          <div
-            class="fd-busy-indicator--circle-1"
-          />
-          
-                
-          <div
-            class="fd-busy-indicator--circle-2"
-          />
-          
-            
-        </div>
-        
-        
       </div>
       
         
-      <footer
-        class="fd-dialog__footer fd-bar fd-bar--footer"
+    </header>
+    
+        
+    <div
+      class="fd-dialog__body"
+    >
+      
+            
+      <strong>
+        Status:
+      </strong>
+       Connecting 127.0.0.1
+            
+      <div
+        aria-hidden="false"
+        aria-label="Loading"
+        class="fd-dialog__loader fd-busy-indicator--l"
       >
         
-            
+                
         <div
-          class="fd-bar__right"
-        >
-          
-                
-          <div
-            class="fd-bar__element"
-          >
-            
-                    
-            <button
-              class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact"
-              onclick="toggleClass('loading-dialog-example', 'fd-dialog--active')"
-            >
-              Cancel
-            </button>
-            
-                
-          </div>
-          
-            
-        </div>
+          class="fd-busy-indicator--circle-0"
+        />
         
+                
+        <div
+          class="fd-busy-indicator--circle-1"
+        />
         
-      </footer>
+                
+        <div
+          class="fd-busy-indicator--circle-2"
+        />
+        
+            
+      </div>
       
-    
+        
     </div>
     
-
-  </div>
+        
+    <footer
+      class="fd-dialog__footer fd-bar fd-bar--footer"
+    >
+      
+            
+      <div
+        class="fd-bar__right"
+      >
+        
+                
+        <div
+          class="fd-bar__element"
+        >
+          
+                    
+          <button
+            class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact"
+          >
+            Cancel
+          </button>
+          
+                
+        </div>
+        
+            
+      </div>
+      
+        
+    </footer>
+    
+    
+  </section>
   
 
-</section>
+</div>
 `;
 
 exports[`Storyshots Components/Dialog Resizable 1`] = `
@@ -424,7 +409,7 @@ exports[`Storyshots Components/Dialog Resizable 1`] = `
 >
   
         
-  <div
+  <section
     aria-labelledby="dialog-title-6"
     aria-modal="true"
     class="fd-dialog__content fd-dialog__content--s"
@@ -526,480 +511,465 @@ exports[`Storyshots Components/Dialog Resizable 1`] = `
     </footer>
     
         
-  </div>
+  </section>
   
     
 </div>
 `;
 
 exports[`Storyshots Components/Dialog Selectable 1`] = `
-<section>
+<div
+  class="fd-dialog-docs-static fd-dialog fd-dialog--active"
+  id="select-dialog-example"
+>
   
-
-  <button
-    class="fd-button"
-    onclick="toggleClass('select-dialog-example', 'fd-dialog--active')"
-  >
-    Open example
-  </button>
-  
-
-  <div
-    class="fd-dialog"
-    id="select-dialog-example"
+    
+  <section
+    aria-labelledby="dialog-title-8"
+    aria-modal="true"
+    class="fd-dialog__content"
+    role="dialog"
   >
     
-    
-    <div
-      aria-labelledby="dialog-title-8"
-      aria-modal="true"
-      class="fd-dialog__content"
-      role="dialog"
+        
+    <header
+      class="fd-dialog__header fd-bar fd-bar--header-with-subheader"
     >
       
-        
-      <header
-        class="fd-dialog__header fd-bar fd-bar--header-with-subheader"
+            
+      <div
+        class="fd-bar__left"
       >
         
-            
+                
         <div
-          class="fd-bar__left"
+          class="fd-bar__element"
         >
           
-                
-          <div
-            class="fd-bar__element"
+                    
+          <h2
+            class="fd-title fd-title--h5"
+            id="dialog-title-8"
           >
             
-                    
-            <h2
-              class="fd-title fd-title--h5"
-              id="dialog-title-8"
-            >
-              
                         Select Dialog
                     
-            </h2>
-            
-                
-          </div>
+          </h2>
           
-            
+                
         </div>
         
             
-        <div
-          class="fd-bar__right"
-        >
-          
-                
-          <div
-            class="fd-bar__element"
-          >
-            
-                    
-            <button
-              class="fd-button fd-button--transparent fd-button--compact"
-            >
-              Clear
-            </button>
-            
-                
-          </div>
-          
-            
-        </div>
-        
-        
-      </header>
+      </div>
       
-        
+            
       <div
-        class="fd-dialog__subheader fd-bar fd-bar--subheader"
+        class="fd-bar__right"
       >
         
-            
+                
         <div
-          class="fd-bar__middle"
+          class="fd-bar__element"
         >
           
+                    
+          <button
+            class="fd-button fd-button--transparent fd-button--compact"
+          >
+            Clear
+          </button>
+          
                 
-          <div
-            class="fd-input-group"
+        </div>
+        
+            
+      </div>
+      
+        
+    </header>
+    
+        
+    <div
+      class="fd-dialog__subheader fd-bar fd-bar--subheader"
+    >
+      
+            
+      <div
+        class="fd-bar__middle"
+      >
+        
+                
+        <div
+          class="fd-input-group"
+        >
+          
+                    
+          <input
+            aria-label="search"
+            class="fd-input fd-input-group__input fd-input--compact"
+            placeholder="Search..."
+            type="text"
+          />
+          
+                    
+          <span
+            class="fd-input-group__addon fd-input-group__addon--button fd-input-group__addon--compact"
           >
             
+                        
+            <button
+              aria-label="perform search"
+              class="fd-button fd-input-group__button fd-button--icon fd-button--transparent fd-button--compact"
+            >
+              
+                            
+              <i
+                class="sap-icon--search"
+                role="presentation"
+              />
+              
+                        
+            </button>
+            
                     
+          </span>
+          
+                
+        </div>
+        
+            
+      </div>
+      
+        
+    </div>
+    
+        
+    <div
+      class="fd-dialog__body fd-dialog__body--no-vertical-padding"
+    >
+      
+            
+      <ul
+        aria-label="selection list"
+        class="fd-list fd-list--selection fd-list--compact fd-list--no-border"
+        role="listbox"
+      >
+        
+                
+        <li
+          class="fd-list__item"
+          role="option"
+          tabindex="0"
+        >
+          
+                    
+          <div
+            class="fd-form-item fd-list__form-item"
+          >
+            
+                        
             <input
-              aria-label="search"
-              class="fd-input fd-input-group__input fd-input--compact"
-              placeholder="Search..."
-              type="text"
+              aria-labelledby="Az0bg4"
+              class="fd-checkbox fd-checkbox--compact"
+              id="Ai4ez4"
+              type="checkbox"
+            />
+            
+                        
+            <label
+              class="fd-checkbox__label fd-checkbox__label--compact"
+              for="Ai4ez4"
+              tabindex="-1"
             />
             
                     
-            <span
-              class="fd-input-group__addon fd-input-group__addon--button fd-input-group__addon--compact"
-            >
-              
-                        
-              <button
-                aria-label="perform search"
-                class="fd-button fd-input-group__button fd-button--icon fd-button--transparent fd-button--compact"
-              >
-                
-                            
-                <i
-                  class="sap-icon--search"
-                  role="presentation"
-                />
-                
-                        
-              </button>
-              
-                    
-            </span>
-            
-                
           </div>
           
+                    
+          <span
+            class="fd-list__title"
+            id="Az0bg4"
+          >
+            List item 1
+          </span>
+          
+                
+        </li>
+        
+                
+        <li
+          aria-selected="true"
+          class="fd-list__item is-selected"
+          role="option"
+          tabindex="0"
+        >
+          
+                    
+          <div
+            class="fd-form-item fd-list__form-item"
+          >
             
-        </div>
+                        
+            <input
+              aria-labelledby="Az0bg5"
+              checked=""
+              class="fd-checkbox fd-checkbox--compact"
+              id="Ai4ez5"
+              type="checkbox"
+            />
+            
+                        
+            <label
+              class="fd-checkbox__label fd-checkbox__label--compact"
+              for="Ai4ez5"
+              tabindex="-1"
+            />
+            
+                    
+          </div>
+          
+                    
+          <span
+            class="fd-list__title"
+            id="Az0bg5"
+          >
+            List item 2
+          </span>
+          
+                
+        </li>
         
+                
+        <li
+          class="fd-list__item is-selected"
+          role="option"
+          tabindex="0"
+        >
+          
+                    
+          <div
+            class="fd-form-item fd-list__form-item"
+          >
+            
+                        
+            <input
+              aria-labelledby="Az0bg6"
+              checked=""
+              class="fd-checkbox fd-checkbox--compact"
+              id="Ai4ez6"
+              type="checkbox"
+            />
+            
+                        
+            <label
+              class="fd-checkbox__label fd-checkbox__label--compact"
+              for="Ai4ez6"
+              tabindex="-1"
+            />
+            
+                    
+          </div>
+          
+                    
+          <span
+            class="fd-list__title"
+            id="Az0bg6"
+          >
+            List item 3
+          </span>
+          
+                
+        </li>
         
-      </div>
+                
+        <li
+          class="fd-list__item"
+          role="option"
+          tabindex="0"
+        >
+          
+                    
+          <div
+            class="fd-form-item fd-list__form-item"
+          >
+            
+                        
+            <input
+              aria-labelledby="440bg6"
+              class="fd-checkbox fd-checkbox--compact"
+              id="Ai4e44"
+              type="checkbox"
+            />
+            
+                        
+            <label
+              class="fd-checkbox__label fd-checkbox__label--compact"
+              for="Ai4e44"
+              tabindex="-1"
+            />
+            
+                    
+          </div>
+          
+                    
+          <span
+            class="fd-list__title"
+            id="440bg6"
+          >
+            List item 4
+          </span>
+          
+                
+        </li>
+        
+                
+        <li
+          class="fd-list__item"
+          role="option"
+          tabindex="0"
+        >
+          
+                    
+          <div
+            class="fd-form-item fd-list__form-item"
+          >
+            
+                        
+            <input
+              aria-labelledby="550bg6"
+              class="fd-checkbox fd-checkbox--compact"
+              id="Ai4e55"
+              type="checkbox"
+            />
+            
+                        
+            <label
+              class="fd-checkbox__label fd-checkbox__label--compact"
+              for="Ai4e55"
+              tabindex="-1"
+            />
+            
+                    
+          </div>
+          
+                    
+          <span
+            class="fd-list__title"
+            id="550bg6"
+          >
+            List item 5
+          </span>
+          
+                
+        </li>
+        
+                
+        <li
+          class="fd-list__item"
+          role="option"
+          tabindex="0"
+        >
+          
+                    
+          <div
+            class="fd-form-item fd-list__form-item"
+          >
+            
+                        
+            <input
+              aria-labelledby="660bg6"
+              class="fd-checkbox fd-checkbox--compact"
+              id="Ai4e66"
+              type="checkbox"
+            />
+            
+                        
+            <label
+              class="fd-checkbox__label fd-checkbox__label--compact"
+              for="Ai4e66"
+              tabindex="-1"
+            />
+            
+                    
+          </div>
+          
+                    
+          <span
+            class="fd-list__title"
+            id="660bg6"
+          >
+            List item 6
+          </span>
+          
+                
+        </li>
+        
+            
+      </ul>
       
-        
-      <div
-        class="fd-dialog__body fd-dialog__body--no-vertical-padding"
+            
+      <span
+        class="fd-list__footer"
       >
         
-            
-        <ul
-          aria-label="selection list"
-          class="fd-list fd-list--selection fd-list--compact fd-list--no-border"
-          role="listbox"
-        >
-          
-                
-          <li
-            class="fd-list__item"
-            role="option"
-            tabindex="0"
-          >
-            
-                    
-            <div
-              class="fd-form-item fd-list__form-item"
-            >
-              
-                        
-              <input
-                aria-labelledby="Az0bg4"
-                class="fd-checkbox fd-checkbox--compact"
-                id="Ai4ez4"
-                type="checkbox"
-              />
-              
-                        
-              <label
-                class="fd-checkbox__label fd-checkbox__label--compact"
-                for="Ai4ez4"
-                tabindex="-1"
-              />
-              
-                    
-            </div>
-            
-                    
-            <span
-              class="fd-list__title"
-              id="Az0bg4"
-            >
-              List item 1
-            </span>
-            
-                
-          </li>
-          
-                
-          <li
-            aria-selected="true"
-            class="fd-list__item is-selected"
-            role="option"
-            tabindex="0"
-          >
-            
-                    
-            <div
-              class="fd-form-item fd-list__form-item"
-            >
-              
-                        
-              <input
-                aria-labelledby="Az0bg5"
-                checked=""
-                class="fd-checkbox fd-checkbox--compact"
-                id="Ai4ez5"
-                type="checkbox"
-              />
-              
-                        
-              <label
-                class="fd-checkbox__label fd-checkbox__label--compact"
-                for="Ai4ez5"
-                tabindex="-1"
-              />
-              
-                    
-            </div>
-            
-                    
-            <span
-              class="fd-list__title"
-              id="Az0bg5"
-            >
-              List item 2
-            </span>
-            
-                
-          </li>
-          
-                
-          <li
-            class="fd-list__item is-selected"
-            role="option"
-            tabindex="0"
-          >
-            
-                    
-            <div
-              class="fd-form-item fd-list__form-item"
-            >
-              
-                        
-              <input
-                aria-labelledby="Az0bg6"
-                checked=""
-                class="fd-checkbox fd-checkbox--compact"
-                id="Ai4ez6"
-                type="checkbox"
-              />
-              
-                        
-              <label
-                class="fd-checkbox__label fd-checkbox__label--compact"
-                for="Ai4ez6"
-                tabindex="-1"
-              />
-              
-                    
-            </div>
-            
-                    
-            <span
-              class="fd-list__title"
-              id="Az0bg6"
-            >
-              List item 3
-            </span>
-            
-                
-          </li>
-          
-                
-          <li
-            class="fd-list__item"
-            role="option"
-            tabindex="0"
-          >
-            
-                    
-            <div
-              class="fd-form-item fd-list__form-item"
-            >
-              
-                        
-              <input
-                aria-labelledby="440bg6"
-                class="fd-checkbox fd-checkbox--compact"
-                id="Ai4e44"
-                type="checkbox"
-              />
-              
-                        
-              <label
-                class="fd-checkbox__label fd-checkbox__label--compact"
-                for="Ai4e44"
-                tabindex="-1"
-              />
-              
-                    
-            </div>
-            
-                    
-            <span
-              class="fd-list__title"
-              id="440bg6"
-            >
-              List item 4
-            </span>
-            
-                
-          </li>
-          
-                
-          <li
-            class="fd-list__item"
-            role="option"
-            tabindex="0"
-          >
-            
-                    
-            <div
-              class="fd-form-item fd-list__form-item"
-            >
-              
-                        
-              <input
-                aria-labelledby="550bg6"
-                class="fd-checkbox fd-checkbox--compact"
-                id="Ai4e55"
-                type="checkbox"
-              />
-              
-                        
-              <label
-                class="fd-checkbox__label fd-checkbox__label--compact"
-                for="Ai4e55"
-                tabindex="-1"
-              />
-              
-                    
-            </div>
-            
-                    
-            <span
-              class="fd-list__title"
-              id="550bg6"
-            >
-              List item 5
-            </span>
-            
-                
-          </li>
-          
-                
-          <li
-            class="fd-list__item"
-            role="option"
-            tabindex="0"
-          >
-            
-                    
-            <div
-              class="fd-form-item fd-list__form-item"
-            >
-              
-                        
-              <input
-                aria-labelledby="660bg6"
-                class="fd-checkbox fd-checkbox--compact"
-                id="Ai4e66"
-                type="checkbox"
-              />
-              
-                        
-              <label
-                class="fd-checkbox__label fd-checkbox__label--compact"
-                for="Ai4e66"
-                tabindex="-1"
-              />
-              
-                    
-            </div>
-            
-                    
-            <span
-              class="fd-list__title"
-              id="660bg6"
-            >
-              List item 6
-            </span>
-            
-                
-          </li>
-          
-            
-        </ul>
-        
-            
-        <span
-          class="fd-list__footer"
-        >
-          
                 2 items selected
             
-        </span>
+      </span>
+      
         
+    </div>
+    
         
+    <footer
+      class="fd-dialog__footer fd-bar fd-bar--footer"
+    >
+      
+            
+      <div
+        class="fd-bar__right"
+      >
+        
+                
+        <div
+          class="fd-bar__element"
+        >
+          
+                    
+          <button
+            class="fd-dialog__decisive-button fd-button fd-button--emphasized fd-button--compact"
+          >
+            Select
+          </button>
+          
+                
+        </div>
+        
+                
+        <div
+          class="fd-bar__element"
+        >
+          
+                    
+          <button
+            class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact"
+          >
+            Cancel
+          </button>
+          
+                
+        </div>
+        
+            
       </div>
       
         
-      <footer
-        class="fd-dialog__footer fd-bar fd-bar--footer"
-      >
-        
-            
-        <div
-          class="fd-bar__right"
-        >
-          
-                
-          <div
-            class="fd-bar__element"
-          >
-            
-                    
-            <button
-              class="fd-dialog__decisive-button fd-button fd-button--emphasized fd-button--compact"
-            >
-              Select
-            </button>
-            
-                
-          </div>
-          
-                
-          <div
-            class="fd-bar__element"
-          >
-            
-                    
-            <button
-              class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact"
-              onclick="toggleClass('select-dialog-example', 'fd-dialog--active')"
-            >
-              Cancel
-            </button>
-            
-                
-          </div>
-          
-            
-        </div>
-        
-        
-      </footer>
-      
+    </footer>
     
-    </div>
     
-
-  </div>
+  </section>
   
 
-</section>
+</div>
 `;
 
 exports[`Storyshots Components/Dialog Sizes 1`] = `
@@ -1011,7 +981,7 @@ exports[`Storyshots Components/Dialog Sizes 1`] = `
   >
     
 
-    <div
+    <section
       aria-labelledby="dialog-title-2"
       aria-modal="true"
       class="fd-dialog__content fd-dialog__content--s"
@@ -1108,7 +1078,7 @@ exports[`Storyshots Components/Dialog Sizes 1`] = `
       </footer>
       
 
-    </div>
+    </section>
     
 
   </div>
@@ -1122,7 +1092,7 @@ exports[`Storyshots Components/Dialog Sizes 1`] = `
   >
     
 
-    <div
+    <section
       aria-labelledby="dialog-title-3"
       aria-modal="true"
       class="fd-dialog__content fd-dialog__content--m"
@@ -1219,7 +1189,7 @@ exports[`Storyshots Components/Dialog Sizes 1`] = `
       </footer>
       
 
-    </div>
+    </section>
      
 
   </div>
@@ -1233,7 +1203,7 @@ exports[`Storyshots Components/Dialog Sizes 1`] = `
   >
     
 
-    <div
+    <section
       aria-labelledby="dialog-title-4"
       aria-modal="true"
       class="fd-dialog__content fd-dialog__content--l"
@@ -1330,7 +1300,7 @@ exports[`Storyshots Components/Dialog Sizes 1`] = `
       </footer>
       
 
-    </div>
+    </section>
     
 
   </div>
@@ -1344,7 +1314,7 @@ exports[`Storyshots Components/Dialog Sizes 1`] = `
   >
     
 
-    <div
+    <section
       aria-labelledby="dialog-title-5"
       aria-modal="true"
       class="fd-dialog__content fd-dialog__content--xl"
@@ -1441,7 +1411,7 @@ exports[`Storyshots Components/Dialog Sizes 1`] = `
       </footer>
       
 
-    </div>
+    </section>
     
 
   </div>

--- a/stories/dialog/dialog.stories.js
+++ b/stories/dialog/dialog.stories.js
@@ -41,8 +41,9 @@ Note: Dialog's header, subheader and footer are elements from the **Bar** compon
     }
 };
 
-export const defaultDialog = () => `<div class="fd-dialog-docs-static fd-dialog fd-dialog--active">
-    <section class="fd-dialog__content" role="dialog" aria-modal="true" aria-labelledby="dialog-title-1">
+export const defaultDialog = () => `
+<section class="fd-dialog-docs-static fd-dialog fd-dialog--active">
+    <div class="fd-dialog__content" role="dialog" aria-modal="true" aria-labelledby="dialog-title-1">
         <span class="fd-dialog__resize-handle"></span>
         <header class="fd-dialog__header fd-bar fd-bar--header-with-subheader">
             <div class="fd-bar__left">
@@ -86,8 +87,8 @@ export const defaultDialog = () => `<div class="fd-dialog-docs-static fd-dialog 
                 </div>
             </div>
         </footer>
-    </section>
-</div>
+    </div>
+</section>
 `;
 
 defaultDialog.storyName = 'Default';
@@ -100,113 +101,113 @@ defaultDialog.parameters = {
 
 
 export const sizes = () => `
-<div class="fd-dialog-docs-static fd-dialog fd-dialog--active">
-<section class="fd-dialog__content fd-dialog__content--s" role="dialog" aria-modal="true" aria-labelledby="dialog-title-2">
-    <header class="fd-dialog__header fd-bar fd-bar--header">
-        <div class="fd-bar__left">
-            <div class="fd-bar__element">
-                <h2 class="fd-title fd-title--h5" id="dialog-title-2">
-                    Small Dialog
-                </h2>
+<section class="fd-dialog-docs-static fd-dialog fd-dialog--active">
+    <div class="fd-dialog__content fd-dialog__content--s" role="dialog" aria-modal="true" aria-labelledby="dialog-title-2">
+        <header class="fd-dialog__header fd-bar fd-bar--header">
+            <div class="fd-bar__left">
+                <div class="fd-bar__element">
+                    <h2 class="fd-title fd-title--h5" id="dialog-title-2">
+                        Small Dialog
+                    </h2>
+                </div>
             </div>
+        </header>
+        <div class="fd-dialog__body">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
         </div>
-    </header>
-    <div class="fd-dialog__body">
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
+        <footer class="fd-dialog__footer fd-bar fd-bar--footer">
+            <div class="fd-bar__right">
+                <div class="fd-bar__element">
+                    <button class="fd-dialog__decisive-button fd-button fd-button--emphasized fd-button--compact">Save</button>
+                </div>
+                <div class="fd-bar__element">
+                    <button class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact">Cancel</button>
+                </div>
+            </div>
+        </footer>
     </div>
-    <footer class="fd-dialog__footer fd-bar fd-bar--footer">
-        <div class="fd-bar__right">
-            <div class="fd-bar__element">
-                <button class="fd-dialog__decisive-button fd-button fd-button--emphasized fd-button--compact">Save</button>
-            </div>
-            <div class="fd-bar__element">
-                <button class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact">Cancel</button>
-            </div>
-        </div>
-    </footer>
 </section>
-</div>
 <br />
-<div class="fd-dialog-docs-static fd-dialog fd-dialog--active">
-<section class="fd-dialog__content fd-dialog__content--m" role="dialog" aria-modal="true" aria-labelledby="dialog-title-3">
-    <header class="fd-dialog__header fd-bar fd-bar--header">
-        <div class="fd-bar__left">
-            <div class="fd-bar__element">
-                <h2 class="fd-title fd-title--h5" id="dialog-title-3">
-                    Medium Dialog
-                </h2>
+<section class="fd-dialog-docs-static fd-dialog fd-dialog--active">
+    <div class="fd-dialog__content fd-dialog__content--m" role="dialog" aria-modal="true" aria-labelledby="dialog-title-3">
+        <header class="fd-dialog__header fd-bar fd-bar--header">
+            <div class="fd-bar__left">
+                <div class="fd-bar__element">
+                    <h2 class="fd-title fd-title--h5" id="dialog-title-3">
+                        Medium Dialog
+                    </h2>
+                </div>
             </div>
+        </header>
+        <div class="fd-dialog__body">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
         </div>
-    </header>
-    <div class="fd-dialog__body">
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
-    </div>
-    <footer class="fd-dialog__footer fd-bar fd-bar--footer">
-        <div class="fd-bar__right">
-            <div class="fd-bar__element">
-                <button class="fd-dialog__decisive-button fd-button fd-button--emphasized fd-button--compact">Save</button>
+        <footer class="fd-dialog__footer fd-bar fd-bar--footer">
+            <div class="fd-bar__right">
+                <div class="fd-bar__element">
+                    <button class="fd-dialog__decisive-button fd-button fd-button--emphasized fd-button--compact">Save</button>
+                </div>
+                <div class="fd-bar__element">
+                    <button class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact">Cancel</button>
+                </div>
             </div>
-            <div class="fd-bar__element">
-                <button class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact">Cancel</button>
-            </div>
-        </div>
-    </footer>
-</section> 
-</div>
-<br />
-<div class="fd-dialog-docs-static fd-dialog fd-dialog--active">
-<section class="fd-dialog__content fd-dialog__content--l" role="dialog" aria-modal="true" aria-labelledby="dialog-title-4">
-    <header class="fd-dialog__header fd-bar fd-bar--header">
-        <div class="fd-bar__left">
-            <div class="fd-bar__element">
-                <h2 class="fd-title fd-title--h5" id="dialog-title-4">
-                    Large Dialog
-                </h2>
-            </div>
-        </div>
-    </header>
-    <div class="fd-dialog__body">
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
-    </div>
-    <footer class="fd-dialog__footer fd-bar fd-bar--footer">
-        <div class="fd-bar__right">
-            <div class="fd-bar__element">
-                <button class="fd-dialog__decisive-button fd-button fd-button--emphasized fd-button--compact">Save</button>
-            </div>
-            <div class="fd-bar__element">
-                <button class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact">Cancel</button>
-            </div>
-        </div>
-    </footer>
+        </footer>
+    </div> 
 </section>
-</div>
 <br />
-<div class="fd-dialog-docs-static fd-dialog fd-dialog--active">
-<section class="fd-dialog__content fd-dialog__content--xl" role="dialog" aria-modal="true" aria-labelledby="dialog-title-5">
-    <header class="fd-dialog__header fd-bar fd-bar--header">
-        <div class="fd-bar__left">
-            <div class="fd-bar__element">
-                <h2 class="fd-title fd-title--h5" id="dialog-title-5">
-                    Extra Large Dialog
-                </h2>
+<section class="fd-dialog-docs-static fd-dialog fd-dialog--active">
+    <div class="fd-dialog__content fd-dialog__content--l" role="dialog" aria-modal="true" aria-labelledby="dialog-title-4">
+        <header class="fd-dialog__header fd-bar fd-bar--header">
+            <div class="fd-bar__left">
+                <div class="fd-bar__element">
+                    <h2 class="fd-title fd-title--h5" id="dialog-title-4">
+                        Large Dialog
+                    </h2>
+                </div>
             </div>
+        </header>
+        <div class="fd-dialog__body">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
         </div>
-    </header>
-    <div class="fd-dialog__body">
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
+        <footer class="fd-dialog__footer fd-bar fd-bar--footer">
+            <div class="fd-bar__right">
+                <div class="fd-bar__element">
+                    <button class="fd-dialog__decisive-button fd-button fd-button--emphasized fd-button--compact">Save</button>
+                </div>
+                <div class="fd-bar__element">
+                    <button class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact">Cancel</button>
+                </div>
+            </div>
+        </footer>
     </div>
-    <footer class="fd-dialog__footer fd-bar fd-bar--footer">
-        <div class="fd-bar__right">
-            <div class="fd-bar__element">
-                <button class="fd-dialog__decisive-button fd-button fd-button--emphasized fd-button--compact">Save</button>
-            </div>
-            <div class="fd-bar__element">
-                <button class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact">Cancel</button>
-            </div>
-        </div>
-    </footer>
 </section>
-</div>
+<br />
+<section class="fd-dialog-docs-static fd-dialog fd-dialog--active">
+    <div class="fd-dialog__content fd-dialog__content--xl" role="dialog" aria-modal="true" aria-labelledby="dialog-title-5">
+        <header class="fd-dialog__header fd-bar fd-bar--header">
+            <div class="fd-bar__left">
+                <div class="fd-bar__element">
+                    <h2 class="fd-title fd-title--h5" id="dialog-title-5">
+                        Extra Large Dialog
+                    </h2>
+                </div>
+            </div>
+        </header>
+        <div class="fd-dialog__body">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
+        </div>
+        <footer class="fd-dialog__footer fd-bar fd-bar--footer">
+            <div class="fd-bar__right">
+                <div class="fd-bar__element">
+                    <button class="fd-dialog__decisive-button fd-button fd-button--emphasized fd-button--compact">Save</button>
+                </div>
+                <div class="fd-bar__element">
+                    <button class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact">Cancel</button>
+                </div>
+            </div>
+        </footer>
+    </div>
+</section>
 `;
 
 sizes.parameters = {
@@ -247,33 +248,34 @@ Note: On mobile devices, the bar component should be used with the <code>fd-bar-
     }
 };
 
-export const Resizable = () => `<div class="fd-dialog-docs-static fd-dialog fd-dialog--active">
-        <section class="fd-dialog__content fd-dialog__content--s" role="dialog" aria-modal="true" aria-labelledby="dialog-title-6">
-            <span class="fd-dialog__resize-handle"></span>
-            <header class="fd-dialog__header fd-bar fd-bar--header">
-                <div class="fd-bar__left">
-                    <div class="fd-bar__element">
-                        <h2 class="fd-title fd-title--h5" id="dialog-title-6">
-                            Lorem ipsum
-                        </h2>
-                    </div>
+export const Resizable = () => `
+<section class="fd-dialog-docs-static fd-dialog fd-dialog--active">
+    <div class="fd-dialog__content fd-dialog__content--s" role="dialog" aria-modal="true" aria-labelledby="dialog-title-6">
+        <span class="fd-dialog__resize-handle"></span>
+        <header class="fd-dialog__header fd-bar fd-bar--header">
+            <div class="fd-bar__left">
+                <div class="fd-bar__element">
+                    <h2 class="fd-title fd-title--h5" id="dialog-title-6">
+                        Lorem ipsum
+                    </h2>
                 </div>
-            </header>
-            <div class="fd-dialog__body">
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
             </div>
-            <footer class="fd-dialog__footer fd-bar fd-bar--footer">
-                <div class="fd-bar__right">
-                    <div class="fd-bar__element">
-                        <button class="fd-dialog__decisive-button fd-button fd-button--emphasized fd-button--compact">Save</button>
-                    </div>
-                    <div class="fd-bar__element">
-                        <button class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact">Cancel</button>
-                    </div>
+        </header>
+        <div class="fd-dialog__body">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
+        </div>
+        <footer class="fd-dialog__footer fd-bar fd-bar--footer">
+            <div class="fd-bar__right">
+                <div class="fd-bar__element">
+                    <button class="fd-dialog__decisive-button fd-button fd-button--emphasized fd-button--compact">Save</button>
                 </div>
-            </footer>
-        </section>
+                <div class="fd-bar__element">
+                    <button class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact">Cancel</button>
+                </div>
+            </div>
+        </footer>
     </div>
+</section>
 `;
 
 Resizable.parameters = {
@@ -286,8 +288,9 @@ Note: This feature should be enabled for desktop screens only.`
     }
 };
 
-export const Draggable = () => `<div class="fd-dialog-docs-static fd-dialog fd-dialog--active">
-    <section class="fd-dialog__content fd-dialog__content--draggable-grab fd-dialog__content--s" role="dialog" aria-modal="true" aria-labelledby="dialog-title-7">
+export const Draggable = () => `
+<section class="fd-dialog-docs-static fd-dialog fd-dialog--active">
+    <div class="fd-dialog__content fd-dialog__content--draggable-grab fd-dialog__content--s" role="dialog" aria-modal="true" aria-labelledby="dialog-title-7">
         <header class="fd-dialog__header fd-bar fd-bar--header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
@@ -310,8 +313,8 @@ export const Draggable = () => `<div class="fd-dialog-docs-static fd-dialog fd-d
                 </div>
             </div>
         </footer>
-    </section>
-</div>
+    </div>
+</section>
 `;
 
 Draggable.parameters = {
@@ -328,8 +331,9 @@ Dialog can be draggable, enabling the user to drag the container around with the
     }
 };
 
-export const Selectable = () => `<div class="fd-dialog-docs-static fd-dialog fd-dialog--active" id="select-dialog-example">
-    <section class="fd-dialog__content" role="dialog" aria-modal="true" aria-labelledby="dialog-title-8">
+export const Selectable = () => `
+<section class="fd-dialog-docs-static fd-dialog fd-dialog--active" id="select-dialog-example">
+    <div class="fd-dialog__content" role="dialog" aria-modal="true" aria-labelledby="dialog-title-8">
         <header class="fd-dialog__header fd-bar fd-bar--header-with-subheader">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
@@ -415,8 +419,8 @@ export const Selectable = () => `<div class="fd-dialog-docs-static fd-dialog fd-
                 </div>
             </div>
         </footer>
-    </section>
-</div>`;
+    </div>
+</section>`;
 
 Selectable.parameters = {
     docs: {
@@ -427,8 +431,9 @@ Selectable.parameters = {
 };
 
 
-export const Loading = () => `<div class="fd-dialog-docs-static fd-dialog fd-dialog--active" id="loading-dialog-example">
-    <section class="fd-dialog__content fd-dialog__content--s" role="dialog" aria-modal="true" aria-labelledby="dialog-title-9">
+export const Loading = () => `
+<section class="fd-dialog-docs-static fd-dialog fd-dialog--active" id="loading-dialog-example">
+    <div class="fd-dialog__content fd-dialog__content--s" role="dialog" aria-modal="true" aria-labelledby="dialog-title-9">
         <header class="fd-dialog__header fd-bar fd-bar--header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
@@ -453,8 +458,8 @@ export const Loading = () => `<div class="fd-dialog-docs-static fd-dialog fd-dia
                 </div>
             </div>
         </footer>
-    </section>
-</div>`;
+    </div>
+</section>`;
 
 Loading.parameters = {
     docs: {

--- a/stories/dialog/dialog.stories.js
+++ b/stories/dialog/dialog.stories.js
@@ -328,9 +328,7 @@ Dialog can be draggable, enabling the user to drag the container around with the
     }
 };
 
-export const Selectable = () => `
-<button class="fd-button" onclick="toggleClass('select-dialog-example', 'fd-dialog--active')">Open example</button>
-<div class="fd-dialog fd-dialog--active" style="position:absolute;" id="select-dialog-example">
+export const Selectable = () => `<div class="fd-dialog-docs-static fd-dialog fd-dialog--active" id="select-dialog-example">
     <section class="fd-dialog__content" role="dialog" aria-modal="true" aria-labelledby="dialog-title-8">
         <header class="fd-dialog__header fd-bar fd-bar--header-with-subheader">
             <div class="fd-bar__left">
@@ -413,14 +411,12 @@ export const Selectable = () => `
                     <button class="fd-dialog__decisive-button fd-button fd-button--emphasized fd-button--compact">Select</button>
                 </div>
                 <div class="fd-bar__element">
-                    <button class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact" onclick="toggleClass('select-dialog-example', 'fd-dialog--active')">Cancel</button>
+                    <button class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact">Cancel</button>
                 </div>
             </div>
         </footer>
     </section>
-</div>
-<div style="margin-bottom:500px"/>
-`;
+</div>`;
 
 Selectable.parameters = {
     docs: {
@@ -431,9 +427,7 @@ Selectable.parameters = {
 };
 
 
-export const Loading = () => `
-<button class="fd-button" onclick="toggleClass('loading-dialog-example', 'fd-dialog--active')">Open example</button>
-<div class="fd-dialog fd-dialog--active" style="position:absolute;" id="loading-dialog-example">
+export const Loading = () => `<div class="fd-dialog-docs-static fd-dialog fd-dialog--active" id="loading-dialog-example">
     <section class="fd-dialog__content fd-dialog__content--s" role="dialog" aria-modal="true" aria-labelledby="dialog-title-9">
         <header class="fd-dialog__header fd-bar fd-bar--header">
             <div class="fd-bar__left">
@@ -455,14 +449,13 @@ export const Loading = () => `
         <footer class="fd-dialog__footer fd-bar fd-bar--footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
-                    <button class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact" onclick="toggleClass('loading-dialog-example', 'fd-dialog--active')">Cancel</button>
+                    <button class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact">Cancel</button>
                 </div>
             </div>
         </footer>
     </section>
-</div>
-<div style="margin-bottom:500px"/>
-`;
+</div>`;
+
 Loading.parameters = {
     docs: {
         iframeHeight: 500,

--- a/stories/dialog/dialog.stories.js
+++ b/stories/dialog/dialog.stories.js
@@ -330,7 +330,7 @@ Dialog can be draggable, enabling the user to drag the container around with the
 
 export const Selectable = () => `
 <button class="fd-button" onclick="toggleClass('select-dialog-example', 'fd-dialog--active')">Open example</button>
-<div class="fd-dialog" id="select-dialog-example">
+<div class="fd-dialog fd-dialog--active" style="position:absolute;" id="select-dialog-example">
     <div class="fd-dialog__content" role="dialog" aria-modal="true" aria-labelledby="dialog-title-8">
         <header class="fd-dialog__header fd-bar fd-bar--header-with-subheader">
             <div class="fd-bar__left">
@@ -419,6 +419,7 @@ export const Selectable = () => `
         </footer>
     </div>
 </div>
+<div style="margin-bottom:500px"/>
 `;
 
 Selectable.parameters = {
@@ -432,7 +433,7 @@ Selectable.parameters = {
 
 export const Loading = () => `
 <button class="fd-button" onclick="toggleClass('loading-dialog-example', 'fd-dialog--active')">Open example</button>
-<div class="fd-dialog" id="loading-dialog-example">
+<div class="fd-dialog fd-dialog--active" style="position:absolute;" id="loading-dialog-example">
     <div class="fd-dialog__content fd-dialog__content--s" role="dialog" aria-modal="true" aria-labelledby="dialog-title-9">
         <header class="fd-dialog__header fd-bar fd-bar--header">
             <div class="fd-bar__left">
@@ -460,6 +461,7 @@ export const Loading = () => `
         </footer>
     </div>
 </div>
+<div style="margin-bottom:500px"/>
 `;
 Loading.parameters = {
     docs: {

--- a/stories/dialog/dialog.stories.js
+++ b/stories/dialog/dialog.stories.js
@@ -42,7 +42,7 @@ Note: Dialog's header, subheader and footer are elements from the **Bar** compon
 };
 
 export const defaultDialog = () => `<div class="fd-dialog-docs-static fd-dialog fd-dialog--active">
-    <div class="fd-dialog__content" role="dialog" aria-modal="true" aria-labelledby="dialog-title-1">
+    <section class="fd-dialog__content" role="dialog" aria-modal="true" aria-labelledby="dialog-title-1">
         <span class="fd-dialog__resize-handle"></span>
         <header class="fd-dialog__header fd-bar fd-bar--header-with-subheader">
             <div class="fd-bar__left">
@@ -86,7 +86,7 @@ export const defaultDialog = () => `<div class="fd-dialog-docs-static fd-dialog 
                 </div>
             </div>
         </footer>
-    </div>
+    </section>
 </div>
 `;
 
@@ -101,7 +101,7 @@ defaultDialog.parameters = {
 
 export const sizes = () => `
 <div class="fd-dialog-docs-static fd-dialog fd-dialog--active">
-<div class="fd-dialog__content fd-dialog__content--s" role="dialog" aria-modal="true" aria-labelledby="dialog-title-2">
+<section class="fd-dialog__content fd-dialog__content--s" role="dialog" aria-modal="true" aria-labelledby="dialog-title-2">
     <header class="fd-dialog__header fd-bar fd-bar--header">
         <div class="fd-bar__left">
             <div class="fd-bar__element">
@@ -124,11 +124,11 @@ export const sizes = () => `
             </div>
         </div>
     </footer>
-</div>
+</section>
 </div>
 <br />
 <div class="fd-dialog-docs-static fd-dialog fd-dialog--active">
-<div class="fd-dialog__content fd-dialog__content--m" role="dialog" aria-modal="true" aria-labelledby="dialog-title-3">
+<section class="fd-dialog__content fd-dialog__content--m" role="dialog" aria-modal="true" aria-labelledby="dialog-title-3">
     <header class="fd-dialog__header fd-bar fd-bar--header">
         <div class="fd-bar__left">
             <div class="fd-bar__element">
@@ -151,11 +151,11 @@ export const sizes = () => `
             </div>
         </div>
     </footer>
-</div> 
+</section> 
 </div>
 <br />
 <div class="fd-dialog-docs-static fd-dialog fd-dialog--active">
-<div class="fd-dialog__content fd-dialog__content--l" role="dialog" aria-modal="true" aria-labelledby="dialog-title-4">
+<section class="fd-dialog__content fd-dialog__content--l" role="dialog" aria-modal="true" aria-labelledby="dialog-title-4">
     <header class="fd-dialog__header fd-bar fd-bar--header">
         <div class="fd-bar__left">
             <div class="fd-bar__element">
@@ -178,11 +178,11 @@ export const sizes = () => `
             </div>
         </div>
     </footer>
-</div>
+</section>
 </div>
 <br />
 <div class="fd-dialog-docs-static fd-dialog fd-dialog--active">
-<div class="fd-dialog__content fd-dialog__content--xl" role="dialog" aria-modal="true" aria-labelledby="dialog-title-5">
+<section class="fd-dialog__content fd-dialog__content--xl" role="dialog" aria-modal="true" aria-labelledby="dialog-title-5">
     <header class="fd-dialog__header fd-bar fd-bar--header">
         <div class="fd-bar__left">
             <div class="fd-bar__element">
@@ -205,7 +205,7 @@ export const sizes = () => `
             </div>
         </div>
     </footer>
-</div>
+</section>
 </div>
 `;
 
@@ -248,7 +248,7 @@ Note: On mobile devices, the bar component should be used with the <code>fd-bar-
 };
 
 export const Resizable = () => `<div class="fd-dialog-docs-static fd-dialog fd-dialog--active">
-        <div class="fd-dialog__content fd-dialog__content--s" role="dialog" aria-modal="true" aria-labelledby="dialog-title-6">
+        <section class="fd-dialog__content fd-dialog__content--s" role="dialog" aria-modal="true" aria-labelledby="dialog-title-6">
             <span class="fd-dialog__resize-handle"></span>
             <header class="fd-dialog__header fd-bar fd-bar--header">
                 <div class="fd-bar__left">
@@ -272,7 +272,7 @@ export const Resizable = () => `<div class="fd-dialog-docs-static fd-dialog fd-d
                     </div>
                 </div>
             </footer>
-        </div>
+        </section>
     </div>
 `;
 
@@ -287,7 +287,7 @@ Note: This feature should be enabled for desktop screens only.`
 };
 
 export const Draggable = () => `<div class="fd-dialog-docs-static fd-dialog fd-dialog--active">
-    <div class="fd-dialog__content fd-dialog__content--draggable-grab fd-dialog__content--s" role="dialog" aria-modal="true" aria-labelledby="dialog-title-7">
+    <section class="fd-dialog__content fd-dialog__content--draggable-grab fd-dialog__content--s" role="dialog" aria-modal="true" aria-labelledby="dialog-title-7">
         <header class="fd-dialog__header fd-bar fd-bar--header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
@@ -310,7 +310,7 @@ export const Draggable = () => `<div class="fd-dialog-docs-static fd-dialog fd-d
                 </div>
             </div>
         </footer>
-    </div>
+    </section>
 </div>
 `;
 
@@ -331,7 +331,7 @@ Dialog can be draggable, enabling the user to drag the container around with the
 export const Selectable = () => `
 <button class="fd-button" onclick="toggleClass('select-dialog-example', 'fd-dialog--active')">Open example</button>
 <div class="fd-dialog fd-dialog--active" style="position:absolute;" id="select-dialog-example">
-    <div class="fd-dialog__content" role="dialog" aria-modal="true" aria-labelledby="dialog-title-8">
+    <section class="fd-dialog__content" role="dialog" aria-modal="true" aria-labelledby="dialog-title-8">
         <header class="fd-dialog__header fd-bar fd-bar--header-with-subheader">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
@@ -417,7 +417,7 @@ export const Selectable = () => `
                 </div>
             </div>
         </footer>
-    </div>
+    </section>
 </div>
 <div style="margin-bottom:500px"/>
 `;
@@ -434,7 +434,7 @@ Selectable.parameters = {
 export const Loading = () => `
 <button class="fd-button" onclick="toggleClass('loading-dialog-example', 'fd-dialog--active')">Open example</button>
 <div class="fd-dialog fd-dialog--active" style="position:absolute;" id="loading-dialog-example">
-    <div class="fd-dialog__content fd-dialog__content--s" role="dialog" aria-modal="true" aria-labelledby="dialog-title-9">
+    <section class="fd-dialog__content fd-dialog__content--s" role="dialog" aria-modal="true" aria-labelledby="dialog-title-9">
         <header class="fd-dialog__header fd-bar fd-bar--header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
@@ -459,7 +459,7 @@ export const Loading = () => `
                 </div>
             </div>
         </footer>
-    </div>
+    </section>
 </div>
 <div style="margin-bottom:500px"/>
 `;

--- a/stories/dialog/dialog.stories.js
+++ b/stories/dialog/dialog.stories.js
@@ -37,7 +37,7 @@ The dialog component is a container that appears in response to an action made b
 Note: Dialog's header, subheader and footer are elements from the **Bar** component. This means that dialog headers and footers can be customized using bar component features. To style the elements according to dialog’s needs, CSS classes are used to slightly override bar’s original behaviour.
 `,
         tags: ['f3', 'a11y', 'theme'],
-        components: ['dialog', 'input-group', 'icon', 'bar', 'button', 'title', 'icon']
+        components: ['dialog', 'input-group', 'icon', 'bar', 'button', 'title', 'icon', 'list', 'checkbox', 'busy-indicator']
     }
 };
 
@@ -99,7 +99,7 @@ defaultDialog.parameters = {
 };
 
 
-export const sizes = () =>`
+export const sizes = () => `
 <div class="fd-dialog-docs-static fd-dialog fd-dialog--active">
 <div class="fd-dialog__content fd-dialog__content--s" role="dialog" aria-modal="true" aria-labelledby="dialog-title-2">
     <header class="fd-dialog__header fd-bar fd-bar--header">
@@ -329,7 +329,7 @@ Dialog can be draggable, enabling the user to drag the container around with the
 };
 
 export const Selectable = () => `
-<button class="fd-button" onclick="toggleDialog('select-dialog-example', true)">Open example</button>
+<button class="fd-button" onclick="toggleClass('select-dialog-example', 'fd-dialog--active')">Open example</button>
 <div class="fd-dialog" id="select-dialog-example">
     <div class="fd-dialog__content" role="dialog" aria-modal="true" aria-labelledby="dialog-title-8">
         <header class="fd-dialog__header fd-bar fd-bar--header-with-subheader">
@@ -349,34 +349,58 @@ export const Selectable = () => `
         <div class="fd-dialog__subheader fd-bar fd-bar--subheader">
             <div class="fd-bar__middle">
                 <div class="fd-input-group">
-                    <input class="fd-input fd-input-group__input fd-input--compact" type="text" placeholder="Search...">
+                    <input class="fd-input fd-input-group__input fd-input--compact" type="text" aria-label="search" placeholder="Search...">
                     <span class="fd-input-group__addon fd-input-group__addon--button fd-input-group__addon--compact">
-                        <button class="fd-button fd-input-group__button fd-button--icon fd-button--transparent fd-button--compact">
-                            <i class="sap-icon--search"></i>
+                        <button class="fd-button fd-input-group__button fd-button--icon fd-button--transparent fd-button--compact" aria-label="perform search">
+                            <i class="sap-icon--search" role="presentation"></i>
                         </button>
                     </span>
                 </div>
             </div>
         </div>
         <div class="fd-dialog__body fd-dialog__body--no-vertical-padding">
-            <ul class="fd-list fd-list--compact">
-                <li class="fd-list__item">
-                    <span class="fd-list__title">List item 1</span>
+            <ul class="fd-list fd-list--selection fd-list--compact fd-list--no-border" aria-label="selection list" role="listbox">
+                <li role="option" tabindex="0" class="fd-list__item">
+                    <div class="fd-form-item fd-list__form-item">
+                        <input type="checkbox" class="fd-checkbox fd-checkbox--compact" id="Ai4ez4" aria-labelledby="Az0bg4">
+                        <label tabindex="-1" class="fd-checkbox__label fd-checkbox__label--compact" for="Ai4ez4"></label>
+                    </div>
+                    <span class="fd-list__title" id="Az0bg4">List item 1</span>
                 </li>
-                <li class="fd-list__item">
-                    <span class="fd-list__title">List item 2</span>
+                <li role="option" tabindex="0" class="fd-list__item is-selected" aria-selected="true">
+                    <div class="fd-form-item fd-list__form-item">
+                        <input type="checkbox" class="fd-checkbox fd-checkbox--compact" id="Ai4ez5" checked aria-labelledby="Az0bg5">
+                        <label tabindex="-1" class="fd-checkbox__label fd-checkbox__label--compact" for="Ai4ez5"></label>
+                    </div>
+                    <span class="fd-list__title" id="Az0bg5">List item 2</span>
                 </li>
-                <li class="fd-list__item is-active">
-                    <span class="fd-list__title">List item 3</span>
+                <li role="option" tabindex="0" class="fd-list__item is-selected">
+                    <div class="fd-form-item fd-list__form-item">
+                        <input type="checkbox" class="fd-checkbox fd-checkbox--compact" id="Ai4ez6" checked aria-labelledby="Az0bg6">
+                        <label tabindex="-1" class="fd-checkbox__label fd-checkbox__label--compact" for="Ai4ez6"></label>
+                    </div>
+                    <span class="fd-list__title" id="Az0bg6">List item 3</span>
                 </li>
-                <li class="fd-list__item is-active">
-                    <span class="fd-list__title">List item 4</span>
+                <li role="option" tabindex="0" class="fd-list__item">
+                    <div class="fd-form-item fd-list__form-item">
+                        <input type="checkbox" class="fd-checkbox fd-checkbox--compact" id="Ai4e44" aria-labelledby="440bg6">
+                        <label tabindex="-1" class="fd-checkbox__label fd-checkbox__label--compact" for="Ai4e44"></label>
+                    </div>
+                    <span class="fd-list__title" id="440bg6">List item 4</span>
                 </li>
-                <li class="fd-list__item">
-                    <span class="fd-list__title">List item 5</span>
+                <li role="option" tabindex="0" class="fd-list__item">
+                    <div class="fd-form-item fd-list__form-item">
+                        <input type="checkbox" class="fd-checkbox fd-checkbox--compact" id="Ai4e55" aria-labelledby="550bg6">
+                        <label tabindex="-1" class="fd-checkbox__label fd-checkbox__label--compact" for="Ai4e55"></label>
+                    </div>
+                    <span class="fd-list__title" id="550bg6">List item 5</span>
                 </li>
-                <li class="fd-list__item">
-                    <span class="fd-list__title">List item 6</span>
+                <li role="option" tabindex="0" class="fd-list__item">
+                    <div class="fd-form-item fd-list__form-item">
+                        <input type="checkbox" class="fd-checkbox fd-checkbox--compact" id="Ai4e66" aria-labelledby="660bg6">
+                        <label tabindex="-1" class="fd-checkbox__label fd-checkbox__label--compact" for="Ai4e66"></label>
+                    </div>
+                    <span class="fd-list__title" id="660bg6">List item 6</span>
                 </li>
             </ul>
             <span class="fd-list__footer">
@@ -389,7 +413,7 @@ export const Selectable = () => `
                     <button class="fd-dialog__decisive-button fd-button fd-button--emphasized fd-button--compact">Select</button>
                 </div>
                 <div class="fd-bar__element">
-                    <button class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact" onclick="toggleDialog('select-dialog-example', false)">Cancel</button>
+                    <button class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact" onclick="toggleClass('select-dialog-example', 'fd-dialog--active')">Cancel</button>
                 </div>
             </div>
         </footer>
@@ -407,7 +431,7 @@ Selectable.parameters = {
 
 
 export const Loading = () => `
-<button class="fd-button" onclick="toggleDialog('loading-dialog-example', true)">Open example</button>
+<button class="fd-button" onclick="toggleClass('loading-dialog-example', 'fd-dialog--active')">Open example</button>
 <div class="fd-dialog" id="loading-dialog-example">
     <div class="fd-dialog__content fd-dialog__content--s" role="dialog" aria-modal="true" aria-labelledby="dialog-title-9">
         <header class="fd-dialog__header fd-bar fd-bar--header">
@@ -430,7 +454,7 @@ export const Loading = () => `
         <footer class="fd-dialog__footer fd-bar fd-bar--footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
-                    <button class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact" onclick="toggleDialog('loading-dialog-example', false)">Cancel</button>
+                    <button class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact" onclick="toggleClass('loading-dialog-example', 'fd-dialog--active')">Cancel</button>
                 </div>
             </div>
         </footer>

--- a/stories/table/__snapshots__/table.stories.storyshot
+++ b/stories/table/__snapshots__/table.stories.storyshot
@@ -5812,7 +5812,7 @@ exports[`Storyshots Components/Table With Advanced Toolbar 1`] = `
             <button
               aria-label="navigation"
               class="fd-dialog__decisive-button fd-button fd-button--emphasized fd-button--compact"
-              onclick="toggleDialog('filter-dialog-example', false)"
+              onclick="toggleClass('filter-dialog-example', 'fd-dialog--active')"
             >
               OK
             </button>
@@ -5829,7 +5829,7 @@ exports[`Storyshots Components/Table With Advanced Toolbar 1`] = `
             <button
               aria-label="navigation"
               class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact"
-              onclick="toggleDialog('filter-dialog-example', false)"
+              onclick="toggleClass('filter-dialog-example', 'fd-dialog--active')"
             >
               Cancel
             </button>
@@ -6199,7 +6199,7 @@ exports[`Storyshots Components/Table With Advanced Toolbar 1`] = `
             <button
               aria-label="navigation"
               class="fd-dialog__decisive-button fd-button fd-button--emphasized fd-button--compact"
-              onclick="toggleDialog('settings-dialog-example', false)"
+              onclick="toggleClass('settings-dialog-example', 'fd-dialog--active')"
             >
               OK
             </button>
@@ -6216,7 +6216,7 @@ exports[`Storyshots Components/Table With Advanced Toolbar 1`] = `
             <button
               aria-label="navigation"
               class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact"
-              onclick="toggleDialog('settings-dialog-example', false)"
+              onclick="toggleClass('settings-dialog-example', 'fd-dialog--active')"
             >
               Cancel
             </button>
@@ -6257,7 +6257,7 @@ exports[`Storyshots Components/Table With Advanced Toolbar 1`] = `
     <button
       aria-label="navigation"
       class="fd-button fd-button--compact fd-button--transparent"
-      onclick="toggleDialog('filter-dialog-example', true)"
+      onclick="toggleClass('filter-dialog-example', 'fd-dialog--active')"
     >
       
         
@@ -6272,7 +6272,7 @@ exports[`Storyshots Components/Table With Advanced Toolbar 1`] = `
     <button
       aria-label="navigation"
       class="fd-button fd-button--compact fd-button--transparent"
-      onclick="toggleDialog('settings-dialog-example', true)"
+      onclick="toggleClass('settings-dialog-example', 'fd-dialog--active')"
     >
       
         

--- a/stories/table/table.stories.js
+++ b/stories/table/table.stories.js
@@ -683,10 +683,10 @@ export const withAdvancedToolbar = () => `
         <footer class="fd-dialog__footer fd-bar fd-bar--footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
-                    <button aria-label="navigation" class="fd-dialog__decisive-button fd-button fd-button--emphasized fd-button--compact" onclick="toggleDialog('filter-dialog-example', false)">OK</button>
+                    <button aria-label="navigation" class="fd-dialog__decisive-button fd-button fd-button--emphasized fd-button--compact" onclick="toggleClass('filter-dialog-example', 'fd-dialog--active')">OK</button>
                 </div>
                 <div class="fd-bar__element">
-                    <button aria-label="navigation" class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact" onclick="toggleDialog('filter-dialog-example', false)">Cancel</button>
+                    <button aria-label="navigation" class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact" onclick="toggleClass('filter-dialog-example', 'fd-dialog--active')">Cancel</button>
                 </div>
             </div>
         </footer>
@@ -762,10 +762,10 @@ export const withAdvancedToolbar = () => `
         <footer class="fd-dialog__footer fd-bar fd-bar--footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
-                    <button aria-label="navigation" class="fd-dialog__decisive-button fd-button fd-button--emphasized fd-button--compact" onclick="toggleDialog('settings-dialog-example', false)">OK</button>
+                    <button aria-label="navigation" class="fd-dialog__decisive-button fd-button fd-button--emphasized fd-button--compact" onclick="toggleClass('settings-dialog-example', 'fd-dialog--active')">OK</button>
                 </div>
                 <div class="fd-bar__element">
-                    <button aria-label="navigation" class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact" onclick="toggleDialog('settings-dialog-example', false)">Cancel</button>
+                    <button aria-label="navigation" class="fd-dialog__decisive-button fd-button fd-button--transparent fd-button--compact" onclick="toggleClass('settings-dialog-example', 'fd-dialog--active')">Cancel</button>
                 </div>
             </div>
         </footer>
@@ -774,10 +774,10 @@ export const withAdvancedToolbar = () => `
 <div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
     <h4 style="margin: 0;">Table With Advanced Shellbar</h4>
     <div class="fd-toolbar__spacer"></div>
-    <button aria-label="navigation" class="fd-button fd-button--compact fd-button--transparent" onclick="toggleDialog('filter-dialog-example', true)">
+    <button aria-label="navigation" class="fd-button fd-button--compact fd-button--transparent" onclick="toggleClass('filter-dialog-example', 'fd-dialog--active')">
         <i class="sap-icon--filter"></i>
     </button>
-    <button aria-label="navigation" class="fd-button fd-button--compact fd-button--transparent" onclick="toggleDialog('settings-dialog-example', true)">
+    <button aria-label="navigation" class="fd-button fd-button--compact fd-button--transparent" onclick="toggleClass('settings-dialog-example', 'fd-dialog--active')">
         <i class="sap-icon--action-settings"></i>
     </button>
 </div>


### PR DESCRIPTION
## Related Issue
Part of: #1760 

## Description
This PR:
- Replaces and removes `toggleDialog` with `toggleClass`
- Updates selection list implementation in Selection Dialog example
- Adds `z-index` to `.fd-dialog` and `.fd-message-box` examples

#### Please check whether the PR fulfills the following requirements

3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
