### PR TITLE
fix: Semantic tabs color

### DIFF
--- a/src/tabs.scss
+++ b/src/tabs.scss
@@ -45,19 +45,19 @@ $block: #{$fd-namespace}-tabs;
       .#{$block}__tag {
         color: $color;
       }
+    }
 
-      @include fd-selected() {
-        .#{$block}__icon {
-          color: var(--sapContent_ContrastIconColor);
+    @include fd-selected() {
+      .#{$block}__icon {
+        color: var(--sapContent_ContrastIconColor);
+        background-color: $color;
+      }
+
+      .#{$block}__icon,
+      .#{$block}__tag,
+      .#{$block}__link {
+        &::after {
           background-color: $color;
-        }
-
-        .#{$block}__icon,
-        .#{$block}__tag,
-        & {
-          &::after {
-            background-color: $color;
-          }
         }
       }
     }
@@ -132,6 +132,25 @@ $block: #{$fd-namespace}-tabs;
     padding: 0;
     margin: 0 $fd-tabs-item-spacing-x;
 
+    @include fd-selected() {
+      .#{$block}__tag {
+        color: var(--fdTabs_Selected_Color);
+      }
+
+      .#{$block}__icon {
+        color: var(--fdTabs_Selected_Icon_Color);
+        background-color: $fd-tabs-selected-color;
+      }
+
+      .#{$block}__icon,
+      .#{$block}__tag,
+      .#{$block}__link {
+        &::after {
+          background-color: var(--fdTabs_Selected_Color);
+        }
+      }
+    }
+
     &--error {
       @include tabs-semantic(var(--sapErrorColor));
     }
@@ -157,25 +176,6 @@ $block: #{$fd-namespace}-tabs;
 
       .#{$block}__link {
         padding-left: 0;
-      }
-    }
-
-    @include fd-selected() {
-      .#{$block}__tag {
-        color: var(--fdTabs_Selected_Color);
-      }
-
-      .#{$block}__icon {
-        color: var(--fdTabs_Selected_Icon_Color);
-        background-color: $fd-tabs-selected-color;
-      }
-
-      .#{$block}__icon,
-      .#{$block}__tag,
-      & {
-        &::after {
-          background-color: var(--fdTabs_Selected_Color);
-        }
       }
     }
 


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-styles/issues/2161

## Description
There are added some selectors into tabs component, to make semantic mode work properly

## Screnshots
Before:
![image](https://user-images.githubusercontent.com/26483208/108843584-28ef6f80-75db-11eb-82dd-82777aefb126.png)
After:
![image](https://user-images.githubusercontent.com/26483208/108843600-30167d80-75db-11eb-8c96-6e543dca6766.png)


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
