### PR TITLE
feat: add modifier class for List being used in a dialog in mobile mode

### DIFF
--- a/src/_listDropdown.scss
+++ b/src/_listDropdown.scss
@@ -117,6 +117,7 @@
     min-width: 7rem;
     max-width: 37.5rem;
 
+    // for when dropdown and multi input are used in mobile mode
     &.#{$block}--mobile {
       max-width: 100%;
     }

--- a/src/_listDropdown.scss
+++ b/src/_listDropdown.scss
@@ -117,6 +117,10 @@
     min-width: 7rem;
     max-width: 37.5rem;
 
+    &.#{$block}--mobile {
+      max-width: 100%;
+    }
+
     .#{$block}__item {
       cursor: pointer;
       border: none;

--- a/stories/combobox-input/__snapshots__/combobox-input.stories.storyshot
+++ b/stories/combobox-input/__snapshots__/combobox-input.stories.storyshot
@@ -1431,7 +1431,7 @@ exports[`Storyshots Patterns/Combobox Input Mobile 1`] = `
             
       <ul
         aria-labelledby="fruitsMobileHeader"
-        class="fd-list fd-list--dropdown"
+        class="fd-list fd-list--dropdown fd-list--mobile"
         role="listbox"
       >
         

--- a/stories/combobox-input/combobox-input.stories.js
+++ b/stories/combobox-input/combobox-input.stories.js
@@ -566,7 +566,7 @@ id="select-dialog-example" style="height:600px">
             <label id="fruitsMobileHeader" class="fd-list__group-header">
                 <span class="fd-list__title">Fruits</span>
             </label>
-            <ul aria-labelledby="fruitsMobileHeader" class="fd-list fd-list--dropdown" role="listbox">
+            <ul aria-labelledby="fruitsMobileHeader" class="fd-list fd-list--dropdown fd-list--mobile" role="listbox">
                 <li role="option" tabindex="0" class="fd-list__item is-selected">
                     <span class="fd-list__title">Apple</span>
                 </li>

--- a/stories/multi-combo-box/__snapshots__/multi-combo-box.stories.storyshot
+++ b/stories/multi-combo-box/__snapshots__/multi-combo-box.stories.storyshot
@@ -2483,7 +2483,7 @@ exports[`Storyshots Patterns/Multi ComboBox Mobile Mode 1`] = `
       <ul
         aria-label="Fruits"
         aria-multiselectable="true"
-        class="fd-list fd-list--multi-input fd-list--has-message"
+        class="fd-list fd-list--multi-input fd-list--has-message fd-list--mobile"
         role="listbox"
       >
         

--- a/stories/multi-combo-box/multi-combo-box.stories.js
+++ b/stories/multi-combo-box/multi-combo-box.stories.js
@@ -776,7 +776,7 @@ export const mobileMode = () => `<div class="fd-dialog fd-dialog-docs-static fd-
             </div>
         </div>
         <div class="fd-dialog__body fd-dialog__body--no-vertical-padding">
-             <ul class="fd-list fd-list--multi-input fd-list--has-message"  role="listbox" aria-multiselectable="true" aria-label="Fruits">
+             <ul class="fd-list fd-list--multi-input fd-list--has-message fd-list--mobile"  role="listbox" aria-multiselectable="true" aria-label="Fruits">
 				<li class="fd-list__message fd-list__message--success" role="option">Success Message</li>
 				<li role="option" tabindex="0" class="fd-list__item is-selected" aria-selected="true">
 					<div class="fd-form-item fd-list__form-item">

--- a/stories/multi-input/__snapshots__/multi-input.stories.storyshot
+++ b/stories/multi-input/__snapshots__/multi-input.stories.storyshot
@@ -3051,7 +3051,7 @@ exports[`Storyshots Patterns/Multi Input Mobile Mode 1`] = `
       <ul
         aria-label="list of fruits"
         aria-multiselectable="true"
