### PR TITLE
fix: update semantic icons in object status and object list

### DIFF
--- a/stories/object-list/__snapshots__/object-list.stories.storyshot
+++ b/stories/object-list/__snapshots__/object-list.stories.storyshot
@@ -397,7 +397,7 @@ exports[`Storyshots Components/Object List Borderless 1`] = `
                   
           
                   <i
-                    class="fd-object-status__icon sap-icon--status-negative"
+                    class="fd-object-status__icon sap-icon--message-error"
                     role="presentation"
                   />
                   
@@ -1147,7 +1147,7 @@ exports[`Storyshots Components/Object List Navigation 1`] = `
                     
           
                     <i
-                      class="fd-object-status__icon sap-icon--status-negative"
+                      class="fd-object-status__icon sap-icon--message-error"
                       role="presentation"
                     />
                     
@@ -1652,7 +1652,7 @@ exports[`Storyshots Components/Object List Selection 1`] = `
                   
           
                   <i
-                    class="fd-object-status__icon sap-icon--status-negative"
+                    class="fd-object-status__icon sap-icon--message-error"
                     role="presentation"
                   />
                   
@@ -2179,7 +2179,7 @@ exports[`Storyshots Components/Object List Selection With Navigation 1`] = `
                     
           
                     <i
-                      class="fd-object-status__icon sap-icon--status-negative"
+                      class="fd-object-status__icon sap-icon--message-error"
                       role="presentation"
                     />
                     
@@ -2685,7 +2685,7 @@ exports[`Storyshots Components/Object List Standard 1`] = `
                 
           
                 <i
-                  class="fd-object-status__icon sap-icon--status-negative"
+                  class="fd-object-status__icon sap-icon--message-error"
                   role="presentation"
                 />
                 

--- a/stories/object-list/object-list.stories.js
+++ b/stories/object-list/object-list.stories.js
@@ -162,7 +162,7 @@ export const object = () => `
           </div>
           <div class="fd-object-list__row-right">
           <span class="fd-object-status fd-object-status--negative">
-          <i class="fd-object-status__icon sap-icon--status-negative" role="presentation"></i>
+          <i class="fd-object-status__icon sap-icon--message-error" role="presentation"></i>
           <span class="fd-object-status__text">Negative</span>
          </span>
           </div>
@@ -416,7 +416,7 @@ export const navigation = () => `
           </div>
           <div class="fd-object-list__row-right">
           <span class="fd-object-status fd-object-status--negative">
-          <i class="fd-object-status__icon sap-icon--status-negative" role="presentation"></i>
+          <i class="fd-object-status__icon sap-icon--message-error" role="presentation"></i>
           <span class="fd-object-status__text">Negative</span>
          </span>
           </div>
@@ -555,7 +555,7 @@ export const selection = () => `
           </div>
           <div class="fd-object-list__row-right">
           <span class="fd-object-status fd-object-status--negative">
-          <i class="fd-object-status__icon sap-icon--status-negative" role="presentation"></i>
+          <i class="fd-object-status__icon sap-icon--message-error" role="presentation"></i>
           <span class="fd-object-status__text">Negative</span>
          </span>
           </div>
@@ -698,7 +698,7 @@ export const selectionWithNavigation = () => `
           </div>
           <div class="fd-object-list__row-right">
           <span class="fd-object-status fd-object-status--negative">
-          <i class="fd-object-status__icon sap-icon--status-negative" role="presentation"></i>
+          <i class="fd-object-status__icon sap-icon--message-error" role="presentation"></i>
           <span class="fd-object-status__text">Negative</span>
          </span>
           </div>
@@ -839,7 +839,7 @@ export const borderless = () => `
           </div>
           <div class="fd-object-list__row-right">
           <span class="fd-object-status fd-object-status--negative">
-          <i class="fd-object-status__icon sap-icon--status-negative" role="presentation"></i>
+          <i class="fd-object-status__icon sap-icon--message-error" role="presentation"></i>
           <span class="fd-object-status__text">Negative</span>
          </span>
           </div>

