### PR TITLE
fix: add delta theming for Switch

### DIFF
--- a/src/switch.scss
+++ b/src/switch.scss
@@ -27,6 +27,7 @@ $block: #{$fd-namespace}-switch;
   $fd-switch-semantic-success-background-color: var(--fdSwitch_Semantic_Success_Background_Color);
   $fd-switch-semantic-error-border-color: var(--fdSwitch_Semantic_Error_Border_Color);
   $fd-switch-semantic-error-background-color: var(--fdSwitch_Semantic_Error_Background_Color);
+  $fd-switch-semantic-success-handle-hover-background-color: var(--fdSwitch_Semantic_Success_Handle_Hover_Background_Color);
 
   $fd-switch-label-width: 1.75rem;
 
@@ -322,7 +323,7 @@ $block: #{$fd-namespace}-switch;
         background-color: $fd-switch-semantic-success-background-color;
         border-color: $fd-switch-semantic-success-border-color;
         .#{$block}__handle {
-          background-color: $fd-switch-semantic-success-background-color;
+          background-color: $fd-switch-semantic-success-handle-hover-background-color;
           border-color: $fd-switch-semantic-success-border-color;
         }
       }

--- a/src/switch.scss
+++ b/src/switch.scss
@@ -28,6 +28,7 @@ $block: #{$fd-namespace}-switch;
   $fd-switch-semantic-error-border-color: var(--fdSwitch_Semantic_Error_Border_Color);
   $fd-switch-semantic-error-background-color: var(--fdSwitch_Semantic_Error_Background_Color);
   $fd-switch-semantic-success-handle-hover-background-color: var(--fdSwitch_Semantic_Success_Handle_Hover_Background_Color);
+  $fd-switch-semantic-error-icon-color: var(--fdSwitch_Semantic_Error_Icon_Color);
 
   $fd-switch-label-width: 1.75rem;
 
@@ -310,8 +311,13 @@ $block: #{$fd-namespace}-switch;
     }
 
     @include fd-hover() {
+
+      .#{$block}__icon {
+        color: $fd-switch-semantic-error-border-color;
+      }
+
       .#{$block}__slider {
-        border-color: $fd-switch-semantic-error-border-color;
+        border-color: $fd-switch-semantic-error-icon-color;
       }
 
       .#{$block}__handle {
@@ -325,6 +331,9 @@ $block: #{$fd-namespace}-switch;
         .#{$block}__handle {
           background-color: $fd-switch-semantic-success-handle-hover-background-color;
           border-color: $fd-switch-semantic-success-border-color;
+        }
+        .#{$block}__icon {
+          color: $fd-switch-semantic-success-border-color;
         }
       }
     }

--- a/src/switch.scss
+++ b/src/switch.scss
@@ -23,8 +23,10 @@ $block: #{$fd-namespace}-switch;
   $fd-switch-border-width: var(--sapButton_BorderWidth);
   $fd-switch-handle-border-width: var(--fdSwitch_Handle_Border_Width);
   $fd-switch-slider-on-hover-background: var(--fdSwitch_On_Hover_Slider_Background);
-  $fd-switch-semantic-success-border-color: var(--fdSwitch_Semantic_Success_Border-Color);
-  $fd-switch-semantic-success-background-color: var(--fdSwitch_Semantic_Success_Background-Color);
+  $fd-switch-semantic-success-border-color: var(--fdSwitch_Semantic_Success_Border_Color);
+  $fd-switch-semantic-success-background-color: var(--fdSwitch_Semantic_Success_Background_Color);
+  $fd-switch-semantic-error-border-color: var(--fdSwitch_Semantic_Error_Border_Color);
+  $fd-switch-semantic-error-background-color: var(--fdSwitch_Semantic_Error_Background_Color);
 
   $fd-switch-label-width: 1.75rem;
 
@@ -308,19 +310,19 @@ $block: #{$fd-namespace}-switch;
 
     @include fd-hover() {
       .#{$block}__slider {
-        border-color: $fd-switch-error-border-color;
+        border-color: $fd-switch-semantic-error-border-color;
       }
 
       .#{$block}__handle {
-        background-color: var(--sapErrorBackground);
-        border-color: $fd-switch-error-border-color;
+        background-color: $fd-switch-semantic-error-background-color;
+        border-color: $fd-switch-semantic-error-border-color;
       }
 
       .#{$block}__input:checked + .#{$block}__slider {
         background-color: $fd-switch-semantic-success-background-color;
         border-color: $fd-switch-semantic-success-border-color;
         .#{$block}__handle {
-          background-color: var(--sapSuccessBackground);
+          background-color: $fd-switch-semantic-success-background-color;
           border-color: $fd-switch-semantic-success-border-color;
         }
       }

--- a/src/switch.scss
+++ b/src/switch.scss
@@ -21,13 +21,6 @@ $block: #{$fd-namespace}-switch;
   $fd-switch-success-border-color: var(--sapSuccessBorderColor);
   $fd-switch-error-border-color: var(--sapErrorBorderColor);
   $fd-switch-border-width: var(--sapButton_BorderWidth);
-  $fd-switch-handle-border-width: var(--fdSwitch_Handle_Border_Width);
-  $fd-switch-slider-on-hover-background: var(--fdSwitch_On_Hover_Slider_Background);
-  $fd-switch-semantic-success-border-color: var(--fdSwitch_Semantic_Success_Border_Color);
-  $fd-switch-semantic-success-background-color: var(--fdSwitch_Semantic_Success_Background_Color);
-  $fd-switch-semantic-error-background-color: var(--fdSwitch_Semantic_Error_Background_Color);
-  $fd-switch-semantic-success-handle-hover-background-color: var(--fdSwitch_Semantic_Success_Handle_Hover_Background_Color);
-  $fd-switch-semantic-error-color: var(--fdSwitch_Semantic_Error_Color);
 
   $fd-switch-label-width: 1.75rem;
 
@@ -124,7 +117,7 @@ $block: #{$fd-namespace}-switch;
     @include fd-reset();
 
     box-sizing: content-box;
-    border: $fd-switch-handle-border-width solid $fd-switch-inactive-border-color;
+    border: var(--fdSwitch_Handle_Border_Width) solid $fd-switch-inactive-border-color;
     background-color: $fd-switch-inactive-handle-background;
     min-width: $fd-switch-handle-size;
     min-height: $fd-switch-handle-size;
@@ -235,7 +228,7 @@ $block: #{$fd-namespace}-switch;
     }
 
     .#{$block}__input:checked + .#{$block}__slider {
-      background-color: $fd-switch-slider-on-hover-background;
+      background-color: var(--fdSwitch_On_Hover_Slider_Background);
 
       .#{$block}__handle {
         border-color: $fd-switch-hover-selected-border-color;
@@ -287,7 +280,7 @@ $block: #{$fd-namespace}-switch;
     }
 
     .#{$block}__input:checked + .#{$block}__slider {
-      background-color: $fd-switch-semantic-success-background-color;
+      background-color: var(--fdSwitch_Semantic_Success_Background_Color);
       border-color: $fd-switch-success-border-color;
 
       .#{$block}__track {
@@ -312,27 +305,27 @@ $block: #{$fd-namespace}-switch;
     @include fd-hover() {
 
       .#{$block}__icon {
-        color: $fd-switch-semantic-error-color;
+        color: var(--fdSwitch_Semantic_Error_Color);
       }
 
       .#{$block}__slider {
-        border-color: $fd-switch-semantic-error-color;
+        border-color: var(--fdSwitch_Semantic_Error_Color);
       }
 
       .#{$block}__handle {
-        background-color: $fd-switch-semantic-error-background-color;
-        border-color: $fd-switch-semantic-error-color;
+        background-color: var(--fdSwitch_Semantic_Error_Background_Color);
+        border-color: var(--fdSwitch_Semantic_Error_Color);
       }
 
       .#{$block}__input:checked + .#{$block}__slider {
