### PR TITLE
feat: Add no-data, remove borders from responsive mode

### DIFF
--- a/src/table.scss
+++ b/src/table.scss
@@ -125,8 +125,6 @@ $block: #{$fd-namespace}-table;
   }
 
   &__text {
-    @include fd-reset();
-
     word-break: break-all;
     white-space: nowrap;
     overflow: hidden;

--- a/src/table.scss
+++ b/src/table.scss
@@ -130,6 +130,7 @@ $block: #{$fd-namespace}-table;
     height: $fd-table-cozy-cell-height;
     padding: 0 $fd-table-cell-padding;
     color: inherit;
+    word-break: break-all;
     border-right: $fd-table-border;
 
     &--valid {
@@ -146,6 +147,10 @@ $block: #{$fd-namespace}-table;
 
     &--information {
       color: var(--sapInformationColor);
+    }
+
+    &--no-data {
+      text-align: center;
     }
 
     &--checkbox {
@@ -486,6 +491,21 @@ $block: #{$fd-namespace}-table;
       .#{$block}__row {
         .#{$block}__cell {
           border-right: none;
+        }
+      }
+    }
+  }
+
+  &--responsive {
+    .#{$block}__body,
+    .#{$block}__header {
+      border: none;
+    }
+
+    .#{$block}-table__row {
+      @include fd-last-child() {
+        .#{$block}-table__cell {
+          border-bottom: none;
         }
       }
     }

--- a/src/table.scss
+++ b/src/table.scss
@@ -125,13 +125,12 @@ $block: #{$fd-namespace}-table;
   }
 
   &__text {
-    word-break: break-all;
-    white-space: nowrap;
+    word-break: break-word;
     overflow: hidden;
     text-overflow: ellipsis;
 
-    &--wrap {
-      white-space: normal;
+    &--no-wrap {
+      white-space: nowrap;
     }
   }
 

--- a/src/table.scss
+++ b/src/table.scss
@@ -124,13 +124,25 @@ $block: #{$fd-namespace}-table;
     }
   }
 
+  &__text {
+    @include fd-reset();
+
+    word-break: break-all;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    &--wrap {
+      white-space: normal;
+    }
+  }
+
   &__cell {
     text-align: left;
     text-shadow: var(--sapContent_TextShadow);
     height: $fd-table-cozy-cell-height;
     padding: 0 $fd-table-cell-padding;
     color: inherit;
-    word-break: break-all;
     border-right: $fd-table-border;
 
     &--valid {
@@ -502,9 +514,9 @@ $block: #{$fd-namespace}-table;
       border: none;
     }
 
-    .#{$block}-table__row {
+    .#{$block}__row {
       @include fd-last-child() {
-        .#{$block}-table__cell {
+        .#{$block}__cell {
           border-bottom: none;
         }
       }

