### PR TITLE
fix: Shellbar button focus color

### DIFF
--- a/src/counter.scss
+++ b/src/counter.scss
@@ -24,6 +24,7 @@ $block: #{$fd-namespace}-counter;
   display: inline-block;
   text-align: center;
   padding: $fd-counter-padding;
+  z-index: 1;
 
   &--notification {
     transform: translate(-40%, -50%);

--- a/src/shellbar.scss
+++ b/src/shellbar.scss
@@ -1,5 +1,6 @@
 @import "./new-settings";
 @import "./mixins";
+@import "./mixins/button/button-helper";
 
 $block: #{$fd-namespace}-shellbar;
 
@@ -233,15 +234,15 @@ $block: #{$fd-namespace}-shellbar;
     color: $fd-shell-icon-button-color;
     overflow: visible;
     padding: 0;
-    outline-color: var(--sapContent_ContrastFocusColor);
 
-    &:hover {
-      background: $fd-shell-hover-background;
+    @include fd-focus() {
+      @include buttonFocus() {
+        border-color: var(--sapContent_ContrastFocusColor);
+      }
     }
 
-    &:active {
+    @include fd-active() {
       background: $fd-shell-active-background;
-      outline-color: var(--sapContent_ContrastFocusColor);
     }
 
     &:hover,
@@ -250,6 +251,8 @@ $block: #{$fd-namespace}-shellbar;
     }
 
     @include fd-hover() {
+      background: $fd-shell-hover-background;
+
       @include fd-disabled() {
         background: $fd-shellbar-background-color;
       }


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-styles/issues/1818

## Description
There is added new strategy of dealing with focus color in shellbar buttons

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/26483208/98367409-dbec8b00-2035-11eb-9d63-1535e8356523.png)


### After:
![image](https://user-images.githubusercontent.com/26483208/98367301-ae9fdd00-2035-11eb-9534-3206b3bf9f42.png)

#### Please check whether the PR fulfills the following requirements

2. The code follows fundamental-styles code standards and style
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
