### PR TITLE
fix: Side Nav taking the whole height of the container

### DIFF
--- a/src/side-nav.scss
+++ b/src/side-nav.scss
@@ -2,19 +2,6 @@
 @import "./mixins";
 @import "./nested-list";
 
-/*!
-.fd-side-nav
-    .fd-side-nav__skip-link
-    .fd-side-nav__group
-        .fd-side-nav__title
-        .fd-side-nav__list
-            .fd-side-nav__item
-                .fd-side-nav__link (.has-child, .is-active, .is-expanded)
-                .fd-side-nav__sublist
-                    .fd-side-nav__subitem
-                    .fd-side-nav__sublink (.is-active)
-*/
-
 $block: #{$fd-namespace}-side-nav;
 $block-nested-list: #{$fd-namespace}-nested-list;
 $has-child-content-arrow-margin: 0.125rem;

--- a/src/side-nav.scss
+++ b/src/side-nav.scss
@@ -30,6 +30,7 @@ $has-child-content-arrow-margin: 0.125rem;
   flex-direction: column;
   justify-content: space-between;
   text-shadow: var(--fdSideNav_Text_Shadow);
+  height: 100%;
 
   &__skip-link {
     @include fd-reset();


### PR DESCRIPTION
closes https://github.com/SAP/fundamental-styles/issues/2146

## Description
The Side Nav should take the whole width of the container. Height 100% is added.