-        background-color: $fd-switch-semantic-success-background-color;
-        border-color: $fd-switch-semantic-success-border-color;
+        background-color: var(--fdSwitch_Semantic_Success_Background_Color);
+        border-color: var(--fdSwitch_Semantic_Success_Border_Color);
         .#{$block}__handle {
-          background-color: $fd-switch-semantic-success-handle-hover-background-color;
-          border-color: $fd-switch-semantic-success-border-color;
+          background-color: var(--fdSwitch_Semantic_Success_Handle_Hover_Background_Color);
+          border-color: var(--fdSwitch_Semantic_Success_Border_Color);
         }
         .#{$block}__icon {
-          color: $fd-switch-semantic-success-border-color;
+          color: var(--fdSwitch_Semantic_Success_Border_Color);
         }
       }
     }

--- a/src/switch.scss
+++ b/src/switch.scss
@@ -21,6 +21,10 @@ $block: #{$fd-namespace}-switch;
   $fd-switch-success-border-color: var(--sapSuccessBorderColor);
   $fd-switch-error-border-color: var(--sapErrorBorderColor);
   $fd-switch-border-width: var(--sapButton_BorderWidth);
+  $fd-switch-handle-border-width: var(--fdSwitch_Handle_Border_Width);
+  $fd-switch-slider-on-hover-background: var(--fdSwitch_On_Hover_Slider_Background);
+  $fd-switch-semantic-success-border-color: var(--fdSwitch_Semantic_Success_Border-Color);
+  $fd-switch-semantic-success-background-color: var(--fdSwitch_Semantic_Success_Background-Color);
 
   $fd-switch-label-width: 1.75rem;
 
@@ -117,7 +121,7 @@ $block: #{$fd-namespace}-switch;
     @include fd-reset();
 
     box-sizing: content-box;
-    border: $fd-switch-border-width solid $fd-switch-inactive-border-color;
+    border: $fd-switch-handle-border-width solid $fd-switch-inactive-border-color;
     background-color: $fd-switch-inactive-handle-background;
     min-width: $fd-switch-handle-size;
     min-height: $fd-switch-handle-size;
@@ -227,8 +231,8 @@ $block: #{$fd-namespace}-switch;
       background-color: var(--sapButton_Hover_Background);
     }
 
-    .#{$block}:checked + .#{$block}__slider {
-      border-color: $fd-switch-hover-selected-border-color;
+    .#{$block}__input:checked + .#{$block}__slider {
+      background-color: $fd-switch-slider-on-hover-background;
 
       .#{$block}__handle {
         border-color: $fd-switch-hover-selected-border-color;
@@ -280,7 +284,7 @@ $block: #{$fd-namespace}-switch;
     }
 
     .#{$block}__input:checked + .#{$block}__slider {
-      background-color: var(--sapSuccessBackground);
+      background-color: $fd-switch-semantic-success-background-color;
       border-color: $fd-switch-success-border-color;
 
       .#{$block}__track {
@@ -313,8 +317,11 @@ $block: #{$fd-namespace}-switch;
       }
 
       .#{$block}__input:checked + .#{$block}__slider {
+        background-color: $fd-switch-semantic-success-background-color;
+        border-color: $fd-switch-semantic-success-border-color;
         .#{$block}__handle {
           background-color: var(--sapSuccessBackground);
+          border-color: $fd-switch-semantic-success-border-color;
         }
       }
     }

--- a/src/switch.scss
+++ b/src/switch.scss
@@ -25,10 +25,9 @@ $block: #{$fd-namespace}-switch;
   $fd-switch-slider-on-hover-background: var(--fdSwitch_On_Hover_Slider_Background);
   $fd-switch-semantic-success-border-color: var(--fdSwitch_Semantic_Success_Border_Color);
   $fd-switch-semantic-success-background-color: var(--fdSwitch_Semantic_Success_Background_Color);
-  $fd-switch-semantic-error-border-color: var(--fdSwitch_Semantic_Error_Border_Color);
   $fd-switch-semantic-error-background-color: var(--fdSwitch_Semantic_Error_Background_Color);
   $fd-switch-semantic-success-handle-hover-background-color: var(--fdSwitch_Semantic_Success_Handle_Hover_Background_Color);
