### PR TITLE
docs: add background to busy indicator example

### DIFF
--- a/stories/busy-indicator/__snapshots__/busy-indicator.stories.storyshot
+++ b/stories/busy-indicator/__snapshots__/busy-indicator.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots Components/Busy Indicator Contrast Mode 1`] = `
 <div
-  style="display:flex;justify-content:center;flex-direction:column;align-items:center;background-color:cadetblue;height:250px"
+  style="display:flex;justify-content:center;flex-direction:column;align-items:center;background-color: lightblue; padding: 2rem;"
 >
   
 
@@ -36,7 +36,7 @@ exports[`Storyshots Components/Busy Indicator Contrast Mode 1`] = `
 
 exports[`Storyshots Components/Busy Indicator Standard 1`] = `
 <div
-  style="text-align: center"
+  style="text-align: center; background-color: lightblue; padding: 2rem"
 >
   
     

--- a/stories/busy-indicator/busy-indicator.stories.js
+++ b/stories/busy-indicator/busy-indicator.stories.js
@@ -30,7 +30,7 @@ The ongoing operation only covers part of a screen that has multiple controls, a
     }
 };
 
-export const Standard = () => `<div style="text-align: center">
+export const Standard = () => `<div style="text-align: center; background-color: lightblue; padding: 2rem">
     <div class="fd-busy-indicator--l" aria-hidden="false" aria-label="Loading">
         <div class="fd-busy-indicator--circle-0"></div>
         <div class="fd-busy-indicator--circle-1"></div>
@@ -52,11 +52,12 @@ export const Standard = () => `<div style="text-align: center">
 Standard.parameters = {
     docs: {
         iframeHeight: 200,
-        storyDescription: 'The standard busy indicator animates a sequence of cascading dots expanding and shrinking in a loop. The component comes in three sizes detailed above. To display the busy indicator, use the <code>fd-busy-indicator</code> class. If you want to display a certain size, add the modifier class of the desired size i.e. <code>--m</code> to the element.'
+        storyDescription:
+            'The standard busy indicator animates a sequence of cascading dots expanding and shrinking in a loop. The component comes in three sizes detailed above. To display the busy indicator, use the <code>fd-busy-indicator</code> class. If you want to display a certain size, add the modifier class of the desired size i.e. <code>--m</code> to the element.'
     }
 };
 
-export const contrastMode = () => `<div style="display:flex;justify-content:center;flex-direction:column;align-items:center;background-color:cadetblue;height:250px">
+export const contrastMode = () => `<div style="display:flex;justify-content:center;flex-direction:column;align-items:center;background-color: lightblue; padding: 2rem;">
 <div class="fd-busy-indicator--l contrast" aria-hidden="false" aria-label="Loading">
     <div class="fd-busy-indicator--circle-0"></div>
     <div class="fd-busy-indicator--circle-1"></div>
@@ -68,6 +69,7 @@ export const contrastMode = () => `<div style="display:flex;justify-content:cent
 contrastMode.parameters = {
     docs: {
         iframeHeight: 200,
-        storyDescription: 'The busy indicator also comes in contrast mode and displays white dots against a dark background. To apply contrast mode, add <code>contrast</code> into the element i.e. <code>fd-busy-indicator--m contrast</code>.'
+        storyDescription:
+            'The busy indicator also comes in contrast mode and displays white dots against a dark background. To apply contrast mode, add <code>contrast</code> into the element i.e. <code>fd-busy-indicator--m contrast</code>.'
     }
 };


### PR DESCRIPTION
## Related Issue
Part of SAP/fundamental-styles#1760

## Description
In HCD mode the Busy Indicator was not visible as the "dots" had the same color as the background. A background color was added to the example to fix this."

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
<img width="2086" alt="Screen Shot 2020-10-28 at 12 32 14 PM" src="https://user-images.githubusercontent.com/39598672/97466568-a353ff80-1919-11eb-83dc-6e0e4ecc598a.png">
<img width="2047" alt="Screen Shot 2020-10-28 at 12 32 03 PM" src="https://user-images.githubusercontent.com/39598672/97466596-abac3a80-1919-11eb-9878-bf0913fd81fb.png">



### After:
<img width="2079" alt="Screen Shot 2020-10-28 at 12 29 53 PM" src="https://user-images.githubusercontent.com/39598672/97466289-51ab7500-1919-11eb-824f-70b2d07fb307.png">
<img width="2016" alt="Screen Shot 2020-10-28 at 12 29 41 PM" src="https://user-images.githubusercontent.com/39598672/97466324-5b34dd00-1919-11eb-87dd-170504739004.png">

