### PR TITLE
fix: Core Carousel navigation buttons - focus/active state in Safari and Firefox browser

### DIFF
--- a/src/carousel.scss
+++ b/src/carousel.scss
@@ -1,5 +1,6 @@
 @import "./new-settings";
 @import "./mixins";
+@import "./mixins/button/button-helper";
 
 $block: #{$fd-namespace}-carousel;
 $button: #{$fd-namespace}-button;
@@ -12,6 +13,15 @@ $button: #{$fd-namespace}-button;
   $fd-carousel-button-content-offset: 0.5rem !default;
   $fd-carousel-dot-size: 0.25rem !default;
   $fd-carousel-dot-active-size: 0.5rem !default;
+
+  @mixin after-position-overwrite() {
+    &::after {
+      top: $fd-carousel-button-focus-outline-offset;
+      bottom: $fd-carousel-button-focus-outline-offset;
+      left: $fd-carousel-button-focus-outline-offset;
+      right: $fd-carousel-button-focus-outline-offset;
+    }
+  }
 
   @include fd-reset();
   @include fd-flex(column);
@@ -148,12 +158,12 @@ $button: #{$fd-namespace}-button;
     }
 
     @include fd-focus() {
-      &::after {
-        top: $fd-carousel-button-focus-outline-offset;
-        bottom: $fd-carousel-button-focus-outline-offset;
-        left: $fd-carousel-button-focus-outline-offset;
-        right: $fd-carousel-button-focus-outline-offset;
-      }
+      @include after-position-overwrite();
+    }
+
+    @include fd-active() {
+      @include buttonFocus();
+      @include after-position-overwrite();
     }
   }
 

--- a/src/carousel.scss
+++ b/src/carousel.scss
@@ -162,7 +162,7 @@ $button: #{$fd-namespace}-button;
     @include fd-active() {
       @include buttonFocus() {
         @include after-position-overwrite();
-      };
+      }
     }
   }
 

--- a/src/carousel.scss
+++ b/src/carousel.scss
@@ -15,12 +15,10 @@ $button: #{$fd-namespace}-button;
   $fd-carousel-dot-active-size: 0.5rem !default;
 
   @mixin after-position-overwrite() {
-    &::after {
-      top: $fd-carousel-button-focus-outline-offset;
-      bottom: $fd-carousel-button-focus-outline-offset;
-      left: $fd-carousel-button-focus-outline-offset;
-      right: $fd-carousel-button-focus-outline-offset;
-    }
+    top: $fd-carousel-button-focus-outline-offset;
+    bottom: $fd-carousel-button-focus-outline-offset;
+    left: $fd-carousel-button-focus-outline-offset;
+    right: $fd-carousel-button-focus-outline-offset;
   }
 
   @include fd-reset();
@@ -162,8 +160,9 @@ $button: #{$fd-namespace}-button;
     }
 
     @include fd-active() {
-      @include buttonFocus();
-      @include after-position-overwrite();
+      @include buttonFocus() {
+        @include after-position-overwrite();
+      };
     }
   }
 


### PR DESCRIPTION
## Related Issue
https://github.com/SAP/fundamental-ngx/issues/3753
## Description
Fixed focus and pressed (active) states for carousel navigation buttons for Safari and Firebox browsers.
## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).
### Before:
![image](https://user-images.githubusercontent.com/53509521/98211940-d7a66c00-1f68-11eb-8aa1-52487dbbfadc.gif)
### After:
Focus
![image](https://user-images.githubusercontent.com/38053194/98469510-c5d2fc00-21e8-11eb-8013-9c57b2d1bca9.png)
Active
![image](https://user-images.githubusercontent.com/38053194/98469498-b9e73a00-21e8-11eb-83f6-816898fbc8ca.png)

#### Please check whether the PR fulfills the following requirements
2. The code follows fundamental-styles code standards and style
- [x] Mixins are used for repeatable code (`fd-active`, `buttonFocus`)
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