-  $fd-switch-semantic-error-icon-color: var(--fdSwitch_Semantic_Error_Icon_Color);
+  $fd-switch-semantic-error-color: var(--fdSwitch_Semantic_Error_Color);
 
   $fd-switch-label-width: 1.75rem;
 
@@ -313,16 +312,16 @@ $block: #{$fd-namespace}-switch;
     @include fd-hover() {
 
       .#{$block}__icon {
-        color: $fd-switch-semantic-error-border-color;
+        color: $fd-switch-semantic-error-color;
       }
 
       .#{$block}__slider {
-        border-color: $fd-switch-semantic-error-icon-color;
+        border-color: $fd-switch-semantic-error-color;
       }
 
       .#{$block}__handle {
         background-color: $fd-switch-semantic-error-background-color;
-        border-color: $fd-switch-semantic-error-border-color;
+        border-color: $fd-switch-semantic-error-color;
       }
 
       .#{$block}__input:checked + .#{$block}__slider {

--- a/src/theming/sap_fiori_3.scss
+++ b/src/theming/sap_fiori_3.scss
@@ -152,8 +152,7 @@
   --fdSwitch_On_Hover_Slider_Background: var(--sapButton_Track_Selected_Background);
   --fdSwitch_Semantic_Success_Border_Color: var(--sapSuccessColor);
   --fdSwitch_Semantic_Success_Background_Color: var(--sapSuccessBackground);
-  --fdSwitch_Semantic_Error_Border_Color: var(--sapErrorBorderColor);
   --fdSwitch_Semantic_Error_Background_Color: var(--sapErrorBackground);
   --fdSwitch_Semantic_Success_Handle_Hover_Background_Color: var(--sapSuccessBackground);
-  --fdSwitch_Semantic_Error_Icon_Color: var(--sapErrorBorderColor);
+  --fdSwitch_Semantic_Error_Color: var(--sapErrorBorderColor);
 }

--- a/src/theming/sap_fiori_3.scss
+++ b/src/theming/sap_fiori_3.scss
@@ -155,4 +155,5 @@
   --fdSwitch_Semantic_Error_Border_Color: var(--sapErrorBorderColor);
   --fdSwitch_Semantic_Error_Background_Color: var(--sapErrorBackground);
   --fdSwitch_Semantic_Success_Handle_Hover_Background_Color: var(--sapSuccessBackground);
+  --fdSwitch_Semantic_Error_Icon_Color: var(--sapErrorBorderColor);
 }

--- a/src/theming/sap_fiori_3.scss
+++ b/src/theming/sap_fiori_3.scss
@@ -146,4 +146,10 @@
 
   /* Message Strip */
   --fdMessageStripBorderWidth: 0.0625rem;
+
+  /* Switch */
+  --fdSwitch_Handle_Border_Width: var(--sapButton_BorderWidth);
+  --fdSwitch_On_Hover_Slider_Background: var(--sapButton_Track_Selected_Background);
+  --fdSwitch_Semantic_Success_Border-Color: var(--sapSuccessColor);
+  --fdSwitch_Semantic_Success_Background-Color: var(--sapSuccessBackground);
 }

--- a/src/theming/sap_fiori_3.scss
+++ b/src/theming/sap_fiori_3.scss
@@ -150,6 +150,8 @@
   /* Switch */
   --fdSwitch_Handle_Border_Width: var(--sapButton_BorderWidth);
   --fdSwitch_On_Hover_Slider_Background: var(--sapButton_Track_Selected_Background);
-  --fdSwitch_Semantic_Success_Border-Color: var(--sapSuccessColor);
-  --fdSwitch_Semantic_Success_Background-Color: var(--sapSuccessBackground);
+  --fdSwitch_Semantic_Success_Border_Color: var(--sapSuccessColor);
+  --fdSwitch_Semantic_Success_Background_Color: var(--sapSuccessBackground);
+  --fdSwitch_Semantic_Error_Border_Color: var(--sapErrorBorderColor);
+  --fdSwitch_Semantic_Error_Background_Color: var(--sapErrorBackground);
 }