-        class="fd-list fd-list--multi-input fd-list--has-message"
+        class="fd-list fd-list--multi-input fd-list--has-message fd-list--mobile"
         role="listbox"
       >
         

--- a/stories/multi-input/multi-input.stories.js
+++ b/stories/multi-input/multi-input.stories.js
@@ -873,7 +873,7 @@ export const mobileMode = () => `<section role="dialog" aria-labelledby="mobileM
         </div>
         <div class="fd-dialog__body fd-dialog__body--no-vertical-padding">
             <span class="fd-list__message fd-list__message--success">Success Message</span>
-             <ul aria-multiselectable="true" role="listbox" aria-label="list of fruits" class="fd-list fd-list--multi-input fd-list--has-message">
+             <ul aria-multiselectable="true" role="listbox" aria-label="list of fruits" class="fd-list fd-list--multi-input fd-list--has-message fd-list--mobile">
                 <li role="option" tabindex="0" class="fd-list__item is-selected" aria-selected="true">
                     <div class="fd-form-item fd-list__form-item">
                         <input type="checkbox" class="fd-checkbox" id="Ai4ez648" checked aria-labelledby="Az0bg57">

--- a/stories/select/__snapshots__/select.stories.storyshot
+++ b/stories/select/__snapshots__/select.stories.storyshot
@@ -2025,7 +2025,7 @@ exports[`Storyshots Components/Select Mobile 1`] = `
             
       <ul
         aria-labelledby="mobileHeader"
-        class="fd-list fd-list--has-message fd-list--dropdown fd-list--compact"
+        class="fd-list fd-list--has-message fd-list--dropdown fd-list--compact fd-list--mobile"
         role="listbox"
       >
         

--- a/stories/select/select.stories.js
+++ b/stories/select/select.stories.js
@@ -176,7 +176,7 @@ export const mobileMode = () => `<div class="fd-dialog fd-dialog-docs-static fd-
         </header>
         <div class="fd-dialog__body fd-dialog__body--no-vertical-padding">
             <div aria-live="assertive" class="fd-list__message fd-list__message--information" role="alert">Choose one item</div>
-            <ul aria-labelledby="mobileHeader" class="fd-list fd-list--has-message fd-list--dropdown fd-list--compact" role="listbox">
+            <ul aria-labelledby="mobileHeader" class="fd-list fd-list--has-message fd-list--dropdown fd-list--compact fd-list--mobile" role="listbox">
                 <li role="option" tabindex="0" class="fd-list__item is-selected" aria-selected="true">
                    <span class="fd-list__title">Apple</span>
                </li>


### PR DESCRIPTION
## Related Issue
Part of SAP/fundamental-styles#2090

## Description
List component used as a dropdown or multi-input has a max-width of 37.5rem. In mobile mode the List is placed in a Dialog and should take the whole width. For this reason a modifier class is added and the width is changed from 37.5rem to 100%

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
<img width="2029" alt="Screen Shot 2021-02-09 at 4 54 24 PM" src="https://user-images.githubusercontent.com/39598672/107433563-7e198480-6af7-11eb-9630-e791ba049faa.png">


### After:
<img width="2030" alt="Screen Shot 2021-02-09 at 4 54 11 PM" src="https://user-images.githubusercontent.com/39598672/107433577-81ad0b80-6af7-11eb-828b-ee48f712c057.png">


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [na] All values are in `rem`
- [na] Text elements follow the truncation rules
- [na] hover state of the element follow design spec
- [na] focus state of the element follow design spec
- [na] active state of the element follow design spec
- [na] selected state of the element follow design spec
- [na] selected hover state of the element follow design spec
- [na] pressed state of the element follow design spec
- [na] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [na] RTL support
2. The code follows fundamental-styles code standards and style
- na] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [na] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [na] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [na] `fd-reset()` mixin is applied to all elements
- [na] Variables are used, if some value is used more than twice.
- na ] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [na] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
