### PR TITLE
fix: fix Grid List styles

### DIFF
--- a/src/list-grid.scss
+++ b/src/list-grid.scss
@@ -32,7 +32,15 @@ $block: #{$fd-namespace}-grid-list;
   &__item {
     @include fd-reset();
     @include fd-flex(column);
-    @include fd-fiori-focus();
+
+    @include fd-fiori-focus() {
+      .#{$block}__highlight {
+        width: 0.25rem;
+        left: 0.1875rem;
+        bottom: 0.1875rem;
+        top: 0.1875rem;
+      }
+    }
 
     background-color: var(--sapList_Background);
     border-radius: $fd-grid-list-border-radius;
@@ -154,8 +162,6 @@ $block: #{$fd-namespace}-grid-list;
   }
 
   &__item-counter {
-    @include fd-fiori-focus(0);
-
     color: var(--sapContent_MarkerTextColor);
   }
 
@@ -322,7 +328,7 @@ $block: #{$fd-namespace}-grid-list;
       position: absolute;
       top: 0;
       left: 0;
-      height: 100%;
+      bottom: 0;
       width: 0.375rem;
       display: block;
       border-radius: $fd-grid-list-border-radius 0 0 $fd-grid-list-border-radius;

--- a/stories/list-grid/__snapshots__/list-grid.stories.storyshot
+++ b/stories/list-grid/__snapshots__/list-grid.stories.storyshot
@@ -127,7 +127,6 @@ exports[`Storyshots Components/Grid List "More" Button 1`] = `
               <span
                 aria-label="Item has 10 children"
                 class="fd-grid-list__item-counter"
-                tabindex="0"
               >
                 10
               </span>
@@ -709,7 +708,6 @@ exports[`Storyshots Components/Grid List Delete mode 1`] = `
               <span
                 aria-label="Item has 10 children"
                 class="fd-grid-list__item-counter"
-                tabindex="0"
               >
                 10
               </span>
@@ -1383,7 +1381,6 @@ exports[`Storyshots Components/Grid List Filter Infobar 1`] = `
               <span
                 aria-label="Item has 10 children"
                 class="fd-grid-list__item-counter"
-                tabindex="0"
               >
                 10
               </span>
@@ -1924,7 +1921,6 @@ exports[`Storyshots Components/Grid List Footer 1`] = `
               <span
                 aria-label="Item has 10 children"
                 class="fd-grid-list__item-counter"
-                tabindex="0"
               >
                 10
               </span>
@@ -2512,7 +2508,6 @@ exports[`Storyshots Components/Grid List Group 1`] = `
               <span
                 aria-label="Item has 10 children"
                 class="fd-grid-list__item-counter"
-                tabindex="0"
               >
                 10
               </span>
@@ -3082,7 +3077,6 @@ exports[`Storyshots Components/Grid List Highlight 1`] = `
               <span
                 aria-label="Item has 10 children"
                 class="fd-grid-list__item-counter"
-                tabindex="0"
               >
                 10
               </span>
@@ -3675,7 +3669,6 @@ exports[`Storyshots Components/Grid List Multi select mode 1`] = `
               <span
                 aria-label="Item has 10 children"
                 class="fd-grid-list__item-counter"
-                tabindex="0"
               >
                 10
               </span>
@@ -3956,7 +3949,6 @@ exports[`Storyshots Components/Grid List Multi select mode 1`] = `
               <span
                 aria-label="Item has 5 children"
                 class="fd-grid-list__item-counter"
-                tabindex="0"
               >
                 5
               </span>
@@ -4086,7 +4078,6 @@ exports[`Storyshots Components/Grid List Multi select mode 1`] = `
               <span
                 aria-label="Item has 5 children"
                 class="fd-grid-list__item-counter"
-                tabindex="0"
               >
                 5
               </span>
@@ -4313,7 +4304,6 @@ exports[`Storyshots Components/Grid List None mode 1`] = `
               <span
                 aria-label="Item has 10 children"
                 class="fd-grid-list__item-counter"
-                tabindex="0"
               >
                 10
               </span>
@@ -4831,7 +4821,6 @@ exports[`Storyshots Components/Grid List None mode 1`] = `
               <span
                 aria-label="Item has 10 children"
                 class="fd-grid-list__item-counter"
-                tabindex="0"
               >
                 10
               </span>
@@ -5179,7 +5168,6 @@ exports[`Storyshots Components/Grid List Single select left mode 1`] = `
               <span
                 aria-label="Item has 10 children"
                 class="fd-grid-list__item-counter"
