### PR TITLE
fix: Make stronger selector for message strip

### DIFF
--- a/src/message-strip.scss
+++ b/src/message-strip.scss
@@ -67,7 +67,7 @@ $block: #{$fd-namespace}-message-strip;
   min-height: 2rem;
 
   // Elements
-  &__close {
+  &__close.#{$fd-namespace}-button {
     @include fd-message-strip-close-btn-container();
 
     @include fd-rtl() {

--- a/src/message-strip.scss
+++ b/src/message-strip.scss
@@ -67,7 +67,7 @@ $block: #{$fd-namespace}-message-strip;
   min-height: 2rem;
 
   // Elements
-  &__close.#{$fd-namespace}-button {
+  .#{$block}__close {
     @include fd-message-strip-close-btn-container();
 
     @include fd-rtl() {


### PR DESCRIPTION
## Description
There is stronger selector for message-strip close element.

## Screenshots

No visual/usage changes predicted