### PR TITLE
fix: Add theming to product switch

### DIFF
--- a/src/product-switch.scss
+++ b/src/product-switch.scss
@@ -83,6 +83,7 @@ $block: #{$fd-namespace}-product-switch;
     margin-bottom: 0.5rem;
     background-color: var(--sapList_Background);
     border-radius: var(--sapElement_BorderCornerRadius);
+    box-shadow: var(--fdProductSwitch_Shadow);
 
     .#{$block}__title:not(:last-child) {
       @include fd-ellipsis();
@@ -90,35 +91,56 @@ $block: #{$fd-namespace}-product-switch;
 
     @include fd-product-pseudo-element-background(var(--sapList_Background));
 
+    @include fd-hover() {
+      background-color: var(--sapList_Hover_Background);
+      border: var(--fdProductSwitch_Border);
+      cursor: pointer;
+
+      @include fd-product-pseudo-element-background(var(--sapList_Hover_Background));
+    }
+
+    @include fd-active() {
+      background-color: var(--sapList_Active_Background);
+      border: var(--fdProductSwitch_Border);
+
+      .#{$block}__title,
+      .#{$block}__subtitle {
+        color: var(--sapList_Active_TextColor);
+      }
+
+      .#{$block}__icon {
+        @include fd-icon-selector() {
+          color: var(--sapList_Active_TextColor);
+        }
+      }
+
+      @include fd-product-pseudo-element-background(var(--sapList_Active_Background));
+
+      @include fd-hover() {
+        @include fd-product-pseudo-element-background(var(--sapList_Active_Background));
+      }
+    }
+
     &.selected {
       background-color: var(--sapList_SelectionBackgroundColor);
-      box-shadow: 0 0 0 0.125rem var(--sapList_SelectionBorderColor);
+      border: 0.125rem solid var(--sapList_SelectionBorderColor);
 
       @include fd-product-pseudo-element-background(var(--sapList_SelectionBackgroundColor));
 
-      &:hover {
+      @include fd-hover() {
         background-color: var(--sapList_Hover_SelectionBackground);
 
         @include fd-product-pseudo-element-background(var(--sapList_Hover_SelectionBackground));
       }
 
-      &:active {
+      @include fd-active() {
         background-color: var(--sapList_Active_Background);
 
         @include fd-product-pseudo-element-background(var(--sapList_Active_Background));
       }
-
-      &:focus {
-        box-shadow: none;
-      }
     }
 
-    &:focus {
-      outline: none;
-      border: 0.0625rem dotted;
-      border-color: var(--sapContent_FocusColor);
-      border-radius: var(--sapElement_BorderCornerRadius);
-    }
+    @include fd-fiori-focus();
 
     &.dragged {
       @include dragged() {
@@ -146,38 +168,10 @@ $block: #{$fd-namespace}-product-switch;
           box-shadow: var(--sapContent_Shadow2);
         }
 
-        &:focus {
+        @include fd-hover() {
           outline: none;
         }
       }
-    }
-  }
-
-  &__item:hover {
-    background-color: var(--sapList_Hover_Background);
-    cursor: pointer;
-
-    @include fd-product-pseudo-element-background(var(--sapList_Hover_Background));
-  }
-
-  &__item:active {
-    background-color: var(--sapList_Active_Background);
-
-    .#{$block}__title,
-    .#{$block}__subtitle {
-      color: var(--sapList_Active_TextColor);
-    }
-
-    .#{$block}__icon {
-      @include fd-icon-selector() {
-        color: var(--sapList_Active_TextColor);
-      }
-    }
-
-    @include fd-product-pseudo-element-background(var(--sapList_Active_Background));
-
-    &:hover {
-      @include fd-product-pseudo-element-background(var(--sapList_Active_Background));
     }
   }
 
@@ -212,7 +206,7 @@ $block: #{$fd-namespace}-product-switch;
     white-space: normal;
     z-index: 1;
 
