### PR TITLE
feat: add Toggle Button to Buttons

### DIFF
--- a/src/button.scss
+++ b/src/button.scss
@@ -137,20 +137,40 @@ $block: #{$fd-namespace}-button;
 @mixin buttonContainer() {
   @include standard();
 
+  &.#{$block}--toggled {
+    @include standardToggled();
+  }
+
   &.#{$block}--ghost {
     @include ghost();
+
+    &.#{$block}--toggled {
+      @include ghostToggled();
+    }
   }
 
   &.#{$block}--positive {
     @include positive();
+
+    &.#{$block}--toggled {
+      @include positiveToggled();
+    }
   }
 
   &.#{$block}--negative {
     @include negative();
+
+    &.#{$block}--toggled {
+      @include negativeToggled();
+    }
   }
 
   &.#{$block}--attention {
     @include attention();
+
+    &.#{$block}--toggled {
+      @include attentionToggled();
+    }
   }
 
   &.#{$block}--emphasized {
@@ -158,10 +178,18 @@ $block: #{$fd-namespace}-button;
     border-width: var(--fdButton_Emphasized_Border_Width);
 
     @include emphasized();
+
+    &.#{$block}--toggled {
+      @include emphasizedToggled();
+    }
   }
 
   &.#{$block}--transparent {
     @include transparent();
+
+    &.#{$block}--toggled {
+      @include transparentToggled();
+    }
   }
 }
 
@@ -186,48 +214,96 @@ $block: #{$fd-namespace}-button;
   @include standardPressed();
   @include standardPressedFocus();
 
+  &.#{$block}--toggled {
+    @include standardToggledPressed();
+  }
+
   &.#{$block}--ghost {
     @include ghostPressed();
+
+    &.#{$block}--toggled {
+      @include ghostToggledPressed();
+    }
   }
 
   &.#{$block}--positive {
     @include positivePressed();
+
+    &.#{$block}--toggled {
+      @include positiveToggledPressed();
+    }
   }
 
   &.#{$block}--negative {
     @include negativePressed();
+
+    &.#{$block}--toggled {
+      @include negativeToggledPressed();
+    }
   }
 
   &.#{$block}--attention {
     @include attentionPressed();
+
+    &.#{$block}--toggled {
+      @include attentionToggledPressed();
+    }
   }
 
   &.#{$block}--emphasized {
     @include emphasizedPressed();
+
+    &.#{$block}--toggled {
+      @include emphasizedToggledPressed();
+    }
   }
 }
 
 @mixin buttonContainerHover() {
   @include standardHover();
 
+  &.#{$block}--toggled {
+    @include standardToggledHover();
+  }
+
   &.#{$block}--ghost {
     @include ghostHover();
+
+    &.#{$block}--toggled {
+      @include ghostToggledHover();
+    }
   }
 
   &.#{$block}--positive {
     @include positiveHover();
+
+    &.#{$block}--toggled {
+      @include positiveToggledHover();
+    }
   }
 
   &.#{$block}--negative {
     @include negativeHover();
+
+    &.#{$block}--toggled {
+      @include negativeToggledHover();
+    }
   }
 
   &.#{$block}--attention {
     @include attentionHover();
+
+    &.#{$block}--toggled {
+      @include attentionToggledHover();
+    }
   }
 
   &.#{$block}--emphasized {
     @include emphasizedHover();
+
+    &.#{$block}--toggled {
+      @include emphasizedToggledHover();
+    }
   }
 }
 

--- a/src/mixins/button/_attention.scss
+++ b/src/mixins/button/_attention.scss
@@ -21,3 +21,28 @@
     var(--sapButton_Attention_Active_Background)
   );
 }
