### PR TITLE
docs: add examples with light and bold 72 fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,20 @@ This project does not contain fonts and icons - they must be added to your proje
         font-weight: normal;
         font-style: normal;
     }
-    and
+    @font-face {
+        font-family: "72";
+        src: url("~@sap-theming/theming-base-content/content/Base/baseLib/sap_base_fiori/fonts/72-Bold-full.woff")
+            format("woff");
+        font-weight: 700;
+        font-style: normal;
+    }
+    @font-face {
+        font-family: "72";
+        src: url("~@sap-theming/theming-base-content/content/Base/baseLib/sap_base_fiori/fonts/72-Light-full.woff")
+            format("woff");
+        font-weight: 300;
+        font-style: normal;
+    }
 
     @font-face {
         font-family: "SAP-icons";


### PR DESCRIPTION
## Related Issue
fixes #2070 

## Description
add examples with font light and bold in `README.me`

