### PR TITLE
fix: update table navigation icons and states

### DIFF
--- a/src/table.scss
+++ b/src/table.scss
@@ -274,12 +274,27 @@ $block: #{$fd-namespace}-table;
           background-color: var(--sapList_Hover_SelectionBackground);
         }
       }
+
+      &--activable {
+        @include fd-selected() {
+          @include fd-active() {
+            background-color: var(--sapList_Active_Background);
+          }
+        }
+      }
     }
   }
 
   &__cell,
   &__row {
     &--hoverable {
+      @include fd-selected() {
+        .#{$block}__cell {
+          @include fd-hover() {
+            background-color: var(--sapList_Hover_SelectionBackground);
+          }
+        }
+      }
       &,
       .#{$block}__cell {
         @include fd-hover() {
@@ -291,6 +306,10 @@ $block: #{$fd-namespace}-table;
 
     &--activable {
       @include fd-trigger-element();
+
+      @include fd-selected() {
+        @include fd-trigger-element();
+      }
     }
 
     &--focusable {
@@ -404,7 +423,7 @@ $block: #{$fd-namespace}-table;
         }
       }
 
-      &.#{$block}__row--activable {
+      &.#{$block}__row--activable:not(:hover) {
         @include fd-active() {
           + .#{$block}__row--secondary {
             @include fd-table-active();

--- a/stories/table/__snapshots__/table.stories.storyshot
+++ b/stories/table/__snapshots__/table.stories.storyshot
@@ -6667,7 +6667,7 @@ exports[`Storyshots Components/Table Navigation indicators 1`] = `
         
       <tr
         aria-selected="true"
-        class="fd-table__row"
+        class="fd-table__row fd-table__row--activable fd-table__row--hoverable"
       >
         
             
@@ -6745,7 +6745,7 @@ exports[`Storyshots Components/Table Navigation indicators 1`] = `
         
       <tr
         aria-selected="true"
-        class="fd-table__row"
+        class="fd-table__row fd-table__row--activable fd-table__row--hoverable"
       >
         
             
@@ -6822,7 +6822,7 @@ exports[`Storyshots Components/Table Navigation indicators 1`] = `
       
         
       <tr
-        class="fd-table__row"
+        class="fd-table__row fd-table__row--activable fd-table__row--hoverable"
       >
         
             
@@ -8154,7 +8154,7 @@ exports[`Storyshots Components/Table Responsive Table 1`] = `
       
         
       <tr
-        class="fd-table__row"
+        class="fd-table__row fd-table__row--activable fd-table__row--hoverable"
       >
         
             
@@ -8224,7 +8224,7 @@ exports[`Storyshots Components/Table Responsive Table 1`] = `
           
                 
           <i
-            class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"
+            class="fd-table__icon fd-table__icon--navigation sap-icon--slim-arrow-right"
             role="presentation"
           />
           
@@ -8236,7 +8236,7 @@ exports[`Storyshots Components/Table Responsive Table 1`] = `
       
         
       <tr
-        class="fd-table__row"
+        class="fd-table__row fd-table__row--activable fd-table__row--hoverable"
       >
         
             
@@ -8306,7 +8306,7 @@ exports[`Storyshots Components/Table Responsive Table 1`] = `
           
                 
           <i
-            class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"
+            class="fd-table__icon fd-table__icon--navigation sap-icon--slim-arrow-right"
             role="presentation"
           />
           
@@ -8318,7 +8318,7 @@ exports[`Storyshots Components/Table Responsive Table 1`] = `
       
         
       <tr
-        class="fd-table__row"
+        class="fd-table__row fd-table__row--activable fd-table__row--hoverable"
       >
         
             
@@ -8388,7 +8388,7 @@ exports[`Storyshots Components/Table Responsive Table 1`] = `
           
                 
           <i
-            class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow"
+            class="fd-table__icon fd-table__icon--navigation sap-icon--slim-arrow-right"
             role="presentation"
           />
           

--- a/stories/table/__snapshots__/table.stories.storyshot
+++ b/stories/table/__snapshots__/table.stories.storyshot
@@ -5991,7 +5991,7 @@ exports[`Storyshots Components/Table Menu header 1`] = `
 </section>
 `;
 
-exports[`Storyshots Components/Table Navigation indicators 1`] = `
+exports[`Storyshots Components/Table Navigation from table rows 1`] = `
 <section>
   
 
@@ -6000,10 +6000,276 @@ exports[`Storyshots Components/Table Navigation indicators 1`] = `
   >
     
     
-    <h4
-      style="margin: 0;"
+    <h4>
+      Responsive Table - row navigation
+    </h4>
+    
+    
+    <span
+      class="fd-toolbar__spacer fd-toolbar__spacer--auto"
+    />
+    
+
+  </div>
+  
+
+  <table
+    class="fd-table fd-table--no-horizontal-borders"
+  >
+    
+    
+    <thead
+      class="fd-table__header"
     >
-      Table with Navigation Indication State
+      
+        
+      <tr
+        class="fd-table__row"
+      >
+        
+            
+        <th
+          class="fd-table__cell"
+          scope="col"
+        >
+          Name
+        </th>
+        
+            
+        <th
+          class="fd-table__cell"
+          scope="col"
+        >
+          Status
+        </th>
+        
+            
+        <th
+          class="fd-table__cell"
+          scope="col"
+        >
+          Price
+        </th>
+        
+            
+        <th
+          class="fd-table__cell"
+          scope="col"
+        >
+          Country
+        </th>
+        
+            
+        <th
+          class="fd-table__cell"
+        />
+        
+        
+      </tr>
+      
+    
+    </thead>
+    
+    
+    <tbody
+      class="fd-table__body"
+    >
+      
+        
+      <tr
+        class="fd-table__row fd-table__row--activable fd-table__row--hoverable"
+      >
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          Banana
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          
+                
+          <span
+            class="fd-object-status fd-object-status--positive"
+          >
+            
+                    Available
+                
+          </span>
+          
+            
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          5 EUR
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          India
+        </td>
+        
+            
+        <td
+          class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding"
+        >
+          
+                
+          <i
+            class="fd-table__icon fd-table__icon--navigation sap-icon--slim-arrow-right"
+            role="presentation"
+          />
+          
+            
+        </td>
+        
+        
+      </tr>
+      
+        
+      <tr
+        class="fd-table__row fd-table__row--activable fd-table__row--hoverable"
+      >
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          Pineapple
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          
+                
+          <span
+            class="fd-object-status fd-object-status--negative"
+          >
+            
+                    Out of stock
+                
+          </span>
+          
+            
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          2 EUR
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          Mexico
+        </td>
+        
+            
+        <td
+          class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding"
+        >
+          
+                
+          <i
+            class="fd-table__icon fd-table__icon--navigation sap-icon--slim-arrow-right"
+            role="presentation"
+          />
+          
+            
+        </td>
+        
+        
+      </tr>
+      
+        
+      <tr
+        class="fd-table__row fd-table__row--activable fd-table__row--hoverable"
+      >
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          Orange
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          
+                
+          <span
+            class="fd-object-status fd-object-status--informative"
+          >
+            
+                    Temporary unavailable
+                
+          </span>
+          
+            
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          6 EUR
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          Spain
+        </td>
+        
+            
+        <td
+          class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding"
+        >
+          
+                
+          <i
+            class="fd-table__icon fd-table__icon--navigation sap-icon--slim-arrow-right"
+            role="presentation"
+          />
+          
+            
+        </td>
+        
+        
+      </tr>
+      
+    
+    </tbody>
+    
+
+  </table>
+  
+
+
+  <div
+    class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active"
+  >
+    
+    
+    <h4>
+      Table - icon button for navigation
     </h4>
     
     
@@ -6028,6 +6294,326 @@ exports[`Storyshots Components/Table Navigation indicators 1`] = `
       <tr
         class="fd-table__row"
       >
+        
+            
+        <th
+          class="fd-table__cell"
+          scope="col"
+        >
+          Name
+        </th>
+        
+            
+        <th
+          class="fd-table__cell"
+          scope="col"
+        >
+          Status
+        </th>
+        
+            
+        <th
+          class="fd-table__cell"
+          scope="col"
+        >
+          Price
+        </th>
+        
+            
+        <th
+          class="fd-table__cell"
+          scope="col"
+        >
+          Country
+        </th>
+        
+            
+        <th
+          class="fd-table__cell"
+        />
+        
+        
+      </tr>
+      
+    
+    </thead>
+    
+    
+    <tbody
+      class="fd-table__body"
+    >
+      
+        
+      <tr
+        class="fd-table__row"
+      >
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          Banana
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          
+                
+          <span
+            class="fd-object-status fd-object-status--positive"
+          >
+            
+                    Available
+                
+          </span>
+          
+            
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          5 EUR
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          India
+        </td>
+        
+            
+        <td
+          class="fd-table__cell fd-table__cell--fit-content"
+        >
+          
+                
+          <button
+            aria-label="navigation"
+            class="fd-button fd-button--transparent"
+          >
+            
+                    
+            <i
+              class="sap-icon--navigation-right-arrow"
+            />
+            
+                
+          </button>
+          
+            
+        </td>
+        
+        
+      </tr>
+      
+        
+      <tr
+        class="fd-table__row"
+      >
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          Pineapple
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          
+                
+          <span
+            class="fd-object-status fd-object-status--negative"
+          >
+            
+                    Out of stock
+                
+          </span>
+          
+            
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          2 EUR
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          Mexico
+        </td>
+        
+            
+        <td
+          class="fd-table__cell fd-table__cell--fit-content"
+        >
+          
+                
+          <button
+            aria-label="navigation"
+            class="fd-button fd-button--transparent"
+          >
+            
+                    
+            <i
+              class="sap-icon--navigation-right-arrow"
+            />
+            
+                
+          </button>
+          
+            
+        </td>
+        
+        
+      </tr>
+      
+        
+      <tr
+        class="fd-table__row"
+      >
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          Orange
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          
+                
+          <span
+            class="fd-object-status fd-object-status--informative"
+          >
+            
+                    Temporary unavailable
+                
+          </span>
+          
+            
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          6 EUR
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          Spain
+        </td>
+        
+            
+        <td
+          class="fd-table__cell fd-table__cell--fit-content"
+        >
+          
+                
+          <button
+            aria-label="navigation"
+            class="fd-button fd-button--transparent"
+          >
+            
+                    
+            <i
+              class="sap-icon--navigation-right-arrow"
+            />
+            
+                
+          </button>
+          
+            
+        </td>
+        
+        
+      </tr>
+      
+    
+    </tbody>
+    
+
+  </table>
+  
+
+</section>
+`;
+
+exports[`Storyshots Components/Table Navigation indicators 1`] = `
+<section>
+  
+
+  <div
+    class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active"
+  >
+    
+    
+    <h4>
+      Table with Navigation Indication State
+    </h4>
+    
+    
+    <span
+      class="fd-toolbar__spacer fd-toolbar__spacer--auto"
+    />
+    
+
+  </div>
+  
+
+  <table
+    class="fd-table fd-table--no-horizontal-borders"
+  >
+    
+    
+    <thead
+      class="fd-table__header"
+    >
+      
+        
+      <tr
+        class="fd-table__row"
+      >
+        
+            
+        <th
+          class="fd-table__cell fd-table__cell--checkbox"
+        >
+          
+                
+          <input
+            aria-label="checkbox"
+            class="fd-checkbox"
+            id="kqqzPI44"
+            type="checkbox"
+          />
+          
+                
+          <label
+            class="fd-checkbox__label"
+            for="kqqzPI44"
+          />
+          
+            
+        </th>
         
             
         <th
@@ -6080,8 +6666,32 @@ exports[`Storyshots Components/Table Navigation indicators 1`] = `
       
         
       <tr
+        aria-selected="true"
         class="fd-table__row"
       >
+        
+            
+        <td
+          class="fd-table__cell fd-table__cell--checkbox"
+        >
+          
+                
+          <input
+            aria-label="checkbox"
+            checked=""
+            class="fd-checkbox"
+            id="EWuzWh33"
+            type="checkbox"
+          />
+          
+                
+          <label
+            class="fd-checkbox__label"
+            for="EWuzWh33"
+          />
+          
+            
+        </td>
         
             
         <td
@@ -6117,22 +6727,92 @@ exports[`Storyshots Components/Table Navigation indicators 1`] = `
         
             
         <td
-          class="fd-table__cell fd-table__cell--fit-content"
+          class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding"
         >
           
                 
-          <button
-            aria-label="navigation"
-            class="fd-button fd-button--transparent"
-          >
+          <i
+            class="fd-table__icon fd-table__icon--navigation sap-icon--slim-arrow-right"
+            role="presentation"
+          />
+          
             
-                    
-            <i
-              class="sap-icon--navigation-right-arrow"
-            />
+        </td>
+        
+        
+      </tr>
+      
+        
+      <tr
+        aria-selected="true"
+        class="fd-table__row"
+      >
+        
             
+        <td
+          class="fd-table__cell fd-table__cell--checkbox"
+        >
+          
                 
-          </button>
+          <input
+            aria-label="checkbox"
+            checked=""
+            class="fd-checkbox"
+            id="EWuzWh334"
+            type="checkbox"
+          />
+          
+                
+          <label
+            class="fd-checkbox__label"
+            for="EWuzWh334"
+          />
+          
+            
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          <a
+            class="fd-link"
+          >
+            user.name@email.com
+          </a>
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          First Name
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          Last Name
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          01/26/17
+        </td>
+        
+            
+        <td
+          class="fd-table__cell fd-table__cell--fit-content fd-table__cell--navigated fd-table__cell--no-padding"
+        >
+          
+                
+          <i
+            class="fd-table__icon fd-table__icon--navigation sap-icon--slim-arrow-right"
+            role="presentation"
+          />
           
             
         </td>
@@ -6147,65 +6827,25 @@ exports[`Storyshots Components/Table Navigation indicators 1`] = `
         
             
         <td
-          class="fd-table__cell"
-        >
-          <a
-            class="fd-link"
-          >
-            user.name@email.com
-          </a>
-        </td>
-        
-            
-        <td
-          class="fd-table__cell"
-        >
-          First Name
-        </td>
-        
-            
-        <td
-          class="fd-table__cell"
-        >
-          Last Name
-        </td>
-        
-            
-        <td
-          class="fd-table__cell"
-        >
-          01/26/17
-        </td>
-        
-            
-        <td
-          class="fd-table__cell fd-table__cell--fit-content fd-table__cell--navigated"
+          class="fd-table__cell fd-table__cell--checkbox"
         >
           
                 
-          <button
-            aria-label="navigation"
-            class="fd-button fd-button--transparent"
-          >
-            
-                    
-            <i
-              class="sap-icon--navigation-right-arrow"
-            />
-            
+          <input
+            aria-label="checkbox"
+            class="fd-checkbox"
+            id="EWuzWh335"
+            type="checkbox"
+          />
+          
                 
-          </button>
+          <label
+            class="fd-checkbox__label"
+            for="EWuzWh335"
+          />
           
             
         </td>
-        
-        
-      </tr>
-      
-        
-      <tr
-        class="fd-table__row"
-      >
         
             
         <td
@@ -6241,22 +6881,14 @@ exports[`Storyshots Components/Table Navigation indicators 1`] = `
         
             
         <td
-          class="fd-table__cell fd-table__cell--fit-content"
+          class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding"
         >
           
-                
-          <button
-            aria-label="navigation"
-            class="fd-button fd-button--transparent"
-          >
-            
-                    
-            <i
-              class="sap-icon--navigation-right-arrow"
-            />
-            
-                
-          </button>
+              
+          <i
+            class="fd-table__icon fd-table__icon--navigation sap-icon--slim-arrow-right"
+            role="presentation"
+          />
           
             
         </td>

--- a/stories/table/table.stories.js
+++ b/stories/table/table.stories.js
@@ -1613,7 +1613,7 @@ export const navIndicators = () => `
         </tr>
     </thead>
     <tbody class="fd-table__body">
-        <tr class="fd-table__row" aria-selected="true">
+        <tr class="fd-table__row fd-table__row--activable fd-table__row--hoverable" aria-selected="true">
             <td class="fd-table__cell fd-table__cell--checkbox">
                 <input aria-label="checkbox" type="checkbox" checked class="fd-checkbox" id="EWuzWh33">
                 <label class="fd-checkbox__label" for="EWuzWh33"></label>
@@ -1626,7 +1626,7 @@ export const navIndicators = () => `
                 <i class="fd-table__icon fd-table__icon--navigation sap-icon--slim-arrow-right" role="presentation"></i>
             </td>
         </tr>
-        <tr class="fd-table__row" aria-selected="true">
+        <tr class="fd-table__row fd-table__row--activable fd-table__row--hoverable" aria-selected="true">
             <td class="fd-table__cell fd-table__cell--checkbox">
                 <input aria-label="checkbox" type="checkbox" checked class="fd-checkbox" id="EWuzWh334">
                 <label class="fd-checkbox__label" for="EWuzWh334"></label>
@@ -1639,7 +1639,7 @@ export const navIndicators = () => `
                 <i class="fd-table__icon fd-table__icon--navigation sap-icon--slim-arrow-right" role="presentation"></i>
             </td>
         </tr>
-        <tr class="fd-table__row">
+        <tr class="fd-table__row fd-table__row--activable fd-table__row--hoverable">
             <td class="fd-table__cell fd-table__cell--checkbox">
                 <input aria-label="checkbox" type="checkbox" class="fd-checkbox" id="EWuzWh335">
                 <label class="fd-checkbox__label" for="EWuzWh335"></label>
@@ -1686,7 +1686,7 @@ export const responsiveTable = () => `
         </tr>
     </thead>
     <tbody class="fd-table__body">
-        <tr class="fd-table__row">
+        <tr class="fd-table__row fd-table__row--activable fd-table__row--hoverable">
             <td class="fd-table__cell fd-table__cell--checkbox">
                 <input aria-label="checkbox" type="checkbox" class="fd-checkbox" id="EWuzWh">
                 <label class="fd-checkbox__label" for="EWuzWh"></label>
@@ -1700,10 +1700,10 @@ export const responsiveTable = () => `
             <td class="fd-table__cell">5 EUR</td>
             <td class="fd-table__cell">India</td>
             <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
-                <i class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow" role="presentation"></i>
+                <i class="fd-table__icon fd-table__icon--navigation sap-icon--slim-arrow-right" role="presentation"></i>
             </td>
         </tr>
-        <tr class="fd-table__row">
+        <tr class="fd-table__row fd-table__row--activable fd-table__row--hoverable">
             <td class="fd-table__cell fd-table__cell--checkbox">
                 <input aria-label="checkbox" type="checkbox" class="fd-checkbox" id="19j0Sc">
                 <label class="fd-checkbox__label" for="19j0Sc"></label>
@@ -1717,10 +1717,10 @@ export const responsiveTable = () => `
             <td class="fd-table__cell">2 EUR</td>
             <td class="fd-table__cell">Mexico</td>
             <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
-                <i class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow" role="presentation"></i>
+                <i class="fd-table__icon fd-table__icon--navigation sap-icon--slim-arrow-right" role="presentation"></i>
             </td>
         </tr>
-        <tr class="fd-table__row">
+        <tr class="fd-table__row fd-table__row--activable fd-table__row--hoverable">
             <td class="fd-table__cell fd-table__cell--checkbox">
                 <input aria-label="checkbox" type="checkbox" class="fd-checkbox" id="a7SfGX">
                 <label class="fd-checkbox__label" for="a7SfGX"></label>
@@ -1734,7 +1734,7 @@ export const responsiveTable = () => `
             <td class="fd-table__cell">6 EUR</td>
             <td class="fd-table__cell">Spain</td>
             <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
-                <i class="fd-table__icon fd-table__icon--navigation sap-icon--navigation-right-arrow" role="presentation"></i>
+                <i class="fd-table__icon fd-table__icon--navigation sap-icon--slim-arrow-right" role="presentation"></i>
             </td>
         </tr>
     </tbody>

--- a/stories/table/table.stories.js
+++ b/stories/table/table.stories.js
@@ -1460,27 +1460,88 @@ It’s important to hardcode the width of the columns, otherwise the cells will 
     }
 };
 
