### PR TITLE
fix: add fix for hover state in selected mode

### DIFF
--- a/src/_listDefinitions.scss
+++ b/src/_listDefinitions.scss
@@ -141,8 +141,8 @@ $semantic-color: (
 }
 
 @mixin ie11-active-state-fix() {
-  // :active selector has issues in IE11 when there are nested elements.
-  // The solution is to remove the pointer events from the nested elements.
+  // :active selector has issues in IE11 when there are nested elements
+  // The solution is to remove the pointer events from the nested elements
 
   pointer-events: none;
 }

--- a/src/_listDefinitions.scss
+++ b/src/_listDefinitions.scss
@@ -104,8 +104,8 @@ $semantic-color: (
   background: var(--sapList_SelectionBackgroundColor);
   border-bottom: $fd-list-selected-state-border-bottom;
 
-  @include fd-hover() {
-    background: var(--sapList_Hover_SelectionBackground);
+  .#{$block}__link {
+    background: inherit;
   }
 }
 

--- a/src/_listDefinitions.scss
+++ b/src/_listDefinitions.scss
@@ -141,8 +141,8 @@ $semantic-color: (
 }
 
 @mixin ie11-active-state-fix() {
-  // :active selector has issues in IE11 when there are nested elements
-  // The solution is to remove the pointer events from the nested elements
+  // :active selector has issues in IE11 when there are nested elements.
+  // The solution is to remove the pointer events from the nested elements.
 
   pointer-events: none;
 }


### PR DESCRIPTION

## Description
Byline list item in selected mode didn't apply the correct background on hover. 

## Screenshots

### Before:
<img width="1192" alt="Screen Shot 2021-02-05 at 4 39 59 PM" src="https://user-images.githubusercontent.com/39598672/107092083-e7845500-67d0-11eb-9e36-4657ecac418c.png">


### After:
<img width="876" alt="Screen Shot 2021-02-05 at 4 44 31 PM" src="https://user-images.githubusercontent.com/39598672/107092364-74c7a980-67d1-11eb-89ef-4f87851029b2.png">

