### PR TITLE
fix: update object status large font-family [ci visual]

### DIFF
--- a/src/object-status.scss
+++ b/src/object-status.scss
@@ -311,6 +311,10 @@ $inverted-color-accents: (
   &--large {
     font-size: $fd-object-status-icon-text-font-size-large;
 
+    .#{$block}__text {
+      font-family: var(--sapFontLightFamily);
+    }
+
     @include fd-object-status-icon-selector() {
       font-size: $fd-object-status-icon-text-font-size-large;
     }


### PR DESCRIPTION
## Related Issue
fixes #2164 

## Description
specify font-family for large object status

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
