### PR TITLE
fix: pagination button to anchor element

### DIFF
--- a/stories/pagination/__snapshots__/pagination.stories.storyshot
+++ b/stories/pagination/__snapshots__/pagination.stories.storyshot
@@ -23,14 +23,14 @@ exports[`Storyshots Components/Pagination First page 1`] = `
       aria-label="Previous"
       class="fd-pagination__link fd-pagination__link--previous"
       href="#"
-      role="link"
+      role="navigation"
     />
     
       
     <button
       class="fd-pagination__link is-selected"
       href="#"
-      role="link"
+      role="navigation"
     >
       1
     </button>
@@ -39,7 +39,7 @@ exports[`Storyshots Components/Pagination First page 1`] = `
     <button
       class="fd-pagination__link"
       href="#"
-      role="link"
+      role="navigation"
     >
       2
     </button>
@@ -48,7 +48,7 @@ exports[`Storyshots Components/Pagination First page 1`] = `
     <button
       class="fd-pagination__link"
       href="#"
-      role="link"
+      role="navigation"
     >
       3
     </button>
@@ -59,7 +59,7 @@ exports[`Storyshots Components/Pagination First page 1`] = `
       aria-label="Next"
       class="fd-pagination__link fd-pagination__link--next"
       href="#"
-      role="link"
+      role="navigation"
     />
     
   
@@ -92,14 +92,14 @@ exports[`Storyshots Components/Pagination Last page 1`] = `
       aria-label="Previous"
       class="fd-pagination__link fd-pagination__link--previous"
       href="#"
-      role="link"
+      role="navigation"
     />
     
   
     <button
       class="fd-pagination__link"
       href="#"
-      role="link"
+      role="navigation"
     >
       1
     </button>
@@ -114,7 +114,7 @@ exports[`Storyshots Components/Pagination Last page 1`] = `
     <button
       class="fd-pagination__link"
       href="#"
-      role="link"
+      role="navigation"
     >
       49
     </button>
@@ -123,7 +123,7 @@ exports[`Storyshots Components/Pagination Last page 1`] = `
     <button
       class="fd-pagination__link is-selected"
       href="#"
-      role="link"
+      role="navigation"
     >
       50
     </button>
@@ -134,7 +134,7 @@ exports[`Storyshots Components/Pagination Last page 1`] = `
       aria-label="Next"
       class="fd-pagination__link fd-pagination__link--next"
       href="#"
-      role="link"
+      role="navigation"
     />
     
 
@@ -167,14 +167,14 @@ exports[`Storyshots Components/Pagination Middle pages 1`] = `
       aria-label="Previous"
       class="fd-pagination__link fd-pagination__link--previous"
       href="#"
-      role="link"
+      role="navigation"
     />
     
   
     <button
       class="fd-pagination__link"
       href="#"
-      role="link"
+      role="navigation"
     >
       1
     </button>
@@ -189,7 +189,7 @@ exports[`Storyshots Components/Pagination Middle pages 1`] = `
     <button
       class="fd-pagination__link"
       href="#"
-      role="link"
+      role="navigation"
     >
       21
     </button>
@@ -198,7 +198,7 @@ exports[`Storyshots Components/Pagination Middle pages 1`] = `
     <button
       class="fd-pagination__link is-selected"
       href="#"
-      role="link"
+      role="navigation"
     >
       22
     </button>
@@ -207,7 +207,7 @@ exports[`Storyshots Components/Pagination Middle pages 1`] = `
     <button
       class="fd-pagination__link"
       href="#"
-      role="link"
+      role="navigation"
     >
       23
     </button>
@@ -222,7 +222,7 @@ exports[`Storyshots Components/Pagination Middle pages 1`] = `
     <button
       class="fd-pagination__link"
       href="#"
-      role="link"
+      role="navigation"
     >
       50
     </button>
@@ -233,7 +233,7 @@ exports[`Storyshots Components/Pagination Middle pages 1`] = `
       aria-label="Next"
       class="fd-pagination__link fd-pagination__link--next"
       href="#"
-      role="link"
+      role="navigation"
     />
     
 
@@ -266,14 +266,14 @@ exports[`Storyshots Components/Pagination Mutliple pages 1`] = `
       aria-label="Previous"
       class="fd-pagination__link fd-pagination__link--previous"
       href="#"
-      role="link"
+      role="navigation"
     />
     
   
     <button
       class="fd-pagination__link"
       href="#"
-      role="link"
+      role="navigation"
     >
       1
     </button>
@@ -282,7 +282,7 @@ exports[`Storyshots Components/Pagination Mutliple pages 1`] = `
     <button
       class="fd-pagination__link is-selected"
       href="#"
