### PR TITLE
fix: object status link focus

### DIFF
--- a/src/object-status.scss
+++ b/src/object-status.scss
@@ -291,6 +291,8 @@ $inverted-color-accents: (
 
   // CLICKABLE OBJECT STATUS
   &--link {
+    @include fd-fiori-focus-within(0);
+
     text-decoration: none;
     cursor: pointer;
 

--- a/src/object-status.scss
+++ b/src/object-status.scss
@@ -291,7 +291,7 @@ $inverted-color-accents: (
 
   // CLICKABLE OBJECT STATUS
   &--link {
-    @include fd-fiori-focus-within(0);
+    @include fd-fiori-focus(0);
 
     text-decoration: none;
     cursor: pointer;

--- a/src/object-status.scss
+++ b/src/object-status.scss
@@ -291,7 +291,7 @@ $inverted-color-accents: (
 
   // CLICKABLE OBJECT STATUS
   &--link {
-    @include fd-fiori-focus(0);
+    @include fd-fiori-focus(0.0625rem);
 
     text-decoration: none;
     cursor: pointer;

--- a/stories/object-status/__snapshots__/object-status.stories.storyshot
+++ b/stories/object-status/__snapshots__/object-status.stories.storyshot
@@ -75,6 +75,7 @@ exports[`Storyshots Components/Object Status Clickable Object Status 1`] = `
   <span
     class="fd-object-status fd-object-status--informative fd-object-status--link"
     role="button"
+    tabindex="0"
   >
     
         
@@ -97,6 +98,7 @@ exports[`Storyshots Components/Object Status Clickable Object Status 1`] = `
   <span
     class="fd-object-status fd-object-status--link"
     role="button"
+    tabindex="0"
   >
     
         
@@ -200,6 +202,7 @@ exports[`Storyshots Components/Object Status Clickable Object Status 1`] = `
   <span
     class="fd-object-status fd-object-status--link fd-object-status--indication-6"
     role="button"
+    tabindex="0"
   >
     
         
@@ -216,6 +219,7 @@ exports[`Storyshots Components/Object Status Clickable Object Status 1`] = `
   <span
     class="fd-object-status fd-object-status--link fd-object-status--indication-7"
     role="button"
+    tabindex="0"
   >
     
         
@@ -232,6 +236,7 @@ exports[`Storyshots Components/Object Status Clickable Object Status 1`] = `
   <span
     class="fd-object-status fd-object-status--link fd-object-status--indication-8"
     role="button"
+    tabindex="0"
   >
     
         
@@ -1039,6 +1044,7 @@ exports[`Storyshots Components/Object Status Inverted Indication 1`] = `
     
     <span
       class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-1"
+      tabindex="0"
     >
       
         
@@ -1054,6 +1060,7 @@ exports[`Storyshots Components/Object Status Inverted Indication 1`] = `
     
     <span
       class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-2"
+      tabindex="0"
     >
       
         
@@ -1069,6 +1076,7 @@ exports[`Storyshots Components/Object Status Inverted Indication 1`] = `
     
     <span
       class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-3"
+      tabindex="0"
     >
       
         
@@ -1084,6 +1092,7 @@ exports[`Storyshots Components/Object Status Inverted Indication 1`] = `
     
     <span
       class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-4"
+      tabindex="0"
     >
       
         
@@ -1099,6 +1108,7 @@ exports[`Storyshots Components/Object Status Inverted Indication 1`] = `
     
     <span
       class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-5"
+      tabindex="0"
     >
       
         
@@ -1114,6 +1124,7 @@ exports[`Storyshots Components/Object Status Inverted Indication 1`] = `
     
     <span
       class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-6"
+      tabindex="0"
     >
       
         
@@ -1129,6 +1140,7 @@ exports[`Storyshots Components/Object Status Inverted Indication 1`] = `
     
     <span
       class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-7"
+      tabindex="0"
     >
       
         
@@ -1144,6 +1156,7 @@ exports[`Storyshots Components/Object Status Inverted Indication 1`] = `
     
     <span
       class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-8"
+      tabindex="0"
     >
       
         

--- a/stories/object-status/object-status.stories.js
+++ b/stories/object-status/object-status.stories.js
@@ -164,11 +164,11 @@ export const clickableObjectStatus = () => `<div class="fddocs-container">
         <i class="fd-object-status__icon sap-icon--status-positive" role="presentation"></i>
         <span class="fd-object-status__text">Positive</span>
     </a>
-    <span role="button" class="fd-object-status fd-object-status--informative fd-object-status--link">
+    <span role="button" class="fd-object-status fd-object-status--informative fd-object-status--link" tabindex="0">
         <i class="fd-object-status__icon sap-icon--hint" role="presentation"></i>
         <span class="fd-object-status__text">Info</span>
     </span>
-    <span role="button" class="fd-object-status fd-object-status--link">
+    <span role="button" class="fd-object-status fd-object-status--link" tabindex="0">
         <i class="fd-object-status__icon sap-icon--to-be-reviewed" role="presentation"></i>
         <span class="fd-object-status__text">Neutral</span>
     </span>
@@ -188,13 +188,13 @@ export const clickableObjectStatus = () => `<div class="fddocs-container">
     <a href="#"  class="fd-object-status fd-object-status--link fd-object-status--indication-5">
         <span class="fd-object-status__text">Blue</span>
     </a>
-    <span role="button" class="fd-object-status fd-object-status--link fd-object-status--indication-6">
+    <span role="button" class="fd-object-status fd-object-status--link fd-object-status--indication-6" tabindex="0">
         <span class="fd-object-status__text">Teal</span>
     </span>
-    <span role="button" class="fd-object-status fd-object-status--link fd-object-status--indication-7">
+    <span role="button" class="fd-object-status fd-object-status--link fd-object-status--indication-7" tabindex="0">
         <span class="fd-object-status__text">Purple</span>
     </span>
-    <span role="button" class="fd-object-status fd-object-status--link fd-object-status--indication-8">
+    <span role="button" class="fd-object-status fd-object-status--link fd-object-status--indication-8" tabindex="0">
         <span class="fd-object-status__text">Pink</span>
     </span>
 </div>
@@ -330,28 +330,28 @@ export const invertedIndication = () => `<div class="fddocs-container">
 
 <h4>Clickable Inverted Object Status</h4>
 <div class="fddocs-container">
-    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-1">
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-1" tabindex="0">
         <span class="fd-object-status__text">Indication1</span>
     </span>
-    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-2">
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-2" tabindex="0">
         <span class="fd-object-status__text">Indication2</span>
     </span>
-    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-3">
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-3" tabindex="0">
         <span class="fd-object-status__text">Indication3</span>
     </span>
-    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-4">
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-4" tabindex="0">
         <span class="fd-object-status__text">Indication4</span>
     </span>
-    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-5">
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-5" tabindex="0">
         <span class="fd-object-status__text">Indication5</span>
     </span>
-    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-6">
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-6" tabindex="0">
         <span class="fd-object-status__text">Indication6</span>
     </span>
-    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-7">
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-7" tabindex="0">
         <span class="fd-object-status__text">Indication7</span>
     </span>
-    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-8">
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-8" tabindex="0">
         <span class="fd-object-status__text">Indication8</span>
     </span>
 </div>


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/2009
Part of https://github.com/SAP/fundamental-ngx/issues/3414

## Description
Added focus for Object status as a link.

## Screenshots
### Before:
![Screenshot at 14-38-09](https://user-images.githubusercontent.com/8318592/103536139-a0860580-4e9a-11eb-84e9-e8288390fa97.png)

### After:
![Screenshot at 14-38-48](https://user-images.githubusercontent.com/8318592/103536150-a5e35000-4e9a-11eb-8c7d-8157b0a7d02e.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [X] All values are in `rem`
- [X] Text elements follow the truncation rules
- [X] hover state of the element follow design spec
- [X] focus state of the element follow design spec
- [X] active state of the element follow design spec
- [X] selected state of the element follow design spec
- [X] selected hover state of the element follow design spec
- [X] pressed state of the element follow design spec
- [X] Responsiveness rules - the component has modifier classes for all breakpoints
- [X] Includes Compact/Cosy/Tablet design
- [X] RTL support
2. The code follows fundamental-styles code standards and style
- [X] only one top level `fd-*` class is used in the file
- [X] BEM naming convention is used
- [X] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [X] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [X] `fd-reset()` mixin is applied to all elements
- [X] Variables are used, if some value is used more than twice.
- [X] Checked if current components can be reused, instead of having new code.
3. Testing
- [X] tested Storybook examples with "CSS Resources" `normalize` option 
- [X] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [X] Verified all styles in IE11
- [X] Updated tests
4. Documentation
- [X] Storybook documentation has been created/updated
- [X] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
