### PR TITLE
fix: remove token max-width

### DIFF
--- a/src/tokenizer.scss
+++ b/src/tokenizer.scss
@@ -29,7 +29,6 @@ $block: #{$fd-namespace}-tokenizer;
 
   .fd-token {
     margin-right: $fd-tokenizer-spacing;
-    max-width: calc(100% - #{$fd-tokenizer-input-width} - #{$fd-tokenizer-spacing});
 
     @include fd-rtl() {
       margin: 0 0 0 $fd-tokenizer-spacing;
@@ -89,7 +88,6 @@ $block: #{$fd-namespace}-tokenizer;
 
     .fd-token {
       margin-right: $fd-tokenizer-compact-spacing;
-      max-width: calc(100% - #{$fd-tokenizer-input-width-compact} - #{$fd-tokenizer-compact-spacing});
 
       @include fd-rtl() {
         margin: 0 0 0 $fd-tokenizer-spacing;


### PR DESCRIPTION
Fixes several issues that bubbled to the Angular implementation of the token/tokenizer. The issue with growing tokens is resolved by replacing `flex: 1 0 auto` with `flex-shrink: 0`, setting the token max-width does not fix the problem stated in the previous defect hunting (screenshot below).  If we want to limit the width of the token, it should be done so by modifying the fd-token__text class to avoid causing problems with the Angular implementations.

![Screen Shot 2020-12-02 at 11 04 11 AM](https://user-images.githubusercontent.com/2471874/100912741-1d822180-348e-11eb-86a1-a2eb13e9e51c.png)
