### PR TITLE
fix: add fix for IE related issues in Tiles

### DIFF
--- a/src/tile.scss
+++ b/src/tile.scss
@@ -383,6 +383,8 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
 
     .#{$block}__content-text {
       @include line-clamp();
+
+      max-height: 2.125rem; // fix for IE11 not supporting line clamp
     }
 
     .#{$block}__content-byline {
@@ -631,7 +633,6 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
       @include fd-icon-element-base() {
         @include set-height(1.375rem);
         @include set-width(1.375rem);
-        @include fd-flex-center();
 
         box-sizing: border-box;
         border-radius: 50%;
@@ -640,20 +641,8 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
         color: var(--sapButton_IconColor);
         font-size: 0.75rem;
 
-        // Extended clickable/touchable area
         &::before {
-          @include set-height(2rem);
-          @include set-width(2rem);
-
-          top: 0;
-          right: 0;
-          left: auto;
-          bottom: auto;
-
-          @include fd-rtl() {
-            right: auto;
-            left: 0;
-          }
+          line-height: 1.25rem;
         }
       }
 

--- a/src/tile.scss
+++ b/src/tile.scss
@@ -384,7 +384,7 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
     .#{$block}__content-text {
       @include line-clamp();
 
-      max-height: 2.125rem; // fix for IE11 not supporting line clamp
+      max-height: 2.125rem; // fix for IE11 not supporting line-clamp
     }
 
     .#{$block}__content-byline {


### PR DESCRIPTION
## Related Issue
Part of SAP/fundamental-styles#2090

## Description
Related IE11 isses:
- Feed Tile - the text should truncate after 2 lines. Line-clamp is not supported in IE11, max-height was added as a fix
- Link Tile - misaligned action close button

## Screenshots
### Before:
<img width="1177" alt="Screen Shot 2021-02-09 at 3 05 06 PM" src="https://user-images.githubusercontent.com/39598672/107421652-37705e00-6ae8-11eb-9288-ca03350e58f6.png">


### After:
<img width="1063" alt="Screen Shot 2021-02-09 at 3 05 40 PM" src="https://user-images.githubusercontent.com/39598672/107421720-4f47e200-6ae8-11eb-9fd6-ad4183e3f86b.png">