-      role="link"
+      role="navigation"
     >
       2
     </button>
@@ -291,7 +291,7 @@ exports[`Storyshots Components/Pagination Mutliple pages 1`] = `
     <button
       class="fd-pagination__link"
       href="#"
-      role="link"
+      role="navigation"
     >
       3
     </button>
@@ -306,7 +306,7 @@ exports[`Storyshots Components/Pagination Mutliple pages 1`] = `
     <button
       class="fd-pagination__link"
       href="#"
-      role="link"
+      role="navigation"
     >
       50
     </button>
@@ -317,7 +317,7 @@ exports[`Storyshots Components/Pagination Mutliple pages 1`] = `
       aria-label="Next"
       class="fd-pagination__link fd-pagination__link--next"
       href="#"
-      role="link"
+      role="navigation"
     />
     
 
@@ -350,14 +350,14 @@ exports[`Storyshots Components/Pagination Second page 1`] = `
       aria-label="Previous"
       class="fd-pagination__link fd-pagination__link--previous"
       href="#"
-      role="link"
+      role="navigation"
     />
     
   
     <button
       class="fd-pagination__link"
       href="#"
-      role="link"
+      role="navigation"
     >
       1
     </button>
@@ -366,7 +366,7 @@ exports[`Storyshots Components/Pagination Second page 1`] = `
     <button
       class="fd-pagination__link is-selected"
       href="#"
-      role="link"
+      role="navigation"
     >
       2
     </button>
@@ -375,7 +375,7 @@ exports[`Storyshots Components/Pagination Second page 1`] = `
     <button
       class="fd-pagination__link"
       href="#"
-      role="link"
+      role="navigation"
     >
       3
     </button>
@@ -386,7 +386,7 @@ exports[`Storyshots Components/Pagination Second page 1`] = `
       aria-label="Next"
       class="fd-pagination__link fd-pagination__link--next"
       href="#"
-      role="link"
+      role="navigation"
     />
     
 

--- a/stories/pagination/__snapshots__/pagination.stories.storyshot
+++ b/stories/pagination/__snapshots__/pagination.stories.storyshot
@@ -18,43 +18,48 @@ exports[`Storyshots Components/Pagination First page 1`] = `
   >
     
       
-    <a
+    <button
       aria-disabled="true"
       aria-label="Previous"
       class="fd-pagination__link fd-pagination__link--previous"
       href="#"
+      role="link"
     />
     
       
-    <a
+    <button
       class="fd-pagination__link is-selected"
       href="#"
+      role="link"
     >
       1
-    </a>
+    </button>
     
       
-    <a
+    <button
       class="fd-pagination__link"
       href="#"
+      role="link"
     >
       2
-    </a>
+    </button>
     
       
-    <a
+    <button
       class="fd-pagination__link"
       href="#"
+      role="link"
     >
       3
-    </a>
+    </button>
     
       
-    <a
+    <button
       aria-disabled="false"
       aria-label="Next"
       class="fd-pagination__link fd-pagination__link--next"
       href="#"
+      role="link"
     />
     
   
@@ -82,20 +87,22 @@ exports[`Storyshots Components/Pagination Last page 1`] = `
   >
     
   
-    <a
+    <button
       aria-disabled="false"
       aria-label="Previous"
       class="fd-pagination__link fd-pagination__link--previous"
       href="#"
+      role="link"
     />
     
   
-    <a
+    <button
       class="fd-pagination__link"
       href="#"
+      role="link"
     >
       1
-    </a>
+    </button>
     
   
     <span
@@ -104,27 +111,30 @@ exports[`Storyshots Components/Pagination Last page 1`] = `
     />
     
   
-    <a
+    <button
       class="fd-pagination__link"
       href="#"
+      role="link"
     >
       49
-    </a>
+    </button>
     
   
-    <a
+    <button
       class="fd-pagination__link is-selected"
       href="#"
+      role="link"
     >
       50
-    </a>
+    </button>
     
   
-    <a
+    <button
       aria-disabled="true"
       aria-label="Next"
       class="fd-pagination__link fd-pagination__link--next"
       href="#"
+      role="link"
     />
     
 