--- a/stories/object-status/__snapshots__/object-status.stories.storyshot
+++ b/stories/object-status/__snapshots__/object-status.stories.storyshot
@@ -13,7 +13,7 @@ exports[`Storyshots Components/Object Status Clickable Object Status 1`] = `
     
         
     <i
-      class="fd-object-status__icon sap-icon--status-negative"
+      class="fd-object-status__icon sap-icon--message-error"
       role="presentation"
     />
     
@@ -35,7 +35,7 @@ exports[`Storyshots Components/Object Status Clickable Object Status 1`] = `
     
         
     <i
-      class="fd-object-status__icon sap-icon--status-critical"
+      class="fd-object-status__icon sap-icon--message-warning"
       role="presentation"
     />
     
@@ -57,7 +57,7 @@ exports[`Storyshots Components/Object Status Clickable Object Status 1`] = `
     
         
     <i
-      class="fd-object-status__icon sap-icon--status-positive"
+      class="fd-object-status__icon sap-icon--message-success"
       role="presentation"
     />
     
@@ -80,7 +80,7 @@ exports[`Storyshots Components/Object Status Clickable Object Status 1`] = `
     
         
     <i
-      class="fd-object-status__icon sap-icon--hint"
+      class="fd-object-status__icon sap-icon--message-information"
       role="presentation"
     />
     
@@ -100,12 +100,6 @@ exports[`Storyshots Components/Object Status Clickable Object Status 1`] = `
     role="button"
     tabindex="0"
   >
-    
-        
-    <i
-      class="fd-object-status__icon sap-icon--to-be-reviewed"
-      role="presentation"
-    />
     
         
     <span
@@ -395,7 +389,7 @@ exports[`Storyshots Components/Object Status Icon 1`] = `
         
     <i
       aria-label="Negative"
-      class="fd-object-status__icon sap-icon--status-negative"
+      class="fd-object-status__icon sap-icon--message-error"
     />
     
     
@@ -409,7 +403,7 @@ exports[`Storyshots Components/Object Status Icon 1`] = `
         
     <i
       aria-label="Warning"
-      class="fd-object-status__icon sap-icon--status-critical"
+      class="fd-object-status__icon sap-icon--message-warning"
     />
     
     
@@ -423,7 +417,7 @@ exports[`Storyshots Components/Object Status Icon 1`] = `
         
     <i
       aria-label="Correct"
-      class="fd-object-status__icon sap-icon--status-positive"
+      class="fd-object-status__icon sap-icon--message-success"
     />
     
     
@@ -437,21 +431,7 @@ exports[`Storyshots Components/Object Status Icon 1`] = `
         
     <i
       aria-label="More information"
-      class="fd-object-status__icon sap-icon--hint"
-    />
-    
-    
-  </span>
-  
-    
-  <span
-    class="fd-object-status"
-  >
-    
-        
-    <i
-      aria-label="To be reviewed"
-      class="fd-object-status__icon sap-icon--to-be-reviewed"
+      class="fd-object-status__icon sap-icon--message-information"
     />
     
     
@@ -473,7 +453,7 @@ exports[`Storyshots Components/Object Status Icon And Text 1`] = `
     
         
     <i
-      class="fd-object-status__icon sap-icon--status-negative"
+      class="fd-object-status__icon sap-icon--message-error"
       role="presentation"
     />
     
@@ -494,7 +474,7 @@ exports[`Storyshots Components/Object Status Icon And Text 1`] = `
     
         
     <i
-      class="fd-object-status__icon sap-icon--status-critical"
+      class="fd-object-status__icon sap-icon--message-warning"
       role="presentation"
     />
     
@@ -515,7 +495,7 @@ exports[`Storyshots Components/Object Status Icon And Text 1`] = `
     
         
     <i
-      class="fd-object-status__icon sap-icon--status-positive"
+      class="fd-object-status__icon sap-icon--message-success"
       role="presentation"
     />
     
@@ -536,7 +516,7 @@ exports[`Storyshots Components/Object Status Icon And Text 1`] = `
     
         
     <i
-      class="fd-object-status__icon sap-icon--hint"
+      class="fd-object-status__icon sap-icon--message-information"
       role="presentation"
     />
     
@@ -554,12 +534,6 @@ exports[`Storyshots Components/Object Status Icon And Text 1`] = `
   <span
     class="fd-object-status"
   >
