### PR TITLE
fix: icons for message-box

### DIFF
--- a/src/message-box.scss
+++ b/src/message-box.scss
@@ -5,6 +5,7 @@
 $block: #{$fd-namespace}-message-box;
 $bar: #{$fd-namespace}-bar;
 $button: #{$fd-namespace}-button;
+$message: #{$fd-namespace}-message;
 
 $fd-message-box-icon-text-spacing: 0.5rem;
 $fd-message-box-title-icon-text-size: 1rem;
@@ -99,8 +100,8 @@ $message-box-states: (
         box-shadow: map_get($state-set, "boxShadow");
       }
 
-      .#{$block}__title {
-        @include fd-icon-base () {
+      .#{$message}__title {
+        @include fd-icon-base ("before") {
           position: relative;
           top: 0.0625rem;
           font-size: $fd-message-box-title-icon-text-size;
@@ -111,18 +112,18 @@ $message-box-states: (
       }
 
       @include fd-rtl() {
-        .#{$block}__title::before {
+        .#{$message}-title::before {
           margin-right: 0;
           margin-left: $fd-message-box-icon-text-spacing;
         }
       }
+    }
+  }
 
-      &.#{$block}--no-icon {
-        .#{$block}__title::before {
-          content: '';
-          margin: 0;
-        }
-      }
+  &--no-icon {
+    .#{$message}__title::before {
+      content: none;
+      margin: 0;
     }
   }
 }

--- a/src/message-box.scss
+++ b/src/message-box.scss
@@ -99,7 +99,7 @@ $message-box-states: (
         box-shadow: map_get($state-set, "boxShadow");
       }
 
