### PR TITLE
fix: remove padding from button in Flexible Column Layout

### DIFF
--- a/src/flexible-column-layout.scss
+++ b/src/flexible-column-layout.scss
@@ -56,6 +56,7 @@ $block: #{$fd-namespace}-flexible-column-layout;
     width: $fd-toggle-button-width;
     min-width: $fd-toggle-button-width;
     justify-content: center;
+    padding: 0;
 
     @include fd-absolute-center();
   }


### PR DESCRIPTION
## Related Issue
Part of https://github.com/SAP/fundamental-styles/issues/1907

## Description
Button inside flexible column layout got fixed width and doesn't need padding.

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/26483208/100856924-4ef9ed80-348c-11eb-9dea-a05d0a7ffb57.png)


### After:
![image](https://user-images.githubusercontent.com/26483208/100856523-d3983c00-348b-11eb-82bd-75e32a8dd463.png)

#### Please check whether the PR fulfills the following requirements

3. Testing
- [x] Verified all styles in IE11