-    
-        
-    <i
-      class="fd-object-status__icon sap-icon--to-be-reviewed"
-      role="presentation"
-    />
     
         
     <span
@@ -663,7 +637,7 @@ exports[`Storyshots Components/Object Status Inverted 1`] = `
       
         
       <i
-        class="fd-object-status__icon sap-icon--status-negative"
+        class="fd-object-status__icon sap-icon--message-error"
         role="presentation"
       />
       
@@ -677,7 +651,7 @@ exports[`Storyshots Components/Object Status Inverted 1`] = `
       
         
       <i
-        class="fd-object-status__icon sap-icon--status-negative"
+        class="fd-object-status__icon sap-icon--message-error"
         role="presentation"
       />
       
@@ -698,7 +672,7 @@ exports[`Storyshots Components/Object Status Inverted 1`] = `
       
         
       <i
-        class="fd-object-status__icon sap-icon--status-critical"
+        class="fd-object-status__icon sap-icon--message-warning"
         role="presentation"
       />
       
@@ -719,7 +693,7 @@ exports[`Storyshots Components/Object Status Inverted 1`] = `
       
         
       <i
-        class="fd-object-status__icon sap-icon--status-positive"
+        class="fd-object-status__icon sap-icon--message-success"
         role="presentation"
       />
       
@@ -740,7 +714,7 @@ exports[`Storyshots Components/Object Status Inverted 1`] = `
       
         
       <i
-        class="fd-object-status__icon sap-icon--hint"
+        class="fd-object-status__icon sap-icon--message-information"
         role="presentation"
       />
       
@@ -758,12 +732,6 @@ exports[`Storyshots Components/Object Status Inverted 1`] = `
     <span
       class="fd-object-status fd-object-status--inverted"
     >
-      
-        
-      <i
-        class="fd-object-status__icon sap-icon--to-be-reviewed"
-        role="presentation"
-      />
       
         
       <span
@@ -796,7 +764,7 @@ exports[`Storyshots Components/Object Status Inverted 1`] = `
       
         
       <i
-        class="fd-object-status__icon sap-icon--status-negative"
+        class="fd-object-status__icon sap-icon--message-error"
         role="presentation"
       />
       
@@ -817,7 +785,7 @@ exports[`Storyshots Components/Object Status Inverted 1`] = `
       
         
       <i
-        class="fd-object-status__icon sap-icon--status-critical"
+        class="fd-object-status__icon sap-icon--message-warning"
         role="presentation"
       />
       
@@ -838,7 +806,7 @@ exports[`Storyshots Components/Object Status Inverted 1`] = `
       
         
       <i
-        class="fd-object-status__icon sap-icon--status-positive"
+        class="fd-object-status__icon sap-icon--message-success"
         role="presentation"
       />
       
@@ -859,7 +827,7 @@ exports[`Storyshots Components/Object Status Inverted 1`] = `
       
         
       <i
-        class="fd-object-status__icon sap-icon--hint"
+        class="fd-object-status__icon sap-icon--message-information"
         role="presentation"
       />
       
@@ -877,12 +845,6 @@ exports[`Storyshots Components/Object Status Inverted 1`] = `
     <a
       class="fd-object-status fd-object-status--link fd-object-status--inverted"
     >
-      
-        
-      <i
-        class="fd-object-status__icon sap-icon--to-be-reviewed"
-        role="presentation"
-      />
       
         
       <span
@@ -1188,7 +1150,7 @@ exports[`Storyshots Components/Object Status Large Object Status 1`] = `
     
         
     <i
-      class="fd-object-status__icon sap-icon--status-negative"
+      class="fd-object-status__icon sap-icon--message-error"
       role="presentation"
     />
     
@@ -1209,7 +1171,7 @@ exports[`Storyshots Components/Object Status Large Object Status 1`] = `
     
         
     <i
-      class="fd-object-status__icon sap-icon--status-critical"
+      class="fd-object-status__icon sap-icon--message-warning"
       role="presentation"
     />
     
@@ -1230,7 +1192,7 @@ exports[`Storyshots Components/Object Status Large Object Status 1`] = `
     
         
     <i
-      class="fd-object-status__icon sap-icon--status-positive"
+      class="fd-object-status__icon sap-icon--message-success"
       role="presentation"
     />
     
