### PR TITLE
feat: introduce expand example for the Text component

### DIFF
--- a/src/text.scss
+++ b/src/text.scss
@@ -24,4 +24,11 @@ $block: #{$fd-namespace}-text;
   &--hyphenation {
     hyphens: auto;
   }
+
+  &__link {
+    &--more {
+      text-transform: uppercase;
+      cursor: pointer;
+    }
+  }
 }

--- a/stories/text/__snapshots__/text.stories.storyshot
+++ b/stories/text/__snapshots__/text.stories.storyshot
@@ -13,6 +13,66 @@ exports[`Storyshots Components/Text Default 1`] = `
 </p>
 `;
 
+exports[`Storyshots Components/Text Expand 1`] = `
+<section>
+  
+    
+  <h3>
+    Show More
+  </h3>
+  
+    
+  <p
+    class="fd-text"
+  >
+    
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+    magna aliqua. Malesuada bibendum arcu vitae elementum. Ut etiam sit amet nisl. Laoreet suspendisse interdum
+    consectetur libero id faucibus nisl. Tellus in metus vulputate eu scelerisque felis imperdiet proin fermentum.
+    Ullamcorper morbi tincidunt ornare massa eget egestas purus viverra accumsan. Mauris vitae ultricies...
+  </p>
+  
+    
+  <a
+    class="fd-link fd-text__link--more"
+    tabindex="0"
+  >
+    More
+  </a>
+  
+
+    
+  <h3>
+    Show Less
+  </h3>
+  
+    
+  <p
+    class="fd-text"
+  >
+    
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+    eiusmod tempor incididunt ut labore et dolore magna aliqua. Malesuada bibendum arcu vitae elementum. Ut etiam sit
+    amet nisl. Laoreet suspendisse interdum consectetur libero id faucibus nisl. Tellus in metus vulputate eu
+    scelerisque felis imperdiet proin fermentum. Ullamcorper morbi tincidunt ornare massa eget egestas purus viverra
+    accumsan. Mauris vitae ultricies leo integer malesuada nunc vel risus. Nisi est sit amet facilisis. Eu turpis
+    egestas pretium aenean. Nunc id cursus metus aliquam eleifend. Placerat in egestas erat imperdiet. Etiam dignissim
+    diam quis enim lobortis scelerisque. A erat nam at lectus. Amet nisl purus in mollis nunc sed id. Purus semper eget
+    duis at tellus at urna.
+  </p>
+  
+    
+  <a
+    class="fd-link fd-text__link--more"
+    tabindex="0"
+  >
+    Less
+  </a>
+  
+
+</section>
+`;
+
 exports[`Storyshots Components/Text Hyphenation 1`] = `
 <div
   class="example-container"

--- a/stories/text/text.stories.js
+++ b/stories/text/text.stories.js
@@ -4,7 +4,7 @@ export default {
         description: `The text component displays text inside a form, table, or any other content area.
         It is generally used throughout the entire application and is responsive to all screen sizes.`,
         tags: ['f3', 'a11y', 'theme'],
-        components: ['text']
+        components: ['text', 'link']
     }
 };
 
@@ -122,6 +122,37 @@ three lines of text.
 **Note**: The property <code class="docs-code">-webkit-line-clamp</code> doesn't work in IE11 and should be changed
 to <code class="docs-code">height</code>. For example, <code class="docs-code">style="height: 200px;"</code>.
 `
+    }
+};
+
+export const expand = () => `
+    <h3>Show More</h3>
+    <p class="fd-text">
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+    magna aliqua. Malesuada bibendum arcu vitae elementum. Ut etiam sit amet nisl. Laoreet suspendisse interdum
+    consectetur libero id faucibus nisl. Tellus in metus vulputate eu scelerisque felis imperdiet proin fermentum.
+    Ullamcorper morbi tincidunt ornare massa eget egestas purus viverra accumsan. Mauris vitae ultricies...</p>
+    <a class="fd-link fd-text__link--more" tabindex="0">More</a>
+
+    <h3>Show Less</h3>
+    <p class="fd-text">
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+    eiusmod tempor incididunt ut labore et dolore magna aliqua. Malesuada bibendum arcu vitae elementum. Ut etiam sit
+    amet nisl. Laoreet suspendisse interdum consectetur libero id faucibus nisl. Tellus in metus vulputate eu
+    scelerisque felis imperdiet proin fermentum. Ullamcorper morbi tincidunt ornare massa eget egestas purus viverra
+    accumsan. Mauris vitae ultricies leo integer malesuada nunc vel risus. Nisi est sit amet facilisis. Eu turpis
+    egestas pretium aenean. Nunc id cursus metus aliquam eleifend. Placerat in egestas erat imperdiet. Etiam dignissim
+    diam quis enim lobortis scelerisque. A erat nam at lectus. Amet nisl purus in mollis nunc sed id. Purus semper eget
+    duis at tellus at urna.</p>
+    <a class="fd-link fd-text__link--more" tabindex="0">Less</a>
+`;
+
+expand.storyName = 'Expand';
+expand.parameters = {
+    docs: {
+        iframeHeight: 200,
+        storyDescription: `Along with max lines, text component can display "MORE" and "LESS" links that can show
+more or less of the text.`
     }
 };
 


### PR DESCRIPTION
## Description
After Core: Text [spec](https://app.gitbook.com/@fundamental-ngx/s/docs/core-text) review
it was decided to add expand option, "MORE" and "LESS" links to show more and less of the text.
The new example was based on similar functionality in [feed-list-items](https://sap.github.io/fundamental-ngx/#/core/feed-list-item#feed-list-item-simple)


## Screenshots
#### Feed list items example
![feed-list-items-example](https://user-images.githubusercontent.com/3996023/105771441-3af0da80-5f69-11eb-9ad8-c394df806650.png)

#### Text expand example
![text-expand-example](https://user-images.githubusercontent.com/3996023/105771483-4a702380-5f69-11eb-95cc-e36e35a8f18e.png)


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated