### PR TITLE
docs: update buttons in compact bars

### DIFF
--- a/stories/bar/__snapshots__/bar.stories.storyshot
+++ b/stories/bar/__snapshots__/bar.stories.storyshot
@@ -199,172 +199,360 @@ exports[`Storyshots Components/Bar Cozy 1`] = `
 `;
 
 exports[`Storyshots Components/Bar Default 1`] = `
-<div
-  class="fd-bar"
->
+<section>
   
-    
+
+  <p>
+    <b>
+      Compact bar with compact elements
+    </b>
+  </p>
+  
+
   <div
-    class="fd-bar__left"
+    class="fd-bar"
   >
     
-        
+    
     <div
-      class="fd-bar__element"
+      class="fd-bar__left"
     >
       
-            
-      <button
-        aria-label="button"
-        class="fd-button fd-button--transparent fd-button--compact"
-      >
         
-                
-        <i
-          class="sap-icon--navigation-left-arrow"
-        />
-        
-            
-      </button>
-      
-        
-    </div>
-    
-        
-    <div
-      class="fd-bar__element"
-    >
-      
-            
-      <span
-        aria-label="text"
-      >
-        TEXT
-      </span>
-      
-        
-    </div>
-    
-    
-  </div>
-  
-    
-  <div
-    class="fd-bar__middle"
-  >
-    
-        
-    <div
-      class="fd-bar__element"
-    >
-      
-            
       <div
-        aria-label="Group label"
-        class="fd-segmented-button"
-        role="group"
+        class="fd-bar__element"
       >
         
-                
-        <button
-          aria-label="button"
-          aria-pressed="true"
-          class="fd-button fd-button--compact"
-        >
-          
-                    
-          <i
-            class="sap-icon--email"
-          />
-          
-                
-        </button>
-        
-                
-        <button
-          aria-label="button"
-          class="fd-button fd-button--compact"
-        >
-          
-                    
-          <i
-            class="sap-icon--iphone"
-          />
-          
-                
-        </button>
-        
-                
-        <button
-          aria-label="button"
-          class="fd-button fd-button--compact"
-        >
-          
-                    
-          <i
-            class="sap-icon--notification-2"
-          />
-          
-                
-        </button>
-        
             
+        <button
+          aria-label="button"
+          class="fd-button fd-button--transparent fd-button--compact"
+        >
+          
+                
+          <i
+            class="sap-icon--navigation-left-arrow"
+          />
+          
+            
+        </button>
+        
+        
       </div>
       
         
-    </div>
-    
-    
-  </div>
-  
-    
-  <div
-    class="fd-bar__right"
-  >
-    
-        
-    <div
-      class="fd-bar__element"
-    >
-      
-        
-      <span
-        aria-label="John Doe"
-        class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail"
-        role="presentation"
-        style="background-image: url('/assets/images/avatars/1.svg')"
-      />
-      
-        
-    </div>
-    
-        
-    <div
-      class="fd-bar__element"
-    >
-      
-            
-      <button
-        aria-label="button"
-        class="fd-button fd-button--transparent fd-button--compact"
+      <div
+        class="fd-bar__element"
       >
         
-                
-        <i
-          class="sap-icon--grid"
-        />
-        
             
-      </button>
-      
+        <span
+          aria-label="text"
+        >
+          TEXT
+        </span>
         
+        
+      </div>
+      
+    
     </div>
     
     
+    <div
+      class="fd-bar__middle"
+    >
+      
+        
+      <div
+        class="fd-bar__element"
+      >
+        
+            
+        <div
+          aria-label="Group label"
+          class="fd-segmented-button"
+          role="group"
+        >
+          
+                
+          <button
+            aria-label="button"
+            aria-pressed="true"
+            class="fd-button fd-button--compact"
+          >
+            
+                    
+            <i
+              class="sap-icon--email"
+            />
+            
+                
+          </button>
+          
+                
+          <button
+            aria-label="button"
+            class="fd-button fd-button--compact"
+          >
+            
+                    
+            <i
+              class="sap-icon--iphone"
+            />
+            
+                
+          </button>
+          
+                
+          <button
+            aria-label="button"
+            class="fd-button fd-button--compact"
+          >
+            
+                    
+            <i
+              class="sap-icon--notification-2"
+            />
+            
+                
+          </button>
+          
+            
+        </div>
+        
+        
+      </div>
+      
+    
+    </div>
+    
+    
+    <div
+      class="fd-bar__right"
+    >
+      
+        
+      <div
+        class="fd-bar__element"
+      >
+        
+        
+        <span
+          aria-label="John Doe"
+          class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail"
+          role="presentation"
+          style="background-image: url('/assets/images/avatars/1.svg')"
+        />
+        
+        
+      </div>
+      
+        
+      <div
+        class="fd-bar__element"
+      >
+        
+            
+        <button
+          aria-label="button"
+          class="fd-button fd-button--transparent fd-button--compact"
+        >
+          
+                
+          <i
+            class="sap-icon--grid"
+          />
+          
+            
+        </button>
+        
+        
+      </div>
+      
+    
+    </div>
+    
+
   </div>
   
 
-</div>
+  <p>
+    <b>
+      Compact bar with cozy elements
+    </b>
+  </p>
+  
+
+  <div
+    class="fd-bar"
+  >
+    
+    
+    <div
+      class="fd-bar__left"
+    >
+      
+        
+      <div
+        class="fd-bar__element"
+      >
+        
+            
+        <button
+          aria-label="button"
+          class="fd-button fd-button--transparent"
+        >
+          
+                
+          <i
+            class="sap-icon--navigation-left-arrow"
+          />
+          
+            
+        </button>
+        
+        
+      </div>
+      
+        
+      <div
+        class="fd-bar__element"
+      >
+        
+            
+        <span
+          aria-label="text"
+        >
+          TEXT
+        </span>
+        
+        
+      </div>
+      
+    
+    </div>
+    
+    
+    <div
+      class="fd-bar__middle"
+    >
+      
+        
+      <div
+        class="fd-bar__element"
+      >
+        
+            
+        <div
+          aria-label="Group label"
+          class="fd-segmented-button"
+          role="group"
+        >
+          
+                
+          <button
+            aria-label="button"
+            aria-pressed="true"
+            class="fd-button"
+          >
+            
+                    
+            <i
+              class="sap-icon--email"
+            />
+            
+                
+          </button>
+          
+                
+          <button
+            aria-label="button"
+            class="fd-button"
+          >
+            
+                    
+            <i
+              class="sap-icon--iphone"
+            />
+            
+                
+          </button>
+          
+                
+          <button
+            aria-label="button"
+            class="fd-button"
+          >
+            
+                    
+            <i
+              class="sap-icon--notification-2"
+            />
+            
+                
+          </button>
+          
+            
+        </div>
+        
+        
+      </div>
+      
+    
+    </div>
+    
+    
+    <div
+      class="fd-bar__right"
+    >
+      
+        
+      <div
+        class="fd-bar__element"
+      >
+        
+        
+        <span
+          aria-label="John Doe"
+          class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail"
+          role="presentation"
+          style="background-image: url('/assets/images/avatars/1.svg')"
+        />
+        
+        
+      </div>
+      
+        
+      <div
+        class="fd-bar__element"
+      >
+        
+            
+        <button
+          aria-label="button"
+          class="fd-button fd-button--transparent"
+        >
+          
+                
+          <i
+            class="sap-icon--grid"
+          />
+          
+            
+        </button>
+        
+        
+      </div>
+      
+    
+    </div>
+    
+
+  </div>
+  
+
+</section>
 `;
 
 exports[`Storyshots Components/Bar Floating Footer 1`] = `

--- a/stories/bar/__snapshots__/bar.stories.storyshot
+++ b/stories/bar/__snapshots__/bar.stories.storyshot
@@ -216,7 +216,7 @@ exports[`Storyshots Components/Bar Default 1`] = `
             
       <button
         aria-label="button"