+
+// Toggled state
+@mixin attentionToggled() {
+  @include applyColors(
+    var(--sapButton_Attention_Selected_TextColor),
+    var(--sapButton_Attention_Selected_BorderColor),
+    var(--sapButton_Attention_Selected_Background)
+  );
+}
+
+@mixin attentionToggledHover() {
+  @include applyColors(
+    var(--sapButton_Attention_Selected_TextColor),
+    var(--sapButton_Attention_Selected_Hover_BorderColor),
+    var(--sapButton_Attention_Selected_Hover_Background)
+  );
+}
+
+@mixin attentionToggledPressed() {
+  @include applyColors(
+    var(--sapButton_Attention_Selected_TextColor),
+    var(--sapButton_Attention_Selected_Hover_BorderColor),
+    var(--sapButton_Attention_Selected_Hover_Background)
+  );
+}

--- a/src/mixins/button/_button-helper.scss
+++ b/src/mixins/button/_button-helper.scss
@@ -19,4 +19,10 @@ $block: #{$fd-namespace}-button;
     border: var(--sapContent_FocusWidth) dotted var(--sapContent_FocusColor);
     @content;
   }
+
+  &.#{$block}--toggled {
+    &::after {
+      border: var(--sapContent_FocusWidth) dotted var(--sapContent_ContrastFocusColor);
+    }
+  }
 }

--- a/src/mixins/button/_button-transparent.scss
+++ b/src/mixins/button/_button-transparent.scss
@@ -2,3 +2,12 @@
   border-color: var(--sapButton_Lite_BorderColor);
   background-color: var(--sapButton_Lite_Background);
 }
+
+// Toggled state
+@mixin transparentToggled() {
+  @include applyColors(
+    var(--sapButton_Selected_TextColor),
+    var(--sapButton_Selected_BorderColor),
+    var(--sapButton_Selected_Background)
+  );
+}

--- a/src/mixins/button/_emphasized.scss
+++ b/src/mixins/button/_emphasized.scss
@@ -21,3 +21,28 @@
     var(--sapButton_Emphasized_Active_Background)
   );
 }
+
+// Toggled state
+@mixin emphasizedToggled() {
+  @include applyColors(
+    var(--sapButton_Selected_TextColor),
+    var(--sapButton_Selected_BorderColor),
+    var(--sapButton_Selected_Background)
+  );
+}
+
+@mixin emphasizedToggledHover {
+  @include applyColors(
+    var(--sapButton_Selected_TextColor),
+    var(--sapButton_Selected_Hover_BorderColor),
+    var(--sapButton_Selected_Hover_Background)
+  );
+}
+
+@mixin emphasizedToggledPressed() {
+  @include applyColors(
+    var(--sapButton_Selected_TextColor),
+    var(--sapButton_Selected_Hover_BorderColor),
+    var(--sapButton_Selected_Hover_Background)
+  );
+}

--- a/src/mixins/button/_ghost.scss
+++ b/src/mixins/button/_ghost.scss
@@ -1,5 +1,9 @@
 @mixin ghost() {
-  @include applyColors(var(--sapButton_TextColor), var(--sapButton_BorderColor), var(--sapButton_Lite_Background));
+  @include applyColors(
+    var(--sapButton_TextColor),
+    var(--sapButton_BorderColor),
+    var(--sapButton_Lite_Background)
+  );
 }
 
 @mixin ghostHover {
@@ -15,5 +19,30 @@
     var(--sapButton_Selected_TextColor),
     var(--sapButton_BorderColor),
     var(--sapButton_Active_Background)
+  );
+}
+
+// Toggled state
+@mixin ghostToggled() {
+  @include applyColors(
+    var(--sapButton_Selected_TextColor),
+    var(--sapButton_Selected_BorderColor),
+    var(--sapButton_Selected_Background)
+  );
+}
+
+@mixin ghostToggledHover {
+  @include applyColors(
+    var(--sapButton_Selected_TextColor),
+    var(--sapButton_Selected_Hover_BorderColor),
+    var(--sapButton_Selected_Hover_Background)
+  );
+}
+
+@mixin ghostToggledPressed() {
+  @include applyColors(
+    var(--sapButton_Selected_TextColor),
+    var(--sapButton_Selected_Hover_BorderColor),
+    var(--sapButton_Selected_Hover_Background)
   );
 }