-export const navIndicators = () => `
+export const navIcon = () => `
 <div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
-    <h4 style="margin: 0;">Table with Navigation Indication State</h4>
+    <h4>Responsive Table - row navigation</h4>
+    <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
+</div>
+<table class="fd-table fd-table--no-horizontal-borders">
+    <thead class="fd-table__header">
+        <tr class="fd-table__row">
+            <th class="fd-table__cell" scope="col">Name</th>
+            <th class="fd-table__cell" scope="col">Status</th>
+            <th class="fd-table__cell" scope="col">Price</th>
+            <th class="fd-table__cell" scope="col">Country</th>
+            <th class="fd-table__cell"></th>
+        </tr>
+    </thead>
+    <tbody class="fd-table__body">
+        <tr class="fd-table__row fd-table__row--activable fd-table__row--hoverable">
+            <td class="fd-table__cell">Banana</td>
+            <td class="fd-table__cell">
+                <span class="fd-object-status fd-object-status--positive">
+                    Available
+                </span>
+            </td>
+            <td class="fd-table__cell">5 EUR</td>
+            <td class="fd-table__cell">India</td>
+            <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
+                <i class="fd-table__icon fd-table__icon--navigation sap-icon--slim-arrow-right" role="presentation"></i>
+            </td>
+        </tr>
+        <tr class="fd-table__row fd-table__row--activable fd-table__row--hoverable">
+            <td class="fd-table__cell">Pineapple</td>
+            <td class="fd-table__cell">
+                <span class="fd-object-status fd-object-status--negative">
+                    Out of stock
+                </span>
+            </td>
+            <td class="fd-table__cell">2 EUR</td>
+            <td class="fd-table__cell">Mexico</td>
+            <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
+                <i class="fd-table__icon fd-table__icon--navigation sap-icon--slim-arrow-right" role="presentation"></i>
+            </td>
+        </tr>
+        <tr class="fd-table__row fd-table__row--activable fd-table__row--hoverable">
+            <td class="fd-table__cell">Orange</td>
+            <td class="fd-table__cell">
+                <span class="fd-object-status fd-object-status--informative">
+                    Temporary unavailable
+                </span>
+            </td>
+            <td class="fd-table__cell">6 EUR</td>
+            <td class="fd-table__cell">Spain</td>
+            <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
+                <i class="fd-table__icon fd-table__icon--navigation sap-icon--slim-arrow-right" role="presentation"></i>
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+<div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
+    <h4>Table - icon button for navigation</h4>
     <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
 </div>
 <table class="fd-table">
     <thead class="fd-table__header">
         <tr class="fd-table__row">
