### PR TITLE
fix: outline color of breakcrumb icon overflow

### DIFF
--- a/src/breadcrumb.scss
+++ b/src/breadcrumb.scss
@@ -54,6 +54,30 @@ $fd-breadcrumb-border-top-radius: 0.125rem !default;
 
     display: inline-block;
     transition: all $fd-animation-speed ease-in;
+
+    &:focus {
+      .#{$block}__dropdown-icon {
+        color: var(--sapLink_Active_Color, #0a6ed1);
+      }
+    }
+
+    &:active {
+      .#{$block}__dropdown-icon {
+        color: var(--sapLink_Active_Color, #0a6ed1);
+      }
+
+      &:hover {
+        .#{$block}__dropdown-icon {
+          color: var(--sapLink_Active_Color, #0a6ed1);
+        }
+      }
+    }
+
+    &:hover {
+      .#{$block}__dropdown-icon {
+        color: var(--sapLink_Hover_Color, #0854a0);
+      }
+    }
   }
 
   &__dropdown-icon {

--- a/src/breadcrumb.scss
+++ b/src/breadcrumb.scss
@@ -13,7 +13,7 @@ $fd-breadcrumb-separator-color: var(--sapContent_LabelColor);
 $fd-breadcrumb-item-color: var(--sapContent_LabelColor);
 $block: #{$fd-namespace}-breadcrumb;
 $fd-breadcrumb-border-top-radius: 0.125rem !default;
-
+$fd-breadcrumb-overflow-active-color: var(--sapLink_Active_Color);
 .#{$block} {
 
   // BLOCK BASE *******************************************
@@ -57,25 +57,25 @@ $fd-breadcrumb-border-top-radius: 0.125rem !default;
 
     &:focus {
       .#{$block}__dropdown-icon {
-        color: var(--sapLink_Active_Color, #0a6ed1);
+        color: $fd-breadcrumb-overflow-active-color;
       }
     }
 
     &:active {
       .#{$block}__dropdown-icon {
-        color: var(--sapLink_Active_Color, #0a6ed1);
+        color: $fd-breadcrumb-overflow-active-color;
       }
 
       &:hover {
         .#{$block}__dropdown-icon {
-          color: var(--sapLink_Active_Color, #0a6ed1);
+          color: $fd-breadcrumb-overflow-active-color;
         }
       }
     }
 
     &:hover {
       .#{$block}__dropdown-icon {
-        color: var(--sapLink_Hover_Color, #0854a0);
+        color: var(--sapLink_Hover_Color);
       }
     }
   }


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#1892

## Description
Make all states have the same color for both items
## Screenshots
### Before:
![image](https://user-images.githubusercontent.com/50607147/102118425-ad6c8780-3e0d-11eb-9109-30a97410147a.png)


### After:
![Screen Shot 2020-12-14 at 1 05 46 PM](https://user-images.githubusercontent.com/50607147/102118394-a3e31f80-3e0d-11eb-98c0-ea37a6fe26f2.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
