### PR TITLE
fix: add fix for Rating indicator parse error

### DIFF
--- a/src/rating-indicator.scss
+++ b/src/rating-indicator.scss
@@ -5,8 +5,8 @@
 $block: #{$fd-namespace}-rating-indicator;
 
 :root {
-  --sapRating-indicator-icon-rated: url();
-  --sapRating-indicator-icon-unrated: url();
+  --sapRating-indicator-icon-rated: none;
+  --sapRating-indicator-icon-unrated: none;
 }
 
 .#{$block} {


### PR DESCRIPTION
## Description
Importing whole dist `fundamental-styles` or `rating-indicator` into NGX file causes parse error. It's because of invalid variables declaration.

## Screenshots

### Before:
![image](https://user-images.githubusercontent.com/26483208/101768565-02df2680-3ae6-11eb-9e0a-877d4bb46908.png)


### After:

#### Please check whether the PR fulfills the following requirements

3. Testing
- [x] Verified all styles in IE11