-                tabindex="0"
               >
                 10
               </span>
@@ -5460,7 +5448,6 @@ exports[`Storyshots Components/Grid List Single select left mode 1`] = `
               <span
                 aria-label="Item has 5 children"
                 class="fd-grid-list__item-counter"
-                tabindex="0"
               >
                 5
               </span>
@@ -5824,7 +5811,6 @@ exports[`Storyshots Components/Grid List Single select mode 1`] = `
               <span
                 aria-label="Item has 10 children"
                 class="fd-grid-list__item-counter"
-                tabindex="0"
               >
                 10
               </span>
@@ -6105,7 +6091,6 @@ exports[`Storyshots Components/Grid List Single select mode 1`] = `
               <span
                 aria-label="Item has 5 children"
                 class="fd-grid-list__item-counter"
-                tabindex="0"
               >
                 5
               </span>
@@ -6455,7 +6440,6 @@ exports[`Storyshots Components/Grid List Single select right mode 1`] = `
               <span
                 aria-label="Item has 10 children"
                 class="fd-grid-list__item-counter"
-                tabindex="0"
               >
                 10
               </span>
@@ -6738,7 +6722,6 @@ exports[`Storyshots Components/Grid List Single select right mode 1`] = `
               <span
                 aria-label="Item has 5 children"
                 class="fd-grid-list__item-counter"
-                tabindex="0"
               >
                 5
               </span>
@@ -7105,7 +7088,6 @@ exports[`Storyshots Components/Grid List States 1`] = `
               <span
                 aria-label="Item has 10 children"
                 class="fd-grid-list__item-counter"
-                tabindex="0"
               >
                 10
               </span>

--- a/stories/list-grid/list-grid.stories.js
+++ b/stories/list-grid/list-grid.stories.js
@@ -71,7 +71,7 @@ export const noneMode = () => `<div style="min-height: 500px;">
                     <div class="fd-toolbar fd-grid-list__item-toolbar">
                         <span class="fd-toolbar__spacer"></span>
 
-                        <span class="fd-grid-list__item-counter" aria-label="Item has 10 children" tabindex="0">10</span>
+                        <span class="fd-grid-list__item-counter" aria-label="Item has 10 children">10</span>
 
                         <button class="fd-button fd-button--compact fd-button--transparent" aria-label="Navigation">
                             <i class="sap-icon--navigation-right-arrow"></i>
@@ -199,7 +199,7 @@ export const noneMode = () => `<div style="min-height: 500px;">
                     <div class="fd-toolbar fd-grid-list__item-toolbar">
                         <span class="fd-toolbar__spacer"></span>
 
-                        <span class="fd-grid-list__item-counter" aria-label="Item has 10 children" tabindex="0">10</span>
+                        <span class="fd-grid-list__item-counter" aria-label="Item has 10 children">10</span>
 
                         <button class="fd-button fd-button--compact fd-button--transparent" aria-label="Navigation">
                             <i class="sap-icon--navigation-right-arrow"></i>
@@ -294,7 +294,7 @@ export const singleSelectMasterMode = () => `<div style="min-height: 300px;">
                     <div class="fd-toolbar fd-grid-list__item-toolbar">
                         <span class="fd-toolbar__spacer"></span>
 
-                        <span class="fd-grid-list__item-counter" aria-label="Item has 10 children" tabindex="0">10</span>
+                        <span class="fd-grid-list__item-counter" aria-label="Item has 10 children">10</span>
 
                         <button class="fd-button fd-button--compact fd-button--transparent" aria-label="Navigation">
                             <i class="sap-icon--navigation-right-arrow"></i>
@@ -362,7 +362,7 @@ export const singleSelectMasterMode = () => `<div style="min-height: 300px;">
                     <div class="fd-toolbar fd-grid-list__item-toolbar">
                         <span class="fd-toolbar__spacer"></span>
 
-                        <span class="fd-grid-list__item-counter" aria-label="Item has 5 children" tabindex="0">5</span>
+                        <span class="fd-grid-list__item-counter" aria-label="Item has 5 children">5</span>
                     </div>
 
                     <div class="fd-grid-list__item-body">
