### PR TITLE
fix: Quick View title gaps

### DIFF
--- a/src/quick-view.scss
+++ b/src/quick-view.scss
@@ -29,24 +29,24 @@ $fd-quick-view-group-item-indent: 0.75rem;
     @include fd-reset();
 
     padding: 1rem;
-  }
 
-  .#{$fd-namespace}-bar {
-    padding: 0;
+    .#{$fd-namespace}-bar {
+      padding: 0;
 
-    &--header-with-subheader {
-      height: auto;
-      padding-bottom: $fd-quick-view-group-item-indent;
+      &--header-with-subheader {
+        height: auto;
+        padding-bottom: $fd-quick-view-group-item-indent;
 
-      .#{$fd-namespace}-avatar {
-        margin-right: $fd-quick-view-avatar-indent;
-      }
+        .#{$fd-namespace}-avatar {
+          margin-right: $fd-quick-view-avatar-indent;
+        }
 
-      .#{$fd-namespace}-bar {
-        &__left,
-        &__middle,
-        &__right {
-          align-items: flex-start;
+        .#{$fd-namespace}-bar {
+          &__left,
+          &__middle,
+          &__right {
+            align-items: flex-start;
+          }
         }
       }
     }

--- a/stories/quick-view/__snapshots__/quick-view.stories.storyshot
+++ b/stories/quick-view/__snapshots__/quick-view.stories.storyshot
@@ -281,7 +281,7 @@ exports[`Storyshots Components/Quick View Popover 1`] = `
         
                 
         <div
-          class="fd-bar__middle"
+          class="fd-bar__left"
         >
           
                     

--- a/stories/quick-view/quick-view.stories.js
+++ b/stories/quick-view/quick-view.stories.js
@@ -13,7 +13,7 @@ export const Popover = () => `<div class="fd-popover">
     <div class="fd-popover__body" aria-hidden="false" id="popoverA1">
         <div class="fd-quick-view">
             <div class="fd-bar fd-bar--header">
-                <div class="fd-bar__middle">
+                <div class="fd-bar__left">
                     <div class="fd-bar__element">Company</div>
                 </div>
             </div>


### PR DESCRIPTION
## Related Issue
Related to https://github.com/SAP/fundamental-ngx/issues/4400

## Description
If you use `fd-bar__left` or `fd-bar__right` instead of `fd-bar__middle` inside `fd-bar--header` your popover header (quick view title as well) will have no gaps.

## Screenshots
### Before:
![image](https://user-images.githubusercontent.com/14160094/105181542-9a4b8680-5b34-11eb-8c89-5bfbd978ec11.png)

### After:
![image](https://user-images.githubusercontent.com/14160094/105181555-9fa8d100-5b34-11eb-9d36-21009c60f3cc.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [n/a] hover state of the element follow design spec
- [n/a] focus state of the element follow design spec
- [n/a] active state of the element follow design spec
- [n/a] selected state of the element follow design spec
- [n/a] selected hover state of the element follow design spec
- [n/a] pressed state of the element follow design spec
- [n/a] Responsiveness rules - the component has modifier classes for all breakpoints
- [n/a] Includes Compact/Cosy/Tablet design
- [n/a] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
4. Documentation
- [x] Storybook documentation has been created/updated
- [n/a] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
