### PR TITLE
fix: add fix for missing space between Menu Button text and expand arrow

### DIFF
--- a/src/button.scss
+++ b/src/button.scss
@@ -232,11 +232,11 @@ $block: #{$fd-namespace}-button;
 }
 
 @mixin iconTextMargin() {
-  margin-left: $fd-button-icon-margin;
+  margin-left: $fd-button-icon-margin !important;
 
   @include fd-rtl() {
-    margin-left: 0;
-    margin-right: $fd-button-icon-margin;
+    margin-left: 0 !important;
+    margin-right: $fd-button-icon-margin !important;
   }
 }
 


### PR DESCRIPTION
## Description
this PR adds `!important` to the rule that sets spacing between the elements inside a Button. Without this rule, the behaviour depends on the import of the components. In Fundamental-ngx, the icons styling was overwriting the margin-left specified in the Button and was causing the issue where the expand icon was rendered right next to the text. 

## Screenshots

### Before:
<img width="1846" alt="Screen Shot 2020-12-01 at 5 08 04 PM" src="https://user-images.githubusercontent.com/39598672/100802697-e2cdaa00-33f7-11eb-918f-5ddd82da1881.png">


### After:
<img width="1974" alt="Screen Shot 2020-12-01 at 5 08 26 PM" src="https://user-images.githubusercontent.com/39598672/100802703-e5c89a80-33f7-11eb-92b5-ad225b24262d.png">


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [NA] All values are in `rem`
- [NA] Text elements follow the truncation rules
- [NA] hover state of the element follow design spec
- [NA] focus state of the element follow design spec
- [NA] active state of the element follow design spec
- [NA] selected state of the element follow design spec
- [NA] selected hover state of the element follow design spec
- [NA] pressed state of the element follow design spec
- [NA] Responsiveness rules - the component has modifier classes for all breakpoints
- [NA] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [NA] only one top level `fd-*` class is used in the file
- [NA] BEM naming convention is used
- [NA] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [NA] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [NA] `fd-reset()` mixin is applied to all elements
- [NA] Variables are used, if some value is used more than twice.
- [NA ] Checked if current components can be reused, instead of having new code.
3. Testing
-  x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [NA] Updated tests
4. Documentation
- [NA] Storybook documentation has been created/updated
- [NA] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