@@ -152,20 +162,22 @@ exports[`Storyshots Components/Pagination Middle pages 1`] = `
   >
     
   
-    <a
+    <button
       aria-disabled="false"
       aria-label="Previous"
       class="fd-pagination__link fd-pagination__link--previous"
       href="#"
+      role="link"
     />
     
   
-    <a
+    <button
       class="fd-pagination__link"
       href="#"
+      role="link"
     >
       1
-    </a>
+    </button>
     
   
     <span
@@ -174,28 +186,31 @@ exports[`Storyshots Components/Pagination Middle pages 1`] = `
     />
     
   
-    <a
+    <button
       class="fd-pagination__link"
       href="#"
+      role="link"
     >
       21
-    </a>
+    </button>
     
   
-    <a
+    <button
       class="fd-pagination__link is-selected"
       href="#"
+      role="link"
     >
       22
-    </a>
+    </button>
     
   
-    <a
+    <button
       class="fd-pagination__link"
       href="#"
+      role="link"
     >
       23
-    </a>
+    </button>
     
   
     <span
@@ -204,19 +219,21 @@ exports[`Storyshots Components/Pagination Middle pages 1`] = `
     />
     
   
-    <a
+    <button
       class="fd-pagination__link"
       href="#"
+      role="link"
     >
       50
-    </a>
+    </button>
     
   
-    <a
+    <button
       aria-disabled="false"
       aria-label="Next"
       class="fd-pagination__link fd-pagination__link--next"
       href="#"
+      role="link"
     />
     
 
@@ -244,36 +261,40 @@ exports[`Storyshots Components/Pagination Mutliple pages 1`] = `
   >
     
   
-    <a
+    <button
       aria-disabled="false"
       aria-label="Previous"
       class="fd-pagination__link fd-pagination__link--previous"
       href="#"
+      role="link"
     />
     
   
-    <a
+    <button
       class="fd-pagination__link"
       href="#"
+      role="link"
     >
       1
-    </a>
+    </button>
     
   
-    <a
+    <button
       class="fd-pagination__link is-selected"
       href="#"
+      role="link"
     >
       2
-    </a>
+    </button>
     
   
-    <a
+    <button
       class="fd-pagination__link"
       href="#"
+      role="link"
     >
       3
-    </a>
+    </button>
     
   
     <span
@@ -282,19 +303,21 @@ exports[`Storyshots Components/Pagination Mutliple pages 1`] = `
     />
     
   
-    <a
+    <button
       class="fd-pagination__link"
       href="#"
+      role="link"
     >
       50
-    </a>
+    </button>
     
   
-    <a
+    <button
       aria-disabled="false"
       aria-label="Next"
       class="fd-pagination__link fd-pagination__link--next"
       href="#"
+      role="link"
     />
     
 
@@ -322,43 +345,48 @@ exports[`Storyshots Components/Pagination Second page 1`] = `
   >
     
   
-    <a
+    <button
       aria-disabled="false"
       aria-label="Previous"
       class="fd-pagination__link fd-pagination__link--previous"
       href="#"
+      role="link"
     />
     
   
-    <a
+    <button
       class="fd-pagination__link"
       href="#"
+      role="link"
     >
       1
-    </a>
+    </button>
     
   
-    <a
+    <button
       class="fd-pagination__link is-selected"
       href="#"
+      role="link"
     >
       2
-    </a>
+    </button>
     
   
-    <a
+    <button
       class="fd-pagination__link"
       href="#"
+      role="link"
     >
       3
-    </a>
+    </button>
     
   
-    <a
+    <button
       aria-disabled="false"
       aria-label="Next"
       class="fd-pagination__link fd-pagination__link--next"
       href="#"
+      role="link"
     />
     
 

--- a/stories/pagination/pagination.stories.js
+++ b/stories/pagination/pagination.stories.js
@@ -35,12 +35,12 @@ Next arrow | \`fd-pagination__link--next\` | The next arrow that users can use t
 export const firstPage = () => `<div class="fd-pagination">
   <span class="fd-pagination__total">30 items</span>
   <nav class="fd-pagination__nav">
