### PR TITLE
fix: improve class structure for Switch component

### DIFF
--- a/src/switch.scss
+++ b/src/switch.scss
@@ -10,50 +10,27 @@ $block: #{$fd-namespace}-switch;
 
 .#{$block} {
 
+  $fd-switch-off-opacity: 0;
+  $fd-switch-transition: all 0.1s;
   $fd-switch-active-border-color: var(--sapButton_Selected_BorderColor);
-  $fd-switch-active-background-color: var(--sapButton_Selected_Background);
   $fd-switch-inactive-border-color: var(--sapContent_ForegroundBorderColor);
   $fd-switch-inactive-handle-background: var(--sapButton_Background);
 
   $fd-switch-hover-border-color: var(--sapButton_Hover_BorderColor);
   $fd-switch-hover-selected-border-color: var(--sapButton_Selected_Hover_BorderColor);
-  $fd-switch-hover-background: var(--sapButton_Hover_Background);
-  $fd-switch-hover-selected-background: var(--sapButton_Selected_Hover_Background);
   $fd-switch-success-border-color: var(--sapSuccessBorderColor);
   $fd-switch-error-border-color: var(--sapErrorBorderColor);
   $fd-switch-border-width: var(--sapButton_BorderWidth);
 
   $fd-switch-label-width: 1.75rem;
 
-  $fd-switch-transition: all 0.1s;
-  $fd-switch-semantic-icon-transition: visibility 0s ease 0.03s, opacity 0s ease 0.03s;
-
-  $fd-switch-container-padding-y: 0.375rem;
-  $fd-switch-size-x: 3.75rem;
-  $fd-switch-size-y: 1.25rem;
   $fd-switch-handle-size: 1.875rem;
-  $fd-switch-border-radius: 0.75rem;
-  $fd-switch-handle-border-radius: 1rem;
-
-  $fd-switch-container-compact-padding-y: 0.1875rem;
-  $fd-switch-container-compact-no-label-padding-y: 0.25rem;
-  $fd-switch-size-compact-x: 3.375rem;
-  $fd-switch-size-compact-y: 1.25rem;
   $fd-switch-handle-compact-size: 1.5rem;
-
-  $fd-switch-track-no-label-width: 3.125rem;
-  $fd-switch-track-no-label-height: 1.25rem;
-
-  $fd-switch-track-no-label-compact-width: 2.375rem;
-  $fd-switch-track-no-label-compact-height: 1rem;
 
   $fd-switch-track-compact-offset: 0.8125rem;
   $fd-switch-track-offset: 1.1875rem;
   $fd-switch-track-semantic-offset: 1.9375rem;
   $fd-switch-track-border-offset: 0.0625rem;
-
-  $fd-switch-off-opacity: 0;
-  $fd-switch-on-opacity: 1;
 
   @include fd-reset();
   @include fd-form-label();
@@ -73,7 +50,7 @@ $block: #{$fd-namespace}-switch;
   &__control {
     display: inline-block;
     position: relative;
-    padding: $fd-switch-container-padding-y 0;
+    padding: 0.375rem 0;
   }
 
   &__slider {
@@ -81,11 +58,11 @@ $block: #{$fd-namespace}-switch;
 
     background-color: var(--sapButton_Track_Background);
     box-sizing: content-box;
-    width: $fd-switch-track-no-label-width;
-    height: $fd-switch-track-no-label-height;
+    width: 3.125rem;
+    height: 1.25rem;
     border: $fd-switch-border-width solid $fd-switch-inactive-border-color;
     transition: $fd-switch-transition;
-    border-radius: $fd-switch-border-radius;
+    border-radius: 0.75rem;
   }
 
   &__track {
@@ -116,7 +93,7 @@ $block: #{$fd-namespace}-switch;
       min-width: $fd-switch-label-width;
       font-size: 0.75rem;
       line-height: 1.375rem;
-      transition: $fd-switch-semantic-icon-transition;
+      transition: visibility 0s ease 0.03s, opacity 0s ease 0.03s;
     }
 
     &--off {
@@ -144,7 +121,7 @@ $block: #{$fd-namespace}-switch;
     background-color: $fd-switch-inactive-handle-background;
     min-width: $fd-switch-handle-size;
     min-height: $fd-switch-handle-size;
-    border-radius: $fd-switch-handle-border-radius;
+    border-radius: 1rem;
     background-clip: padding-box;
   }
 
