### PR TITLE
fix: add avatar selector under the header

### DIFF
--- a/src/card.scss
+++ b/src/card.scss
@@ -63,19 +63,19 @@ $fd-card-content-avatar-text-spacing: 0.5rem !default;
     text-decoration: none;
     cursor: pointer;
 
+    .#{$block}__avatar {
+      margin-right: $fd-card-avatar-text-spacing;
+
+      @include fd-rtl() {
+        margin-right: 0;
+        margin-left: $fd-card-avatar-text-spacing;
+      }
+    }
+
     &:last-child {
       border-bottom: none;
       border-top: $fd-card-header-border;
       border-radius: 0 0 $fd-card-header-border-radius $fd-card-header-border-radius;
-    }
-  }
-
-  &__avatar {
-    margin-right: $fd-card-avatar-text-spacing;
-
-    @include fd-rtl() {
-      margin-right: 0;
-      margin-left: $fd-card-avatar-text-spacing;
     }
   }
 


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#1715

## Description
Make the avatar selector under the card header so that it can apply the right styling in react, angular and vue

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