-      <a href="#" class="fd-pagination__link fd-pagination__link--previous" aria-label="Previous"aria-disabled="true"></a>
-      <a href="#" class="fd-pagination__link is-selected" >1</a>
-      <a href="#" class="fd-pagination__link">2</a>
-      <a href="#" class="fd-pagination__link">3</a>
-      <a href="#" class="fd-pagination__link fd-pagination__link--next" aria-label="Next"
-      aria-disabled="false"></a>
+      <button role="link" href="#" class="fd-pagination__link fd-pagination__link--previous" aria-label="Previous"aria-disabled="true"></button>
+      <button role="link" href="#" class="fd-pagination__link is-selected" >1</button>
+      <button role="link" href="#" class="fd-pagination__link">2</button>
+      <button role="link" href="#" class="fd-pagination__link">3</button>
+      <button role="link" href="#" class="fd-pagination__link fd-pagination__link--next" aria-label="Next"
+      aria-disabled="false"></button>
   </nav>
 </div>
 `;
@@ -57,13 +57,13 @@ firstPage.parameters = {
 export const secondPage = () => `<div class="fd-pagination">
 <span class="fd-pagination__total">30 items</span>
 <nav class="fd-pagination__nav">
-  <a href="#" class="fd-pagination__link fd-pagination__link--previous" aria-label="Previous"
-  aria-disabled="false"></a>
-  <a href="#" class="fd-pagination__link">1</a>
-  <a href="#" class="fd-pagination__link is-selected">2</a>
-  <a href="#" class="fd-pagination__link">3</a>
-  <a href="#" class="fd-pagination__link fd-pagination__link--next" aria-label="Next"
-  aria-disabled="false"></a>
+  <button role="link" href="#" class="fd-pagination__link fd-pagination__link--previous" aria-label="Previous"
+  aria-disabled="false"></button>
+  <button role="link" href="#" class="fd-pagination__link">1</button>
+  <button role="link" href="#" class="fd-pagination__link is-selected">2</button>
+  <button role="link" href="#" class="fd-pagination__link">3</button>
+  <button role="link" href="#" class="fd-pagination__link fd-pagination__link--next" aria-label="Next"
+  aria-disabled="false"></button>
 </nav>
 </div>
 `;
@@ -80,15 +80,15 @@ secondPage.parameters = {
 export const multiplePages = () => `<div class="fd-pagination">
 <span class="fd-pagination__total">500 items</span>
 <nav class="fd-pagination__nav">
-  <a href="#" class="fd-pagination__link fd-pagination__link--previous" aria-label="Previous"
-  aria-disabled="false"></a>
-  <a href="#" class="fd-pagination__link">1</a>
-  <a href="#" class="fd-pagination__link is-selected">2</a>
-  <a href="#" class="fd-pagination__link">3</a>
+  <button role="link" href="#" class="fd-pagination__link fd-pagination__link--previous" aria-label="Previous"
+  aria-disabled="false"></button>
+  <button role="link" href="#" class="fd-pagination__link">1</button>
+  <button role="link" href="#" class="fd-pagination__link is-selected">2</button>
+  <button role="link" href="#" class="fd-pagination__link">3</button>
   <span class="fd-pagination__more" role="presentation"></span>
-  <a href="#" class="fd-pagination__link">50</a>
-  <a href="#" class="fd-pagination__link fd-pagination__link--next" aria-label="Next"
-  aria-disabled="false"></a>
+  <button role="link" href="#" class="fd-pagination__link">50</button>
+  <button role="link" href="#" class="fd-pagination__link fd-pagination__link--next" aria-label="Next"
+  aria-disabled="false"></button>
 </nav>
 </div>
 `;
@@ -105,17 +105,17 @@ multiplePages.parameters = {
 export const middlePage = () => `<div class="fd-pagination">
 <span class="fd-pagination__total">500 items</span>
 <nav class="fd-pagination__nav">
-  <a href="#" class="fd-pagination__link fd-pagination__link--previous" aria-label="Previous"
-  aria-disabled="false"></a>
-  <a href="#" class="fd-pagination__link">1</a>
+  <button role="link" href="#" class="fd-pagination__link fd-pagination__link--previous" aria-label="Previous"
+  aria-disabled="false"></button>
+  <button role="link" href="#" class="fd-pagination__link">1</button>
   <span class="fd-pagination__more" role="presentation"></span>
-  <a href="#" class="fd-pagination__link">21</a>
-  <a href="#" class="fd-pagination__link is-selected">22</a>
-  <a href="#" class="fd-pagination__link">23</a>
+  <button role="link" href="#" class="fd-pagination__link">21</button>
+  <button role="link" href="#" class="fd-pagination__link is-selected">22</button>
+  <button role="link" href="#" class="fd-pagination__link">23</button>
   <span class="fd-pagination__more" role="presentation"></span>