-            <th class="fd-table__cell" scope="col">Column Header</th>
-            <th class="fd-table__cell" scope="col">Column Header</th>
-            <th class="fd-table__cell" scope="col">Column Header</th>
-            <th class="fd-table__cell" scope="col">Column Header</th>
-            <th class="fd-table__cell" scope="col"></th>
+            <th class="fd-table__cell" scope="col">Name</th>
+            <th class="fd-table__cell" scope="col">Status</th>
+            <th class="fd-table__cell" scope="col">Price</th>
+            <th class="fd-table__cell" scope="col">Country</th>
+            <th class="fd-table__cell"></th>
         </tr>
     </thead>
     <tbody class="fd-table__body">
         <tr class="fd-table__row">
-            <td class="fd-table__cell"><a class="fd-link">user.name@email.com</a></td>
-            <td class="fd-table__cell">First Name</td>
-            <td class="fd-table__cell">Last Name</td>
-            <td class="fd-table__cell">01/26/17</td>
+            <td class="fd-table__cell">Banana</td>
+            <td class="fd-table__cell">
+                <span class="fd-object-status fd-object-status--positive">
+                    Available
+                </span>
+            </td>
+            <td class="fd-table__cell">5 EUR</td>
+            <td class="fd-table__cell">India</td>
             <td class="fd-table__cell fd-table__cell--fit-content">
                 <button aria-label="navigation" class="fd-button fd-button--transparent">
                     <i class="sap-icon--navigation-right-arrow"></i>
