### PR TITLE
fix: add fix for overflowing card numeric content

### DIFF
--- a/src/card.scss
+++ b/src/card.scss
@@ -231,7 +231,8 @@ $fd-card-content-avatar-text-spacing: 0.5rem !default;
   }
 
   &__numeric-content.#{$numeric-content} {
-    width: initial;
+    width: auto;
+    flex-shrink: 0;
   }
 
   &__content {

--- a/src/card.scss
+++ b/src/card.scss
@@ -231,8 +231,8 @@ $fd-card-content-avatar-text-spacing: 0.5rem !default;
   }
 
   &__numeric-content.#{$numeric-content} {
-    width: auto;
     flex-shrink: 0;
+    width: auto;
   }
 
   &__content {

--- a/src/numeric-content.scss
+++ b/src/numeric-content.scss
@@ -96,7 +96,6 @@ $fd-numeric-content-elements-spacing-s: 0.5rem !default;
     @include fd-reset();
 
     display: flex;
-    flex: 1;
     height: 100%;
     overflow: hidden;
     padding-top: 0.5rem;


### PR DESCRIPTION
## Related Issue
Part of: #1907 

## Description
IE11 does not support `width: initial` property.
To ensure that the numeric content and units keep required width `flex-shrink` has been added.

## Before
(IE11)
![image](https://user-images.githubusercontent.com/17496353/101160503-70dfa580-362f-11eb-9149-2891c35f7fca.png)

## AFTER
(IE11)
![image](https://user-images.githubusercontent.com/17496353/101160337-2b22dd00-362f-11eb-81c4-75022f74f354.png)
