### PR TITLE
fix: inherit font weight on button text

### DIFF
--- a/src/button.scss
+++ b/src/button.scss
@@ -350,7 +350,7 @@ $block: #{$fd-namespace}-button;
     @include fd-reset();
     @include fd-ellipsis();
 
-    font-width: inherit;
+    font-weight: inherit;
     color: inherit;
   }
 

--- a/src/button.scss
+++ b/src/button.scss
@@ -350,6 +350,7 @@ $block: #{$fd-namespace}-button;
     @include fd-reset();
     @include fd-ellipsis();
 
+    font-width: inherit;
     color: inherit;
   }
 


### PR DESCRIPTION
## Description
In case of usage `fd-button__text` , the text should be emphasized as well

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/26483208/101908950-20cb8a80-3bbd-11eb-90ab-d4355d64e13d.png)


### After:
![image](https://user-images.githubusercontent.com/26483208/101909200-730cab80-3bbd-11eb-8816-504fc07e4e4a.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] Design matches
3. Testing
- [x] Verified all styles in IE11
