### PR TITLE
fix: toolbar button not having any margin

### DIFF
--- a/src/toolbar.scss
+++ b/src/toolbar.scss
@@ -165,6 +165,13 @@ $title-toolbar-height: 2.75rem;
           background-color: var(--sapToolbar_SeparatorColor);
         }
 
+        .#{$fd-namespace}-button {
+          margin-top: 0.1875rem;
+          &:last-of-type {
+            margin-bottom: 0.1875rem;
+          }
+        }
+
         .#{$block}__overflow__label {
           &.#{$fd-namespace}-label {
             margin: 0.375rem 0;
@@ -198,6 +205,13 @@ $title-toolbar-height: 2.75rem;
           padding: 0.25rem 0.5rem;
         }
       }
+      .#{$fd-namespace}-button {
+        margin-top: 0.1875rem;
+        &:last-of-type {
+          margin-bottom: 0.1875rem;
+        }
+      }
     }
+
   }
 }

--- a/src/toolbar.scss
+++ b/src/toolbar.scss
@@ -153,36 +153,20 @@ $title-toolbar-height: 2.75rem;
           display: block;
           text-align: left;
           width: auto;
+          margin: 0.1875rem 0;
 
           @include fd-rtl() {
             text-align: right;
           }
         }
+
         > .#{$block}__separator {
           height: 0.0625rem;
-          margin: 0.375rem 0.1875rem;
+          margin: 0.1875rem;
           width: auto;
           background-color: var(--sapToolbar_SeparatorColor);
         }
 
-        .#{$fd-namespace}-button {
-          margin-top: 0.1875rem;
-          &:last-of-type {
-            margin-bottom: 0.1875rem;
-          }
-        }
-
-        .#{$block}__overflow__label {
-          &.#{$fd-namespace}-label {
-            margin: 0.375rem 0;
-          }
-        }
-
-        .#{$block}__overflow__form-label {
-          &.#{$fd-namespace}-form-label {
-            margin: 0.625rem 0 0.125rem 0;
-          }
-        }
         .#{$block}__overflow__form-label,
         .#{$block}__overflow__label {
           overflow: hidden;
@@ -205,13 +189,6 @@ $title-toolbar-height: 2.75rem;
           padding: 0.25rem 0.5rem;
         }
       }
-      .#{$fd-namespace}-button {
-        margin-top: 0.1875rem;
-        &:last-of-type {
-          margin-bottom: 0.1875rem;
-        }
-      }
     }
-
   }
 }


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#1155

## Description
Added margins for buttons in toolbar overflow 

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/2508127/110981218-22951d80-8367-11eb-8bce-106b7fe976f0.png)


### After:
![image](https://user-images.githubusercontent.com/2508127/110980999-ca5e1b80-8366-11eb-8e5b-9668dc2571ba.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [na] Text elements follow the truncation rules
- [na] hover state of the element follow design spec
- [na] focus state of the element follow design spec
- [na] active state of the element follow design spec
- [na] selected state of the element follow design spec
- [na] selected hover state of the element follow design spec
- [na] pressed state of the element follow design spec
- [na] Responsiveness rules - the component has modifier classes for all breakpoints
- [na] Includes Compact/Cosy/Tablet design
- [na] RTL support
2. The code follows fundamental-styles code standards and style
- [na] only one top level `fd-*` class is used in the file
- [na] BEM naming convention is used
- [na] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [na] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [na] `fd-reset()` mixin is applied to all elements
- [na] Variables are used, if some value is used more than twice.
- [na] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [na] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [na] Storybook documentation has been created/updated
- [na] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
