### PR TITLE
fix: added color accents to Overflow Button in Avatar Group

### DIFF
--- a/src/avatar-group.scss
+++ b/src/avatar-group.scss
@@ -32,6 +32,18 @@ $block: #{$fd-namespace}-avatar-group;
     "xl": ("ratio": ($fd-const-ratio * 7), "font-size": 3rem)
   );
   $fd-focus-outline-offset: 0.0625rem;
+  $fd-avatar-group-more-button-accent-colors: (
+    "1": ("background-color": var(--sapAccentColor1)),
+    "2": ("background-color": var(--sapAccentColor2)),
+    "3": ("background-color": var(--sapAccentColor3)),
+    "4": ("background-color": var(--sapAccentColor4)),
+    "5": ("background-color": var(--sapAccentColor5)),
+    "6": ("background-color": var(--sapAccentColor6)),
+    "7": ("background-color": var(--sapAccentColor7)),
+    "8": ("background-color": var(--sapAccentColor8)),
+    "9": ("background-color": var(--sapAccentColor9)),
+    "10": ("background-color": var(--sapAccentColor10))
+  );
 
   @include fd-reset();
 
@@ -100,6 +112,13 @@ $block: #{$fd-namespace}-avatar-group;
           }
         }
       }
+    }
+  }
+
+  @each $accent-name, $color-set in $fd-avatar-group-more-button-accent-colors {
+    .#{$block}__more-button--accent-color-#{$accent-name} {
+      background-color: map_get($color-set, "background-color");
+      color: var(--fdAvatar_Accent_Color);
     }
   }
 }

--- a/stories/avatar-group/__snapshots__/avatar-group.stories.storyshot
+++ b/stories/avatar-group/__snapshots__/avatar-group.stories.storyshot
@@ -134,7 +134,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
         
             
       <button
-        class="fd-button fd-avatar-group__more-button fd-avatar-group__more-button--m"
+        class="fd-button fd-avatar-group__more-button fd-avatar-group__more-button--m fd-avatar-group__more-button--accent-color-6"
         role="button"
         tabindex="-1"
       >

--- a/stories/avatar-group/avatar-group.stories.js
+++ b/stories/avatar-group/avatar-group.stories.js
@@ -37,6 +37,10 @@ Do not use the **AvatarGroup** if:
 - You want to display a gallery for simple images.
 - You want to use it for other visual content than avatars.
 
+##Overflow Button
+
+To change the background color of the button, add the <code>fd-avatar-group\\_\\_more-button--accent-color-*</code> class with the number indicating the desired color. The color options include numbers ranging from 1 to 10, for example: <code>fd-avatar-group\\_\\_more-button--accent-color-1</code>
+
 `,
         docs: { iframeHeight: 250 },
         tags: ['a11y', 'f3', 'theme'],
@@ -284,7 +288,7 @@ export const individualType = () => `<div class="fd-avatar-group fd-avatar-group
 individualType.parameters = {
     docs: {
         iframeHeight: 250,
-        storyDescription: ''
+        storyDescription: 'To use Individual type of Avatar Group use the <code>--individual-type</code> modifier class <i>(<code>fd-avatar-group--individual-type</code> class)<i>.'
     }
 };
 
@@ -322,7 +326,7 @@ export const groupType = () => `<div class="fd-popover">
                 <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/2.svg')" role="presentation" aria-label="John Doe"></span>
             </div>
         
-            <button class="fd-button fd-avatar-group__more-button fd-avatar-group__more-button--m" role="button" tabindex="-1">
+            <button class="fd-button fd-avatar-group__more-button fd-avatar-group__more-button--m fd-avatar-group__more-button--accent-color-6" role="button" tabindex="-1">
                 <bdi class="fd-button__text fd-avatar-group__button-text">+8</bdi>
             </button>
         </div>
@@ -429,7 +433,7 @@ export const groupType = () => `<div class="fd-popover">
 groupType.parameters = {
     docs: {
         iframeHeight: 250,
-        storyDescription: ''
+        storyDescription: 'To use Group type of Avatar Group use the <code>--group-type</code> modifier class <i>(<code>fd-avatar-group--group-type</code> class)<i>.'
     }
 };
 


### PR DESCRIPTION
## Related Issue
Related to https://github.com/SAP/fundamental-styles/issues/2023

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [n/a] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing 
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
- [n/a] tested Storybook examples with "CSS Resources" `normalize` option 
- [n/a] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
4. Documentation
- [x] Storybook documentation has been created/updated
- [n/a] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
