### PR TITLE
fix: form controls in Table

### DIFF
--- a/src/popover.scss
+++ b/src/popover.scss
@@ -224,6 +224,10 @@ $block: #{$fd-namespace}-popover;
     }
   }
 
+  &--full-width {
+    width: 100%;
+  }
+
   &__popper {
     @include fd-reset();
 

--- a/stories/table/__snapshots__/table.stories.storyshot
+++ b/stories/table/__snapshots__/table.stories.storyshot
@@ -1178,7 +1178,7 @@ exports[`Storyshots Components/Table Grid Table 1`] = `
           
                     
           <div
-            class="fd-popover"
+            class="fd-popover fd-popover--full-width"
           >
             
                         
@@ -1312,7 +1312,7 @@ exports[`Storyshots Components/Table Grid Table 1`] = `
         
                 
         <div
-          class="fd-popover"
+          class="fd-popover fd-popover--full-width"
         >
           
                     
@@ -1495,7 +1495,7 @@ exports[`Storyshots Components/Table Grid Table 1`] = `
           
                     
           <div
-            class="fd-popover"
+            class="fd-popover fd-popover--full-width"
           >
             
                         
@@ -1629,7 +1629,7 @@ exports[`Storyshots Components/Table Grid Table 1`] = `
         
                 
         <div
-          class="fd-popover"
+          class="fd-popover fd-popover--full-width"
         >
           
                     
@@ -1812,7 +1812,7 @@ exports[`Storyshots Components/Table Grid Table 1`] = `
           
                     
           <div
-            class="fd-popover"
+            class="fd-popover fd-popover--full-width"
           >
             
                         
@@ -1946,7 +1946,7 @@ exports[`Storyshots Components/Table Grid Table 1`] = `
         
                 
         <div
-          class="fd-popover"
+          class="fd-popover fd-popover--full-width"
         >
           
                     
@@ -2130,7 +2130,7 @@ exports[`Storyshots Components/Table Grid Table 1`] = `
           
                     
           <div
-            class="fd-popover"
+            class="fd-popover fd-popover--full-width"
           >
             
                         
@@ -2264,7 +2264,7 @@ exports[`Storyshots Components/Table Grid Table 1`] = `
         
                 
         <div
-          class="fd-popover"
+          class="fd-popover fd-popover--full-width"
         >
           
                     

--- a/stories/table/table.stories.js
+++ b/stories/table/table.stories.js
@@ -1680,7 +1680,7 @@ export const gridTable = () => `<table class="fd-table" aria-describedby="FU4EwF
             </td>
             <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
                 <div class="fd-form-item">
-                    <div class="fd-popover">
+                    <div class="fd-popover fd-popover--full-width">
                         <div class="fd-popover__control">
                             <div class="fd-select" tabindex="-1" aria-labelledby="fd-hEzpEm5PMU2" aria-expanded="false" aria-haspopup="listbox">
                                 <div class="fd-select__control">
@@ -1704,7 +1704,7 @@ export const gridTable = () => `<table class="fd-table" aria-describedby="FU4EwF
                 <input aria-labelledby="fd-OspcU6H7F0q" class="fd-input" type="text" value="" tabindex="-1" />
             </td>
             <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
-                <div class="fd-popover">
+                <div class="fd-popover fd-popover--full-width">
                     <div class="fd-popover__control">
                         <div aria-expanded="false" aria-haspopup="true" class="fd-input-group--control fd-input-group">
                             <input aria-labelledby="fd-nEac1Ko5K0e" class="fd-input fd-input-group__input" placeholder="MM/DD/YYYY" type="text" value="" tabindex="-1" />
@@ -1739,7 +1739,7 @@ export const gridTable = () => `<table class="fd-table" aria-describedby="FU4EwF
             </td>
             <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
                 <div class="fd-form-item">
-                    <div class="fd-popover">
+                    <div class="fd-popover fd-popover--full-width">
                         <div class="fd-popover__control">
                             <div class="fd-select" tabindex="-1" aria-labelledby="fd-hEzpEm5PMU2" aria-expanded="false" aria-haspopup="listbox">
                                 <div class="fd-select__control">
@@ -1763,7 +1763,7 @@ export const gridTable = () => `<table class="fd-table" aria-describedby="FU4EwF
                 <input aria-labelledby="fd-OspcU6H7F0q" class="fd-input" type="text" value="" tabindex="-1" />
             </td>
             <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
-                <div class="fd-popover">
+                <div class="fd-popover fd-popover--full-width">
                     <div class="fd-popover__control">
                         <div aria-expanded="false" aria-haspopup="true" class="fd-input-group--control fd-input-group">
                             <input aria-labelledby="fd-nEac1Ko5K0e" class="fd-input fd-input-group__input" placeholder="MM/DD/YYYY" type="text" value="" tabindex="-1" />
@@ -1798,7 +1798,7 @@ export const gridTable = () => `<table class="fd-table" aria-describedby="FU4EwF
             </td>
             <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
                 <div class="fd-form-item">
-                    <div class="fd-popover">
+                    <div class="fd-popover fd-popover--full-width">
                         <div class="fd-popover__control">
                             <div class="fd-select" tabindex="-1" aria-labelledby="fd-hEzpEm5PMU2" aria-expanded="false" aria-haspopup="listbox">
                                 <div class="fd-select__control">
@@ -1822,7 +1822,7 @@ export const gridTable = () => `<table class="fd-table" aria-describedby="FU4EwF
                 <input aria-labelledby="fd-OspcU6H7F0q" class="fd-input" type="text" value="" tabindex="-1" />
             </td>
             <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
-                <div class="fd-popover">
+                <div class="fd-popover fd-popover--full-width">
                     <div class="fd-popover__control">
                         <div aria-expanded="false" aria-haspopup="true" class="fd-input-group--control fd-input-group">
                                 <input aria-labelledby="fd-nEac1Ko5K0e" class="fd-input fd-input-group__input" placeholder="MM/DD/YYYY" type="text" value="" tabindex="-1" />
@@ -1858,7 +1858,7 @@ export const gridTable = () => `<table class="fd-table" aria-describedby="FU4EwF
             </td>
             <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
                 <div class="fd-form-item">
-                    <div class="fd-popover">
+                    <div class="fd-popover fd-popover--full-width">
                         <div class="fd-popover__control">
                             <div class="fd-select" tabindex="-1" aria-labelledby="fd-hEzpEm5PMU2" aria-expanded="false" aria-haspopup="listbox">
                                 <div class="fd-select__control">
@@ -1882,7 +1882,7 @@ export const gridTable = () => `<table class="fd-table" aria-describedby="FU4EwF
                 <input aria-labelledby="fd-OspcU6H7F0q" class="fd-input" type="text" value="" tabindex="-1" />
             </td>
             <td class="fd-table__cell fd-table__cell--focusable" tabindex="-1">
-                <div class="fd-popover">
+                <div class="fd-popover fd-popover--full-width">
                     <div class="fd-popover__control">
                         <div aria-expanded="false" aria-haspopup="true" class="fd-input-group--control fd-input-group">
                             <input aria-labelledby="fd-nEac1Ko5K0e" class="fd-input fd-input-group__input" placeholder="MM/DD/YYYY" type="text" value="" tabindex="-1" />


### PR DESCRIPTION
## Related Issue
Part of: #1907

## Description
This PR adds `full-width` modifier to popover to easily extend popover width when the popover and its content needs to fill the container.

The vertical misalignment seems to be "caused" by `display: inline-block` on `fd-popover` level. I don't know if there is a way to fix it.

## Before
![image](https://user-images.githubusercontent.com/17496353/101166163-231b6b00-3638-11eb-9fa6-4e41863e0bc4.png)

## After
![image](https://user-images.githubusercontent.com/17496353/101165472-02064a80-3637-11eb-8ce4-4e8d09aa83bc.png)