-        class="fd-button fd-button--transparent"
+        class="fd-button fd-button--transparent fd-button--compact"
       >
         
                 
@@ -346,7 +346,7 @@ exports[`Storyshots Components/Bar Default 1`] = `
             
       <button
         aria-label="button"
-        class="fd-button fd-button--transparent"
+        class="fd-button fd-button--transparent fd-button--compact"
       >
         
                 
@@ -607,7 +607,7 @@ exports[`Storyshots Components/Bar Footer 1`] = `
             
         <button
           aria-label="button"
-          class="fd-button fd-button--emphasized"
+          class="fd-button fd-button--emphasized fd-button--compact"
         >
           Save
         </button>
@@ -623,7 +623,7 @@ exports[`Storyshots Components/Bar Footer 1`] = `
             
         <button
           aria-label="button"
-          class="fd-button fd-button--transparent"
+          class="fd-button fd-button--transparent fd-button--compact"
         >
           Cancel
         </button>
@@ -672,7 +672,7 @@ exports[`Storyshots Components/Bar Header 1`] = `
             
         <button
           aria-label="button"
-          class="fd-button fd-button--transparent"
+          class="fd-button fd-button--transparent fd-button--compact"
         >
           
                 
@@ -694,7 +694,7 @@ exports[`Storyshots Components/Bar Header 1`] = `
             
         <button
           aria-label="button"
-          class="fd-button fd-button--transparent"
+          class="fd-button fd-button--transparent fd-button--compact"
         >
           
                 
@@ -716,7 +716,7 @@ exports[`Storyshots Components/Bar Header 1`] = `
             
         <button
           aria-label="button"
