### PR TITLE
docs: change the icon of the button showing/hiding the second level of Side Nav

### DIFF
--- a/.storybook/static/preview-head.js
+++ b/.storybook/static/preview-head.js
@@ -345,3 +345,9 @@ function isSpaceOrEnter(event, buttonFn) {
             break;
     }
 }
+
+function toggleNestedListSubmenu(event) {
+    let button = event.target;
+    let icon = button.children[0];
+    icon.classList= button && button.classList.contains('is-expanded') ? 'sap-icon--navigation-right-arrow' : 'sap-icon--navigation-down-arrow';
+}

--- a/.storybook/static/preview-head.js
+++ b/.storybook/static/preview-head.js
@@ -349,5 +349,10 @@ function isSpaceOrEnter(event, buttonFn) {
 function toggleNestedListSubmenu(event) {
     let button = event.target;
     let icon = button.children[0];
-    icon.classList= button && button.classList.contains('is-expanded') ? 'sap-icon--navigation-right-arrow' : 'sap-icon--navigation-down-arrow';
+    
+    if(button && button.classList.contains('is-expanded')) {
+        icon.classList = 'sap-icon--navigation-right-arrow';
+    } else {
+        icon.classList = 'sap-icon--navigation-down-arrow';
+    }
 }

--- a/stories/side-navigation/__snapshots__/side-navigation.stories.storyshot
+++ b/stories/side-navigation/__snapshots__/side-navigation.stories.storyshot
@@ -134,6 +134,7 @@ exports[`Storyshots Components/Side Navigation Complex (compact) 1`] = `
             aria-haspopup="true"
             aria-label="Expand submenu"
             class="fd-button fd-nested-list__button"
+            onclick="toggleNestedListSubmenu(event)"
           >
             
                         
@@ -558,6 +559,7 @@ exports[`Storyshots Components/Side Navigation Complex 1`] = `
             aria-haspopup="true"
             aria-label="Expand submenu"
             class="fd-button fd-nested-list__button"
+            onclick="toggleNestedListSubmenu(event)"
           >
             
                         
@@ -1686,6 +1688,7 @@ exports[`Storyshots Components/Side Navigation Group 1`] = `
             aria-haspopup="true"
             aria-label="Expand submenu"
             class="fd-button fd-nested-list__button"
+            onclick="toggleNestedListSubmenu(event)"
           >
             
                         

--- a/stories/side-navigation/side-navigation.stories.js
+++ b/stories/side-navigation/side-navigation.stories.js
@@ -170,7 +170,9 @@ export const cozyGrouping = () => `<div class="fd-side-nav">
                         aria-controls="EX100L2" 
                         aria-haspopup="true" 
                         aria-expanded="false" 
-                        aria-label="Expand submenu">
+                        aria-label="Expand submenu"
+                        onclick="toggleNestedListSubmenu(event)"
+                        >
                         <i class="sap-icon--navigation-right-arrow" role="presentation"></i>    
                     </button>
                 </div>
@@ -263,7 +265,8 @@ export const complexCozySideNav = () => `<div class="fd-side-nav">
                         aria-controls="EX400L2" 
                         aria-haspopup="true" 
                         aria-expanded="false" 
-                        aria-label="Expand submenu">
+                        aria-label="Expand submenu"
+                        onclick="toggleNestedListSubmenu(event)">
                         <i class="sap-icon--navigation-right-arrow" role="presentation"></i>    
                     </button>
                 </div>
@@ -368,7 +371,8 @@ export const complexCompactSideNav = () => `<div class="fd-side-nav">
                         aria-controls="EX500L2" 
                         aria-haspopup="true" 
                         aria-expanded="false" 
-                        aria-label="Expand submenu">
+                        aria-label="Expand submenu"
+                        onclick="toggleNestedListSubmenu(event)">
                         <i class="sap-icon--navigation-right-arrow" role="presentation"></i>    
                     </button>
                 </div>


### PR DESCRIPTION
## Related Issue
Part of SAP/fundamental-styles#2045

## Description
Add JS to the documentation for changing the icon of the button responsible for opening/hiding the second level of the Side navigation

## Screenshots

### Before:
<img width="1087" alt="Screen Shot 2021-01-13 at 3 11 12 PM" src="https://user-images.githubusercontent.com/39598672/104505238-97d7b280-55b1-11eb-83a5-b1c9f67cbaf6.png">


### After:
<img width="1276" alt="Screen Shot 2021-01-13 at 3 10 12 PM" src="https://user-images.githubusercontent.com/39598672/104505133-74ad0300-55b1-11eb-8c7b-5b61fcded022.png">


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
NA
2. The code follows fundamental-styles code standards and style
NA
3. Testing
- [na] tested Storybook examples with "CSS Resources" `normalize` option 
- [na] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [na] Verified all styles in IE11
- [x] Updated tests
4. Documentation
- [x] Storybook documentation has been created/updated
- [na] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