@@ -193,7 +170,7 @@ $block: #{$fd-namespace}-switch;
     border-color: $fd-switch-active-border-color;
 
     .#{$block}__handle {
-      background-color: $fd-switch-active-background-color;
+      background-color: var(--sapButton_Selected_Background);
       border-color: $fd-switch-active-border-color;
     }
 
@@ -211,7 +188,7 @@ $block: #{$fd-namespace}-switch;
 
       &--on {
         @include fd-icon-selector() {
-          opacity: $fd-switch-on-opacity;
+          opacity: 1;
           visibility: visible;
         }
       }
@@ -247,7 +224,7 @@ $block: #{$fd-namespace}-switch;
 
     .#{$block}__handle {
       border-color: $fd-switch-hover-border-color;
-      background-color: $fd-switch-hover-background;
+      background-color: var(--sapButton_Hover_Background);
     }
 
     .#{$block}:checked + .#{$block}__slider {
@@ -255,13 +232,13 @@ $block: #{$fd-namespace}-switch;
 
       .#{$block}__handle {
         border-color: $fd-switch-hover-selected-border-color;
-        background-color: $fd-switch-hover-selected-background;
+        background-color: var(--sapButton_Selected_Hover_Background);
       }
     }
   }
 
   &--compact {
-    padding: $fd-switch-container-compact-no-label-padding-y 0;
+    padding: 0.25rem 0;
 
     .#{$block}__handle {
       min-width: $fd-switch-handle-compact-size;
@@ -269,8 +246,8 @@ $block: #{$fd-namespace}-switch;
     }
 
     .#{$block}__slider {
-      width: $fd-switch-track-no-label-compact-width;
-      height: $fd-switch-track-no-label-compact-height;
+      width: 2.375rem;
+      height: 1rem;
     }
 
     .#{$block}__track {
@@ -287,8 +264,8 @@ $block: #{$fd-namespace}-switch;
 
   &--semantic {
     .#{$block}__slider {
-      width: $fd-switch-size-x;
-      height: $fd-switch-size-y;
+      width: 3.75rem;
+      height: 1.25rem;
       border-color: $fd-switch-error-border-color;
       background-color: var(--sapErrorBackground);
     }
@@ -317,11 +294,11 @@ $block: #{$fd-namespace}-switch;
     }
 
     &.#{$block}--compact {
-      padding: $fd-switch-container-compact-padding-y 0;
+      padding: 0.1875rem 0;
 
       .#{$block}__slider {
-        width: $fd-switch-size-compact-x;
-        height: $fd-switch-size-compact-y;
+        width: 3.375rem;
+        height: 1.25rem;
       }
     }
 

--- a/src/switch.scss
+++ b/src/switch.scss
@@ -56,28 +56,27 @@ $block: #{$fd-namespace}-switch;
   $fd-switch-on-opacity: 1;
 
   @include fd-reset();
+  @include fd-form-label();
 
-  display: inline-block;
-  position: relative;
-  padding: $fd-switch-container-padding-y 0;
+  overflow: initial;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  padding: 0;
 