-          class="fd-button fd-button--transparent"
+          class="fd-button fd-button--transparent fd-button--compact"
         >
           
                 
@@ -834,7 +834,7 @@ exports[`Storyshots Components/Bar Header 1`] = `
             
       <button
         aria-label="button"
-        class="fd-button fd-button--transparent"
+        class="fd-button fd-button--transparent fd-button--compact"
       >
         
                 
@@ -1099,7 +1099,7 @@ exports[`Storyshots Components/Bar Header With Subheader 1`] = `
             
         <button
           aria-label="button"
-          class="fd-button fd-button--transparent"
+          class="fd-button fd-button--transparent fd-button--compact"
         >
           
                 
@@ -1121,7 +1121,7 @@ exports[`Storyshots Components/Bar Header With Subheader 1`] = `
             
         <button
           aria-label="button"
-          class="fd-button fd-button--transparent"
+          class="fd-button fd-button--transparent fd-button--compact"
         >
           
                 
@@ -1143,7 +1143,7 @@ exports[`Storyshots Components/Bar Header With Subheader 1`] = `
             
         <button
           aria-label="button"
-          class="fd-button fd-button--transparent"
+          class="fd-button fd-button--transparent fd-button--compact"
         >
           
                 
@@ -1261,7 +1261,7 @@ exports[`Storyshots Components/Bar Header With Subheader 1`] = `
             
       <button
         aria-label="button"
-        class="fd-button fd-button--transparent"
+        class="fd-button fd-button--transparent fd-button--compact"
       >
         
                 
@@ -1482,7 +1482,7 @@ exports[`Storyshots Components/Bar Subheader 1`] = `
             <button
               aria-label="button"
               aria-pressed="true"
-              class="fd-button fd-button--compact"
+              class="fd-button"
             >
               
                         
@@ -1496,7 +1496,7 @@ exports[`Storyshots Components/Bar Subheader 1`] = `
                     
             <button
               aria-label="button"
-              class="fd-button fd-button--compact"
+              class="fd-button"
             >
               
                         
@@ -1510,7 +1510,7 @@ exports[`Storyshots Components/Bar Subheader 1`] = `
                     
             <button
               aria-label="button"
-              class="fd-button fd-button--compact"
+              class="fd-button"
             >
               
                         

--- a/stories/bar/bar.stories.js
+++ b/stories/bar/bar.stories.js
@@ -39,7 +39,9 @@ export default {
     }
 };
 
-export const Default = () => `<div class="fd-bar">
+export const Default = () => `
+<p><b>Compact bar with compact elements</b></p>
+<div class="fd-bar">
     <div class="fd-bar__left">
         <div class="fd-bar__element">
             <button aria-label="button" class="fd-button fd-button--transparent fd-button--compact">
