### PR TITLE
fix: hover text decoration of icon with link

### DIFF
--- a/src/link.scss
+++ b/src/link.scss
@@ -11,13 +11,9 @@ $block: #{$fd-namespace}-link;
   @include fd-link();
 
   &:hover {
-    .#{$block}__icon {
-      @include fd-reset();
-
-      &::before {
-        text-decoration: underline;
-        color: var(--sapLink_Hover_Color);
-      }
+    @include fd-icon-selector() {
+      text-decoration: underline;
+      color: var(--sapLink_Hover_Color);
     }
   }
 }

--- a/src/link.scss
+++ b/src/link.scss
@@ -9,4 +9,15 @@ $block: #{$fd-namespace}-link;
 .#{$block} {
   @include fd-reset();
   @include fd-link();
+
+  &:hover {
+    .#{$block}__icon {
+      @include fd-reset();
+
+      &::before {
+        text-decoration: underline;
+        color: var(--sapLink_Hover_Color);
+      }
+    }
+  }
 }

--- a/stories/link/__snapshots__/link.stories.storyshot
+++ b/stories/link/__snapshots__/link.stories.storyshot
@@ -17,10 +17,6 @@ exports[`Storyshots Components/Link Types 1`] = `
   <br />
   
 
-  <br />
-  <br />
-  
-
   <a
     class="fd-link fd-link--emphasized"
     href="#"
@@ -51,7 +47,6 @@ exports[`Storyshots Components/Link Types 1`] = `
     class="fd-link"
   >
     Disabled link
-
   </a>
   
 
@@ -88,7 +83,7 @@ exports[`Storyshots Components/Link Types 1`] = `
     Right icon link 
     
     <span
-      class="sap-icon--slim-arrow-right sap-icon--s fd-link__icon"
+      class="sap-icon--slim-arrow-right sap-icon--s"
     />
     
 
@@ -107,7 +102,7 @@ exports[`Storyshots Components/Link Types 1`] = `
     
     
     <span
-      class="sap-icon--slim-arrow-left sap-icon--s fd-link__icon"
+      class="sap-icon--slim-arrow-left sap-icon--s"
     />
      
     Left icon link

--- a/stories/link/__snapshots__/link.stories.storyshot
+++ b/stories/link/__snapshots__/link.stories.storyshot
@@ -17,6 +17,10 @@ exports[`Storyshots Components/Link Types 1`] = `
   <br />
   
 
+  <br />
+  <br />
+  
+
   <a
     class="fd-link fd-link--emphasized"
     href="#"
@@ -47,6 +51,7 @@ exports[`Storyshots Components/Link Types 1`] = `
     class="fd-link"
   >
     Disabled link
+
   </a>
   
 
@@ -83,7 +88,7 @@ exports[`Storyshots Components/Link Types 1`] = `
     Right icon link 
     
     <span
-      class="sap-icon--slim-arrow-right sap-icon--s"
+      class="sap-icon--slim-arrow-right sap-icon--s fd-link__icon"
     />
     
 
@@ -102,7 +107,7 @@ exports[`Storyshots Components/Link Types 1`] = `
     
     
     <span
-      class="sap-icon--slim-arrow-left sap-icon--s"
+      class="sap-icon--slim-arrow-left sap-icon--s fd-link__icon"
     />
      
     Left icon link

--- a/stories/link/link.stories.js
+++ b/stories/link/link.stories.js
@@ -28,13 +28,11 @@ Avoid texts such as *Click Here* or *Link*, as these do not make it clear to the
 export const primary = () => `
 <a href="#" class="fd-link" tabindex="0">Default link</a>
 <br><br>
-<br><br>
 <a href="#" class="fd-link fd-link--emphasized" tabindex="0">Emphasized link</a>
 <br><br>
 <a href="#" class="fd-link fd-link--subtle">Subtle link</a>
 <br><br>
-<a class="fd-link" aria-disabled="true">Disabled link
-</a>
+<a class="fd-link" aria-disabled="true">Disabled link</a>
 <br><br>
 <div style="background-color:#314a5e;padding:10px">
     <a href="#" class="fd-link fd-link--inverted">Inverted link</a>
@@ -42,11 +40,11 @@ export const primary = () => `
 <br><br>
 <a href="#" class="fd-link" tabindex="0">
     Right icon link 
-    <span class="sap-icon--slim-arrow-right sap-icon--s fd-link__icon"></span>
+    <span class="sap-icon--slim-arrow-right sap-icon--s"></span>
 </a>
 <br><br>
 <a href="#" class="fd-link" tabindex="0">
-    <span class="sap-icon--slim-arrow-left sap-icon--s fd-link__icon"></span> 
+    <span class="sap-icon--slim-arrow-left sap-icon--s"></span> 
     Left icon link
 </a>
 `;

--- a/stories/link/link.stories.js
+++ b/stories/link/link.stories.js
@@ -21,18 +21,20 @@ Use a meaningful link text that indicates what will happen when the user interac
 Avoid texts such as *Click Here* or *Link*, as these do not make it clear to the user what the purpose of the link is.
 `,
         tags: ['f3', 'a11y', 'theme'],
-        components: ['link']
+        components: ['icon', 'link']
     }
 };
 
 export const primary = () => `
 <a href="#" class="fd-link" tabindex="0">Default link</a>
 <br><br>
+<br><br>
 <a href="#" class="fd-link fd-link--emphasized" tabindex="0">Emphasized link</a>
 <br><br>
 <a href="#" class="fd-link fd-link--subtle">Subtle link</a>
 <br><br>
-<a class="fd-link" aria-disabled="true">Disabled link</a>
+<a class="fd-link" aria-disabled="true">Disabled link
+</a>
 <br><br>
 <div style="background-color:#314a5e;padding:10px">
     <a href="#" class="fd-link fd-link--inverted">Inverted link</a>
@@ -40,11 +42,11 @@ export const primary = () => `
 <br><br>
 <a href="#" class="fd-link" tabindex="0">
     Right icon link 
-    <span class="sap-icon--slim-arrow-right sap-icon--s"></span>
+    <span class="sap-icon--slim-arrow-right sap-icon--s fd-link__icon"></span>
 </a>
 <br><br>
 <a href="#" class="fd-link" tabindex="0">
-    <span class="sap-icon--slim-arrow-left sap-icon--s"></span> 
+    <span class="sap-icon--slim-arrow-left sap-icon--s fd-link__icon"></span> 
     Left icon link
 </a>
 `;


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#1777

## Description
Fix the color and underline of the icon when user hovers over link 
## Screenshots

### Before:

![image](https://user-images.githubusercontent.com/50607147/102276845-69ed4880-3ef5-11eb-9062-f8d8c6c8ada5.png)

### After:
![Screen Shot 2020-12-15 at 4 49 36 PM](https://user-images.githubusercontent.com/50607147/102276917-8c7f6180-3ef5-11eb-93f3-9d00c96dae91.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
