### PR TITLE
chore: bump bundlesize version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10369,23 +10369,32 @@
       "dev": true
     },
     "bundlesize": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/bundlesize/-/bundlesize-0.18.0.tgz",
-      "integrity": "sha512-GZURr25umfYxZYZUyOlOtJRbYjAn0VfbjbnS0NBcOiF8VcjmhoEhmx8Gw4va8HeQb8j7Ra0ZltY/IeHgSHFXFw==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/bundlesize/-/bundlesize-0.18.1.tgz",
+      "integrity": "sha512-NAsKBH6BeVmDopoa4tod0m5/koM7iLY3saKyGn7wyAravBYmKNUpDJba4zyVhwRm5Dw9WXv8FIO0N//tCkx68Q==",
       "dev": true,
       "requires": {
-        "axios": "^0.19.0",
+        "axios": "^0.21.1",
         "brotli-size": "0.1.0",
         "bytes": "^3.1.0",
         "ci-env": "^1.4.0",
         "commander": "^2.20.0",
         "cosmiconfig": "^5.2.1",
-        "github-build": "^1.2.0",
+        "github-build": "^1.2.2",
         "glob": "^7.1.4",
         "gzip-size": "^4.0.0",
         "prettycli": "^1.4.3"
       },
       "dependencies": {
+        "axios": {
+          "version": "0.21.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+          "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.10.0"
+          }
+        },
         "commander": {
           "version": "2.20.3",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -10403,6 +10412,12 @@
             "js-yaml": "^3.13.1",
             "parse-json": "^4.0.0"
           }
+        },
+        "follow-redirects": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
+          "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==",
+          "dev": true
         },
         "gzip-size": {
           "version": "4.1.0",
@@ -11128,9 +11143,9 @@
       }
     },
     "ci-env": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/ci-env/-/ci-env-1.15.0.tgz",
-      "integrity": "sha512-pXv9CQo9ORLqY6tshecGkj3cRkbHKcHU8RnPf269knEL9ggvpg954Qi+Ow0DpTOk1/Bo5hySxyLHdt44CImMJw==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/ci-env/-/ci-env-1.16.0.tgz",
+      "integrity": "sha512-ucF9caQEX5wQlY449KZBIJPx91+kRg9tJ3tWSc4+KzrvC5KNiPm/3g1noP8VhdI3046+Vw3jLmKAD0fjCRJTmw==",
       "dev": true
     },
     "ci-info": {
@@ -16061,12 +16076,29 @@
       }
     },
     "github-build": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/github-build/-/github-build-1.2.1.tgz",
-      "integrity": "sha512-VAT4NFU8hm9Ks5yNKuuczD2zMbmouAKHtxtwvmCj34Q2DpZsjgp3LLjtrKlm/YvGSzSNGmj22ccJQQei+f/vIw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/github-build/-/github-build-1.2.2.tgz",
+      "integrity": "sha512-xHVy8w+J09eD+uBqJ4CcRPr5HTa1BYaF6vPJ67yJekCWurPzimB/ExH1SGzW5iAFC2Uvw9TD1FpSIjh56hcB9Q==",
       "dev": true,
       "requires": {
-        "axios": "0.19.0"
+        "axios": "0.21.1"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.21.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+          "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.10.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
+          "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==",
+          "dev": true
+        }
       }
     },
     "github-from-package": {
@@ -16294,7 +16326,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "gud": {
       "version": "1.0.0",
@@ -21970,9 +22003,9 @@
       }
     },
     "node-abi": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.18.0.tgz",
-      "integrity": "sha512-yi05ZoiuNNEbyT/xXfSySZE+yVnQW6fxPZuFbLyS1s6b5Kw3HzV2PHOM4XR+nsjzkHxByK+2Wg+yCQbe35l8dw==",
+      "version": "2.19.3",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.3.tgz",
+      "integrity": "sha512-9xZrlyfvKhWme2EXFKQhZRp1yNWT/uI1luYPr3sFl+H4keYY4xR+1jO7mvTTijIsHf1M+QDe9uWuKeEpLInIlg==",
       "dev": true,
       "requires": {
         "semver": "^5.4.1"
@@ -22120,6 +22153,7 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -22134,6 +22168,7 @@
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -22143,6 +22178,7 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
           "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -22152,6 +22188,7 @@
           "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -22160,7 +22197,8 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -24220,16 +24258,16 @@
       }
     },
     "prebuild-install": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.4.tgz",
-      "integrity": "sha512-AkKN+pf4fSEihjapLEEj8n85YIw/tN6BQqkhzbDc0RvEZGdkpJBGMUYx66AAMcPG2KzmPQS7Cm16an4HVBRRMA==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
+      "integrity": "sha512-s8Aai8++QQGi4sSbs/M1Qku62PFK49Jm1CbgXklGz4nmHveDq0wzJkg7Na5QbnO1uNH8K7iqx2EQ/mV0MZEmOg==",
       "dev": true,
       "requires": {
         "detect-libc": "^1.0.3",
         "expand-template": "^2.0.3",
         "github-from-package": "0.0.0",
         "minimist": "^1.2.3",
-        "mkdirp": "^0.5.1",
+        "mkdirp-classic": "^0.5.3",
         "napi-build-utils": "^1.0.1",
         "node-abi": "^2.7.0",
         "noop-logger": "^0.1.1",
@@ -24240,17 +24278,6 @@
         "tar-fs": "^2.0.0",
         "tunnel-agent": "^0.6.0",
         "which-pm-runs": "^1.0.0"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        }
       }
     },
     "prelude-ls": {
@@ -26565,7 +26592,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "side-channel": {
       "version": "1.0.3",
@@ -26645,9 +26673,9 @@
       "dev": true
     },
     "simple-concat": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
       "dev": true
     },
     "simple-get": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.6.3",
     "babel-loader": "^8.1.0",
-    "bundlesize": "^0.18.0",
+    "bundlesize": "^0.18.1",
     "case": "^1.6.3",
     "chromatic": "^5.2.0",
     "clean-css-cli": "^4.3.0",


### PR DESCRIPTION
security fix