--- a/src/theming/sap_fiori_3.scss
+++ b/src/theming/sap_fiori_3.scss
@@ -154,4 +154,5 @@
   --fdSwitch_Semantic_Success_Background_Color: var(--sapSuccessBackground);
   --fdSwitch_Semantic_Error_Border_Color: var(--sapErrorBorderColor);
   --fdSwitch_Semantic_Error_Background_Color: var(--sapErrorBackground);
+  --fdSwitch_Semantic_Success_Handle_Hover_Background_Color: var(--sapSuccessBackground);
 }

--- a/src/theming/sap_fiori_3_dark.scss
+++ b/src/theming/sap_fiori_3_dark.scss
@@ -153,4 +153,5 @@
   --fdSwitch_Semantic_Success_Background_Color: var(--sapSuccessBackground);
   --fdSwitch_Semantic_Error_Border_Color: var(--sapErrorBorderColor);
   --fdSwitch_Semantic_Error_Background_Color: var(--sapErrorBackground);
+  --fdSwitch_Semantic_Success_Handle_Hover_Background_Color: var(--sapSuccessBackground);
 }

--- a/src/theming/sap_fiori_3_dark.scss
+++ b/src/theming/sap_fiori_3_dark.scss
@@ -151,8 +151,7 @@
   --fdSwitch_On_Hover_Slider_Background: var(--sapButton_Track_Selected_Background);
   --fdSwitch_Semantic_Success_Border_Color: var(--sapSuccessColor);
   --fdSwitch_Semantic_Success_Background_Color: var(--sapSuccessBackground);
-  --fdSwitch_Semantic_Error_Border_Color: var(--sapErrorBorderColor);
   --fdSwitch_Semantic_Error_Background_Color: var(--sapErrorBackground);
   --fdSwitch_Semantic_Success_Handle_Hover_Background_Color: var(--sapSuccessBackground);
-  --fdSwitch_Semantic_Error_Icon_Color: var(--sapErrorBorderColor);
+  --fdSwitch_Semantic_Error_Color: var(--sapErrorBorderColor);
 }

--- a/src/theming/sap_fiori_3_dark.scss
+++ b/src/theming/sap_fiori_3_dark.scss
@@ -145,4 +145,10 @@
 
   /* Message Strip */
   --fdMessageStripBorderWidth: 0.0625rem;
+
+  /* Switch */
+  --fdSwitch_Handle_Border_Width: var(--sapButton_BorderWidth);
+  --fdSwitch_On_Hover_Slider_Background: var(--sapButton_Track_Selected_Background);
+  --fdSwitch_Semantic_Success_Border-Color: var(--sapSuccessColor);
+  --fdSwitch_Semantic_Success_Background-Color: var(--sapSuccessBackground);
 }

--- a/src/theming/sap_fiori_3_dark.scss
+++ b/src/theming/sap_fiori_3_dark.scss
@@ -149,6 +149,8 @@
   /* Switch */
   --fdSwitch_Handle_Border_Width: var(--sapButton_BorderWidth);
   --fdSwitch_On_Hover_Slider_Background: var(--sapButton_Track_Selected_Background);
-  --fdSwitch_Semantic_Success_Border-Color: var(--sapSuccessColor);
-  --fdSwitch_Semantic_Success_Background-Color: var(--sapSuccessBackground);
+  --fdSwitch_Semantic_Success_Border_Color: var(--sapSuccessColor);
+  --fdSwitch_Semantic_Success_Background_Color: var(--sapSuccessBackground);
+  --fdSwitch_Semantic_Error_Border_Color: var(--sapErrorBorderColor);
+  --fdSwitch_Semantic_Error_Background_Color: var(--sapErrorBackground);
 }

--- a/src/theming/sap_fiori_3_dark.scss
+++ b/src/theming/sap_fiori_3_dark.scss
@@ -154,4 +154,5 @@
   --fdSwitch_Semantic_Error_Border_Color: var(--sapErrorBorderColor);
   --fdSwitch_Semantic_Error_Background_Color: var(--sapErrorBackground);
   --fdSwitch_Semantic_Success_Handle_Hover_Background_Color: var(--sapSuccessBackground);