-    &:last-child {
+    @include fd-last-child() {
       @include line-clamp(2);
     }
 
@@ -283,11 +277,11 @@ $block: #{$fd-namespace}-product-switch;
 
       @include fd-product-pseudo-element-background(var(--sapTile_Background));
 
-      &:hover {
+      @include fd-hover() {
         @include fd-product-pseudo-element-background(var(--sapList_Hover_Background));
       }
 
-      &:active {
+      @include fd-active() {
         @include fd-product-pseudo-element-background(var(--sapList_SelectionBorderColor));
       }
 
@@ -297,25 +291,20 @@ $block: #{$fd-namespace}-product-switch;
 
         @include fd-product-pseudo-element-background(var(--sapList_SelectionBorderColor));
 
-        &:hover {
+        @include fd-hover() {
           @include fd-product-pseudo-element-background(var(--sapList_Hover_SelectionBackground));
         }
 
-        &:active {
+        @include fd-active() {
           @include fd-product-pseudo-element-background(var(--sapList_Active_Background));
 
-          &:hover {
+          @include fd-hover() {
             @include fd-product-pseudo-element-background(var(--sapList_Active_Background));
           }
         }
       }
 
-      &:focus {
-        outline: none;
-        border: 0.0625rem dotted;
-        border-color: var(--sapContent_FocusColor);
-        border-radius: 0;
-      }
+      @include fd-fiori-focus();
 
       .#{$block}__title {
         &::before,
@@ -395,7 +384,7 @@ $block: #{$fd-namespace}-product-switch;
           }
         }
 
-        &:active {
+        @include fd-active() {
           .#{$block}__subtitle {
             color: var(--sapList_Active_TextColor);
           }

--- a/src/theming/sap_fiori_3.scss
+++ b/src/theming/sap_fiori_3.scss
@@ -85,6 +85,8 @@
 
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: none;
+  --fdProductSwitch_Shadow: none;
+  --fdProductSwitch_Border: none;
 
   /* Menu */
   --fdMenu_Text_Shadow: none;

--- a/src/theming/sap_fiori_3_dark.scss
+++ b/src/theming/sap_fiori_3_dark.scss
@@ -85,6 +85,8 @@
 
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: none;
+  --fdProductSwitch_Shadow: none;
+  --fdProductSwitch_Border: none;
 
   /* Menu */
   --fdMenu_Text_Shadow: none;

--- a/src/theming/sap_fiori_3_hcb.scss
+++ b/src/theming/sap_fiori_3_hcb.scss
@@ -85,6 +85,8 @@
 
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: 0 0 0.125rem #000;
+  --fdProductSwitch_Shadow: var(--sapContent_Shadow0);
+  --fdProductSwitch_Border: 0.125rem solid var(--sapList_SelectionBorderColor);
 
   /* Menu */
   --fdMenu_Text_Shadow: 0 0 0.125rem #000;

--- a/src/theming/sap_fiori_3_hcw.scss
+++ b/src/theming/sap_fiori_3_hcw.scss
@@ -85,6 +85,8 @@
 
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: none;
+  --fdProductSwitch_Shadow: var(--sapContent_Shadow0);
+  --fdProductSwitch_Border: 0.125rem solid var(--sapList_SelectionBorderColor);
 
   /* Menu */
   --fdMenu_Text_Shadow: none;

--- a/src/theming/sap_fiori_3_light_dark.scss
+++ b/src/theming/sap_fiori_3_light_dark.scss
@@ -85,6 +85,8 @@
 
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: none;
+  --fdProductSwitch_Shadow: none;
+  --fdProductSwitch_Border: none;
 
   /* Menu */
   --fdMenu_Text_Shadow: none;


### PR DESCRIPTION
## Related Issue
Part of https://github.com/SAP/fundamental-styles/issues/1357

## Description

In this PR I changed all `&:hover/active` states to ``fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus` mixins

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/26483208/103642377-514fdb80-4f53-11eb-8f6e-5b891190c119.png)


### After:
![image](https://user-images.githubusercontent.com/26483208/103642233-26fe1e00-4f53-11eb-9677-dcc76d1bb7ee.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
2. The code follows fundamental-styles code standards and style
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
