### PR TITLE
fix: Step Input focus within

### DIFF
--- a/src/mixins/_states.scss
+++ b/src/mixins/_states.scss
@@ -61,6 +61,7 @@
 
 // Newer FOCUS state which follows fiori3 spec (tab onto, click into)
 // `.is-focus` is for demo purposes
+// This brings border + pseudo element
 @mixin fd-fiori-pseudo-focus($_offset: -0.0625rem) {
   &:focus,
   &.is-focus {
@@ -70,8 +71,8 @@
   }
 }
 
-// Newer FOCUS state which follows fiori3 spec (tab onto, click into)
-// `.is-focus` is for demo purposes
+// Focus state, which is not support by IE11. Use it with `fd-fiori-focus` mixin.
+// This brings border + pseudo element
 @mixin fd-fiori-pseudo-focus-within($_offset: -0.0625rem) {
   &:focus-within {
     @include fd-internal-pseudo-element-focus($_offset) {

--- a/src/mixins/_states.scss
+++ b/src/mixins/_states.scss
@@ -1,7 +1,24 @@
 // These mixins ensure that all state selectors — ARIA, pseudos, `is` fallbacks — get applied properly.
 
-// ACTIVE state (press and hold)
+@mixin fd-internal-pseudo-element-focus($_offset) {
+  $offset: -$_offset;
 
+  &::after {
+    border-width: var(--sapContent_FocusWidth);
+    border-color: var(--sapContent_FocusColor);
+    border-style: var(--sapContent_FocusStyle);
+    content: '';
+    position: absolute;
+    pointer-events: none;
+    top: $offset;
+    bottom: $offset;
+    left: $offset;
+    right: $offset;
+    @content;
+  }
+}
+
+// ACTIVE state (press and hold)
 @mixin fd-active {
   &:active,
   &.is-active {
@@ -31,7 +48,6 @@
 
 // Newer FOCUS state which follows fiori3 spec (tab onto, click into)
 // `.is-focus` is for demo purposes
-
 @mixin fd-fiori-focus($offset: -0.1875rem) {
   &:focus,
   &.is-focus {
@@ -40,6 +56,27 @@
     outline-color: var(--sapContent_FocusColor);
     outline-style: var(--sapContent_FocusStyle);
     @content;
+  }
+}
+
+// Newer FOCUS state which follows fiori3 spec (tab onto, click into)
+// `.is-focus` is for demo purposes
+@mixin fd-fiori-pseudo-focus($_offset: -0.0625rem) {
+  &:focus,
+  &.is-focus {
+    @include fd-internal-pseudo-element-focus($_offset) {
+      @content;
+    }
+  }
+}
+
+// Newer FOCUS state which follows fiori3 spec (tab onto, click into)
+// `.is-focus` is for demo purposes
+@mixin fd-fiori-pseudo-focus-within($_offset: -0.0625rem) {
+  &:focus-within {
+    @include fd-internal-pseudo-element-focus($_offset) {
+      @content;
+    }
   }
 }
 

--- a/src/step-input.scss
+++ b/src/step-input.scss
@@ -14,8 +14,12 @@ $block: #{$fd-namespace}-step-input;
 
   @include fd-reset();
   @include fd-form-states();
-  @include fd-fiori-focus-within();
 
+  @include fd-fiori-pseudo-focus-within() {
+    z-index: 10;
+  }
+
+  position: relative;
   width: auto;
   border-style: solid;
   border-width: var(--sapField_BorderWidth);


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-styles/issues/2089

## Description
So there is workaround to make focus within work - even when something inside is on hover

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
