### PR TITLE
fix: update delta theming for Button, Card, Badge and Carousel

### DIFF
--- a/src/badge.scss
+++ b/src/badge.scss
@@ -15,7 +15,7 @@ $block: #{$fd-namespace}-badge;
   background: var(--sapHighlightColor);
   color: var(--sapContent_ContrastTextColor);
   padding: 0 0.5rem;
-  border: 0.0625rem solid transparent;
+  border: 0.0625rem solid var(--fdBadge_Border_Color);
   border-radius: 0.5rem;
   position: absolute;
   right: 0.5rem;

--- a/src/button.scss
+++ b/src/button.scss
@@ -67,7 +67,7 @@ $block: #{$fd-namespace}-button;
 
   // Extended touchable area
   &::before {
-    content: "";
+    content: '';
     display: block;
     position: absolute;
     height: auto;
@@ -155,6 +155,7 @@ $block: #{$fd-namespace}-button;
 
   &.#{$block}--emphasized {
     font-weight: bold;
+    border-width: var(--fdButton_Emphasized_Border_Width);
 
     @include emphasized();
   }

--- a/src/card.scss
+++ b/src/card.scss
@@ -6,6 +6,7 @@ $object-status: #{$fd-namespace}-object-status;
 $numeric-content: #{$fd-namespace}-numeric-content;
 
 $fd-card-header-border: 0.0625rem solid var(--sapTile_SeparatorColor) !default;
+$fd-card-header-border-radius: var(--sapElement_BorderCornerRadius) !default;
 $fd-card-avatar-text-spacing: 0.75rem !default;
 $fd-card-title-counter-spacing: 1rem !default;
 $fd-card-currency-spacing: 0.25rem !default;
@@ -32,7 +33,7 @@ $fd-card-content-avatar-text-spacing: 0.5rem !default;
   width: 100%;
   position: relative;
   background: var(--sapTile_Background);
-  box-shadow: var(--sapContent_Shadow0);
+  box-shadow: var(--fdCard_Box_Shadow);
   border-radius: var(--sapElement_BorderCornerRadius);
   border: 0.0625rem solid var(--sapTile_BorderColor);
 
@@ -58,12 +59,14 @@ $fd-card-content-avatar-text-spacing: 0.5rem !default;
     padding: 1rem;
     background: var(--sapTile_Background);
     border-bottom: $fd-card-header-border;
+    border-radius: $fd-card-header-border-radius $fd-card-header-border-radius 0 0;
     text-decoration: none;
     cursor: pointer;
 
     &:last-child {
       border-bottom: none;
       border-top: $fd-card-header-border;
+      border-radius: 0 0 $fd-card-header-border-radius $fd-card-header-border-radius;
     }
   }
 

--- a/src/carousel.scss
+++ b/src/carousel.scss
@@ -11,7 +11,7 @@ $button: #{$fd-namespace}-button;
   $fd-carousel-touchable-button-size: 2.625rem !default;
   $fd-carousel-button-focus-outline-offset: -0.125rem !default;
   $fd-carousel-button-content-offset: 0.5rem !default;
