### PR TITLE
fix: Shellbar menu button focus outline

### DIFF
--- a/src/shellbar.scss
+++ b/src/shellbar.scss
@@ -281,7 +281,6 @@ $block: #{$fd-namespace}-shellbar;
 
   .#{$fd-namespace}-button.#{$block}__button--menu {
     font-size: var(--sapFontSize);
-    outline-color: var(--sapContent_ContrastFocusColor);
 
     &:hover {
       background: $fd-shell-hover-background;
@@ -292,7 +291,10 @@ $block: #{$fd-namespace}-shellbar;
     &:focus {
       background: $fd-shell-active-background;
       color: $fd-shell-active-text-color;
-      outline-color: var(--sapContent_ContrastFocusColor);
+
+      &::after {
+        border-color: var(--sapContent_ContrastFocusColor);
+      }
     }
   }
 


### PR DESCRIPTION
## Related Issue
Closes: #1726

## Description
Previous styling was targeting focus outline on the `fd-button` element. With button refactor, focus indicator has been moved to `fd-button::after`. Shellbar button styling has been updated to target `::after` element

## Screenshots
### Before:
![image](https://user-images.githubusercontent.com/17496353/101648561-3b292b00-3a3a-11eb-912b-153f1cb55347.png)

### After:
![image](https://user-images.githubusercontent.com/17496353/101648474-23ea3d80-3a3a-11eb-9f55-affca6e10a69.png)
