### PR TITLE
fix: a11y changes to tabs

### DIFF
--- a/src/tabs.scss
+++ b/src/tabs.scss
@@ -25,7 +25,7 @@ $block: #{$fd-namespace}-tabs;
       transition: all $fd-tabs-link-transition-params;
       content: "";
       position: absolute;
-      bottom: -$fd-tabs-link-padding-y;
+      bottom: -0.9375rem;
       left: -$fd-tabs-active-link-line-offset-x;
       display: inline-block;
       height: $fd-tabs-link-border-width;
@@ -107,6 +107,7 @@ $block: #{$fd-namespace}-tabs;
     @include action-cursor();
 
     transition: 0s;
+    background-color: var(--sapObjectHeader_Background, #fff);
     display: block;
     position: relative;
     text-decoration: none;
@@ -129,6 +130,7 @@ $block: #{$fd-namespace}-tabs;
     @include fd-reset();
 
     position: relative;
+    border-bottom: 1px solid transparent;
     padding: 0;
     margin: 0 $fd-tabs-item-spacing-x;
 

--- a/src/tabs.scss
+++ b/src/tabs.scss
@@ -98,6 +98,7 @@ $block: #{$fd-namespace}-tabs;
     @include fd-reset();
 
     line-height: 1rem;
+    text-align: left;
     padding-bottom: 0.125rem;
     color: $fd-tabs-label-color;
   }
@@ -271,6 +272,7 @@ $block: #{$fd-namespace}-tabs;
     @include fd-reset();
 
     display: block;
+    text-align: left;
     padding-left: 0.125rem;
     font-size: var(--sapFontSmallSize);
     color: $fd-tabs-label-color;

--- a/stories/tabs/__snapshots__/tabs.stories.storyshot
+++ b/stories/tabs/__snapshots__/tabs.stories.storyshot
@@ -20,6 +20,7 @@ exports[`Storyshots Components/Tabs Counters 1`] = `
       <button
         class="fd-tabs__link"
         href="#d9vOir"
+        role="link"
       >
         
             
@@ -56,6 +57,7 @@ exports[`Storyshots Components/Tabs Counters 1`] = `
       <button
         class="fd-tabs__link"
         href="#bSj6ft"
+        role="link"
       >
         
             
@@ -91,6 +93,7 @@ exports[`Storyshots Components/Tabs Counters 1`] = `
       <button
         class="fd-tabs__link"
         href="#VrHfHi"
+        role="link"
       >
         
             
@@ -193,6 +196,7 @@ exports[`Storyshots Components/Tabs Default 1`] = `
       <button
         class="fd-tabs__link"
         href="#fuCwV550"
+        role="link"
       >
         
             
@@ -222,6 +226,7 @@ exports[`Storyshots Components/Tabs Default 1`] = `
       <button
         class="fd-tabs__link"
         href="#AiWfz165"
+        role="link"
       >
         
             
@@ -250,6 +255,7 @@ exports[`Storyshots Components/Tabs Default 1`] = `
       <button
         class="fd-tabs__link"
         href="#7ae0T849"
+        role="link"
       >
         
             
@@ -345,6 +351,7 @@ exports[`Storyshots Components/Tabs Filter mode (compact) 1`] = `
       <button
         class="fd-tabs__link"
         href="#YETAv8"
+        role="link"
       >
         
             
@@ -391,6 +398,7 @@ exports[`Storyshots Components/Tabs Filter mode (compact) 1`] = `
       <button
         class="fd-tabs__link"
         href="#eu3WeD"
+        role="link"
       >
         
             
@@ -438,6 +446,7 @@ exports[`Storyshots Components/Tabs Filter mode (compact) 1`] = `
       <button
         class="fd-tabs__link"
         href="#VqJcYO"
+        role="link"
       >
         
             
@@ -485,6 +494,7 @@ exports[`Storyshots Components/Tabs Filter mode (compact) 1`] = `
       <button
         class="fd-tabs__link"
         href="#ceoDu7"
+        role="link"
       >
         
             
@@ -611,6 +621,7 @@ exports[`Storyshots Components/Tabs Filter mode 1`] = `
       <button
         class="fd-tabs__link"
         href="#5ZkDVE"
+        role="link"
       >
         
             
@@ -657,6 +668,7 @@ exports[`Storyshots Components/Tabs Filter mode 1`] = `
       <button
         class="fd-tabs__link"
         href="#znvnwr"
+        role="link"
       >
         
             
@@ -704,6 +716,7 @@ exports[`Storyshots Components/Tabs Filter mode 1`] = `
       <button
         class="fd-tabs__link"
         href="#oyYpL7"
+        role="link"
       >
         
             
@@ -751,6 +764,7 @@ exports[`Storyshots Components/Tabs Filter mode 1`] = `
       <button
         class="fd-tabs__link"
         href="#gRpu9H"
+        role="link"
       >
         
             
@@ -877,6 +891,7 @@ exports[`Storyshots Components/Tabs Icon (compact) 1`] = `
       <button
         class="fd-tabs__link"
         href="#0bT4aB"
+        role="link"
       >
         
             
@@ -918,6 +933,7 @@ exports[`Storyshots Components/Tabs Icon (compact) 1`] = `
       <button
         class="fd-tabs__link"
         href="#kzRyN3"
+        role="link"
       >
         
             
@@ -958,6 +974,7 @@ exports[`Storyshots Components/Tabs Icon (compact) 1`] = `
       <button
         class="fd-tabs__link"
         href="#f2epu6"
+        role="link"
       >
         
             
@@ -1065,6 +1082,7 @@ exports[`Storyshots Components/Tabs Icon 1`] = `
       <button
         class="fd-tabs__link"
         href="#pliA92"
+        role="link"
       >
         
             
@@ -1106,6 +1124,7 @@ exports[`Storyshots Components/Tabs Icon 1`] = `
       <button
         class="fd-tabs__link"
         href="#ZAN8Hd"
+        role="link"
       >
         
             
@@ -1146,6 +1165,7 @@ exports[`Storyshots Components/Tabs Icon 1`] = `
       <button
         class="fd-tabs__link"
         href="#QrQ5Cl"
+        role="link"
       >
         
             
@@ -1252,6 +1272,7 @@ exports[`Storyshots Components/Tabs Navigable 1`] = `
       <button
         class="fd-tabs__link"
         href="#kf8369"
+        role="link"
       >
         
             
@@ -1279,6 +1300,7 @@ exports[`Storyshots Components/Tabs Navigable 1`] = `
       <button
         class="fd-tabs__link"
         href="#9uQ282"
+        role="link"
       >
         
             
@@ -1306,6 +1328,7 @@ exports[`Storyshots Components/Tabs Navigable 1`] = `
       <button
         class="fd-tabs__link"
         href="#DGl707"
+        role="link"
       >
         
             
@@ -1401,6 +1424,7 @@ exports[`Storyshots Components/Tabs Process mode (compact) 1`] = `
       <button
         class="fd-tabs__link"
         href="#LHsxsZ"
+        role="link"
       >
         
             
@@ -1461,6 +1485,7 @@ exports[`Storyshots Components/Tabs Process mode (compact) 1`] = `
       <button
         class="fd-tabs__link"
         href="#ZQvAjG"
+        role="link"
       >
         
             
@@ -1521,6 +1546,7 @@ exports[`Storyshots Components/Tabs Process mode (compact) 1`] = `
       <button
         class="fd-tabs__link"
         href="#wdqPV9"
+        role="link"
       >
         
             
@@ -1643,6 +1669,7 @@ exports[`Storyshots Components/Tabs Process mode 1`] = `
       <button
         class="fd-tabs__link"
         href="#NoQLy6"
+        role="link"
       >
         
             
@@ -1703,6 +1730,7 @@ exports[`Storyshots Components/Tabs Process mode 1`] = `
       <button
         class="fd-tabs__link"
         href="#h4yBDR"
+        role="link"
       >
         
             
@@ -1763,6 +1791,7 @@ exports[`Storyshots Components/Tabs Process mode 1`] = `
       <button
         class="fd-tabs__link"
         href="#nd1EMQ"
+        role="link"
       >
         
             
@@ -1885,6 +1914,7 @@ exports[`Storyshots Components/Tabs Semantic filter mode 1`] = `
       <button
         class="fd-tabs__link"
         href="#5ZkDVE"
+        role="link"
       >
         
             
@@ -1931,6 +1961,7 @@ exports[`Storyshots Components/Tabs Semantic filter mode 1`] = `
       <button
         class="fd-tabs__link"
         href="#znvnwr"
+        role="link"
       >
         
             
@@ -1978,6 +2009,7 @@ exports[`Storyshots Components/Tabs Semantic filter mode 1`] = `
       <button
         class="fd-tabs__link"
         href="#oyYpL7"
+        role="link"
       >
         
             
@@ -2025,6 +2057,7 @@ exports[`Storyshots Components/Tabs Semantic filter mode 1`] = `
       <button
         class="fd-tabs__link"
         href="#gRpu9H"
+        role="link"
       >
         
             
@@ -2072,6 +2105,7 @@ exports[`Storyshots Components/Tabs Semantic filter mode 1`] = `
       <button
         class="fd-tabs__link"
         href="#gRpu1A"
+        role="link"
       >
         
             
@@ -2210,6 +2244,7 @@ exports[`Storyshots Components/Tabs Semantic inline 1`] = `
       <button
         class="fd-tabs__link"
         href="#5abyKZ"
+        role="link"
       >
         
             
@@ -2281,6 +2316,7 @@ exports[`Storyshots Components/Tabs Semantic inline 1`] = `
       <button
         class="fd-tabs__link"
         href="#XlKpQM"
+        role="link"
       >
         
             
@@ -2316,6 +2352,7 @@ exports[`Storyshots Components/Tabs Semantic inline 1`] = `
         aria-controls="3dUJAI"
         class="fd-tabs__link"
         href="#3dUJAI"
+        role="link"
       >
         
             
@@ -2351,6 +2388,7 @@ exports[`Storyshots Components/Tabs Semantic inline 1`] = `
       <button
         class="fd-tabs__link"
         href="#TWlAup"
+        role="link"
       >
         
             
@@ -2477,6 +2515,7 @@ exports[`Storyshots Components/Tabs Semantic mode 1`] = `
       <button
         class="fd-tabs__link"
         href="#XTsSDD"
+        role="link"
       >
         
             
@@ -2558,6 +2597,7 @@ exports[`Storyshots Components/Tabs Semantic mode 1`] = `
       <button
         class="fd-tabs__link"
         href="#DqIStt"
