### PR TITLE
fix: RTL mode arrow button direction

### DIFF
--- a/src/panel.scss
+++ b/src/panel.scss
@@ -55,7 +55,9 @@ $block: #{$fd-namespace}-panel;
     font-size: 1rem;
 
     @include fd-rtl() {
-      @include fd-icon('slim-arrow-left');
+      .sap-icon--slim-arrow-right {
+        transform: rotate(180deg);
+      }
     }
   }
 


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/1779
Related https://github.com/SAP/fundamental-ngx/issues/3674 

## Description
- Rotate arrow icon

## Screenshots
### Before:
![image](https://user-images.githubusercontent.com/14160094/98348712-c5d4cf80-2021-11eb-8c79-fc08d1ec5e31.png)

### After:
![image](https://user-images.githubusercontent.com/14160094/98461061-de73ef80-21b1-11eb-8c91-9c114e8b481e.png)