--- a/src/mixins/button/_negative.scss
+++ b/src/mixins/button/_negative.scss
@@ -21,3 +21,28 @@
     var(--sapButton_Reject_Active_Background)
   );
 }
+
+// Toggled state
+@mixin negativeToggled() {
+  @include applyColors(
+    var(--sapButton_Reject_Selected_TextColor),
+    var(--sapButton_Reject_Selected_BorderColor),
+    var(--sapButton_Reject_Selected_Background)
+  );
+}
+
+@mixin negativeToggledHover() {
+  @include applyColors(
+    var(--sapButton_Reject_Selected_TextColor),
+    var(--sapButton_Reject_Selected_Hover_BorderColor),
+    var(--sapButton_Reject_Selected_Hover_Background)
+  );
+}
+
+@mixin negativeToggledPressed() {
+  @include applyColors(
+    var(--sapButton_Reject_Selected_TextColor),
+    var(--sapButton_Reject_Selected_Hover_BorderColor),
+    var(--sapButton_Reject_Selected_Hover_Background)
+  );
+}

--- a/src/mixins/button/_positive.scss
+++ b/src/mixins/button/_positive.scss
@@ -21,3 +21,28 @@
     var(--sapButton_Accept_Active_Background)
   );
 }
+
+// Toggled state
+@mixin positiveToggled() {
+  @include applyColors(
+    var(--sapButton_Accept_Selected_TextColor),
+    var(--sapButton_Accept_Selected_BorderColor),
+    var(--sapButton_Accept_Selected_Background)
+  );
+}
+
+@mixin positiveToggledHover {
+  @include applyColors(
+    var(--sapButton_Accept_Selected_TextColor),
+    var(--sapButton_Accept_Selected_Hover_BorderColor),
+    var(--sapButton_Accept_Selected_Hover_Background)
+  );
+}
+
+@mixin positiveToggledPressed {
+  @include applyColors(
+    var(--sapButton_Accept_Selected_TextColor),
+    var(--sapButton_Accept_Selected_Hover_BorderColor),
+    var(--sapButton_Accept_Selected_Hover_Background)
+  );
+}

--- a/src/mixins/button/_standard.scss
+++ b/src/mixins/button/_standard.scss
@@ -18,6 +18,31 @@
   );
 }
 
