### PR TITLE
feat: introduce Margins and Paddings

### DIFF
--- a/.storybook/custom/custom.scss
+++ b/.storybook/custom/custom.scss
@@ -379,6 +379,14 @@ code.docs-code-grey {
     height: 100%;
   }
 
+  &--padded {
+    padding: 1.5rem;
+  }
+
+  &--margin {
+    margin: 1.5rem;
+  }
+
   &--color-1 {
     background-color: #30c5d2;
     color: white;
@@ -608,5 +616,14 @@ body.sb-show-main {
   .card-six-dimensions {
     width: 20rem;
     height: 20rem;
+  }
+}
+
+.docs-column-flex {
+  display: flex;
+  flex-direction: column;
+
+  &--inline {
+    display: inline-flex;
   }
 }

--- a/.storybook/custom/custom.scss
+++ b/.storybook/custom/custom.scss
@@ -379,12 +379,8 @@ code.docs-code-grey {
     height: 100%;
   }
 
-  &--padded {
-    padding: 1.5rem;
-  }
-
-  &--margin {
-    margin: 1.5rem;
+  &--border {
+    border: 2px solid #000000;
   }
 
   &--color-1 {
@@ -623,8 +619,60 @@ body.sb-show-main {
   display: flex;
   flex-direction: column;
 
-  &--inline {
-    display: inline-flex;
+  &--align-start {
+    align-items: flex-start;
+  }
+}
+
+.docs-layout-margins-paddings {
+  background-color: #3d6299;
+  color: #ffffff;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 4rem;
+  text-align: center;
+
+  &--color-13 {
+    background-color: #3d6299;
+    color: white;
+    border: 2px solid red;
+  }
+
+  &--color-14 {
+    background-color: #30c5d2;
+    color: white;
+    border: 2px solid black;
+  }
+
+  &--secondary-bg {
+    background-color: #dbdbdb;
+    display: inline-block;
+  }
+
+  &--padded {
+    padding: 1.5rem;
+  }
+
+  &--margin {
+    margin: 1.5rem;
+  }
+
+  // padding+width = actual width, so specifying different widths to show the backgrounds correctly
+  &--width {
+    width: 19rem; // for tiny 0.5rem each(horizontal padding)+19rem = 20rem total
+
+    &-sm {
+      width: 18rem; // for tiny 1rem each(horizontal padding)+18rem = 20rem total
+    }
+
+    &-md {
+      width: 16rem; // for tiny 2rem each(horizontal padding)+16rem = 20rem total
+    }
+
+    &-lg {
+      width: 14rem; // for tiny 3rem each(horizontal padding)+14rem = 20rem total
+    }
   }
 }
 

--- a/.storybook/custom/custom.scss
+++ b/.storybook/custom/custom.scss
@@ -627,3 +627,8 @@ body.sb-show-main {
     display: inline-flex;
   }
 }
+
+.fddocs-margin-end-none,
+[dir="rtl"] .fddocs-margin-end-none {
+  margin: 1.5rem;
+}

--- a/src/fundamental-styles.scss
+++ b/src/fundamental-styles.scss
@@ -31,6 +31,7 @@
 @import "./link";
 @import "./list-grid";
 @import "./list";
+@import "./margins";
 @import "./menu";
 @import "./message-box";
 @import "./message-page";
@@ -40,6 +41,7 @@
 @import "./numeric-content";
 @import "./object-marker";
 @import "./object-status";
+@import "./paddings";
 @import "./page";
 @import "./pagination";
 @import "./panel";

--- a/src/margins.scss
+++ b/src/margins.scss
@@ -100,7 +100,7 @@ $block: #{$fd-namespace}-margin;
     }
 
     &--none {
-      margin-right: 0 !important;
+      margin-right: 0;
 
       @include fd-rtl() {
         margin-left: 0 !important;
@@ -170,7 +170,7 @@ $block: #{$fd-namespace}-margin;
     }
 
     &--none {
-      margin-left: 0 !important;
+      margin-left: 0;
 
       @include fd-rtl() {
         margin-right: 0 !important;

--- a/src/margins.scss
+++ b/src/margins.scss
@@ -65,22 +65,46 @@ $block: #{$fd-namespace}-margin;
   &-end {
     &--tiny {
       margin-right: $fd-margin-tiny !important;
+
+      @include fd-rtl() {
+        margin-left: $fd-margin-tiny !important;
+        margin-right: 0 !important;
+      }
     }
 
     &--sm {
       margin-right: $fd-margin-small !important;
+
+      @include fd-rtl() {
+        margin-left: $fd-margin-small !important;
+        margin-right: 0 !important;
+      }
     }
 
     &--md {
       margin-right: $fd-margin-medium !important;
+
+      @include fd-rtl() {
+        margin-left: $fd-margin-medium !important;
+        margin-right: 0 !important;
+      }
     }
 
     &--lg {
       margin-right: $fd-margin-large !important;
+
+      @include fd-rtl() {
+        margin-left: $fd-margin-large !important;
+        margin-right: 0 !important;
+      }
     }
 
     &--none {
       margin-right: 0 !important;
+
+      @include fd-rtl() {
+        margin-left: 0 !important;
+      }
     }
   }
 
@@ -111,22 +135,46 @@ $block: #{$fd-namespace}-margin;
   &-begin {
     &--tiny {
       margin-left: $fd-margin-tiny !important;
+
+      @include fd-rtl() {
+        margin-right: $fd-margin-tiny !important;
+        margin-left: 0 !important;
+      }
     }
 
     &--sm {
       margin-left: $fd-margin-small !important;
+
+      @include fd-rtl() {
+        margin-right: $fd-margin-small !important;
+        margin-left: 0 !important;
+      }
     }
 
     &--md {
       margin-left: $fd-margin-medium !important;
+
+      @include fd-rtl() {
+        margin-right: $fd-margin-medium !important;
+        margin-left: 0 !important;
+      }
     }
 
     &--lg {
       margin-left: $fd-margin-large !important;
+
+      @include fd-rtl() {
+        margin-right: $fd-margin-large !important;
+        margin-left: 0 !important;
+      }
     }
 
     &--none {
       margin-left: 0 !important;
+
+      @include fd-rtl() {
+        margin-right: 0 !important;
+      }
     }
   }
 

--- a/src/margins.scss
+++ b/src/margins.scss
@@ -1,0 +1,216 @@
+@import "./new-settings";
+@import "./mixins";
+
+$block: #{$fd-namespace}-margin;
+
+.#{$block} {
+  $fd-margin-tiny: 0.5rem;
+  $fd-margin-small: 1rem;
+  $fd-margin-medium: 2rem;
+  $fd-margin-large: 3rem;
+  $fd-margin-negative-tiny: -0.5rem;
+  $fd-margin-negative-small: -1rem;
+  $fd-margin-negative-medium: -2rem;
+  $fd-margin-negative-large: -3rem;
+  $fd-margin-responsive-vertical: 1rem;
+  $fd-margin-responsive-medium: 1rem;
+  $fd-margin-responsive-large: 2rem;
+  $fd-margin-responsive-extra-large: 3rem;
+
+  // margin
+  &--tiny {
+    margin: $fd-margin-tiny !important;
+  }
+
+  &--sm {
+    margin: $fd-margin-small !important;
+  }
+
+  &--md {
+    margin: $fd-margin-medium !important;
+  }
+
+  &--lg {
+    margin: $fd-margin-large !important;
+  }
+
+  &--none {
+    margin: 0 !important;
+  }
+
+  // margin top
+  &-top {
+    &--tiny {
+      margin-top: $fd-margin-tiny !important;
+    }
+
+    &--sm {
+      margin-top: $fd-margin-small !important;
+    }
+
+    &--md {
+      margin-top: $fd-margin-medium !important;
+    }
+
+    &--lg {
+      margin-top: $fd-margin-large !important;
+    }
+
+    &--none {
+      margin-top: 0 !important;
+    }
+  }
+
+  // margin end
+  &-end {
+    &--tiny {
+      margin-right: $fd-margin-tiny !important;
+    }
+
+    &--sm {
+      margin-right: $fd-margin-small !important;
+    }
+
+    &--md {
+      margin-right: $fd-margin-medium !important;
+    }
+
+    &--lg {
+      margin-right: $fd-margin-large !important;
+    }
+
+    &--none {
+      margin-right: 0 !important;
+    }
+  }
+
+  // margin bottom
+  &-bottom {
+    &--tiny {
+      margin-bottom: $fd-margin-tiny !important;
+    }
+
+    &--sm {
+      margin-bottom: $fd-margin-small !important;
+    }
+
+    &--md {
+      margin-bottom: $fd-margin-medium !important;
+    }
+
+    &--lg {
+      margin-bottom: $fd-margin-large !important;
+    }
+
+    &--none {
+      margin-bottom: 0 !important;
+    }
+  }
+
+  // margin begin
+  &-begin {
+    &--tiny {
+      margin-left: $fd-margin-tiny !important;
+    }
+
+    &--sm {
+      margin-left: $fd-margin-small !important;
+    }
+
+    &--md {
+      margin-left: $fd-margin-medium !important;
+    }
+
+    &--lg {
+      margin-left: $fd-margin-large !important;
+    }
+
+    &--none {
+      margin-left: 0 !important;
+    }
+  }
+
+  // double-sided top bottom margin
+  &-top-bottom {
+    &--tiny {
+      margin-top: $fd-margin-tiny !important;
+      margin-bottom: $fd-margin-tiny !important;
+    }
+
+    &--sm {
+      margin-top: $fd-margin-small !important;
+      margin-bottom: $fd-margin-small !important;
+    }
+
+    &--md {
+      margin-top: $fd-margin-medium !important;
+      margin-bottom: $fd-margin-medium !important;
+    }
+
+    &--lg {
+      margin-top: $fd-margin-large !important;
+      margin-bottom: $fd-margin-large !important;
+    }
+  }
+
+  // double-sided begin end margin
+  &-begin-end {
+    &--tiny {
+      margin-left: $fd-margin-tiny !important;
+      margin-right: $fd-margin-tiny !important;
+    }
+
+    &--sm {
+      margin-left: $fd-margin-small !important;
+      margin-right: $fd-margin-small !important;
+    }
+
+    &--md {
+      margin-left: $fd-margin-medium !important;
+      margin-right: $fd-margin-medium !important;
+    }
+
+    &--lg {
+      margin-left: $fd-margin-large !important;
+      margin-right: $fd-margin-large !important;
+    }
+  }
+
+  // responsive margin
+  &-responsive {
+    &--sm {
+      margin: 0 0 $fd-margin-responsive-vertical 0 !important;
+    }
+
+    &--md {
+      margin: $fd-margin-responsive-medium !important;
+    }
+
+    &--lg {
+      margin: $fd-margin-responsive-vertical $fd-margin-responsive-large !important;
+    }
+
+    &--xl {
+      margin: $fd-margin-responsive-vertical $fd-margin-responsive-extra-large !important;
+    }
+  }
+
+  // negative margins
+  &-negative-begin-end {
+    &--tiny {
+      margin: 0 $fd-margin-negative-tiny !important;
+    }
+
+    &--sm {
+      margin: 0 $fd-margin-negative-small !important;
+    }
+
+    &--md {
+      margin: 0 $fd-margin-negative-medium !important;
+    }
+
+    &--lg {
+      margin: 0 $fd-margin-negative-large !important;
+    }
+  }
+}

--- a/src/paddings.scss
+++ b/src/paddings.scss
@@ -1,0 +1,57 @@
+@import './new-settings';
+@import './mixins';
+
+$block: #{$fd-namespace}-padding;
+
+.#{$block} {
+  $fd-padding-tiny: 0.5rem;
+  $fd-padding-small: 1rem;
+  $fd-padding-medium: 2rem;
+  $fd-padding-large: 3rem;
+  $fd-padding-responsive-horizontal: 1rem;
+  $fd-padding-responsive-medium-large: 2rem;
+  $fd-padding-responsive-extra-large: 3rem;
+
+  padding: 1rem !important;
+
+  &-begin-end {
+    &--tiny {
+      padding-left: $fd-padding-tiny !important;
+      padding-right: $fd-padding-tiny !important;
+    }
+
+    &--sm {
+      padding-left: $fd-padding-small !important;
+      padding-right: $fd-padding-small !important;
+    }
+
+    &--md {
+      padding-left: $fd-padding-medium !important;
+      padding-right: $fd-padding-medium !important;
+    }
+
+    &--lg {
+      padding-left: $fd-padding-large !important;
+      padding-right: $fd-padding-large !important;
+    }
+  }
+
+  &--none {
+    padding: 0 !important;
+  }
+
+  &-responsive {
+    &--sm {
+      padding: 0 $fd-padding-responsive-horizontal !important;
+    }
+
+    &--md,
+    &--lg {
+      padding: 0 $fd-padding-responsive-medium-large !important;
+    }
+
+    &--xl {
+      padding: 0 $fd-padding-responsive-extra-large !important;
+    }
+  }
+}

--- a/stories/margins/__snapshots__/margins.stories.storyshot
+++ b/stories/margins/__snapshots__/margins.stories.storyshot
@@ -250,11 +250,12 @@ exports[`Storyshots Layouts/Margins Double-Sided Negative Margin Begin-End 1`] =
     >
       
                 
-      <h4
+      <h1
         class="fd-panel__title"
+        title="Panel header"
       >
         Panel header
-      </h4>
+      </h1>
       
             
     </div>
@@ -274,11 +275,12 @@ exports[`Storyshots Layouts/Margins Double-Sided Negative Margin Begin-End 1`] =
     >
       
                 
-      <h4
+      <h1
         class="fd-panel__title"
+        title="Panel header"
       >
         Panel header
-      </h4>
+      </h1>
       
             
     </div>
@@ -297,11 +299,12 @@ exports[`Storyshots Layouts/Margins Double-Sided Negative Margin Begin-End 1`] =
     >
       
                 
-      <h4
+      <h1
         class="fd-panel__title"
+        title="Panel header"
       >
         Panel header
-      </h4>
+      </h1>
       
             
     </div>
@@ -320,11 +323,12 @@ exports[`Storyshots Layouts/Margins Double-Sided Negative Margin Begin-End 1`] =
     >
       
                 
-      <h4
+      <h1
         class="fd-panel__title"
+        title="Panel header"
       >
         Panel header
-      </h4>
+      </h1>
       
             
     </div>

--- a/stories/margins/__snapshots__/margins.stories.storyshot
+++ b/stories/margins/__snapshots__/margins.stories.storyshot
@@ -388,7 +388,7 @@ exports[`Storyshots Layouts/Margins No Margin 1`] = `
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 docs-layout-grid-bg--margin fd-margin-end--none"
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fddocs-margin-end-none fd-margin-end--none"
     >
       container
     </div>
@@ -424,7 +424,7 @@ exports[`Storyshots Layouts/Margins No Margin 1`] = `
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 docs-layout-grid-bg--margin fd-margin-begin--none"
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fddocs-margin-end-none fd-margin-begin--none"
     >
       container
     </div>

--- a/stories/margins/__snapshots__/margins.stories.storyshot
+++ b/stories/margins/__snapshots__/margins.stories.storyshot
@@ -1,0 +1,823 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Layouts/Margins All-Round Margin 1`] = `
+<div
+  class="docs-column-flex docs-column-flex--inline"
+>
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin--tiny"
+    >
+      container(tiny)
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin--sm"
+    >
+      container(sm)
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin--md"
+    >
+      container(md)
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin--lg"
+    >
+      container(lg)
+    </div>
+    
+        
+  </div>
+  
+    
+</div>
+`;
+
+exports[`Storyshots Layouts/Margins Double-Sided Margin Begin-End 1`] = `
+<div
+  class="docs-column-flex docs-column-flex--inline"
+>
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin-end--tiny"
+    >
+      container(tiny)
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin-end--sm"
+    >
+      container(sm)
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin-end--md"
+    >
+      container(md)
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin-end--lg"
+    >
+      container(lg)
+    </div>
+    
+        
+  </div>
+  
+    
+</div>
+`;
+
+exports[`Storyshots Layouts/Margins Double-Sided Margin Top-Bottom 1`] = `
+<div
+  class="docs-column-flex docs-column-flex--inline"
+>
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top-bottom--tiny"
+    >
+      container(tiny)
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top-bottom--sm"
+    >
+      container(sm)
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top-bottom--md"
+    >
+      container(md)
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top-bottom--lg"
+    >
+      container(lg)
+    </div>
+    
+        
+  </div>
+  
+    
+</div>
+`;
+
+exports[`Storyshots Layouts/Margins Double-Sided Negative Margin Begin-End 1`] = `
+<div
+  class="docs-column-flex docs-layout-grid-bg--padded"
+>
+  
+        
+  <div
+    class="fd-panel fd-panel--fixed fd-margin-negative-begin-end--tiny"
+  >
+    
+            
+    <div
+      class="fd-panel__header"
+    >
+      
+                
+      <h4
+        class="fd-panel__title"
+      >
+        Panel header
+      </h4>
+      
+            
+    </div>
+    
+        
+  </div>
+  
+
+        
+  <div
+    class="fd-panel fd-panel--fixed fd-margin-negative-begin-end--sm"
+  >
+    
+            
+    <div
+      class="fd-panel__header"
+    >
+      
+                
+      <h4
+        class="fd-panel__title"
+      >
+        Panel header
+      </h4>
+      
+            
+    </div>
+    
+        
+  </div>
+  
+        
+  <div
+    class="fd-panel fd-panel--fixed fd-margin-negative-begin-end--md"
+  >
+    
+            
+    <div
+      class="fd-panel__header"
+    >
+      
+                
+      <h4
+        class="fd-panel__title"
+      >
+        Panel header
+      </h4>
+      
+            
+    </div>
+    
+        
+  </div>
+  
+        
+  <div
+    class="fd-panel fd-panel--fixed fd-margin-negative-begin-end--lg"
+  >
+    
+            
+    <div
+      class="fd-panel__header"
+    >
+      
+                
+      <h4
+        class="fd-panel__title"
+      >
+        Panel header
+      </h4>
+      
+            
+    </div>
+    
+        
+  </div>
+  
+    
+</div>
+`;
+
+exports[`Storyshots Layouts/Margins No Margin 1`] = `
+<div
+  class="docs-column-flex docs-column-flex--inline"
+>
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 docs-layout-grid-bg--margin fd-margin--none"
+    >
+      container
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 docs-layout-grid-bg--margin fd-margin-top--none"
+    >
+      container
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 docs-layout-grid-bg--margin fd-margin-end--none"
+    >
+      container
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 docs-layout-grid-bg--margin fd-margin-bottom--none"
+    >
+      container
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 docs-layout-grid-bg--margin fd-margin-begin--none"
+    >
+      container
+    </div>
+    
+        
+  </div>
+  
+    
+</div>
+`;
+
+exports[`Storyshots Layouts/Margins Responsive Margin 1`] = `
+<div
+  class="docs-column-flex docs-column-flex--inline"
+>
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-responsive--sm"
+    >
+      container(sm)
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-responsive--md"
+    >
+      container(md)
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-responsive--lg"
+    >
+      container(lg)
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-responsive--xl"
+    >
+      container(xl)
+    </div>
+    
+        
+  </div>
+  
+    
+</div>
+`;
+
+exports[`Storyshots Layouts/Margins Single-Sided Margin Begin 1`] = `
+<div
+  class="docs-column-flex docs-column-flex--inline"
+>
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin--tiny"
+    >
+      container(tiny)
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin--sm"
+    >
+      container(sm)
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin--md"
+    >
+      container(md)
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin--lg"
+    >
+      container(lg)
+    </div>
+    
+        
+  </div>
+  
+    
+</div>
+`;
+
+exports[`Storyshots Layouts/Margins Single-Sided Margin Bottom 1`] = `
+<div
+  class="docs-column-flex docs-column-flex--inline"
+>
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-bottom--tiny"
+    >
+      container(tiny)
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-bottom--sm"
+    >
+      container(sm)
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-bottom--md"
+    >
+      container(md)
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-bottom--lg"
+    >
+      container(lg)
+    </div>
+    
+        
+  </div>
+  
+    
+</div>
+`;
+
+exports[`Storyshots Layouts/Margins Single-Sided Margin End 1`] = `
+<div
+  class="docs-column-flex docs-column-flex--inline"
+>
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-end--tiny"
+    >
+      container(tiny)
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-end--sm"
+    >
+      container(sm)
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-end--md"
+    >
+      container(md)
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-end--lg"
+    >
+      container(lg)
+    </div>
+    
+        
+  </div>
+  
+    
+</div>
+`;
+
+exports[`Storyshots Layouts/Margins Single-Sided Margin Top 1`] = `
+<div
+  class="docs-column-flex docs-column-flex--inline"
+>
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top--tiny"
+    >
+      container(tiny)
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top--sm"
+    >
+      container(sm)
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top--md"
+    >
+      container(md)
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top--lg"
+    >
+      container(lg)
+    </div>
+    
+        
+  </div>
+  
+    
+</div>
+`;

--- a/stories/margins/__snapshots__/margins.stories.storyshot
+++ b/stories/margins/__snapshots__/margins.stories.storyshot
@@ -2,17 +2,17 @@
 
 exports[`Storyshots Layouts/Margins All-Round Margin 1`] = `
 <div
-  class="docs-column-flex docs-column-flex--inline"
+  class="docs-column-flex docs-column-flex--align-start"
 >
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin--tiny"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin--tiny"
     >
       container(tiny)
     </div>
@@ -25,12 +25,12 @@ exports[`Storyshots Layouts/Margins All-Round Margin 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin--sm"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin--sm"
     >
       container(sm)
     </div>
@@ -43,12 +43,12 @@ exports[`Storyshots Layouts/Margins All-Round Margin 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin--md"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin--md"
     >
       container(md)
     </div>
@@ -61,12 +61,12 @@ exports[`Storyshots Layouts/Margins All-Round Margin 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin--lg"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin--lg"
     >
       container(lg)
     </div>
@@ -80,17 +80,17 @@ exports[`Storyshots Layouts/Margins All-Round Margin 1`] = `
 
 exports[`Storyshots Layouts/Margins Double-Sided Margin Begin-End 1`] = `
 <div
-  class="docs-column-flex docs-column-flex--inline"
+  class="docs-column-flex docs-column-flex--align-start"
 >
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin-end--tiny"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-begin-end--tiny"
     >
       container(tiny)
     </div>
@@ -103,12 +103,12 @@ exports[`Storyshots Layouts/Margins Double-Sided Margin Begin-End 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin-end--sm"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-begin-end--sm"
     >
       container(sm)
     </div>
@@ -121,12 +121,12 @@ exports[`Storyshots Layouts/Margins Double-Sided Margin Begin-End 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin-end--md"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-begin-end--md"
     >
       container(md)
     </div>
@@ -139,12 +139,12 @@ exports[`Storyshots Layouts/Margins Double-Sided Margin Begin-End 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin-end--lg"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-begin-end--lg"
     >
       container(lg)
     </div>
@@ -158,17 +158,17 @@ exports[`Storyshots Layouts/Margins Double-Sided Margin Begin-End 1`] = `
 
 exports[`Storyshots Layouts/Margins Double-Sided Margin Top-Bottom 1`] = `
 <div
-  class="docs-column-flex docs-column-flex--inline"
+  class="docs-column-flex docs-column-flex--align-start"
 >
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top-bottom--tiny"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-top-bottom--tiny"
     >
       container(tiny)
     </div>
@@ -181,12 +181,12 @@ exports[`Storyshots Layouts/Margins Double-Sided Margin Top-Bottom 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top-bottom--sm"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-top-bottom--sm"
     >
       container(sm)
     </div>
@@ -199,12 +199,12 @@ exports[`Storyshots Layouts/Margins Double-Sided Margin Top-Bottom 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top-bottom--md"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-top-bottom--md"
     >
       container(md)
     </div>
@@ -217,12 +217,12 @@ exports[`Storyshots Layouts/Margins Double-Sided Margin Top-Bottom 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top-bottom--lg"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-top-bottom--lg"
     >
       container(lg)
     </div>
@@ -236,7 +236,7 @@ exports[`Storyshots Layouts/Margins Double-Sided Margin Top-Bottom 1`] = `
 
 exports[`Storyshots Layouts/Margins Double-Sided Negative Margin Begin-End 1`] = `
 <div
-  class="docs-column-flex docs-layout-grid-bg--padded"
+  class="docs-column-flex docs-layout-margins-paddings--padded"
 >
   
         
@@ -342,17 +342,17 @@ exports[`Storyshots Layouts/Margins Double-Sided Negative Margin Begin-End 1`] =
 
 exports[`Storyshots Layouts/Margins No Margin 1`] = `
 <div
-  class="docs-column-flex docs-column-flex--inline"
+  class="docs-column-flex docs-column-flex--align-start"
 >
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 docs-layout-grid-bg--margin fd-margin--none"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 docs-layout-margins-paddings--margin fd-margin--none"
     >
       container
     </div>
@@ -365,12 +365,12 @@ exports[`Storyshots Layouts/Margins No Margin 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 docs-layout-grid-bg--margin fd-margin-top--none"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 docs-layout-margins-paddings--margin fd-margin-top--none"
     >
       container
     </div>
@@ -383,12 +383,12 @@ exports[`Storyshots Layouts/Margins No Margin 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fddocs-margin-end-none fd-margin-end--none"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fddocs-margin-end-none fd-margin-end--none"
     >
       container
     </div>
@@ -401,12 +401,12 @@ exports[`Storyshots Layouts/Margins No Margin 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 docs-layout-grid-bg--margin fd-margin-bottom--none"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 docs-layout-margins-paddings--margin fd-margin-bottom--none"
     >
       container
     </div>
@@ -419,12 +419,12 @@ exports[`Storyshots Layouts/Margins No Margin 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fddocs-margin-end-none fd-margin-begin--none"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fddocs-margin-end-none fd-margin-begin--none"
     >
       container
     </div>
@@ -438,17 +438,17 @@ exports[`Storyshots Layouts/Margins No Margin 1`] = `
 
 exports[`Storyshots Layouts/Margins Responsive Margin 1`] = `
 <div
-  class="docs-column-flex docs-column-flex--inline"
+  class="docs-column-flex docs-column-flex--align-start"
 >
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-responsive--sm"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-responsive--sm"
     >
       container(sm)
     </div>
@@ -461,12 +461,12 @@ exports[`Storyshots Layouts/Margins Responsive Margin 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-responsive--md"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-responsive--md"
     >
       container(md)
     </div>
@@ -479,12 +479,12 @@ exports[`Storyshots Layouts/Margins Responsive Margin 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-responsive--lg"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-responsive--lg"
     >
       container(lg)
     </div>
@@ -497,12 +497,12 @@ exports[`Storyshots Layouts/Margins Responsive Margin 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-responsive--xl"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-responsive--xl"
     >
       container(xl)
     </div>
@@ -516,17 +516,17 @@ exports[`Storyshots Layouts/Margins Responsive Margin 1`] = `
 
 exports[`Storyshots Layouts/Margins Single-Sided Margin Begin 1`] = `
 <div
-  class="docs-column-flex docs-column-flex--inline"
+  class="docs-column-flex docs-column-flex--align-start"
 >
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin--tiny"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-begin--tiny"
     >
       container(tiny)
     </div>
@@ -539,12 +539,12 @@ exports[`Storyshots Layouts/Margins Single-Sided Margin Begin 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin--sm"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13  fd-margin-begin--sm"
     >
       container(sm)
     </div>
@@ -557,12 +557,12 @@ exports[`Storyshots Layouts/Margins Single-Sided Margin Begin 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin--md"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-begin--md"
     >
       container(md)
     </div>
@@ -575,12 +575,12 @@ exports[`Storyshots Layouts/Margins Single-Sided Margin Begin 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin--lg"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-begin--lg"
     >
       container(lg)
     </div>
@@ -594,17 +594,17 @@ exports[`Storyshots Layouts/Margins Single-Sided Margin Begin 1`] = `
 
 exports[`Storyshots Layouts/Margins Single-Sided Margin Bottom 1`] = `
 <div
-  class="docs-column-flex docs-column-flex--inline"
+  class="docs-column-flex docs-column-flex--align-start"
 >
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-bottom--tiny"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-bottom--tiny"
     >
       container(tiny)
     </div>
@@ -617,12 +617,12 @@ exports[`Storyshots Layouts/Margins Single-Sided Margin Bottom 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-bottom--sm"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-bottom--sm"
     >
       container(sm)
     </div>
@@ -635,12 +635,12 @@ exports[`Storyshots Layouts/Margins Single-Sided Margin Bottom 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-bottom--md"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-bottom--md"
     >
       container(md)
     </div>
@@ -653,12 +653,12 @@ exports[`Storyshots Layouts/Margins Single-Sided Margin Bottom 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-bottom--lg"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-bottom--lg"
     >
       container(lg)
     </div>
@@ -672,17 +672,17 @@ exports[`Storyshots Layouts/Margins Single-Sided Margin Bottom 1`] = `
 
 exports[`Storyshots Layouts/Margins Single-Sided Margin End 1`] = `
 <div
-  class="docs-column-flex docs-column-flex--inline"
+  class="docs-column-flex docs-column-flex--align-start"
 >
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-end--tiny"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-end--tiny"
     >
       container(tiny)
     </div>
@@ -695,12 +695,12 @@ exports[`Storyshots Layouts/Margins Single-Sided Margin End 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-end--sm"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-end--sm"
     >
       container(sm)
     </div>
@@ -713,12 +713,12 @@ exports[`Storyshots Layouts/Margins Single-Sided Margin End 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-end--md"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-end--md"
     >
       container(md)
     </div>
@@ -731,12 +731,12 @@ exports[`Storyshots Layouts/Margins Single-Sided Margin End 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-end--lg"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-end--lg"
     >
       container(lg)
     </div>
@@ -750,17 +750,17 @@ exports[`Storyshots Layouts/Margins Single-Sided Margin End 1`] = `
 
 exports[`Storyshots Layouts/Margins Single-Sided Margin Top 1`] = `
 <div
-  class="docs-column-flex docs-column-flex--inline"
+  class="docs-column-flex docs-column-flex--align-start"
 >
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top--tiny"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-top--tiny"
     >
       container(tiny)
     </div>
@@ -773,12 +773,12 @@ exports[`Storyshots Layouts/Margins Single-Sided Margin Top 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top--sm"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-top--sm"
     >
       container(sm)
     </div>
@@ -791,12 +791,12 @@ exports[`Storyshots Layouts/Margins Single-Sided Margin Top 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top--md"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-top--md"
     >
       container(md)
     </div>
@@ -809,12 +809,12 @@ exports[`Storyshots Layouts/Margins Single-Sided Margin Top 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg"
+    class="docs-layout-margins-paddings--secondary-bg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top--lg"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-top--lg"
     >
       container(lg)
     </div>

--- a/stories/margins/margins.stories.js
+++ b/stories/margins/margins.stories.js
@@ -1,0 +1,293 @@
+export default {
+    title: 'Layouts/Margins',
+    parameters: {
+        description: `The CSS margin properties are used to create space around elements, outside of any defined borders. 
+        With CSS, you have full control over the margins. There are properties for setting the margin for each side of an element. 
+        We now provide a number of predefined margin clases which add predefined margin values.`,
+        tags: ['f3', 'theme'],
+        components: ['margins', 'panel']
+    }
+};
+
+export const AllRoundMargin = () =>
+    `<div class="docs-column-flex docs-column-flex--inline">
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin--tiny">container(tiny)</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin--sm">container(sm)</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin--md">container(md)</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin--lg">container(lg)</div>
+        </div>
+    </div>
+`;
+AllRoundMargin.storyName = 'All-Round Margin';
+AllRoundMargin.parameters = {
+    docs: {
+        storyDescription: `All-round margin appears on all sides of the container they are applied to. Use <code>fd-margin</code>
+        class with any of the following modifiers:
+        
+| Element | Modifier class | Margin applied |
+| ----------------: | :------------ | :------------ |
+| Tiny | \`fd-margin--tiny\` | 0.5rem |
+| Small | \`fd-margin--sm\` | 1rem |
+| Medium | \`fd-margin--md\` | 2rem |
+| Large | \`fd-margin--lg\` | 3rem |
+`
+    }
+};
+
+export const SingleSidedMarginTop = () =>
+    `<div class="docs-column-flex docs-column-flex--inline">
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top--tiny">container(tiny)</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top--sm">container(sm)</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top--md">container(md)</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top--lg">container(lg)</div>
+        </div>
+    </div>
+`;
+SingleSidedMarginTop.storyName = 'Single-Sided Margin Top';
+SingleSidedMarginTop.parameters = {
+    docs: {
+        storyDescription: `Single sided margins appear on only one of the sides of the element:
+
+- top - displayed on top of the element
+- end - displayed on the right side and in right-to-left mode on the left side of the element
+- bottom - displayed on the bottom of the element
+- begin - displayed on the left side and in right-to-left mode on the right side of the element. 
+
+Use <code>fd-margin-top</code> or <code>fd-margin-end</code> or <code>fd-margin-bottom</code> or <code>fd-margin-begin</code>
+class with any of the size modifiers as mentioned above.
+`
+    }
+};
+
+export const SingleSidedMarginEnd = () =>
+    `<div class="docs-column-flex docs-column-flex--inline">
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-end--tiny">container(tiny)</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-end--sm">container(sm)</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-end--md">container(md)</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-end--lg">container(lg)</div>
+        </div>
+    </div>
+`;
+SingleSidedMarginEnd.storyName = 'Single-Sided Margin End';
+
+export const SingleSidedMarginBottom = () =>
+    `<div class="docs-column-flex docs-column-flex--inline">
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-bottom--tiny">container(tiny)</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-bottom--sm">container(sm)</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-bottom--md">container(md)</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-bottom--lg">container(lg)</div>
+        </div>
+    </div>
+`;
+SingleSidedMarginBottom.storyName = 'Single-Sided Margin Bottom';
+
+export const SingleSidedMarginBegin = () =>
+    `<div class="docs-column-flex docs-column-flex--inline">
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin--tiny">container(tiny)</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin--sm">container(sm)</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin--md">container(md)</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin--lg">container(lg)</div>
+        </div>
+    </div>
+`;
+SingleSidedMarginBegin.storyName = 'Single-Sided Margin Begin';
+
+export const DoubleSidedMarginTopBottom = () =>
+    `<div class="docs-column-flex docs-column-flex--inline">
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top-bottom--tiny">container(tiny)</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top-bottom--sm">container(sm)</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top-bottom--md">container(md)</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top-bottom--lg">container(lg)</div>
+        </div>
+    </div>
+`;
+DoubleSidedMarginTopBottom.storyName = 'Double-Sided Margin Top-Bottom';
+DoubleSidedMarginTopBottom.parameters = {
+    docs: {
+        storyDescription: `Double sided margins appear on two opposite sides of the element.
+
+- top-bottom - displayed on top and bottom of the element
+- begin-end - displayed on left and right side of the element
+
+Use <code>fd-margin-top-bottom</code> or <code>fd-margin-begin-end</code> class with any of the size modifiers as mentioned above.`
+    }
+};
+
+export const DoubleSidedMarginBeginEnd = () =>
+    `<div class="docs-column-flex docs-column-flex--inline">
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin-end--tiny">container(tiny)</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin-end--sm">container(sm)</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin-end--md">container(md)</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin-end--lg">container(lg)</div>
+        </div>
+    </div>
+`;
+DoubleSidedMarginBeginEnd.storyName = 'Double-Sided Margin Begin-End';
+
+export const NoMargin = () =>
+    `<div class="docs-column-flex docs-column-flex--inline">
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 docs-layout-grid-bg--margin fd-margin--none">container</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 docs-layout-grid-bg--margin fd-margin-top--none">container</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 docs-layout-grid-bg--margin fd-margin-end--none">container</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 docs-layout-grid-bg--margin fd-margin-bottom--none">container</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 docs-layout-grid-bg--margin fd-margin-begin--none">container</div>
+        </div>
+    </div>
+`;
+NoMargin.parameters = {
+    docs: {
+        storyDescription: `No margin classes remove existing container margins. Use <code>fd-margin--none</code> or  <code>fd-margin-top--none</code>
+        or <code>fd-margin-end--none</code> or <code>fd-margin-bottom--none</code> or <code>fd-margin-begin--none</code>
+        modifier classes to remove existing margin. Place the no margin classes last to make sure they will be applied.`
+    }
+};
+
+export const ResponsiveMargin = () =>
+    `<div class="docs-column-flex docs-column-flex--inline">
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-responsive--sm">container(sm)</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-responsive--md">container(md)</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-responsive--lg">container(lg)</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-responsive--xl">container(xl)</div>
+        </div>
+    </div>
+`;
+ResponsiveMargin.parameters = {
+    docs: {
+        storyDescription: `The responsive margins class adds a margin around an element based on the width of the container the element is in. Use <code>fd-margin-responsive</code>
+        class with any of the following modifiers:
+
+| Element | Modifier class |
+| ----------------: | :------------ |
+| Small | \`fd-margin-responsive--sm\` |
+| Medium | \`fd-margin-responsive--md\` |
+| Large | \`fd-margin-responsive--lg\` |
+| Extra-large | \`fd-margin-responsive--xl\` |
+`
+    }
+};
+
+export const DoubleSidedNegativeMarginBeginEnd = () =>
+    `<div class="docs-column-flex docs-layout-grid-bg--padded">
+        <div class="fd-panel fd-panel--fixed fd-margin-negative-begin-end--tiny">
+            <div class="fd-panel__header">
+                <h4 class="fd-panel__title">Panel header</h4>
+            </div>
+        </div>
+
+        <div class="fd-panel fd-panel--fixed fd-margin-negative-begin-end--sm">
+            <div class="fd-panel__header">
+                <h4 class="fd-panel__title">Panel header</h4>
+            </div>
+        </div>
+        <div class="fd-panel fd-panel--fixed fd-margin-negative-begin-end--md">
+            <div class="fd-panel__header">
+                <h4 class="fd-panel__title">Panel header</h4>
+            </div>
+        </div>
+        <div class="fd-panel fd-panel--fixed fd-margin-negative-begin-end--lg">
+            <div class="fd-panel__header">
+                <h4 class="fd-panel__title">Panel header</h4>
+            </div>
+        </div>
+    </div>
+`;
+DoubleSidedNegativeMarginBeginEnd.storyName = 'Double-Sided Negative Margin Begin-End';
+DoubleSidedNegativeMarginBeginEnd.parameters = {
+    docs: {
+        storyDescription: `The negative margin class adds a double sided negative margin to an element. This is useful when aligning elements with built-in paddings.
+  Use <code>fd-margin-negative-begin-end</code> class with any of the size modifiers as mentioned above.`
+    }
+};

--- a/stories/margins/margins.stories.js
+++ b/stories/margins/margins.stories.js
@@ -215,7 +215,8 @@ NoMargin.parameters = {
         or <code>fd-margin-end--none</code> or <code>fd-margin-bottom--none</code> or <code>fd-margin-begin--none</code>
         modifier classes to remove existing margin. Place the no margin classes last to make sure they will be applied.
         In the case of <code>fd-margin-begin--none</code> and <code>fd-margin-end--none</code>, <code>!important</code> is not applied since we want
-        the user-specified margins(if any) to be reapplied in the RTL mode.`
+        the user-specified margins(if any) to be reapplied in the RTL mode. Please note that for RTL to work correctly,
+        you must add <code>[dir="rtl"]</code> style on the class where these modifiers will be applied.`
     }
 };
 

--- a/stories/margins/margins.stories.js
+++ b/stories/margins/margins.stories.js
@@ -9,8 +9,7 @@ export default {
     }
 };
 
-export const AllRoundMargin = () =>
-    `<div class="docs-column-flex docs-column-flex--inline">
+export const AllRoundMargin = () => `<div class="docs-column-flex docs-column-flex--inline">
         <div class="docs-layout-grid-bg">
             <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin--tiny">container(tiny)</div>
         </div>
@@ -44,8 +43,7 @@ AllRoundMargin.parameters = {
     }
 };
 
-export const SingleSidedMarginTop = () =>
-    `<div class="docs-column-flex docs-column-flex--inline">
+export const SingleSidedMarginTop = () => `<div class="docs-column-flex docs-column-flex--inline">
         <div class="docs-layout-grid-bg">
             <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top--tiny">container(tiny)</div>
         </div>
@@ -79,8 +77,7 @@ class with any of the size modifiers as mentioned above.
     }
 };
 
-export const SingleSidedMarginEnd = () =>
-    `<div class="docs-column-flex docs-column-flex--inline">
+export const SingleSidedMarginEnd = () => `<div class="docs-column-flex docs-column-flex--inline">
         <div class="docs-layout-grid-bg">
             <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-end--tiny">container(tiny)</div>
         </div>
@@ -100,8 +97,7 @@ export const SingleSidedMarginEnd = () =>
 `;
 SingleSidedMarginEnd.storyName = 'Single-Sided Margin End';
 
-export const SingleSidedMarginBottom = () =>
-    `<div class="docs-column-flex docs-column-flex--inline">
+export const SingleSidedMarginBottom = () => `<div class="docs-column-flex docs-column-flex--inline">
         <div class="docs-layout-grid-bg">
             <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-bottom--tiny">container(tiny)</div>
         </div>
@@ -121,8 +117,7 @@ export const SingleSidedMarginBottom = () =>
 `;
 SingleSidedMarginBottom.storyName = 'Single-Sided Margin Bottom';
 
-export const SingleSidedMarginBegin = () =>
-    `<div class="docs-column-flex docs-column-flex--inline">
+export const SingleSidedMarginBegin = () => `<div class="docs-column-flex docs-column-flex--inline">
         <div class="docs-layout-grid-bg">
             <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin--tiny">container(tiny)</div>
         </div>
@@ -142,8 +137,7 @@ export const SingleSidedMarginBegin = () =>
 `;
 SingleSidedMarginBegin.storyName = 'Single-Sided Margin Begin';
 
-export const DoubleSidedMarginTopBottom = () =>
-    `<div class="docs-column-flex docs-column-flex--inline">
+export const DoubleSidedMarginTopBottom = () => `<div class="docs-column-flex docs-column-flex--inline">
         <div class="docs-layout-grid-bg">
             <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top-bottom--tiny">container(tiny)</div>
         </div>
@@ -173,8 +167,7 @@ Use <code>fd-margin-top-bottom</code> or <code>fd-margin-begin-end</code> class 
     }
 };
 
-export const DoubleSidedMarginBeginEnd = () =>
-    `<div class="docs-column-flex docs-column-flex--inline">
+export const DoubleSidedMarginBeginEnd = () => `<div class="docs-column-flex docs-column-flex--inline">
         <div class="docs-layout-grid-bg">
             <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin-end--tiny">container(tiny)</div>
         </div>
@@ -194,8 +187,7 @@ export const DoubleSidedMarginBeginEnd = () =>
 `;
 DoubleSidedMarginBeginEnd.storyName = 'Double-Sided Margin Begin-End';
 
-export const NoMargin = () =>
-    `<div class="docs-column-flex docs-column-flex--inline">
+export const NoMargin = () => `<div class="docs-column-flex docs-column-flex--inline">
         <div class="docs-layout-grid-bg">
             <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 docs-layout-grid-bg--margin fd-margin--none">container</div>
         </div>
@@ -225,8 +217,7 @@ NoMargin.parameters = {
     }
 };
 
-export const ResponsiveMargin = () =>
-    `<div class="docs-column-flex docs-column-flex--inline">
+export const ResponsiveMargin = () => `<div class="docs-column-flex docs-column-flex--inline">
         <div class="docs-layout-grid-bg">
             <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-responsive--sm">container(sm)</div>
         </div>
@@ -259,27 +250,26 @@ ResponsiveMargin.parameters = {
     }
 };
 
-export const DoubleSidedNegativeMarginBeginEnd = () =>
-    `<div class="docs-column-flex docs-layout-grid-bg--padded">
+export const DoubleSidedNegativeMarginBeginEnd = () => `<div class="docs-column-flex docs-layout-grid-bg--padded">
         <div class="fd-panel fd-panel--fixed fd-margin-negative-begin-end--tiny">
             <div class="fd-panel__header">
-                <h4 class="fd-panel__title">Panel header</h4>
+                <h1 class="fd-panel__title" title="Panel header">Panel header</h1>
             </div>
         </div>
 
         <div class="fd-panel fd-panel--fixed fd-margin-negative-begin-end--sm">
             <div class="fd-panel__header">
-                <h4 class="fd-panel__title">Panel header</h4>
+                <h1 class="fd-panel__title" title="Panel header">Panel header</h1>
             </div>
         </div>
         <div class="fd-panel fd-panel--fixed fd-margin-negative-begin-end--md">
             <div class="fd-panel__header">
-                <h4 class="fd-panel__title">Panel header</h4>
+                <h1 class="fd-panel__title" title="Panel header">Panel header</h1>
             </div>
         </div>
         <div class="fd-panel fd-panel--fixed fd-margin-negative-begin-end--lg">
             <div class="fd-panel__header">
-                <h4 class="fd-panel__title">Panel header</h4>
+                <h1 class="fd-panel__title" title="Panel header">Panel header</h1>
             </div>
         </div>
     </div>

--- a/stories/margins/margins.stories.js
+++ b/stories/margins/margins.stories.js
@@ -9,21 +9,21 @@ export default {
     }
 };
 
-export const AllRoundMargin = () => `<div class="docs-column-flex docs-column-flex--inline">
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin--tiny">container(tiny)</div>
+export const AllRoundMargin = () => `<div class="docs-column-flex docs-column-flex--align-start">
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin--tiny">container(tiny)</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin--sm">container(sm)</div>
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin--sm">container(sm)</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin--md">container(md)</div>
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin--md">container(md)</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin--lg">container(lg)</div>
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin--lg">container(lg)</div>
         </div>
     </div>
 `;
@@ -43,21 +43,21 @@ AllRoundMargin.parameters = {
     }
 };
 
-export const SingleSidedMarginTop = () => `<div class="docs-column-flex docs-column-flex--inline">
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top--tiny">container(tiny)</div>
+export const SingleSidedMarginTop = () => `<div class="docs-column-flex docs-column-flex--align-start">
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-top--tiny">container(tiny)</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top--sm">container(sm)</div>
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-top--sm">container(sm)</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top--md">container(md)</div>
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-top--md">container(md)</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top--lg">container(lg)</div>
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-top--lg">container(lg)</div>
         </div>
     </div>
 `;
@@ -77,81 +77,81 @@ class with any of the size modifiers as mentioned above.
     }
 };
 
-export const SingleSidedMarginEnd = () => `<div class="docs-column-flex docs-column-flex--inline">
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-end--tiny">container(tiny)</div>
+export const SingleSidedMarginEnd = () => `<div class="docs-column-flex docs-column-flex--align-start">
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-end--tiny">container(tiny)</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-end--sm">container(sm)</div>
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-end--sm">container(sm)</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-end--md">container(md)</div>
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-end--md">container(md)</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-end--lg">container(lg)</div>
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-end--lg">container(lg)</div>
         </div>
     </div>
 `;
 SingleSidedMarginEnd.storyName = 'Single-Sided Margin End';
 
-export const SingleSidedMarginBottom = () => `<div class="docs-column-flex docs-column-flex--inline">
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-bottom--tiny">container(tiny)</div>
+export const SingleSidedMarginBottom = () => `<div class="docs-column-flex docs-column-flex--align-start">
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-bottom--tiny">container(tiny)</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-bottom--sm">container(sm)</div>
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-bottom--sm">container(sm)</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-bottom--md">container(md)</div>
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-bottom--md">container(md)</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-bottom--lg">container(lg)</div>
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-bottom--lg">container(lg)</div>
         </div>
     </div>
 `;
 SingleSidedMarginBottom.storyName = 'Single-Sided Margin Bottom';
 
-export const SingleSidedMarginBegin = () => `<div class="docs-column-flex docs-column-flex--inline">
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin--tiny">container(tiny)</div>
+export const SingleSidedMarginBegin = () => `<div class="docs-column-flex docs-column-flex--align-start">
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-begin--tiny">container(tiny)</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin--sm">container(sm)</div>
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13  fd-margin-begin--sm">container(sm)</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin--md">container(md)</div>
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-begin--md">container(md)</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin--lg">container(lg)</div>
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-begin--lg">container(lg)</div>
         </div>
     </div>
 `;
 SingleSidedMarginBegin.storyName = 'Single-Sided Margin Begin';
 
-export const DoubleSidedMarginTopBottom = () => `<div class="docs-column-flex docs-column-flex--inline">
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top-bottom--tiny">container(tiny)</div>
+export const DoubleSidedMarginTopBottom = () => `<div class="docs-column-flex docs-column-flex--align-start">
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-top-bottom--tiny">container(tiny)</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top-bottom--sm">container(sm)</div>
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-top-bottom--sm">container(sm)</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top-bottom--md">container(md)</div>
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-top-bottom--md">container(md)</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-top-bottom--lg">container(lg)</div>
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-top-bottom--lg">container(lg)</div>
         </div>
     </div>
 `;
@@ -167,45 +167,45 @@ Use <code>fd-margin-top-bottom</code> or <code>fd-margin-begin-end</code> class 
     }
 };
 
-export const DoubleSidedMarginBeginEnd = () => `<div class="docs-column-flex docs-column-flex--inline">
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin-end--tiny">container(tiny)</div>
+export const DoubleSidedMarginBeginEnd = () => `<div class="docs-column-flex docs-column-flex--align-start">
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-begin-end--tiny">container(tiny)</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin-end--sm">container(sm)</div>
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-begin-end--sm">container(sm)</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin-end--md">container(md)</div>
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-begin-end--md">container(md)</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-begin-end--lg">container(lg)</div>
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-begin-end--lg">container(lg)</div>
         </div>
     </div>
 `;
 DoubleSidedMarginBeginEnd.storyName = 'Double-Sided Margin Begin-End';
 
-export const NoMargin = () => `<div class="docs-column-flex docs-column-flex--inline">
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 docs-layout-grid-bg--margin fd-margin--none">container</div>
+export const NoMargin = () => `<div class="docs-column-flex docs-column-flex--align-start">
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 docs-layout-margins-paddings--margin fd-margin--none">container</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 docs-layout-grid-bg--margin fd-margin-top--none">container</div>
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 docs-layout-margins-paddings--margin fd-margin-top--none">container</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fddocs-margin-end-none fd-margin-end--none">container</div>
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fddocs-margin-end-none fd-margin-end--none">container</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 docs-layout-grid-bg--margin fd-margin-bottom--none">container</div>
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 docs-layout-margins-paddings--margin fd-margin-bottom--none">container</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fddocs-margin-end-none fd-margin-begin--none">container</div>
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fddocs-margin-end-none fd-margin-begin--none">container</div>
         </div>
     </div>
 `;
@@ -220,21 +220,21 @@ NoMargin.parameters = {
     }
 };
 
-export const ResponsiveMargin = () => `<div class="docs-column-flex docs-column-flex--inline">
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-responsive--sm">container(sm)</div>
+export const ResponsiveMargin = () => `<div class="docs-column-flex docs-column-flex--align-start">
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-responsive--sm">container(sm)</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-responsive--md">container(md)</div>
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-responsive--md">container(md)</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-responsive--lg">container(lg)</div>
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-responsive--lg">container(lg)</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fd-margin-responsive--xl">container(xl)</div>
+        <div class="docs-layout-margins-paddings--secondary-bg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-margins-paddings--color-13 fd-margin-responsive--xl">container(xl)</div>
         </div>
     </div>
 `;
@@ -253,7 +253,7 @@ ResponsiveMargin.parameters = {
     }
 };
 
-export const DoubleSidedNegativeMarginBeginEnd = () => `<div class="docs-column-flex docs-layout-grid-bg--padded">
+export const DoubleSidedNegativeMarginBeginEnd = () => `<div class="docs-column-flex docs-layout-margins-paddings--padded">
         <div class="fd-panel fd-panel--fixed fd-margin-negative-begin-end--tiny">
             <div class="fd-panel__header">
                 <h1 class="fd-panel__title" title="Panel header">Panel header</h1>

--- a/stories/margins/margins.stories.js
+++ b/stories/margins/margins.stories.js
@@ -197,7 +197,7 @@ export const NoMargin = () => `<div class="docs-column-flex docs-column-flex--in
         </div>
         <br />
         <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 docs-layout-grid-bg--margin fd-margin-end--none">container</div>
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fddocs-margin-end-none fd-margin-end--none">container</div>
         </div>
         <br />
         <div class="docs-layout-grid-bg">
@@ -205,7 +205,7 @@ export const NoMargin = () => `<div class="docs-column-flex docs-column-flex--in
         </div>
         <br />
         <div class="docs-layout-grid-bg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 docs-layout-grid-bg--margin fd-margin-begin--none">container</div>
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7 fddocs-margin-end-none fd-margin-begin--none">container</div>
         </div>
     </div>
 `;
@@ -213,7 +213,9 @@ NoMargin.parameters = {
     docs: {
         storyDescription: `No margin classes remove existing container margins. Use <code>fd-margin--none</code> or  <code>fd-margin-top--none</code>
         or <code>fd-margin-end--none</code> or <code>fd-margin-bottom--none</code> or <code>fd-margin-begin--none</code>
-        modifier classes to remove existing margin. Place the no margin classes last to make sure they will be applied.`
+        modifier classes to remove existing margin. Place the no margin classes last to make sure they will be applied.
+        In the case of <code>fd-margin-begin--none</code> and <code>fd-margin-end--none</code>, <code>!important</code> is not applied since we want
+        the user-specified margins(if any) to be reapplied in the RTL mode.`
     }
 };
 

--- a/stories/paddings/__snapshots__/paddings.stories.storyshot
+++ b/stories/paddings/__snapshots__/paddings.stories.storyshot
@@ -1,0 +1,205 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Layouts/Paddings All-Round Padding 1`] = `
+<div
+  class="docs-column-flex docs-column-flex--inline"
+>
+  
+        
+  <div
+    class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7"
+    >
+      container
+    </div>
+    
+        
+  </div>
+  
+    
+</div>
+`;
+
+exports[`Storyshots Layouts/Paddings Double-Sided Padding 1`] = `
+<div
+  class="docs-column-flex docs-column-flex--inline"
+>
+  
+        
+  <div
+    class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-begin-end--tiny"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7"
+    >
+      container(tiny)
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-begin-end--sm"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7"
+    >
+      container(sm)
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-begin-end--md"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7"
+    >
+      container(md)
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-begin-end--lg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7"
+    >
+      container(lg)
+    </div>
+    
+        
+  </div>
+  
+    
+</div>
+`;
+
+exports[`Storyshots Layouts/Paddings No Padding 1`] = `
+<div
+  class="docs-column-flex docs-column-flex--inline"
+>
+  
+        
+  <div
+    class="docs-layout-grid-bg docs-layout-grid-bg--color-1 docs-layout-grid-bg--padded fd-padding--none"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7"
+    >
+      container
+    </div>
+    
+        
+  </div>
+  
+    
+</div>
+`;
+
+exports[`Storyshots Layouts/Paddings Responsive Padding 1`] = `
+<div
+  class="docs-column-flex docs-column-flex--inline"
+>
+  
+        
+  <div
+    class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-responsive--sm"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7"
+    >
+      container(sm)
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-responsive--md"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7"
+    >
+      container(md)
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-responsive--lg"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7"
+    >
+      container(lg)
+    </div>
+    
+        
+  </div>
+  
+        
+  <br />
+  
+        
+  <div
+    class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-responsive--xl"
+  >
+    
+            
+    <div
+      class="docs-layout-grid-bg docs-layout-grid-bg--color-7"
+    >
+      container(xl)
+    </div>
+    
+        
+  </div>
+  
+    
+</div>
+`;

--- a/stories/paddings/__snapshots__/paddings.stories.storyshot
+++ b/stories/paddings/__snapshots__/paddings.stories.storyshot
@@ -2,17 +2,17 @@
 
 exports[`Storyshots Layouts/Paddings All-Round Padding 1`] = `
 <div
-  class="docs-column-flex docs-column-flex--inline"
+  class="docs-column-flex docs-column-flex--align-start"
 >
   
         
   <div
-    class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding"
+    class="docs-layout-margins-paddings--color-14 fd-padding"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-grid-bg--color-7"
     >
       container
     </div>
@@ -26,17 +26,17 @@ exports[`Storyshots Layouts/Paddings All-Round Padding 1`] = `
 
 exports[`Storyshots Layouts/Paddings Double-Sided Padding 1`] = `
 <div
-  class="docs-column-flex docs-column-flex--inline"
+  class="docs-column-flex docs-column-flex--align-start"
 >
   
         
   <div
-    class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-begin-end--tiny"
+    class="docs-layout-margins-paddings--color-14 fd-padding-begin-end--tiny"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-grid-bg--color-7"
     >
       container(tiny)
     </div>
@@ -49,12 +49,12 @@ exports[`Storyshots Layouts/Paddings Double-Sided Padding 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-begin-end--sm"
+    class="docs-layout-margins-paddings--color-14 fd-padding-begin-end--sm"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7"
+      class="docs-layout-margins-paddings  docs-layout-margins-paddings--width-sm docs-layout-grid-bg--color-7"
     >
       container(sm)
     </div>
@@ -67,12 +67,12 @@ exports[`Storyshots Layouts/Paddings Double-Sided Padding 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-begin-end--md"
+    class="docs-layout-margins-paddings--color-14 fd-padding-begin-end--md"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width-md docs-layout-grid-bg--color-7"
     >
       container(md)
     </div>
@@ -85,12 +85,12 @@ exports[`Storyshots Layouts/Paddings Double-Sided Padding 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-begin-end--lg"
+    class="docs-layout-margins-paddings--color-14 fd-padding-begin-end--lg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width-lg docs-layout-grid-bg--color-7"
     >
       container(lg)
     </div>
@@ -104,17 +104,17 @@ exports[`Storyshots Layouts/Paddings Double-Sided Padding 1`] = `
 
 exports[`Storyshots Layouts/Paddings No Padding 1`] = `
 <div
-  class="docs-column-flex docs-column-flex--inline"
+  class="docs-column-flex docs-column-flex--align-start"
 >
   
         
   <div
-    class="docs-layout-grid-bg docs-layout-grid-bg--color-1 docs-layout-grid-bg--padded fd-padding--none"
+    class="docs-layout-margins-paddings--color-14 docs-layout-margins-paddings--padded fd-padding--none"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-grid-bg--color-7"
     >
       container
     </div>
@@ -128,17 +128,17 @@ exports[`Storyshots Layouts/Paddings No Padding 1`] = `
 
 exports[`Storyshots Layouts/Paddings Responsive Padding 1`] = `
 <div
-  class="docs-column-flex docs-column-flex--inline"
+  class="docs-column-flex docs-column-flex--align-start"
 >
   
         
   <div
-    class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-responsive--sm"
+    class="docs-layout-margins-paddings--color-14 fd-padding-responsive--sm"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width-sm docs-layout-grid-bg--color-7"
     >
       container(sm)
     </div>
@@ -151,12 +151,12 @@ exports[`Storyshots Layouts/Paddings Responsive Padding 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-responsive--md"
+    class="docs-layout-margins-paddings--color-14 fd-padding-responsive--md"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width-md docs-layout-grid-bg--color-7"
     >
       container(md)
     </div>
@@ -169,12 +169,12 @@ exports[`Storyshots Layouts/Paddings Responsive Padding 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-responsive--lg"
+    class="docs-layout-margins-paddings--color-14 fd-padding-responsive--lg"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width-md docs-layout-grid-bg--color-7"
     >
       container(lg)
     </div>
@@ -187,12 +187,12 @@ exports[`Storyshots Layouts/Paddings Responsive Padding 1`] = `
   
         
   <div
-    class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-responsive--xl"
+    class="docs-layout-margins-paddings--color-14 fd-padding-responsive--xl"
   >
     
             
     <div
-      class="docs-layout-grid-bg docs-layout-grid-bg--color-7"
+      class="docs-layout-margins-paddings docs-layout-margins-paddings--width-lg docs-layout-grid-bg--color-7"
     >
       container(xl)
     </div>

--- a/stories/paddings/paddings.stories.js
+++ b/stories/paddings/paddings.stories.js
@@ -9,8 +9,7 @@ export default {
     }
 };
 
-export const AllRoundPadding = () =>
-    `<div class="docs-column-flex docs-column-flex--inline">
+export const AllRoundPadding = () => `<div class="docs-column-flex docs-column-flex--inline">
         <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding">
             <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7">container</div>
         </div>
@@ -24,8 +23,7 @@ AllRoundPadding.parameters = {
     }
 };
 
-export const DoubleSidedPadding = () =>
-    `<div class="docs-column-flex docs-column-flex--inline">
+export const DoubleSidedPadding = () => `<div class="docs-column-flex docs-column-flex--inline">
         <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-begin-end--tiny">
             <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7">container(tiny)</div>
         </div>
@@ -60,8 +58,7 @@ DoubleSidedPadding.parameters = {
 };
 
 
-export const NoPadding = () =>
-    `<div class="docs-column-flex docs-column-flex--inline">
+export const NoPadding = () => `<div class="docs-column-flex docs-column-flex--inline">
         <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1 docs-layout-grid-bg--padded fd-padding--none">
             <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7">container</div>
         </div>
@@ -74,8 +71,7 @@ NoPadding.parameters = {
     }
 };
 
-export const ResponsivePadding = () =>
-    `<div class="docs-column-flex docs-column-flex--inline">
+export const ResponsivePadding = () => `<div class="docs-column-flex docs-column-flex--inline">
         <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-responsive--sm">
             <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7">container(sm)</div>
         </div>

--- a/stories/paddings/paddings.stories.js
+++ b/stories/paddings/paddings.stories.js
@@ -1,0 +1,109 @@
+export default {
+    title: 'Layouts/Paddings',
+    parameters: {
+        description: `The CSS padding properties are used to generate space around an element's content, inside of any defined borders.
+        With CSS, you have full control over the padding. There are properties for setting the padding for each side of an element.
+        We now provide a number of predefined padding clases which add predefined padding values.`,
+        tags: ['f3', 'theme'],
+        components: ['paddings']
+    }
+};
+
+export const AllRoundPadding = () =>
+    `<div class="docs-column-flex docs-column-flex--inline">
+        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7">container</div>
+        </div>
+    </div>
+`;
+AllRoundPadding.storyName = 'All-Round Padding';
+AllRoundPadding.parameters = {
+    docs: {
+        storyDescription: `All-round padding appears on all sides of the container they are applied to. Use <code>fd-padding</code>
+        class to apply a padding of 1rem.`
+    }
+};
+
+export const DoubleSidedPadding = () =>
+    `<div class="docs-column-flex docs-column-flex--inline">
+        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-begin-end--tiny">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7">container(tiny)</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-begin-end--sm">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7">container(sm)</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-begin-end--md">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7">container(md)</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-begin-end--lg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7">container(lg)</div>
+        </div>
+    </div>
+`;
+DoubleSidedPadding.storyName = 'Double-Sided Padding';
+DoubleSidedPadding.parameters = {
+    docs: {
+        storyDescription: `Double sided paddings appear on two opposite sides of the element. Use <code>fd-padding-begin-end</code>
+        class with any of the following modifiers:
+
+| Element | Modifier class |
+| ----------------: | :------------ |
+| Tiny | \`fd-padding-begin-end--tiny\` |
+| Small | \`fd-padding-begin-end--sm\` |
+| Medium | \`fd-padding-begin-end--md\` |
+| Large | \`fd-padding-begin-end--lg\` |
+`
+    }
+};
+
+
+export const NoPadding = () =>
+    `<div class="docs-column-flex docs-column-flex--inline">
+        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1 docs-layout-grid-bg--padded fd-padding--none">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7">container</div>
+        </div>
+    </div>
+`;
+NoPadding.parameters = {
+    docs: {
+        storyDescription: `No padding classes remove existing container paddings. Use <code>fd-padding--none</code>
+        modifier to remove existing padding. Place the no padding classes last to make sure they will be applied.`
+    }
+};
+
+export const ResponsivePadding = () =>
+    `<div class="docs-column-flex docs-column-flex--inline">
+        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-responsive--sm">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7">container(sm)</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-responsive--md">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7">container(md)</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-responsive--lg">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7">container(lg)</div>
+        </div>
+        <br />
+        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-responsive--xl">
+            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7">container(xl)</div>
+        </div>
+    </div>
+`;
+ResponsivePadding.parameters = {
+    docs: {
+        storyDescription: `The responsive padding class adds a double sided padding inside a container based on its width. Use <code>fd-padding-responsive</code>
+        class with any of the following modifiers:
+
+| Element | Modifier class |
+| ----------------: | :------------ |
+| Small | \`fd-padding-responsive--sm\` |
+| Medium | \`fd-padding-responsive--md\` |
+| Large | \`fd-padding-responsive--lg\` |
+| Extra-large | \`fd-padding-responsive--xl\` |
+`
+    }
+};

--- a/stories/paddings/paddings.stories.js
+++ b/stories/paddings/paddings.stories.js
@@ -9,9 +9,9 @@ export default {
     }
 };
 
-export const AllRoundPadding = () => `<div class="docs-column-flex docs-column-flex--inline">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7">container</div>
+export const AllRoundPadding = () => `<div class="docs-column-flex docs-column-flex--align-start">
+        <div class="docs-layout-margins-paddings--color-14 fd-padding">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-grid-bg--color-7">container</div>
         </div>
     </div>
 `;
@@ -23,21 +23,21 @@ AllRoundPadding.parameters = {
     }
 };
 
-export const DoubleSidedPadding = () => `<div class="docs-column-flex docs-column-flex--inline">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-begin-end--tiny">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7">container(tiny)</div>
+export const DoubleSidedPadding = () => `<div class="docs-column-flex docs-column-flex--align-start">
+        <div class="docs-layout-margins-paddings--color-14 fd-padding-begin-end--tiny">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-grid-bg--color-7">container(tiny)</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-begin-end--sm">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7">container(sm)</div>
+        <div class="docs-layout-margins-paddings--color-14 fd-padding-begin-end--sm">
+            <div class="docs-layout-margins-paddings  docs-layout-margins-paddings--width-sm docs-layout-grid-bg--color-7">container(sm)</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-begin-end--md">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7">container(md)</div>
+        <div class="docs-layout-margins-paddings--color-14 fd-padding-begin-end--md">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width-md docs-layout-grid-bg--color-7">container(md)</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-begin-end--lg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7">container(lg)</div>
+        <div class="docs-layout-margins-paddings--color-14 fd-padding-begin-end--lg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width-lg docs-layout-grid-bg--color-7">container(lg)</div>
         </div>
     </div>
 `;
@@ -58,9 +58,9 @@ DoubleSidedPadding.parameters = {
 };
 
 
-export const NoPadding = () => `<div class="docs-column-flex docs-column-flex--inline">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1 docs-layout-grid-bg--padded fd-padding--none">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7">container</div>
+export const NoPadding = () => `<div class="docs-column-flex docs-column-flex--align-start">
+        <div class="docs-layout-margins-paddings--color-14 docs-layout-margins-paddings--padded fd-padding--none">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width docs-layout-grid-bg--color-7">container</div>
         </div>
     </div>
 `;
@@ -71,21 +71,21 @@ NoPadding.parameters = {
     }
 };
 
-export const ResponsivePadding = () => `<div class="docs-column-flex docs-column-flex--inline">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-responsive--sm">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7">container(sm)</div>
+export const ResponsivePadding = () => `<div class="docs-column-flex docs-column-flex--align-start">
+        <div class="docs-layout-margins-paddings--color-14 fd-padding-responsive--sm">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width-sm docs-layout-grid-bg--color-7">container(sm)</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-responsive--md">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7">container(md)</div>
+        <div class="docs-layout-margins-paddings--color-14 fd-padding-responsive--md">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width-md docs-layout-grid-bg--color-7">container(md)</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-responsive--lg">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7">container(lg)</div>
+        <div class="docs-layout-margins-paddings--color-14 fd-padding-responsive--lg">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width-md docs-layout-grid-bg--color-7">container(lg)</div>
         </div>
         <br />
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1 fd-padding-responsive--xl">
-            <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7">container(xl)</div>
+        <div class="docs-layout-margins-paddings--color-14 fd-padding-responsive--xl">
+            <div class="docs-layout-margins-paddings docs-layout-margins-paddings--width-lg docs-layout-grid-bg--color-7">container(xl)</div>
         </div>
     </div>
 `;


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#2119

## Description
This PR introduces helper modifier classes that can be added to any element that needs some spacings through paddings or margins.

## Screenshots
### Before:
NA
### After:
Margins:
![image](https://user-images.githubusercontent.com/53509521/107478395-6ac1f400-6b9f-11eb-94c4-9c791806a3aa.png)
Paddings:
![image](https://user-images.githubusercontent.com/53509521/107478496-8f1dd080-6b9f-11eb-8d7f-93def29fd4ac.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [n/a] Text elements follow the truncation rules
- [n/a] hover state of the element follow design spec
- [n/a] focus state of the element follow design spec
- [n/a] active state of the element follow design spec
- [n/a] selected state of the element follow design spec
- [n/a] selected hover state of the element follow design spec
- [n/a] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [n/a] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [n/a] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