@@ -1251,7 +1213,7 @@ exports[`Storyshots Components/Object Status Large Object Status 1`] = `
     
         
     <i
-      class="fd-object-status__icon sap-icon--hint"
+      class="fd-object-status__icon sap-icon--message-information"
       role="presentation"
     />
     
@@ -1269,12 +1231,6 @@ exports[`Storyshots Components/Object Status Large Object Status 1`] = `
   <span
     class="fd-object-status fd-object-status--large"
   >
-    
-        
-    <i
-      class="fd-object-status__icon sap-icon--to-be-reviewed"
-      role="presentation"
-    />
     
         
     <span
@@ -1302,7 +1258,7 @@ exports[`Storyshots Components/Object Status Primary 1`] = `
     
         
     <i
-      class="fd-object-status__icon sap-icon--status-negative"
+      class="fd-object-status__icon sap-icon--message-error"
       role="presentation"
     />
     
@@ -1323,7 +1279,7 @@ exports[`Storyshots Components/Object Status Primary 1`] = `
     
         
     <i
-      class="fd-object-status__icon sap-icon--status-critical"
+      class="fd-object-status__icon sap-icon--message-warning"
       role="presentation"
     />
     
@@ -1344,7 +1300,7 @@ exports[`Storyshots Components/Object Status Primary 1`] = `
     
         
     <i
-      class="fd-object-status__icon sap-icon--status-positive"
+      class="fd-object-status__icon sap-icon--message-success"
       role="presentation"
     />
     
@@ -1365,7 +1321,7 @@ exports[`Storyshots Components/Object Status Primary 1`] = `
     
         
     <i
-      class="fd-object-status__icon sap-icon--hint"
+      class="fd-object-status__icon sap-icon--message-information"
       role="presentation"
     />
     
@@ -1374,27 +1330,6 @@ exports[`Storyshots Components/Object Status Primary 1`] = `
       class="fd-object-status__text"
     >
       Info
-    </span>
-    
-    
-  </span>
-  
-    
-  <span
-    class="fd-object-status"
-  >
-    
-        
-    <i
-      class="fd-object-status__icon sap-icon--to-be-reviewed"
-      role="presentation"
-    />
-    
-        
-    <span
-      class="fd-object-status__text"
-    >
-      Neutral
     </span>
     
     

--- a/stories/object-status/__snapshots__/object-status.stories.storyshot
+++ b/stories/object-status/__snapshots__/object-status.stories.storyshot
@@ -530,21 +530,6 @@ exports[`Storyshots Components/Object Status Icon And Text 1`] = `
     
   </span>
   
-    
-  <span
-    class="fd-object-status"
-  >
-    
-        
-    <span
-      class="fd-object-status__text"
-    >
-      Neutral
-    </span>
-    
-    
-  </span>
-  
 
 </div>
 `;

--- a/stories/object-status/object-status.stories.js
+++ b/stories/object-status/object-status.stories.js
@@ -99,9 +99,6 @@ export const iconAndText = () => `<div class="fddocs-container">
         <i class="fd-object-status__icon sap-icon--message-information" role="presentation"></i>
         <span class="fd-object-status__text">Info</span>
     </span>
-    <span class="fd-object-status">
-        <span class="fd-object-status__text">Neutral</span>
-    </span>
 </div>
 `;
 

--- a/stories/object-status/object-status.stories.js
+++ b/stories/object-status/object-status.stories.js
@@ -17,24 +17,20 @@ attribute of a line item in a table. `,
 
 export const primary = () => `<div class="fddocs-container">
     <span class="fd-object-status fd-object-status--negative">
-        <i class="fd-object-status__icon sap-icon--status-negative" role="presentation"></i>
+        <i class="fd-object-status__icon sap-icon--message-error" role="presentation"></i>
         <span class="fd-object-status__text">Negative</span>
     </span>
     <span class="fd-object-status fd-object-status--critical">
-        <i class="fd-object-status__icon sap-icon--status-critical" role="presentation"></i>
+        <i class="fd-object-status__icon sap-icon--message-warning" role="presentation"></i>
         <span class="fd-object-status__text">Critical</span>
     </span>
     <span class="fd-object-status fd-object-status--positive">
-        <i class="fd-object-status__icon sap-icon--status-positive" role="presentation"></i>
+        <i class="fd-object-status__icon sap-icon--message-success" role="presentation"></i>
         <span class="fd-object-status__text">Positive</span>
     </span>
     <span class="fd-object-status fd-object-status--informative">
-        <i class="fd-object-status__icon sap-icon--hint" role="presentation"></i>
+        <i class="fd-object-status__icon sap-icon--message-information" role="presentation"></i>
         <span class="fd-object-status__text">Info</span>
-    </span>
-    <span class="fd-object-status">
-        <i class="fd-object-status__icon sap-icon--to-be-reviewed" role="presentation"></i>
-        <span class="fd-object-status__text">Neutral</span>
     </span>
 </div>
 `;
