### PR TITLE
fix: Add theming properties to message strip

### DIFF
--- a/src/message-strip.scss
+++ b/src/message-strip.scss
@@ -8,7 +8,6 @@
 $block: #{$fd-namespace}-message-strip;
 
 .#{$block} {
-  $fd-message-strip-border: 1px solid;
   $fd-message-strip-border-radius: 0.25rem;
   $fd-message-strip-padding: 0.4375rem 1rem;
   $fd-message-strip-padding-default: 1rem;
@@ -58,7 +57,8 @@ $block: #{$fd-namespace}-message-strip;
   position: relative;
   color: $fd-message-strip-text-color;
   background-color: $fd-message-strip-background-color;
-  border: $fd-message-strip-border;
+  border-width: var(--fdMessageStripBorderWidth);
+  border-style: solid;
   border-color: $fd-message-strip-border-color;
   border-radius: $fd-message-strip-border-radius;
   padding: $fd-message-strip-padding;

--- a/src/theming/sap_fiori_3.scss
+++ b/src/theming/sap_fiori_3.scss
@@ -135,4 +135,7 @@
 
   /* Grid List */
   --fdGrid_List_Item_Hover_Border_Color: var(--sapTile_Interactive_BorderColor);
+
+  /* Message Strip */
+  --fdMessageStripBorderWidth: 0.0625rem;
 }

--- a/src/theming/sap_fiori_3_dark.scss
+++ b/src/theming/sap_fiori_3_dark.scss
@@ -135,4 +135,7 @@
 
   /* Grid List */
   --fdGrid_List_Item_Hover_Border_Color: var(--sapTile_Interactive_BorderColor);
+
+  /* Message Strip */
+  --fdMessageStripBorderWidth: 0.0625rem;
 }

--- a/src/theming/sap_fiori_3_hcb.scss
+++ b/src/theming/sap_fiori_3_hcb.scss
@@ -135,4 +135,7 @@
 
   /* Grid List */
   --fdGrid_List_Item_Hover_Border_Color: var(--sapTile_Interactive_BorderColor);
+
+  /* Message Strip */
+  --fdMessageStripBorderWidth: 0.125rem;
 }

--- a/src/theming/sap_fiori_3_hcw.scss
+++ b/src/theming/sap_fiori_3_hcw.scss
@@ -135,4 +135,7 @@
 
   /* Grid List */
   --fdGrid_List_Item_Hover_Border_Color: var(--sapTile_Interactive_BorderColor);
+
+  /* Message Strip */
+  --fdMessageStripBorderWidth: 0.125rem;
 }

--- a/src/theming/sap_fiori_3_light_dark.scss
+++ b/src/theming/sap_fiori_3_light_dark.scss
@@ -135,4 +135,7 @@
 
   /* Grid List */
   --fdGrid_List_Item_Hover_Border_Color: var(--sapTile_Interactive_BorderColor);
+
+  /* Message Strip */
+  --fdMessageStripBorderWidth: 0.0625rem;
 }


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-styles/issues/1357

## Description
Message Strip has different border-width, depending on theme

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
2. The code follows fundamental-styles code standards and style
- [x] Variables are used, if some value is used more than twice.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
