### PR TITLE
fix: positioning of overflowed shellbar notification counter

### DIFF
--- a/src/shellbar.scss
+++ b/src/shellbar.scss
@@ -162,6 +162,12 @@ $block: #{$fd-namespace}-shellbar;
       vertical-align: middle;
     }
 
+    .#{$block}__counter--overflowed {
+      position: absolute;
+      right: (-$fd-shellbar-counter-notification-offset);
+      top: $fd-shellbar-counter-notification-offset;
+    }
+
     .#{$block}__counter--notification {
       max-width: 2.5rem;
       text-overflow: ellipsis;

--- a/stories/shellbar/__snapshots__/shellbar.stories.storyshot
+++ b/stories/shellbar/__snapshots__/shellbar.stories.storyshot
@@ -2625,6 +2625,13 @@ exports[`Storyshots Components/Shellbar Small 1`] = `
                         Notifications Out
                       </span>
                       
+                                                
+                      <span
+                        class="fd-counter fd-shellbar__counter--overflowed"
+                      >
+                        21
+                      </span>
+                      
                                             
                     </a>
                     
@@ -2647,6 +2654,13 @@ exports[`Storyshots Components/Shellbar Small 1`] = `
                         class="fd-menu__title"
                       >
                         Pool
+                      </span>
+                      
+                                                
+                      <span
+                        class="fd-counter fd-shellbar__counter--overflowed"
+                      >
+                        4
                       </span>
                       
                                             

--- a/stories/shellbar/shellbar.stories.js
+++ b/stories/shellbar/shellbar.stories.js
@@ -468,11 +468,13 @@ export const linksWithCollapsibleMenuSSize = () => `<div style="height:300px; ma
                                         <li class="fd-menu__item">
                                             <a role="button" class="fd-menu__link">
                                                 <span class="fd-menu__title">Notifications Out</span>
+                                                <span class="fd-counter fd-shellbar__counter--overflowed">21</span>
                                             </a>
                                         </li>
                                         <li class="fd-menu__item">
                                             <a role="button" class="fd-menu__link">
                                                 <span class="fd-menu__title">Pool</span>
+                                                <span class="fd-counter fd-shellbar__counter--overflowed">4</span>
                                             </a>
                                         </li>
                                     </ul>


### PR DESCRIPTION
part of #2089 

The shellbar notifications, when moved into the overflow menu on small screens, were not positioned correctly.  This was not known in the styles library because we had only seen it in ngx thus far.  This PR fixes the positioning and adds an example

Before:
![Screen Shot 2021-01-27 at 11 44 40 AM](https://user-images.githubusercontent.com/2471874/106038322-0bd78780-6095-11eb-9d47-d31bb7584551.png)

After:
![Screen Shot 2021-01-27 at 11 37 22 AM](https://user-images.githubusercontent.com/2471874/106037518-075e9f00-6094-11eb-8a56-6970a933a81a.png)