+  --fdSwitch_Semantic_Error_Icon_Color: var(--sapErrorBorderColor);
 }

--- a/src/theming/sap_fiori_3_hcb.scss
+++ b/src/theming/sap_fiori_3_hcb.scss
@@ -153,4 +153,5 @@
   --fdSwitch_Semantic_Success_Background_Color: var(--sapButton_Background);
   --fdSwitch_Semantic_Error_Border_Color: var(--sapButton_Hover_BorderColor);
   --fdSwitch_Semantic_Error_Background_Color: var(--sapButton_Selected_Hover_Background);
+  --fdSwitch_Semantic_Success_Handle_Hover_Background_Color: var(--sapButton_Selected_Hover_Background);
 }

--- a/src/theming/sap_fiori_3_hcb.scss
+++ b/src/theming/sap_fiori_3_hcb.scss
@@ -145,4 +145,10 @@
 
   /* Message Strip */
   --fdMessageStripBorderWidth: 0.125rem;
+
+  /* Switch */
+  --fdSwitch_Handle_Border_Width: 0.125rem;
+  --fdSwitch_On_Hover_Slider_Background: var(--sapButton_Background);
+  --fdSwitch_Semantic_Success_Border-Color: var(--sapButton_Hover_BorderColor);
+  --fdSwitch_Semantic_Success_Background-Color: var(--sapButton_Background);
 }

--- a/src/theming/sap_fiori_3_hcb.scss
+++ b/src/theming/sap_fiori_3_hcb.scss
@@ -149,6 +149,8 @@
   /* Switch */
   --fdSwitch_Handle_Border_Width: 0.125rem;
   --fdSwitch_On_Hover_Slider_Background: var(--sapButton_Background);
-  --fdSwitch_Semantic_Success_Border-Color: var(--sapButton_Hover_BorderColor);
-  --fdSwitch_Semantic_Success_Background-Color: var(--sapButton_Background);
+  --fdSwitch_Semantic_Success_Border_Color: var(--sapButton_Hover_BorderColor);
+  --fdSwitch_Semantic_Success_Background_Color: var(--sapButton_Background);
+  --fdSwitch_Semantic_Error_Border_Color: var(--sapButton_Hover_BorderColor);
+  --fdSwitch_Semantic_Error_Background_Color: var(--sapButton_Selected_Hover_Background);
 }

--- a/src/theming/sap_fiori_3_hcb.scss
+++ b/src/theming/sap_fiori_3_hcb.scss
@@ -151,8 +151,7 @@
   --fdSwitch_On_Hover_Slider_Background: var(--sapButton_Background);
   --fdSwitch_Semantic_Success_Border_Color: var(--sapButton_Hover_BorderColor);
   --fdSwitch_Semantic_Success_Background_Color: var(--sapButton_Background);
-  --fdSwitch_Semantic_Error_Border_Color: var(--sapButton_Hover_BorderColor);
   --fdSwitch_Semantic_Error_Background_Color: var(--sapButton_Selected_Hover_Background);
   --fdSwitch_Semantic_Success_Handle_Hover_Background_Color: var(--sapButton_Selected_Hover_Background);
-  --fdSwitch_Semantic_Error_Icon_Color: var(--sapButton_Hover_BorderColor);
+  --fdSwitch_Semantic_Error_Color: var(--sapButton_Hover_BorderColor);
 }

--- a/src/theming/sap_fiori_3_hcb.scss
+++ b/src/theming/sap_fiori_3_hcb.scss
@@ -154,4 +154,5 @@
   --fdSwitch_Semantic_Error_Border_Color: var(--sapButton_Hover_BorderColor);
   --fdSwitch_Semantic_Error_Background_Color: var(--sapButton_Selected_Hover_Background);
   --fdSwitch_Semantic_Success_Handle_Hover_Background_Color: var(--sapButton_Selected_Hover_Background);