@@ -1488,21 +1549,29 @@ export const navIndicators = () => `
             </td>
         </tr>
         <tr class="fd-table__row">
-            <td class="fd-table__cell"><a class="fd-link">user.name@email.com</a></td>
-            <td class="fd-table__cell">First Name</td>
-            <td class="fd-table__cell">Last Name</td>
-            <td class="fd-table__cell">01/26/17</td>
-            <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--navigated">
+            <td class="fd-table__cell">Pineapple</td>
+            <td class="fd-table__cell">
+                <span class="fd-object-status fd-object-status--negative">
+                    Out of stock
+                </span>
+            </td>
+            <td class="fd-table__cell">2 EUR</td>
+            <td class="fd-table__cell">Mexico</td>
+            <td class="fd-table__cell fd-table__cell--fit-content">
                 <button aria-label="navigation" class="fd-button fd-button--transparent">
                     <i class="sap-icon--navigation-right-arrow"></i>
                 </button>
             </td>
         </tr>
         <tr class="fd-table__row">
-            <td class="fd-table__cell"><a class="fd-link">user.name@email.com</a></td>
-            <td class="fd-table__cell">First Name</td>
-            <td class="fd-table__cell">Last Name</td>
-            <td class="fd-table__cell">01/26/17</td>
+            <td class="fd-table__cell">Orange</td>
+            <td class="fd-table__cell">
+                <span class="fd-object-status fd-object-status--informative">
+                    Temporary unavailable
+                </span>
+            </td>
+            <td class="fd-table__cell">6 EUR</td>
+            <td class="fd-table__cell">Spain</td>
             <td class="fd-table__cell fd-table__cell--fit-content">
                 <button aria-label="navigation" class="fd-button fd-button--transparent">
                     <i class="sap-icon--navigation-right-arrow"></i>
@@ -1513,11 +1582,86 @@ export const navIndicators = () => `
 </table>
 `;
 
+navIcon.storyName = 'Navigation from table rows';
+navIcon.parameters = {
+    docs: {
+        storyDescription: `
+Responsive table allows navigation from a line item. For that purpose you need to add a column with the icon \`sap-icon--slim-arrow-right\` at the end. The entire line needs to be clickable 
+
+You have an option to add icon button \`sap-icon--navigation-right-arrow\` as a separate column for non responsive table.
+    `
+    }
+};
+
+export const navIndicators = () => `
+<div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
+    <h4>Table with Navigation Indication State</h4>
+    <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
+</div>
+<table class="fd-table fd-table--no-horizontal-borders">
+    <thead class="fd-table__header">
+        <tr class="fd-table__row">
+            <th class="fd-table__cell fd-table__cell--checkbox">
+                <input aria-label="checkbox" type="checkbox" class="fd-checkbox" id="kqqzPI44">
+                <label class="fd-checkbox__label" for="kqqzPI44"></label>
+            </th>
+            <th class="fd-table__cell" scope="col">Column Header</th>
+            <th class="fd-table__cell" scope="col">Column Header</th>
+            <th class="fd-table__cell" scope="col">Column Header</th>
+            <th class="fd-table__cell" scope="col">Column Header</th>
+            <th class="fd-table__cell" scope="col"></th>
+        </tr>
+    </thead>
+    <tbody class="fd-table__body">
+        <tr class="fd-table__row" aria-selected="true">
+            <td class="fd-table__cell fd-table__cell--checkbox">
+                <input aria-label="checkbox" type="checkbox" checked class="fd-checkbox" id="EWuzWh33">
+                <label class="fd-checkbox__label" for="EWuzWh33"></label>
+            </td>
+            <td class="fd-table__cell"><a class="fd-link">user.name@email.com</a></td>
+            <td class="fd-table__cell">First Name</td>
+            <td class="fd-table__cell">Last Name</td>
+            <td class="fd-table__cell">01/26/17</td>
+            <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
+                <i class="fd-table__icon fd-table__icon--navigation sap-icon--slim-arrow-right" role="presentation"></i>
+            </td>
+        </tr>
+        <tr class="fd-table__row" aria-selected="true">
+            <td class="fd-table__cell fd-table__cell--checkbox">
+                <input aria-label="checkbox" type="checkbox" checked class="fd-checkbox" id="EWuzWh334">
+                <label class="fd-checkbox__label" for="EWuzWh334"></label>
+            </td>
+            <td class="fd-table__cell"><a class="fd-link">user.name@email.com</a></td>
+            <td class="fd-table__cell">First Name</td>
+            <td class="fd-table__cell">Last Name</td>
+            <td class="fd-table__cell">01/26/17</td>
+            <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--navigated fd-table__cell--no-padding">
+                <i class="fd-table__icon fd-table__icon--navigation sap-icon--slim-arrow-right" role="presentation"></i>
+            </td>
+        </tr>
+        <tr class="fd-table__row">
+            <td class="fd-table__cell fd-table__cell--checkbox">
+                <input aria-label="checkbox" type="checkbox" class="fd-checkbox" id="EWuzWh335">
+                <label class="fd-checkbox__label" for="EWuzWh335"></label>
+            </td>
+            <td class="fd-table__cell"><a class="fd-link">user.name@email.com</a></td>
+            <td class="fd-table__cell">First Name</td>
+            <td class="fd-table__cell">Last Name</td>
+            <td class="fd-table__cell">01/26/17</td>
+            <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
+              <i class="fd-table__icon fd-table__icon--navigation sap-icon--slim-arrow-right" role="presentation"></i>
+            </td>
+        </tr>
+    </tbody>
+</table>
+`;
+
 navIndicators.storyName = 'Navigation indicators';
 navIndicators.parameters = {
     docs: {
         storyDescription: `
-The table component can display navigation indicators. You can also display a “navigated” indicator, as indicated in the second row, to mark an item that is currently open. To display a navigated indicator, add the \`fd-table__cell--navigated\` class to the desired table cell.
+
+The table component can display navigation indicators. When multi-selection is used in a master-detail scenario, it is not clear which item was last opened, you can mark it as a “navigated” indicator, as indicated in the second row, to mark an item that is currently open. To display a navigated indicator, add the \`fd-table__cell--navigated\` class to the desired table cell.
     `
     }
 };


