### PR TITLE
fix: add proper alignment for the text inside Split button

### DIFF
--- a/src/button-split.scss
+++ b/src/button-split.scss
@@ -82,6 +82,10 @@ $fd-button-split-margin: 0.125rem / 2;
       justify-content: flex-start;
     }
 
+    .#{$block}__text {
+      display: inline-block;
+    }
+
     &:hover {
       .#{$block}__text {
         color: var(--sapButton_TextColor);
@@ -89,7 +93,6 @@ $fd-button-split-margin: 0.125rem / 2;
     }
 
     &:active {
-
       .#{$block}__text {
         color: var(--sapButton_Selected_TextColor);
       }

--- a/src/button-split.scss
+++ b/src/button-split.scss
@@ -78,6 +78,10 @@ $fd-button-split-margin: 0.125rem / 2;
   }
 
   & > :first-child {
+    @include fd-flex-vertical-center() {
+      justify-content: flex-start;
+    }
+
     &:hover {
       .#{$block}__text {
         color: var(--sapButton_TextColor);


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#1981

## Description
The text inside Split button should be left-aligned, not centered. 

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)

3. Testing
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)