--- a/src/table.scss
+++ b/src/table.scss
@@ -125,9 +125,12 @@ $block: #{$fd-namespace}-table;
   }
 
   &__text {
+    @include fd-ellipsis();
+
     word-break: break-word;
     overflow: hidden;
     text-overflow: ellipsis;
+    white-space: normal;
 
     &--no-wrap {
       white-space: nowrap;

--- a/stories/table/__snapshots__/table.stories.storyshot
+++ b/stories/table/__snapshots__/table.stories.storyshot
@@ -6083,7 +6083,7 @@ exports[`Storyshots Components/Table Navigation from table rows 1`] = `
   
 
   <table
-    class="fd-table fd-table--no-horizontal-borders"
+    class="fd-table fd-table--responsive fd-table--no-horizontal-borders"
   >
     
     
@@ -6351,7 +6351,7 @@ exports[`Storyshots Components/Table Navigation from table rows 1`] = `
   
 
   <table
-    class="fd-table"
+    class="fd-table "
   >
     
     
@@ -7551,7 +7551,7 @@ exports[`Storyshots Components/Table Responsive Table (pop-in mode) 1`] = `
     
     
     <table
-      class="fd-table fd-table--no-horizontal-borders fd-table--no-vertical-borders fd-table--pop-in"
+      class="fd-table fd-table--responsive fd-table--no-horizontal-borders fd-table--no-vertical-borders fd-table--pop-in"
     >
       
         
@@ -7818,7 +7818,7 @@ exports[`Storyshots Components/Table Responsive Table (pop-in mode) 1`] = `
     
     
     <table
-      class="fd-table fd-table--no-horizontal-borders fd-table--no-vertical-borders fd-table--pop-in"
+      class="fd-table fd-table--responsive fd-table--no-horizontal-borders fd-table--no-vertical-borders fd-table--pop-in"
     >
       
         
@@ -8138,7 +8138,7 @@ exports[`Storyshots Components/Table Responsive Table 1`] = `
   
 
   <table
-    class="fd-table fd-table--no-horizontal-borders"
+    class="fd-table fd-table--responsive fd-table--no-horizontal-borders"
   >
     
     
@@ -9203,4 +9203,9 @@ exports[`Storyshots Components/Table Semantic 1`] = `
   
 
 </section>
+`;
+
+exports[`Storyshots Components/Table Table without data 1`] = `
+
+      
 `;

--- a/stories/table/__snapshots__/table.stories.storyshot
+++ b/stories/table/__snapshots__/table.stories.storyshot
@@ -7390,7 +7390,23 @@ exports[`Storyshots Components/Table Primary 1`] = `
         <td
           class="fd-table__cell"
         >
-          First Name
+          
+                
+          <div
+            class="fd-table__text"
+            style="max-width: 250px"
+          >
+            
+                    Very long Text, limited by max-width
+                    Very long Text, limited by max-width
+                    Very long Text, limited by max-width
+                    Very long Text, limited by max-width
+                    Very long Text, limited by max-width
+                    Very long Text, limited by max-width
+                
+          </div>
+          
+            
         </td>
         
             
@@ -7437,7 +7453,20 @@ exports[`Storyshots Components/Table Primary 1`] = `
         <td
           class="fd-table__cell"
         >
-          First Name
+          
+                
+          <div
+            class="fd-table__text fd-table__text--wrap"
+            style="max-width: 250px"
+          >
+            
+                    Very long Text Wrapped, limited by max-width
+                    Very long Text Wrapped, limited by max-width
+                    Very long Text Wrapped, limited by max-width
+                
+          </div>
+          
+            
         </td>
         
             

--- a/stories/table/__snapshots__/table.stories.storyshot
+++ b/stories/table/__snapshots__/table.stories.storyshot
@@ -7393,16 +7393,16 @@ exports[`Storyshots Components/Table Primary 1`] = `
           
                 
           <div
-            class="fd-table__text"
+            class="fd-table__text fd-table__text--no-wrap"
             style="max-width: 250px"
           >
             
-                    Very long Text, limited by max-width
-                    Very long Text, limited by max-width
-                    Very long Text, limited by max-width
-                    Very long Text, limited by max-width
-                    Very long Text, limited by max-width
-                    Very long Text, limited by max-width
+                    Very long Text Not Wrapped, limited by max-width
+                    Very long Text Not Wrapped, limited by max-width
+                    Very long Text Not Wrapped, limited by max-width
+                    Very long Text Not Wrapped, limited by max-width
+                    Very long Text Not Wrapped, limited by max-width
+                    Very long Text Not Wrapped, limited by max-width
                 
           </div>
           
@@ -7456,10 +7456,11 @@ exports[`Storyshots Components/Table Primary 1`] = `
           
                 
           <div
-            class="fd-table__text fd-table__text--wrap"
+            class="fd-table__text"
             style="max-width: 250px"
           >
             
+                    Very long Text Wrapped, limited by max-width
                     Very long Text Wrapped, limited by max-width
                     Very long Text Wrapped, limited by max-width
                     Very long Text Wrapped, limited by max-width

--- a/stories/table/table.stories.js
+++ b/stories/table/table.stories.js
@@ -87,14 +87,29 @@ export const primary = () => `
     <tbody class="fd-table__body">
         <tr class="fd-table__row">
             <td class="fd-table__cell"><a class="fd-link">user.name@email.com</a></td>
-            <td class="fd-table__cell">First Name</td>
+            <td class="fd-table__cell">
+                <div class="fd-table__text" style="max-width: 250px">
+                    Very long Text, limited by max-width
+                    Very long Text, limited by max-width
+                    Very long Text, limited by max-width
+                    Very long Text, limited by max-width
+                    Very long Text, limited by max-width
+                    Very long Text, limited by max-width
+                </div>
+            </td>
             <td class="fd-table__cell">Middle Name</td>
             <td class="fd-table__cell">Last Name</td>
             <td class="fd-table__cell">01/26/17</td>
         </tr>
         <tr class="fd-table__row">
             <td class="fd-table__cell"><a class="fd-link">user.name@email.com</a></td>
-            <td class="fd-table__cell">First Name</td>
+            <td class="fd-table__cell">
+                <div class="fd-table__text fd-table__text--wrap" style="max-width: 250px">
+                    Very long Text Wrapped, limited by max-width
+                    Very long Text Wrapped, limited by max-width
+                    Very long Text Wrapped, limited by max-width
+                </div>
+            </td>
             <td class="fd-table__cell">Middle Name</td>
             <td class="fd-table__cell">Last Name</td>
             <td class="fd-table__cell">01/26/17</td>

--- a/stories/table/table.stories.js
+++ b/stories/table/table.stories.js
@@ -88,13 +88,13 @@ export const primary = () => `
         <tr class="fd-table__row">
             <td class="fd-table__cell"><a class="fd-link">user.name@email.com</a></td>
             <td class="fd-table__cell">
-                <div class="fd-table__text" style="max-width: 250px">
-                    Very long Text, limited by max-width
-                    Very long Text, limited by max-width
-                    Very long Text, limited by max-width
-                    Very long Text, limited by max-width
-                    Very long Text, limited by max-width
-                    Very long Text, limited by max-width
+                <div class="fd-table__text fd-table__text--no-wrap" style="max-width: 250px">
+                    Very long Text Not Wrapped, limited by max-width
+                    Very long Text Not Wrapped, limited by max-width
+                    Very long Text Not Wrapped, limited by max-width
+                    Very long Text Not Wrapped, limited by max-width
+                    Very long Text Not Wrapped, limited by max-width
+                    Very long Text Not Wrapped, limited by max-width
                 </div>
             </td>
             <td class="fd-table__cell">Middle Name</td>
@@ -104,7 +104,8 @@ export const primary = () => `
         <tr class="fd-table__row">
             <td class="fd-table__cell"><a class="fd-link">user.name@email.com</a></td>
             <td class="fd-table__cell">
-                <div class="fd-table__text fd-table__text--wrap" style="max-width: 250px">
+                <div class="fd-table__text" style="max-width: 250px">
+                    Very long Text Wrapped, limited by max-width
                     Very long Text Wrapped, limited by max-width
                     Very long Text Wrapped, limited by max-width
                     Very long Text Wrapped, limited by max-width

--- a/stories/table/table.stories.js
+++ b/stories/table/table.stories.js
@@ -1482,7 +1482,7 @@ export const navIcon = () => `
     <h4>Responsive Table - row navigation</h4>
     <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
 </div>
-<table class="fd-table fd-table--no-horizontal-borders">
+<table class="fd-table fd-table--responsive fd-table--no-horizontal-borders">
     <thead class="fd-table__header">
         <tr class="fd-table__row">
             <th class="fd-table__cell" scope="col">Name</th>
@@ -1539,7 +1539,7 @@ export const navIcon = () => `
     <h4>Table - icon button for navigation</h4>
     <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
 </div>
-<table class="fd-table">
+<table class="fd-table ">
     <thead class="fd-table__header">
         <tr class="fd-table__row">
             <th class="fd-table__cell" scope="col">Name</th>
@@ -1688,7 +1688,7 @@ export const responsiveTable = () => `
     <h4 style="margin: 0;">Responsive Table</h4>
     <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
 </div>
-<table class="fd-table fd-table--no-horizontal-borders">
+<table class="fd-table fd-table--responsive fd-table--no-horizontal-borders">
     <thead class="fd-table__header">
         <tr class="fd-table__row">
             <th class="fd-table__cell fd-table__cell--checkbox">
@@ -1761,7 +1761,7 @@ responsiveTable.storyName = 'Responsive Table';
 responsiveTable.parameters = {
     docs: {
         storyDescription: `
-The desktop responsive table markup is exactly the same as the regular table.
+The desktop responsive table should contain \`fd-table--responsive\` modifier.
     `
     }
 };
