### PR TITLE
fix: date time picker segmented button

### DIFF
--- a/stories/datepicker/__snapshots__/datepicker.stories.storyshot
+++ b/stories/datepicker/__snapshots__/datepicker.stories.storyshot
@@ -3086,6 +3086,7 @@ exports[`Storyshots Patterns/Date Picker Mobile portrait mode with today navigat
               
               
               <button
+                aria-label="date-button"
                 class="fd-button is-active"
               >
                 Date
@@ -3093,6 +3094,7 @@ exports[`Storyshots Patterns/Date Picker Mobile portrait mode with today navigat
               
               
               <button
+                aria-label="time-button"
                 class="fd-button"
               >
                 Time

--- a/stories/datepicker/datepicker.stories.js
+++ b/stories/datepicker/datepicker.stories.js
@@ -10,7 +10,7 @@ The date-picker component is an opinionated composition of the <code>input-group
 
 This component mostly relies on the CSS of other components and has very little CSS of its own.
 `,
-        components: ['calendar', 'input-group', 'popover', 'title', 'button', 'input', 'form-label', 'icon', 'bar', 'dialog']
+        components: ['calendar', 'input-group', 'popover', 'title', 'button', 'input', 'form-label', 'icon', 'bar', 'dialog', 'segmented-button']
     }
 };
 
@@ -1118,8 +1118,8 @@ export const mobilePortrait = () => `<div class="fd-dialog-docs-static fd-calend
         <div class="fd-calendar__header">
           <div class="fd-calendar__navigation">
             <div class="fd-segmented-button" role="group" aria-label="Switch Date/Time picker">
-              <button class="fd-button is-active">Date</button>
-              <button class="fd-button">Time</button>
+              <button aria-label="date-button" class="fd-button is-active">Date</button>
+              <button aria-label="time-button" class="fd-button">Time</button>
             </div>
           </div>
           <div class="fd-calendar__navigation">


### PR DESCRIPTION
## Related Issue
Part of #907 

## Description
Changes the two buttons two one split button for the DateTime picker

## Screenshots

### Before:
![Screen Shot 2020-12-01 at 11 42 08 AM](https://user-images.githubusercontent.com/50607147/100769697-6a9cbf80-33ca-11eb-9d36-7dc64cf5ed39.png)

### After:
![Screen Shot 2020-12-01 at 11 41 46 AM](https://user-images.githubusercontent.com/50607147/100769716-6ec8dd00-33ca-11eb-8db3-092f9155c8b0.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
