### PR TITLE
fix: replace fade functions

### DIFF
--- a/.storybook/custom/custom.scss
+++ b/.storybook/custom/custom.scss
@@ -290,6 +290,10 @@ code.docs-code-grey {
   .fd-message-box {
     position: static;
     background-color: transparent;
+
+    &::before {
+      background-color: transparent;
+    }
   }
 
   &.fd-dialog__content,

--- a/src/_dialog-placeholders.scss
+++ b/src/_dialog-placeholders.scss
@@ -8,7 +8,6 @@ $fd-dialog-content-padding-x: (s: 1rem, m: 2rem, l: 2rem, xl: 3rem);
 $fd-dialog-title-font-size: 1rem;
 $fd-dialog-footer-button-min-width: 4rem;
 $fd-dialog-body-color: var(--sapGroup_ContentBackground);
-$fd-dialog-overlay-color: rgba(0, 0, 0, 0.6); // Should be fade(var(--sapBlockLayer_Background), 60)
 
 %dialog {
   position: fixed;
@@ -18,7 +17,17 @@ $fd-dialog-overlay-color: rgba(0, 0, 0, 0.6); // Should be fade(var(--sapBlockLa
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: $fd-dialog-overlay-color;
+
+  &::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background-color: var(--sapBlockLayer_Background);
+    opacity: var(--fdDialogBackgroundOpacity);
+  }
 }
 
 %dialog-content {

--- a/src/tabs.scss
+++ b/src/tabs.scss
@@ -89,7 +89,7 @@ $block: #{$fd-namespace}-tabs;
   flex-wrap: wrap;
   padding-left: 0;
   list-style: none;
-  box-shadow: 0 0 0.25rem 0 fade(var(--sapContent_ShadowColor), 15), inset 0 -0.0625rem 0 0 var(--sapObjectHeader_BorderColor);
+  box-shadow: var(--sapContent_HeaderShadow);
   background-color: var(--sapObjectHeader_Background);
   color: $fd-tabs-label-color;
   border-color: var(--sapObjectHeader_BorderColor);

--- a/src/theming/sap_fiori_3.scss
+++ b/src/theming/sap_fiori_3.scss
@@ -129,4 +129,7 @@
   --fdFlexibleColumnBackgroundSolid: var(--sapShell_Background);
   --fdFlexibleColumnBackgroundTranslucent: var(--sapGroup_ContentBackground);
   --fdFlexibleColumnBackgroundTransparent: transparent;
+
+  /** Dialog */
+  --fdDialogBackgroundOpacity: 0.6;
 }

--- a/src/theming/sap_fiori_3_dark.scss
+++ b/src/theming/sap_fiori_3_dark.scss
@@ -129,4 +129,7 @@
   --fdFlexibleColumnBackgroundSolid: var(--sapShell_Background);
   --fdFlexibleColumnBackgroundTranslucent: var(--sapGroup_ContentBackground);
   --fdFlexibleColumnBackgroundTransparent: transparent;
+
+  /** Dialog */
+  --fdDialogBackgroundOpacity: 0.6;
 }

--- a/src/theming/sap_fiori_3_hcb.scss
+++ b/src/theming/sap_fiori_3_hcb.scss
@@ -129,4 +129,7 @@
   --fdFlexibleColumnBackgroundSolid: var(--sapBackgroundColor);
   --fdFlexibleColumnBackgroundTranslucent: var(--sapBackgroundColor);
   --fdFlexibleColumnBackgroundTransparent: var(--sapBackgroundColor);
+
+  /** Dialog */
+  --fdDialogBackgroundOpacity: 0.8;
 }

--- a/src/theming/sap_fiori_3_hcw.scss
+++ b/src/theming/sap_fiori_3_hcw.scss
@@ -129,4 +129,7 @@
   --fdFlexibleColumnBackgroundSolid: var(--sapBackgroundColor);
   --fdFlexibleColumnBackgroundTranslucent: var(--sapBackgroundColor);
   --fdFlexibleColumnBackgroundTransparent: var(--sapBackgroundColor);
+
+  /** Dialog */
+  --fdDialogBackgroundOpacity: 0.8;
 }

--- a/src/theming/sap_fiori_3_light_dark.scss
+++ b/src/theming/sap_fiori_3_light_dark.scss
@@ -129,4 +129,7 @@
   --fdFlexibleColumnBackgroundSolid: var(--sapShell_Background);
   --fdFlexibleColumnBackgroundTranslucent: var(--sapGroup_ContentBackground);
   --fdFlexibleColumnBackgroundTransparent: transparent;
+
+  /** Dialog */
+  --fdDialogBackgroundOpacity: 0.6;
 }

--- a/src/tile.scss
+++ b/src/tile.scss
@@ -4,6 +4,9 @@
 
 $block: #{$fd-namespace}-tile;
 
+// BASE
+$fd-tile-interactive-border: 0.0625rem solid var(--sapTile_Interactive_BorderColor);
+
 // SIZES
 $fd-tile-height: 11rem !default;
 $fd-tile-width: 11rem !default;
@@ -150,12 +153,12 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
   // STATES
   @include fd-active() {
     background: var(--sapTile_Active_Background);
-    // box-shadow: 0 0 0 1px fade(var(--sapContent_ShadowColor), 30);
+    border: $fd-tile-interactive-border;
   }
 
   @include fd-hover() {
     background: var(--sapTile_Hover_Background);
-    // box-shadow: 0 0 0 1px fade(var(--sapContent_ShadowColor), 30);
+    border: $fd-tile-interactive-border;
 
     .#{$block}__toggle {
       display: block;

--- a/src/toolbar.scss
+++ b/src/toolbar.scss
@@ -32,11 +32,10 @@ $title-toolbar-height: 2.75rem;
 }
 
 @mixin toolbarInfo() {
-  // no contrast function color: contrast(@sapUiInfobarBackground, @ sapUiBaseText , @ sapUiContentContrastTextColor , @sapUiContentContrastTextThreshold);
-  $active-color: white;
+  $active-color: var(--sapInfobar__TextColor);
 
-  // no contrast function: background: darken(@sapUiListBackground, 10);
-  background-color: var(--sapBackgroundColor);
+  background-color: var(--sapInfobar_NonInteractive_Background);
+  color: var(--sapList_TextColor);
 
   @include activeStyles() {
     background-color: var(--sapInfobar_Background);


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#625

## Description
There is:
- Dialog component changed overlay - from fade usage to pseudo element with opacity.
- tabs variable corrected
- tile variable corrected
- toolbar variable corrected

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:


### After:

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] Colors
2. The code follows fundamental-styles code standards and style
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests