### PR TITLE
chore: skip Chromatic build on release

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,5 +1,6 @@
 name: "Chromatic"
 on: push
+if: "! contains(toJSON(github.event.commits.*.message), '[ci skip]')"
 
 jobs:
   test:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -3,14 +3,13 @@ on: push
 
 jobs:
   test:
+    if: "! contains(toJSON(github.event.commits[0].message), '[ci skip]')"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-      if: "! contains(toJSON(github.event.commits[0].message), '[ci skip]')"
     - run: |
         yarn && yarn build
     - uses: chromaui/action@v1
-      if: "! contains(toJSON(github.event.commits[0].message), '[ci skip]')"
       with: 
         projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -5,11 +5,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - if: "! contains(toJSON(github.event.commits[0].message), '[ci skip]')"
     - uses: actions/checkout@v1
+      if: "! contains(toJSON(github.event.commits[0].message), '[ci skip]')"
     - run: |
         yarn && yarn build
     - uses: chromaui/action@v1
+      if: "! contains(toJSON(github.event.commits[0].message), '[ci skip]')"
       with: 
         projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,6 +1,6 @@
 name: "Chromatic"
 on: push
-if: "! contains(toJSON(github.event.commits.*.message), '[ci skip]')"
+if: "! contains(toJSON(github.event.commits[0].message), '[ci skip]')"
 
 jobs:
   test:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,11 +1,11 @@
 name: "Chromatic"
 on: push
-if: "! contains(toJSON(github.event.commits[0].message), '[ci skip]')"
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+    - if: "! contains(toJSON(github.event.commits[0].message), '[ci skip]')"
     - uses: actions/checkout@v1
     - run: |
         yarn && yarn build

--- a/stories/button/button.stories.js
+++ b/stories/button/button.stories.js
@@ -41,6 +41,7 @@ export const primary = () => `
  */
 
 export const types = () => `<div class="fddocs-container"> 
+        <button class="fd-button">Default Button</button>
         <button class="fd-button fd-button--emphasized">Emphasized Button</button>
         <button class="fd-button fd-button--ghost">Ghost Button</button>
         <button class="fd-button fd-button--positive">Positive Button</button>

--- a/stories/button/button.stories.js
+++ b/stories/button/button.stories.js
@@ -41,7 +41,6 @@ export const primary = () => `
  */
 
 export const types = () => `<div class="fddocs-container"> 
-        <button class="fd-button">Default Button</button>
         <button class="fd-button fd-button--emphasized">Emphasized Button</button>
         <button class="fd-button fd-button--ghost">Ghost Button</button>
         <button class="fd-button fd-button--positive">Positive Button</button>


### PR DESCRIPTION
## Description
Only run Chromatic build for commits without [ci skip] in the message. This prevents Chromatic builds from triggering on release commits.

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [N.A.] All values are in `rem`
- [N.A.] Text elements follow the truncation rules
- [N.A.] hover state of the element follow design spec
- [N.A.] focus state of the element follow design spec
- [N.A.] active state of the element follow design spec
- [N.A.] selected state of the element follow design spec
- [N.A.] selected hover state of the element follow design spec
- [N.A.] pressed state of the element follow design spec
- [N.A.] Responsiveness rules - the component has modifier classes for all breakpoints
- [N.A.] Includes Compact/Cosy/Tablet design
- [N.A.] RTL support
2. The code follows fundamental-styles code standards and style
- [N.A.] BEM naming convention is used
- [N.A.] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [N.A.] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [N.A.] `fd-reset()` mixin is applied to all elements
- [N.A.] Variables are used, if some value is used more than twice.
- [N.A.] Checked if current components can be reused, instead of having new code.
3. Testing
- [N.A.] tested Storybook examples with "CSS Resources" `normalize` option 
- [N.A.] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [N.A.] Verified all styles in IE11
- [N.A.] Updated tests
4. Documentation
- [N.A.] Storybook documentation has been created/updated
- [N.A.] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
