### PR TITLE
fix: add delta theming for Generic Tiles

### DIFF
--- a/src/theming/sap_fiori_3.scss
+++ b/src/theming/sap_fiori_3.scss
@@ -188,4 +188,15 @@
 
   /* Feed Input */
   --fdFeed_Input_Placeholder_Font_Style: italic;
+
+  /* Generic Tile */
+  --fdSlide_Tile_Background_Color: var(--sapBlockLayer_Background);
+  --fdSlide_Tile_Background_Opacity: 0.85;
+  --fdSlide_Tile_Indicator_Dot_Size: 0.188rem;
+  --fdSlide_Tile_Indicator_Ative_Dot_Size: 0.313rem;
+  --fdSlide_Tile_Indicator_Dot_Spacing: 0.375rem;
+  --fdSlide_Tile_Indicator_Dot_Color: var(--sapTile_TextColor);
+  --fdSlide_Tile_Indicator_Active_Dot_Color: var(--sapTile_TitleTextColor);
+  --fdSlide_Tile_Indicator_Dot_Border: none;
+  --fdSlide_Tile_Indicator_Active_Dot_Border: none;
 }

--- a/src/theming/sap_fiori_3_dark.scss
+++ b/src/theming/sap_fiori_3_dark.scss
@@ -187,4 +187,15 @@
 
   /* Feed Input */
   --fdFeed_Input_Placeholder_Font_Style: italic;
+
+  /* Generic Tile */
+  --fdSlide_Tile_Background_Color: var(--sapBlockLayer_Background);
+  --fdSlide_Tile_Background_Opacity: 0.85;
+  --fdSlide_Tile_Indicator_Dot_Size: 0.188rem;
+  --fdSlide_Tile_Indicator_Ative_Dot_Size: 0.313rem;
+  --fdSlide_Tile_Indicator_Dot_Spacing: 0.375rem;
+  --fdSlide_Tile_Indicator_Dot_Color: var(--sapTile_TextColor);
+  --fdSlide_Tile_Indicator_Active_Dot_Color: var(--sapTile_TitleTextColor);
+  --fdSlide_Tile_Indicator_Dot_Border: none;
+  --fdSlide_Tile_Indicator_Active_Dot_Border: none;
 }

--- a/src/theming/sap_fiori_3_hcb.scss
+++ b/src/theming/sap_fiori_3_hcb.scss
@@ -187,4 +187,15 @@
 
   /* Feed Input */
   --fdFeed_Input_Placeholder_Font_Style: normal;
+
+  /* Generic Tile */
+  --fdSlide_Tile_Background_Color: var(--sapTile_Background);
+  --fdSlide_Tile_Background_Opacity: 1;
+  --fdSlide_Tile_Indicator_Dot_Size: 0.25rem;
+  --fdSlide_Tile_Indicator_Ative_Dot_Size: 0.25rem;
+  --fdSlide_Tile_Indicator_Dot_Spacing: 0.188rem;
+  --fdSlide_Tile_Indicator_Dot_Color: var(--sapTile_Background);
+  --fdSlide_Tile_Indicator_Active_Dot_Color: var(--sapContent_NonInteractiveIconColor);
+  --fdSlide_Tile_Indicator_Dot_Border: solid 0.0625rem var(--sapContent_NonInteractiveIconColor);
+  --fdSlide_Tile_Indicator_Active_Dot_Border: solid 0.0625rem var(--sapContent_NonInteractiveIconColor);
 }

--- a/src/theming/sap_fiori_3_hcw.scss
+++ b/src/theming/sap_fiori_3_hcw.scss
@@ -187,4 +187,15 @@
 
   /* Feed Input */
   --fdFeed_Input_Placeholder_Font_Style: normal;
+
+  /* Generic Tile */
+  --fdSlide_Tile_Background_Color: var(--sapTile_Background);
+  --fdSlide_Tile_Background_Opacity: 1;
+  --fdSlide_Tile_Indicator_Dot_Size: 0.25rem;
+  --fdSlide_Tile_Indicator_Ative_Dot_Size: 0.25rem;
+  --fdSlide_Tile_Indicator_Dot_Spacing: 0.188rem;
+  --fdSlide_Tile_Indicator_Dot_Color: var(--sapTile_Background);
+  --fdSlide_Tile_Indicator_Active_Dot_Color: var(--sapContent_NonInteractiveIconColor);
+  --fdSlide_Tile_Indicator_Dot_Border: solid 0.0625rem var(--sapContent_NonInteractiveIconColor);
+  --fdSlide_Tile_Indicator_Active_Dot_Border: solid 0.0625rem var(--sapContent_NonInteractiveIconColor);
 }