+  --fdSwitch_Semantic_Error_Icon_Color: var(--sapButton_Hover_BorderColor);
 }

--- a/src/theming/sap_fiori_3_hcw.scss
+++ b/src/theming/sap_fiori_3_hcw.scss
@@ -153,4 +153,5 @@
   --fdSwitch_Semantic_Success_Background_Color: var(--sapButton_Background);
   --fdSwitch_Semantic_Error_Border_Color: var(--sapButton_Hover_BorderColor);
   --fdSwitch_Semantic_Error_Background_Color: var(--sapButton_Selected_Hover_Background);
+  --fdSwitch_Semantic_Success_Handle_Hover_Background_Color: var(--sapButton_Selected_Hover_Background);
 }

--- a/src/theming/sap_fiori_3_hcw.scss
+++ b/src/theming/sap_fiori_3_hcw.scss
@@ -145,4 +145,10 @@
 
   /* Message Strip */
   --fdMessageStripBorderWidth: 0.125rem;
+
+  /* Switch */
+  --fdSwitch_Handle_Border_Width: 0.125rem;
+  --fdSwitch_On_Hover_Slider_Background: var(--sapButton_Background);
+  --fdSwitch_Semantic_Success_Border-Color: var(--sapButton_Hover_BorderColor);
+  --fdSwitch_Semantic_Success_Background-Color: var(--sapButton_Background);
 }

--- a/src/theming/sap_fiori_3_hcw.scss
+++ b/src/theming/sap_fiori_3_hcw.scss
@@ -149,6 +149,8 @@
   /* Switch */
   --fdSwitch_Handle_Border_Width: 0.125rem;
   --fdSwitch_On_Hover_Slider_Background: var(--sapButton_Background);
-  --fdSwitch_Semantic_Success_Border-Color: var(--sapButton_Hover_BorderColor);
-  --fdSwitch_Semantic_Success_Background-Color: var(--sapButton_Background);
+  --fdSwitch_Semantic_Success_Border_Color: var(--sapButton_Hover_BorderColor);
+  --fdSwitch_Semantic_Success_Background_Color: var(--sapButton_Background);
+  --fdSwitch_Semantic_Error_Border_Color: var(--sapButton_Hover_BorderColor);
+  --fdSwitch_Semantic_Error_Background_Color: var(--sapButton_Selected_Hover_Background);
 }

--- a/src/theming/sap_fiori_3_hcw.scss
+++ b/src/theming/sap_fiori_3_hcw.scss
@@ -151,8 +151,7 @@
   --fdSwitch_On_Hover_Slider_Background: var(--sapButton_Background);
   --fdSwitch_Semantic_Success_Border_Color: var(--sapButton_Hover_BorderColor);
   --fdSwitch_Semantic_Success_Background_Color: var(--sapButton_Background);
-  --fdSwitch_Semantic_Error_Border_Color: var(--sapButton_Hover_BorderColor);
   --fdSwitch_Semantic_Error_Background_Color: var(--sapButton_Selected_Hover_Background);
   --fdSwitch_Semantic_Success_Handle_Hover_Background_Color: var(--sapButton_Selected_Hover_Background);
-  --fdSwitch_Semantic_Error_Icon_Color: var(--sapButton_Hover_BorderColor);
+  --fdSwitch_Semantic_Error_Color: var(--sapButton_Hover_BorderColor);
 }

--- a/src/theming/sap_fiori_3_hcw.scss
+++ b/src/theming/sap_fiori_3_hcw.scss
@@ -154,4 +154,5 @@
   --fdSwitch_Semantic_Error_Border_Color: var(--sapButton_Hover_BorderColor);
   --fdSwitch_Semantic_Error_Background_Color: var(--sapButton_Selected_Hover_Background);
   --fdSwitch_Semantic_Success_Handle_Hover_Background_Color: var(--sapButton_Selected_Hover_Background);
+  --fdSwitch_Semantic_Error_Icon_Color: var(--sapButton_Hover_BorderColor);
 }

