### PR TITLE
fix: pagination colors

### DIFF
--- a/src/pagination.scss
+++ b/src/pagination.scss
@@ -44,7 +44,7 @@ $block: #{$fd-namespace}-pagination;
 
     &::before {
       content: "...";
-      color: var(--sapContent_LabelColor);
+      color: var(--sapLinkColor);
       font-weight: bold;
     }
   }
@@ -75,6 +75,10 @@ $block: #{$fd-namespace}-pagination;
       font-size: var(--sapFontSize);
       padding-left: $fd-pagination-padding-x;
       padding-right: $fd-pagination-padding-x;
+
+      @include fd-disabled() {
+        color: var(--sapField_PlaceholderTextColor);
+      }
     }
 
     &--previous {


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles/issues/1860

## Description
left and right arrows for the disabled state will be displayed in  **rgba(51,51,51,0.5)** 
dots between pages will be displayed in **rgb(6, 56, 6);**

For arrows I have applied fd-disabled after fd-link as fd-link is widely used in the framework 


## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
ARROW
![image](https://user-images.githubusercontent.com/2508127/110458773-72a48380-80cc-11eb-80f5-095051aad023.png)

DOTS
![image](https://user-images.githubusercontent.com/2508127/110458801-7a642800-80cc-11eb-961c-0d39685adf98.png)

### After:

ARROW Left
![image](https://user-images.githubusercontent.com/2508127/110458853-894ada80-80cc-11eb-9df5-fb15682aa68a.png)

ARROW Right 
![image](https://user-images.githubusercontent.com/2508127/110458896-95cf3300-80cc-11eb-86c0-c626e78ae60f.png)


DOTS
![image](https://user-images.githubusercontent.com/2508127/110458827-8354f980-80cc-11eb-8126-783f2680f8ad.png)


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [na] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [na] active state of the element follow design spec
- [na] selected state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [na] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [na ] only one top level `fd-*` class is used in the file
- [na] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [na] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [na] `fd-reset()` mixin is applied to all elements
- [na] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [na] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [na] Storybook documentation has been created/updated
- [na] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
