### PR TITLE
docs: add fix for missing box-shadow for Dialog in IE11

### DIFF
--- a/.storybook/custom/custom.scss
+++ b/.storybook/custom/custom.scss
@@ -312,7 +312,7 @@ code.docs-code-grey {
   .fd-message-box__content {
     position: relative;
     transform: translate(0%, 0%);
-    width: 30rem;
+    width: 50%;
     margin: auto;
     height: auto;
 


### PR DESCRIPTION
## Related Issue
Part of SAP/fundamental-styles#2045

## Description
In IE11 the top box-shadow was missing for Dialog. I changed the custom docs css rules responsible for rendering static dialogs
#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
NA
2. The code follows fundamental-styles code standards and style
NA
3. Testing
NA
4. Documentation
NA
