### PR TITLE
docs: remove radio readonly examples

### DIFF
--- a/stories/radio/__snapshots__/radio.stories.storyshot
+++ b/stories/radio/__snapshots__/radio.stories.storyshot
@@ -278,7 +278,7 @@ exports[`Storyshots Components/Forms/Radio Interaction States 1`] = `
           for="iSpDidh7611"
         >
           
-                    Field label(disabled)
+                    Field label (disabled)
                 
         </label>
         
@@ -305,7 +305,7 @@ exports[`Storyshots Components/Forms/Radio Interaction States 1`] = `
           for="iSpDidh76121"
         >
           
-                    Field label(disabled)
+                    Field label (disabled)
                 
         </label>
         
@@ -332,7 +332,7 @@ exports[`Storyshots Components/Forms/Radio Interaction States 1`] = `
           for="iSpDidh76131"
         >
           
-                    Field label(disabled)
+                    Field label (disabled)
                 
         </label>
         
@@ -359,7 +359,7 @@ exports[`Storyshots Components/Forms/Radio Interaction States 1`] = `
           for="iSpDidh76141"
         >
           
-                    Field label(disabled)
+                    Field label (disabled)
                 
         </label>
         
@@ -386,7 +386,7 @@ exports[`Storyshots Components/Forms/Radio Interaction States 1`] = `
           for="iSpDidh76151"
         >
           
-                    Field label(disabled)
+                    Field label (disabled)
                 
         </label>
         
@@ -568,7 +568,7 @@ exports[`Storyshots Components/Forms/Radio Interaction States 1`] = `
           for="iSpDidh76193"
         >
           
-                    Field label(disabled)
+                    Field label (disabled)
                 
         </label>
         
@@ -595,7 +595,7 @@ exports[`Storyshots Components/Forms/Radio Interaction States 1`] = `
           for="iSpDidh761293"
         >
           
-                    Field label(disabled)
+                    Field label (disabled)
                 
         </label>
         
@@ -622,7 +622,7 @@ exports[`Storyshots Components/Forms/Radio Interaction States 1`] = `
           for="iSpDidh761393"
         >
           
-                    Field label(disabled)
+                    Field label (disabled)
                 
         </label>
         
@@ -649,7 +649,7 @@ exports[`Storyshots Components/Forms/Radio Interaction States 1`] = `
           for="iSpDidh761493"
         >
           
-                    Field label(disabled)
+                    Field label (disabled)
                 
         </label>
         
@@ -676,7 +676,7 @@ exports[`Storyshots Components/Forms/Radio Interaction States 1`] = `
           for="iSpDidh761593"
         >
           
-                    Field label(disabled)
+                    Field label (disabled)
                 
         </label>
         
@@ -777,33 +777,6 @@ exports[`Storyshots Components/Forms/Radio Responsiveness 1`] = `
                 
         <input
           class="fd-radio"
-          id="pDidh7613"
-          name="radio1"
-          readonly=""
-          type="radio"
-        />
-        
-                
-        <label
-          class="fd-radio__label"
-          for="pDidh7613"
-        >
-          
-                    Field label(read only)
-                
-        </label>
-        
-            
-      </div>
-      
-            
-      <div
-        class="fd-form-item"
-      >
-        
-                
-        <input
-          class="fd-radio"
           disabled=""
           id="pDidh764"
           name="radio3"
@@ -816,7 +789,7 @@ exports[`Storyshots Components/Forms/Radio Responsiveness 1`] = `
           for="pDidh764"
         >
           
-                    Field label(disabled)
+                    Field label (disabled)
                 
         </label>
         
@@ -908,33 +881,6 @@ exports[`Storyshots Components/Forms/Radio Responsiveness 1`] = `
                 
         <input
           class="fd-radio fd-radio--compact"
-          id="pDidh761311"
-          name="radio2"
-          readonly=""
-          type="radio"
-        />
-        
-                
-        <label
-          class="fd-radio__label"
-          for="pDidh761311"
-        >
-          
-                    Field label(read only)
-                
-        </label>
-        
-            
-      </div>
-      
-            
-      <div
-        class="fd-form-item"
-      >
-        
-                
-        <input
-          class="fd-radio fd-radio--compact"
           disabled=""
           id="pDidh76131133"
           name="radio2"
@@ -947,7 +893,7 @@ exports[`Storyshots Components/Forms/Radio Responsiveness 1`] = `
           for="pDidh76131133"
         >
           
