### PR TITLE
feat: list interractive states

### DIFF
--- a/src/_listBase.scss
+++ b/src/_listBase.scss
@@ -38,6 +38,10 @@
       }
     }
 
+    &--interractive {
+      @include list-item-states();
+    }
+
     &--action {
       padding: 0;
       text-align: center;
@@ -63,12 +67,7 @@
         border: var(--fdList_Item_Action_Button_Border);
         border-radius: var(--fdList_Item_Action_Button_Border_Radius);
 
-        @include fd-focus() {
-          outline-style: dotted;
-          outline-width: var(--sapContent_FocusWidth);
-          outline-color: var(--sapContent_FocusColor);
-          outline-offset: -0.125rem;
-
+        @include fd-fiori-focus(-0.125rem) {
           @include fd-active() {
             outline-color: var(--sapContent_ContrastFocusColor);
           }
@@ -78,6 +77,10 @@
           border: 0;
         }
       }
+    }
+
+    @include fd-selected() {
+      @include list-item-selected-state();
     }
   }
 

--- a/src/_listDefinitions.scss
+++ b/src/_listDefinitions.scss
@@ -50,6 +50,27 @@ $semantic-color: (
   "informative": ("color": var(--sapInformativeTextColor))
 );
 
+@mixin list-part-elements() {
+  .#{$block}__title,
+  .#{$block}__secondary,
+  .#{$block}__icon,
+  .#{$block}__content,
+  .#{$block}__byline,
+  .#{$block}__byline-left,
+  .#{$block}__byline-right,
+  .#{$block}__thumbnail,
+  &.#{$block}__link--navigation-indicator::after,
+  & {
+    @content;
+  }
+
+  @each $set-name, $color-set in $semantic-color {
+    .#{$block}__byline-right--#{$set-name} {
+      @content;
+    }
+  }
+}
+
 @mixin fake-list-outline() {
   &:focus,
   &.is-focus {
@@ -107,23 +128,8 @@ $semantic-color: (
       }
     }
 
-    .#{$block}__title,
-    .#{$block}__secondary,
-    .#{$block}__icon,
-    .#{$block}__content,
-    .#{$block}__byline,
-    .#{$block}__byline-left,
-    .#{$block}__byline-right,
-    .#{$block}__thumbnail,
-    &.#{$block}__link--navigation-indicator::after,
-    & {
+    @include list-part-elements() {
       color: var(--sapList_Active_TextColor);
-    }
-
-    @each $set-name, $color-set in $semantic-color {
-      .#{$block}__byline-right--#{$set-name} {
-        color: var(--sapList_Active_TextColor);
-      }
     }
   }
 }

--- a/stories/list/byline/__snapshots__/byline-list.stories.storyshot
+++ b/stories/list/byline/__snapshots__/byline-list.stories.storyshot
@@ -563,6 +563,11 @@ exports[`Storyshots Components/List/Byline Default 1`] = `
 </section>
 `;
 