@@ -1772,7 +1772,7 @@ export const responsiveTablePopInMode = () => `
         <h4 style="margin: 0;">Responsive Table - Pop-in mode</h4>
         <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
     </div>
-    <table class="fd-table fd-table--no-horizontal-borders fd-table--no-vertical-borders fd-table--pop-in">
+    <table class="fd-table fd-table--responsive fd-table--no-horizontal-borders fd-table--no-vertical-borders fd-table--pop-in">
         <tbody class="fd-table__body">
             <tr class="fd-table__row fd-table__row--main fd-table__row--activable fd-table__row--hoverable">
                 <td class="fd-table__cell">
@@ -1835,7 +1835,7 @@ export const responsiveTablePopInMode = () => `
         <h4 style="margin: 0;">Responsive Table - Pop-in Mode with Checkboxes and Navigation Indicator</h4>
         <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
     </div>
-    <table class="fd-table fd-table--no-horizontal-borders fd-table--no-vertical-borders fd-table--pop-in">
+    <table class="fd-table fd-table--responsive fd-table--no-horizontal-borders fd-table--no-vertical-borders fd-table--pop-in">
         <tbody class="fd-table__body">
             <tr class="fd-table__row fd-table__row--main">
                 <td class="fd-table__cell fd-table__cell--checkbox">
