### PR TITLE
fix: (Core) add fix for Carousel button position on click

### DIFF
--- a/src/carousel.scss
+++ b/src/carousel.scss
@@ -157,7 +157,9 @@ $button: #{$fd-namespace}-button;
     }
 
     @include fd-focus() {
-      @include after-position-overwrite();
+      &::after {
+        @include after-position-overwrite();
+      }
     }
 
     @include fd-active() {


### PR DESCRIPTION
## Related Issue
Part of https://github.com/SAP/fundamental-ngx/issues/3922

## Description
Add fix for the bug where clicking on the button changes it position.

![jumping-carousel-buttons](https://user-images.githubusercontent.com/17496353/100731347-8c4a7680-33cb-11eb-83c6-db5b2953baf1.gif)