-  &__label {
-    @include fd-form-label();
-
-    overflow: initial;
-    display: flex;
-    align-items: center;
-    cursor: pointer;
-    padding: 0;
-
-    @include fd-disabled() {
-      cursor: auto;
-      pointer-events: none;
-      opacity: var(--sapContent_DisabledOpacity);
-    }
+  @include fd-disabled() {
+    cursor: auto;
+    pointer-events: none;
+    opacity: var(--sapContent_DisabledOpacity);
   }
 
-  &__wrapper {
+  &__control {
+    display: inline-block;
+    position: relative;
+    padding: $fd-switch-container-padding-y 0;
+  }
+
+  &__slider {
     @include fd-reset();
 
     background-color: var(--sapButton_Track_Background);
@@ -173,7 +172,7 @@ $block: #{$fd-namespace}-switch;
     opacity: var(--sapContent_DisabledOpacity);
   }
 
-  &__input:focus + .#{$block}__wrapper {
+  &__input:focus + .#{$block}__slider {
     &::before {
       position: absolute;
       display: block;
@@ -189,7 +188,7 @@ $block: #{$fd-namespace}-switch;
     }
   }
 
-  &__input:checked + &__wrapper {
+  &__input:checked + &__slider {
     background-color: var(--sapButton_Track_Selected_Background);
     border-color: $fd-switch-active-border-color;
 
@@ -234,7 +233,7 @@ $block: #{$fd-namespace}-switch;
       transform: translate($fd-switch-track-offset, -50%);
     }
 
-    .#{$block}__input:checked + .#{$block}__wrapper {
+    .#{$block}__input:checked + .#{$block}__slider {
       .#{$block}__track {
         transform: translate(-$fd-switch-track-border-offset, -50%);
       }
@@ -242,7 +241,7 @@ $block: #{$fd-namespace}-switch;
   }
 
   @include fd-hover() {
-    .#{$block}__wrapper {
+    .#{$block}__slider {
       border-color: $fd-switch-hover-border-color;
     }
 
@@ -251,7 +250,7 @@ $block: #{$fd-namespace}-switch;
       background-color: $fd-switch-hover-background;
     }
 
-    .#{$block}:checked + .#{$block}__wrapper {
+    .#{$block}:checked + .#{$block}__slider {
       border-color: $fd-switch-hover-selected-border-color;
 
       .#{$block}__handle {
@@ -269,7 +268,7 @@ $block: #{$fd-namespace}-switch;
       min-height: $fd-switch-handle-compact-size;
     }
 
-    .#{$block}__wrapper {
+    .#{$block}__slider {
       width: $fd-switch-track-no-label-compact-width;
       height: $fd-switch-track-no-label-compact-height;
     }
@@ -287,7 +286,7 @@ $block: #{$fd-namespace}-switch;
   }
 
   &--semantic {
-    .#{$block}__wrapper {
+    .#{$block}__slider {
       width: $fd-switch-size-x;
       height: $fd-switch-size-y;
       border-color: $fd-switch-error-border-color;
@@ -303,7 +302,7 @@ $block: #{$fd-namespace}-switch;
       border-color: $fd-switch-error-border-color;
     }
 
-    .#{$block}__input:checked + .#{$block}__wrapper {
+    .#{$block}__input:checked + .#{$block}__slider {
       background-color: var(--sapSuccessBackground);
       border-color: $fd-switch-success-border-color;
 
@@ -320,14 +319,14 @@ $block: #{$fd-namespace}-switch;
     &.#{$block}--compact {
       padding: $fd-switch-container-compact-padding-y 0;
 
-      .#{$block}__wrapper {
+      .#{$block}__slider {
         width: $fd-switch-size-compact-x;
         height: $fd-switch-size-compact-y;
       }
     }
 
     @include fd-hover() {
-      .#{$block}__wrapper {
+      .#{$block}__slider {
         border-color: $fd-switch-error-border-color;
       }
 
@@ -336,7 +335,7 @@ $block: #{$fd-namespace}-switch;
         border-color: $fd-switch-error-border-color;
       }
 
-      .#{$block}__input:checked + .#{$block}__wrapper {
+      .#{$block}__input:checked + .#{$block}__slider {
         .#{$block}__handle {
           background-color: var(--sapSuccessBackground);
         }
@@ -348,7 +347,7 @@ $block: #{$fd-namespace}-switch;
         transform: translate($fd-switch-track-semantic-offset, -50%);
       }
 
-      .#{$block}__input:checked + .#{$block}__wrapper {
+      .#{$block}__input:checked + .#{$block}__slider {
         .#{$block}__track {
           transform: translate($fd-switch-track-border-offset, -50%);
         }

--- a/stories/switch/switch.stories.js
+++ b/stories/switch/switch.stories.js
@@ -18,10 +18,10 @@ export const basic = () => `
 <div class="fd-form-group">
     <div class="fd-form-item">
         <div class="fd-form-label" id="label1">Default (Cozy) Switch</div>
-        <label class="fd-switch__label">
-            <span class="fd-switch">
+        <label class="fd-switch">
+            <span class="fd-switch__control">
                 <input class="fd-switch__input" type="checkbox" name="" value="" aria-labelledby="label1" id="y21YO3251">
-                <div class="fd-switch__wrapper">
+                <div class="fd-switch__slider">
                     <div class="fd-switch__track">
                         <span class="fd-switch__handle" role="presentation"></span>
                     </div>
@@ -31,10 +31,10 @@ export const basic = () => `
     </div>
     <div class="fd-form-item">
         <div class="fd-form-label" id="label2">Compact Switch</div>