--- a/src/theming/sap_fiori_3_light_dark.scss
+++ b/src/theming/sap_fiori_3_light_dark.scss
@@ -187,4 +187,15 @@
 
   /* Feed Input */
   --fdFeed_Input_Placeholder_Font_Style: italic;
+
+  /* Generic Tile */
+  --fdSlide_Tile_Background_Color: var(--sapBlockLayer_Background);
+  --fdSlide_Tile_Background_Opacity: 0.85;
+  --fdSlide_Tile_Indicator_Dot_Size: 0.188rem;
+  --fdSlide_Tile_Indicator_Ative_Dot_Size: 0.313rem;
+  --fdSlide_Tile_Indicator_Dot_Spacing: 0.375rem;
+  --fdSlide_Tile_Indicator_Dot_Color: var(--sapTile_TextColor);
+  --fdSlide_Tile_Indicator_Active_Dot_Color: var(--sapTile_TitleTextColor);
+  --fdSlide_Tile_Indicator_Dot_Border: none;
+  --fdSlide_Tile_Indicator_Active_Dot_Border: none;
 }

--- a/src/tile.scss
+++ b/src/tile.scss
@@ -1,6 +1,6 @@
-@import "./new-settings";
-@import "./mixins";
-@import "./mixins/button/button-helper";
+@import './new-settings';
+@import './mixins';
+@import './mixins/button/button-helper';
 
 $block: #{$fd-namespace}-tile;
 
@@ -30,9 +30,9 @@ $fd-tile-refresh-icon-spacing: 0.5rem !default;
 $fd-tile-feed-kpi-spacing: 0.5rem !default;
 
 // INDICATOR DOTS
-$fd-tile-indicator-dot-size: 0.188rem !default;
-$fd-tile-indicator-dot-active-size: 0.313rem !default;
-$fd-tile-indicator-dot-spacing: 0.375rem !default;
+$fd-tile-indicator-dot-size: var(--fdSlide_Tile_Indicator_Dot_Size);
+$fd-tile-indicator-dot-active-size: var(--fdSlide_Tile_Indicator_Ative_Dot_Size);
+$fd-tile-indicator-dot-spacing: var(--fdSlide_Tile_Indicator_Dot_Spacing);
 
 // TOGGLE BUTTON
 $fd-tile-toggle-button-position: -0.0625rem !default;
@@ -475,12 +475,12 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
         font-size: 1rem;
         color: var(--sapButton_Emphasized_TextColor);
         text-shadow: var(--sapButton_Emphasized_TextShadow);
-        content: "\e14b";
+        content: '\e14b';
       }
 
       &--pause {
         &::before {
-          content: "\e14c";
+          content: '\e14c';
         }
       }
 
@@ -512,8 +512,8 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
       z-index: 2;
       width: 100%;
       max-width: 100%;
-      background-color: var(--sapBlockLayer_Background);
-      opacity: 0.8;
+      background-color: var(--fdSlide_Tile_Background_Color);
+      opacity: var(--fdSlide_Tile_Background_Opacity);
       padding-top: $fd-tile-inner-padding;
       padding-left: $fd-tile-padding;
       padding-right: $fd-tile-padding;
@@ -521,13 +521,18 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
       border-bottom-right-radius: $fd-tile-border-radius;
     }
 
-    .#{$block}__title,
-    .#{$block}__subtitle,
-    .#{$block}__footer-text {
-      color: var(--sapContent_ContrastTextColor); // TO BE CONFIRMED
-      text-shadow: var(--sapContent_ContrastShadowColor); // TO BE CONFIRMED
+    .#{$block}__title {
       font-size: var(--sapFontSize);
       line-height: normal;
+      color: var(--sapTile_TitleTextColor);
+      text-shadow: 0 0 0.125rem var(--sapContent_ShadowColor);
+    }
+
+    .#{$block}__footer-text,
+    .#{$block}__subtitle {
+      font-size: var(--sapFontSize);
+      line-height: normal;
+      color: var(--sapTile_TextColor);
     }
 
     .#{$block}__page-indicator {
@@ -545,8 +550,9 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
       @include set-width($fd-tile-indicator-dot-size);
 
       border-radius: 50%;