@@ -79,12 +81,54 @@ export const Default = () => `<div class="fd-bar">
         </div>
     </div>
 </div>
+<p><b>Compact bar with cozy elements</b></p>
+<div class="fd-bar">
+    <div class="fd-bar__left">
+        <div class="fd-bar__element">
+            <button aria-label="button" class="fd-button fd-button--transparent">
+                <i class="sap-icon--navigation-left-arrow"></i>
+            </button>
+        </div>
+        <div class="fd-bar__element">
+            <span aria-label="text">TEXT</span>
+        </div>
+    </div>
+    <div class="fd-bar__middle">
+        <div class="fd-bar__element">
+            <div class="fd-segmented-button" role="group" aria-label="Group label">
+                <button aria-label="button" class="fd-button" aria-pressed="true">
+                    <i class="sap-icon--email"></i>
+                </button>
+                <button aria-label="button" class="fd-button">
+                    <i class="sap-icon--iphone"></i>
+                </button>
+                <button aria-label="button" class="fd-button">
+                    <i class="sap-icon--notification-2"></i>
+                </button>
+            </div>
+        </div>
+    </div>
+    <div class="fd-bar__right">
+        <div class="fd-bar__element">
+        <span
+            class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail"
+            style="background-image: url('/assets/images/avatars/1.svg')"
+            role="presentation" aria-label="John Doe"></span>
+        </div>
+        <div class="fd-bar__element">
+            <button aria-label="button" class="fd-button fd-button--transparent">
+                <i class="sap-icon--grid"></i>
+            </button>
+        </div>
+    </div>
+</div>
 `;
 
 Default.parameters = {
     docs: {
         iframeHeight: 200,
-        storyDescription: 'The default bar contains a back button, page title, segmented button and product switch button. It can be displayed by using the <code class="docs-code">fd-bar</code> class, and is responsive to desktop screen sizes.'
+        storyDescription: `
+The default bar contains a back button, page title, segmented button and product switch button. It can be displayed by using the <code class="docs-code">fd-bar</code> class, and is responsive to desktop screen sizes. The default bar is in compact mode. Fiori 3 doesn't forbid including cozy elements inside (e.g. cozy buttons)`
     }
 };
 

--- a/stories/bar/bar.stories.js
+++ b/stories/bar/bar.stories.js
@@ -127,8 +127,7 @@ export const Default = () => `
 Default.parameters = {
     docs: {
         iframeHeight: 200,
-        storyDescription: `
-The default bar contains a back button, page title, segmented button and product switch button. It can be displayed by using the <code class="docs-code">fd-bar</code> class, and is responsive to desktop screen sizes. The default bar is in compact mode. Fiori 3 doesn't forbid including cozy elements inside (e.g. cozy buttons)`
+        storyDescription: 'The default bar contains a back button, page title, segmented button and product switch button. It can be displayed by using the <code class="docs-code">fd-bar</code> class, and is responsive to desktop screen sizes. The default bar is in compact mode. Fiori 3 doesn\'t forbid including cozy elements inside (e.g. cozy buttons)'
     }
 };
 

