### PR TITLE
fix: center the content of Button by default

### DIFF
--- a/src/button.scss
+++ b/src/button.scss
@@ -263,7 +263,7 @@ $block: #{$fd-namespace}-button;
   @include buttonContainer();
   @include iconStyles();
 
-  @include fd-flex-vertical-center() {
+  @include fd-flex-center() {
     display: inline-flex;
   }
 


### PR DESCRIPTION
## Related Issue
Part of https://github.com/SAP/fundamental-styles/issues/1907

## Description
Buttons need to be centered by default

## Screenshots
### Before:


### After:

#### Please check whether the PR fulfills the following requirements

2. The code follows fundamental-styles code standards and style
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