-        <label class="fd-switch__label">
-            <span class="fd-switch fd-switch--compact">
+        <label class="fd-switch">
+            <span class="fd-switch__control fd-switch--compact">
                 <input class="fd-switch__input" type="checkbox" name="" value="" aria-labelledby="label2" id="y21YO3431">
-                <div class="fd-switch__wrapper">
+                <div class="fd-switch__slider">
                     <div class="fd-switch__track">
                         <span class="fd-switch__handle" role="presentation"></span>
                     </div>
@@ -44,10 +44,10 @@ export const basic = () => `
     </div>
     <div class="fd-form-item">
         <div class="fd-form-label" id="label7">Disabled Switch</div>
-        <label class="fd-switch__label is-disabled">
-            <span class="fd-switch">
+        <label class="fd-switch is-disabled">
+            <span class="fd-switch__control">
                 <input class="fd-switch__input" type="checkbox" name="" value="" aria-labelledby="label7" id="y21Y13431">
-                <div class="fd-switch__wrapper">
+                <div class="fd-switch__slider">
                     <div class="fd-switch__track">
                         <span class="fd-switch__handle" role="presentation"></span>
                     </div>
@@ -57,10 +57,10 @@ export const basic = () => `
     </div>
     <div class="fd-form-item">
         <div class="fd-form-label" id="label8">Disabled Compact Switch</div>
-        <label class="fd-switch__label is-disabled">
-            <span class="fd-switch fd-switch--compact">
+        <label class="fd-switch is-disabled">
+            <span class="fd-switch__control fd-switch--compact">
                 <input class="fd-switch__input" type="checkbox" name="" value="" aria-labelledby="label8" id="y21Y13491">
-                <div class="fd-switch__wrapper">
+                <div class="fd-switch__slider">
                     <div class="fd-switch__track">
                         <span class="fd-switch__handle" role="presentation"></span>
                     </div>
@@ -82,11 +82,23 @@ export const withText = () => `
 <div class="fd-form-group">
     <div class="fd-form-item">
         <div class="fd-form-label" id="label3">With Off Text</div>
-        <label class="fd-switch__label">
+        <label class="fd-switch">
             <span class="fd-switch__text">Off</span> 
-            <span class="fd-switch">
+            <span class="fd-switch__control">
                 <input class="fd-switch__input" type="checkbox" name="" aria-labelledby="label3" value="" id="y21Y677251">
-                <div class="fd-switch__wrapper">
+                <div class="fd-switch__slider">
+                    <div class="fd-switch__track">
+                        <span class="fd-switch__handle" role="presentation"></span>
+                    </div>
+                </div>
+            </span>
+        </label>
+        
+        <label class="fd-switch">
+            <span class="fd-switch__text">Off</span> 
+            <span class="fd-switch__control">
+                <input class="fd-switch__input" type="checkbox" name="" aria-labelledby="label3" value="" id="y21Y677251">
+                <div class="fd-switch__slider">
                     <div class="fd-switch__track">
                         <span class="fd-switch__handle" role="presentation"></span>
                     </div>
@@ -96,11 +108,11 @@ export const withText = () => `
     </div>
     <div class="fd-form-item">
         <div class="fd-form-label" id="label4">With On Text</div>
-        <label class="fd-switch__label">
+        <label class="fd-switch">
             <span class="fd-switch__text">On</span> 
-            <span class="fd-switch">
+            <span class="fd-switch__control">
                 <input class="fd-switch__input" checked type="checkbox" aria-labelledby="label4" name="" value="" id="y21653431">
-                <div class="fd-switch__wrapper">
+                <div class="fd-switch__slider">
                     <div class="fd-switch__track">
                         <span class="fd-switch__handle" role="presentation"></span>
                     </div>