+// Toggled state
+@mixin standardToggled() {
+  @include applyColors(
+    var(--sapButton_Selected_TextColor),
+    var(--sapButton_Selected_BorderColor),
+    var(--sapButton_Selected_Background)
+  );
+}
+
+@mixin standardToggledHover {
+  @include applyColors(
+    var(--sapButton_Selected_TextColor),
+    var(--sapButton_Selected_Hover_BorderColor),
+    var(--sapButton_Selected_Hover_Background)
+  );
+}
+
+@mixin standardToggledPressed() {
+  @include applyColors(
+    var(--sapButton_Selected_TextColor),
+    var(--sapButton_Selected_Hover_BorderColor),
+    var(--sapButton_Selected_Hover_Background)
+  );
+}
+
 @mixin standardPressedFocus() {
   &::after {
     border-color: var(--sapContent_ContrastFocusColor);

--- a/stories/button/__snapshots__/button.stories.storyshot
+++ b/stories/button/__snapshots__/button.stories.storyshot
@@ -1745,3 +1745,345 @@ exports[`Storyshots Components/Button Split menu button 1`] = `
 
 </section>
 `;
+
+exports[`Storyshots Components/Button Toggle button 1`] = `
+<section>
+  <h4>
+    Inactive state of toggle button
+  </h4>
+  
+
+  <div
+    class="fddocs-container"
+  >
+     
+    
+    <button
+      class="fd-button"
+    >
+      Default Toggle
+    </button>
+    
+    
+    <button
+      class="fd-button fd-button--emphasized"
+    >
+      Emphasized Toggle
+    </button>
+    
+    
+    <button
+      class="fd-button fd-button--ghost"
+    >
+      Ghost Toggle
+    </button>
+    
+    
+    <button
+      class="fd-button fd-button--positive"
+    >
+      Positive Toggle
+    </button>
+    
+    
+    <button
+      class="fd-button fd-button--negative"
+    >
+      Negative Toggle
+    </button>
+    
+    
+    <button
+      class="fd-button fd-button--attention"
+    >
+      Attention Toggle
+    </button>
+    
+    
+    <button
+      class="fd-button fd-button--transparent"
+    >
+      Transparent Toggle
+    </button>
+    
+    
+    <button
+      class="fd-button fd-button--menu"
+    >
+      
+        
+      <span
+        class="fd-button__text"
+      >
+        Action Button
+      </span>
+      
+        
+      <i
+        class="sap-icon--slim-arrow-down"
+      />
+      
+    
+    </button>
+    
+    
+    <button
+      aria-label="Add to cart"
+      class="fd-button fd-button--menu fd-button--attention"
+    >
+      
+        
+      <i
+        class="sap-icon--cart"
+      />
+      <i
+        class="sap-icon--slim-arrow-down"
+      />
+      
+    
+    </button>
+    
+    
+    <button
+      aria-label="Accept"
+      class="fd-button fd-button--positive"
+    >
+      <i
+        class="sap-icon--accept"
+      />
+    </button>
+    
+
+  </div>
+  
+
+  <h4>
+    Active (toggled) state of toggle button
+  </h4>
+  
+
+  <div
+    class="fddocs-container"
+  >
+     
+    
+    <button
+      class="fd-button fd-button--toggled"
+    >
+      Default Toggle
+    </button>
+    
+    
+    <button
+      class="fd-button fd-button--emphasized fd-button--toggled"
+    >
+      Emphasized Toggle
+    </button>
+    
+    
+    <button
+      class="fd-button fd-button--ghost fd-button--toggled"
+    >
+      Ghost Toggle
+    </button>
+    
+    
+    <button
+      class="fd-button fd-button--positive fd-button--toggled"
+    >
+      Positive Toggle
+    </button>
+    
+    
+    <button
+      class="fd-button fd-button--negative fd-button--toggled"
+    >
+      Negative Toggle
+    </button>
+    
+    
+    <button
+      class="fd-button fd-button--attention fd-button--toggled"
+    >
+      Attention Toggle
+    </button>
+    
+    
+    <button
+      class="fd-button fd-button--transparent fd-button--toggled"
+    >
+      Transparent Toggle
+    </button>
+    
+    
+    <button
+      class="fd-button fd-button--menu fd-button--toggled"
+    >
+      
+        
+      <span
+        class="fd-button__text"
+      >
+        Action Button
+      </span>
+      
+        
+      <i
+        class="sap-icon--slim-arrow-down"
+      />
+      
+    
+    </button>
+    
+    
+    <button
+      aria-label="Add to cart"
+      class="fd-button fd-button--menu fd-button--attention fd-button--toggled"
+    >
+      
+        
+      <i
+        class="sap-icon--cart"
+      />
+      <i
+        class="sap-icon--slim-arrow-down"
+      />
+      
+    
+    </button>
+    
+    
+    <button
+      aria-label="Accept"
+      class="fd-button fd-button--positive fd-button--toggled"
+    >
+      <i
+        class="sap-icon--accept"
+      />
+    </button>
+    
+
+  </div>
+  
+
+  <h4>
+    Disabled Toggle button in active state
+  </h4>
+  
+
+  <div
+    class="fddocs-container"
+  >
+     
+    
+    <button
+      class="fd-button fd-button--toggled"
+      disabled=""
+    >
+      Default Toggle
+    </button>
+    
+    
+    <button
+      class="fd-button fd-button--emphasized fd-button--toggled"
+      disabled=""
+    >
+      Emphasized Toggle
+    </button>
+    
+    
+    <button
+      class="fd-button fd-button--ghost fd-button--toggled"
+      disabled=""
+    >
+      Ghost Toggle
+    </button>
+    
+    
+    <button
+      class="fd-button fd-button--positive fd-button--toggled"
+      disabled=""
+    >
+      Positive Toggle
+    </button>
+    
+    
+    <button
+      class="fd-button fd-button--negative fd-button--toggled"
+      disabled=""
+    >
+      Negative Toggle
+    </button>
+    
+    
+    <button
+      class="fd-button fd-button--attention fd-button--toggled"
+      disabled=""
+    >
+      Attention Toggle
+    </button>
+    
+    
+    <button
+      class="fd-button fd-button--transparent fd-button--toggled"
+      disabled=""
+    >
+      Transparent Toggle
+    </button>
+    
+    
+    <button
+      aria-disabled="true"
+      class="fd-button fd-button--menu fd-button--toggled"
+      disabled=""
+    >
+      
+        
+      <span
+        class="fd-button__text"
+      >
+        Action Button
+      </span>
+      
+        
+      <i
+        class="sap-icon--slim-arrow-down"
+      />
+      
+    
+    </button>
+    
+    
+    <button
+      aria-disabled="true"
+      aria-label="Add to cart"
+      class="fd-button fd-button--menu fd-button--attention fd-button--toggled"
+      disabled=""
+    >
+      
+        
+      <i
+        class="sap-icon--cart"
+      />
+      <i
+        class="sap-icon--slim-arrow-down"
+      />
+      
+    
+    </button>
+    
+    
+    <button
+      aria-label="Accept"
+      class="fd-button fd-button--positive"
+      disabled=""
+    >
+      <i
+        class="sap-icon--accept"
+      />
+    </button>
+    
+
+  </div>
+</section>
+`;

--- a/stories/button/button.stories.js
+++ b/stories/button/button.stories.js
@@ -66,40 +66,65 @@ types.parameters = {
     }
 };
 
-export const toggle = () => `<div class="fddocs-container"> 
-        <button class="fd-button">Default Toggle</button>
-        <button class="fd-button fd-button--emphasized">Emphasized Toggle</button>
-        <button class="fd-button fd-button--ghost">Ghost Toggle</button>
-        <button class="fd-button fd-button--positive">Positive Toggle</button>
-        <button class="fd-button fd-button--negative">Negative Toggle</button>
-        <button class="fd-button fd-button--attention">Attention Toggle</button>
-        <button class="fd-button fd-button--transparent">Transparent Toggle</button>
-</div>
-<h4>Toggled State</h4>
+export const toggle = () => `<h4>Inactive state of toggle button</h4>
 <div class="fddocs-container"> 
-        <button class="fd-button fd-button--toggled">Default Toggle</button>
-        <button class="fd-button fd-button--emphasized fd-button--toggled">Emphasized Toggle</button>
-        <button class="fd-button fd-button--ghost fd-button--toggled">Ghost Toggle</button>
-        <button class="fd-button fd-button--positive fd-button--toggled">Positive Toggle</button>
-        <button class="fd-button fd-button--negative fd-button--toggled">Negative Toggle</button>
-        <button class="fd-button fd-button--attention fd-button--toggled">Attention Toggle</button>
-        <button class="fd-button fd-button--transparent fd-button--toggled">Transparent Toggle</button>
+    <button class="fd-button">Default Toggle</button>
+    <button class="fd-button fd-button--emphasized">Emphasized Toggle</button>
+    <button class="fd-button fd-button--ghost">Ghost Toggle</button>
+    <button class="fd-button fd-button--positive">Positive Toggle</button>
+    <button class="fd-button fd-button--negative">Negative Toggle</button>
+    <button class="fd-button fd-button--attention">Attention Toggle</button>
+    <button class="fd-button fd-button--transparent">Transparent Toggle</button>
+    <button class="fd-button fd-button--menu">
+        <span class="fd-button__text">Action Button</span>
+        <i class="sap-icon--slim-arrow-down"></i>
+    </button>
+    <button aria-label="Add to cart" class="fd-button fd-button--menu fd-button--attention">
+        <i class="sap-icon--cart"></i><i class="sap-icon--slim-arrow-down"></i>
+    </button>
+    <button aria-label="Accept" class="fd-button fd-button--positive"><i class="sap-icon--accept"></i></button>
 </div>
-<h4>Disabled Toggled State</h4>
+<h4>Active (toggled) state of toggle button</h4>
 <div class="fddocs-container"> 
-        <button class="fd-button fd-button--toggled" disabled>Default Toggle</button>
-        <button class="fd-button fd-button--emphasized fd-button--toggled" disabled>Emphasized Toggle</button>
-        <button class="fd-button fd-button--ghost fd-button--toggled" disabled>Ghost Toggle</button>
-        <button class="fd-button fd-button--positive fd-button--toggled" disabled>Positive Toggle</button>
-        <button class="fd-button fd-button--negative fd-button--toggled" disabled>Negative Toggle</button>
-        <button class="fd-button fd-button--attention fd-button--toggled" disabled>Attention Toggle</button>
-        <button class="fd-button fd-button--transparent fd-button--toggled" disabled>Transparent Toggle</button>
+    <button class="fd-button fd-button--toggled">Default Toggle</button>
+    <button class="fd-button fd-button--emphasized fd-button--toggled">Emphasized Toggle</button>
+    <button class="fd-button fd-button--ghost fd-button--toggled">Ghost Toggle</button>
+    <button class="fd-button fd-button--positive fd-button--toggled">Positive Toggle</button>
+    <button class="fd-button fd-button--negative fd-button--toggled">Negative Toggle</button>
+    <button class="fd-button fd-button--attention fd-button--toggled">Attention Toggle</button>
+    <button class="fd-button fd-button--transparent fd-button--toggled">Transparent Toggle</button>
+    <button class="fd-button fd-button--menu fd-button--toggled">
+        <span class="fd-button__text">Action Button</span>
+        <i class="sap-icon--slim-arrow-down"></i>
+    </button>
+    <button aria-label="Add to cart" class="fd-button fd-button--menu fd-button--attention fd-button--toggled">
+        <i class="sap-icon--cart"></i><i class="sap-icon--slim-arrow-down"></i>
+    </button>
+    <button aria-label="Accept" class="fd-button fd-button--positive fd-button--toggled"><i class="sap-icon--accept"></i></button>
+</div>
+<h4>Disabled Toggle button in active state</h4>
+<div class="fddocs-container"> 
+    <button class="fd-button fd-button--toggled" disabled>Default Toggle</button>
+    <button class="fd-button fd-button--emphasized fd-button--toggled" disabled>Emphasized Toggle</button>
+    <button class="fd-button fd-button--ghost fd-button--toggled" disabled>Ghost Toggle</button>
+    <button class="fd-button fd-button--positive fd-button--toggled" disabled>Positive Toggle</button>
+    <button class="fd-button fd-button--negative fd-button--toggled" disabled>Negative Toggle</button>
+    <button class="fd-button fd-button--attention fd-button--toggled" disabled>Attention Toggle</button>
+    <button class="fd-button fd-button--transparent fd-button--toggled" disabled>Transparent Toggle</button>
+    <button class="fd-button fd-button--menu fd-button--toggled" aria-disabled="true" disabled>
+        <span class="fd-button__text">Action Button</span>
+        <i class="sap-icon--slim-arrow-down"></i>
+    </button>
+    <button aria-label="Add to cart" class="fd-button fd-button--menu fd-button--attention fd-button--toggled" aria-disabled="true" disabled>
+        <i class="sap-icon--cart"></i><i class="sap-icon--slim-arrow-down"></i>
+    </button>
+    <button aria-label="Accept" class="fd-button fd-button--positive" disabled><i class="sap-icon--accept"></i></button>
 </div>`;
 
-toggle.storyName = 'Toggle Buttons';
+toggle.storyName = 'Toggle button';
 toggle.parameters = {
     docs: {
-        storyDescription: 'Bla bla bla'
+        storyDescription: 'A toggle button switches between two actions. One of the actions is always active, one is inactive. Use the toggle button for secondary actions. Apply the <code>fd-button--toggled</code> modifier class to set the action to active.'
     }
 };
 

--- a/stories/button/button.stories.js
+++ b/stories/button/button.stories.js
@@ -66,6 +66,44 @@ types.parameters = {
     }
 };
 
+export const toggle = () => `<div class="fddocs-container"> 
+        <button class="fd-button">Default Toggle</button>
+        <button class="fd-button fd-button--emphasized">Emphasized Toggle</button>
+        <button class="fd-button fd-button--ghost">Ghost Toggle</button>
+        <button class="fd-button fd-button--positive">Positive Toggle</button>
+        <button class="fd-button fd-button--negative">Negative Toggle</button>
+        <button class="fd-button fd-button--attention">Attention Toggle</button>
+        <button class="fd-button fd-button--transparent">Transparent Toggle</button>
+</div>
+<h4>Toggled State</h4>
+<div class="fddocs-container"> 
+        <button class="fd-button fd-button--toggled">Default Toggle</button>
+        <button class="fd-button fd-button--emphasized fd-button--toggled">Emphasized Toggle</button>
+        <button class="fd-button fd-button--ghost fd-button--toggled">Ghost Toggle</button>
+        <button class="fd-button fd-button--positive fd-button--toggled">Positive Toggle</button>
+        <button class="fd-button fd-button--negative fd-button--toggled">Negative Toggle</button>
+        <button class="fd-button fd-button--attention fd-button--toggled">Attention Toggle</button>
+        <button class="fd-button fd-button--transparent fd-button--toggled">Transparent Toggle</button>
+</div>
+<h4>Disabled Toggled State</h4>
+<div class="fddocs-container"> 
+        <button class="fd-button fd-button--toggled" disabled>Default Toggle</button>
+        <button class="fd-button fd-button--emphasized fd-button--toggled" disabled>Emphasized Toggle</button>
+        <button class="fd-button fd-button--ghost fd-button--toggled" disabled>Ghost Toggle</button>
+        <button class="fd-button fd-button--positive fd-button--toggled" disabled>Positive Toggle</button>
+        <button class="fd-button fd-button--negative fd-button--toggled" disabled>Negative Toggle</button>
+        <button class="fd-button fd-button--attention fd-button--toggled" disabled>Attention Toggle</button>
+        <button class="fd-button fd-button--transparent fd-button--toggled" disabled>Transparent Toggle</button>
+</div>`;
+
+toggle.storyName = 'Toggle Buttons';
+toggle.parameters = {
+    docs: {
+        storyDescription: 'Bla bla bla'
+    }
+};
+
+
 export const segmentedButton = () => `
     <div class="fd-segmented-button" role="group" aria-label="Group label">
         <button aria-label="Survey" class="fd-button"><i class="sap-icon--survey"></i></button>


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#1943

## Description
this PR adds an enhancement to Buttons - Toggle button. A toggle button switches between two actions. One of the actions is always active, one is inactive. 

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [na] All values are in `rem`
- [na] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [na] Responsiveness rules - the component has modifier classes for all breakpoints
- [na] Includes Compact/Cosy/Tablet design
- [na] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [na] `fd-reset()` mixin is applied to all elements
- [na] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
4. Documentation
- [x] Storybook documentation has been created/updated
- [na] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
