### PR TITLE
fix: add missing icons to semantic Message Box

### DIFF
--- a/.storybook/custom/custom.scss
+++ b/.storybook/custom/custom.scss
@@ -288,7 +288,7 @@ code.docs-code-grey {
   .fd-dialog,
   &.fd-message-box,
   .fd-message-box {
-    position: static;
+    position: relative;
     background-color: transparent;
 
     &::before {
@@ -300,7 +300,7 @@ code.docs-code-grey {
   .fd-dialog__content,
   &.fd-message-box__content,
   .fd-message-box__content {
-    position: static;
+    position: relative;
     transform: translate(0%, 0%);
     width: 30rem;
     margin: auto;

--- a/.storybook/custom/custom.scss
+++ b/.storybook/custom/custom.scss
@@ -290,6 +290,7 @@ code.docs-code-grey {
   .fd-message-box {
     position: relative;
     background-color: transparent;
+    z-index: 1;
 
     &::before {
       background-color: transparent;

--- a/src/message-box.scss
+++ b/src/message-box.scss
@@ -17,11 +17,11 @@ $warningBoxShadow: inset 0 -0.0625rem var(--sapWarningBorderColor), var(--sapCon
 $informationBoxShadow: inset 0 -0.0625rem var(--sapInformationBorderColor), var(--sapContent_HeaderShadow);
 
 $message-box-states: (
-  "confirmation": ("iconColor": var(--sapNeutralElementColor), "icon": "\e1c4", "boxShadow": var(--sapContent_HeaderShadow)),
-  "error": ("iconColor": var(--sapNegativeElementColor), "icon": "\e0b1", "boxShadow": $errorBoxShadow),
-  "success": ("iconColor": var(--sapPositiveElementColor), "icon": "\e203", "boxShadow": $successBoxShadow),
-  "warning": ("iconColor": var(--sapCriticalElementColor), "icon": "\e201", "boxShadow": $warningBoxShadow),
-  "information": ("iconColor": var(--sapInformativeElementColor), "icon": "\e05c", "boxShadow": $informationBoxShadow)
+  "confirmation": ("iconColor": var(--sapNeutralElementColor), "boxShadow": var(--sapContent_HeaderShadow)),
+  "error": ("iconColor": var(--sapNegativeElementColor), "boxShadow": $errorBoxShadow),
+  "success": ("iconColor": var(--sapPositiveElementColor), "boxShadow": $successBoxShadow),
+  "warning": ("iconColor": var(--sapCriticalElementColor), "boxShadow": $warningBoxShadow),
+  "information": ("iconColor": var(--sapInformativeElementColor), "boxShadow": $informationBoxShadow)
 );
 
 .#{$block} {
@@ -97,30 +97,16 @@ $message-box-states: (
     &--#{$set-name} {
       .#{$block}__header.#{$bar} {
         box-shadow: map_get($state-set, "boxShadow");
-      }
 
-      .#{$block}__title {
-        @include fd-icon-base () {
-          position: relative;
-          top: 0.0625rem;
-          font-size: $fd-message-box-title-icon-text-size;
+        [class*=sap-icon] {
+          font-size: 1rem;
           margin-right: $fd-message-box-icon-text-spacing;
           color: map_get($state-set, "iconColor");
-          content: map_get($state-set, "icon");
-        }
-      }
 
-      @include fd-rtl() {
-        .#{$block}__title::before {
-          margin-right: 0;
-          margin-left: $fd-message-box-icon-text-spacing;
-        }
-      }
-
-      &.#{$block}--no-icon {
-        .#{$block}__title::before {
-          content: '';
-          margin: 0;
+          @include fd-rtl() {
+            margin-right: 0;
+            margin-left: $fd-message-box-icon-text-spacing;
+          }
         }
       }
     }

--- a/stories/message-box/__snapshots__/message-box.stories.storyshot
+++ b/stories/message-box/__snapshots__/message-box.stories.storyshot
@@ -107,215 +107,6 @@ exports[`Storyshots Components/Message Box Default 1`] = `
 </div>
 `;
 
-exports[`Storyshots Components/Message Box No icon 1`] = `
-<section>
-  
-
-  <div
-    class="fd-message-box-docs-static fd-message-box fd-message-box--no-icon fd-message-box--success fd-message-box--active"
-  >
-    
-    
-    <section
-      class="fd-message-box__content"
-    >
-      
-        
-      <header
-        class="fd-bar fd-bar--header fd-message-box__header"
-      >
-        
-            
-        <div
-          class="fd-bar__left"
-        >
-          
-                
-          <div
-            class="fd-bar__element"
-          >
-            
-                    
-            <h2
-              class="fd-title fd-title--h5"
-            >
-              Success
-            </h2>
-            
-                
-          </div>
-          
-            
-        </div>
-        
-        
-      </header>
-      
-        
-      <div
-        class="fd-message-box__body"
-      >
-        
-            Success message box without an icon in the title and a "Show more" link in the body.
-            
-        <div
-          class="fd-message-box__more"
-        >
-          
-                
-          <a
-            class="fd-link"
-            href="#"
-            tabindex="0"
-          >
-            Show more
-          </a>
-          
-            
-        </div>
-        
-        
-      </div>
-      
-        
-      <footer
-        class="fd-bar fd-bar--footer fd-message-box__footer"
-      >
-        
-            
-        <div
-          class="fd-bar__right"
-        >
-          
-                
-          <div
-            class="fd-bar__element"
-          >
-            
-                    
-            <button
-              class="fd-button fd-button--emphasized fd-button--compact fd-message-box__decisive-button"
-            >
-              
-                        Close
-                    
-            </button>
-            
-                
-          </div>
-          
-            
-        </div>
-        
-        
-      </footer>
-      
-    
-    </section>
-    
-
-  </div>
-  
-
-
-  <br />
-  <br />
-  <br />
-  
-
-
-  <div
-    class="fd-message-box-docs-static fd-message-box fd-message-box--error fd-message-box--no-icon fd-message-box--active"
-  >
-    
-    
-    <section
-      class="fd-message-box__content"
-    >
-      
-        
-      <header
-        class="fd-bar fd-bar--header fd-message-box__header"
-      >
-        
-            
-        <div
-          class="fd-bar__left"
-        >
-          
-                
-          <div
-            class="fd-bar__element"
-          >
-            
-                    
-            <h2
-              class="fd-title fd-title--h5"
-            >
-              Error
-            </h2>
-            
-                
-          </div>
-          
-            
-        </div>
-        
-        
-      </header>
-      
-        
-      <div
-        class="fd-message-box__body"
-      >
-        
-            Error message box without an icon in the title.
-        
-      </div>
-      
-        
-      <footer
-        class="fd-bar fd-bar--footer fd-message-box__footer"
-      >
-        
-            
-        <div
-          class="fd-bar__right"
-        >
-          
-                
-          <div
-            class="fd-bar__element"
-          >
-            
-                    
-            <button
-              class="fd-button fd-button--emphasized fd-button--compact fd-message-box__decisive-button"
-            >
-              
-                        Close
-                    
-            </button>
-            
-                
-          </div>
-          
-            
-        </div>
-        
-        
-      </footer>
-      
-    
-    </section>
-    
-
-  </div>
-  
-
-</section>
-`;
-
 exports[`Storyshots Components/Message Box Responsive 1`] = `
 <section>
   
@@ -745,6 +536,11 @@ exports[`Storyshots Components/Message Box Semantic types 1`] = `
           >
             
                     
+            <i
+              class="sap-icon--question-mark"
+            />
+            
+                    
             <h2
               class="fd-title fd-title--h5"
             >
@@ -858,6 +654,11 @@ exports[`Storyshots Components/Message Box Semantic types 1`] = `
           >
             
                     
+            <i
+              class="sap-icon--message-error"
+            />
+            
+                    
             <h2
               class="fd-title fd-title--h5"
             >
@@ -952,6 +753,11 @@ exports[`Storyshots Components/Message Box Semantic types 1`] = `
           <div
             class="fd-bar__element"
           >
+            
+                    
+            <i
+              class="sap-icon--message-success"
+            />
             
                     
             <h2
@@ -1050,6 +856,11 @@ exports[`Storyshots Components/Message Box Semantic types 1`] = `
           >
             
                     
+            <i
+              class="sap-icon--message-warning"
+            />
+            
+                    
             <h2
               class="fd-title fd-title--h5"
             >
@@ -1144,6 +955,11 @@ exports[`Storyshots Components/Message Box Semantic types 1`] = `
           <div
             class="fd-bar__element"
           >
+            
+                    
+            <i
+              class="sap-icon--message-information"
+            />
             
                     
             <h2

--- a/stories/message-box/message-box.stories.js
+++ b/stories/message-box/message-box.stories.js
@@ -36,16 +36,16 @@ Note: Include two action buttons in the message box when the user's decision is 
 ##Structure 
 **Message box follows the structure of a dialog, consisting of following elements:**
 
-- \`.fd-message-box\`: styles the backdrop and displays the message box container with \`position: fixed\`. The message box becomes visible by adding the \`.fd-message--active\` modifier class to the container.
-    - \`.fd-message__content\`: Content container
-        - \`.fd-message__header\`: Header
-            - \`.fd-message__title\`: Title
-        - \`.fd-message__body\`: Content body
-        - \`.fd-message__footer\`: Footer
-            - \`.fd-message__decisive-button\`: Action buttons in footer
+- \`.fd-message-box\`: styles the backdrop and displays the message box container with \`position: fixed\`. The message box becomes visible by adding the \`.fd-message-box--active\` modifier class to the container.
+    - \`.fd-message-box__content\`: Content container
+        - \`.fd-message-box__header\`: Header
+            - \`.fd-message-box__title\`: Title
+        - \`.fd-message-box__body\`: Content body
+        - \`.fd-message-box__footer\`: Footer
+            - \`.fd-message-box__decisive-button\`: Action buttons in footer
         `,
         tags: ['f3', 'a11y', 'theme'],
-        components: ['message-box', 'title', 'bar', 'button', 'link']
+        components: ['message-box', 'title', 'bar', 'button', 'link', 'icon']
     }
 };
 
@@ -97,6 +97,7 @@ export const types = () => `<div class="fd-message-box-docs-static fd-message-bo
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
+                    <i class="sap-icon--question-mark"></i>
                     <h2 class="fd-title fd-title--h5">Confirmation</h2>
                 </div>
             </div>
@@ -128,6 +129,7 @@ export const types = () => `<div class="fd-message-box-docs-static fd-message-bo
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
+                    <i class="sap-icon--message-error"></i>
                     <h2 class="fd-title fd-title--h5">Error</h2>
                 </div>
             </div>
@@ -154,6 +156,7 @@ export const types = () => `<div class="fd-message-box-docs-static fd-message-bo
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
+                    <i class="sap-icon--message-success"></i>
                     <h2 class="fd-title fd-title--h5">Success</h2>
                 </div>
             </div>
@@ -180,6 +183,7 @@ export const types = () => `<div class="fd-message-box-docs-static fd-message-bo
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
+                    <i class="sap-icon--message-warning"></i>
                     <h2 class="fd-title fd-title--h5">Warning</h2>
                 </div>
             </div>
@@ -206,6 +210,7 @@ export const types = () => `<div class="fd-message-box-docs-static fd-message-bo
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
+                    <i class="sap-icon--message-information"></i>
                     <h2 class="fd-title fd-title--h5">Information</h2>
                 </div>
             </div>
@@ -244,73 +249,6 @@ Information | \`fd-message-box--information\` | Information messages provide inf
         `
     }
 };
-
-
-export const noIcon = () =>
-    `
-<div class="fd-message-box-docs-static fd-message-box fd-message-box--no-icon fd-message-box--success fd-message-box--active">
-    <section class="fd-message-box__content">
-        <header class="fd-bar fd-bar--header fd-message-box__header">
-            <div class="fd-bar__left">
-                <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5">Success</h2>
-                </div>
-            </div>
-        </header>
-        <div class="fd-message-box__body">
-            Success message box without an icon in the title and a "Show more" link in the body.
-            <div class="fd-message-box__more">
-                <a href="#" class="fd-link" tabindex="0">Show more</a>
-            </div>
-        </div>
-        <footer class="fd-bar fd-bar--footer fd-message-box__footer">
-            <div class="fd-bar__right">
-                <div class="fd-bar__element">
-                    <button class="fd-button fd-button--emphasized fd-button--compact fd-message-box__decisive-button">
-                        Close
-                    </button>
-                </div>
-            </div>
-        </footer>
-    </section>
-</div>
-
-<br><br><br>
-
-<div class="fd-message-box-docs-static fd-message-box fd-message-box--error fd-message-box--no-icon fd-message-box--active">
-    <section class="fd-message-box__content">
-        <header class="fd-bar fd-bar--header fd-message-box__header">
-            <div class="fd-bar__left">
-                <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5">Error</h2>
-                </div>
-            </div>
-        </header>
-        <div class="fd-message-box__body">
-            Error message box without an icon in the title.
-        </div>
-        <footer class="fd-bar fd-bar--footer fd-message-box__footer">
-            <div class="fd-bar__right">
-                <div class="fd-bar__element">
-                    <button class="fd-button fd-button--emphasized fd-button--compact fd-message-box__decisive-button">
-                        Close
-                    </button>
-                </div>
-            </div>
-        </footer>
-    </section>
-</div>
-`;
-
-noIcon.storyName = 'No icon';
-noIcon.parameters = {
-    docs: {
-        iframeHeight: messageBoxHeight * 2,
-        storyDescription: `Message box can be displayed without an icon. To remove the icon from the title, add the \`fd-message-box--no-icon\` modifier class to the container.
-        `
-    }
-};
-
 
 export const responsive = () =>
     `


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#1896

## Description
1. Add semantic icons to the Message Box title
2. Remove `.fd-message-box--no-icon` modifier class as by default the Message Box title does not have an icon.
3. In some Message Box examples it was not possible to click on the buttons or highlight the text. This issue was fixed by changing the position from static to relative (documentation class change)
4. Correct the documentation where instead of `.fd-message-box__xxx`, `.fd-message__xxx` was used.

BREAKING CHANGE: 
`.fd-message-box--no-icon` modifier class is removed
Semantic icons are added separately: `<i class="sap-icon--message-error"></i>` 

## Screenshots
### Before:
<img width="546" alt="Screen Shot 2020-12-07 at 3 48 33 PM" src="https://user-images.githubusercontent.com/39598672/101403773-b2788680-38a3-11eb-925b-096403ca0f6f.png">


### After:
<img width="553" alt="Screen Shot 2020-12-07 at 3 47 18 PM" src="https://user-images.githubusercontent.com/39598672/101403652-8a892300-38a3-11eb-8f54-8813743f64b3.png">


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [na] Text elements follow the truncation rules
- [na] hover state of the element follow design spec
- [na] focus state of the element follow design spec
- [na] active state of the element follow design spec
- [na] selected state of the element follow design spec
- [na] selected hover state of the element follow design spec
- [na] pressed state of the element follow design spec
- [na] Responsiveness rules - the component has modifier classes for all breakpoints
- [na] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [na] only one top level `fd-*` class is used in the file
- [na] BEM naming convention is used
- [na] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [na] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [na] `fd-reset()` mixin is applied to all elements
- [na] Variables are used, if some value is used more than twice.
- [na] Checked if current components can be reused, instead of having new code.
3. Testing
- [na] tested Storybook examples with "CSS Resources" `normalize` option 
- [na] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