-  $fd-carousel-dot-size: 0.25rem !default;
+  $fd-carousel-dot-size: var(--fdCarousel_Dot_Size) !default;
   $fd-carousel-dot-active-size: 0.5rem !default;
 
   @mixin after-position-overwrite() {
@@ -110,11 +110,12 @@ $button: #{$fd-namespace}-button;
     @include fd-reset();
 
     list-style-type: none;
-    margin: 0 0.375rem;
+    margin: var(--fdCarousel_Dot_Margin);
     width: $fd-carousel-dot-size;
     height: $fd-carousel-dot-size;
     border-radius: 50%;
     background-color: var(--sapContent_NonInteractiveIconColor);
+    border: var(--fdCarousel_Dot_Border);
 
     &--active {
       margin: 0 0.25rem;

--- a/src/mixins/button/_emphasized.scss
+++ b/src/mixins/button/_emphasized.scss
@@ -9,7 +9,7 @@
 @mixin emphasizedHover {
   @include applyColors(
     var(--sapButton_Emphasized_Hover_TextColor),
-    var(--fdButton_Emphasized_Border_Color),
+    var(--sapButton_Emphasized_Hover_BorderColor),
     var(--sapButton_Emphasized_Hover_Background)
   );
 }

--- a/src/mixins/button/_emphasized.scss
+++ b/src/mixins/button/_emphasized.scss
@@ -9,7 +9,7 @@
 @mixin emphasizedHover {
   @include applyColors(
     var(--sapButton_Emphasized_Hover_TextColor),
-    var(--sapButton_Emphasized_Hover_Background),
+    var(--fdButton_Emphasized_Border_Color),
     var(--sapButton_Emphasized_Hover_Background)
   );
 }

--- a/src/theming/sap_fiori_3.scss
+++ b/src/theming/sap_fiori_3.scss
@@ -95,7 +95,6 @@
   /* Button */
   --fdButton_Text_Shadow: none;
   --fdButton_Emphasized_Border_Width: var(--sapButton_BorderWidth);
-  --fdButton_Emphasized_Border_Color: var(--sapButton_Emphasized_Hover_Background);
 
   /* Input Group */
   --fdInputGroup_Text_Shadow: none;

--- a/src/theming/sap_fiori_3.scss
+++ b/src/theming/sap_fiori_3.scss
@@ -94,6 +94,8 @@
 
   /* Button */
   --fdButton_Text_Shadow: none;
+  --fdButton_Emphasized_Border_Width: var(--sapButton_BorderWidth);
+  --fdButton_Emphasized_Border_Color: var(--sapButton_Emphasized_Hover_Background);
 
   /* Input Group */
   --fdInputGroup_Text_Shadow: none;
@@ -110,4 +112,15 @@
 
   /* Form Header */
   --fdFormHeader_Border_Width: var(--sapList_BorderWidth);
+
+  /* Card */
+  --fdCard_Box_Shadow: var(--sapContent_Shadow0);
+
+  /* Badge */
+  --fdBadge_Border_Color: transparent;
+
+  /* Carousel */
+  --fdCarousel_Dot_Size: 0.25rem;
+  --fdCarousel_Dot_Margin: 0 0.375rem;
+  --fdCarousel_Dot_Border: none;
 }

--- a/src/theming/sap_fiori_3_dark.scss
+++ b/src/theming/sap_fiori_3_dark.scss
@@ -95,7 +95,6 @@
   /* Button */
   --fdButton_Text_Shadow: none;
   --fdButton_Emphasized_Border_Width: var(--sapButton_BorderWidth);
-  --fdButton_Emphasized_Border_Color: var(--sapButton_Emphasized_Hover_Background);
 
   /* Input Group */
   --fdInputGroup_Text_Shadow: none;

--- a/src/theming/sap_fiori_3_dark.scss
+++ b/src/theming/sap_fiori_3_dark.scss
@@ -94,6 +94,8 @@
 
   /* Button */
   --fdButton_Text_Shadow: none;
+  --fdButton_Emphasized_Border_Width: var(--sapButton_BorderWidth);
+  --fdButton_Emphasized_Border_Color: var(--sapButton_Emphasized_Hover_Background);
 
   /* Input Group */
   --fdInputGroup_Text_Shadow: none;
@@ -110,4 +112,15 @@
 
   /** Badge on Button */
   --fdBadgeButton_Border_Color: var(--sapContent_BadgeBackground);
+
+  /* Card */
+  --fdCard_Box_Shadow: var(--sapContent_Shadow0);
+
+  /* Badge */
+  --fdBadge_Border_Color: transparent;
+
+  /* Carousel */
+  --fdCarousel_Dot_Size: 0.25rem;
+  --fdCarousel_Dot_Margin: 0 0.375rem;
+  --fdCarousel_Dot_Border: none;
 }

--- a/src/theming/sap_fiori_3_hcb.scss
+++ b/src/theming/sap_fiori_3_hcb.scss
@@ -94,6 +94,8 @@
 
   /* Button */
   --fdButton_Text_Shadow: 0 0 0.125rem #000;
+  --fdButton_Emphasized_Border_Width: 0.125rem;
+  --fdButton_Emphasized_Border_Color: var(--sapButton_Emphasized_BorderColor);
 
   /* Input Group */
   --fdInputGroup_Text_Shadow: 0 0 0.125rem #000;
@@ -110,4 +112,15 @@
 
   /** Badge on Button */
   --fdBadgeButton_Border_Color: var(--sapGroup_ContentBorderColor);