-  <a href="#" class="fd-pagination__link">50</a>
-  <a href="#" class="fd-pagination__link fd-pagination__link--next" aria-label="Next"
-  aria-disabled="false"></a>
+  <button role="link" href="#" class="fd-pagination__link">50</button>
+  <button role="link" href="#" class="fd-pagination__link fd-pagination__link--next" aria-label="Next"
+  aria-disabled="false"></button>
 </nav>
 </div>
 `;
@@ -132,14 +132,14 @@ middlePage.parameters = {
 export const lastPage = () => `<div class="fd-pagination">
 <span class="fd-pagination__total">500 items</span>
 <nav class="fd-pagination__nav">
-  <a href="#" class="fd-pagination__link fd-pagination__link--previous" aria-label="Previous"
-  aria-disabled="false"></a>
-  <a href="#" class="fd-pagination__link">1</a>
+  <button role="link" href="#" class="fd-pagination__link fd-pagination__link--previous" aria-label="Previous"
+  aria-disabled="false"></button>
+  <button role="link" href="#" class="fd-pagination__link">1</button>
   <span class="fd-pagination__more" role="presentation"></span>
-  <a href="#" class="fd-pagination__link">49</a>
-  <a href="#" class="fd-pagination__link is-selected">50</a>
-  <a href="#" class="fd-pagination__link fd-pagination__link--next" aria-label="Next"
-  aria-disabled="true"></a>
+  <button role="link" href="#" class="fd-pagination__link">49</button>
+  <button role="link" href="#" class="fd-pagination__link is-selected">50</button>
+  <button role="link" href="#" class="fd-pagination__link fd-pagination__link--next" aria-label="Next"
+  aria-disabled="true"></button>
 </nav>
 </div>
 `;

--- a/stories/pagination/pagination.stories.js
+++ b/stories/pagination/pagination.stories.js
@@ -35,11 +35,11 @@ Next arrow | \`fd-pagination__link--next\` | The next arrow that users can use t
 export const firstPage = () => `<div class="fd-pagination">
   <span class="fd-pagination__total">30 items</span>
   <nav class="fd-pagination__nav">
-      <button role="link" href="#" class="fd-pagination__link fd-pagination__link--previous" aria-label="Previous"aria-disabled="true"></button>
-      <button role="link" href="#" class="fd-pagination__link is-selected" >1</button>
-      <button role="link" href="#" class="fd-pagination__link">2</button>
-      <button role="link" href="#" class="fd-pagination__link">3</button>
-      <button role="link" href="#" class="fd-pagination__link fd-pagination__link--next" aria-label="Next"
+      <button role="navigation" href="#" class="fd-pagination__link fd-pagination__link--previous" aria-label="Previous"aria-disabled="true"></button>
+      <button role="navigation" href="#" class="fd-pagination__link is-selected" >1</button>
+      <button role="navigation" href="#" class="fd-pagination__link">2</button>
+      <button role="navigation" href="#" class="fd-pagination__link">3</button>
+      <button role="navigation" href="#" class="fd-pagination__link fd-pagination__link--next" aria-label="Next"
       aria-disabled="false"></button>
   </nav>
 </div>
