### PR TITLE
fix: add truncation for List group header text

### DIFF
--- a/src/_listBase.scss
+++ b/src/_listBase.scss
@@ -168,10 +168,13 @@
     border-bottom: var(--sapList_BorderWidth) solid var(--sapList_GroupHeaderBorderColor);
     color: var(--sapList_GroupHeaderTextColor);
     align-items: flex-end;
-    font-size: $fd-list-normal-font-size;
-    font-weight: bold;
     height: 2.75rem;
-    line-height: 2rem;
+
+    .#{$block}__title {
+      font-size: $fd-list-normal-font-size;
+      font-weight: bold;
+      line-height: 2rem;
+    }
   }
 
   &__footer {

--- a/stories/combobox-input/__snapshots__/combobox-input.stories.storyshot
+++ b/stories/combobox-input/__snapshots__/combobox-input.stories.storyshot
@@ -1417,7 +1417,15 @@ exports[`Storyshots Patterns/Combobox Input Mobile 1`] = `
         class="fd-list__group-header"
         id="fruitsMobileHeader"
       >
-        Fruits
+        
+                
+        <span
+          class="fd-list__title"
+        >
+          Fruits
+        </span>
+        
+            
       </label>
       
             
@@ -1503,7 +1511,15 @@ exports[`Storyshots Patterns/Combobox Input Mobile 1`] = `
         class="fd-list__group-header"
         id="vegMobileHeader"
       >
-        Vegetables
+        
+                
+        <span
+          class="fd-list__title"
+        >
+          Vegetables
+        </span>
+        
+            
       </label>
       
             
@@ -2127,7 +2143,13 @@ exports[`Storyshots Patterns/Combobox Input Two Items And Items Grouping 1`] = `
             id="fruitListHeader"
           >
             
-                        Fruits
+                        
+            <span
+              class="fd-list__title"
+            >
+              Fruits
+            </span>
+            
                     
           </label>
           
@@ -2215,7 +2237,13 @@ exports[`Storyshots Patterns/Combobox Input Two Items And Items Grouping 1`] = `
             id="vegListHeader"
           >
             
-                        Vegetables
+                        
+            <span
+              class="fd-list__title"
+            >
+              Vegetables
+            </span>
+            
                     
           </label>
           

--- a/stories/combobox-input/combobox-input.stories.js
+++ b/stories/combobox-input/combobox-input.stories.js
@@ -322,7 +322,7 @@ export const twoItemsAndItemsGrouping = () => `<div style="display:flex;justify-
             <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown fd-popover__body--dropdown-fill" aria-hidden="false" id="F4GcXLK6">
                 <div class="fd-popover__wrapper">
                     <label id="fruitListHeader" class="fd-list__group-header">
-                        Fruits
+                        <span class="fd-list__title">Fruits</span>
                     </label>
                     <ul aria-labelledby="fruitListHeader" class="fd-list fd-list--dropdown" role="listbox">
                         <li role="option" tabindex="0" class="fd-list__item is-selected">
@@ -339,7 +339,7 @@ export const twoItemsAndItemsGrouping = () => `<div style="display:flex;justify-
                         </li>
                     </ul>
                     <label id="vegListHeader" class="fd-list__group-header">
-                        Vegetables
+                        <span class="fd-list__title">Vegetables</span>
                     </label>
                     <ul aria-labelledby="vegListHeader" class="fd-list fd-list--dropdown" role="listbox">
                         <li role="option" tabindex="0" class="fd-list__item">
@@ -563,7 +563,9 @@ id="select-dialog-example" style="height:600px">
             </div>
         </div>
         <div class="fd-dialog__body fd-dialog__body--no-vertical-padding">
-            <label id="fruitsMobileHeader" class="fd-list__group-header">Fruits</label>
+            <label id="fruitsMobileHeader" class="fd-list__group-header">
+                <span class="fd-list__title">Fruits</span>
+            </label>
             <ul aria-labelledby="fruitsMobileHeader" class="fd-list fd-list--dropdown" role="listbox">
                 <li role="option" tabindex="0" class="fd-list__item is-selected">
                     <span class="fd-list__title">Apple</span>
@@ -578,7 +580,9 @@ id="select-dialog-example" style="height:600px">
                     <span class="fd-list__title">Kiwi</span>
                 </li>
             </ul>
-            <label id="vegMobileHeader" class="fd-list__group-header">Vegetables</label>
+            <label id="vegMobileHeader" class="fd-list__group-header">
+                <span class="fd-list__title">Vegetables</span>
+            </label>
             <ul aria-labelledby="vegMobileHeader" class="fd-list fd-list--dropdown" role="listbox">
                 <li role="option" tabindex="0" class="fd-list__item">
                     <span class="fd-list__title">Tomato</span>

--- a/stories/list/byline/__snapshots__/byline-list.stories.storyshot
+++ b/stories/list/byline/__snapshots__/byline-list.stories.storyshot
@@ -215,14 +215,14 @@ exports[`Storyshots Components/List/Byline Default 1`] = `
     role="list"
   >
     
-
+  
     <li
       class="fd-list__item"
       role="listitem"
       tabindex="0"
     >
       
-    
+      
       <span
         class="fd-list__thumbnail"
       >
@@ -232,39 +232,39 @@ exports[`Storyshots Components/List/Byline Default 1`] = `
         />
       </span>
       
-    
+      
       <div
         class="fd-list__content"
       >
         
-      
+        
         <div
           class="fd-list__title"
         >
           Title
         </div>
         
-      
+        
         <div
           class="fd-list__byline"
         >
           Byline (description)
         </div>
         
-    
+      
       </div>
       
-
+  
     </li>
     
-
+  
     <li
       class="fd-list__item"
       role="listitem"
       tabindex="0"
     >
       
-    
+      
       <span
         class="fd-list__thumbnail"
       >
@@ -274,108 +274,108 @@ exports[`Storyshots Components/List/Byline Default 1`] = `
         />
       </span>
       
-    
+      
       <div
         class="fd-list__content"
       >
         
-      
+        
         <div
           class="fd-list__title"
         >
           List item with no byline
         </div>
         
-    
+      
       </div>
       
-
+  
     </li>
     
-
+  
     <li
       class="fd-list__item"
       role="listitem"
       tabindex="0"
     >
       
-  
+    
       <span
         aria-label="Godafoss waterfall in northern Iceland"
         class="fd-image--s fd-list__thumbnail"
         style="background-image: url('assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg'); background-size:cover;"
       />
       
-  
+    
       <div
         class="fd-list__content"
       >
         
-      
+        
         <div
           class="fd-list__title"
         >
           List item with 2-column byline
         </div>
         
-      
+        
         <div
           class="fd-list__byline fd-list__byline--2-col"
         >
           
-          
+            
           <div
             class="fd-list__byline-left"
           >
             First text item in byline (standard text)
           </div>
           
-          
+            
           <div
             class="fd-list__byline-right"
           >
             Second text item in byline (can be semantic)
           </div>
           
-      
+        
         </div>
         
-  
+    
       </div>
       
-
+  
     </li>
     
-
+  
     <li
       class="fd-list__item"
       role="listitem"
       tabindex="0"
     >
       
-    
+      
       <div
         class="fd-list__content"
       >
         
-      
+        
         <div
           class="fd-list__title"
         >
           Text-only list item
         </div>
         
-      
+        
         <div
           class="fd-list__byline"
         >
           Byline (description)
         </div>
         
-    
+      
       </div>
       
-
+  
     </li>
     
 
@@ -393,14 +393,14 @@ exports[`Storyshots Components/List/Byline Default 1`] = `
     role="list"
   >
     
-
+  
     <li
       class="fd-list__item"
       role="listitem"
       tabindex="0"
     >
       
-    
+      
       <span
         class="fd-list__thumbnail"
       >
@@ -410,39 +410,39 @@ exports[`Storyshots Components/List/Byline Default 1`] = `
         />
       </span>
       
-    
+      
       <div
         class="fd-list__content"
       >
         
-      
+        
         <div
           class="fd-list__title"
         >
           Title
         </div>
         
-      
+        
         <div
           class="fd-list__byline"
         >
           Byline (description)
         </div>
         
-    
+      
       </div>
       
-
+  
     </li>
     
-
+  
     <li
       class="fd-list__item"
       role="listitem"
       tabindex="0"
     >
       
-    
+      
       <span
         class="fd-list__thumbnail"
       >
@@ -452,108 +452,108 @@ exports[`Storyshots Components/List/Byline Default 1`] = `
         />
       </span>
       
-    
+      
       <div
         class="fd-list__content"
       >
         
-      
+        
         <div
           class="fd-list__title"
         >
           List item with no byline
         </div>
         
-    
+      
       </div>
       
-
+  
     </li>
     
-
+  
     <li
       class="fd-list__item"
       role="listitem"
       tabindex="0"
     >
       
-  
+    
       <span
         aria-label="Godafoss waterfall in northern Iceland"
         class="fd-image--s fd-list__thumbnail"
         style="background-image: url('assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg'); background-size:cover;"
       />
       
-  
+    
       <div
         class="fd-list__content"
       >
         
-      
+        
         <div
           class="fd-list__title"
         >
           List item with 2-column byline
         </div>
         
-      
+        
         <div
           class="fd-list__byline fd-list__byline--2-col"
         >
           
-          
+            
           <div
             class="fd-list__byline-left"
           >
             First text item in byline (standard text)
           </div>
           
-          
+            
           <div
             class="fd-list__byline-right"
           >
             Second text item in byline (can be semantic)
           </div>
           
-      
+        
         </div>
         
-  
+    
       </div>
       
-
+  
     </li>
     
-
+  
     <li
       class="fd-list__item"
       role="listitem"
       tabindex="0"
     >
       
-    
+      
       <div
         class="fd-list__content"
       >
         
-      
+        
         <div
           class="fd-list__title"
         >
           Text-only list item
         </div>
         
-      
+        
         <div
           class="fd-list__byline"
         >
           Byline (description)
         </div>
         
-    
+      
       </div>
       
-
+  
     </li>
     
 

--- a/stories/list/byline/byline-list.stories.js
+++ b/stories/list/byline/byline-list.stories.js
@@ -34,70 +34,70 @@ Modifier/Class | Description
 
 export const standard = () => `<h4>Standard size</h4>
 <ul class="fd-list fd-list--byline" role="list">
-<li role="listitem" tabindex="0" class="fd-list__item">
-    <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
-    <div class="fd-list__content">
-      <div class="fd-list__title">Title</div>
-      <div class="fd-list__byline">Byline (description)</div>
-    </div>
-</li>
-<li role="listitem" tabindex="0" class="fd-list__item">
-    <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--employee"></i></span>
-    <div class="fd-list__content">
-      <div class="fd-list__title">List item with no byline</div>
-    </div>
-</li>
-<li role="listitem" tabindex="0" class="fd-list__item">
-  <span class="fd-image--s fd-list__thumbnail" aria-label="Godafoss waterfall in northern Iceland"
-style="background-image: url('assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg'); background-size:cover;"></span>
-  <div class="fd-list__content">
-      <div class="fd-list__title">List item with 2-column byline</div>
-      <div class="fd-list__byline fd-list__byline--2-col">
-          <div class="fd-list__byline-left">First text item in byline (standard text)</div>
-          <div class="fd-list__byline-right">Second text item in byline (can be semantic)</div>
+  <li role="listitem" tabindex="0" class="fd-list__item">
+      <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
+      <div class="fd-list__content">
+        <div class="fd-list__title">Title</div>
+        <div class="fd-list__byline">Byline (description)</div>
       </div>
-  </div>
-</li>
-<li role="listitem" tabindex="0" class="fd-list__item">
+  </li>
+  <li role="listitem" tabindex="0" class="fd-list__item">
+      <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--employee"></i></span>
+      <div class="fd-list__content">
+        <div class="fd-list__title">List item with no byline</div>
+      </div>
+  </li>
+  <li role="listitem" tabindex="0" class="fd-list__item">
+    <span class="fd-image--s fd-list__thumbnail" aria-label="Godafoss waterfall in northern Iceland"
+  style="background-image: url('assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg'); background-size:cover;"></span>
     <div class="fd-list__content">
-      <div class="fd-list__title">Text-only list item</div>
-      <div class="fd-list__byline">Byline (description)</div>
+        <div class="fd-list__title">List item with 2-column byline</div>
+        <div class="fd-list__byline fd-list__byline--2-col">
+            <div class="fd-list__byline-left">First text item in byline (standard text)</div>
+            <div class="fd-list__byline-right">Second text item in byline (can be semantic)</div>
+        </div>
     </div>
-</li>
+  </li>
+  <li role="listitem" tabindex="0" class="fd-list__item">
+      <div class="fd-list__content">
+        <div class="fd-list__title">Text-only list item</div>
+        <div class="fd-list__byline">Byline (description)</div>
+      </div>
+  </li>
 </ul>
 
 <h4>Compact size</h4>
 <ul class="fd-list fd-list--compact fd-list--byline" role="list">
-<li role="listitem" tabindex="0" class="fd-list__item">
-    <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
-    <div class="fd-list__content">
-      <div class="fd-list__title">Title</div>
-      <div class="fd-list__byline">Byline (description)</div>
-    </div>
-</li>
-<li role="listitem" tabindex="0" class="fd-list__item">
-    <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--employee"></i></span>
-    <div class="fd-list__content">
-      <div class="fd-list__title">List item with no byline</div>
-    </div>
-</li>
-<li role="listitem" tabindex="0" class="fd-list__item">
-  <span class="fd-image--s fd-list__thumbnail" aria-label="Godafoss waterfall in northern Iceland"
-style="background-image: url('assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg'); background-size:cover;"></span>
-  <div class="fd-list__content">
-      <div class="fd-list__title">List item with 2-column byline</div>
-      <div class="fd-list__byline fd-list__byline--2-col">
-          <div class="fd-list__byline-left">First text item in byline (standard text)</div>
-          <div class="fd-list__byline-right">Second text item in byline (can be semantic)</div>
+  <li role="listitem" tabindex="0" class="fd-list__item">
+      <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
+      <div class="fd-list__content">
+        <div class="fd-list__title">Title</div>
+        <div class="fd-list__byline">Byline (description)</div>
       </div>
-  </div>
-</li>
-<li role="listitem" tabindex="0" class="fd-list__item">
+  </li>
+  <li role="listitem" tabindex="0" class="fd-list__item">
+      <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--employee"></i></span>
+      <div class="fd-list__content">
+        <div class="fd-list__title">List item with no byline</div>
+      </div>
+  </li>
+  <li role="listitem" tabindex="0" class="fd-list__item">
+    <span class="fd-image--s fd-list__thumbnail" aria-label="Godafoss waterfall in northern Iceland"
+  style="background-image: url('assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg'); background-size:cover;"></span>
     <div class="fd-list__content">
-      <div class="fd-list__title">Text-only list item</div>
-      <div class="fd-list__byline">Byline (description)</div>
+        <div class="fd-list__title">List item with 2-column byline</div>
+        <div class="fd-list__byline fd-list__byline--2-col">
+            <div class="fd-list__byline-left">First text item in byline (standard text)</div>
+            <div class="fd-list__byline-right">Second text item in byline (can be semantic)</div>
+        </div>
     </div>
-</li>
+  </li>
+  <li role="listitem" tabindex="0" class="fd-list__item">
+      <div class="fd-list__content">
+        <div class="fd-list__title">Text-only list item</div>
+        <div class="fd-list__byline">Byline (description)</div>
+      </div>
+  </li>
 </ul>
 `;
 

--- a/stories/list/standard/__snapshots__/standard-list.stories.storyshot
+++ b/stories/list/standard/__snapshots__/standard-list.stories.storyshot
@@ -673,7 +673,13 @@ exports[`Storyshots Components/List/Standard Group 1`] = `
     role="listitem"
   >
     
-    Group header 1
+    
+    <span
+      class="fd-list__title"
+    >
+      Group header 1
+    </span>
+    
   
   </li>
   
@@ -734,7 +740,13 @@ exports[`Storyshots Components/List/Standard Group 1`] = `
     role="listitem"
   >
     
-    Group header 2
+    
+    <span
+      class="fd-list__title"
+    >
+      Group header 2
+    </span>
+    
   
   </li>
   

--- a/stories/list/standard/standard-list.stories.js
+++ b/stories/list/standard/standard-list.stories.js
@@ -378,7 +378,7 @@ icons.parameters = {
 
 export const groups = () => `<ul class="fd-list" role="list">
   <li role="listitem" class="fd-list__group-header">
-    Group header 1
+    <span class="fd-list__title">Group header 1</span>
   </li>
   <li role="listitem" tabindex="0" class="fd-list__item">
       <span class="fd-list__title">List item 1</span>
@@ -390,7 +390,7 @@ export const groups = () => `<ul class="fd-list" role="list">
       <span class="fd-list__title">List item 3</span>
   </li>
   <li role="listitem" class="fd-list__group-header">
-    Group header 2
+    <span class="fd-list__title">Group header 2</span>
   </li>
   <li role="listitem" tabindex="0" class="fd-list__item">
       <span class="fd-list__title">List item 4</span>

--- a/stories/multi-combo-box/__snapshots__/multi-combo-box.stories.storyshot
+++ b/stories/multi-combo-box/__snapshots__/multi-combo-box.stories.storyshot
@@ -1451,7 +1451,13 @@ exports[`Storyshots Patterns/Multi ComboBox Grouping 1`] = `
           id="selectMultipleFruitsLabel"
         >
           
-                Fruits
+                
+          <span
+            class="fd-list__title"
+          >
+            Fruits
+          </span>
+          
             
         </label>
         
@@ -1684,7 +1690,13 @@ exports[`Storyshots Patterns/Multi ComboBox Grouping 1`] = `
           id="selectMultipleVegsLabel"
         >
           
-                Vegetables
+                
+          <span
+            class="fd-list__title"
+          >
+            Vegetables
+          </span>
+          
             
         </label>
         

--- a/stories/multi-combo-box/multi-combo-box.stories.js
+++ b/stories/multi-combo-box/multi-combo-box.stories.js
@@ -336,7 +336,7 @@ export const grouping = () => `<div style="height: 450px;">
         <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown fd-popover__body--dropdown-fill" aria-hidden="false" id="F4H8X34a">
         <div class="fd-popover__wrapper">
            <label class="fd-list__group-header" id="selectMultipleFruitsLabel">
-                Fruits
+                <span class="fd-list__title">Fruits</span>
             </label>
             <ul class="fd-list fd-list--multi-input" role="listbox" aria-multiselectable="true" aria-labelledby="selectMultipleFruitsLabel">
                <li role="option" tabindex="0" class="fd-list__item is-selected" aria-selected="true">
@@ -377,7 +377,7 @@ export const grouping = () => `<div style="height: 450px;">
 				</li>
             </ul>
             <label class="fd-list__group-header" id="selectMultipleVegsLabel">
-                Vegetables
+                <span class="fd-list__title">Vegetables</span>
             </label>
             <ul class="fd-list fd-list--multi-input" role="listbox" aria-multiselectable="true" aria-labelledby="selectMultipleVegsLabel">
  				<li role="option" tabindex="0" class="fd-list__item is-selected" aria-selected="true">

--- a/stories/multi-input/__snapshots__/multi-input.stories.storyshot
+++ b/stories/multi-input/__snapshots__/multi-input.stories.storyshot
@@ -2002,7 +2002,13 @@ exports[`Storyshots Patterns/Multi Input Grouping 1`] = `
           id="fruitListHeader"
         >
           
-                Fruits
+                
+          <span
+            class="fd-list__title"
+          >
+            Fruits
+          </span>
+          
             
         </h3>
         
@@ -2235,7 +2241,13 @@ exports[`Storyshots Patterns/Multi Input Grouping 1`] = `
           id="selectMultipleVegsLabel"
         >
           
-                Vegetables
+                
+          <span
+            class="fd-list__title"
+          >
+            Vegetables
+          </span>
+          
             
         </label>
         

--- a/stories/multi-input/multi-input.stories.js
+++ b/stories/multi-input/multi-input.stories.js
@@ -373,7 +373,7 @@ export const grouping = () => `<div style="height:450px">
         <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown fd-popover__body--dropdown-fill" aria-hidden="false" id="F4H8X34a">
         <div class="fd-popover__wrapper">
             <h3 id="fruitListHeader" class="fd-list__group-header">
-                Fruits
+                <span class="fd-list__title">Fruits</span>
             </h3>
             <ul aria-multiselectable="true" role="listbox" aria-labelledby="fruitListHeader" class="fd-list fd-list--multi-input">
                <li role="option" tabindex="0" class="fd-list__item is-selected" aria-selected="true">
@@ -414,7 +414,7 @@ export const grouping = () => `<div style="height:450px">
 				</li>
             </ul>
             <label class="fd-list__group-header" id="selectMultipleVegsLabel">
-                Vegetables
+                <span class="fd-list__title">Vegetables</span>
             </label>
             <ul class="fd-list fd-list--multi-input" role="listbox" aria-multiselectable="true" aria-labelledby="selectMultipleVegsLabel">
  				<li role="option" tabindex="0" class="fd-list__item is-selected" aria-selected="true">

--- a/stories/select/__snapshots__/select.stories.storyshot
+++ b/stories/select/__snapshots__/select.stories.storyshot
@@ -1731,7 +1731,13 @@ exports[`Storyshots Components/Select Grouping 1`] = `
         id="fruitsHeader"
       >
         
-                Fruits
+                
+        <span
+          class="fd-list__title"
+        >
+          Fruits
+        </span>
+        
             
       </label>
       
@@ -1822,7 +1828,13 @@ exports[`Storyshots Components/Select Grouping 1`] = `
         id="vegHeader"
       >
         
-                Vegetables
+                
+        <span
+          class="fd-list__title"
+        >
+          Vegetables
+        </span>
+        
             
       </label>
       

--- a/stories/select/select.stories.js
+++ b/stories/select/select.stories.js
@@ -794,7 +794,7 @@ export const itemGrouping = () => `<div style="height: 450px">
         class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown fd-popover__body--dropdown-fill"
         aria-hidden="false">
             <label class="fd-list__group-header" id="fruitsHeader">
-                Fruits
+                <span class="fd-list__title">Fruits</span>
             </label>
             <ul
                 aria-activedescendant="itemGroupingSelectCombobox-currentlyFocusedItem"
@@ -815,7 +815,7 @@ export const itemGrouping = () => `<div style="height: 450px">
                 </li>
             </ul>
             <label class="fd-list__group-header" id="vegHeader">
-                Vegetables
+                <span class="fd-list__title">Vegetables</span>
             </label>
             <ul aria-labelledby="itemGroupingLabel vegHeader" class="fd-list fd-list--dropdown" role="listbox">
                 <li role="option" tabindex="-1" class="fd-list__item">


### PR DESCRIPTION
## Related Issue
Part of SAP/fundamental-styles#2063

## Description
This PR adds truncation rules for the List component Group Header <li> element

BREAKING CHANGE:
change in the markup, now the text is wrapped in a span with `fd-list__title` class.
Affected components: combobox-input, standard list, multi combobox, multi input, select

Before:
```
<li role="listitem" class="fd-list__group-header">
    Group header 1
</li>
```
Now:
```
<li role="listitem" class="fd-list__group-header">
    <span class="fd-list__title">Group header 1</span>
 </li>
```

## Screenshots

### Before:
<img width="1188" alt="Screen Shot 2021-01-29 at 11 39 19 AM" src="https://user-images.githubusercontent.com/39598672/106302243-b501b780-6226-11eb-9844-c6c4c17f5de7.png">

### After:
<img width="1196" alt="Screen Shot 2021-01-29 at 11 39 37 AM" src="https://user-images.githubusercontent.com/39598672/106302259-b8953e80-6226-11eb-9d54-08e2cb953896.png">


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [na] hover state of the element follow design spec
- [na] focus state of the element follow design spec
- [na] active state of the element follow design spec
- [na] selected state of the element follow design spec
- [na] selected hover state of the element follow design spec
- [na] pressed state of the element follow design spec
- [na] Responsiveness rules - the component has modifier classes for all breakpoints
- [na] Includes Compact/Cosy/Tablet design
- [na] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [na] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [na] `fd-reset()` mixin is applied to all elements
- [na] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
