### PR TITLE
fix: checkbox label for required

### DIFF
--- a/src/checkbox.scss
+++ b/src/checkbox.scss
@@ -62,6 +62,18 @@ $block: #{$fd-namespace}-checkbox;
       border-radius: var(--sapField_BorderCornerRadius);
     }
 
+    &::after {
+      padding-left: 0.125rem;
+      position: relative;
+    }
+
+    @include fd-rtl() {
+      &::after {
+        padding-left: 0;
+        padding-right: 0.125rem;
+      }
+    }
+
     @include fd-hover() {
       &::before {
         background-color: var(--sapField_Hover_Background);

--- a/stories/checkbox/__snapshots__/checkbox.stories.storyshot
+++ b/stories/checkbox/__snapshots__/checkbox.stories.storyshot
@@ -584,6 +584,11 @@ exports[`Storyshots Components/Forms/Checkbox Mobile 1`] = `
 </section>
 `;
 
+exports[`Storyshots Components/Forms/Checkbox Required 1`] = `
+
+
+`;
+
 exports[`Storyshots Components/Forms/Checkbox States 1`] = `
 <section>
   

--- a/stories/checkbox/checkbox.stories.js
+++ b/stories/checkbox/checkbox.stories.js
@@ -92,6 +92,28 @@ On desktop screens, the checkbox appears smaller and uses the <code>fd-checkbox\
     }
 };
 
+export const required = () => `
+<fieldset class="fd-fieldset">
+    <legend class="fd-fieldset__legend">Required checkbox</legend>
+    <div class="fd-form-group">
+        <div class="fd-form-item">
+            <input type="checkbox" class="fd-checkbox fd-checkbox--compact" id="Ai4ez611c">
+            <label class="fd-form-label--required fd-checkbox__label fd-checkbox__label--compact" for="Ai4ez611c">
+                <span class="fd-checkbox__text">Required Checkbox</span>
+            </label>
+        </div>
+    </div>
+</fieldset>
+`;
+required.storyName = 'Required';
+required.parameters = {
+    docs: {
+        iframeHeight: 330,
+        storyDescription: `To show that a checkbox input is required, use the <code>fd-from-label--required</code> class.
+        `
+    }
+};
+
 export const mobile = () => `
 ${localStyles}
 <fieldset class="fd-fieldset">

--- a/stories/checkbox/checkbox.stories.js
+++ b/stories/checkbox/checkbox.stories.js
@@ -97,8 +97,8 @@ export const required = () => `
     <legend class="fd-fieldset__legend">Required checkbox</legend>
     <div class="fd-form-group">
         <div class="fd-form-item">
-            <input type="checkbox" class="fd-checkbox fd-checkbox--compact" id="Ai4ez611c">
-            <label class="fd-form-label--required fd-checkbox__label fd-checkbox__label--compact" for="Ai4ez611c">
+            <input type="checkbox" class="fd-checkbox fd-checkbox--compact" id="Ai4ez61rc">
+            <label class="fd-form-label--required fd-checkbox__label fd-checkbox__label--compact" for="Ai4ez61rc">
                 <span class="fd-checkbox__text">Required Checkbox</span>
             </label>
         </div>


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#883

## Description
Fixes the positioning of the required label
## Screenshots
### Before:
![image](https://user-images.githubusercontent.com/50607147/103313005-bf911d00-49ec-11eb-88fe-234a4b531626.png)

### After:
![Screen Shot 2020-12-29 at 3 44 16 PM](https://user-images.githubusercontent.com/50607147/103312998-ba33d280-49ec-11eb-82c2-acab3bbdb626.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
