### PR TITLE
fix: Dialog - no border radius in mobile mode

### DIFF
--- a/src/_dialog-placeholders.scss
+++ b/src/_dialog-placeholders.scss
@@ -25,6 +25,7 @@ $fd-dialog-overlay-color: rgba(0, 0, 0, 0.6); // Should be fade(var(--sapBlockLa
   display: flex;
   flex-direction: column;
   outline: none;
+  overflow: hidden;
   position: absolute;
   min-width: $fd-dialog-content-min-width;
   min-height: $fd-dialog-content-min-height;
@@ -51,6 +52,7 @@ $fd-dialog-overlay-color: rgba(0, 0, 0, 0.6); // Should be fade(var(--sapBlockLa
   height: 100vh;
   max-width: 100vw;
   max-height: 100vh;
+  border-radius: 0;
 }
 
 %dialog-title {

--- a/src/dialog.scss
+++ b/src/dialog.scss
@@ -20,9 +20,6 @@ $button: #{$fd-namespace}-button;
 
 .#{$block} {
 
-  // OVERLAY
-  $fd-dialog-overlay-color: rgba(0, 0, 0, 0.6); // Should be fade(var(--sapBlockLayer_Background), 60)
-
   // CONTENT
   $fd-dialog-content-margin-y: 6%;
   $fd-dialog-content-margin-x: 10%;
@@ -77,6 +74,7 @@ $button: #{$fd-namespace}-button;
     }
 
     &--no-mobile-stretch {
+      border-radius: $fd-dialog-content-border-radius;
       max-width: calc(100vw - #{$fd-dialog-content-margin-x});
       max-height: calc(100vh - #{$fd-dialog-content-margin-y});
     }
@@ -119,8 +117,6 @@ $button: #{$fd-namespace}-button;
 
   &__header.#{$bar} {
     position: relative;
-    border-top-left-radius: $fd-dialog-content-border-radius;
-    border-top-right-radius: $fd-dialog-content-border-radius;
   }
 
   &__body {
@@ -150,11 +146,6 @@ $button: #{$fd-namespace}-button;
     }
   }
 
-  &__footer.#{$bar} {
-    border-bottom-left-radius: $fd-dialog-content-border-radius;
-    border-bottom-right-radius: $fd-dialog-content-border-radius;
-  }
-
   &__loader {
     @include fd-reset();
 
@@ -172,7 +163,6 @@ $button: #{$fd-namespace}-button;
     font-size: 1rem;
     cursor: se-resize;
     overflow: hidden;
-    border-bottom-right-radius: $fd-dialog-content-border-radius;
 
     @include fd-rtl() {
       right: unset;


### PR DESCRIPTION
## Related Issue
Closes: #1100 

## Description
This PR:
- Adds overflow hidden for the Dialog window
- Moves border radius from header and footer to Dialog window
- Removes border radius from the dialog window if the Dialog is used in mobile mode