### PR TITLE
fix: add delta theming for Select

### DIFF
--- a/src/select.scss
+++ b/src/select.scss
@@ -5,6 +5,15 @@ $block: #{$fd-namespace}-select;
 $outline-offset: 0.1875rem;
 
 .#{$block} {
+  @mixin fd-control-button-side-border() {
+    border-left: var(--fdSelect_Button_Interractive_SideBorder);
+
+    @include fd-rtl() {
+      border-left: none;
+      border-right: var(--fdSelect_Button_Interractive_SideBorder);
+    }
+  }
+
   $fd-select-padding-x: 0.625rem;
   $fd-select-padding-compact-x: 0.5rem;
   $fd-select-button-active-text-color: var(--sapButton_Active_TextColor);
@@ -76,6 +85,8 @@ $outline-offset: 0.1875rem;
     @include fd-hover() {
       .#{$block}__button {
         background-color: var(--sapButton_Lite_Hover_Background);
+
+        @include fd-control-button-side-border();
       }
     }
 
@@ -88,6 +99,8 @@ $outline-offset: 0.1875rem;
         @include fd-fiori-focus() {
           outline-color: $fd-select-button-active-focus-color;
         }
+
+        @include fd-control-button-side-border();
       }
     }
 
@@ -99,6 +112,8 @@ $outline-offset: 0.1875rem;
         @include fd-fiori-focus() {
           outline-color: $fd-select-button-active-focus-color;
         }
+
+        @include fd-control-button-side-border();
       }
     }
 

--- a/src/theming/sap_fiori_3.scss
+++ b/src/theming/sap_fiori_3.scss
@@ -79,6 +79,7 @@
 
   /* Select */
   --fdSelect_Text_Shadow: none;
+  --fdSelect_Button_Interractive_SideBorder: none;
 
   /* Popover */
   --fdPopover_Text_Shadow: none;

--- a/src/theming/sap_fiori_3_dark.scss
+++ b/src/theming/sap_fiori_3_dark.scss
@@ -79,6 +79,7 @@
 
   /* Select */
   --fdSelect_Text_Shadow: none;
+  --fdSelect_Button_Interractive_SideBorder: none;
 
   /* Popover */
   --fdPopover_Text_Shadow: none;

--- a/src/theming/sap_fiori_3_hcb.scss
+++ b/src/theming/sap_fiori_3_hcb.scss
@@ -79,6 +79,7 @@
 
   /* Select */
   --fdSelect_Text_Shadow: 0 0 0.125rem #000;
+  --fdSelect_Button_Interractive_SideBorder: solid 0.0625rem var(--sapField_BorderColor);
 
   /* Popover */
   --fdPopover_Text_Shadow: 0 0 0.125rem #000;

--- a/src/theming/sap_fiori_3_hcw.scss
+++ b/src/theming/sap_fiori_3_hcw.scss
@@ -79,6 +79,7 @@
 
   /* Select */
   --fdSelect_Text_Shadow: none;
+  --fdSelect_Button_Interractive_SideBorder: solid 0.0625rem var(--sapField_BorderColor);
 
   /* Popover */
   --fdPopover_Text_Shadow: none;

--- a/src/theming/sap_fiori_3_light_dark.scss
+++ b/src/theming/sap_fiori_3_light_dark.scss
@@ -79,6 +79,7 @@
 
   /* Select */
   --fdSelect_Text_Shadow: none;
+  --fdSelect_Button_Interractive_SideBorder: none;
 
   /* Popover */
   --fdPopover_Text_Shadow: none;


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-styles/issues/1357

## Description
Added border on sides on HCB/HCW with interactive states

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] RTL support
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
3. Testing
- [x] Verified all styles in IE11
