### PR TITLE
feat: unread selection

### DIFF
--- a/src/_listBase.scss
+++ b/src/_listBase.scss
@@ -26,6 +26,12 @@
     background: var(--sapList_Background);
     position: relative;
 
+    &--unread {
+      .#{$block}__title {
+        font-weight: bold;
+      }
+    }
+
     &--no-data {
       .#{$block}__title {
         text-align: center;

--- a/stories/list/standard/__snapshots__/standard-list.stories.storyshot
+++ b/stories/list/standard/__snapshots__/standard-list.stories.storyshot
@@ -1544,3 +1544,90 @@ exports[`Storyshots Components/List/Standard Selection 1`] = `
 
 </section>
 `;
+
+exports[`Storyshots Components/List/Standard Unread 1`] = `
+<section>
+  <h4>
+    Unread Options
+  </h4>
+  
+
+  <ul
+    class="fd-list"
+    role="list"
+  >
+    
+  
+    <li
+      class="fd-list__item fd-list__item--unread"
+      role="listitem"
+      tabindex="0"
+    >
+      
+      
+      <span
+        class="fd-list__title"
+      >
+        List item 1 Unread
+      </span>
+      
+  
+    </li>
+    
+  
+    <li
+      class="fd-list__item fd-list__item--unread"
+      role="listitem"
+      tabindex="0"
+    >
+      
+      
+      <span
+        class="fd-list__title"
+      >
+        List item 2 Unread
+      </span>
+      
+  
+    </li>
+    
+  
+    <li
+      class="fd-list__item"
+      role="listitem"
+      tabindex="0"
+    >
+      
+      
+      <span
+        class="fd-list__title"
+      >
+        List item 3 Read
+      </span>
+      
+  
+    </li>
+    
+  
+    <li
+      class="fd-list__item"
+      role="listitem"
+      tabindex="0"
+    >
+      
+      
+      <span
+        class="fd-list__title"
+      >
+        List item 4 Read
+      </span>
+      
+  
+    </li>
+    
+
+  </ul>
+  
+
+</section>
+`;

--- a/stories/list/standard/standard-list.stories.js
+++ b/stories/list/standard/standard-list.stories.js
@@ -66,6 +66,33 @@ standard.parameters = {
     }
 };
 
+export const unread = () => `<h4>Unread Options</h4>
+<ul class="fd-list" role="list">
+  <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--unread">
+      <span class="fd-list__title">List item 1 Unread</span>
+  </li>
+  <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--unread">
+      <span class="fd-list__title">List item 2 Unread</span>
+  </li>
+  <li role="listitem" tabindex="0" class="fd-list__item">
+      <span class="fd-list__title">List item 3 Read</span>
+  </li>
+  <li role="listitem" tabindex="0" class="fd-list__item">
+      <span class="fd-list__title">List item 4 Read</span>
+  </li>
+</ul>
+`;
+
+unread.storyName = 'Unread';
+
+unread.parameters = {
+    docs: {
+        iframeHeight: 445,
+        storyDescription: `The \`fd-list__item--unread\` modifier will change the font weight to bold for easier legibility.
+        `
+    }
+};
+
 export const navigation = () => `<ul class="fd-list fd-list--navigation" role="list">
   <li tabindex="-1" role="listitem" class="fd-list__item fd-list__item--link">
       <a tabindex="0" class="fd-list__link">


### PR DESCRIPTION
BREAKING CHANGES: fd-list__item--unread modifier added

## Related Issue
Closes SAP/fundamental-styles#1111

## Description
Add unread modifier to list item per new fiori 3 spec
## Screenshots

### After:
![Screen Shot 2020-12-29 at 1 15 25 PM](https://user-images.githubusercontent.com/50607147/103304961-f4df4000-49d7-11eb-8489-116231f656ca.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