--- a/src/theming/sap_fiori_3_light_dark.scss
+++ b/src/theming/sap_fiori_3_light_dark.scss
@@ -153,4 +153,5 @@
   --fdSwitch_Semantic_Success_Background_Color: var(--sapSuccessBackground);
   --fdSwitch_Semantic_Error_Border_Color: var(--sapErrorBorderColor);
   --fdSwitch_Semantic_Error_Background_Color: var(--sapErrorBackground);
+  --fdSwitch_Semantic_Success_Handle_Hover_Background_Color: var(--sapSuccessBackground);
 }

--- a/src/theming/sap_fiori_3_light_dark.scss
+++ b/src/theming/sap_fiori_3_light_dark.scss
@@ -151,8 +151,7 @@
   --fdSwitch_On_Hover_Slider_Background: var(--sapButton_Track_Selected_Background);
   --fdSwitch_Semantic_Success_Border_Color: var(--sapSuccessColor);
   --fdSwitch_Semantic_Success_Background_Color: var(--sapSuccessBackground);
-  --fdSwitch_Semantic_Error_Border_Color: var(--sapErrorBorderColor);
   --fdSwitch_Semantic_Error_Background_Color: var(--sapErrorBackground);
   --fdSwitch_Semantic_Success_Handle_Hover_Background_Color: var(--sapSuccessBackground);
-  --fdSwitch_Semantic_Error_Icon_Color: var(--sapErrorBorderColor);
+  --fdSwitch_Semantic_Error_Color: var(--sapErrorBorderColor);
 }

--- a/src/theming/sap_fiori_3_light_dark.scss
+++ b/src/theming/sap_fiori_3_light_dark.scss
@@ -145,4 +145,10 @@
 
   /* Message Strip */
   --fdMessageStripBorderWidth: 0.0625rem;
+
+  /* Switch */
+  --fdSwitch_Handle_Border_Width: var(--sapButton_BorderWidth);
+  --fdSwitch_On_Hover_Slider_Background: var(--sapButton_Track_Selected_Background);
+  --fdSwitch_Semantic_Success_Border-Color: var(--sapSuccessColor);
+  --fdSwitch_Semantic_Success_Background-Color: var(--sapSuccessBackground);
 }

--- a/src/theming/sap_fiori_3_light_dark.scss
+++ b/src/theming/sap_fiori_3_light_dark.scss
@@ -149,6 +149,8 @@
   /* Switch */
   --fdSwitch_Handle_Border_Width: var(--sapButton_BorderWidth);
   --fdSwitch_On_Hover_Slider_Background: var(--sapButton_Track_Selected_Background);
-  --fdSwitch_Semantic_Success_Border-Color: var(--sapSuccessColor);
-  --fdSwitch_Semantic_Success_Background-Color: var(--sapSuccessBackground);
+  --fdSwitch_Semantic_Success_Border_Color: var(--sapSuccessColor);
+  --fdSwitch_Semantic_Success_Background_Color: var(--sapSuccessBackground);
+  --fdSwitch_Semantic_Error_Border_Color: var(--sapErrorBorderColor);
+  --fdSwitch_Semantic_Error_Background_Color: var(--sapErrorBackground);
 }

--- a/src/theming/sap_fiori_3_light_dark.scss
+++ b/src/theming/sap_fiori_3_light_dark.scss
@@ -154,4 +154,5 @@
   --fdSwitch_Semantic_Error_Border_Color: var(--sapErrorBorderColor);
   --fdSwitch_Semantic_Error_Background_Color: var(--sapErrorBackground);
   --fdSwitch_Semantic_Success_Handle_Hover_Background_Color: var(--sapSuccessBackground);
+  --fdSwitch_Semantic_Error_Icon_Color: var(--sapErrorBorderColor);
 }


### PR DESCRIPTION
part of #1357 

example (semantic hover):
<img width="249" alt="Screen Shot 2021-01-05 at 10 30 31 PM" src="https://user-images.githubusercontent.com/2471874/103733005-ebd90a80-4fa5-11eb-9046-df2a3e43124c.png">