@@ -460,7 +460,7 @@ export const singleSelectLeftMode = () => `<div style="min-height: 300px;">
 
                         <span class="fd-toolbar__spacer"></span>
 
-                        <span class="fd-grid-list__item-counter" aria-label="Item has 10 children" tabindex="0">10</span>
+                        <span class="fd-grid-list__item-counter" aria-label="Item has 10 children">10</span>
 
                         <button class="fd-button fd-button--compact fd-button--transparent" aria-label="Navigation">
                             <i class="sap-icon--navigation-right-arrow"></i>
@@ -526,7 +526,7 @@ export const singleSelectLeftMode = () => `<div style="min-height: 300px;">
                         <label class="fd-radio__label fd-grid-list__radio-label" for="p12Didh1761" tabindex="-1"></label>
                         <span class="fd-toolbar__spacer"></span>
 
-                        <span class="fd-grid-list__item-counter" aria-label="Item has 5 children" tabindex="0">5</span>
+                        <span class="fd-grid-list__item-counter" aria-label="Item has 5 children">5</span>
                     </div>
 
                     <div class="fd-grid-list__item-body">
@@ -628,7 +628,7 @@ export const singleSelectRightMode = () => `<div style="min-height: 300px;">
 
                         <span class="fd-toolbar__spacer"></span>
 
-                        <span class="fd-grid-list__item-counter" aria-label="Item has 10 children" tabindex="0">10</span>
+                        <span class="fd-grid-list__item-counter" aria-label="Item has 10 children">10</span>
 
                         <button class="fd-button fd-button--compact fd-button--transparent" aria-label="Navigation">
                             <i class="sap-icon--navigation-right-arrow"></i>
@@ -696,7 +696,7 @@ export const singleSelectRightMode = () => `<div style="min-height: 300px;">
 
                         <span class="fd-toolbar__spacer"></span>
 
-                        <span class="fd-grid-list__item-counter" aria-label="Item has 5 children" tabindex="0">5</span>
+                        <span class="fd-grid-list__item-counter" aria-label="Item has 5 children">5</span>
                     </div>
 
                     <div class="fd-grid-list__item-body">
@@ -797,7 +797,7 @@ export const multiSelectMode = () => `<div style="min-height: 300px;">
                         
                         <span class="fd-toolbar__spacer"></span>
 
-                        <span class="fd-grid-list__item-counter" aria-label="Item has 10 children" tabindex="0">10</span>
+                        <span class="fd-grid-list__item-counter" aria-label="Item has 10 children">10</span>
 
                         <button class="fd-button fd-button--compact fd-button--transparent" aria-label="Navigation">
                             <i class="sap-icon--navigation-right-arrow"></i>
@@ -865,7 +865,7 @@ export const multiSelectMode = () => `<div style="min-height: 300px;">
 
                         <span class="fd-toolbar__spacer"></span>
 
-                        <span class="fd-grid-list__item-counter" aria-label="Item has 5 children" tabindex="0">5</span>
+                        <span class="fd-grid-list__item-counter" aria-label="Item has 5 children">5</span>
                     </div>
 
                     <div class="fd-grid-list__item-body">
@@ -896,7 +896,7 @@ export const multiSelectMode = () => `<div style="min-height: 300px;">
 
                         <span class="fd-toolbar__spacer"></span>
 
-                        <span class="fd-grid-list__item-counter" aria-label="Item has 5 children" tabindex="0">5</span>
+                        <span class="fd-grid-list__item-counter" aria-label="Item has 5 children">5</span>
                     </div>
 
                     <div class="fd-grid-list__item-body">
@@ -966,7 +966,7 @@ export const deleteMode = () => `<div style="min-height: 300px;">
                     <div class="fd-toolbar fd-grid-list__item-toolbar">
                         <span class="fd-toolbar__spacer"></span>
 
-                        <span class="fd-grid-list__item-counter" aria-label="Item has 10 children" tabindex="0">10</span>
+                        <span class="fd-grid-list__item-counter" aria-label="Item has 10 children">10</span>
 
                         <button class="fd-button fd-button--compact fd-button--transparent" aria-label="Delete">
                             <i class="sap-icon--decline"></i>
@@ -1143,7 +1143,7 @@ export const group = () => `<div style="min-height: 600px;">
                     <div class="fd-toolbar fd-grid-list__item-toolbar">
                         <span class="fd-toolbar__spacer"></span>
 
-                        <span class="fd-grid-list__item-counter" aria-label="Item has 10 children" tabindex="0">10</span>
+                        <span class="fd-grid-list__item-counter" aria-label="Item has 10 children">10</span>
 
                         <button class="fd-button fd-button--compact fd-button--transparent" aria-label="Navigation">
                             <i class="sap-icon--navigation-right-arrow"></i>
@@ -1302,7 +1302,7 @@ export const states = () => `<div style="min-height: 600px;">
                     <div class="fd-toolbar fd-grid-list__item-toolbar">
                         <span class="fd-toolbar__spacer"></span>
 
