### PR TITLE
fix: add fix for Slider labels not being centered in  IE11

### DIFF
--- a/src/slider.scss
+++ b/src/slider.scss
@@ -90,8 +90,8 @@ $handle-hit-area-mobile-dimensions: 2.75rem;
   &__label {
     @include fd-reset();
 
-    @include fd-flex() {
-      justify-content: center;
+    @include fd-flex(column) {
+      align-items: center;
     }
 
     width: 0;


### PR DESCRIPTION
## Related Issue

part of https://github.com/SAP/fundamental-styles/issues/1907

## Description

## Screenshots

### Before:

### After:

#### Please check whether the PR fulfills the following requirements

- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] Verified all styles in IE11