-      .#{$block}__title {
+      .#{$block}__icon {
         font-style: normal;
 
         @include fd-icon-base () {
@@ -113,7 +113,7 @@ $message-box-states: (
       }
 
       @include fd-rtl() {
-        .#{$block}__title::before {
+        .#{$block}__icon::before {
           margin-right: 0;
           margin-left: $fd-message-box-icon-text-spacing;
         }
@@ -122,7 +122,7 @@ $message-box-states: (
   }
 
   &--no-icon {
-    .#{$block}__title::before {
+    .#{$block}__icon::before {
       content: none;
       margin: 0;
     }

--- a/src/message-box.scss
+++ b/src/message-box.scss
@@ -100,7 +100,7 @@ $message-box-states: (
         box-shadow: map_get($state-set, "boxShadow");
       }
 
-      .#{$message}__title {
+      .#{$block}__title {
         @include fd-icon-base ("before") {
           position: relative;
           top: 0.0625rem;

--- a/src/message-box.scss
+++ b/src/message-box.scss
@@ -27,6 +27,9 @@ $message-box-states: (
 .#{$block} {
   @include fd-reset();
 
+  position: relative;
+  z-index: 1;
+
   @extend %dialog;
 
   display: none;

--- a/src/message-box.scss
+++ b/src/message-box.scss
@@ -29,14 +29,22 @@ $message-box-states: (
 
   position: relative;
   z-index: 1;
+  background-color: transparent;
 
   @extend %dialog;
 
   display: none;
 
+  &::before {
+    background-color: transparent;
+  }
+
   // ELEMENTS
   &__content {
     @include fd-reset();
+
+    position: relative;
+    z-index: 1;
 
     @extend %dialog-content;
 

--- a/src/message-box.scss
+++ b/src/message-box.scss
@@ -5,7 +5,6 @@
 $block: #{$fd-namespace}-message-box;
 $bar: #{$fd-namespace}-bar;
 $button: #{$fd-namespace}-button;
-$message: #{$fd-namespace}-message;
 
 $fd-message-box-icon-text-spacing: 0.5rem;
 $fd-message-box-title-icon-text-size: 1rem;
@@ -101,7 +100,9 @@ $message-box-states: (
       }
 
       .#{$block}__title {
-        @include fd-icon-base ("before") {
+        font-style: normal;
+
+        @include fd-icon-base () {
           position: relative;
           top: 0.0625rem;
           font-size: $fd-message-box-title-icon-text-size;
@@ -112,7 +113,7 @@ $message-box-states: (
       }
 
       @include fd-rtl() {
-        .#{$message}-title::before {
+        .#{$block}__title::before {
           margin-right: 0;
           margin-left: $fd-message-box-icon-text-spacing;
         }
@@ -121,7 +122,7 @@ $message-box-states: (
   }
 
   &--no-icon {
-    .#{$message}__title::before {
+    .#{$block}__title::before {
       content: none;
       margin: 0;
     }

--- a/stories/message-box/__snapshots__/message-box.stories.storyshot
+++ b/stories/message-box/__snapshots__/message-box.stories.storyshot
@@ -26,8 +26,13 @@ exports[`Storyshots Components/Message Box Default 1`] = `
         >
           
                     
+          <i
+            class="fd-message-box__icon"
+          />
+          
+                    
           <h2
-            class="fd-title fd-title--h5 fd-message__title"
+            class="fd-title fd-title--h5 fd-message-box__title"
           >
             Title
           </h2>
@@ -136,8 +141,13 @@ exports[`Storyshots Components/Message Box No icon 1`] = `
           >
             
                     
+            <i
+              class="fd-message-box__icon"
+            />
+            
+                    
             <h2
-              class="fd-title fd-title--h5 fd-message__title"
+              class="fd-title fd-title--h5 fd-message-box__title"
             >
               Success
             </h2>
@@ -249,8 +259,13 @@ exports[`Storyshots Components/Message Box No icon 1`] = `
           >
             
                     
+            <i
+              class="fd-message-box__icon"
+            />
+            
+                    
             <h2
-              class="fd-title fd-title--h5 fd-message__title"
+              class="fd-title fd-title--h5 fd-message-box__title"
             >
               Error
             </h2>
@@ -345,8 +360,13 @@ exports[`Storyshots Components/Message Box Responsive 1`] = `
           >
             
                     
+            <i
+              class="fd-message-box__icon"
+            />
+            
+                    
             <h2
-              class="fd-title fd-title--h5 fd-message__title"
+              class="fd-title fd-title--h5 fd-message-box__title"
             >
               Information
             </h2>
@@ -458,8 +478,13 @@ exports[`Storyshots Components/Message Box Responsive 1`] = `
           >
             
                     
+            <i
+              class="fd-message-box__icon"
+            />
+            
+                    
             <h2
-              class="fd-title fd-title--h5 fd-message__title"
+              class="fd-title fd-title--h5 fd-message-box__title"
             >
               Error
             </h2>
@@ -555,8 +580,13 @@ exports[`Storyshots Components/Message Box Responsive 1`] = `
           >
             
                     
+            <i
+              class="fd-message-box__icon"
+            />
+            
+                    
             <h2
-              class="fd-title fd-title--h5 fd-message__title"
+              class="fd-title fd-title--h5 fd-message-box__title"
             >
               Success
             </h2>
@@ -651,8 +681,13 @@ exports[`Storyshots Components/Message Box Responsive 1`] = `
           >
             
                     
+            <i
+              class="fd-message-box__icon"
+            />
+            
+                    
             <h2
-              class="fd-title fd-title--h5 fd-message__title"
+              class="fd-title fd-title--h5 fd-message-box__title"
             >
               Warning
             </h2>
@@ -745,8 +780,13 @@ exports[`Storyshots Components/Message Box Semantic types 1`] = `
           >
             
                     
+            <i
+              class="fd-message-box__icon"
+            />
+            
+                    
             <h2
-              class="fd-title fd-title--h5 fd-message__title"
+              class="fd-title fd-title--h5 fd-message-box__title"
             >
               Confirmation
             </h2>
@@ -858,8 +898,13 @@ exports[`Storyshots Components/Message Box Semantic types 1`] = `
           >
             
                     
+            <i
+              class="fd-message-box__icon"
+            />
+            
+                    
             <h2
-              class="fd-title fd-title--h5 fd-message__title"
+              class="fd-title fd-title--h5 fd-message-box__title"
             >
               Error
             </h2>
@@ -954,8 +999,13 @@ exports[`Storyshots Components/Message Box Semantic types 1`] = `
           >
             
                     
+            <i
+              class="fd-message-box__icon"
+            />
+            
+                    
             <h2
-              class="fd-title fd-title--h5 fd-message__title"
+              class="fd-title fd-title--h5 fd-message-box__title"
             >
               Success
             </h2>
@@ -1050,8 +1100,13 @@ exports[`Storyshots Components/Message Box Semantic types 1`] = `
           >
             
                     
+            <i
+              class="fd-message-box__icon"
+            />
+            
+                    
             <h2
-              class="fd-title fd-title--h5 fd-message__title"
+              class="fd-title fd-title--h5 fd-message-box__title"
             >
               Warning
             </h2>
@@ -1146,8 +1201,13 @@ exports[`Storyshots Components/Message Box Semantic types 1`] = `
           >
             
                     
+            <i
+              class="fd-message-box__icon"
+            />
+            
+                    
             <h2
-              class="fd-title fd-title--h5 fd-message__title"
+              class="fd-title fd-title--h5 fd-message-box__title"
             >
               Information
             </h2>

--- a/stories/message-box/__snapshots__/message-box.stories.storyshot
+++ b/stories/message-box/__snapshots__/message-box.stories.storyshot
@@ -27,7 +27,7 @@ exports[`Storyshots Components/Message Box Default 1`] = `
           
                     
           <h2
-            class="fd-title fd-title--h5"
+            class="fd-title fd-title--h5 fd-message__title"
           >
             Title
           </h2>
@@ -112,7 +112,7 @@ exports[`Storyshots Components/Message Box No icon 1`] = `
   
 
   <div
-    class="fd-message-box-docs-static fd-message-box fd-message-box--no-icon fd-message-box--success fd-message-box--active"
+    class="fd-message-box-docs-static fd-message-box fd-message-box--success fd-message-box--no-icon fd-message-box--active"
   >
     
     
@@ -137,7 +137,7 @@ exports[`Storyshots Components/Message Box No icon 1`] = `
             
                     
             <h2
-              class="fd-title fd-title--h5"
+              class="fd-title fd-title--h5 fd-message__title"
             >
               Success
             </h2>
@@ -250,7 +250,7 @@ exports[`Storyshots Components/Message Box No icon 1`] = `
             
                     
             <h2
-              class="fd-title fd-title--h5"
+              class="fd-title fd-title--h5 fd-message__title"
             >
               Error
             </h2>
@@ -346,7 +346,7 @@ exports[`Storyshots Components/Message Box Responsive 1`] = `
             
                     
             <h2
-              class="fd-title fd-title--h5"
+              class="fd-title fd-title--h5 fd-message__title"
             >
               Information
             </h2>
@@ -459,7 +459,7 @@ exports[`Storyshots Components/Message Box Responsive 1`] = `
             
                     
             <h2
-              class="fd-title fd-title--h5"
+              class="fd-title fd-title--h5 fd-message__title"
             >
               Error
             </h2>
@@ -556,7 +556,7 @@ exports[`Storyshots Components/Message Box Responsive 1`] = `
             
                     
             <h2
-              class="fd-title fd-title--h5"
+              class="fd-title fd-title--h5 fd-message__title"
             >
               Success
             </h2>
@@ -652,7 +652,7 @@ exports[`Storyshots Components/Message Box Responsive 1`] = `
             
                     
             <h2
-              class="fd-title fd-title--h5"
+              class="fd-title fd-title--h5 fd-message__title"
             >
               Warning
             </h2>
@@ -746,7 +746,7 @@ exports[`Storyshots Components/Message Box Semantic types 1`] = `
             
                     
             <h2
-              class="fd-title fd-title--h5"
+              class="fd-title fd-title--h5 fd-message__title"
             >
               Confirmation
             </h2>
@@ -859,7 +859,7 @@ exports[`Storyshots Components/Message Box Semantic types 1`] = `
             
                     
             <h2
-              class="fd-title fd-title--h5"
+              class="fd-title fd-title--h5 fd-message__title"
             >
               Error
             </h2>
@@ -955,7 +955,7 @@ exports[`Storyshots Components/Message Box Semantic types 1`] = `
             
                     
             <h2
-              class="fd-title fd-title--h5"
+              class="fd-title fd-title--h5 fd-message__title"
             >
               Success
             </h2>
@@ -1051,7 +1051,7 @@ exports[`Storyshots Components/Message Box Semantic types 1`] = `
             
                     
             <h2
-              class="fd-title fd-title--h5"
+              class="fd-title fd-title--h5 fd-message__title"
             >
               Warning
             </h2>
@@ -1147,7 +1147,7 @@ exports[`Storyshots Components/Message Box Semantic types 1`] = `
             
                     
             <h2
-              class="fd-title fd-title--h5"
+              class="fd-title fd-title--h5 fd-message__title"
             >
               Information
             </h2>

--- a/stories/message-box/message-box.stories.js
+++ b/stories/message-box/message-box.stories.js
@@ -56,7 +56,8 @@ export const structure = () => `<div class="fd-message-box-docs-static fd-messag
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Title</h2>
+                    <i class="fd-message-box__title"></i>
+                    <h2 class="fd-title fd-title--h5">Title</h2>
                 </div>
             </div>
         </header>
@@ -97,7 +98,8 @@ export const types = () => `<div class="fd-message-box-docs-static fd-message-bo
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Confirmation</h2>
+                    <i class="fd-message-box__title"></i>
+                    <h2 class="fd-title fd-title--h5">Confirmation</h2>
                 </div>
             </div>
         </header>
@@ -128,7 +130,8 @@ export const types = () => `<div class="fd-message-box-docs-static fd-message-bo
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Error</h2>
+                    <i class="fd-message-box__title"></i>
+                    <h2 class="fd-title fd-title--h5">Error</h2>
                 </div>
             </div>
         </header>
@@ -154,7 +157,8 @@ export const types = () => `<div class="fd-message-box-docs-static fd-message-bo
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Success</h2>
+                    <i class="fd-message-box__title"></i>
+                    <h2 class="fd-title fd-title--h5">Success</h2>
                 </div>
             </div>
         </header>
@@ -180,7 +184,8 @@ export const types = () => `<div class="fd-message-box-docs-static fd-message-bo
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Warning</h2>
+                    <i class="fd-message-box__title"></i>
+                    <h2 class="fd-title fd-title--h5">Warning</h2>
                 </div>
             </div>
         </header>
@@ -206,7 +211,8 @@ export const types = () => `<div class="fd-message-box-docs-static fd-message-bo
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Information</h2>
+                    <i class="fd-message-box__title"></i>
+                    <h2 class="fd-title fd-title--h5">Information</h2>
                 </div>
             </div>
         </header>
@@ -253,7 +259,8 @@ export const noIcon = () =>
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Success</h2>
+                    <i class="fd-message-box__title"></i>
+                    <h2 class="fd-title fd-title--h5">Success</h2>
                 </div>
             </div>
         </header>
@@ -282,7 +289,8 @@ export const noIcon = () =>
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Error</h2>
+                    <i class="fd-message-box__title"></i>
+                    <h2 class="fd-title fd-title--h5">Error</h2>
                 </div>
             </div>
         </header>
@@ -319,7 +327,8 @@ export const responsive = () =>
         <header class="fd-bar fd-bar--cozy fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Information</h2>
+                    <i class="fd-message-box__title"></i>
+                    <h2 class="fd-title fd-title--h5">Information</h2>
                 </div>
             </div>
         </header>
@@ -348,7 +357,8 @@ export const responsive = () =>
         <header class="fd-bar fd-bar--cozy fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Error</h2>
+                    <i class="fd-message-box__title"></i>
+                    <h2 class="fd-title fd-title--h5">Error</h2>
                 </div>
             </div>
         </header>
@@ -375,7 +385,8 @@ export const responsive = () =>
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Success</h2>
+                    <i class="fd-message-box__title"></i>
+                    <h2 class="fd-title fd-title--h5">Success</h2>
                 </div>
             </div>
         </header>
@@ -401,7 +412,8 @@ export const responsive = () =>
         <header class="fd-bar fd-bar--header fd-message-box__header">
              <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Warning</h2>
+                    <i class="fd-message-box__title"></i>
+                    <h2 class="fd-title fd-title--h5">Warning</h2>
                 </div>
             </div>
         </header>

--- a/stories/message-box/message-box.stories.js
+++ b/stories/message-box/message-box.stories.js
@@ -56,7 +56,7 @@ export const structure = () => `<div class="fd-message-box-docs-static fd-messag
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5">Title</h2>
+                    <h2 class="fd-title fd-title--h5 fd-message__title">Title</h2>
                 </div>
             </div>
         </header>
@@ -97,7 +97,7 @@ export const types = () => `<div class="fd-message-box-docs-static fd-message-bo
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5">Confirmation</h2>
+                    <h2 class="fd-title fd-title--h5 fd-message__title">Confirmation</h2>
                 </div>
             </div>
         </header>
@@ -128,7 +128,7 @@ export const types = () => `<div class="fd-message-box-docs-static fd-message-bo
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5">Error</h2>
+                    <h2 class="fd-title fd-title--h5 fd-message__title">Error</h2>
                 </div>
             </div>
         </header>
@@ -154,7 +154,7 @@ export const types = () => `<div class="fd-message-box-docs-static fd-message-bo
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5">Success</h2>
+                    <h2 class="fd-title fd-title--h5 fd-message__title">Success</h2>
                 </div>
             </div>
         </header>
@@ -180,7 +180,7 @@ export const types = () => `<div class="fd-message-box-docs-static fd-message-bo
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5">Warning</h2>
+                    <h2 class="fd-title fd-title--h5 fd-message__title">Warning</h2>
                 </div>
             </div>
         </header>
@@ -206,7 +206,7 @@ export const types = () => `<div class="fd-message-box-docs-static fd-message-bo
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5">Information</h2>
+                    <h2 class="fd-title fd-title--h5 fd-message__title">Information</h2>
                 </div>
             </div>
         </header>
@@ -248,12 +248,12 @@ Information | \`fd-message-box--information\` | Information messages provide inf
 
 export const noIcon = () =>
     `
-<div class="fd-message-box-docs-static fd-message-box fd-message-box--no-icon fd-message-box--success fd-message-box--active">
+<div class="fd-message-box-docs-static fd-message-box fd-message-box--success fd-message-box--no-icon fd-message-box--active">
     <section class="fd-message-box__content">
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5">Success</h2>
+                    <h2 class="fd-title fd-title--h5 fd-message__title">Success</h2>
                 </div>
             </div>
         </header>
@@ -282,7 +282,7 @@ export const noIcon = () =>
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5">Error</h2>
+                    <h2 class="fd-title fd-title--h5 fd-message__title">Error</h2>
                 </div>
             </div>
         </header>
@@ -319,7 +319,7 @@ export const responsive = () =>
         <header class="fd-bar fd-bar--cozy fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5">Information</h2>
+                    <h2 class="fd-title fd-title--h5 fd-message__title">Information</h2>
                 </div>
             </div>
         </header>
@@ -348,7 +348,7 @@ export const responsive = () =>
         <header class="fd-bar fd-bar--cozy fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5">Error</h2>
+                    <h2 class="fd-title fd-title--h5 fd-message__title">Error</h2>
                 </div>
             </div>
         </header>
@@ -375,7 +375,7 @@ export const responsive = () =>
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5">Success</h2>
+                    <h2 class="fd-title fd-title--h5 fd-message__title">Success</h2>
                 </div>
             </div>
         </header>
@@ -401,7 +401,7 @@ export const responsive = () =>
         <header class="fd-bar fd-bar--header fd-message-box__header">
              <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5">Warning</h2>
+                    <h2 class="fd-title fd-title--h5 fd-message__title">Warning</h2>
                 </div>
             </div>
         </header>

--- a/stories/message-box/message-box.stories.js
+++ b/stories/message-box/message-box.stories.js
@@ -40,6 +40,7 @@ Note: Include two action buttons in the message box when the user's decision is 
     - \`.fd-message-box__content\`: Content container
         - \`.fd-message-box__header\`: Header
             - \`.fd-message-box__title\`: Title
+            - \`.fd-message-box__icon\`: Icon
         - \`.fd-message-box__body\`: Content body
         - \`.fd-message-box__footer\`: Footer
             - \`.fd-message-box__decisive-button\`: Action buttons in footer
@@ -56,8 +57,8 @@ export const structure = () => `<div class="fd-message-box-docs-static fd-messag
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <i class="fd-message-box__title"></i>
-                    <h2 class="fd-title fd-title--h5">Title</h2>
+                    <i class="fd-message-box__icon"></i>
+                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Title</h2>
                 </div>
             </div>
         </header>
@@ -98,8 +99,8 @@ export const types = () => `<div class="fd-message-box-docs-static fd-message-bo
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <i class="fd-message-box__title"></i>
-                    <h2 class="fd-title fd-title--h5">Confirmation</h2>
+                    <i class="fd-message-box__icon"></i>
+                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Confirmation</h2>
                 </div>
             </div>
         </header>
@@ -130,8 +131,8 @@ export const types = () => `<div class="fd-message-box-docs-static fd-message-bo
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <i class="fd-message-box__title"></i>
-                    <h2 class="fd-title fd-title--h5">Error</h2>
+                    <i class="fd-message-box__icon"></i>
+                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Error</h2>
                 </div>
             </div>
         </header>
@@ -157,8 +158,8 @@ export const types = () => `<div class="fd-message-box-docs-static fd-message-bo
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <i class="fd-message-box__title"></i>
-                    <h2 class="fd-title fd-title--h5">Success</h2>
+                    <i class="fd-message-box__icon"></i>
+                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Success</h2>
                 </div>
             </div>
         </header>
@@ -184,8 +185,8 @@ export const types = () => `<div class="fd-message-box-docs-static fd-message-bo
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <i class="fd-message-box__title"></i>
-                    <h2 class="fd-title fd-title--h5">Warning</h2>
+                    <i class="fd-message-box__icon"></i>
+                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Warning</h2>
                 </div>
             </div>
         </header>
@@ -211,8 +212,8 @@ export const types = () => `<div class="fd-message-box-docs-static fd-message-bo
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <i class="fd-message-box__title"></i>
-                    <h2 class="fd-title fd-title--h5">Information</h2>
+                    <i class="fd-message-box__icon"></i>
+                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Information</h2>
                 </div>
             </div>
         </header>
@@ -259,8 +260,8 @@ export const noIcon = () =>
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <i class="fd-message-box__title"></i>
-                    <h2 class="fd-title fd-title--h5">Success</h2>
+                    <i class="fd-message-box__icon"></i>
+                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Success</h2>
                 </div>
             </div>
         </header>
@@ -289,8 +290,8 @@ export const noIcon = () =>
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <i class="fd-message-box__title"></i>
-                    <h2 class="fd-title fd-title--h5">Error</h2>
+                    <i class="fd-message-box__icon"></i>
+                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Error</h2>
                 </div>
             </div>
         </header>
@@ -327,8 +328,8 @@ export const responsive = () =>
         <header class="fd-bar fd-bar--cozy fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <i class="fd-message-box__title"></i>
-                    <h2 class="fd-title fd-title--h5">Information</h2>
+                    <i class="fd-message-box__icon"></i>
+                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Information</h2>
                 </div>
             </div>
         </header>
@@ -357,8 +358,8 @@ export const responsive = () =>
         <header class="fd-bar fd-bar--cozy fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <i class="fd-message-box__title"></i>
-                    <h2 class="fd-title fd-title--h5">Error</h2>
+                    <i class="fd-message-box__icon"></i>
+                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Error</h2>
                 </div>
             </div>
         </header>
@@ -385,8 +386,8 @@ export const responsive = () =>
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <i class="fd-message-box__title"></i>
-                    <h2 class="fd-title fd-title--h5">Success</h2>
+                    <i class="fd-message-box__icon"></i>
+                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Success</h2>
                 </div>
             </div>
         </header>
@@ -412,8 +413,8 @@ export const responsive = () =>
         <header class="fd-bar fd-bar--header fd-message-box__header">
              <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <i class="fd-message-box__title"></i>
-                    <h2 class="fd-title fd-title--h5">Warning</h2>
+                    <i class="fd-message-box__icon"></i>
+                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Warning</h2>
                 </div>
             </div>
         </header>

--- a/stories/message-box/message-box.stories.js
+++ b/stories/message-box/message-box.stories.js
@@ -37,12 +37,12 @@ Note: Include two action buttons in the message box when the user's decision is 
 **Message box follows the structure of a dialog, consisting of following elements:**
 
 - \`.fd-message-box\`: styles the backdrop and displays the message box container with \`position: fixed\`. The message box becomes visible by adding the \`.fd-message--active\` modifier class to the container.
-    - \`.fd-message__content\`: Content container
-        - \`.fd-message__header\`: Header
-            - \`.fd-message__title\`: Title
-        - \`.fd-message__body\`: Content body
-        - \`.fd-message__footer\`: Footer
-            - \`.fd-message__decisive-button\`: Action buttons in footer
+    - \`.fd-message-box__content\`: Content container
+        - \`.fd-message-box__header\`: Header
+            - \`.fd-message-box__title\`: Title
+        - \`.fd-message-box__body\`: Content body
+        - \`.fd-message-box__footer\`: Footer
+            - \`.fd-message-box__decisive-button\`: Action buttons in footer
         `,
         tags: ['f3', 'a11y', 'theme'],
         components: ['message-box', 'title', 'bar', 'button', 'link']
@@ -56,7 +56,7 @@ export const structure = () => `<div class="fd-message-box-docs-static fd-messag
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5 fd-message__title">Title</h2>
+                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Title</h2>
                 </div>
             </div>
         </header>
@@ -97,7 +97,7 @@ export const types = () => `<div class="fd-message-box-docs-static fd-message-bo
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5 fd-message__title">Confirmation</h2>
+                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Confirmation</h2>
                 </div>
             </div>
         </header>
@@ -128,7 +128,7 @@ export const types = () => `<div class="fd-message-box-docs-static fd-message-bo
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5 fd-message__title">Error</h2>
+                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Error</h2>
                 </div>
             </div>
         </header>
@@ -154,7 +154,7 @@ export const types = () => `<div class="fd-message-box-docs-static fd-message-bo
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5 fd-message__title">Success</h2>
+                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Success</h2>
                 </div>
             </div>
         </header>
@@ -180,7 +180,7 @@ export const types = () => `<div class="fd-message-box-docs-static fd-message-bo
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5 fd-message__title">Warning</h2>
+                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Warning</h2>
                 </div>
             </div>
         </header>
@@ -206,7 +206,7 @@ export const types = () => `<div class="fd-message-box-docs-static fd-message-bo
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5 fd-message__title">Information</h2>
+                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Information</h2>
                 </div>
             </div>
         </header>
@@ -253,7 +253,7 @@ export const noIcon = () =>
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5 fd-message__title">Success</h2>
+                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Success</h2>
                 </div>
             </div>
         </header>
@@ -282,7 +282,7 @@ export const noIcon = () =>
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5 fd-message__title">Error</h2>
+                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Error</h2>
                 </div>
             </div>
         </header>
@@ -319,7 +319,7 @@ export const responsive = () =>
         <header class="fd-bar fd-bar--cozy fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5 fd-message__title">Information</h2>
+                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Information</h2>
                 </div>
             </div>
         </header>
@@ -348,7 +348,7 @@ export const responsive = () =>
         <header class="fd-bar fd-bar--cozy fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5 fd-message__title">Error</h2>
+                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Error</h2>
                 </div>
             </div>
         </header>
@@ -375,7 +375,7 @@ export const responsive = () =>
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5 fd-message__title">Success</h2>
+                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Success</h2>
                 </div>
             </div>
         </header>
@@ -401,7 +401,7 @@ export const responsive = () =>
         <header class="fd-bar fd-bar--header fd-message-box__header">
              <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5 fd-message__title">Warning</h2>
+                    <h2 class="fd-title fd-title--h5 fd-message-box__title">Warning</h2>
                 </div>
             </div>
         </header>

--- a/stories/message-box/message-box.stories.js
+++ b/stories/message-box/message-box.stories.js
@@ -52,7 +52,7 @@ Note: Include two action buttons in the message box when the user's decision is 
 
 const messageBoxHeight = 200;
 
-export const structure = () => `<div class="fd-message-box-docs-static fd-message-box fd-message-box--active">
+export const structure = () => `<div class="fd-message-box fd-message-box--active">
     <section class="fd-message-box__content">
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
@@ -94,7 +94,7 @@ The default message box displays a small dialog with a title, message text and a
     }
 };
 
-export const types = () => `<div class="fd-message-box-docs-static fd-message-box fd-message-box--confirmation fd-message-box--active">
+export const types = () => `<div class="fd-message-box fd-message-box--confirmation fd-message-box--active">
     <section class="fd-message-box__content">
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
@@ -126,7 +126,7 @@ export const types = () => `<div class="fd-message-box-docs-static fd-message-bo
 
 <br><br><br>
 
-<div class="fd-message-box-docs-static fd-message-box fd-message-box--error fd-message-box--active">
+<div class="fd-message-box fd-message-box--error fd-message-box--active">
     <section class="fd-message-box__content">
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
@@ -153,7 +153,7 @@ export const types = () => `<div class="fd-message-box-docs-static fd-message-bo
 
 <br><br><br>
 
-<div class="fd-message-box-docs-static fd-message-box fd-message-box--success fd-message-box--active">
+<div class="fd-message-box fd-message-box--success fd-message-box--active">
     <section class="fd-message-box__content">
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
@@ -180,7 +180,7 @@ export const types = () => `<div class="fd-message-box-docs-static fd-message-bo
 
 <br><br><br>
 
-<div class="fd-message-box-docs-static fd-message-box fd-message-box--warning fd-message-box--active">
+<div class="fd-message-box fd-message-box--warning fd-message-box--active">
     <section class="fd-message-box__content">
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
@@ -207,7 +207,7 @@ export const types = () => `<div class="fd-message-box-docs-static fd-message-bo
 
 <br><br><br>
 
-<div class="fd-message-box-docs-static fd-message-box fd-message-box--information fd-message-box--active">
+<div class="fd-message-box fd-message-box--information fd-message-box--active">
     <section class="fd-message-box__content">
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
@@ -255,7 +255,7 @@ Information | \`fd-message-box--information\` | Information messages provide inf
 
 export const noIcon = () =>
     `
-<div class="fd-message-box-docs-static fd-message-box fd-message-box--success fd-message-box--no-icon fd-message-box--active">
+<div class="fd-message-box fd-message-box--success fd-message-box--no-icon fd-message-box--active">
     <section class="fd-message-box__content">
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
@@ -285,7 +285,7 @@ export const noIcon = () =>
 
 <br><br><br>
 
-<div class="fd-message-box-docs-static fd-message-box fd-message-box--error fd-message-box--no-icon fd-message-box--active">
+<div class="fd-message-box fd-message-box--error fd-message-box--no-icon fd-message-box--active">
     <section class="fd-message-box__content">
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
@@ -323,7 +323,7 @@ noIcon.parameters = {
 
 export const responsive = () =>
     `
-<div class="fd-message-box-docs-static fd-message-box fd-message-box--information fd-message-box--active">
+<div class="fd-message-box fd-message-box--information fd-message-box--active">
     <section class="fd-message-box__content fd-message-box__content--s">
         <header class="fd-bar fd-bar--cozy fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
@@ -353,7 +353,7 @@ export const responsive = () =>
 
 <br><br><br>
 
-<div class="fd-message-box-docs-static fd-message-box fd-message-box--error fd-message-box--active">
+<div class="fd-message-box fd-message-box--error fd-message-box--active">
     <section class="fd-message-box__content fd-message-box__content--m">
         <header class="fd-bar fd-bar--cozy fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
@@ -381,7 +381,7 @@ export const responsive = () =>
 
 <br><br><br>
 
-<div class="fd-message-box-docs-static fd-message-box fd-message-box--success fd-message-box--active">
+<div class="fd-message-box fd-message-box--success fd-message-box--active">
     <section class="fd-message-box__content fd-message-box__content--l">
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
@@ -408,7 +408,7 @@ export const responsive = () =>
 
 <br><br><br>
 
-<div class="fd-message-box-docs-static fd-message-box fd-message-box--warning fd-message-box--active">
+<div class="fd-message-box fd-message-box--warning fd-message-box--active">
     <section class="fd-message-box__content fd-message-box__content--xl">
         <header class="fd-bar fd-bar--header fd-message-box__header">
              <div class="fd-bar__left">


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#1896

## Description
Fixes the icons so that they are displayed with message box
## Screenshots

### Before:
![Screen Shot 2020-11-24 at 10 38 11 AM](https://user-images.githubusercontent.com/50607147/100116052-4a588800-2e41-11eb-800d-b279d3303da7.png)


### After:
![Screen Shot 2020-11-24 at 10 37 51 AM](https://user-images.githubusercontent.com/50607147/100116028-4298e380-2e41-11eb-9bc8-ee2338be3ee1.png)

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
