### PR TITLE
fix: Change height of title and solve counter issues on byline

### DIFF
--- a/src/_listByline.scss
+++ b/src/_listByline.scss
@@ -57,12 +57,13 @@
       min-height: $fd-list-byline-thumbnail-dimensions;
       min-width: $fd-list-byline-thumbnail-dimensions;
       height: 100%;
-      width: 100%;
+      flex: 1 1 auto;
       padding: 0.125rem 0;
     }
 
     .#{$block}__title {
       font-size: $fd-list-large-font-size;
+      min-height: $fd-list-byline-text-line-height;
     }
 
     .#{$block}__byline {


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-styles/issues/2090

## Description
There are 2 bugs fixed for byline list:
- Counter is fully visible now on IE11
- title has proper min-height, same as line-height
#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [\x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
