### PR TITLE
fix: center buttons in Product Switch and Dialog

### DIFF
--- a/src/dialog.scss
+++ b/src/dialog.scss
@@ -112,6 +112,7 @@ $button: #{$fd-namespace}-button;
   &__footer.#{$bar} {
     .#{$block}__decisive-button {
       min-width: $fd-dialog-footer-button-min-width;
+      justify-content: center;
     }
   }
 

--- a/src/product-switch.scss
+++ b/src/product-switch.scss
@@ -23,6 +23,7 @@ $block: #{$fd-namespace}-product-switch;
     @include fd-reset();
 
     color: var(--sapShell_InteractiveTextColor);
+    justify-content: center;
 
     &::before {
       margin-right: 0;


### PR DESCRIPTION
## Related Issue

## Description

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/26483208/98653673-97b30080-233d-11eb-89c6-7b8ed195d8a2.png)

![image](https://user-images.githubusercontent.com/26483208/98653721-aa2d3a00-233d-11eb-888a-42de0b5310a0.png)

### After:
![image](https://user-images.githubusercontent.com/26483208/98653678-9d104b00-233d-11eb-9b1a-79bf4696fb91.png)
![image](https://user-images.githubusercontent.com/26483208/98653750-b2857500-233d-11eb-8734-78a0331b1474.png)

#### Please check whether the PR fulfills the following requirements

2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] Verified all styles in IE11
- [x] Updated tests