-                        <span class="fd-grid-list__item-counter" aria-label="Item has 10 children" tabindex="0">10</span>
+                        <span class="fd-grid-list__item-counter" aria-label="Item has 10 children">10</span>
 
                         <button class="fd-button fd-button--compact fd-button--transparent" aria-label="Navigation">
                             <i class="sap-icon--navigation-right-arrow"></i>
@@ -1491,7 +1491,7 @@ export const highlight = () => `<div style="min-height: 350px;">
                     <div class="fd-toolbar fd-grid-list__item-toolbar">
                         <span class="fd-toolbar__spacer"></span>
 
-                        <span class="fd-grid-list__item-counter" aria-label="Item has 10 children" tabindex="0">10</span>
+                        <span class="fd-grid-list__item-counter" aria-label="Item has 10 children">10</span>
 
                         <button class="fd-button fd-button--compact fd-button--transparent" aria-label="Navigation">
                             <i class="sap-icon--navigation-right-arrow"></i>
@@ -1661,7 +1661,7 @@ export const filterInfobar = () => `<div style="min-height: 350px;">
                     <div class="fd-toolbar fd-grid-list__item-toolbar">
                         <span class="fd-toolbar__spacer"></span>
 
-                        <span class="fd-grid-list__item-counter" aria-label="Item has 10 children" tabindex="0">10</span>
+                        <span class="fd-grid-list__item-counter" aria-label="Item has 10 children">10</span>
 
                         <button class="fd-button fd-button--compact fd-button--transparent" aria-label="Navigation">
                             <i class="sap-icon--navigation-right-arrow"></i>
@@ -1809,7 +1809,7 @@ export const more = () => `<div style="min-height: 400px;">
                     <div class="fd-toolbar fd-grid-list__item-toolbar">
                         <span class="fd-toolbar__spacer"></span>
 
-                        <span class="fd-grid-list__item-counter" aria-label="Item has 10 children" tabindex="0">10</span>
+                        <span class="fd-grid-list__item-counter" aria-label="Item has 10 children">10</span>
 
                         <button class="fd-button fd-button--compact fd-button--transparent" aria-label="Navigation">
                             <i class="sap-icon--navigation-right-arrow"></i>
@@ -1966,7 +1966,7 @@ export const footer = () => `<div style="min-height: 300px;">
                     <div class="fd-toolbar fd-grid-list__item-toolbar">
                         <span class="fd-toolbar__spacer"></span>
 
-                        <span class="fd-grid-list__item-counter" aria-label="Item has 10 children" tabindex="0">10</span>
+                        <span class="fd-grid-list__item-counter" aria-label="Item has 10 children">10</span>
 
                         <button class="fd-button fd-button--compact fd-button--transparent" aria-label="Navigation">
                             <i class="sap-icon--navigation-right-arrow"></i>


### PR DESCRIPTION
## Related Issue
Comments 2, 5 https://github.com/SAP/fundamental-ngx/pull/4610#issuecomment-776993841

## Description
Removed counter focus
Fixed focus on the status indicator

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [X] All values are in `rem`
- [X] Text elements follow the truncation rules
- [X] hover state of the element follow design spec
- [X] focus state of the element follow design spec
- [X] active state of the element follow design spec
- [X] selected state of the element follow design spec
- [X] selected hover state of the element follow design spec
- [X] pressed state of the element follow design spec
- [X] Responsiveness rules - the component has modifier classes for all breakpoints
- [X] Includes Compact/Cosy/Tablet design
- [X] RTL support
2. The code follows fundamental-styles code standards and style
- [X] only one top level `fd-*` class is used in the file
- [X] BEM naming convention is used
- [X] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [X] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [X] `fd-reset()` mixin is applied to all elements
- [X] Variables are used, if some value is used more than twice.
- [X] Checked if current components can be reused, instead of having new code.
3. Testing
- [X] tested Storybook examples with "CSS Resources" `normalize` option 
- [X] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [X] Verified all styles in IE11
- [X] Updated tests
- [X] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [X] Storybook documentation has been created/updated
- [X] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