+exports[`Storyshots Components/List/Byline Interractive 1`] = `
+
+
+`;
+
 exports[`Storyshots Components/List/Byline Navigation 1`] = `
 <ul
   class="fd-list fd-list--byline fd-list--navigation"

--- a/stories/list/byline/byline-list.stories.js
+++ b/stories/list/byline/byline-list.stories.js
@@ -188,6 +188,33 @@ buttons.parameters = {
     }
 };
 
+export const interractive = () => `
+<ul class="fd-list fd-list--byline" role="list">
+    <li role="listitem" tabindex="-1" class="fd-list__item fd-list__item--interractive">
+        <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
+        <div class="fd-list__content">
+          <div class="fd-list__title">Title</div>
+          <div class="fd-list__byline">Byline</div>
+        </div>
+    </li>
+    <li role="listitem" tabindex="-1" class="fd-list__item fd-list__item--interractive is-selected">
+        <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--employee"></i></span>
+        <div class="fd-list__content">
+          <div class="fd-list__title">Selected List</div>
+          <div class="fd-list__byline">Byline</div>
+        </div>
+    </li>
+</ul>
+`;
+
+interractive.parameters = {
+    docs: {
+        iframeHeight: 300,
+        storyDescription: `The \`fd-list__item--interractive\` will force list item to handle hover and active states. 
+            Usage of this modifier is not needed on \`Selection\`, \`Navigation\` and \`Action\` modes.`
+    }
+};
+
 export const navigationIndicator = () => `<ul class="fd-list fd-list--byline fd-list--navigation fd-list--navigation-indication" role="list">
 <li role="listitem" tabindex="-1" class="fd-list__item fd-list__item--link">
   <a tabindex="0" class="fd-list__link fd-list__link--navigation-indicator" href="#"> 

--- a/stories/list/standard/__snapshots__/standard-list.stories.storyshot
+++ b/stories/list/standard/__snapshots__/standard-list.stories.storyshot
@@ -895,6 +895,108 @@ exports[`Storyshots Components/List/Standard Icon 1`] = `
 </ul>
 `;
 
+exports[`Storyshots Components/List/Standard Interractive 1`] = `
+<section>
+  <h4>
+    Interractive Items
+  </h4>
+  
+
+  <ul
+    class="fd-list"
+    role="list"
+  >
+    
+  
+    <li
+      class="fd-list__item fd-list__item--interractive"
+      role="listitem"
+      tabindex="0"
+    >
+      
+      
+      <span
+        class="fd-list__title"
+      >
+        List item 1
+      </span>
+      
+  
+    </li>
+    
+  
+    <li
+      class="fd-list__item fd-list__item--interractive"
+      role="listitem"
+      tabindex="0"
+    >
+      
+      
+      <span
+        class="fd-list__title"
+      >
+        List item 2
+      </span>
+      
+  
+    </li>
+    
+  
+    <li
+      class="fd-list__item fd-list__item--interractive"
+      role="listitem"
+      tabindex="0"
+    >
+      
+      
+      <span
+        class="fd-list__title"
+      >
+        List item 3
+      </span>
+      
+  
+    </li>
+    
+  
+    <li
+      class="fd-list__item fd-list__item--interractive"
+      role="listitem"
+      tabindex="0"
+    >
+      
+      
+      <span
+        class="fd-list__title"
+      >
+        List item 4
+      </span>
+      
+  
+    </li>
+    
+  
+    <li
+      class="fd-list__item fd-list__item--interractive is-selected"
+      role="listitem"
+      tabindex="0"
+    >
+      
+      
+      <span
+        class="fd-list__title"
+      >
+        List item 5 - with .is-selected
+      </span>
+      
+  
+    </li>
+    
+
+  </ul>
+</section>
+`;
+
 exports[`Storyshots Components/List/Standard Item Counter 1`] = `
 <ul
   class="fd-list"

--- a/stories/list/standard/standard-list.stories.js
+++ b/stories/list/standard/standard-list.stories.js
@@ -93,6 +93,37 @@ unread.parameters = {
     }
 };
 
+export const interractive = () => `<h4>Interractive Items</h4>
+<ul class="fd-list" role="list">
+  <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
+      <span class="fd-list__title">List item 1</span>
+  </li>
+  <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
+      <span class="fd-list__title">List item 2</span>
+  </li>
+  <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
+      <span class="fd-list__title">List item 3</span>
+  </li>
+  <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
+      <span class="fd-list__title">List item 4</span>
+  </li>
+  <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive is-selected">
+      <span class="fd-list__title">List item 5 - with .is-selected</span>
+  </li>
+`;
+
+interractive.storyName = 'Interractive';
+
+interractive.parameters = {
+    docs: {
+        iframeHeight: 445,
+        storyDescription: `
+            The \`fd-list__item--interractive\` will force list item to handle hover and active states. 
+            Usage of this modifier is not needed on \`Selection\`, \`Navigation\` and \`Action\` modes.
+        `
+    }
+};
+
 export const navigation = () => `<ul class="fd-list fd-list--navigation" role="list">
   <li tabindex="-1" role="listitem" class="fd-list__item fd-list__item--link">
       <a tabindex="0" class="fd-list__link">


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-styles/issues/2063

## Description
There is added: 
- `fd-list__item--interractive` modifier for interractive (hover/active) states for list item
- `is-selected` is now supported by basic `fd-list__item`

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