--- a/stories/bar/bar.stories.js
+++ b/stories/bar/bar.stories.js
@@ -42,7 +42,7 @@ export default {
 export const Default = () => `<div class="fd-bar">
     <div class="fd-bar__left">
         <div class="fd-bar__element">
-            <button aria-label="button" class="fd-button fd-button--transparent">
+            <button aria-label="button" class="fd-button fd-button--transparent fd-button--compact">
                 <i class="sap-icon--navigation-left-arrow"></i>
             </button>
         </div>
@@ -73,7 +73,7 @@ export const Default = () => `<div class="fd-bar">
             role="presentation" aria-label="John Doe"></span>
         </div>
         <div class="fd-bar__element">
-            <button aria-label="button" class="fd-button fd-button--transparent">
+            <button aria-label="button" class="fd-button fd-button--transparent fd-button--compact">
                 <i class="sap-icon--grid"></i>
             </button>
         </div>
@@ -151,17 +151,17 @@ export const Header = () => `
 <div class="fd-bar fd-bar--header">
     <div class="fd-bar__left">
         <div class="fd-bar__element">
-            <button aria-label="button" class="fd-button fd-button--transparent">
+            <button aria-label="button" class="fd-button fd-button--transparent fd-button--compact">
                 <i class="sap-icon--navigation-left-arrow"></i>
             </button>
         </div>
         <div class="fd-bar__element">
-            <button aria-label="button" class="fd-button fd-button--transparent">
+            <button aria-label="button" class="fd-button fd-button--transparent fd-button--compact">
                 <i class="sap-icon--home"></i>
             </button>
         </div>
         <div class="fd-bar__element">
-            <button aria-label="button" class="fd-button fd-button--transparent">
+            <button aria-label="button" class="fd-button fd-button--transparent fd-button--compact">
                 <i class="sap-icon--account"></i>
             </button>
         </div>
@@ -190,7 +190,7 @@ export const Header = () => `
             </div>
         </div>
         <div class="fd-bar__element">
-            <button aria-label="button" class="fd-button fd-button--transparent">
+            <button aria-label="button" class="fd-button fd-button--transparent fd-button--compact">
                 <i class="sap-icon--grid"></i>
             </button>
         </div>
@@ -296,13 +296,13 @@ export const Subheader = () => `
         <div class="fd-bar__element">
             <div class="fd-form-item">
                 <div class="fd-segmented-button" role="group" aria-label="Group label">
-                    <button aria-label="button" class="fd-button fd-button--compact" aria-pressed="true">
+                    <button aria-label="button" class="fd-button" aria-pressed="true">
                         <i class="sap-icon--email"></i>
                     </button>
-                    <button aria-label="button" class="fd-button fd-button--compact">
+                    <button aria-label="button" class="fd-button">
                         <i class="sap-icon--iphone"></i>
                     </button>
-                    <button aria-label="button" class="fd-button fd-button--compact">
+                    <button aria-label="button" class="fd-button">
                         <i class="sap-icon--notification-2"></i>
                     </button>
                 </div>
@@ -336,17 +336,17 @@ export const HeaderWithSubheader = () => `
 <div class="fd-bar fd-bar--header-with-subheader">
     <div class="fd-bar__left">
         <div class="fd-bar__element">
-            <button aria-label="button" class="fd-button fd-button--transparent">
+            <button aria-label="button" class="fd-button fd-button--transparent fd-button--compact">
                 <i class="sap-icon--navigation-left-arrow"></i>
             </button>
         </div>
         <div class="fd-bar__element">
-            <button aria-label="button" class="fd-button fd-button--transparent">
+            <button aria-label="button" class="fd-button fd-button--transparent fd-button--compact">
                 <i class="sap-icon--home"></i>
             </button>
         </div>
         <div class="fd-bar__element">
-            <button aria-label="button" class="fd-button fd-button--transparent">
+            <button aria-label="button" class="fd-button fd-button--transparent fd-button--compact">
                 <i class="sap-icon--account"></i>
             </button>
         </div>
@@ -375,7 +375,7 @@ export const HeaderWithSubheader = () => `
         </div>
         </div>
         <div class="fd-bar__element">
-            <button aria-label="button" class="fd-button fd-button--transparent">
+            <button aria-label="button" class="fd-button fd-button--transparent fd-button--compact">
                 <i class="sap-icon--grid"></i>
             </button>
         </div>
@@ -416,10 +416,10 @@ export const Footer = () => `
 <div class="fd-bar fd-bar--footer fd-bar--cozy">
     <div class="fd-bar__right">
         <div class="fd-bar__element">
-            <button aria-label="button" class="fd-button fd-button--emphasized">Save</button>
+            <button aria-label="button" class="fd-button fd-button--emphasized fd-button--compact">Save</button>
         </div>
         <div class="fd-bar__element">
-            <button aria-label="button" class="fd-button fd-button--transparent">Cancel</button>
+            <button aria-label="button" class="fd-button fd-button--transparent fd-button--compact">Cancel</button>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Related Issue
fixes: #2030

## Description
use compact buttons in compact bars

## Screenshots


### Before:

<img width="1373" alt="Screen Shot 2021-01-17 at 6 56 16 PM" src="https://user-images.githubusercontent.com/4380815/104859820-d93fc900-58f5-11eb-9075-5f132c082330.png">


### After:

<img width="1379" alt="Screen Shot 2021-01-17 at 6 57 13 PM" src="https://user-images.githubusercontent.com/4380815/104859824-de047d00-58f5-11eb-9d58-dc591c46717a.png">


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] Includes Compact/Cosy/Tablet design
2. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Updated tests
3. Documentation
- [x] Storybook documentation has been created/updated
