### PR TITLE
feat: add busy state to the Action List

### DIFF
--- a/src/_listBase.scss
+++ b/src/_listBase.scss
@@ -84,12 +84,18 @@
         @include fd-flex-center();
       }
 
-      .#{$block}__busy-indicator {
-        margin-right: $fd-list-rating-indicator-spacing;
+      .#{$block}__title-text {
+        @include fd-reset();
+        @include fd-ellipsis();
+
+        color: inherit;
+        text-shadow: inherit;
+        font-size: inherit;
+        margin-left: $fd-list-rating-indicator-spacing;
 
         @include fd-rtl() {
-          margin-left: $fd-list-rating-indicator-spacing;
-          margin-right: 0;
+          margin-right: $fd-list-rating-indicator-spacing;
+          margin-left: 0;
         }
       }
     }

--- a/src/_listBase.scss
+++ b/src/_listBase.scss
@@ -79,6 +79,21 @@
       }
     }
 
+    &--growing {
+      .#{$block}__title {
+        @include fd-flex-center();
+      }
+
+      .#{$block}__busy-indicator {
+        margin-right: $fd-list-rating-indicator-spacing;
+
+        @include fd-rtl() {
+          margin-left: $fd-list-rating-indicator-spacing;
+          margin-right: 0;
+        }
+      }
+    }
+
     @include fd-selected() {
       @include list-item-selected-state();
     }

--- a/src/_listDefinitions.scss
+++ b/src/_listDefinitions.scss
@@ -42,6 +42,8 @@ $fd-list-navigation-indicator-width: 2.75rem !default;
 
 $fd-list-item-counter-spacing: 1rem !default;
 
+$fd-list-rating-indicator-spacing: 0.5rem !default;
+
 $semantic-color: (
   "neutral": ("color": var(--sapNeutralTextColor)),
   "positive": ("color": var(--sapPositiveTextColor)),

--- a/stories/list/standard/__snapshots__/standard-list.stories.storyshot
+++ b/stories/list/standard/__snapshots__/standard-list.stories.storyshot
@@ -206,6 +206,118 @@ exports[`Storyshots Components/List/Standard Action 1`] = `
   </ul>
   
 
+
+  <h4>
+    Growing List item with Busy Indicator 
+  </h4>
+  
+
+  <ul
+    class="fd-list"
+    role="list"
+  >
+    
+  
+    <li
+      class="fd-list__item"
+      role="listitem"
+    >
+      
+      
+      <span
+        class="fd-list__title"
+      >
+        List Item 1
+      </span>
+      
+  
+    </li>
+    
+  
+    <li
+      class="fd-list__item"
+      role="listitem"
+    >
+      
+      
+      <span
+        class="fd-list__title"
+      >
+        List Item 2
+      </span>
+      
+  
+    </li>
+    
+  
+    <li
+      class="fd-list__item"
+      role="listitem"
+    >
+      
+      
+      <span
+        class="fd-list__title"
+      >
+        List Item 3
+      </span>
+      
+  
+    </li>
+    
+  
+    <li
+      class="fd-list__item fd-list__item--action fd-list__item--growing"
+      role="listitem"
+    >
+      
+      
+      <button
+        class="fd-list__title"
+      >
+        
+        
+        <div
+          aria-hidden="false"
+          aria-label="Loading"
+          class="fd-busy-indicator--m"
+        >
+          
+            
+          <div
+            class="fd-busy-indicator--circle-0"
+          />
+          
+            
+          <div
+            class="fd-busy-indicator--circle-1"
+          />
+          
+            
+          <div
+            class="fd-busy-indicator--circle-2"
+          />
+          
+        
+        </div>
+        
+        
+        <div
+          class="fd-list__title-text"
+        >
+          More Options
+        </div>
+        
+    
+      </button>
+      
+  
+    </li>
+    
+
+  </ul>
+  
+
 </section>
 `;
 

--- a/stories/list/standard/standard-list.stories.js
+++ b/stories/list/standard/standard-list.stories.js
@@ -285,12 +285,12 @@ export const actionList = () => `<h4>Standard Size</h4>
   </li>
   <li role="listitem" class="fd-list__item fd-list__item--action fd-list__item--growing">
       <button class="fd-list__title">
-        <div class="fd-busy-indicator--m fd-list__busy-indicator" aria-hidden="false" aria-label="Loading">
+        <div class="fd-busy-indicator--m" aria-hidden="false" aria-label="Loading">
             <div class="fd-busy-indicator--circle-0"></div>
             <div class="fd-busy-indicator--circle-1"></div>
             <div class="fd-busy-indicator--circle-2"></div>
         </div>
-        More Options
+        <div class="fd-list__title-text">More Options</div>
     </button>
   </li>
 </ul>

--- a/stories/list/standard/standard-list.stories.js
+++ b/stories/list/standard/standard-list.stories.js
@@ -19,7 +19,7 @@ In SAP Fiori, we distinguish between tables and lists. Both usually contain homo
         
 `,
         tags: ['f3', 'a11y', 'theme', 'development'],
-        components: ['list', 'icon', 'checkbox', 'button']
+        components: ['list', 'icon', 'checkbox', 'button', 'busy-indicator']
     }
 };
 
@@ -269,6 +269,29 @@ export const actionList = () => `<h4>Standard Size</h4>
   </li>
   <li role="listitem" class="fd-list__item fd-list__item--action">
       <button class="fd-list__title">More Options</button>
+  </li>
+</ul>
+
+<h4>Growing List item with Busy Indicator </h4>
+<ul class="fd-list" role="list">
+  <li role="listitem" class="fd-list__item">
+      <span class="fd-list__title">List Item 1</span>
+  </li>
+  <li role="listitem" class="fd-list__item">
+      <span class="fd-list__title">List Item 2</span>
+  </li>
+  <li role="listitem" class="fd-list__item">
+      <span class="fd-list__title">List Item 3</span>
+  </li>
+  <li role="listitem" class="fd-list__item fd-list__item--action fd-list__item--growing">
+      <button class="fd-list__title">
+        <div class="fd-busy-indicator--m fd-list__busy-indicator" aria-hidden="false" aria-label="Loading">
+            <div class="fd-busy-indicator--circle-0"></div>
+            <div class="fd-busy-indicator--circle-1"></div>
+            <div class="fd-busy-indicator--circle-2"></div>
+        </div>
+        More Options
+    </button>
   </li>
 </ul>
 `;


### PR DESCRIPTION
## Related Issue
Part of SAP/fundamental-styles#2063

## Description
List has a Growing List functionality which is implemented in Fundamental-styles with Action List item. For Busy State a Busy Indicator component is added to the title of the list item

## Screenshots
### After:

<img width="915" alt="Screen Shot 2021-01-28 at 4 58 51 PM" src="https://user-images.githubusercontent.com/39598672/106203931-25a6c680-618a-11eb-9bb0-f5ce98307c5c.png">

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [na] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