-      background-color: var(--sapContent_ContrastTextColor); // TO BE CONFIRMED
-      box-shadow: 0 0 0.25rem var(--sapContent_ShadowColor);
+      background-color: var(--fdSlide_Tile_Indicator_Dot_Color);
+      border: var(--fdSlide_Tile_Indicator_Dot_Border);
+      box-shadow: 0 0 0.063rem var(--sapContent_ShadowColor);
       margin-right: $fd-tile-indicator-dot-spacing;
 
       @include fd-rtl() {
@@ -558,7 +564,8 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
         @include set-height($fd-tile-indicator-dot-active-size);
         @include set-width($fd-tile-indicator-dot-active-size);
 
-        color: var(--sapContent_ContrastTextColor); // TO BE CONFIRMED
+        background-color: var(--fdSlide_Tile_Indicator_Active_Dot_Color);
+        border: var(--fdSlide_Tile_Indicator_Active_Dot_Border);
       }
 
       &:last-child {
@@ -590,7 +597,6 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
 
   // MODES
   &--action {
-
     .#{$block}__action-close,
     .#{$block}__action-indicator,
     .#{$block}__overlay {
@@ -748,12 +754,44 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
 
       .#{$block}--action {
         .#{$block}__header {
-          mask-image: linear-gradient(linear, right top, left top, from(transparent), color-stop(7%, #000000), to(#000000));
-          -webkit-mask-image: -webkit-gradient(linear, right top, left top, from(transparent), color-stop(7%, #000000), to(#000000));
+          mask-image:
+            linear-gradient(
+              linear,
+              right top,
+              left top,
+              from(transparent),
+              color-stop(7%, #000000),
+              to(#000000)
+            );
+          -webkit-mask-image:
+            -webkit-gradient(
+              linear,
+              right top,
+              left top,
+              from(transparent),
+              color-stop(7%, #000000),
+              to(#000000)
+            );
 
           @include fd-rtl() {
-            mask-image: linear-gradient(linear, left top, right top, from(transparent), color-stop(7%, #000000), to(#000000));
-            -webkit-mask-image: -webkit-gradient(linear, left top, right top, from(transparent), color-stop(7%, #000000), to(#000000));
+            mask-image:
+              linear-gradient(
+                linear,
+                left top,
+                right top,
+                from(transparent),
+                color-stop(7%, #000000),
+                to(#000000)
+              );
+            -webkit-mask-image:
+              -webkit-gradient(
+                linear,
+                left top,
+                right top,
+                from(transparent),
+                color-stop(7%, #000000),
+                to(#000000)
+              );
           }
         }
       }


### PR DESCRIPTION
## Related Issue
Part of SAP/fundamental-styles#1357

## Description
The current PR adds the delta theming for Generic Tiles. Changed values: in Slide Tile - the container background and the opacity, the dot sizes and colors, as well as the spacing between them.

This PR can be merged after the designers confirm the colors as it looks like something is off:
Element A - Transparent background layer on tile image. Has `background-color: --sapBlockLayer_Background` which results in #000000 in Quartz Light. It has opacity 0.85

Element B - title and subtitle area. The title (text) has color `--sapTile_TitleTextColor` which results in #32363A. The subtitle has  `--sapTile_TextColor` which results in #6A6D70. The final result in Quartz Light is a dark grey text on black background with 0.85 opacity. 

Text-shadow for HCW looks weird

## Screenshots
Quartz Light:
<img width="2326" alt="Screen Shot 2021-01-05 at 3 46 04 PM" src="https://user-images.githubusercontent.com/39598672/103696997-49049a00-4f6d-11eb-9efc-22a2decd597c.png">

Quartz Dark:
<img width="2324" alt="Screen Shot 2021-01-05 at 3 45 53 PM" src="https://user-images.githubusercontent.com/39598672/103697028-528e0200-4f6d-11eb-81ef-937ef0fbe59e.png">

HCW:
<img width="2345" alt="Screen Shot 2021-01-05 at 3 46 20 PM" src="https://user-images.githubusercontent.com/39598672/103697049-5b7ed380-4f6d-11eb-8f8a-96842e2d356b.png">

HCB:
<img width="2347" alt="Screen Shot 2021-01-05 at 3 46 45 PM" src="https://user-images.githubusercontent.com/39598672/103697067-63d70e80-4f6d-11eb-8995-43b10ff01fda.png">


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
NA
2. The code follows fundamental-styles code standards and style
NA
3. Testing
NA
4. Documentation
NA