-                    Field label(disabled)
+                    Field label (disabled)
                 
         </label>
         

--- a/stories/radio/radio.stories.js
+++ b/stories/radio/radio.stories.js
@@ -37,15 +37,9 @@ export const primary = () => `<div style="display:flex;justify-content:space-bet
                 </label>
             </div>
             <div class="fd-form-item">
-                <input type="radio" class="fd-radio" id="pDidh7613" name="radio1" readonly>
-                <label class="fd-radio__label" for="pDidh7613">
-                    Field label(read only)
-                </label>
-            </div>
-            <div class="fd-form-item">
                 <input type="radio" class="fd-radio" id="pDidh764" name="radio3" disabled>
                 <label class="fd-radio__label" for="pDidh764">
-                    Field label(disabled)
+                    Field label (disabled)
                 </label>
             </div>
         </div>
@@ -66,15 +60,9 @@ export const primary = () => `<div style="display:flex;justify-content:space-bet
                 </label>
             </div>
             <div class="fd-form-item">
-                <input type="radio" class="fd-radio fd-radio--compact" id="pDidh761311" name="radio2" readonly>
-                <label class="fd-radio__label" for="pDidh761311">
-                    Field label(read only)
-                </label>
-            </div>
-            <div class="fd-form-item">
                 <input type="radio" class="fd-radio fd-radio--compact" id="pDidh76131133" name="radio2" disabled>
                 <label class="fd-radio__label" for="pDidh76131133">
-                    Field label(disabled)
+                    Field label (disabled)
                 </label>
             </div>
         </div>
@@ -164,31 +152,31 @@ export const interactionStates = () => `<div style="display:flex;justify-content
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio" id="iSpDidh7611" name="radio5" disabled>
                 <label class="fd-radio__label" for="iSpDidh7611">
-                    Field label(disabled)
+                    Field label (disabled)
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio is-success" id="iSpDidh76121" name="radio5" disabled>
                 <label class="fd-radio__label" for="iSpDidh76121">
-                    Field label(disabled)
+                    Field label (disabled)
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio is-error" id="iSpDidh76131" name="radio5" disabled>
                 <label class="fd-radio__label" for="iSpDidh76131">
-                    Field label(disabled)
+                    Field label (disabled)
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio is-warning" id="iSpDidh76141" name="radio5" disabled>
                 <label class="fd-radio__label" for="iSpDidh76141">
-                    Field label(disabled)
+                    Field label (disabled)
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio is-information" id="iSpDidh76151" name="radio5" disabled>
                 <label class="fd-radio__label" for="iSpDidh76151">
-                    Field label(disabled)
+                    Field label (disabled)
                 </label>
             </div>
         </div>
@@ -229,31 +217,31 @@ export const interactionStates = () => `<div style="display:flex;justify-content
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio fd-radio--compact" id="iSpDidh76193" name="radio6" disabled>
                 <label class="fd-radio__label" for="iSpDidh76193">
-                    Field label(disabled)
+                    Field label (disabled)
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio fd-radio--compact is-success" id="iSpDidh761293" name="radio6" disabled>
                 <label class="fd-radio__label" for="iSpDidh761293">
-                    Field label(disabled)
+                    Field label (disabled)
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio fd-radio--compact is-error" id="iSpDidh761393" name="radio6" disabled>
                 <label class="fd-radio__label" for="iSpDidh761393">
-                    Field label(disabled)
+                    Field label (disabled)
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio fd-radio--compact is-warning" id="iSpDidh761493" name="radio6" disabled>
                 <label class="fd-radio__label" for="iSpDidh761493">
-                    Field label(disabled)
+                    Field label (disabled)
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio fd-radio--compact is-information" id="iSpDidh761593" name="radio6" disabled>
                 <label class="fd-radio__label" for="iSpDidh761593">
-                    Field label(disabled)
+                    Field label (disabled)
                 </label>
             </div>
         </div>


### PR DESCRIPTION
part of #2090 

HTML radio buttons do not support "readonly" functionality like a text input would, so I'm removing these examples from the docs.