### PR DESCRIPTION
## Related Issue
fixes #2042 

## Description
Update Table navigation examples; fix the color and background on mouse down

BREAKING CHANGE:
update responsive table navigation icon

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:

<img width="962" alt="Screen Shot 2021-02-20 at 8 46 03 PM" src="https://user-images.githubusercontent.com/4380815/108614995-a6de2b80-73cd-11eb-879f-73865d1c4b71.png">

<img width="962" alt="Screen Shot 2021-02-20 at 8 46 47 PM" src="https://user-images.githubusercontent.com/4380815/108614998-ab0a4900-73cd-11eb-8309-0e7ce1158b01.png">

### After:

<img width="493" alt="Screen Shot 2021-02-20 at 8 46 08 PM" src="https://user-images.githubusercontent.com/4380815/108615005-afcefd00-73cd-11eb-8611-0d9f526ff716.png">

<img width="960" alt="Screen Shot 2021-02-20 at 8 46 55 PM" src="https://user-images.githubusercontent.com/4380815/108615013-b3fb1a80-73cd-11eb-8b2d-01c14777bb48.png">


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [X] hover state of the element follow design spec
- [X] focus state of the element follow design spec
- [X] active state of the element follow design spec
- [X] selected state of the element follow design spec
- [X] selected hover state of the element follow design spec
- [X] pressed state of the element follow design spec
2. The code follows fundamental-styles code standards and style
- [X] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
3. Testing
- [X] tested Storybook examples with "CSS Resources" `normalize` option 
- [X] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [X] Updated tests
- [X] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [X] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