@@ -45,19 +41,16 @@ export const primary = () => `<div class="fddocs-container">
 
 export const icon = () => `<div class="fddocs-container">
     <span class="fd-object-status fd-object-status--negative">
-        <i class="fd-object-status__icon sap-icon--status-negative" aria-label="Negative"></i>
+        <i class="fd-object-status__icon sap-icon--message-error" aria-label="Negative"></i>
     </span>
     <span class="fd-object-status fd-object-status--critical">
-        <i class="fd-object-status__icon sap-icon--status-critical" aria-label="Warning"></i>
+        <i class="fd-object-status__icon sap-icon--message-warning" aria-label="Warning"></i>
     </span>
     <span class="fd-object-status fd-object-status--positive">
-        <i class="fd-object-status__icon sap-icon--status-positive" aria-label="Correct"></i>
+        <i class="fd-object-status__icon sap-icon--message-success" aria-label="Correct"></i>
     </span>
     <span class="fd-object-status fd-object-status--informative">
-        <i class="fd-object-status__icon sap-icon--hint" aria-label="More information"></i>
-    </span>
-    <span class="fd-object-status">
-        <i class="fd-object-status__icon sap-icon--to-be-reviewed" aria-label="To be reviewed"></i>
+        <i class="fd-object-status__icon sap-icon--message-information" aria-label="More information"></i>
     </span>
 </div>
 `;
@@ -91,23 +84,22 @@ export const text = () => `<div class="fddocs-container">
 
 export const iconAndText = () => `<div class="fddocs-container">
     <span class="fd-object-status fd-object-status--negative">
-        <i class="fd-object-status__icon sap-icon--status-negative" role="presentation"></i>
+        <i class="fd-object-status__icon sap-icon--message-error" role="presentation"></i>
         <span class="fd-object-status__text">Negative</span>
     </span>
     <span class="fd-object-status fd-object-status--critical">
-        <i class="fd-object-status__icon sap-icon--status-critical" role="presentation"></i>
+        <i class="fd-object-status__icon sap-icon--message-warning" role="presentation"></i>
         <span class="fd-object-status__text">Critical</span>
     </span>
     <span class="fd-object-status fd-object-status--positive">
-        <i class="fd-object-status__icon sap-icon--status-positive" role="presentation"></i>
+        <i class="fd-object-status__icon sap-icon--message-success" role="presentation"></i>
         <span class="fd-object-status__text">Positive</span>
     </span>
     <span class="fd-object-status fd-object-status--informative">
-        <i class="fd-object-status__icon sap-icon--hint" role="presentation"></i>
+        <i class="fd-object-status__icon sap-icon--message-information" role="presentation"></i>
         <span class="fd-object-status__text">Info</span>
     </span>
     <span class="fd-object-status">
-        <i class="fd-object-status__icon sap-icon--to-be-reviewed" role="presentation"></i>
         <span class="fd-object-status__text">Neutral</span>
     </span>
 </div>
@@ -153,23 +145,22 @@ export const genericIndicationColors = () => `<div class="fddocs-container">
 
 export const clickableObjectStatus = () => `<div class="fddocs-container">
     <a href="#"  class="fd-object-status fd-object-status--negative fd-object-status--link">
-        <i class="fd-object-status__icon sap-icon--status-negative" role="presentation"></i>
+        <i class="fd-object-status__icon sap-icon--message-error" role="presentation"></i>
         <span class="fd-object-status__text">Negative</span>
     </a>
     <a href="#"  class="fd-object-status fd-object-status--critical fd-object-status--link">
-        <i class="fd-object-status__icon sap-icon--status-critical" role="presentation"></i>
+        <i class="fd-object-status__icon sap-icon--message-warning" role="presentation"></i>
         <span class="fd-object-status__text">Critical</span>
     </a>
     <a href="#"class="fd-object-status fd-object-status--positive fd-object-status--link">
-        <i class="fd-object-status__icon sap-icon--status-positive" role="presentation"></i>
+        <i class="fd-object-status__icon sap-icon--message-success" role="presentation"></i>
         <span class="fd-object-status__text">Positive</span>
     </a>
     <span role="button" class="fd-object-status fd-object-status--informative fd-object-status--link" tabindex="0">
-        <i class="fd-object-status__icon sap-icon--hint" role="presentation"></i>
+        <i class="fd-object-status__icon sap-icon--message-information" role="presentation"></i>
         <span class="fd-object-status__text">Info</span>
     </span>
     <span role="button" class="fd-object-status fd-object-status--link" tabindex="0">
-        <i class="fd-object-status__icon sap-icon--to-be-reviewed" role="presentation"></i>
         <span class="fd-object-status__text">Neutral</span>
     </span>
 
@@ -203,23 +194,22 @@ export const clickableObjectStatus = () => `<div class="fddocs-container">
 
 export const largeObjectStatus = () => `<div class="fddocs-container">
     <span class="fd-object-status fd-object-status--large fd-object-status--negative">
-        <i class="fd-object-status__icon sap-icon--status-negative" role="presentation"></i>
+        <i class="fd-object-status__icon sap-icon--message-error" role="presentation"></i>
         <span class="fd-object-status__text">Negative</span>
     </span>
     <span class="fd-object-status fd-object-status--large fd-object-status--critical">
-        <i class="fd-object-status__icon sap-icon--status-critical" role="presentation"></i>
+        <i class="fd-object-status__icon sap-icon--message-warning" role="presentation"></i>
         <span class="fd-object-status__text">Critical</span>
     </span>
     <span class="fd-object-status fd-object-status--large fd-object-status--positive">
-        <i class="fd-object-status__icon sap-icon--status-positive" role="presentation"></i>
+        <i class="fd-object-status__icon sap-icon--message-success" role="presentation"></i>
         <span class="fd-object-status__text">Positive</span>
     </span>
     <span class="fd-object-status fd-object-status--large fd-object-status--informative">
-        <i class="fd-object-status__icon sap-icon--hint" role="presentation"></i>
+        <i class="fd-object-status__icon sap-icon--message-information" role="presentation"></i>
         <span class="fd-object-status__text">Info</span>
     </span>
     <span class="fd-object-status fd-object-status--large">
-        <i class="fd-object-status__icon sap-icon--to-be-reviewed" role="presentation"></i>
         <span class="fd-object-status__text">Neutral</span>
     </span>
 </div>
@@ -248,26 +238,25 @@ export const inverted = () => `<div class="fddocs-container">
         <span class="fd-object-status__text">Inverted Neutral</span>
     </span>
     <span class="fd-object-status fd-object-status--inverted fd-object-status--negative">