@@ -2208,6 +2208,49 @@ Grid tables can contain various input elements inside of cells, such as checkbox
 
 ####Accessibility
 Information about the table such as a title, summary, and/or keyboard navigation instructions should be provided in captions for screen readers. To caption table information, use the \`fd-table__caption\` class.        
+    `
+    }
+};
+
+export const noDataTable = () => `
+      <table class="fd-table">
+         <thead class="fd-table__header">
+            <tr class="fd-table__row">
+               <th class="fd-table__cell" scope="col">
+                    Header Column
+               </th>
+               <th class="fd-table__cell" scope="col">
+                    Header Column
+               </th>
+               <th class="fd-table__cell" scope="col">
+                    Header Column
+               </th>
+               <th class="fd-table__cell" scope="col">
+                    Header Column
+               </th>
+               <th class="fd-table__cell" scope="col">
+                    Header Column
+               </th>
+               <th class="fd-table__cell" scope="col">
+                    Header Column
+               </th>
+            </tr>
+         </thead>
+         <tbody class="fd-table__body">
+            <tr class="fd-table__row">
+                <td colspan="100%" class="fd-table__cell fd-table__cell--no-data">No Items Found!</td>
+            </tr>
+         </tbody>
+      </table>
+    </div>
+</div>
+`;
+
+noDataTable.storyName = 'Table without data';
+noDataTable.parameters = {
+    docs: {
+        storyDescription: `
+Table can indicate that there is no data to display.
     `
     }
 };


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-ngx/issues/4622
part of https://github.tools.sap/dxp/jukebox/issues/420

## Description
There are
- added no-data mode
- responsvie mode borders removed
- word break css included into cells

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
