### PR TITLE
fix: add fix for Dynamic Page title alignment issues

### DIFF
--- a/src/dynamic-page.scss
+++ b/src/dynamic-page.scss
@@ -149,7 +149,7 @@ $block: #{$fd-namespace}-dynamic-page;
     @include fd-reset();
 
     @include fd-flex() {
-      align-items: baseline;
+      align-items: center;
     }
   }
 
@@ -179,7 +179,6 @@ $block: #{$fd-namespace}-dynamic-page;
 
     color: var(--sapGroup_TitleTextColor);
     font-size: var(--sapFontHeader3Size);
-    padding: 0.3125rem 0 0 0;
 
     @include fd-ellipsis();
 
@@ -398,12 +397,8 @@ $block: #{$fd-namespace}-dynamic-page;
       padding: 0;
     }
 
-    .#{$block}__title {
-      padding: 0.6875rem 0 0 0;
-    }
-
     .#{$block}__title-container {
-      align-items: flex-start;
+      align-items: center;
     }
 
     .#{$block}__toolbar {
@@ -437,9 +432,6 @@ $block: #{$fd-namespace}-dynamic-page;
   }
 
   &--md {
-    .#{$block}__title {
-      padding: 0.6875rem 0 0 0;
-    }
 
     .#{$block}__breadcrumb-container {
       align-items: flex-end;


### PR DESCRIPTION
## Related Issue
Portal related issue

## Description
The elements in the Title container of Dynamic Page were not aligned vertically due to padding top added to the title and items being aligned `baseline`.

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
<img width="603" alt="Screen Shot 2021-03-08 at 3 17 06 PM" src="https://user-images.githubusercontent.com/39598672/110376619-6adbd500-8021-11eb-8da1-768768fdc75c.png">
<img width="635" alt="Screen Shot 2021-03-08 at 3 16 44 PM" src="https://user-images.githubusercontent.com/39598672/110376623-6b746b80-8021-11eb-8e08-1104541b5a91.png">
<img width="1089" alt="Screen Shot 2021-03-08 at 3 15 41 PM" src="https://user-images.githubusercontent.com/39598672/110376627-6c0d0200-8021-11eb-80fc-ffce7bc4eccf.png">
<img width="1090" alt="Screen Shot 2021-03-08 at 3 16 24 PM" src="https://user-images.githubusercontent.com/39598672/110376711-847d1c80-8021-11eb-9e85-c16476ec4931.png">


### After:

<img width="466" alt="Screen Shot 2021-03-08 at 3 14 40 PM" src="https://user-images.githubusercontent.com/39598672/110376687-7e873b80-8021-11eb-9b83-605e8d437fa8.png">
<img width="1078" alt="Screen Shot 2021-03-08 at 3 14 15 PM" src="https://user-images.githubusercontent.com/39598672/110376690-7f1fd200-8021-11eb-9403-f751ebabcc16.png">
<img width="1084" alt="Screen Shot 2021-03-08 at 3 13 41 PM" src="https://user-images.githubusercontent.com/39598672/110376694-7fb86880-8021-11eb-8195-8e1f83e494d8.png">
<img width="1082" alt="Screen Shot 2021-03-08 at 3 18 51 PM" src="https://user-images.githubusercontent.com/39598672/110376834-ab3b5300-8021-11eb-92f7-c006f0eb13c2.png">