-        <i class="fd-object-status__icon sap-icon--status-negative" role="presentation"></i>
+        <i class="fd-object-status__icon sap-icon--message-error" role="presentation"></i>
     </span>
     <span class="fd-object-status fd-object-status--inverted fd-object-status--negative">
-        <i class="fd-object-status__icon sap-icon--status-negative" role="presentation"></i>
+        <i class="fd-object-status__icon sap-icon--message-error" role="presentation"></i>
         <span class="fd-object-status__text">Negative</span>
     </span>
     <span class="fd-object-status fd-object-status--inverted fd-object-status--critical">
-        <i class="fd-object-status__icon sap-icon--status-critical" role="presentation"></i>
+        <i class="fd-object-status__icon sap-icon--message-warning" role="presentation"></i>
         <span class="fd-object-status__text">Critical</span>
     </span>
     <span class="fd-object-status fd-object-status--inverted fd-object-status--positive">
-        <i class="fd-object-status__icon sap-icon--status-positive" role="presentation"></i>
+        <i class="fd-object-status__icon sap-icon--message-success" role="presentation"></i>
         <span class="fd-object-status__text">Positive</span>
     </span>
     <span class="fd-object-status fd-object-status--inverted fd-object-status--informative">
-        <i class="fd-object-status__icon sap-icon--hint" role="presentation"></i>
+        <i class="fd-object-status__icon sap-icon--message-information" role="presentation"></i>
         <span class="fd-object-status__text">Informative</span>
     </span>
     <span class="fd-object-status fd-object-status--inverted">