+
+  /* Card */
+  --fdCard_Box_Shadow: none;
+
+  /* Badge */
+  --fdBadge_Border_Color: var(--sapContent_ForegroundBorderColor);
+
+  /* Carousel */
+  --fdCarousel_Dot_Size: 0.5rem;
+  --fdCarousel_Dot_Margin: 0 0.25rem;
+  --fdCarousel_Dot_Border: 1px solid var(--sapContent_ForegroundBorderColor);
 }

--- a/src/theming/sap_fiori_3_hcb.scss
+++ b/src/theming/sap_fiori_3_hcb.scss
@@ -95,7 +95,6 @@
   /* Button */
   --fdButton_Text_Shadow: 0 0 0.125rem #000;
   --fdButton_Emphasized_Border_Width: 0.125rem;
-  --fdButton_Emphasized_Border_Color: var(--sapButton_Emphasized_BorderColor);
 
   /* Input Group */
   --fdInputGroup_Text_Shadow: 0 0 0.125rem #000;

--- a/src/theming/sap_fiori_3_hcw.scss
+++ b/src/theming/sap_fiori_3_hcw.scss
@@ -95,7 +95,6 @@
   /* Button */
   --fdButton_Text_Shadow: none;
   --fdButton_Emphasized_Border_Width: 0.125rem;
-  --fdButton_Emphasized_Border_Color: var(--sapButton_Emphasized_BorderColor);
 
   /* Input Group */
   --fdInputGroup_Text_Shadow: none;

--- a/src/theming/sap_fiori_3_hcw.scss
+++ b/src/theming/sap_fiori_3_hcw.scss
@@ -94,6 +94,8 @@
 
   /* Button */
   --fdButton_Text_Shadow: none;
+  --fdButton_Emphasized_Border_Width: 0.125rem;
+  --fdButton_Emphasized_Border_Color: var(--sapButton_Emphasized_BorderColor);
 
   /* Input Group */
   --fdInputGroup_Text_Shadow: none;
@@ -110,4 +112,15 @@
 
   /** Badge on Button */
   --fdBadgeButton_Border_Color: var(--sapGroup_ContentBorderColor);
+
+  /* Card */
+  --fdCard_Box_Shadow: none;
+
+  /* Badge */
+  --fdBadge_Border_Color: var(--sapContent_ForegroundBorderColor);
+
+  /* Carousel */
+  --fdCarousel_Dot_Size: 0.5rem;
+  --fdCarousel_Dot_Margin: 0 0.25rem;
+  --fdCarousel_Dot_Border: 1px solid var(--sapContent_ForegroundBorderColor);
 }

--- a/src/theming/sap_fiori_3_light_dark.scss
+++ b/src/theming/sap_fiori_3_light_dark.scss
@@ -95,7 +95,6 @@
   /* Button */
   --fdButton_Text_Shadow: none;
   --fdButton_Emphasized_Border_Width: var(--sapButton_BorderWidth);
-  --fdButton_Emphasized_Border_Color: var(--sapButton_Emphasized_Hover_Background);
 
   /* Input Group */
   --fdInputGroup_Text_Shadow: none;

--- a/src/theming/sap_fiori_3_light_dark.scss
+++ b/src/theming/sap_fiori_3_light_dark.scss
@@ -94,6 +94,8 @@
 
   /* Button */
   --fdButton_Text_Shadow: none;
+  --fdButton_Emphasized_Border_Width: var(--sapButton_BorderWidth);
+  --fdButton_Emphasized_Border_Color: var(--sapButton_Emphasized_Hover_Background);
 
   /* Input Group */
   --fdInputGroup_Text_Shadow: none;
@@ -110,4 +112,15 @@
 
   /** Badge on Button */
   --fdBadgeButton_Border_Color: var(--sapContent_BadgeBackground);
+
+  /* Card */
+  --fdCard_Box_Shadow: var(--sapContent_Shadow0);
+
+  /* Badge */
+  --fdBadge_Border_Color: transparent;
+
+  /* Carousel */
+  --fdCarousel_Dot_Size: 0.25rem;
+  --fdCarousel_Dot_Margin: 0 0.375rem;
+  --fdCarousel_Dot_Border: none;
 }


### PR DESCRIPTION
## Related Issue
Part of SAP/fundamental-styles#1357

## Description
The delta theming parameters for Button, Card, Badge and Carousel have been updates. Also introduced minor styling changes that I noticed when I introduced the deltas, such as the missing border radius for Card Header.

## Screenshots

