### PR TITLE
fix: add fixes for buttons not changing position in RTL in IE11 and cut badges in RTL

### DIFF
--- a/src/badge.scss
+++ b/src/badge.scss
@@ -23,7 +23,7 @@ $block: #{$fd-namespace}-badge;
   z-index: 10;
 
   @include fd-rtl() {
-    right: initial;
+    right: auto;
     left: 0.5rem;
   }
 }

--- a/src/tile.scss
+++ b/src/tile.scss
@@ -459,7 +459,7 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
       right: $fd-tile-toggle-button-position;
 
       @include fd-rtl() {
-        right: initial;
+        right: auto;
         left: $fd-tile-toggle-button-position;
       }
 
@@ -636,7 +636,7 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
       z-index: 5;
 
       @include fd-rtl() {
-        right: initial;
+        right: auto;
         left: $fd-tile-close-button-position;
       }
 
@@ -676,9 +676,9 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
       z-index: 5;
 
       @include fd-rtl() {
-        right: initial;
+        right: auto;
         left: 0;
-        margin-right: initial;
+        margin-right: auto;
         margin-left: $fd-tile-action-indicator-offset;
       }
 
@@ -913,6 +913,8 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
       @include fd-rtl() {
         margin-left: $fd-line-tile-badge-horizontal-spacing;
         margin-right: 0;
+        left: 0;
+        right: 0;
       }
     }
   }


### PR DESCRIPTION
## Related Issue
Part of SAP/fundamental-styles#1907

## Description
The Play/Pause button, as well as the close button in Action mode were not changing positions in RTL mode in IE11 due to IE11 not supporting `initial`. `initial` is not changed to `auto`. 
Also, I notices the badges in RTL were cut so I added a quick fix for this.

## Screenshots for Badge issue

### Before:
<img width="1189" alt="Screen Shot 2020-12-02 at 2 36 28 PM" src="https://user-images.githubusercontent.com/39598672/100923279-f5ee8180-34ac-11eb-8cb3-b4c8826282ad.png">


### After:
<img width="1183" alt="Screen Shot 2020-12-02 at 2 36 04 PM" src="https://user-images.githubusercontent.com/39598672/100923317-0272da00-34ad-11eb-9fbd-b3b304c630c3.png">


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [na] All values are in `rem`
- [na] Text elements follow the truncation rules
- [na] hover state of the element follow design spec
- [na] focus state of the element follow design spec
- [na] active state of the element follow design spec
- [na] selected state of the element follow design spec
- [na] selected hover state of the element follow design spec
- [na] pressed state of the element follow design spec
- [na] Responsiveness rules - the component has modifier classes for all breakpoints
- [na] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [na] only one top level `fd-*` class is used in the file
- [na] BEM naming convention is used
- [na] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [na] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [na] `fd-reset()` mixin is applied to all elements
- [na] Variables are used, if some value is used more than twice.
- [na] Checked if current components can be reused, instead of having new code.
3. Testing
- [na] tested Storybook examples with "CSS Resources" `normalize` option 
- [na] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
4. Documentation
- [na] Storybook documentation has been created/updated
- [na] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
