### PR TITLE
fix: add fix for missing icons in RTL mode for Message Strip

### DIFF
--- a/src/message-strip.scss
+++ b/src/message-strip.scss
@@ -104,10 +104,6 @@ $block: #{$fd-namespace}-message-strip;
       &::before {
         display: none;
       }
-
-      &::after {
-        display: none;
-      }
     }
 
     &.#{$block}--dismissible {
@@ -138,6 +134,10 @@ $block: #{$fd-namespace}-message-strip;
     @include fd-icon("message-warning");
 
     @include fd-rtl() {
+      &::before {
+        display: none;
+      }
+
       @include fd-icon("message-warning", "after");
     }
   }


### PR DESCRIPTION
## Related Issue
Part of #1907

## Description
Add icons to rtl mode for message strip 

## Screenshots

### Before:
![Screen Shot 2020-12-01 at 12 48 12 PM](https://user-images.githubusercontent.com/50607147/100777530-efd8a200-33d3-11eb-84a6-aecc6cfb95f7.png)

### After:
![Screen Shot 2020-12-01 at 12 45 04 PM](https://user-images.githubusercontent.com/50607147/100777556-f7984680-33d3-11eb-97ef-1d49e4e6890a.png)


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