### Before:
**Button:**
<img width="184" alt="Screen Shot 2020-11-13 at 4 12 03 PM" src="https://user-images.githubusercontent.com/39598672/99122157-d100a000-25cb-11eb-8ebf-9c65fe4e5dda.png">
<img width="174" alt="Screen Shot 2020-11-13 at 4 12 07 PM" src="https://user-images.githubusercontent.com/39598672/99122160-d1993680-25cb-11eb-9aca-248b1418622a.png">
<img width="182" alt="Screen Shot 2020-11-13 at 4 11 55 PM" src="https://user-images.githubusercontent.com/39598672/99122162-d231cd00-25cb-11eb-8418-9656eb70ec38.png">
<img width="167" alt="Screen Shot 2020-11-13 at 4 11 51 PM" src="https://user-images.githubusercontent.com/39598672/99122163-d231cd00-25cb-11eb-898c-92acf709aed7.png">

**Card and Badge:**
<img width="1723" alt="Screen Shot 2020-11-13 at 4 21 32 PM" src="https://user-images.githubusercontent.com/39598672/99122426-4ff5d880-25cc-11eb-9c0c-73530174ba5a.png">
<img width="1720" alt="Screen Shot 2020-11-13 at 4 21 12 PM" src="https://user-images.githubusercontent.com/39598672/99122430-52583280-25cc-11eb-8211-208c200fdda9.png">

**Carousel:**
<img width="505" alt="Screen Shot 2020-11-13 at 4 22 24 PM" src="https://user-images.githubusercontent.com/39598672/99122501-6e5bd400-25cc-11eb-9971-c894a17befd9.png">
<img width="498" alt="Screen Shot 2020-11-13 at 4 22 16 PM" src="https://user-images.githubusercontent.com/39598672/99122504-6ef46a80-25cc-11eb-8891-81e18990afc5.png">


### After:
**Button:**
<img width="186" alt="Screen Shot 2020-11-13 at 4 19 06 PM" src="https://user-images.githubusercontent.com/39598672/99122262-fd1c2100-25cb-11eb-9f51-e69b4fde8940.png">
<img width="201" alt="Screen Shot 2020-11-13 at 4 19 10 PM" src="https://user-images.githubusercontent.com/39598672/99122265-fdb4b780-25cb-11eb-9589-db86c3b06dbf.png">
<img width="212" alt="Screen Shot 2020-11-13 at 4 18 59 PM" src="https://user-images.githubusercontent.com/39598672/99122267-fe4d4e00-25cb-11eb-84fe-308e3aceb5d9.png">
<img width="200" alt="Screen Shot 2020-11-13 at 4 18 53 PM" src="https://user-images.githubusercontent.com/39598672/99122268-fee5e480-25cb-11eb-91db-d3fc2b3cedc4.png">

**Card and Badge:**
<img width="1709" alt="Screen Shot 2020-11-13 at 4 20 17 PM" src="https://user-images.githubusercontent.com/39598672/99122339-276dde80-25cc-11eb-9db3-6392332c56c8.png">
<img width="1705" alt="Screen Shot 2020-11-13 at 4 20 45 PM" src="https://user-images.githubusercontent.com/39598672/99122365-3359a080-25cc-11eb-9595-5fa88c1d5a70.png">

**Carousel:**
<img width="503" alt="Screen Shot 2020-11-13 at 4 23 08 PM" src="https://user-images.githubusercontent.com/39598672/99122553-892e4880-25cc-11eb-871b-375803e4b010.png">
<img width="512" alt="Screen Shot 2020-11-13 at 4 23 01 PM" src="https://user-images.githubusercontent.com/39598672/99122554-89c6df00-25cc-11eb-838b-2115964ed162.png">


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [NA] Text elements follow the truncation rules
- [x ] hover state of the element follow design spec
- [ NA] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [NA] selected hover state of the element follow design spec
- [NA] pressed state of the element follow design spec
- [NA] Responsiveness rules - the component has modifier classes for all breakpoints
- [NA] Includes Compact/Cosy/Tablet design
- [NA] RTL support
2. The code follows fundamental-styles code standards and style
- [NA] only one top level `fd-*` class is used in the file
- [NA] BEM naming convention is used
- [NA] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [NA] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [NA] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [NA] Checked if current components can be reused, instead of having new code.
3. Testing
- [NA] tested Storybook examples with "CSS Resources" `normalize` option 
- [NA] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [NA] Verified all styles in IE11
- [x] Updated tests
4. Documentation
- [NA] Storybook documentation has been created/updated
- [NA] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
