### PR TITLE
 fix: Remove unnecessary code form pagination.scss 

### DIFF
--- a/src/pagination.scss
+++ b/src/pagination.scss
@@ -75,10 +75,6 @@ $block: #{$fd-namespace}-pagination;
       font-size: var(--sapFontSize);
       padding-left: $fd-pagination-padding-x;
       padding-right: $fd-pagination-padding-x;
-
-      @include fd-disabled() {
-        color: var(--sapField_PlaceholderTextColor);
-      }
     }
 
     &--previous {


### PR DESCRIPTION
## Description
There is some code, that is unnecesary, needs to be removed


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [NA] All values are in `rem`
- [NA] Text elements follow the truncation rules
- [NA] hover state of the element follow design spec
- [NA] focus state of the element follow design spec
- [NA] active state of the element follow design spec
- [NA] selected state of the element follow design spec
- [NA] selected hover state of the element follow design spec
- [NA] pressed state of the element follow design spec
- [NA] Responsiveness rules - the component has modifier classes for all breakpoints
- [NA] Includes Compact/Cosy/Tablet design
- [NA] RTL support
2. The code follows fundamental-styles code standards and style
- [NA] only one top level `fd-*` class is used in the file
- [NA] BEM naming convention is used
- [NA] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [NA] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [NA] `fd-reset()` mixin is applied to all elements
- [NA] Variables are used, if some value is used more than twice.
- [NA] Checked if current components can be reused, instead of having new code.
3. Testing
- [NA] tested Storybook examples with "CSS Resources" `normalize` option 
- [NA] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [NA] Verified all styles in IE11
- [NA] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [NA] Storybook documentation has been created/updated
- [NA] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