@@ -110,11 +122,11 @@ export const withText = () => `
     </div>
     <div class="fd-form-item">
         <div class="fd-form-label" id="label9">Disabled With Text</div>
-        <label class="fd-switch__label is-disabled">
+        <label class="fd-switch is-disabled">
             <span class="fd-switch__text">On</span> 
-            <span class="fd-switch">
+            <span class="fd-switch__control">
                 <input class="fd-switch__input" checked type="checkbox" aria-labelledby="label9" name="" value="" id="y29653431">
-                <div class="fd-switch__wrapper">
+                <div class="fd-switch__slider">
                     <div class="fd-switch__track">
                         <span class="fd-switch__handle" role="presentation"></span>
                     </div>
@@ -134,10 +146,10 @@ export const semanticSwitch = () => `
 <div class="fd-form-group">
     <div class="fd-form-item">
         <label class="fd-form-label" id="label5">Semantic Switch</label>
-        <label class="fd-switch__label">
-            <span class="fd-switch fd-switch--semantic">
+        <label class="fd-switch">
+            <span class="fd-switch__control fd-switch--semantic">
                 <input class="fd-switch__input" type="checkbox" aria-labelledby="label5" name="" value="" id="y21YO3251">
-                <div class="fd-switch__wrapper">
+                <div class="fd-switch__slider">
                     <div class="fd-switch__track">
                         <i role="presentation" class="fd-switch__icon--on fd-switch__icon sap-icon--accept"></i>
                         <span class="fd-switch__handle" role="presentation"></span>
@@ -149,10 +161,10 @@ export const semanticSwitch = () => `
     </div>
     <div class="fd-form-item">
         <label class="fd-form-label" id="label6">Semantic Compact Switch</label>
-        <label class="fd-switch__label">
-            <span class="fd-switch fd-switch--semantic fd-switch--compact">
+        <label class="fd-switch">
+            <span class="fd-switch__control fd-switch--semantic fd-switch--compact">
                 <input class="fd-switch__input" type="checkbox" name="" aria-labelledby="label6" value="" id="y21YO3431">
-                <div class="fd-switch__wrapper">
+                <div class="fd-switch__slider">
                     <div class="fd-switch__track">
                         <i role="presentation" class="fd-switch__icon--on fd-switch__icon sap-icon--accept"></i>
                         <span class="fd-switch__handle" role="presentation"></span>

--- a/stories/switch/switch.stories.js
+++ b/stories/switch/switch.stories.js
@@ -85,7 +85,7 @@ export const withText = () => `
         <label class="fd-switch">
             <span class="fd-switch__text">Off</span> 
             <span class="fd-switch__control">
-                <input class="fd-switch__input" type="checkbox" name="" aria-labelledby="label3" value="" id="y21Y677251">
+                <input class="fd-switch__input" type="checkbox" name="" aria-labelledby="label3" value="" id="y21O677251">
                 <div class="fd-switch__slider">
                     <div class="fd-switch__track">
                         <span class="fd-switch__handle" role="presentation"></span>

--- a/stories/switch/switch.stories.js
+++ b/stories/switch/switch.stories.js
@@ -85,18 +85,6 @@ export const withText = () => `
         <label class="fd-switch">
             <span class="fd-switch__text">Off</span> 
             <span class="fd-switch__control">
-                <input class="fd-switch__input" type="checkbox" name="" aria-labelledby="label3" value="" id="y21O677251">
-                <div class="fd-switch__slider">
-                    <div class="fd-switch__track">
-                        <span class="fd-switch__handle" role="presentation"></span>
-                    </div>
-                </div>
-            </span>
-        </label>
-        
-        <label class="fd-switch">
-            <span class="fd-switch__text">Off</span> 
-            <span class="fd-switch__control">
                 <input class="fd-switch__input" type="checkbox" name="" aria-labelledby="label3" value="" id="y21Y677251">
                 <div class="fd-switch__slider">
                     <div class="fd-switch__track">

--- a/stories/switch/switch.stories.js
+++ b/stories/switch/switch.stories.js
@@ -31,8 +31,8 @@ export const basic = () => `
     </div>
     <div class="fd-form-item">
         <div class="fd-form-label" id="label2">Compact Switch</div>