@@ -57,12 +57,12 @@ firstPage.parameters = {
 export const secondPage = () => `<div class="fd-pagination">
 <span class="fd-pagination__total">30 items</span>
 <nav class="fd-pagination__nav">
-  <button role="link" href="#" class="fd-pagination__link fd-pagination__link--previous" aria-label="Previous"
+  <button role="navigation" href="#" class="fd-pagination__link fd-pagination__link--previous" aria-label="Previous"
   aria-disabled="false"></button>
-  <button role="link" href="#" class="fd-pagination__link">1</button>
-  <button role="link" href="#" class="fd-pagination__link is-selected">2</button>
-  <button role="link" href="#" class="fd-pagination__link">3</button>
-  <button role="link" href="#" class="fd-pagination__link fd-pagination__link--next" aria-label="Next"
+  <button role="navigation" href="#" class="fd-pagination__link">1</button>
+  <button role="navigation" href="#" class="fd-pagination__link is-selected">2</button>
+  <button role="navigation" href="#" class="fd-pagination__link">3</button>
+  <button role="navigation" href="#" class="fd-pagination__link fd-pagination__link--next" aria-label="Next"
   aria-disabled="false"></button>
 </nav>
 </div>
@@ -80,14 +80,14 @@ secondPage.parameters = {
 export const multiplePages = () => `<div class="fd-pagination">
 <span class="fd-pagination__total">500 items</span>
 <nav class="fd-pagination__nav">
-  <button role="link" href="#" class="fd-pagination__link fd-pagination__link--previous" aria-label="Previous"
+  <button role="navigation" href="#" class="fd-pagination__link fd-pagination__link--previous" aria-label="Previous"
   aria-disabled="false"></button>
-  <button role="link" href="#" class="fd-pagination__link">1</button>
-  <button role="link" href="#" class="fd-pagination__link is-selected">2</button>
-  <button role="link" href="#" class="fd-pagination__link">3</button>
+  <button role="navigation" href="#" class="fd-pagination__link">1</button>
+  <button role="navigation" href="#" class="fd-pagination__link is-selected">2</button>
+  <button role="navigation" href="#" class="fd-pagination__link">3</button>
   <span class="fd-pagination__more" role="presentation"></span>
-  <button role="link" href="#" class="fd-pagination__link">50</button>
-  <button role="link" href="#" class="fd-pagination__link fd-pagination__link--next" aria-label="Next"
+  <button role="navigation" href="#" class="fd-pagination__link">50</button>
+  <button role="navigation" href="#" class="fd-pagination__link fd-pagination__link--next" aria-label="Next"
   aria-disabled="false"></button>
 </nav>
 </div>
@@ -105,16 +105,16 @@ multiplePages.parameters = {
 export const middlePage = () => `<div class="fd-pagination">
 <span class="fd-pagination__total">500 items</span>
 <nav class="fd-pagination__nav">
-  <button role="link" href="#" class="fd-pagination__link fd-pagination__link--previous" aria-label="Previous"
+  <button role="navigation" href="#" class="fd-pagination__link fd-pagination__link--previous" aria-label="Previous"
   aria-disabled="false"></button>
-  <button role="link" href="#" class="fd-pagination__link">1</button>
+  <button role="navigation" href="#" class="fd-pagination__link">1</button>
   <span class="fd-pagination__more" role="presentation"></span>
-  <button role="link" href="#" class="fd-pagination__link">21</button>
-  <button role="link" href="#" class="fd-pagination__link is-selected">22</button>
-  <button role="link" href="#" class="fd-pagination__link">23</button>
+  <button role="navigation" href="#" class="fd-pagination__link">21</button>
+  <button role="navigation" href="#" class="fd-pagination__link is-selected">22</button>
+  <button role="navigation" href="#" class="fd-pagination__link">23</button>
   <span class="fd-pagination__more" role="presentation"></span>
-  <button role="link" href="#" class="fd-pagination__link">50</button>
-  <button role="link" href="#" class="fd-pagination__link fd-pagination__link--next" aria-label="Next"
+  <button role="navigation" href="#" class="fd-pagination__link">50</button>
+  <button role="navigation" href="#" class="fd-pagination__link fd-pagination__link--next" aria-label="Next"
   aria-disabled="false"></button>
 </nav>
 </div>
@@ -132,13 +132,13 @@ middlePage.parameters = {
 export const lastPage = () => `<div class="fd-pagination">
 <span class="fd-pagination__total">500 items</span>
 <nav class="fd-pagination__nav">
-  <button role="link" href="#" class="fd-pagination__link fd-pagination__link--previous" aria-label="Previous"
+  <button role="navigation" href="#" class="fd-pagination__link fd-pagination__link--previous" aria-label="Previous"
   aria-disabled="false"></button>
-  <button role="link" href="#" class="fd-pagination__link">1</button>
+  <button role="navigation" href="#" class="fd-pagination__link">1</button>
   <span class="fd-pagination__more" role="presentation"></span>
-  <button role="link" href="#" class="fd-pagination__link">49</button>
-  <button role="link" href="#" class="fd-pagination__link is-selected">50</button>
-  <button role="link" href="#" class="fd-pagination__link fd-pagination__link--next" aria-label="Next"
+  <button role="navigation" href="#" class="fd-pagination__link">49</button>
+  <button role="navigation" href="#" class="fd-pagination__link is-selected">50</button>
+  <button role="navigation" href="#" class="fd-pagination__link fd-pagination__link--next" aria-label="Next"
   aria-disabled="true"></button>
 </nav>
 </div>


### PR DESCRIPTION
BREAKING CHANGES: change anchor element to button element for pagination links

## Related Issue
Closes SAP/fundamental-styles#107

## Description
Change all anchor elements to button elements with role="link" for a11y

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
