### PR TITLE
fix: add delta theming for Message Box

### DIFF
--- a/src/message-box.scss
+++ b/src/message-box.scss
@@ -11,10 +11,10 @@ $fd-message-box-title-icon-text-size: 1rem;
 $fd-message-box-footer-button-min-width: 4rem;
 $fd-message-box-content-padding-x: (s: 1rem, m: 2rem, l: 2rem, xl: 3rem);
 $defaultBoxShadow: var(--sapContent_HeaderShadow);
-$errorBoxShadow: inset 0 -0.0625rem var(--sapErrorBorderColor), var(--sapContent_HeaderShadow);
-$successBoxShadow: inset 0 -0.0625rem var(--sapSuccessBorderColor), var(--sapContent_HeaderShadow);
-$warningBoxShadow: inset 0 -0.0625rem var(--sapWarningBorderColor), var(--sapContent_HeaderShadow);
-$informationBoxShadow: inset 0 -0.0625rem var(--sapInformationBorderColor), var(--sapContent_HeaderShadow);
+$errorBoxShadow: var(--fdMessage_Box_Error_Box_Shadow);
+$successBoxShadow: var(--fdMessage_Box_Success_Box_Shadow);
+$warningBoxShadow: var(--fdMessage_Box_Warning_Box_Shadow);
+$informationBoxShadow: var(--fdMessage_Box_Information_Box_Shadow);
 
 $message-box-states: (
   "confirmation": ("iconColor": var(--sapNeutralElementColor), "boxShadow": var(--sapContent_HeaderShadow)),

--- a/src/theming/sap_fiori_3.scss
+++ b/src/theming/sap_fiori_3.scss
@@ -171,4 +171,10 @@
   /* Link */
   --fdLink_Text_Decoration_Opposite: underline;
   --fdLink_Text_Decoration: none;
+
+  /* Message Box */
+  --fdMessage_Box_Error_Box_Shadow: inset 0 -0.0625rem var(--sapErrorBorderColor), var(--sapContent_HeaderShadow);
+  --fdMessage_Box_Success_Box_Shadow: inset 0 -0.0625rem var(--sapSuccessBorderColor), var(--sapContent_HeaderShadow);
+  --fdMessage_Box_Warning_Box_Shadow: inset 0 -0.0625rem var(--sapWarningBorderColor), var(--sapContent_HeaderShadow);
+  --fdMessage_Box_Information_Box_Shadow: inset 0 -0.0625rem var(--sapInformationBorderColor), var(--sapContent_HeaderShadow);
 }

--- a/src/theming/sap_fiori_3_dark.scss
+++ b/src/theming/sap_fiori_3_dark.scss
@@ -170,4 +170,10 @@
   /* Link */
   --fdLink_Text_Decoration_Opposite: underline;
   --fdLink_Text_Decoration: none;
+
+  /* Message Box */
+  --fdMessage_Box_Error_Box_Shadow: inset 0 -0.0625rem var(--sapErrorBorderColor), var(--sapContent_HeaderShadow);
+  --fdMessage_Box_Success_Box_Shadow: inset 0 -0.0625rem var(--sapSuccessBorderColor), var(--sapContent_HeaderShadow);
+  --fdMessage_Box_Warning_Box_Shadow: inset 0 -0.0625rem var(--sapWarningBorderColor), var(--sapContent_HeaderShadow);
+  --fdMessage_Box_Information_Box_Shadow: inset 0 -0.0625rem var(--sapInformationBorderColor), var(--sapContent_HeaderShadow);
 }

--- a/src/theming/sap_fiori_3_hcb.scss
+++ b/src/theming/sap_fiori_3_hcb.scss
@@ -170,4 +170,10 @@
   /* Link */
   --fdLink_Text_Decoration_Opposite: none;
   --fdLink_Text_Decoration: underline;
+
+  /* Message Box */
+  --fdMessage_Box_Error_Box_Shadow: inset 0 -0.125rem var(--sapErrorBorderColor);
+  --fdMessage_Box_Success_Box_Shadow: inset 0 -0.125rem var(--sapSuccessBorderColor);
+  --fdMessage_Box_Warning_Box_Shadow: inset 0 -0.125rem var(--sapWarningBorderColor);
+  --fdMessage_Box_Information_Box_Shadow: inset 0 -0.125rem var(--sapInformationBorderColor);
 }

--- a/src/theming/sap_fiori_3_hcw.scss
+++ b/src/theming/sap_fiori_3_hcw.scss
@@ -170,4 +170,10 @@
   /* Link */
   --fdLink_Text_Decoration_Opposite: none;
   --fdLink_Text_Decoration: underline;
+
+  /* Message Box */
+  --fdMessage_Box_Error_Box_Shadow: inset 0 -0.125rem var(--sapErrorBorderColor);
+  --fdMessage_Box_Success_Box_Shadow: inset 0 -0.125rem var(--sapSuccessBorderColor);
+  --fdMessage_Box_Warning_Box_Shadow: inset 0 -0.125rem var(--sapWarningBorderColor);
+  --fdMessage_Box_Information_Box_Shadow: inset 0 -0.125rem var(--sapInformationBorderColor);
 }

--- a/src/theming/sap_fiori_3_light_dark.scss
+++ b/src/theming/sap_fiori_3_light_dark.scss
@@ -170,4 +170,10 @@
   /* Link */
   --fdLink_Text_Decoration_Opposite: underline;
   --fdLink_Text_Decoration: none;
+
+  /* Message Box */
+  --fdMessage_Box_Error_Box_Shadow: inset 0 -0.0625rem var(--sapErrorBorderColor), var(--sapContent_HeaderShadow);
+  --fdMessage_Box_Success_Box_Shadow: inset 0 -0.0625rem var(--sapSuccessBorderColor), var(--sapContent_HeaderShadow);
+  --fdMessage_Box_Warning_Box_Shadow: inset 0 -0.0625rem var(--sapWarningBorderColor), var(--sapContent_HeaderShadow);
+  --fdMessage_Box_Information_Box_Shadow: inset 0 -0.0625rem var(--sapInformationBorderColor), var(--sapContent_HeaderShadow);
 }


### PR DESCRIPTION
## Related Issue
Part of SAP/fundamental-styles#1357

## Description
add delta theming for Message Box

## Screenshots

### Before:
<img width="1841" alt="Screen Shot 2021-01-06 at 11 04 16 AM" src="https://user-images.githubusercontent.com/39598672/103791041-f9c37580-500f-11eb-8c06-16eb10b6e9fa.png">
<img width="1827" alt="Screen Shot 2021-01-06 at 11 04 03 AM" src="https://user-images.githubusercontent.com/39598672/103791048-fb8d3900-500f-11eb-904d-fc47b01eb44e.png">


### After:
<img width="1811" alt="Screen Shot 2021-01-06 at 11 02 13 AM" src="https://user-images.githubusercontent.com/39598672/103791329-52930e00-5010-11eb-9d93-20812a0d78ec.png">

<img width="1814" alt="Screen Shot 2021-01-06 at 11 02 21 AM" src="https://user-images.githubusercontent.com/39598672/103791099-08aa2800-5010-11eb-8176-c5a75b9ef73e.png">



#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
NA
2. The code follows fundamental-styles code standards and style
NA
3. Testing
NA
4. Documentation
NA