-        <i class="fd-object-status__icon sap-icon--to-be-reviewed" role="presentation"></i>
         <span class="fd-object-status__text">Neutral</span>
     </span>
 </div>
@@ -275,23 +264,22 @@ export const inverted = () => `<div class="fddocs-container">
     <h4>Clickable Inverted Object Status</h4>
 <div class="fddocs-container">
     <a class="fd-object-status fd-object-status--link fd-object-status--negative fd-object-status--inverted">
-        <i class="fd-object-status__icon sap-icon--status-negative" role="presentation"></i>
+        <i class="fd-object-status__icon sap-icon--message-error" role="presentation"></i>
         <span class="fd-object-status__text">Inverted Negative</span>
     </a>
     <a class="fd-object-status fd-object-status--link fd-object-status--critical fd-object-status--inverted">
-        <i class="fd-object-status__icon sap-icon--status-critical" role="presentation"></i>
+        <i class="fd-object-status__icon sap-icon--message-warning" role="presentation"></i>
         <span class="fd-object-status__text">Inverted Warning</span>
     </a>
     <a class="fd-object-status fd-object-status--link fd-object-status--positive fd-object-status--inverted">
-        <i class="fd-object-status__icon sap-icon--status-positive" role="presentation"></i>
+        <i class="fd-object-status__icon sap-icon--message-success" role="presentation"></i>
         <span class="fd-object-status__text">Inverted Success</span>
     </a>
     <a class="fd-object-status fd-object-status--link fd-object-status--informative fd-object-status--inverted">
-        <i class="fd-object-status__icon sap-icon--hint" role="presentation"></i>
+        <i class="fd-object-status__icon sap-icon--message-information" role="presentation"></i>
         <span class="fd-object-status__text">Inverted informative</span>
     </a>
     <a class="fd-object-status fd-object-status--link fd-object-status--inverted">
-        <i class="fd-object-status__icon sap-icon--to-be-reviewed" role="presentation"></i>
         <span class="fd-object-status__text">Inverted Neutral</span>
     </a>
 </div>


### PR DESCRIPTION
## Related Issue

BREAKING CHANGE: 
update the semantic icons for Object Status and Object List and remove icon for neutral one

## Description
update the semantic icons for Object Status and Object List and remove icon for neutral one


## Screenshots

### Before:

<img width="488" alt="Screen Shot 2021-01-15 at 12 48 05 PM" src="https://user-images.githubusercontent.com/4380815/104760884-06427f00-5730-11eb-9fda-f9cae3189bda.png">
<img width="446" alt="Screen Shot 2021-01-15 at 12 47 56 PM" src="https://user-images.githubusercontent.com/4380815/104760888-080c4280-5730-11eb-990e-b731a36f8a27.png">
<img width="496" alt="Screen Shot 2021-01-15 at 12 47 52 PM" src="https://user-images.githubusercontent.com/4380815/104760889-08a4d900-5730-11eb-92a3-c588aed0e0a9.png">


### After:

<img width="585" alt="Screen Shot 2021-01-15 at 12 48 36 PM" src="https://user-images.githubusercontent.com/4380815/104760915-10647d80-5730-11eb-9e65-065e2e296448.png">
<img width="511" alt="Screen Shot 2021-01-15 at 12 48 33 PM" src="https://user-images.githubusercontent.com/4380815/104760917-10fd1400-5730-11eb-8e32-22d13e8cab57.png">
<img width="568" alt="Screen Shot 2021-01-15 at 12 48 29 PM" src="https://user-images.githubusercontent.com/4380815/104760919-10fd1400-5730-11eb-9a17-affb4d935360.png">


#### Please check whether the PR fulfills the following requirements

1. Testing
- [x] Updated tests
2. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
