### PR TITLE
fix: Center vertically text in switch component

### DIFF
--- a/src/switch.scss
+++ b/src/switch.scss
@@ -104,6 +104,7 @@ $block: #{$fd-namespace}-switch;
   &__text {
     @include fd-form-label();
 
+    align-self: auto;
     cursor: pointer;
   }
 


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-styles/issues/1818

## Description


## Screenshots

### Before:
![image](https://user-images.githubusercontent.com/26483208/98362764-16522a00-202e-11eb-91f2-0336e6ccc673.png)

### After:
![image](https://user-images.githubusercontent.com/26483208/98362751-118d7600-202e-11eb-8e0e-937272fd1cae.png)

#### Please check whether the PR fulfills the following requirements
3. Testing
- [x] Verified all styles in IE11
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
