### PR TITLE
fix: add fix for Table text shadow and focus color

### DIFF
--- a/src/_listDefinitions.scss
+++ b/src/_listDefinitions.scss
@@ -118,6 +118,7 @@ $semantic-color: (
     &.#{$block}__link--navigation-indicator::after,
     & {
       color: var(--sapList_Active_TextColor);
+      text-shadow: none;
     }
 
     @each $set-name, $color-set in $semantic-color {

--- a/src/table.scss
+++ b/src/table.scss
@@ -15,9 +15,11 @@ $block: #{$fd-namespace}-table;
   @mixin fd-table-active() {
     background-color: var(--sapList_Active_Background);
     color: var(--sapList_Active_TextColor);
+    text-shadow: none;
 
     .#{$block}__cell {
       border-bottom-color: var(--sapList_SelectionBorderColor);
+      text-shadow: none;
 
       @include fd-hover() {
         background-color: var(--sapList_Active_Background);
@@ -42,6 +44,12 @@ $block: #{$fd-namespace}-table;
 
     @include fd-active() {
       @include fd-table-active();
+
+      &--focusable {
+        @include fd-fiori-focus() {
+          outline-color: var(--sapContent_ContrastFocusColor);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/2085

## Description
This PR removes text-shadow, when cell/row is activated.
And changes focus color to contrast, when row/cell is active


### Before:


### After:

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
3. Testing
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
- [x] Verified all styles in IE11
