### PR TITLE
fix: split button overflow

### DIFF
--- a/src/button-split.scss
+++ b/src/button-split.scss
@@ -77,7 +77,7 @@ $fd-button-split-margin: 0.125rem / 2;
     }
   }
 
-  .fd-button__text {
+  .#{$fd-namespace}-button__text {
     @include fd-ellipsis();
 
     max-width: 9.75rem;

--- a/src/button-split.scss
+++ b/src/button-split.scss
@@ -76,4 +76,16 @@ $fd-button-split-margin: 0.125rem / 2;
       }
     }
   }
+
+  &__text {
+    max-width: 9.75rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    display: block;
+
+    &--compact {
+      max-width: 10rem;
+    }
+  }
 }

--- a/src/button-split.scss
+++ b/src/button-split.scss
@@ -78,10 +78,9 @@ $fd-button-split-margin: 0.125rem / 2;
   }
 
   &__text {
+    @include fd-ellipsis();
+
     max-width: 9.75rem;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
     display: block;
 
     &--compact {

--- a/src/button-split.scss
+++ b/src/button-split.scss
@@ -77,7 +77,7 @@ $fd-button-split-margin: 0.125rem / 2;
     }
   }
 
-  &__text {
+  .fd-button__text {
     @include fd-ellipsis();
 
     max-width: 9.75rem;

--- a/src/button-split.scss
+++ b/src/button-split.scss
@@ -77,9 +77,67 @@ $fd-button-split-margin: 0.125rem / 2;
     }
   }
 
-  .#{$fd-namespace}-button__text {
+  & > :first-child {
+    &:hover {
+      .#{$block}__text {
+        color: var(--sapButton_TextColor);
+      }
+    }
+
+    &:active {
+
+      .#{$block}__text {
+        color: var(--sapButton_Selected_TextColor);
+      }
+    }
+  }
+
+  &--emphasized {
+    > [class*="--emphasized"] {
+      & > .#{$block}__text {
+        color: var(--sapButton_Emphasized_TextColor);
+        font-weight: bold;
+      }
+
+      &:hover {
+        & > .#{$block}__text {
+          color: var(--sapButton_Emphasized_Hover_TextColor);
+        }
+      }
+
+      &:active {
+        & > .#{$block}__text {
+          color: var(--sapButton_Selected_TextColor);
+        }
+      }
+    }
+  }
+
+  &--transparent {
+    > [class*="--transparent"] {
+      & > .#{$block}__text {
+        color: var(--sapButton_TextColor);
+      }
+
+      &:hover {
+        & > .#{$block}__text {
+          color: var(--sapButton_TextColor);
+        }
+      }
+
+      &:active {
+        & > .#{$block}__text {
+          color: var(--sapButton_Selected_TextColor);
+        }
+      }
+    }
+  }
+
+  .#{$block}__text {
+    @include fd-reset();
     @include fd-ellipsis();
 
+    color: var(--sapButton_TextColor);
     max-width: 9.75rem;
     display: block;
 

--- a/stories/button/__snapshots__/button.stories.storyshot
+++ b/stories/button/__snapshots__/button.stories.storyshot
@@ -1432,7 +1432,7 @@ exports[`Storyshots Components/Button Split menu button 1`] = `
       
     
       <span
-        class="fd-button__text"
+        class="fd-button-split__text"
       >
         Button with a big amount of text
       </span>
@@ -1536,7 +1536,7 @@ exports[`Storyshots Components/Button Split menu button 1`] = `
 
   <div
     aria-label="button-split"
-    class="fd-button-split"
+    class="fd-button-split fd-button-split--emphasized"
     role="group"
   >
     
@@ -1545,7 +1545,15 @@ exports[`Storyshots Components/Button Split menu button 1`] = `
       aria-label="button"
       class="fd-button fd-button--emphasized"
     >
-      Button with text
+      
+    
+      <span
+        class="fd-button-split__text"
+      >
+        Button with text
+      </span>
+      
+  
     </button>
     
   
@@ -1645,7 +1653,7 @@ exports[`Storyshots Components/Button Split menu button 1`] = `
 
   <div
     aria-label="button-split"
-    class="fd-button-split"
+    class="fd-button-split fd-button-split--transparent"
     role="group"
   >
     
@@ -1654,7 +1662,17 @@ exports[`Storyshots Components/Button Split menu button 1`] = `
       aria-label="button"
       class="fd-button fd-button--transparent"
     >
-      Button with text
+      
+    
+      <span
+        class="fd-button-split__text"
+      >
+        
+        Button with text
+    
+      </span>
+      
+ 
     </button>
     
   

--- a/stories/button/__snapshots__/button.stories.storyshot
+++ b/stories/button/__snapshots__/button.stories.storyshot
@@ -1427,9 +1427,9 @@ exports[`Storyshots Components/Button Split menu button 1`] = `
   
     <button
       aria-label="button"
-      class="fd-button"
+      class="fd-button fd-button-split__text"
     >
-      Button with text
+      Button with a lot of text
     </button>
     
   

--- a/stories/button/__snapshots__/button.stories.storyshot
+++ b/stories/button/__snapshots__/button.stories.storyshot
@@ -1427,9 +1427,17 @@ exports[`Storyshots Components/Button Split menu button 1`] = `
   
     <button
       aria-label="button"
-      class="fd-button fd-button-split__text"
+      class="fd-button"
     >
-      Button with a lot of text
+      
+    
+      <span
+        class="fd-button__text"
+      >
+        Button with a big amount of text
+      </span>
+      
+  
     </button>
     
   

--- a/stories/button/button.stories.js
+++ b/stories/button/button.stories.js
@@ -284,7 +284,9 @@ menuButton.parameters = {
 
 export const splitMenuButton = () => `
 <div class="fd-button-split fd-has-margin-right-small" role="group" aria-label="button-split">
-  <button class="fd-button fd-button-split__text" aria-label="button">Button with a lot of text</button>
+  <button class="fd-button" aria-label="button">
+    <span class="fd-button__text">Button with a big amount of text</span>
+  </button>
   <button class="fd-button" aria-controls="t4c0o273" aria-haspopup="true" aria-expanded="false" aria-label="More"><i class="sap-icon--slim-arrow-down"></i></button>
   <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right"  aria-hidden="true" 
   id="t4c0o273">

--- a/stories/button/button.stories.js
+++ b/stories/button/button.stories.js
@@ -285,7 +285,7 @@ menuButton.parameters = {
 export const splitMenuButton = () => `
 <div class="fd-button-split fd-has-margin-right-small" role="group" aria-label="button-split">
   <button class="fd-button" aria-label="button">
-    <span class="fd-button__text">Button with a big amount of text</span>
+    <span class="fd-button-split__text">Button with a big amount of text</span>
   </button>
   <button class="fd-button" aria-controls="t4c0o273" aria-haspopup="true" aria-expanded="false" aria-label="More"><i class="sap-icon--slim-arrow-down"></i></button>
   <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right"  aria-hidden="true" 
@@ -307,8 +307,10 @@ export const splitMenuButton = () => `
   </div>
 </div>
 
-<div class="fd-button-split" role="group" aria-label="button-split">
-  <button class="fd-button fd-button--emphasized" aria-label="button">Button with text</button>
+<div class="fd-button-split fd-button-split--emphasized" role="group" aria-label="button-split">
+  <button class="fd-button fd-button--emphasized" aria-label="button">
+    <span class="fd-button-split__text">Button with text</span>
+  </button>
   <button class="fd-button fd-button--emphasized" aria-controls="t4c0o2732" 
   aria-haspopup="true" aria-expanded="false" aria-label="More"><i class="sap-icon--slim-arrow-down"></i></button>
 
@@ -331,8 +333,12 @@ export const splitMenuButton = () => `
   </div>
 </div>
 
-<div class="fd-button-split" role="group" aria-label="button-split">
-  <button class="fd-button fd-button--transparent" aria-label="button">Button with text</button>
+<div class="fd-button-split fd-button-split--transparent" role="group" aria-label="button-split">
+  <button class="fd-button fd-button--transparent" aria-label="button">
+    <span class="fd-button-split__text">
+        Button with text
+    </span>
+ </button>
   <button class="fd-button fd-button--transparent" aria-controls="t4c0o27322" aria-haspopup="true" aria-expanded="false" aria-label="More"><i class="sap-icon--slim-arrow-down"></i></button>
   <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right"  aria-hidden="true" 
     id="t4c0o27322">

--- a/stories/button/button.stories.js
+++ b/stories/button/button.stories.js
@@ -19,7 +19,7 @@ export default {
 
 - You want to link to a different page or object. Instead, use the **Link** component.
 `,
-        components: ['popover', 'segmented-button', 'menu', 'icon', 'button-split', 'button']
+        components: ['popover', 'segmented-button', 'menu', 'icon', 'button', 'button-split']
     }
 };
 
@@ -284,7 +284,7 @@ menuButton.parameters = {
 
 export const splitMenuButton = () => `
 <div class="fd-button-split fd-has-margin-right-small" role="group" aria-label="button-split">
-  <button class="fd-button" aria-label="button">Button with text</button>
+  <button class="fd-button fd-button-split__text" aria-label="button">Button with a lot of text</button>
   <button class="fd-button" aria-controls="t4c0o273" aria-haspopup="true" aria-expanded="false" aria-label="More"><i class="sap-icon--slim-arrow-down"></i></button>
   <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right"  aria-hidden="true" 
   id="t4c0o273">


### PR DESCRIPTION
## Related Issue
Closes  https://github.com/SAP/fundamental-styles/issues/1721

## Description
Add text overflow to the text of split button
For regular cosy button 9.75rem is used because the other button takes 2.25rem and the max-width is always 12rem
For compact 10rem is used to keep this same 12rem max-width

## Screenshots

### Before:
![image](https://user-images.githubusercontent.com/50607147/102256626-9b581b00-3ed9-11eb-90d7-160ebecde881.png)

### After:
![Screen Shot 2020-12-15 at 1 16 52 PM](https://user-images.githubusercontent.com/50607147/102256644-a1e69280-3ed9-11eb-98aa-58f800180f2b.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