+        role="link"
       >
         
             
@@ -2598,6 +2638,7 @@ exports[`Storyshots Components/Tabs Semantic mode 1`] = `
       <button
         class="fd-tabs__link"
         href="#bRCSzS"
+        role="link"
       >
         
             
@@ -2638,6 +2679,7 @@ exports[`Storyshots Components/Tabs Semantic mode 1`] = `
       <button
         class="fd-tabs__link"
         href="#xMN6I9"
+        role="link"
       >
         
             

--- a/stories/tabs/__snapshots__/tabs.stories.storyshot
+++ b/stories/tabs/__snapshots__/tabs.stories.storyshot
@@ -17,7 +17,7 @@ exports[`Storyshots Components/Tabs Counters 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#d9vOir"
       >
@@ -39,7 +39,7 @@ exports[`Storyshots Components/Tabs Counters 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -53,7 +53,7 @@ exports[`Storyshots Components/Tabs Counters 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#bSj6ft"
       >
@@ -75,7 +75,7 @@ exports[`Storyshots Components/Tabs Counters 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -88,7 +88,7 @@ exports[`Storyshots Components/Tabs Counters 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#VrHfHi"
       >
@@ -110,7 +110,7 @@ exports[`Storyshots Components/Tabs Counters 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -190,7 +190,7 @@ exports[`Storyshots Components/Tabs Default 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#fuCwV550"
       >
@@ -205,7 +205,7 @@ exports[`Storyshots Components/Tabs Default 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -219,7 +219,7 @@ exports[`Storyshots Components/Tabs Default 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#AiWfz165"
       >
@@ -234,7 +234,7 @@ exports[`Storyshots Components/Tabs Default 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -247,7 +247,7 @@ exports[`Storyshots Components/Tabs Default 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#7ae0T849"
       >
@@ -262,7 +262,7 @@ exports[`Storyshots Components/Tabs Default 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -342,7 +342,7 @@ exports[`Storyshots Components/Tabs Filter mode (compact) 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#YETAv8"
       >
@@ -370,7 +370,7 @@ exports[`Storyshots Components/Tabs Filter mode (compact) 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -388,7 +388,7 @@ exports[`Storyshots Components/Tabs Filter mode (compact) 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#eu3WeD"
       >
@@ -422,7 +422,7 @@ exports[`Storyshots Components/Tabs Filter mode (compact) 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -435,7 +435,7 @@ exports[`Storyshots Components/Tabs Filter mode (compact) 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#VqJcYO"
       >
@@ -469,7 +469,7 @@ exports[`Storyshots Components/Tabs Filter mode (compact) 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -482,7 +482,7 @@ exports[`Storyshots Components/Tabs Filter mode (compact) 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#ceoDu7"
       >
@@ -516,7 +516,7 @@ exports[`Storyshots Components/Tabs Filter mode (compact) 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -608,7 +608,7 @@ exports[`Storyshots Components/Tabs Filter mode 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#5ZkDVE"
       >
@@ -636,7 +636,7 @@ exports[`Storyshots Components/Tabs Filter mode 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -654,7 +654,7 @@ exports[`Storyshots Components/Tabs Filter mode 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#znvnwr"
       >
@@ -688,7 +688,7 @@ exports[`Storyshots Components/Tabs Filter mode 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -701,7 +701,7 @@ exports[`Storyshots Components/Tabs Filter mode 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#oyYpL7"
       >
@@ -735,7 +735,7 @@ exports[`Storyshots Components/Tabs Filter mode 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -748,7 +748,7 @@ exports[`Storyshots Components/Tabs Filter mode 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#gRpu9H"
       >
@@ -782,7 +782,7 @@ exports[`Storyshots Components/Tabs Filter mode 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -874,7 +874,7 @@ exports[`Storyshots Components/Tabs Icon (compact) 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#0bT4aB"
       >
@@ -901,7 +901,7 @@ exports[`Storyshots Components/Tabs Icon (compact) 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -915,7 +915,7 @@ exports[`Storyshots Components/Tabs Icon (compact) 1`] = `
     >
       
       
-      <a
+      <button
         class="fd-tabs__link"
         href="#kzRyN3"
       >
@@ -942,7 +942,7 @@ exports[`Storyshots Components/Tabs Icon (compact) 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -955,7 +955,7 @@ exports[`Storyshots Components/Tabs Icon (compact) 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#f2epu6"
       >
@@ -982,7 +982,7 @@ exports[`Storyshots Components/Tabs Icon (compact) 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -1062,7 +1062,7 @@ exports[`Storyshots Components/Tabs Icon 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#pliA92"
       >
@@ -1089,7 +1089,7 @@ exports[`Storyshots Components/Tabs Icon 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -1103,7 +1103,7 @@ exports[`Storyshots Components/Tabs Icon 1`] = `
     >
       
       
-      <a
+      <button
         class="fd-tabs__link"
         href="#ZAN8Hd"
       >
@@ -1130,7 +1130,7 @@ exports[`Storyshots Components/Tabs Icon 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -1143,7 +1143,7 @@ exports[`Storyshots Components/Tabs Icon 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#QrQ5Cl"
       >
@@ -1170,7 +1170,7 @@ exports[`Storyshots Components/Tabs Icon 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -1249,7 +1249,7 @@ exports[`Storyshots Components/Tabs Navigable 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#kf8369"
       >
@@ -1264,7 +1264,7 @@ exports[`Storyshots Components/Tabs Navigable 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </span>
@@ -1276,7 +1276,7 @@ exports[`Storyshots Components/Tabs Navigable 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#9uQ282"
       >
@@ -1291,7 +1291,7 @@ exports[`Storyshots Components/Tabs Navigable 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </span>
@@ -1303,7 +1303,7 @@ exports[`Storyshots Components/Tabs Navigable 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#DGl707"
       >
@@ -1318,7 +1318,7 @@ exports[`Storyshots Components/Tabs Navigable 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </span>
@@ -1398,7 +1398,7 @@ exports[`Storyshots Components/Tabs Process mode (compact) 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#LHsxsZ"
       >
@@ -1440,7 +1440,7 @@ exports[`Storyshots Components/Tabs Process mode (compact) 1`] = `
         </div>
         
         
-      </a>
+      </button>
       
         
       <span
@@ -1458,7 +1458,7 @@ exports[`Storyshots Components/Tabs Process mode (compact) 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#ZQvAjG"
       >
@@ -1500,7 +1500,7 @@ exports[`Storyshots Components/Tabs Process mode (compact) 1`] = `
         </div>
         
         
-      </a>
+      </button>
       
         
       <span
@@ -1518,7 +1518,7 @@ exports[`Storyshots Components/Tabs Process mode (compact) 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#wdqPV9"
       >
@@ -1560,7 +1560,7 @@ exports[`Storyshots Components/Tabs Process mode (compact) 1`] = `
         </div>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -1640,7 +1640,7 @@ exports[`Storyshots Components/Tabs Process mode 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#NoQLy6"
       >
@@ -1682,7 +1682,7 @@ exports[`Storyshots Components/Tabs Process mode 1`] = `
         </div>
         
         
-      </a>
+      </button>
       
         
       <span
@@ -1700,7 +1700,7 @@ exports[`Storyshots Components/Tabs Process mode 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#h4yBDR"
       >
@@ -1742,7 +1742,7 @@ exports[`Storyshots Components/Tabs Process mode 1`] = `
         </div>
         
         
-      </a>
+      </button>
       
         
       <span
@@ -1760,7 +1760,7 @@ exports[`Storyshots Components/Tabs Process mode 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#nd1EMQ"
       >
@@ -1802,7 +1802,7 @@ exports[`Storyshots Components/Tabs Process mode 1`] = `
         </div>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -1882,7 +1882,7 @@ exports[`Storyshots Components/Tabs Semantic filter mode 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#5ZkDVE"
       >
@@ -1910,7 +1910,7 @@ exports[`Storyshots Components/Tabs Semantic filter mode 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -1928,7 +1928,7 @@ exports[`Storyshots Components/Tabs Semantic filter mode 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#znvnwr"
       >
@@ -1962,7 +1962,7 @@ exports[`Storyshots Components/Tabs Semantic filter mode 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -1975,7 +1975,7 @@ exports[`Storyshots Components/Tabs Semantic filter mode 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#oyYpL7"
       >
@@ -2009,7 +2009,7 @@ exports[`Storyshots Components/Tabs Semantic filter mode 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -2022,7 +2022,7 @@ exports[`Storyshots Components/Tabs Semantic filter mode 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#gRpu9H"
       >
@@ -2056,7 +2056,7 @@ exports[`Storyshots Components/Tabs Semantic filter mode 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -2069,7 +2069,7 @@ exports[`Storyshots Components/Tabs Semantic filter mode 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#gRpu1A"
       >
@@ -2103,7 +2103,7 @@ exports[`Storyshots Components/Tabs Semantic filter mode 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -2207,7 +2207,7 @@ exports[`Storyshots Components/Tabs Semantic inline 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#5abyKZ"
       >
@@ -2229,7 +2229,7 @@ exports[`Storyshots Components/Tabs Semantic inline 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -2243,7 +2243,7 @@ exports[`Storyshots Components/Tabs Semantic inline 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link is-selected"
         href="#wupC7s"
       >
@@ -2265,7 +2265,7 @@ exports[`Storyshots Components/Tabs Semantic inline 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -2278,7 +2278,7 @@ exports[`Storyshots Components/Tabs Semantic inline 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#XlKpQM"
       >
@@ -2300,7 +2300,7 @@ exports[`Storyshots Components/Tabs Semantic inline 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -2312,7 +2312,7 @@ exports[`Storyshots Components/Tabs Semantic inline 1`] = `
     >
       
         
-      <a
+      <button
         aria-controls="3dUJAI"
         class="fd-tabs__link"
         href="#3dUJAI"
@@ -2335,7 +2335,7 @@ exports[`Storyshots Components/Tabs Semantic inline 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -2348,7 +2348,7 @@ exports[`Storyshots Components/Tabs Semantic inline 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#TWlAup"
       >
@@ -2370,7 +2370,7 @@ exports[`Storyshots Components/Tabs Semantic inline 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -2474,7 +2474,7 @@ exports[`Storyshots Components/Tabs Semantic mode 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#XTsSDD"
       >
@@ -2501,7 +2501,7 @@ exports[`Storyshots Components/Tabs Semantic mode 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -2515,7 +2515,7 @@ exports[`Storyshots Components/Tabs Semantic mode 1`] = `
     >
       
       
-      <a
+      <button
         class="fd-tabs__link is-selected"
         href="#DomvG6"
       >
@@ -2542,7 +2542,7 @@ exports[`Storyshots Components/Tabs Semantic mode 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -2555,7 +2555,7 @@ exports[`Storyshots Components/Tabs Semantic mode 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#DqIStt"
       >
@@ -2582,7 +2582,7 @@ exports[`Storyshots Components/Tabs Semantic mode 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -2595,7 +2595,7 @@ exports[`Storyshots Components/Tabs Semantic mode 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#bRCSzS"
       >
@@ -2622,7 +2622,7 @@ exports[`Storyshots Components/Tabs Semantic mode 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>
@@ -2635,7 +2635,7 @@ exports[`Storyshots Components/Tabs Semantic mode 1`] = `
     >
       
         
-      <a
+      <button
         class="fd-tabs__link"
         href="#xMN6I9"
       >
@@ -2662,7 +2662,7 @@ exports[`Storyshots Components/Tabs Semantic mode 1`] = `
         </span>
         
         
-      </a>
+      </button>
       
     
     </li>

--- a/stories/tabs/tabs.stories.js
+++ b/stories/tabs/tabs.stories.js
@@ -43,22 +43,22 @@ These modifier classes are used to display horizontal padding for tabs in variou
 
 export const primary = () => `
 <ul class="fd-tabs" role="tablist">
-    <li role="tab" class="fd-tabs__item" aria-controls="fuCwV550">
-        <button role="link" class="fd-tabs__link" href="#fuCwV550">
+    <li role="listitem" class="fd-tabs__item" aria-controls="fuCwV550" aria-selected="false" id="tab-001">
+        <button role="tab" class="fd-tabs__link" href="#fuCwV550" aria-label="tab-button">
             <span class="fd-tabs__tag">
                 Link
             </span>
         </button>
     </li>
-    <li role="tab" class="fd-tabs__item" aria-selected="true" aria-controls="AiWfz165">
-        <button role="link" class="fd-tabs__link" href="#AiWfz165">
+    <li role="listitem" class="fd-tabs__item" aria-selected="true" aria-controls="AiWfz165" id="tab-002">
+        <button role="tab" class="fd-tabs__link is-selected" href="#AiWfz165" aria-label="tab-button">
             <span class="fd-tabs__tag">
                 Selected
             </span>
         </button>
     </li>
-    <li role="tab" class="fd-tabs__item" aria-controls="7ae0T849">
-        <button role="link" class="fd-tabs__link" href="#7ae0T849">
+    <li role="listitem" class="fd-tabs__item" aria-controls="7ae0T849" aria-selected="false" id="tab-003">
+        <button role="tab" class="fd-tabs__link" href="#7ae0T849" aria-label="tab-button">
             <span class="fd-tabs__tag">
                 Link
             </span>
@@ -68,13 +68,13 @@ export const primary = () => `
         <i class="sap-icon--slim-arrow-down" role="presentation"></i>
     </button>
 </ul>
-<div class="fd-tabs__panel" aria-expanded="false" id="fuCwV550" role="tabpanel">
+<div aria-labelledby="tab-001" class="fd-tabs__panel" aria-expanded="false" id="fuCwV550" role="tabpanel">
     Lorem ipsum
 </div>
-<div class="fd-tabs__panel" aria-expanded="true" id="AiWfz165" role="tabpanel">
+<div aria-labelledby="tab-002" class="fd-tabs__panel" aria-expanded="true" id="AiWfz165" role="tabpanel">
     Dolor sit
 </div>
-<div class="fd-tabs__panel" aria-expanded="false" id="7ae0T849" role="tabpanel">
+<div aria-labelledby="tab-003" class="fd-tabs__panel" aria-expanded="false" id="7ae0T849" role="tabpanel">
     Nullam ut
 </div>
 `;
@@ -90,24 +90,24 @@ primary.parameters = {
 
 export const tabWithCounters = () => `
 <ul class="fd-tabs fd-tabs--xl fd-tabs--compact" role="tablist">
-    <li role="tab" class="fd-tabs__item" aria-controls="d9vOir">
-        <button role="link" class="fd-tabs__link" href="#d9vOir">
+    <li role="listitem" class="fd-tabs__item" aria-controls="d9vOir" aria-selected="false" id="tab-004">
+        <button role="tab" class="fd-tabs__link" href="#d9vOir" aria-label="tab-button">
             <p class="fd-tabs__count">13</p>
             <span class="fd-tabs__tag">
                 Link
             </span>
         </button>
     </li>
-    <li role="tab" class="fd-tabs__item" aria-controls="bSj6ft" aria-selected="true">
-        <button role="link" class="fd-tabs__link" href="#bSj6ft">
+    <li role="listitem" class="fd-tabs__item" aria-controls="bSj6ft" aria-selected="true" id="tab-005">
+        <button role="tab" class="fd-tabs__link is-selected" href="#bSj6ft" aria-label="tab-button">
             <p class="fd-tabs__count">1</p>
             <span class="fd-tabs__tag">
                 Selected
             </span>
         </button>
     </li>
-    <li role="tab" class="fd-tabs__item" aria-controls="VrHfHi">
-        <button role="link" class="fd-tabs__link" href="#VrHfHi">
+    <li role="listitem" class="fd-tabs__item" aria-controls="VrHfHi" aria-selected="false" id="tab-006">
+        <button role="tab" class="fd-tabs__link" href="#VrHfHi" aria-label="tab-button">
             <p class="fd-tabs__count">97</p>
             <span class="fd-tabs__tag">
                 Link
@@ -118,13 +118,13 @@ export const tabWithCounters = () => `
         <i class="sap-icon--slim-arrow-down" role="presentation"></i>
     </button>
 </ul>
-<div class="fd-tabs__panel" aria-expanded="false" id="d9vOir" role="tabpanel">
+<div aria-labelledby="tab-004" class="fd-tabs__panel" aria-expanded="false" id="d9vOir" role="tabpanel">
     Lorem ipsum
 </div>
-<div class="fd-tabs__panel" aria-expanded="true" id="bSj6ft" role="tabpanel">
+<div aria-labelledby="tab-005" class="fd-tabs__panel" aria-expanded="true" id="bSj6ft" role="tabpanel">
     Dolor sit
 </div>
-<div class="fd-tabs__panel" aria-expanded="false" id="VrHfHi" role="tabpanel">
+<div aria-labelledby="tab-006" class="fd-tabs__panel" aria-expanded="false" id="VrHfHi" role="tabpanel">
     Nullam ut
 </div>
 `;
@@ -142,22 +142,22 @@ In the example below, the tabs component is optimized for an extra-large screen 
 
 export const navTab = () => `
 <nav class="fd-tabs fd-tabs--l" role="navigation">
-    <span class="fd-tabs__item" aria-controls="kf8369">
-        <button role="link" class="fd-tabs__link" href="#kf8369">
+    <span role="listitem" class="fd-tabs__item" aria-controls="kf8369" id="tab-007" aria-selected="false">
+        <button role="tab" class="fd-tabs__link" href="#kf8369" aria-label="tab-button">
             <span class="fd-tabs__tag">
                 Link
             </span>
         </button>
     </span>
-    <span class="fd-tabs__item is-selected" aria-controls="9uQ282">
-        <button role="link" class="fd-tabs__link" href="#9uQ282">
+    <span role="listitem" class="fd-tabs__item" aria-controls="9uQ282" id="tab-008" aria-selected="true">
+        <button role="tab" class="fd-tabs__link is-selected" href="#9uQ282" aria-label="tab-button">
             <span class="fd-tabs__tag">
                 Selected
             </span>
         </button>
     </span>
-    <span class="fd-tabs__item" aria-controls="DGl707">
-        <button role="link" class="fd-tabs__link" href="#DGl707">
+    <span role="listitem" class="fd-tabs__item" aria-controls="DGl707" id="tab-009" aria-selected="false">
+        <button role="tab" class="fd-tabs__link" href="#DGl707" aria-label="tab-button">
             <span class="fd-tabs__tag">
                 Link
             </span>
@@ -167,13 +167,13 @@ export const navTab = () => `
         <i class="sap-icon--slim-arrow-down" role="presentation"></i>
     </button>
 </nav>
-<div class="fd-tabs__panel" aria-expanded="false" id="kf8369" role="tabpanel">
+<div aria-labelledby="tab-007" class="fd-tabs__panel" aria-expanded="false" id="kf8369" role="tabpanel">
     Lorem ipsum
 </div>
-<div class="fd-tabs__panel" aria-expanded="true" id="9uQ282" role="tabpanel">
+<div aria-labelledby="tab-008" class="fd-tabs__panel" aria-expanded="true" id="9uQ282" role="tabpanel">
     Dolor sit
 </div>
-<div class="fd-tabs__panel" aria-expanded="false" id="DGl707" role="tabpanel">
+<div aria-labelledby="tab-009" class="fd-tabs__panel" aria-expanded="false" id="DGl707" role="tabpanel">
     Nullam ut
 </div>
 `;
@@ -190,24 +190,24 @@ navTab.parameters = {
 
 export const iconOnly = () => `
 <ul class="fd-tabs fd-tabs--s fd-tabs--icon-only" role="tablist">
-    <li role="tab" class="fd-tabs__item" aria-controls="pliA92">
-        <button role="link" class="fd-tabs__link" href="#pliA92">
+    <li role="listitem" class="fd-tabs__item" aria-controls="pliA92" id="tab-010" aria-selected="false">
+        <button role="tab" class="fd-tabs__link" href="#pliA92" aria-label="tab-button">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">12</p>
             </span>
         </button>
     </li>
-    <li role="tab" aria-selected="true" class="fd-tabs__item" aria-controls="ZAN8Hd">
-      <button role="link" class="fd-tabs__link" href="#ZAN8Hd">
+    <li role="listitem" aria-selected="true" class="fd-tabs__item" aria-controls="ZAN8Hd" id="tab-011">
+      <button role="tab" class="fd-tabs__link is-selected" href="#ZAN8Hd" aria-label="tab-button">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">15</p>
             </span>
         </button>
     </li>
-    <li role="tab" class="fd-tabs__item" aria-controls="QrQ5Cl">
-        <button role="link" class="fd-tabs__link" href="#QrQ5Cl">
+    <li role="listitem" class="fd-tabs__item" aria-controls="QrQ5Cl" id="tab-012" aria-selected="false">
+        <button role="tab" class="fd-tabs__link" href="#QrQ5Cl" aria-label="tab-button">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">1</p>
@@ -218,13 +218,13 @@ export const iconOnly = () => `
         <i class="sap-icon--slim-arrow-down" role="presentation"></i>
     </button>
 </ul>
-<div class="fd-tabs__panel" aria-expanded="false" id="pliA92" role="tabpanel">
+<div aria-labelledby="tab-010" class="fd-tabs__panel" aria-expanded="false" id="pliA92" role="tabpanel">
     Lorem ipsum
 </div>
-<div class="fd-tabs__panel" aria-expanded="true" id="ZAN8Hd" role="tabpanel">
+<div aria-labelledby="tab-011" class="fd-tabs__panel" aria-expanded="true" id="ZAN8Hd" role="tabpanel">
     Dolor sit
 </div>
-<div class="fd-tabs__panel" aria-expanded="false" id="QrQ5Cl" role="tabpanel">
+<div aria-labelledby="tab-012" class="fd-tabs__panel" aria-expanded="false" id="QrQ5Cl" role="tabpanel">
     Nullam ut
 </div>
 `;
@@ -240,24 +240,24 @@ iconOnly.parameters = {
 
 export const compactIconOnly = () => `
 <ul class="fd-tabs fd-tabs--xl fd-tabs--icon-only fd-tabs--compact" role="tablist">
-    <li role="tab" class="fd-tabs__item fd-tabs__item--icon-only" aria-controls="0bT4aB">
-        <button role="link" class="fd-tabs__link" href="#0bT4aB">
+    <li role="listitem" class="fd-tabs__item fd-tabs__item--icon-only" aria-controls="0bT4aB" aria-selected="false" id="tab-013">
+        <button role="tab" class="fd-tabs__link" href="#0bT4aB" aria-label="tab-button">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">5</p>
             </span>
         </button>
     </li>
-    <li role="tab" class="fd-tabs__item" aria-selected="true" aria-controls="kzRyN3">
-      <button role="link" class="fd-tabs__link" href="#kzRyN3">
+    <li role="listitem" class="fd-tabs__item" aria-selected="true" aria-controls="kzRyN3" id="tab-014">
+      <button role="tab" class="fd-tabs__link is-selected" href="#kzRyN3" aria-label="tab-button">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">78</p>
             </span>
         </button>
     </li>
-    <li role="tab" class="fd-tabs__item" aria-controls="f2epu6">
-        <button role="link" class="fd-tabs__link" href="#f2epu6">
+    <li role="listitem" class="fd-tabs__item" aria-controls="f2epu6" aria-selected="false" id="tab-015">
+        <button role="tab" class="fd-tabs__link" href="#f2epu6" aria-label="tab-button">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">43</p>
@@ -268,13 +268,13 @@ export const compactIconOnly = () => `
         <i class="sap-icon--slim-arrow-down" role="presentation"></i>
     </button>
 </ul>
-<div class="fd-tabs__panel" aria-expanded="false" id="0bT4aB" role="tabpanel">
+<div aria-labelledby="tab-013" class="fd-tabs__panel" aria-expanded="false" id="0bT4aB" role="tabpanel">
     Lorem ipsum
 </div>
-<div class="fd-tabs__panel" aria-expanded="true" id="kzRyN3" role="tabpanel">
+<div aria-labelledby="tab-014" class="fd-tabs__panel" aria-expanded="true" id="kzRyN3" role="tabpanel">
     Dolor sit
 </div>
-<div class="fd-tabs__panel" aria-expanded="false" id="f2epu6" role="tabpanel">
+<div aria-labelledby="tab-015" class="fd-tabs__panel" aria-expanded="false" id="f2epu6" role="tabpanel">
     Nullam ut
 </div>
 `;
@@ -290,8 +290,8 @@ compactIconOnly.parameters = {
 
 export const processMode = () => `
 <ul class="fd-tabs fd-tabs--l fd-tabs--process" role="tablist">
-    <li role="tab" class="fd-tabs__item" aria-controls="NoQLy6">
-        <button role="link" class="fd-tabs__link" href="#NoQLy6">
+    <li role="listitem" class="fd-tabs__item" aria-controls="NoQLy6" id="tab-016" aria-selected="true">
+        <button role="tab" class="fd-tabs__link is-selected" href="#NoQLy6" aria-label="tab-button">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
             </span>
@@ -302,8 +302,8 @@ export const processMode = () => `
         </button>
         <span class="fd-tabs__process-icon"></span>
     </li>
-    <li role="tab" class="fd-tabs__item" aria-controls="h4yBDR">
-        <button role="link" class="fd-tabs__link" href="#h4yBDR">
+    <li role="listitem" class="fd-tabs__item" aria-controls="h4yBDR" id="tab-017" aria-selected="false">
+        <button role="tab" class="fd-tabs__link" href="#h4yBDR" aria-label="tab-button">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
             </span>
@@ -314,8 +314,8 @@ export const processMode = () => `
         </button>
         <span class="fd-tabs__process-icon"></span>
     </li>
-    <li role="tab" class="fd-tabs__item" aria-controls="nd1EMQ">
-        <button role="link" class="fd-tabs__link" href="#nd1EMQ">
+    <li role="listitem" class="fd-tabs__item" aria-controls="nd1EMQ" id="tab-018" aria-selected="false">
+        <button role="tab" class="fd-tabs__link" href="#nd1EMQ" aria-label="tab-button">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
             </span>
@@ -329,13 +329,13 @@ export const processMode = () => `
         <i class="sap-icon--slim-arrow-right" role="presentation"></i>
     </button>
 </ul>
-<div class="fd-tabs__panel" aria-expanded="false" id="NoQLy6" role="tabpanel">
+<div aria-labelledby="tab-016" class="fd-tabs__panel" aria-expanded="false" id="NoQLy6" role="tabpanel">
     Lorem ipsum
 </div>
-<div class="fd-tabs__panel" aria-expanded="true" id="h4yBDR" role="tabpanel">
+<div aria-labelledby="tab-017" class="fd-tabs__panel" aria-expanded="true" id="h4yBDR" role="tabpanel">
     Dolor sit
 </div>
-<div class="fd-tabs__panel" aria-expanded="false" id="nd1EMQ" role="tabpanel">
+<div aria-labelledby="tab-018" class="fd-tabs__panel" aria-expanded="false" id="nd1EMQ" role="tabpanel">
     Tincidunt nunc
 </div>
 `;
@@ -351,8 +351,8 @@ processMode.parameters = {
 
 export const compactProcessMode = () => `
 <ul class="fd-tabs fd-tabs--l fd-tabs--process fd-tabs--compact" role="tablist">
-    <li role="tab" class="fd-tabs__item" aria-controls="LHsxsZ">
-        <button role="link" class="fd-tabs__link" href="#LHsxsZ">
+    <li role="listitem" class="fd-tabs__item" aria-controls="LHsxsZ" id="tab-019" aria-selected="true">
+        <button role="tab" class="fd-tabs__link is-selected" href="#LHsxsZ" aria-label="tab-button">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
             </span>
@@ -363,8 +363,8 @@ export const compactProcessMode = () => `
         </button>
         <span class="fd-tabs__process-icon"></span>
     </li>
-    <li role="tab" class="fd-tabs__item" aria-controls="ZQvAjG">
-        <button role="link" class="fd-tabs__link" href="#ZQvAjG">
+    <li role="listitem" class="fd-tabs__item" aria-controls="ZQvAjG" id="tab-020" aria-selected="false">
+        <button role="tab" class="fd-tabs__link" href="#ZQvAjG" aria-label="tab-button">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
             </span>
@@ -375,8 +375,8 @@ export const compactProcessMode = () => `
         </button>
         <span class="fd-tabs__process-icon"></span>
     </li>
-    <li role="tab" class="fd-tabs__item" aria-controls="wdqPV9">
-        <button role="link" class="fd-tabs__link" href="#wdqPV9">
+    <li role="listitem" class="fd-tabs__item" aria-controls="wdqPV9" id="tab-021" aria-selected="false">
+        <button role="tab" class="fd-tabs__link" href="#wdqPV9" aria-label="tab-button">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
             </span>
@@ -390,13 +390,13 @@ export const compactProcessMode = () => `
         <i class="sap-icon--slim-arrow-down" role="presentation"></i>
     </button>
 </ul>
-<div class="fd-tabs__panel" aria-expanded="false" id="LHsxsZ" role="tabpanel">
+<div aria-labelledby="tab-019" class="fd-tabs__panel" aria-expanded="false" id="LHsxsZ" role="tabpanel">
     Lorem ipsum
 </div>
-<div class="fd-tabs__panel" aria-expanded="true" id="ZQvAjG" role="tabpanel">
+<div aria-labelledby="tab-020" class="fd-tabs__panel" aria-expanded="true" id="ZQvAjG" role="tabpanel">
     Dolor sit
 </div>
-<div class="fd-tabs__panel" aria-expanded="false" id="wdqPV9" role="tabpanel">
+<div aria-labelledby="tab-021" class="fd-tabs__panel" aria-expanded="false" id="wdqPV9" role="tabpanel">
     Nullam ut
 </div>
 `;
@@ -412,8 +412,8 @@ compactProcessMode.parameters = {
 
 export const filterMode = () => `
 <ul class="fd-tabs fd-tabs--l fd-tabs--filter" role="tablist">
-    <li role="tab" class="fd-tabs__item fd-tabs__item--header" aria-controls="5ZkDVE">
-        <button role="link" class="fd-tabs__link" href="#5ZkDVE">
+    <li role="listitem" class="fd-tabs__item fd-tabs__item--header" aria-controls="5ZkDVE" id="tab-022">
+        <button role="tab" class="fd-tabs__link" href="#5ZkDVE" aria-label="tab-button">
             <span class="fd-tabs__header">
                 <span class="fd-tabs__counter-header">100</span>
                 <span class="fd-tabs__label">products</span>
@@ -421,8 +421,8 @@ export const filterMode = () => `
         </button>
     </li>
     <div class="fd-tabs__separator"></div>
-    <li role="tab" class="fd-tabs__item" aria-controls="znvnwr">
-        <button role="link" class="fd-tabs__link" href="#znvnwr">
+    <li role="listitem" class="fd-tabs__item" aria-controls="znvnwr" id="tab-023" aria-selected="true">
+        <button role="tab" class="fd-tabs__link is-selected" href="#znvnwr" aria-label="tab-button">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">35</p>
@@ -430,8 +430,8 @@ export const filterMode = () => `
             <span class="fd-tabs__label">Description</span>
         </button>
     </li>
-    <li role="tab" class="fd-tabs__item" aria-controls="oyYpL7">
-        <button role="link" class="fd-tabs__link" href="#oyYpL7">
+    <li role="listitem" class="fd-tabs__item" aria-controls="oyYpL7" id="tab-024" aria-selected="false">
+        <button role="tab" class="fd-tabs__link" href="#oyYpL7" aria-label="tab-button">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">5</p>
@@ -439,8 +439,8 @@ export const filterMode = () => `
             <span class="fd-tabs__label">Description</span>
         </button>
     </li>
-    <li role="tab" class="fd-tabs__item" aria-controls="gRpu9H">
-        <button role="link" class="fd-tabs__link" href="#gRpu9H">
+    <li role="listitem" class="fd-tabs__item" aria-controls="gRpu9H" id="tab-025" aria-selected="false">
+        <button role="tab" class="fd-tabs__link" href="#gRpu9H" aria-label="tab-button">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">60</p>
@@ -452,16 +452,16 @@ export const filterMode = () => `
         <i class="sap-icon--slim-arrow-down" role="presentation"></i>
     </button>
 </ul>
-<div class="fd-tabs__panel" aria-expanded="false" id="5ZkDVE" role="tabpanel">
+<div aria-labelledby="tab-022" class="fd-tabs__panel" aria-expanded="false" id="5ZkDVE" role="tabpanel">
     Lorem ipsum
 </div>
-<div class="fd-tabs__panel" aria-expanded="true" id="znvnwr" role="tabpanel">
+<div aria-labelledby="tab-023" class="fd-tabs__panel" aria-expanded="true" id="znvnwr" role="tabpanel">
     Dolor sit
 </div>
-<div class="fd-tabs__panel" aria-expanded="false" id="oyYpL7" role="tabpanel">
+<div aria-labelledby="tab-024" class="fd-tabs__panel" aria-expanded="false" id="oyYpL7" role="tabpanel">
     Nullam ut
 </div>
-<div class="fd-tabs__panel" aria-expanded="false" id="gRpu9H" role="tabpanel">
+<div aria-labelledby="tab-025" class="fd-tabs__panel" aria-expanded="false" id="gRpu9H" role="tabpanel">
     Occaecat cupidatat
 </div>
 `;
@@ -477,8 +477,8 @@ filterMode.parameters = {
 
 export const compactFilterMode = () => `
 <ul class="fd-tabs fd-tabs--l fd-tabs--filter fd-tabs--compact" role="tablist">
-    <li role="tab" class="fd-tabs__item fd-tabs__item--header" aria-controls="YETAv8">
-        <button role="link" class="fd-tabs__link" href="#YETAv8">
+    <li role="listitem" class="fd-tabs__item fd-tabs__item--header" aria-controls="YETAv8" id="tab-026">
+        <button role="tab" class="fd-tabs__link" href="#YETAv8" aria-label="tab-button">
             <span class="fd-tabs__header">
                 <span class="fd-tabs__counter-header">150</span>
                 <span class="fd-tabs__label">products</span>
@@ -486,8 +486,8 @@ export const compactFilterMode = () => `
         </button>
     </li>
     <div class="fd-tabs__separator"></div>
-    <li role="tab" class="fd-tabs__item" aria-controls="eu3WeD">
-        <button role="link" class="fd-tabs__link" href="#eu3WeD">
+    <li role="listitem" class="fd-tabs__item" aria-controls="eu3WeD" id="tab-027" aria-selected="true">
+        <button role="tab" class="fd-tabs__link is-selected" href="#eu3WeD" aria-label="tab-button">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">3</p>
@@ -495,8 +495,8 @@ export const compactFilterMode = () => `
             <span class="fd-tabs__label">Description</span>
         </button>
     </li>
-    <li role="tab" class="fd-tabs__item" aria-controls="VqJcYO">
-        <button role="link" class="fd-tabs__link" href="#VqJcYO">
+    <li role="listitem" class="fd-tabs__item" aria-controls="VqJcYO" id="tab-028" aria-selected="false">
+        <button role="tab" class="fd-tabs__link" href="#VqJcYO" aria-label="tab-button">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">40</p>
@@ -504,8 +504,8 @@ export const compactFilterMode = () => `
             <span class="fd-tabs__label">Description</span>
         </button>
     </li>
-    <li role="tab" class="fd-tabs__item" aria-controls="ceoDu7">
-        <button role="link" class="fd-tabs__link" href="#ceoDu7">
+    <li role="listitem" class="fd-tabs__item" aria-controls="ceoDu7" id="tab-029" aria-selected="false">
+        <button role="tab" class="fd-tabs__link" href="#ceoDu7" aria-label="tab-button">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">107</p>
@@ -517,16 +517,16 @@ export const compactFilterMode = () => `
         <i class="sap-icon--slim-arrow-down" role="presentation"></i>
     </button>
 </ul>
-<div class="fd-tabs__panel" aria-expanded="false" id="YETAv8" role="tabpanel">
+<div aria-labelledby="tab-026" class="fd-tabs__panel" aria-expanded="false" id="YETAv8" role="tabpanel">
     Lorem ipsum
 </div>
-<div class="fd-tabs__panel" aria-expanded="true" id="eu3WeD" role="tabpanel">
+<div aria-labelledby="tab-027" class="fd-tabs__panel" aria-expanded="true" id="eu3WeD" role="tabpanel">
     Dolor sit
 </div>
-<div class="fd-tabs__panel" aria-expanded="false" id="VqJcYO" role="tabpanel">
+<div aria-labelledby="tab-028" class="fd-tabs__panel" aria-expanded="false" id="VqJcYO" role="tabpanel">
     Nullam ut
 </div>
-<div class="fd-tabs__panel" aria-expanded="false" id="ceoDu7" role="tabpanel">
+<div aria-labelledby="tab-029" class="fd-tabs__panel" aria-expanded="false" id="ceoDu7" role="tabpanel">
     Occaecat cupidatat
 </div>
 `;
@@ -542,40 +542,40 @@ compactFilterMode.parameters = {
 
 export const semanticMode = () => `
 <ul class="fd-tabs fd-tabs--l fd-tabs--icon-only fd-tabs--compact" role="tablist">
-    <li role="tab" class="fd-tabs__item fd-tabs__item--success" aria-controls="XTsSDD">
-        <button role="link" class="fd-tabs__link" href="#XTsSDD">
+    <li role="listitem" class="fd-tabs__item fd-tabs__item--success" aria-controls="XTsSDD" id="tab-030" aria-selected="false">
+        <button role="tab" class="fd-tabs__link" href="#XTsSDD" aria-label="tab-button">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">54</p>
             </span>
         </button>
     </li>
-    <li role="tab" class="fd-tabs__item fd-tabs__item--warning" aria-selected="true" aria-controls="DomvG6">
-      <button class="fd-tabs__link is-selected" href="#DomvG6">
+    <li role="listitem" class="fd-tabs__item fd-tabs__item--warning" aria-selected="true" aria-controls="DomvG6" id="tab-031">
+      <button class="fd-tabs__link is-selected" href="#DomvG6" aria-label="tab-button">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">71</p>
             </span>
         </button>
     </li>
-    <li role="tab" class="fd-tabs__item fd-tabs__item--information" aria-controls="DqIStt">
-        <button role="link" class="fd-tabs__link" href="#DqIStt">
+    <li role="listitem" class="fd-tabs__item fd-tabs__item--information" aria-controls="DqIStt" id="tab-032" aria-selected="false">
+        <button role="tab" class="fd-tabs__link" href="#DqIStt" aria-label="tab-button">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">23</p>
             </span>
         </button>
     </li>
-    <li role="tab" class="fd-tabs__item fd-tabs__item--error" aria-controls="bRCSzS">
-        <button role="link" class="fd-tabs__link" href="#bRCSzS">
+    <li role="listitem" class="fd-tabs__item fd-tabs__item--error" aria-controls="bRCSzS" id="tab-033" aria-selected="false">
+        <button role="tab" class="fd-tabs__link" href="#bRCSzS" aria-label="tab-button">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">4</p>
             </span>
         </button>
     </li>
-    <li role="tab" class="fd-tabs__item fd-tabs__item--neutral" aria-controls="xMN6I9">
-        <button role="link" class="fd-tabs__link" href="#xMN6I9">
+    <li role="listitem" class="fd-tabs__item fd-tabs__item--neutral" aria-controls="xMN6I9" id="tab-034" aria-selected="false">
+        <button role="tab" class="fd-tabs__link" href="#xMN6I9" aria-label="tab-button">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">100</p>
@@ -586,19 +586,19 @@ export const semanticMode = () => `
         <i class="sap-icon--slim-arrow-down" role="presentation"></i>
     </button>
 </ul>
-<div class="fd-tabs__panel" aria-expanded="false" id="XTsSDD" role="tabpanel">
+<div aria-labelledby="tab-030" class="fd-tabs__panel" aria-expanded="false" id="XTsSDD" role="tabpanel">
     Lorem ipsum
 </div>
-<div class="fd-tabs__panel" aria-expanded="true" id="DomvG6" role="tabpanel">
+<div aria-labelledby="tab-031" class="fd-tabs__panel" aria-expanded="true" id="DomvG6" role="tabpanel">
     Dolor sit
 </div>
-<div class="fd-tabs__panel" aria-expanded="false" id="DqIStt" role="tabpanel">
+<div aria-labelledby="tab-032" class="fd-tabs__panel" aria-expanded="false" id="DqIStt" role="tabpanel">
     Nullam ut
 </div>
-<div class="fd-tabs__panel" aria-expanded="false" id="bRCSzS" role="tabpanel">
+<div aria-labelledby="tab-033" class="fd-tabs__panel" aria-expanded="false" id="bRCSzS" role="tabpanel">
     Quaerat voluptatem
 </div>
-<div class="fd-tabs__panel" aria-expanded="false" id="xMN6I9" role="tabpanel">
+<div aria-labelledby="tab-034" class="fd-tabs__panel" aria-expanded="false" id="xMN6I9" role="tabpanel">
     Occaecat cupidatat
 </div>
 `;
@@ -623,8 +623,8 @@ Neutral | \`fd-tabs__item--neutral\`
 
 export const semanticFilterMode = () => `
 <ul class="fd-tabs fd-tabs--l fd-tabs--filter" role="tablist">
-    <li role="tab" class="fd-tabs__item fd-tabs__item--header" aria-controls="5ZkDVE">
-        <button role="link" class="fd-tabs__link" href="#5ZkDVE">
+    <li role="listitem" class="fd-tabs__item fd-tabs__item--header" aria-controls="5ZkDVE" id="tab-035">
+        <button role="tab" class="fd-tabs__link" href="#5ZkDVE" aria-label="tab-button">
             <span class="fd-tabs__header">
                 <span class="fd-tabs__counter-header">150</span>
                 <span class="fd-tabs__label">products</span>
@@ -632,8 +632,8 @@ export const semanticFilterMode = () => `
         </button>
     </li>
     <div class="fd-tabs__separator"></div>
-    <li role="tab" class="fd-tabs__item fd-tabs__item--success" aria-controls="znvnwr">
-        <button role="link" class="fd-tabs__link" href="#znvnwr">
+    <li role="listitem" class="fd-tabs__item fd-tabs__item--success" aria-controls="znvnwr" id="tab-036" aria-selected="true">
+        <button role="tab" class="fd-tabs__link is-selected" href="#znvnwr" aria-label="tab-button">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">35</p>
@@ -641,8 +641,8 @@ export const semanticFilterMode = () => `
             <span class="fd-tabs__label">Success</span>
         </button>
     </li>
-    <li role="tab" class="fd-tabs__item fd-tabs__item--warning" aria-controls="oyYpL7">
-        <button role="link" class="fd-tabs__link" href="#oyYpL7">
+    <li role="listitem" class="fd-tabs__item fd-tabs__item--warning" aria-controls="oyYpL7" id="tab-037" aria-selected="false">
+        <button role="tab" class="fd-tabs__link" href="#oyYpL7" aria-label="tab-button">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">5</p>
@@ -650,8 +650,8 @@ export const semanticFilterMode = () => `
             <span class="fd-tabs__label">Warning</span>
         </button>
     </li>
-    <li role="tab" class="fd-tabs__item fd-tabs__item--information" aria-controls="gRpu9H">
-        <button role="link" class="fd-tabs__link" href="#gRpu9H">
+    <li role="listitem" class="fd-tabs__item fd-tabs__item--information" aria-controls="gRpu9H" id="tab-038" aria-selected="false">
+        <button role="tab" class="fd-tabs__link" href="#gRpu9H" aria-label="tab-button">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">60</p>
@@ -659,8 +659,8 @@ export const semanticFilterMode = () => `
             <span class="fd-tabs__label">Information</span>
         </button>
     </li>
-    <li role="tab" class="fd-tabs__item fd-tabs__item--error" aria-controls="gRpu1A">
-        <button role="link" class="fd-tabs__link" href="#gRpu1A">
+    <li role="listitem" class="fd-tabs__item fd-tabs__item--error" aria-controls="gRpu1A" id="tab-039" aria-selected="false">
+        <button role="tab" class="fd-tabs__link" href="#gRpu1A" aria-label="tab-button">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">50</p>
@@ -672,19 +672,19 @@ export const semanticFilterMode = () => `
         <i class="sap-icon--slim-arrow-down" role="presentation"></i>
     </button>
 </ul>
-<div class="fd-tabs__panel" aria-expanded="false" id="5ZkDVE" role="tabpanel">
+<div aria-labelledby="tab-035" class="fd-tabs__panel" aria-expanded="false" id="5ZkDVE" role="tabpanel">
     Lorem ipsum
 </div>
-<div class="fd-tabs__panel" aria-expanded="true" id="znvnwr" role="tabpanel">
+<div aria-labelledby="tab-036" class="fd-tabs__panel" aria-expanded="true" id="znvnwr" role="tabpanel">
     Dolor sit
 </div>
-<div class="fd-tabs__panel" aria-expanded="false" id="oyYpL7" role="tabpanel">
+<div aria-labelledby="tab-037" class="fd-tabs__panel" aria-expanded="false" id="oyYpL7" role="tabpanel">
     Nullam ut
 </div>
-<div class="fd-tabs__panel" aria-expanded="false" id="gRpu9H" role="tabpanel">
+<div aria-labelledby="tab-038" class="fd-tabs__panel" aria-expanded="false" id="gRpu9H" role="tabpanel">
     Occaecat cupidatat
 </div>
-<div class="fd-tabs__panel" aria-expanded="false" id="gRpu1A" role="tabpanel">
+<div aria-labelledby="tab-039" class="fd-tabs__panel" aria-expanded="false" id="gRpu1A" role="tabpanel">
     Nullam sit
 </div>
 `;
@@ -700,40 +700,40 @@ semanticFilterMode.parameters = {
 
 export const semanticInline = () => `
 <ul class="fd-tabs fd-tabs--l" role="tablist">
-    <li role="tab" class="fd-tabs__item fd-tabs__item--error" aria-controls="5abyKZ">
-        <button role="link" class="fd-tabs__link" href="#5abyKZ">
+    <li role="listitem" class="fd-tabs__item fd-tabs__item--error" aria-controls="5abyKZ" id="tab-040" aria-selected="false">
+        <button role="tab" class="fd-tabs__link" href="#5abyKZ" aria-label="tab-button">
             <p class="fd-tabs__count">13</p>
             <span class="fd-tabs__tag">
                 Error
             </span>
         </button>
     </li>
-    <li role="tab" aria-selected="true" class="fd-tabs__item fd-tabs__item--information" aria-controls="wupC7s">
-        <button class="fd-tabs__link is-selected" href="#wupC7s">
+    <li role="listitem" aria-selected="true" class="fd-tabs__item fd-tabs__item--information" aria-controls="wupC7s" id="tab-041">
+        <button class="fd-tabs__link is-selected" href="#wupC7s" aria-label="tab-button">
             <p class="fd-tabs__count">24</p>
             <span class="fd-tabs__tag">
                 Information
             </span>
         </button>
     </li>
-    <li role="tab" class="fd-tabs__item fd-tabs__item--warning" aria-controls="XlKpQM">
-        <button role="link" class="fd-tabs__link" href="#XlKpQM">
+    <li role="listitem" class="fd-tabs__item fd-tabs__item--warning" aria-controls="XlKpQM" id="tab-042" aria-selected="false">
+        <button role="tab" class="fd-tabs__link" href="#XlKpQM" aria-label="tab-button">
             <p class="fd-tabs__count">31</p>
             <span class="fd-tabs__tag">
                 Warning
             </span>
         </button>
     </li>
-    <li role="tab" class="fd-tabs__item fd-tabs__item--success">
-        <button role="link" class="fd-tabs__link" aria-controls="3dUJAI" href="#3dUJAI">
+    <li role="listitem" class="fd-tabs__item fd-tabs__item--success">
+        <button role="tab" class="fd-tabs__link" aria-controls="3dUJAI" href="#3dUJAI" id="tab-043" aria-label="tab-button" aria-selected="false">
             <p class="fd-tabs__count">65</p>
             <span class="fd-tabs__tag">
                 Success
             </span>
         </button>
     </li>
-    <li role="tab" class="fd-tabs__item fd-tabs__item--neutral" aria-controls="TWlAup">
-        <button role="link" class="fd-tabs__link" href="#TWlAup">
+    <li role="listitem" class="fd-tabs__item fd-tabs__item--neutral" aria-controls="TWlAup" id="tab-044" aria-selected="false">
+        <button role="tab" class="fd-tabs__link" href="#TWlAup" aria-label="tab-button">
             <p class="fd-tabs__count">159</p>
             <span class="fd-tabs__tag">
                 Neutral
@@ -744,19 +744,19 @@ export const semanticInline = () => `
         <i class="sap-icon--slim-arrow-down" role="presentation"></i>
     </button>
 </ul>
-<div class="fd-tabs__panel" aria-expanded="false" id="5abyKZ" role="tabpanel">
+<div aria-labelledby="tab-040" class="fd-tabs__panel" aria-expanded="false" id="5abyKZ" role="tabpanel">
     Lorem ipsum
 </div>
-<div class="fd-tabs__panel" aria-expanded="true" id="wupC7s" role="tabpanel">
+<div aria-labelledby="tab-041" class="fd-tabs__panel" aria-expanded="true" id="wupC7s" role="tabpanel">
     Dolor sit
 </div>
-<div class="fd-tabs__panel" aria-expanded="false" id="XlKpQM" role="tabpanel">
+<div aria-labelledby="tab-042" class="fd-tabs__panel" aria-expanded="false" id="XlKpQM" role="tabpanel">
     Nullam ut
 </div>
-<div class="fd-tabs__panel" aria-expanded="false" id="3dUJAI" role="tabpanel">
+<div aria-labelledby="tab-043" class="fd-tabs__panel" aria-expanded="false" id="3dUJAI" role="tabpanel">
     Tincidunt nunc
 </div>
-<div class="fd-tabs__panel" aria-expanded="false" id="TWlAup" role="tabpanel">
+<div aria-labelledby="tab-044" class="fd-tabs__panel" aria-expanded="false" id="TWlAup" role="tabpanel">
     Occaecat cupidatat
 </div>
 `;

--- a/stories/tabs/tabs.stories.js
+++ b/stories/tabs/tabs.stories.js
@@ -44,25 +44,25 @@ These modifier classes are used to display horizontal padding for tabs in variou
 export const primary = () => `
 <ul class="fd-tabs" role="tablist">
     <li role="tab" class="fd-tabs__item" aria-controls="fuCwV550">
-        <a class="fd-tabs__link" href="#fuCwV550">
+        <button role="link" class="fd-tabs__link" href="#fuCwV550">
             <span class="fd-tabs__tag">
                 Link
             </span>
-        </a>
+        </button>
     </li>
     <li role="tab" class="fd-tabs__item" aria-selected="true" aria-controls="AiWfz165">
-        <a class="fd-tabs__link" href="#AiWfz165">
+        <button role="link" class="fd-tabs__link" href="#AiWfz165">
             <span class="fd-tabs__tag">
                 Selected
             </span>
-        </a>
+        </button>
     </li>
     <li role="tab" class="fd-tabs__item" aria-controls="7ae0T849">
-        <a class="fd-tabs__link" href="#7ae0T849">
+        <button role="link" class="fd-tabs__link" href="#7ae0T849">
             <span class="fd-tabs__tag">
                 Link
             </span>
-        </a>
+        </button>
     </li>
     <button class="fd-button fd-button--transparent fd-tabs__overflow" aria-label="See More">
         <i class="sap-icon--slim-arrow-down" role="presentation"></i>
@@ -91,28 +91,28 @@ primary.parameters = {
 export const tabWithCounters = () => `
 <ul class="fd-tabs fd-tabs--xl fd-tabs--compact" role="tablist">
     <li role="tab" class="fd-tabs__item" aria-controls="d9vOir">
-        <a class="fd-tabs__link" href="#d9vOir">
+        <button role="link" class="fd-tabs__link" href="#d9vOir">
             <p class="fd-tabs__count">13</p>
             <span class="fd-tabs__tag">
                 Link
             </span>
-        </a>
+        </button>
     </li>
     <li role="tab" class="fd-tabs__item" aria-controls="bSj6ft" aria-selected="true">
-        <a class="fd-tabs__link" href="#bSj6ft">
+        <button role="link" class="fd-tabs__link" href="#bSj6ft">
             <p class="fd-tabs__count">1</p>
             <span class="fd-tabs__tag">
                 Selected
             </span>
-        </a>
+        </button>
     </li>
     <li role="tab" class="fd-tabs__item" aria-controls="VrHfHi">
-        <a class="fd-tabs__link" href="#VrHfHi">
+        <button role="link" class="fd-tabs__link" href="#VrHfHi">
             <p class="fd-tabs__count">97</p>
             <span class="fd-tabs__tag">
                 Link
             </span>
-        </a>
+        </button>
     </li>
     <button class="fd-button fd-button--transparent fd-button--compact fd-tabs__overflow" aria-label="See More">
         <i class="sap-icon--slim-arrow-down" role="presentation"></i>
@@ -143,25 +143,25 @@ In the example below, the tabs component is optimized for an extra-large screen 
 export const navTab = () => `
 <nav class="fd-tabs fd-tabs--l" role="navigation">
     <span class="fd-tabs__item" aria-controls="kf8369">
-        <a class="fd-tabs__link" href="#kf8369">
+        <button role="link" class="fd-tabs__link" href="#kf8369">
             <span class="fd-tabs__tag">
                 Link
             </span>
-        </a>
+        </button>
     </span>
     <span class="fd-tabs__item is-selected" aria-controls="9uQ282">
-        <a class="fd-tabs__link" href="#9uQ282">
+        <button role="link" class="fd-tabs__link" href="#9uQ282">
             <span class="fd-tabs__tag">
                 Selected
             </span>
-        </a>
+        </button>
     </span>
     <span class="fd-tabs__item" aria-controls="DGl707">
-        <a class="fd-tabs__link" href="#DGl707">
+        <button role="link" class="fd-tabs__link" href="#DGl707">
             <span class="fd-tabs__tag">
                 Link
             </span>
-        </a>
+        </button>
     </span>
     <button class="fd-button fd-button--transparent fd-tabs__overflow" aria-label="See More">
         <i class="sap-icon--slim-arrow-down" role="presentation"></i>
@@ -191,28 +191,28 @@ navTab.parameters = {
 export const iconOnly = () => `
 <ul class="fd-tabs fd-tabs--s fd-tabs--icon-only" role="tablist">
     <li role="tab" class="fd-tabs__item" aria-controls="pliA92">
-        <a class="fd-tabs__link" href="#pliA92">
+        <button role="link" class="fd-tabs__link" href="#pliA92">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">12</p>
             </span>
-        </a>
+        </button>
     </li>
     <li role="tab" aria-selected="true" class="fd-tabs__item" aria-controls="ZAN8Hd">
-      <a class="fd-tabs__link" href="#ZAN8Hd">
+      <button role="link" class="fd-tabs__link" href="#ZAN8Hd">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">15</p>
             </span>
-        </a>
+        </button>
     </li>
     <li role="tab" class="fd-tabs__item" aria-controls="QrQ5Cl">
-        <a class="fd-tabs__link" href="#QrQ5Cl">
+        <button role="link" class="fd-tabs__link" href="#QrQ5Cl">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">1</p>
             </span>
-        </a>
+        </button>
     </li>
     <button class="fd-button fd-button--transparent fd-tabs__overflow" aria-label="See More">
         <i class="sap-icon--slim-arrow-down" role="presentation"></i>
@@ -241,28 +241,28 @@ iconOnly.parameters = {
 export const compactIconOnly = () => `
 <ul class="fd-tabs fd-tabs--xl fd-tabs--icon-only fd-tabs--compact" role="tablist">
     <li role="tab" class="fd-tabs__item fd-tabs__item--icon-only" aria-controls="0bT4aB">
-        <a class="fd-tabs__link" href="#0bT4aB">
+        <button role="link" class="fd-tabs__link" href="#0bT4aB">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">5</p>
             </span>
-        </a>
+        </button>
     </li>
     <li role="tab" class="fd-tabs__item" aria-selected="true" aria-controls="kzRyN3">
-      <a class="fd-tabs__link" href="#kzRyN3">
+      <button role="link" class="fd-tabs__link" href="#kzRyN3">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">78</p>
             </span>
-        </a>
+        </button>
     </li>
     <li role="tab" class="fd-tabs__item" aria-controls="f2epu6">
-        <a class="fd-tabs__link" href="#f2epu6">
+        <button role="link" class="fd-tabs__link" href="#f2epu6">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">43</p>
             </span>
-        </a>
+        </button>
     </li>
     <button class="fd-button fd-button--transparent fd-button--compact fd-tabs__overflow" aria-label="See More">
         <i class="sap-icon--slim-arrow-down" role="presentation"></i>
@@ -291,7 +291,7 @@ compactIconOnly.parameters = {
 export const processMode = () => `
 <ul class="fd-tabs fd-tabs--l fd-tabs--process" role="tablist">
     <li role="tab" class="fd-tabs__item" aria-controls="NoQLy6">
-        <a class="fd-tabs__link" href="#NoQLy6">
+        <button role="link" class="fd-tabs__link" href="#NoQLy6">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
             </span>
@@ -299,11 +299,11 @@ export const processMode = () => `
                 <span class="fd-tabs__label">58 of 122 items</span>
                 <span class="fd-tabs__label">Description</span>
             </div>
-        </a>
+        </button>
         <span class="fd-tabs__process-icon"></span>
     </li>
     <li role="tab" class="fd-tabs__item" aria-controls="h4yBDR">
-        <a class="fd-tabs__link" href="#h4yBDR">
+        <button role="link" class="fd-tabs__link" href="#h4yBDR">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
             </span>
@@ -311,11 +311,11 @@ export const processMode = () => `
                 <span class="fd-tabs__label">22 of 122 items</span>
                 <span class="fd-tabs__label">Description</span>
             </div>
-        </a>
+        </button>
         <span class="fd-tabs__process-icon"></span>
     </li>
     <li role="tab" class="fd-tabs__item" aria-controls="nd1EMQ">
-        <a class="fd-tabs__link" href="#nd1EMQ">
+        <button role="link" class="fd-tabs__link" href="#nd1EMQ">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
             </span>
@@ -323,7 +323,7 @@ export const processMode = () => `
                 <span class="fd-tabs__label">42 of 122 items</span>
                 <span class="fd-tabs__label">Description</span>
             </div>
-        </a>
+        </button>
     </li>
     <button class="fd-button fd-button--transparent fd-tabs__overflow" aria-label="See More">
         <i class="sap-icon--slim-arrow-right" role="presentation"></i>
@@ -352,7 +352,7 @@ processMode.parameters = {
 export const compactProcessMode = () => `
 <ul class="fd-tabs fd-tabs--l fd-tabs--process fd-tabs--compact" role="tablist">
     <li role="tab" class="fd-tabs__item" aria-controls="LHsxsZ">
-        <a class="fd-tabs__link" href="#LHsxsZ">
+        <button role="link" class="fd-tabs__link" href="#LHsxsZ">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
             </span>
@@ -360,11 +360,11 @@ export const compactProcessMode = () => `
                 <span class="fd-tabs__label">58 of 122 items</span>
                 <span class="fd-tabs__label">Description</span>
             </div>
-        </a>
+        </button>
         <span class="fd-tabs__process-icon"></span>
     </li>
     <li role="tab" class="fd-tabs__item" aria-controls="ZQvAjG">
-        <a class="fd-tabs__link" href="#ZQvAjG">
+        <button role="link" class="fd-tabs__link" href="#ZQvAjG">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
             </span>
@@ -372,11 +372,11 @@ export const compactProcessMode = () => `
                 <span class="fd-tabs__label">42 of 122 items</span>
                 <span class="fd-tabs__label">Description</span>
             </div>
-        </a>
+        </button>
         <span class="fd-tabs__process-icon"></span>
     </li>
     <li role="tab" class="fd-tabs__item" aria-controls="wdqPV9">
-        <a class="fd-tabs__link" href="#wdqPV9">
+        <button role="link" class="fd-tabs__link" href="#wdqPV9">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
             </span>
@@ -384,7 +384,7 @@ export const compactProcessMode = () => `
                 <span class="fd-tabs__label">22 of 122 items</span>
                 <span class="fd-tabs__label">Description</span>
             </div>
-        </a>
+        </button>
     </li>
     <button class="fd-button fd-button--transparent fd-button--compact fd-tabs__overflow" aria-label="See More">
         <i class="sap-icon--slim-arrow-down" role="presentation"></i>
@@ -413,40 +413,40 @@ compactProcessMode.parameters = {
 export const filterMode = () => `
 <ul class="fd-tabs fd-tabs--l fd-tabs--filter" role="tablist">
     <li role="tab" class="fd-tabs__item fd-tabs__item--header" aria-controls="5ZkDVE">
-        <a class="fd-tabs__link" href="#5ZkDVE">
+        <button role="link" class="fd-tabs__link" href="#5ZkDVE">
             <span class="fd-tabs__header">
                 <span class="fd-tabs__counter-header">100</span>
                 <span class="fd-tabs__label">products</span>
             </span>
-        </a>
+        </button>
     </li>
     <div class="fd-tabs__separator"></div>
     <li role="tab" class="fd-tabs__item" aria-controls="znvnwr">
-        <a class="fd-tabs__link" href="#znvnwr">
+        <button role="link" class="fd-tabs__link" href="#znvnwr">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">35</p>
             </span>
             <span class="fd-tabs__label">Description</span>
-        </a>
+        </button>
     </li>
     <li role="tab" class="fd-tabs__item" aria-controls="oyYpL7">
-        <a class="fd-tabs__link" href="#oyYpL7">
+        <button role="link" class="fd-tabs__link" href="#oyYpL7">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">5</p>
             </span>
             <span class="fd-tabs__label">Description</span>
-        </a>
+        </button>
     </li>
     <li role="tab" class="fd-tabs__item" aria-controls="gRpu9H">
-        <a class="fd-tabs__link" href="#gRpu9H">
+        <button role="link" class="fd-tabs__link" href="#gRpu9H">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">60</p>
             </span>
             <span class="fd-tabs__label">Description</span>
-        </a>
+        </button>
     </li>
     <button class="fd-button fd-button--transparent fd-tabs__overflow" aria-label="See More">
         <i class="sap-icon--slim-arrow-down" role="presentation"></i>
@@ -478,40 +478,40 @@ filterMode.parameters = {
 export const compactFilterMode = () => `
 <ul class="fd-tabs fd-tabs--l fd-tabs--filter fd-tabs--compact" role="tablist">
     <li role="tab" class="fd-tabs__item fd-tabs__item--header" aria-controls="YETAv8">
-        <a class="fd-tabs__link" href="#YETAv8">
+        <button role="link" class="fd-tabs__link" href="#YETAv8">
             <span class="fd-tabs__header">
                 <span class="fd-tabs__counter-header">150</span>
                 <span class="fd-tabs__label">products</span>
             </span>
-        </a>
+        </button>
     </li>
     <div class="fd-tabs__separator"></div>
     <li role="tab" class="fd-tabs__item" aria-controls="eu3WeD">
-        <a class="fd-tabs__link" href="#eu3WeD">
+        <button role="link" class="fd-tabs__link" href="#eu3WeD">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">3</p>
             </span>
             <span class="fd-tabs__label">Description</span>
-        </a>
+        </button>
     </li>
     <li role="tab" class="fd-tabs__item" aria-controls="VqJcYO">
-        <a class="fd-tabs__link" href="#VqJcYO">
+        <button role="link" class="fd-tabs__link" href="#VqJcYO">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">40</p>
             </span>
             <span class="fd-tabs__label">Description</span>
-        </a>
+        </button>
     </li>
     <li role="tab" class="fd-tabs__item" aria-controls="ceoDu7">
-        <a class="fd-tabs__link" href="#ceoDu7">
+        <button role="link" class="fd-tabs__link" href="#ceoDu7">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">107</p>
             </span>
             <span class="fd-tabs__label">Description</span>
-        </a>
+        </button>
     </li>
     <button class="fd-button fd-button--transparent fd-button--compact fd-tabs__overflow" aria-label="See More">
         <i class="sap-icon--slim-arrow-down" role="presentation"></i>
@@ -543,44 +543,44 @@ compactFilterMode.parameters = {
 export const semanticMode = () => `
 <ul class="fd-tabs fd-tabs--l fd-tabs--icon-only fd-tabs--compact" role="tablist">
     <li role="tab" class="fd-tabs__item fd-tabs__item--success" aria-controls="XTsSDD">
-        <a class="fd-tabs__link" href="#XTsSDD">
+        <button role="link" class="fd-tabs__link" href="#XTsSDD">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">54</p>
             </span>
-        </a>
+        </button>
     </li>
     <li role="tab" class="fd-tabs__item fd-tabs__item--warning" aria-selected="true" aria-controls="DomvG6">
-      <a class="fd-tabs__link is-selected" href="#DomvG6">
+      <button class="fd-tabs__link is-selected" href="#DomvG6">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">71</p>
             </span>
-        </a>
+        </button>
     </li>
     <li role="tab" class="fd-tabs__item fd-tabs__item--information" aria-controls="DqIStt">
-        <a class="fd-tabs__link" href="#DqIStt">
+        <button role="link" class="fd-tabs__link" href="#DqIStt">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">23</p>
             </span>
-        </a>
+        </button>
     </li>
     <li role="tab" class="fd-tabs__item fd-tabs__item--error" aria-controls="bRCSzS">
-        <a class="fd-tabs__link" href="#bRCSzS">
+        <button role="link" class="fd-tabs__link" href="#bRCSzS">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">4</p>
             </span>
-        </a>
+        </button>
     </li>
     <li role="tab" class="fd-tabs__item fd-tabs__item--neutral" aria-controls="xMN6I9">
-        <a class="fd-tabs__link" href="#xMN6I9">
+        <button role="link" class="fd-tabs__link" href="#xMN6I9">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">100</p>
             </span>
-        </a>
+        </button>
     </li>
     <button class="fd-button fd-button--transparent fd-tabs__overflow" aria-label="See More">
         <i class="sap-icon--slim-arrow-down" role="presentation"></i>
@@ -624,49 +624,49 @@ Neutral | \`fd-tabs__item--neutral\`
 export const semanticFilterMode = () => `
 <ul class="fd-tabs fd-tabs--l fd-tabs--filter" role="tablist">
     <li role="tab" class="fd-tabs__item fd-tabs__item--header" aria-controls="5ZkDVE">
-        <a class="fd-tabs__link" href="#5ZkDVE">
+        <button role="link" class="fd-tabs__link" href="#5ZkDVE">
             <span class="fd-tabs__header">
                 <span class="fd-tabs__counter-header">150</span>
                 <span class="fd-tabs__label">products</span>
             </span>
-        </a>
+        </button>
     </li>
     <div class="fd-tabs__separator"></div>
     <li role="tab" class="fd-tabs__item fd-tabs__item--success" aria-controls="znvnwr">
-        <a class="fd-tabs__link" href="#znvnwr">
+        <button role="link" class="fd-tabs__link" href="#znvnwr">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">35</p>
             </span>
             <span class="fd-tabs__label">Success</span>
-        </a>
+        </button>
     </li>
     <li role="tab" class="fd-tabs__item fd-tabs__item--warning" aria-controls="oyYpL7">
-        <a class="fd-tabs__link" href="#oyYpL7">
+        <button role="link" class="fd-tabs__link" href="#oyYpL7">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">5</p>
             </span>
             <span class="fd-tabs__label">Warning</span>
-        </a>
+        </button>
     </li>
     <li role="tab" class="fd-tabs__item fd-tabs__item--information" aria-controls="gRpu9H">
-        <a class="fd-tabs__link" href="#gRpu9H">
+        <button role="link" class="fd-tabs__link" href="#gRpu9H">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">60</p>
             </span>
             <span class="fd-tabs__label">Information</span>
-        </a>
+        </button>
     </li>
     <li role="tab" class="fd-tabs__item fd-tabs__item--error" aria-controls="gRpu1A">
-        <a class="fd-tabs__link" href="#gRpu1A">
+        <button role="link" class="fd-tabs__link" href="#gRpu1A">
             <span class="fd-tabs__icon">
                 <i class="sap-icon--cart" role="presentation"></i>
                 <p class="fd-tabs__count">50</p>
             </span>
             <span class="fd-tabs__label">Error</span>
-        </a>
+        </button>
     </li>
     <button class="fd-button fd-button--transparent fd-tabs__overflow" aria-label="See More">
         <i class="sap-icon--slim-arrow-down" role="presentation"></i>
@@ -701,44 +701,44 @@ semanticFilterMode.parameters = {
 export const semanticInline = () => `
 <ul class="fd-tabs fd-tabs--l" role="tablist">
     <li role="tab" class="fd-tabs__item fd-tabs__item--error" aria-controls="5abyKZ">
-        <a class="fd-tabs__link" href="#5abyKZ">
+        <button role="link" class="fd-tabs__link" href="#5abyKZ">
             <p class="fd-tabs__count">13</p>
             <span class="fd-tabs__tag">
                 Error
             </span>
-        </a>
+        </button>
     </li>
     <li role="tab" aria-selected="true" class="fd-tabs__item fd-tabs__item--information" aria-controls="wupC7s">
-        <a class="fd-tabs__link is-selected" href="#wupC7s">
+        <button class="fd-tabs__link is-selected" href="#wupC7s">
             <p class="fd-tabs__count">24</p>
             <span class="fd-tabs__tag">
                 Information
             </span>
-        </a>
+        </button>
     </li>
     <li role="tab" class="fd-tabs__item fd-tabs__item--warning" aria-controls="XlKpQM">
-        <a class="fd-tabs__link" href="#XlKpQM">
+        <button role="link" class="fd-tabs__link" href="#XlKpQM">
             <p class="fd-tabs__count">31</p>
             <span class="fd-tabs__tag">
                 Warning
             </span>
-        </a>
+        </button>
     </li>
     <li role="tab" class="fd-tabs__item fd-tabs__item--success">
-        <a class="fd-tabs__link" aria-controls="3dUJAI" href="#3dUJAI">
+        <button role="link" class="fd-tabs__link" aria-controls="3dUJAI" href="#3dUJAI">
             <p class="fd-tabs__count">65</p>
             <span class="fd-tabs__tag">
                 Success
             </span>
-        </a>
+        </button>
     </li>
     <li role="tab" class="fd-tabs__item fd-tabs__item--neutral" aria-controls="TWlAup">
-        <a class="fd-tabs__link" href="#TWlAup">
+        <button role="link" class="fd-tabs__link" href="#TWlAup">
             <p class="fd-tabs__count">159</p>
             <span class="fd-tabs__tag">
                 Neutral
             </span>
-        </a>
+        </button>
     </li>
     <button class="fd-button fd-button--transparent fd-tabs__overflow" aria-label="See More">
         <i class="sap-icon--slim-arrow-down" role="presentation"></i>


### PR DESCRIPTION
BREAKING CHANGES: change anchor element to button element on tab

## Related Issue


## Description
Change the anchor element to a button element
Adds border bottom to remove the white overlapping the container border
fixes the offset on the navigation line to compensate
adds role=link for a11y

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