-        <label class="fd-switch">
-            <span class="fd-switch__control fd-switch--compact">
+        <label class="fd-switch fd-switch--compact">
+            <span class="fd-switch__control">
                 <input class="fd-switch__input" type="checkbox" name="" value="" aria-labelledby="label2" id="y21YO3431">
                 <div class="fd-switch__slider">
                     <div class="fd-switch__track">
@@ -57,8 +57,8 @@ export const basic = () => `
     </div>
     <div class="fd-form-item">
         <div class="fd-form-label" id="label8">Disabled Compact Switch</div>
-        <label class="fd-switch is-disabled">
-            <span class="fd-switch__control fd-switch--compact">
+        <label class="fd-switch fd-switch--compact is-disabled">
+            <span class="fd-switch__control">
                 <input class="fd-switch__input" type="checkbox" name="" value="" aria-labelledby="label8" id="y21Y13491">
                 <div class="fd-switch__slider">
                     <div class="fd-switch__track">
@@ -134,14 +134,14 @@ export const semanticSwitch = () => `
 <div class="fd-form-group">
     <div class="fd-form-item">
         <label class="fd-form-label" id="label5">Semantic Switch</label>
-        <label class="fd-switch">
-            <span class="fd-switch__control fd-switch--semantic">
+        <label class="fd-switch fd-switch--semantic">
+            <span class="fd-switch__control">
                 <input class="fd-switch__input" type="checkbox" aria-labelledby="label5" name="" value="" id="y21YO3251">
                 <div class="fd-switch__slider">
                     <div class="fd-switch__track">
-                        <i role="presentation" class="fd-switch__icon--on fd-switch__icon sap-icon--accept"></i>
+                        <i role="presentation" class="fd-switch__icon fd-switch__icon--on sap-icon--accept"></i>
                         <span class="fd-switch__handle" role="presentation"></span>
-                        <i role="presentation" class="fd-switch__icon--off fd-switch__icon sap-icon--decline"></i>
+                        <i role="presentation" class="fd-switch__icon fd-switch__icon--off sap-icon--decline"></i>
                     </div>
                 </div>
             </span>
@@ -149,14 +149,14 @@ export const semanticSwitch = () => `
     </div>
     <div class="fd-form-item">
         <label class="fd-form-label" id="label6">Semantic Compact Switch</label>
-        <label class="fd-switch">
-            <span class="fd-switch__control fd-switch--semantic fd-switch--compact">
+        <label class="fd-switch fd-switch--semantic fd-switch--compact">
+            <span class="fd-switch__control">
                 <input class="fd-switch__input" type="checkbox" name="" aria-labelledby="label6" value="" id="y21YO3431">
                 <div class="fd-switch__slider">
                     <div class="fd-switch__track">
-                        <i role="presentation" class="fd-switch__icon--on fd-switch__icon sap-icon--accept"></i>
+                        <i role="presentation" class="fd-switch__icon fd-switch__icon--on sap-icon--accept"></i>
                         <span class="fd-switch__handle" role="presentation"></span>
-                        <i role="presentation" class="fd-switch__icon--off fd-switch__icon sap-icon--decline"></i>
+                        <i role="presentation" class="fd-switch__icon fd-switch__icon--off sap-icon--decline"></i>
                     </div>
                 </div>
             </span>


### PR DESCRIPTION
## Related Issue
Closes: #1869

## Description
This PR:
- improves switch component class structure.
- removes unnecessary SCSS variables

BREAKING CHANGE:
- On `.fd-switch__label` level should be used `.fd-switch` class
- On `.fd-switch` level should be used `.fd-switch__control` class
- On `.fd-switch` level should be used `.fd-switch__control` class
- Instead of  class should be used `.fd-switch__slider`
- `.fd-switch__label` and `.fd-switch__wrapper` have been removed

### Before:
```
.fd-switch__label
    .fd-switch__text
    .fd-switch
        .fd-switch__input
        .fd-switch__wrapper
            .fd-switch__track
                .fd-switch__icon
                .fd-switch__handle
```

### After:
```
.fd-switch
    .fd-switch__text
    .fd-switch__control
        .fd-switch__input
        .fd-switch__slider
            .fd-switch__track
                .fd-switch__icon
                .fd-switch__handle
```
#### Please check whether the PR fulfills the following requirements

2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
