### PR TITLE
fix: add fix for missing spacing in Multi Combobox secondary data in IE11 

### DIFF
--- a/src/_listDropdown.scss
+++ b/src/_listDropdown.scss
@@ -2,7 +2,7 @@
 @import "./listDefinitions.scss";
 
 @mixin ie11-combo-box-fix() {
-  // ie11 does not support display: 'contents'
+  // ie11 does not support [display: contents]
 
   display: flex;
   justify-content: center;
@@ -144,6 +144,7 @@
 
       width: auto;
       max-width: 15rem;
+      display: contents;
     }
 
     .#{$block}__icon {

--- a/src/_listDropdown.scss
+++ b/src/_listDropdown.scss
@@ -1,6 +1,13 @@
 
 @import "./listDefinitions.scss";
 
+@mixin ie11-combo-box-fix() {
+  // ie11 does not support display: 'contents'
+
+  display: flex;
+  justify-content: center;
+}
+
 .#{$block} {
   &--dropdown {
     @include fd-focus() {
@@ -133,15 +140,10 @@
     }
 
     .#{$block}__secondary {
+      @include ie11-combo-box-fix();
+
       width: auto;
       max-width: 15rem;
-      display: contents;
-    }
-
-    @supports not (display: contents) { /* workaround because Edge doesn't support display: contents; */
-      .#{$block}__secondary {
-        display: inline-block;
-      }
     }
 
     .#{$block}__icon {

--- a/src/_listDropdown.scss
+++ b/src/_listDropdown.scss
@@ -1,13 +1,6 @@
 
 @import "./listDefinitions.scss";
 
-@mixin ie11-combo-box-fix() {
-  // ie11 does not support [display: contents]
-
-  display: flex;
-  justify-content: center;
-}
-
 .#{$block} {
   &--dropdown {
     @include fd-focus() {
@@ -26,6 +19,12 @@
         height: auto;
         padding: $fd-dropdown-vertical-compact-padding $fd-list-item-padding-x;
       }
+    }
+
+    .#{$block}__secondary {
+      width: auto;
+      max-width: 15rem;
+      display: contents;
     }
   }
 
@@ -67,6 +66,14 @@
             right: $fd-multi-input-focus-offset;
           }
         }
+      }
+    }
+
+    .#{$block}__secondary {
+      padding-right: 1rem;
+
+      @include fd-rtl() {
+        padding-left: 1rem;
       }
     }
 
@@ -137,14 +144,6 @@
       &:first-child:last-child {
         max-width: 37.5rem;
       }
-    }
-
-    .#{$block}__secondary {
-      @include ie11-combo-box-fix();
-
-      width: auto;
-      max-width: 15rem;
-      display: contents;
     }
 
     .#{$block}__icon {

--- a/src/_listDropdown.scss
+++ b/src/_listDropdown.scss
@@ -138,6 +138,12 @@
       display: contents;
     }
 
+    @supports not (display: contents) { /* workaround because Edge doesn't support display: contents; */
+      .#{$block}__secondary {
+        display: inline-block;
+      }
+    }
+
     .#{$block}__icon {
       line-height: 1rem;
     }


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-styles/issues/1907

Before:
<img width="302" alt="Screen Shot 2020-12-09 at 9 51 13 AM" src="https://user-images.githubusercontent.com/39598672/101645260-2762d200-3a04-11eb-9ba8-b1eb7d2d5e68.png">

After:
<img width="488" alt="Screen Shot 2020-12-09 at 9 57 33 AM" src="https://user-images.githubusercontent.com/39598672/101645988-fb941c00-3a04-11eb-98e2-249e80c0c267.png">
