### PR TITLE
fix: change the naming of status indicator classes to follow BEM

### DIFF
--- a/src/status-indicator.scss
+++ b/src/status-indicator.scss
@@ -46,12 +46,16 @@ $color-states: (
     flex-direction: unset;
   }
 
+  &--link {
+    cursor: pointer;
+  }
+
   @each $set-name, $color-set in $color-states {
     &--#{$set-name} {
       fill: map_get($color-set, "color");
     }
 
-    &--#{$set-name}__text {
+    &__text--#{$set-name} {
       color: map_get($color-set, "color");
     }
   }
@@ -64,7 +68,7 @@ $color-states: (
       width: map-get($size-set, 'width');
       height: map-get($size-set, 'height');
     }
-    &--#{$set-name}__text {
+    &__text--#{$set-name} {
       font-size: map-get($size-set, 'font-size');
       margin: map-get($size-set, 'margin');
     }

--- a/src/status-indicator.scss
+++ b/src/status-indicator.scss
@@ -33,14 +33,14 @@ $color-states: (
   flex-direction: column;
   align-items: center;
 
-  &:focus {
-    outline: 1px dotted #000;
-    outline-offset: 1px;
+  @include fd-focus() {
+    outline: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
+    outline-offset: var(--sapContent_FocusWidth);
   }
 
   @include fd-reset();
 
-  &--htext {
+  &--horizontal-label {
     @include fd-reset();
 
     flex-direction: unset;
@@ -53,9 +53,6 @@ $color-states: (
   @each $set-name, $color-set in $color-states {
     &--#{$set-name} {
       fill: map_get($color-set, "color");
-    }
-
-    &__text--#{$set-name} {
       color: map_get($color-set, "color");
     }
   }
@@ -68,7 +65,7 @@ $color-states: (
       width: map-get($size-set, 'width');
       height: map-get($size-set, 'height');
     }
-    &__text--#{$set-name} {
+    &__label--#{$set-name} {
       font-size: map-get($size-set, 'font-size');
       margin: map-get($size-set, 'margin');
     }

--- a/src/status-indicator.scss
+++ b/src/status-indicator.scss
@@ -22,6 +22,8 @@ $color-states: (
   $fd-status-indicator-default-color-stroke-width: 0.25 !default;
   $fd-status-indicator-default-color-fill: transparent !default;
   $fd-status-indicator-default-color: var(--sapContent_LabelColor) !default;
+  $fd-status-indicator-default-font-size: var(--sapFontSmallSize, 0.75rem);
+  $fd-status-indicator-default-margin: 0.375rem !default;
 
   font-family: var(--sapFontFamily);
   border-color: var(--sapContent_ForegroundBorderColor);
@@ -50,6 +52,19 @@ $color-states: (
     cursor: pointer;
   }
 
+  &__label {
+    font-size: $fd-status-indicator-default-font-size;
+    margin: $fd-status-indicator-default-margin;
+
+    // sizes
+    @each $set-name, $size-set in $fd-status-indicator-sizes {
+      &--#{$set-name} {
+        font-size: map-get($size-set, 'font-size');
+        margin: map-get($size-set, 'margin');
+      }
+    }
+  }
+
   @each $set-name, $color-set in $color-states {
     &--#{$set-name} {
       fill: map_get($color-set, "color");
@@ -60,14 +75,10 @@ $color-states: (
   // sizes
   @each $set-name, $size-set in $fd-status-indicator-sizes {
     &--#{$set-name} {
-      @include fd-reset-spacing();
-
-      width: map-get($size-set, 'width');
-      height: map-get($size-set, 'height');
-    }
-    &__label--#{$set-name} {
-      font-size: map-get($size-set, 'font-size');
-      margin: map-get($size-set, 'margin');
+      .#{$block}__svg {
+        width: map-get($size-set, 'width');
+        height: map-get($size-set, 'height');
+      }
     }
   }
 }

--- a/stories/status-indicator/__snapshots__/status-indicator.stories.storyshot
+++ b/stories/status-indicator/__snapshots__/status-indicator.stories.storyshot
@@ -1731,7 +1731,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Label 1`] 
       
 	
       <span
-        class="fd-status-indicator__label--lg"
+        class="fd-status-indicator__label fd-status-indicator__label--lg"
       >
         100%
       </span>
@@ -1994,7 +1994,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Label 1`] 
       
 	
       <span
-        class="fd-status-indicator__label--lg"
+        class="fd-status-indicator__label fd-status-indicator__label--lg"
       >
         100%
       </span>
@@ -2031,7 +2031,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Label 1`] 
       
 	
       <span
-        class="fd-status-indicator__label--lg"
+        class="fd-status-indicator__label fd-status-indicator__label--lg"
       >
         100%
       </span>
@@ -2294,7 +2294,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Label 1`] 
       
 	
       <span
-        class="fd-status-indicator__label--lg"
+        class="fd-status-indicator__label fd-status-indicator__label--lg"
       >
         100%
       </span>

--- a/stories/status-indicator/__snapshots__/status-indicator.stories.storyshot
+++ b/stories/status-indicator/__snapshots__/status-indicator.stories.storyshot
@@ -1724,7 +1724,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Label 1`] 
       
 	
       <span
-        class="fd-status-indicator--lg__text fd-status-indicator--critical__text"
+        class="fd-status-indicator__label--lg"
       >
         100%
       </span>
@@ -1865,7 +1865,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Label 1`] 
       aria-label="Euro Status Indicator With Labelled On Bottom"
       aria-roledescription="Status Indicator"
       aria-valuetext="100%"
-      class="fd-status-indicator fd-status-indicator--positive "
+      class="fd-status-indicator fd-status-indicator--positive"
       focusable="true"
       role="progressbar"
       tabindex="0"
@@ -1987,7 +1987,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Label 1`] 
       
 	
       <span
-        class="fd-status-indicator--lg__text fd-status-indicator--positive__text"
+        class="fd-status-indicator__label--lg"
       >
         100%
       </span>
@@ -2015,7 +2015,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Label 1`] 
       aria-label="Euro Status Indicator With Labelled On Left"
       aria-roledescription="Status Indicator"
       aria-valuetext="100%"
-      class="fd-status-indicator fd-status-indicator--critical fd-status-indicator--htext "
+      class="fd-status-indicator fd-status-indicator--critical fd-status-indicator--horizontal-label"
       focusable="true"
       role="progressbar"
       tabindex="0"
@@ -2024,15 +2024,15 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Label 1`] 
       
 	
       <span
-        class="fd-status-indicator--lg__text fd-status-indicator--critical__text"
+        class="fd-status-indicator__label--lg"
       >
         100%
       </span>
       
 	
       <svg
+        __shape0-__box21-24"=""
         class="fd-status-indicator--lg"
-        data-sap-ui="__shape0-__box21-24"
         height="100%"
         id="__shape0__box12-24"
         preserveAspectRatio="xMidYMid meet"
@@ -2165,7 +2165,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Label 1`] 
       aria-label="Euro Status Indicator With Labelled On Right"
       aria-roledescription="Status Indicator"
       aria-valuetext="100%"
-      class="fd-status-indicator fd-status-indicator--positive fd-status-indicator--htext"
+      class="fd-status-indicator fd-status-indicator--positive fd-status-indicator--horizontal-label"
       focusable="true"
       role="progressbar"
       tabindex="0"
@@ -2287,7 +2287,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Label 1`] 
       
 	
       <span
-        class="fd-status-indicator--lg__text fd-status-indicator--positive__text"
+        class="fd-status-indicator__label--lg"
       >
         100%
       </span>

--- a/stories/status-indicator/__snapshots__/status-indicator.stories.storyshot
+++ b/stories/status-indicator/__snapshots__/status-indicator.stories.storyshot
@@ -29,6 +29,7 @@ exports[`Storyshots Components/Status Indicator Fill values 1`] = `
       
 	
       <svg
+        class="fd-status-indicator__svg"
         data-sap-ui="__shape0-__box21-24"
         height="100%"
         id="__shape0__box5-24"
@@ -171,6 +172,7 @@ exports[`Storyshots Components/Status Indicator Fill values 1`] = `
       
 	
       <svg
+        class="fd-status-indicator__svg"
         data-sap-ui="__shape0-__box21-24"
         height="100%"
         id="__shape0__box6-24"
@@ -313,6 +315,7 @@ exports[`Storyshots Components/Status Indicator Fill values 1`] = `
       
 	
       <svg
+        class="fd-status-indicator__svg"
         data-sap-ui="__shape0-__box21-24"
         height="100%"
         id="__shape0__box7-24"
@@ -462,6 +465,7 @@ exports[`Storyshots Components/Status Indicator Sizes 1`] = `
       
 	
       <svg
+        class="fd-status-indicator__svg"
         data-sap-ui="__shape0-__box21-24"
         height="100%"
         id="__shape0__box1-24"
@@ -604,6 +608,7 @@ exports[`Storyshots Components/Status Indicator Sizes 1`] = `
       
 	
       <svg
+        class="fd-status-indicator__svg"
         data-sap-ui="__shape0-__box21-24"
         height="100%"
         id="__shape0__box2-24"
@@ -746,6 +751,7 @@ exports[`Storyshots Components/Status Indicator Sizes 1`] = `
       
 	
       <svg
+        class="fd-status-indicator__svg"
         data-sap-ui="__shape0-__box21-24"
         height="100%"
         id="__shape0__box3-24"
@@ -888,6 +894,7 @@ exports[`Storyshots Components/Status Indicator Sizes 1`] = `
       
 	
       <svg
+        class="fd-status-indicator__svg"
         data-sap-ui="__shape0-__box21-24"
         height="100%"
         id="__shape0__box4-24"
@@ -1028,7 +1035,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Angular fi
       aria-label="Euro Status Indicator Angled filling at 270 degree"
       aria-roledescription="Status Indicator"
       aria-valuetext="80%"
-      class="fd-status-indicator fd-status-indicator--positive"
+      class="fd-status-indicator fd-status-indicator--positive fd-status-indicator--xl"
       focusable="true"
       role="progressbar"
       tabindex="0"
@@ -1037,7 +1044,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Angular fi
       
 	
       <svg
-        class="fd-status-indicator--xl"
+        class="fd-status-indicator__svg"
         data-sap-ui="__shape0-__box21-24"
         height="100%"
         id="__shape0__box36-24"
@@ -1197,7 +1204,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Angular fi
       aria-label="Euro Status Indicator Angled filling at 40 degree"
       aria-roledescription="Status Indicator"
       aria-valuetext="50%"
-      class="fd-status-indicator fd-status-indicator--critical"
+      class="fd-status-indicator fd-status-indicator--critical fd-status-indicator--xl"
       focusable="true"
       role="progressbar"
       tabindex="0"
@@ -1206,7 +1213,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Angular fi
       
 	
       <svg
-        class="fd-status-indicator--xl"
+        class="fd-status-indicator__svg"
         data-sap-ui="__shape0-__box21-24"
         height="100%"
         id="__shape0__box37-24"
@@ -1366,7 +1373,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Angular fi
       aria-label="Euro Status Indicator Angled filling at 98 degree"
       aria-roledescription="Status Indicator"
       aria-valuetext="50%"
-      class="fd-status-indicator fd-status-indicator--positive"
+      class="fd-status-indicator fd-status-indicator--positive fd-status-indicator--xl"
       focusable="true"
       role="progressbar"
       tabindex="0"
@@ -1375,7 +1382,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Angular fi
       
 	
       <svg
-        class="fd-status-indicator--xl"
+        class="fd-status-indicator__svg"
         data-sap-ui="__shape0-__box21-24"
         height="100%"
         id="__shape0__box38-24"
@@ -1535,7 +1542,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Angular fi
       aria-label="Euro Status Indicator Angled filling at 140 degree"
       aria-roledescription="Status Indicator"
       aria-valuetext="40%"
-      class="fd-status-indicator fd-status-indicator--negative"
+      class="fd-status-indicator fd-status-indicator--negative fd-status-indicator--xl"
       focusable="true"
       role="progressbar"
       tabindex="0"
@@ -1544,7 +1551,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Angular fi
       
 	
       <svg
-        class="fd-status-indicator--xl"
+        class="fd-status-indicator__svg"
         data-sap-ui="__shape0-__box21-24"
         height="100%"
         id="__shape0__box39-24"
@@ -1715,7 +1722,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Label 1`] 
       aria-label="Euro Status Indicator With Labelled On Top"
       aria-roledescription="Status Indicator"
       aria-valuetext="100%"
-      class="fd-status-indicator fd-status-indicator--critical"
+      class="fd-status-indicator fd-status-indicator--critical fd-status-indicator--lg"
       focusable="true"
       role="progressbar"
       tabindex="0"
@@ -1731,7 +1738,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Label 1`] 
       
 	
       <svg
-        class="fd-status-indicator--lg"
+        class="fd-status-indicator__svg"
         data-sap-ui="__shape0-__box21-24"
         height="100%"
         id="__shape0__box9-24"
@@ -1865,7 +1872,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Label 1`] 
       aria-label="Euro Status Indicator With Labelled On Bottom"
       aria-roledescription="Status Indicator"
       aria-valuetext="100%"
-      class="fd-status-indicator fd-status-indicator--positive"
+      class="fd-status-indicator fd-status-indicator--positive fd-status-indicator--lg"
       focusable="true"
       role="progressbar"
       tabindex="0"
@@ -1874,7 +1881,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Label 1`] 
       
 	
       <svg
-        class="fd-status-indicator--lg"
+        class="fd-status-indicator__svg"
         data-sap-ui="__shape0-__box21-24"
         height="100%"
         id="__shape0__box10-24"
@@ -2015,7 +2022,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Label 1`] 
       aria-label="Euro Status Indicator With Labelled On Left"
       aria-roledescription="Status Indicator"
       aria-valuetext="100%"
-      class="fd-status-indicator fd-status-indicator--critical fd-status-indicator--horizontal-label"
+      class="fd-status-indicator fd-status-indicator--critical fd-status-indicator--horizontal-label fd-status-indicator--lg"
       focusable="true"
       role="progressbar"
       tabindex="0"
@@ -2032,7 +2039,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Label 1`] 
 	
       <svg
         __shape0-__box21-24"=""
-        class="fd-status-indicator--lg"
+        class="fd-status-indicator__svg"
         height="100%"
         id="__shape0__box12-24"
         preserveAspectRatio="xMidYMid meet"
@@ -2165,7 +2172,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Label 1`] 
       aria-label="Euro Status Indicator With Labelled On Right"
       aria-roledescription="Status Indicator"
       aria-valuetext="100%"
-      class="fd-status-indicator fd-status-indicator--positive fd-status-indicator--horizontal-label"
+      class="fd-status-indicator fd-status-indicator--positive fd-status-indicator--horizontal-label fd-status-indicator--lg"
       focusable="true"
       role="progressbar"
       tabindex="0"
@@ -2174,7 +2181,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Label 1`] 
       
 	
       <svg
-        class="fd-status-indicator--lg"
+        class="fd-status-indicator__svg"
         data-sap-ui="__shape0-__box21-24"
         height="100%"
         id="__shape0__box101-24"
@@ -2323,7 +2330,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Linear fil
       aria-label="Euro status indicator animated left to right filling "
       aria-roledescription="Status Indicator"
       aria-valuetext="80%"
-      class="fd-status-indicator fd-status-indicator--negative"
+      class="fd-status-indicator fd-status-indicator--negative fd-status-indicator--lg"
       focusable="true"
       role="progressbar"
       tabindex="0"
@@ -2332,7 +2339,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Linear fil
       
 	
       <svg
-        class="fd-status-indicator--lg"
+        class="fd-status-indicator__svg"
         data-sap-ui="__shape0-__box32-24"
         height="100%"
         id="__shape0__box32a-24"
@@ -2491,7 +2498,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Linear fil
       aria-label="Euro status indicator animated bottom up filling"
       aria-roledescription="Status Indicator"
       aria-valuetext="80%"
-      class="fd-status-indicator fd-status-indicator--negative"
+      class="fd-status-indicator fd-status-indicator--negative fd-status-indicator--lg"
       focusable="true"
       role="progressbar"
       tabindex="0"
@@ -2500,7 +2507,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Linear fil
       
 	
       <svg
-        class="fd-status-indicator--lg"
+        class="fd-status-indicator__svg"
         data-sap-ui="__shape0-__box21-24"
         height="100%"
         id="__shape0__box33-24"
@@ -2666,7 +2673,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Radial fil
       aria-label="Euro Status Indicator Radial clock wise filling"
       aria-roledescription="Status Indicator"
       aria-valuetext="30%"
-      class="fd-status-indicator fd-status-indicator--negative"
+      class="fd-status-indicator fd-status-indicator--negative fd-status-indicator--xl"
       focusable="true"
       role="progressbar"
       tabindex="0"
@@ -2675,7 +2682,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Radial fil
       
 	
       <svg
-        class="fd-status-indicator--xl "
+        class="fd-status-indicator__svg"
         data-sap-ui="__shape0-__box21-24"
         height="100%"
         id="__shape0__box34-24"
@@ -2832,7 +2839,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Radial fil
       aria-label="Euro Status Indicator Radial clock wise filling"
       aria-roledescription="Status Indicator"
       aria-valuetext="30%"
-      class="fd-status-indicator fd-status-indicator--negative"
+      class="fd-status-indicator fd-status-indicator--negative fd-status-indicator--xl"
       focusable="true"
       role="progressbar"
       tabindex="0"
@@ -2841,7 +2848,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Radial fil
       
 	
       <svg
-        class="fd-status-indicator--xl "
+        class="fd-status-indicator__svg"
         data-sap-ui="__shape0-__box21-24"
         height="100%"
         id="__shape0__box35-24"

--- a/stories/status-indicator/__snapshots__/status-indicator.stories.storyshot
+++ b/stories/status-indicator/__snapshots__/status-indicator.stories.storyshot
@@ -2670,14 +2670,14 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Radial fil
     
 
     <div
-      aria-label="Euro Status Indicator Radial clock wise filling"
+      aria-label="Euro Status Indicator Radial clockwise filling"
       aria-roledescription="Status Indicator"
       aria-valuetext="30%"
       class="fd-status-indicator fd-status-indicator--negative fd-status-indicator--xl"
       focusable="true"
       role="progressbar"
       tabindex="0"
-      title="30% radial filling with clock wise"
+      title="30% radial filling with clockwise"
     >
       
 	
@@ -2836,14 +2836,14 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Radial fil
     
 
     <div
-      aria-label="Euro Status Indicator Radial clock wise filling"
+      aria-label="Euro Status Indicator Radial clockwise filling"
       aria-roledescription="Status Indicator"
       aria-valuetext="30%"
       class="fd-status-indicator fd-status-indicator--negative fd-status-indicator--xl"
       focusable="true"
       role="progressbar"
       tabindex="0"
-      title="30% radial filling with counter clock wise"
+      title="30% radial filling with counterclockwise"
     >
       
 	

--- a/stories/status-indicator/status-indicator.stories.js
+++ b/stories/status-indicator/status-indicator.stories.js
@@ -270,7 +270,7 @@ export const StatusIndicatorLabels = () => `
 <div class="example-container">
 <span style="min-width: 150px;">Top Label :</span>
 <div class="fd-status-indicator fd-status-indicator--critical fd-status-indicator--lg"  aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="100%" tabindex=0 aria-label="Euro Status Indicator With Labelled On Top" focusable="true" title="100% with label on top">
-	<span class="fd-status-indicator__label--lg">100%</span>
+	<span class="fd-status-indicator__label fd-status-indicator__label--lg">100%</span>
 	<svg id="__shape0__box9-24" class="fd-status-indicator__svg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path25" data-sap-ui="__path25">
 			<defs>
@@ -330,13 +330,13 @@ export const StatusIndicatorLabels = () => `
 			</path>
 		</svg>	
 	</svg>
-	<span class="fd-status-indicator__label--lg">100%</span>
+	<span class="fd-status-indicator__label fd-status-indicator__label--lg">100%</span>
 </div>
 </div>
 <div class="example-container">
 <span style="min-width: 150px;">Left Label :</span>
 <div class="fd-status-indicator fd-status-indicator--critical fd-status-indicator--horizontal-label fd-status-indicator--lg" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="100%" tabindex=0 aria-label="Euro Status Indicator With Labelled On Left" focusable="true" title="100% with label on left">
-	<span class="fd-status-indicator__label--lg">100%</span>
+	<span class="fd-status-indicator__label fd-status-indicator__label--lg">100%</span>
 	<svg id="__shape0__box12-24" class="fd-status-indicator__svg"  class=" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 36 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path261" data-sap-ui="__path261">
 			<defs>
@@ -396,7 +396,7 @@ export const StatusIndicatorLabels = () => `
 			</path>
 		</svg>	
 	</svg>
-	<span class="fd-status-indicator__label--lg">100%</span>
+	<span class="fd-status-indicator__label fd-status-indicator__label--lg">100%</span>
 </div>
 </div>
 

--- a/stories/status-indicator/status-indicator.stories.js
+++ b/stories/status-indicator/status-indicator.stories.js
@@ -17,7 +17,7 @@ export const Sizes = () => `
 <div class="example-container">
 <span style="min-width: 150px;">Small size :</span>
 <div class="fd-status-indicator fd-status-indicator--negative fd-status-indicator--sm" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="35%" tabindex=0 aria-label=" Euro Status Indicator small size" focusable="true" title="35% with small size">
-	<svg id="__shape0__box1-24" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
+	<svg id="__shape0__box1-24" class="fd-status-indicator__svg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path1" data-sap-ui="__path1">
 			<defs>
 				<linearGradient id="__path1-gradient" x1="0" y1="1" x2="0" y2="0">
@@ -49,7 +49,7 @@ export const Sizes = () => `
 <div class="example-container">
 <span style="min-width: 150px;">Medium size(Default) :</span>
 <div class="fd-status-indicator fd-status-indicator--critical fd-status-indicator--md" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="50%" tabindex=0 aria-label="Euro Status Indicator Medium default size" focusable="true" title="50% with default medium size">
-	<svg id="__shape0__box2-24" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
+	<svg id="__shape0__box2-24" class="fd-status-indicator__svg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path11" data-sap-ui="__path11">
 			<defs>
 				<linearGradient id="__path11-gradient" x1="0" y1="1" x2="0" y2="0">
@@ -81,7 +81,7 @@ export const Sizes = () => `
 <div class="example-container">
 <span style="min-width: 150px;">Large Size :</span>
 <div class="fd-status-indicator fd-status-indicator--positive fd-status-indicator--lg" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="80%" tabindex=0 aria-label="Euro Status Indicator large size" focusable="true" title="80% with large size">
-	<svg id="__shape0__box3-24" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
+	<svg id="__shape0__box3-24" class="fd-status-indicator__svg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path12" data-sap-ui="__path12">
 			<defs>
 				<linearGradient id="__path12-gradient" x1="0" y1="1" x2="0" y2="0">
@@ -113,7 +113,7 @@ export const Sizes = () => `
 <div class="example-container">
 <span style="min-width: 150px;">Extra Large Size :</span>
 <div class="fd-status-indicator fd-status-indicator--xl" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="0%" tabindex=0 aria-label="Euro Status Indicator Extra Large size" focusable="true" title="0% with size extra large">
-	<svg id="__shape0__box4-24" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
+	<svg id="__shape0__box4-24" class="fd-status-indicator__svg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path13" data-sap-ui="__path13">
 			<defs>
 				<linearGradient id="__path13-gradient" x1="0" y1="1" x2="0" y2="0">
@@ -161,7 +161,7 @@ export const fillValues = () => `
 <div  class="example-container">
 <span style="min-width: 150px;">Negative Filling :</span>
 <div class="fd-status-indicator fd-status-indicator--negative fd-status-indicator--lg" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="35%" tabindex=0 aria-label="Euro Status Indicator With Negative Filling" focusable="true" title="35% fill with negative color">
-	<svg id="__shape0__box5-24" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
+	<svg id="__shape0__box5-24" class="fd-status-indicator__svg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path21" data-sap-ui="__path21">
 			<defs>
 				<linearGradient id="__path21-gradient" x1="0" y1="1" x2="0" y2="0">
@@ -193,7 +193,7 @@ export const fillValues = () => `
 <div class="example-container">
 <span style="min-width: 150px;">Critical Filling :</span>
 <div class="fd-status-indicator fd-status-indicator--critical fd-status-indicator--lg" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="60%" tabindex=0 aria-label="Euro Status Indicator With Critical Filling" focusable="true" title="60% with critical color filling">
-	<svg id="__shape0__box6-24" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
+	<svg id="__shape0__box6-24" class="fd-status-indicator__svg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path22" data-sap-ui="__path22">
 			<defs>
 				<linearGradient id="__path22-gradient" x1="0" y1="1" x2="0" y2="0">
@@ -225,7 +225,7 @@ export const fillValues = () => `
 <div class="example-container">
 <span style="min-width: 150px;">Positive Filling :</span>
 <div class="fd-status-indicator fd-status-indicator--positive fd-status-indicator--lg" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="100%" tabindex=0 aria-label="Euro Status Indicator With Positive Filling" focusable="true" title="100% with Positive color filling">
-	<svg id="__shape0__box7-24" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
+	<svg id="__shape0__box7-24" class="fd-status-indicator__svg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path23" data-sap-ui="__path23">
 			<defs>
 				<linearGradient id="__path23-gradient" x1="0" y1="1" x2="0" y2="0">
@@ -269,9 +269,9 @@ modifier class together with the \`fd-status-indicator\` class.
 export const StatusIndicatorLabels = () => `
 <div class="example-container">
 <span style="min-width: 150px;">Top Label :</span>
-<div class="fd-status-indicator fd-status-indicator--critical"  aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="100%" tabindex=0 aria-label="Euro Status Indicator With Labelled On Top" focusable="true" title="100% with label on top">
+<div class="fd-status-indicator fd-status-indicator--critical fd-status-indicator--lg"  aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="100%" tabindex=0 aria-label="Euro Status Indicator With Labelled On Top" focusable="true" title="100% with label on top">
 	<span class="fd-status-indicator__label--lg">100%</span>
-	<svg id="__shape0__box9-24" class="fd-status-indicator--lg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
+	<svg id="__shape0__box9-24" class="fd-status-indicator__svg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path25" data-sap-ui="__path25">
 			<defs>
 				<linearGradient id="__path25-gradient" x1="0" y1="1" x2="0" y2="0">
@@ -302,8 +302,8 @@ export const StatusIndicatorLabels = () => `
 </div>
 <div class="example-container">
 	<span style="min-width: 150px;">Bottom Label :</span>
-<div class="fd-status-indicator fd-status-indicator--positive" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="100%" tabindex=0 aria-label="Euro Status Indicator With Labelled On Bottom" focusable="true" title="100% with label on bottom">
-	<svg id="__shape0__box10-24" class="fd-status-indicator--lg"  data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
+<div class="fd-status-indicator fd-status-indicator--positive fd-status-indicator--lg" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="100%" tabindex=0 aria-label="Euro Status Indicator With Labelled On Bottom" focusable="true" title="100% with label on bottom">
+	<svg id="__shape0__box10-24" class="fd-status-indicator__svg"  data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path26" data-sap-ui="__path26">
 			<defs>
 				<linearGradient id="__path26-gradient" x1="0" y1="1" x2="0" y2="0">
@@ -335,9 +335,9 @@ export const StatusIndicatorLabels = () => `
 </div>
 <div class="example-container">
 <span style="min-width: 150px;">Left Label :</span>
-<div class="fd-status-indicator fd-status-indicator--critical fd-status-indicator--horizontal-label" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="100%" tabindex=0 aria-label="Euro Status Indicator With Labelled On Left" focusable="true" title="100% with label on left">
+<div class="fd-status-indicator fd-status-indicator--critical fd-status-indicator--horizontal-label fd-status-indicator--lg" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="100%" tabindex=0 aria-label="Euro Status Indicator With Labelled On Left" focusable="true" title="100% with label on left">
 	<span class="fd-status-indicator__label--lg">100%</span>
-	<svg id="__shape0__box12-24" class="fd-status-indicator--lg"  class=" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 36 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
+	<svg id="__shape0__box12-24" class="fd-status-indicator__svg"  class=" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 36 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path261" data-sap-ui="__path261">
 			<defs>
 				<linearGradient id="__path261-gradient" x1="0" y1="1" x2="0" y2="0">
@@ -368,8 +368,8 @@ export const StatusIndicatorLabels = () => `
 </div>
 <div class="example-container">
 	<span style="min-width: 150px;">Right Label :</span>
-<div class="fd-status-indicator fd-status-indicator--positive fd-status-indicator--horizontal-label"  aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="100%" tabindex=0 aria-label="Euro Status Indicator With Labelled On Right" focusable="true" title="100% with label on right">
-	<svg id="__shape0__box101-24" class="fd-status-indicator--lg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 16 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
+<div class="fd-status-indicator fd-status-indicator--positive fd-status-indicator--horizontal-label fd-status-indicator--lg"  aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="100%" tabindex=0 aria-label="Euro Status Indicator With Labelled On Right" focusable="true" title="100% with label on right">
+	<svg id="__shape0__box101-24" class="fd-status-indicator__svg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 16 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path262" data-sap-ui="__path262">
 			<defs>
 				<linearGradient id="__path262-gradient" x1="0" y1="1" x2="0" y2="0">
@@ -415,8 +415,8 @@ modifier class for defining the font size and colour of the Label together with 
 export const StatusIndicatorLinearFilling = () => `
 <div class="example-container">
 	<span style="min-width: 150px;">Left to Right fill :</span>
-<div class="fd-status-indicator fd-status-indicator--negative" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="80%" tabindex=0 aria-label="Euro status indicator animated left to right filling " focusable="true" title="80% fill from left to right">
-	<svg id="__shape0__box32a-24" class="fd-status-indicator--lg" data-sap-ui="__shape0-__box32-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
+<div class="fd-status-indicator fd-status-indicator--negative fd-status-indicator--lg" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="80%" tabindex=0 aria-label="Euro status indicator animated left to right filling " focusable="true" title="80% fill from left to right">
+	<svg id="__shape0__box32a-24" class="fd-status-indicator__svg"  data-sap-ui="__shape0-__box32-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path32a" data-sap-ui="__path32a">
 			<defs>
 				<linearGradient id="__path32a-gradient" x1="0" y1="0" x2="1" y2="0">
@@ -452,8 +452,8 @@ export const StatusIndicatorLinearFilling = () => `
 </div>
 <div class="example-container">
 	<span style="min-width: 150px;">Bottom to Top fill</span>
-<div class="fd-status-indicator fd-status-indicator--negative" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="80%" tabindex=0 aria-label="Euro status indicator animated bottom up filling" focusable="true" title="80% fill from bottom to top">
-	<svg id="__shape0__box33-24" class="fd-status-indicator--lg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
+<div class="fd-status-indicator fd-status-indicator--negative fd-status-indicator--lg" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="80%" tabindex=0 aria-label="Euro status indicator animated bottom up filling" focusable="true" title="80% fill from bottom to top">
+	<svg id="__shape0__box33-24" class="fd-status-indicator__svg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path33" data-sap-ui="__path33">
 			<defs>
 				<linearGradient id="__path33-gradient" x1="0" y1="1" x2="0" y2="0">
@@ -500,8 +500,8 @@ To display Linear filling from left to right instead default bottom to top appro
 
 export const StatusIndicatorCoreoGraphy = () => `
 <div class="example-container">
-<div class="fd-status-indicator fd-status-indicator--positive coreographed"  aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="70%" tabindex=0 aria-label="Status Indicator example for order dispatching" focusable="true" title="Fill object to form single filling pattern">
-	<svg id="__shape0__box32-24-cart" class="fd-status-indicator--md" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
+<div class="fd-status-indicator fd-status-indicator--positive coreographed fd-status-indicator--md"  aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="70%" tabindex=0 aria-label="Status Indicator example for order dispatching" focusable="true" title="Fill object to form single filling pattern">
+	<svg id="__shape0__box32-24-cart" class="fd-status-indicator__svg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path32" data-sap-ui="__path32">
 			<defs>
 				<linearGradient id="__path32-gradient" x1="0" y1="1" x2="0" y2="0">
@@ -525,7 +525,7 @@ export const StatusIndicatorCoreoGraphy = () => `
 			</path>
 		</svg>
 	</svg>
-	<svg id="__shape0__box28-24-euro" data-sap-ui="__shape0-__box21-24" class="fd-status-indicator--md fd-status-indicator--positive" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
+	<svg id="__shape0__box28-24-euro" data-sap-ui="__shape0-__box21-24" class="fd-status-indicator__svg fd-status-indicator--negative" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path28" data-sap-ui="__path28">
 			<defs>
 				<linearGradient id="__path28-gradient" x1="0" y1="1" x2="0" y2="0">
@@ -552,7 +552,7 @@ export const StatusIndicatorCoreoGraphy = () => `
 			</path>
 		</svg>
 	</svg>
-	<svg id="__shape0__box29-24-factory" data-sap-ui="__shape0-__box21-24" version="1.1" class="fd-status-indicator--md fd-status-indicator--positive"  xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
+	<svg id="__shape0__box29-24-factory" data-sap-ui="__shape0-__box21-24" version="1.1" class="fd-status-indicator__svg fd-status-indicator--critical"  xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path29" data-sap-ui="__path29">
 			<defs>
 				<linearGradient id="__path29-gradient" x1="0" y1="1" x2="0" y2="0">
@@ -573,7 +573,7 @@ export const StatusIndicatorCoreoGraphy = () => `
 			</path>
 		</svg>
 	</svg>
-	<svg id="__shape0__box30-24-truck" data-sap-ui="__shape0-__box21-24" version="1.1" class="fd-status-indicator--md fd-status-indicator--negative" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 45 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
+	<svg id="__shape0__box30-24-truck" data-sap-ui="__shape0-__box21-24" version="1.1" class="fd-status-indicator__svg" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 45 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path30" data-sap-ui="__path30">
 			<defs>
 				<linearGradient id="__path30-gradient" x1="0" y1="1" x2="0" y2="0">
@@ -597,7 +597,7 @@ export const StatusIndicatorCoreoGraphy = () => `
 			</path>
 		</svg>
 	</svg>
-	<svg id="__shape0__box31-24-plane" data-sap-ui="__shape0-__box21-24" version="1.1" class="fd-status-indicator--md" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
+	<svg id="__shape0__box31-24-plane" data-sap-ui="__shape0-__box21-24" version="1.1" class="fd-status-indicator__svg" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path31" data-sap-ui="__path31">
 			<defs>
 				<linearGradient id="__path31-gradient" x1="0" y1="1" x2="0" y2="0">
@@ -646,8 +646,8 @@ StatusIndicatorCoreoGraphy.parameters = {
 export const StatusIndicatorRadialFilling = () => `
 <div class="example-container">
 	<span style="min-width: 150px;">Radial Clock filling:</span>
-<div class="fd-status-indicator fd-status-indicator--negative" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="30%" tabindex=0 aria-label="Euro Status Indicator Radial clock wise filling" focusable="true" title="30% radial filling with clock wise">
-	<svg id="__shape0__box34-24" data-sap-ui="__shape0-__box21-24" version="1.1" class="fd-status-indicator--xl " xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
+<div class="fd-status-indicator fd-status-indicator--negative fd-status-indicator--xl" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="30%" tabindex=0 aria-label="Euro Status Indicator Radial clock wise filling" focusable="true" title="30% radial filling with clock wise">
+	<svg id="__shape0__box34-24" data-sap-ui="__shape0-__box21-24" class="fd-status-indicator__svg"  version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path34" data-sap-ui="__path34">
 			<defs>
 				<radialGradient id="__path34-gradient" cx="43" cy="28" r="30" fx="50%" fy="50%">
@@ -680,8 +680,8 @@ export const StatusIndicatorRadialFilling = () => `
 
 <div class="example-container">
 	<span style="min-width: 150px;">Radial Counter Clock filling:</span>
-<div class="fd-status-indicator fd-status-indicator--negative" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="30%" tabindex=0 aria-label="Euro Status Indicator Radial clock wise filling" focusable="true" title="30% radial filling with counter clock wise">
-	<svg id="__shape0__box35-24" data-sap-ui="__shape0-__box21-24" version="1.1" class="fd-status-indicator--xl " xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
+<div class="fd-status-indicator fd-status-indicator--negative fd-status-indicator--xl" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="30%" tabindex=0 aria-label="Euro Status Indicator Radial clock wise filling" focusable="true" title="30% radial filling with counter clock wise">
+	<svg id="__shape0__box35-24" data-sap-ui="__shape0-__box21-24" version="1.1" class="fd-status-indicator__svg" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path35" data-sap-ui="__path35">
 			<defs>
 				<radialGradient id="__path35-gradient" cx="30" cy="40" r="30" fx="50%" fy="50%">
@@ -725,8 +725,8 @@ To display Radial filling instead of default bottom to top approach type of stat
 export const StatusIndicatorAngularFilling = () => `
 <div class="example-container">
 	<span style="min-width: 150px;">Angular filling 270 degree:</span>
-<div class="fd-status-indicator fd-status-indicator--positive" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="80%" tabindex=0 aria-label="Euro Status Indicator Angled filling at 270 degree" focusable="true"  title="80% angled filling in 270 degree">
-	<svg id="__shape0__box36-24" class="fd-status-indicator--xl" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
+<div class="fd-status-indicator fd-status-indicator--positive fd-status-indicator--xl" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="80%" tabindex=0 aria-label="Euro Status Indicator Angled filling at 270 degree" focusable="true"  title="80% angled filling in 270 degree">
+	<svg id="__shape0__box36-24" class="fd-status-indicator__svg"  data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path36" data-sap-ui="__path6">
 			<defs>
 				<linearGradient id="__path36-gradient" x1="0" y1="1" x2="1" y2="0">
@@ -763,8 +763,8 @@ export const StatusIndicatorAngularFilling = () => `
 
 <div class="example-container">
 	<span style="min-width: 150px;">Angular filling 40 degree:</span>
-<div class="fd-status-indicator fd-status-indicator--critical" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="50%" tabindex=0 aria-label="Euro Status Indicator Angled filling at 40 degree" focusable="true"  title="50% angled filling in 40 degree">
-	<svg id="__shape0__box37-24" class="fd-status-indicator--xl" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
+<div class="fd-status-indicator fd-status-indicator--critical fd-status-indicator--xl" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="50%" tabindex=0 aria-label="Euro Status Indicator Angled filling at 40 degree" focusable="true"  title="50% angled filling in 40 degree">
+	<svg id="__shape0__box37-24" class="fd-status-indicator__svg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path37" data-sap-ui="__path37">
 			<defs>
 				<linearGradient id="__path37-gradient" x1="1" y1="1" x2="0" y2="0">
@@ -801,8 +801,8 @@ export const StatusIndicatorAngularFilling = () => `
 
 <div class="example-container">
 	<span style="min-width: 150px;">Angular filling 98 degree:</span>
-<div class="fd-status-indicator fd-status-indicator--positive" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="50%" tabindex=0 aria-label="Euro Status Indicator Angled filling at 98 degree" focusable="true"  title="50% angled filling in 98 degree">
-	<svg id="__shape0__box38-24" class="fd-status-indicator--xl" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
+<div class="fd-status-indicator fd-status-indicator--positive fd-status-indicator--xl" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="50%" tabindex=0 aria-label="Euro Status Indicator Angled filling at 98 degree" focusable="true"  title="50% angled filling in 98 degree">
+	<svg id="__shape0__box38-24" class="fd-status-indicator__svg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path38" data-sap-ui="__path38">
 			<defs>
 				<linearGradient id="__path38-gradient" x1="0" y1="0" x2="1" y2="1">
@@ -839,8 +839,8 @@ export const StatusIndicatorAngularFilling = () => `
 
 <div class="example-container">
 	<span style="min-width: 150px;">Angular filling 140 degree:</span>
-<div class="fd-status-indicator fd-status-indicator--negative" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="40%" tabindex=0 aria-label="Euro Status Indicator Angled filling at 140 degree" focusable="true"  title="40% angled filling in 140 degree">
-	<svg id="__shape0__box39-24" class="fd-status-indicator--xl" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
+<div class="fd-status-indicator fd-status-indicator--negative fd-status-indicator--xl" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="40%" tabindex=0 aria-label="Euro Status Indicator Angled filling at 140 degree" focusable="true"  title="40% angled filling in 140 degree">
+	<svg id="__shape0__box39-24" class="fd-status-indicator__svg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path39" data-sap-ui="__path39">
 			<defs>
 				<linearGradient id="__path39-gradient" x1="1" y1="0" x2="0" y2="1">

--- a/stories/status-indicator/status-indicator.stories.js
+++ b/stories/status-indicator/status-indicator.stories.js
@@ -270,7 +270,7 @@ export const StatusIndicatorLabels = () => `
 <div class="example-container">
 <span style="min-width: 150px;">Top Label :</span>
 <div class="fd-status-indicator fd-status-indicator--critical"  aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="100%" tabindex=0 aria-label="Euro Status Indicator With Labelled On Top" focusable="true" title="100% with label on top">
-	<span class="fd-status-indicator--lg__text fd-status-indicator--critical__text">100%</span>
+	<span class="fd-status-indicator__text--lg fd-status-indicator__text--critical">100%</span>
 	<svg id="__shape0__box9-24" class="fd-status-indicator--lg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path25" data-sap-ui="__path25">
 			<defs>
@@ -330,13 +330,13 @@ export const StatusIndicatorLabels = () => `
 			</path>
 		</svg>	
 	</svg>
-	<span class="fd-status-indicator--lg__text fd-status-indicator--positive__text">100%</span>
+	<span class="fd-status-indicator__text--lg fd-status-indicator__text--positive">100%</span>
 </div>
 </div>
 <div class="example-container">
 <span style="min-width: 150px;">Left Label :</span>
 <div class="fd-status-indicator fd-status-indicator--critical fd-status-indicator--htext " aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="100%" tabindex=0 aria-label="Euro Status Indicator With Labelled On Left" focusable="true" title="100% with label on left">
-	<span class="fd-status-indicator--lg__text fd-status-indicator--critical__text">100%</span>
+	<span class="fd-status-indicator__text--lg fd-status-indicator__text--critical">100%</span>
 	<svg id="__shape0__box12-24" class="fd-status-indicator--lg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 36 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path261" data-sap-ui="__path261">
 			<defs>
@@ -396,7 +396,7 @@ export const StatusIndicatorLabels = () => `
 			</path>
 		</svg>	
 	</svg>
-	<span class="fd-status-indicator--lg__text fd-status-indicator--positive__text">100%</span>
+	<span class="fd-status-indicator__text--lg fd-status-indicator__text--positive">100%</span>
 </div>
 </div>
 

--- a/stories/status-indicator/status-indicator.stories.js
+++ b/stories/status-indicator/status-indicator.stories.js
@@ -493,7 +493,7 @@ StatusIndicatorLinearFilling.storyName = 'Status Indicator With Linear filling';
 StatusIndicatorLinearFilling.parameters = {
     docs: {
         storyDescription: `
-To display Linear filling from left to right instead default bottom to top approach type of the status indicator Object, The object can be filled based on changing the value of  \`<linearGradient>\` property  \`x1,Y1,x2,y2\`. Filling can be done either Clock wise or Counter Clock wise.
+To display Linear filling from left to right instead default bottom to top approach type of the status indicator Object, The object can be filled based on changing the value of  \`<linearGradient>\` property  \`x1,Y1,x2,y2\`. Filling can be done either clockwise or counterclockwise.
 `
     }
 };
@@ -646,7 +646,7 @@ StatusIndicatorCoreoGraphy.parameters = {
 export const StatusIndicatorRadialFilling = () => `
 <div class="example-container">
 	<span style="min-width: 150px;">Radial Clock filling:</span>
-<div class="fd-status-indicator fd-status-indicator--negative fd-status-indicator--xl" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="30%" tabindex=0 aria-label="Euro Status Indicator Radial clock wise filling" focusable="true" title="30% radial filling with clock wise">
+<div class="fd-status-indicator fd-status-indicator--negative fd-status-indicator--xl" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="30%" tabindex=0 aria-label="Euro Status Indicator Radial clockwise filling" focusable="true" title="30% radial filling with clockwise">
 	<svg id="__shape0__box34-24" data-sap-ui="__shape0-__box21-24" class="fd-status-indicator__svg"  version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path34" data-sap-ui="__path34">
 			<defs>
@@ -680,7 +680,7 @@ export const StatusIndicatorRadialFilling = () => `
 
 <div class="example-container">
 	<span style="min-width: 150px;">Radial Counter Clock filling:</span>
-<div class="fd-status-indicator fd-status-indicator--negative fd-status-indicator--xl" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="30%" tabindex=0 aria-label="Euro Status Indicator Radial clock wise filling" focusable="true" title="30% radial filling with counter clock wise">
+<div class="fd-status-indicator fd-status-indicator--negative fd-status-indicator--xl" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="30%" tabindex=0 aria-label="Euro Status Indicator Radial clockwise filling" focusable="true" title="30% radial filling with counterclockwise">
 	<svg id="__shape0__box35-24" data-sap-ui="__shape0-__box21-24" version="1.1" class="fd-status-indicator__svg" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path35" data-sap-ui="__path35">
 			<defs>
@@ -717,7 +717,7 @@ StatusIndicatorRadialFilling.storyName = 'Status Indicator With Radial filling';
 StatusIndicatorRadialFilling.parameters = {
     docs: {
         storyDescription: `
-To display Radial filling instead of default bottom to top approach type of status indicator Object, The object can be filled based on changing the value of  \`<radialGradient>\` property  \`cx,cy,r,fx,fy\`. Filling can be done either Clock wise or Counter Clock wise.
+To display Radial filling instead of default bottom to top approach type of status indicator Object, The object can be filled based on changing the value of  \`<radialGradient>\` property  \`cx,cy,r,fx,fy\`. Filling can be done either clockwise or counterclockwise.
 `
     }
 };
@@ -880,7 +880,7 @@ StatusIndicatorAngularFilling.storyName = 'Status Indicator With Angular filling
 StatusIndicatorAngularFilling.parameters = {
     docs: {
         storyDescription: `
-To display Angular filling instead of default bottom to top approach type of status indicator Object, The object can be filled based on changing the value of  \`<linearGradient>\` property  \`x1,Y1,x2,y2\`. Filling can be done either Clock wise or Counter Clock wise.
+To display Angular filling instead of default bottom to top approach type of status indicator Object, The object can be filled based on changing the value of  \`<linearGradient>\` property  \`x1,Y1,x2,y2\`. Filling can be done either clockwise or counterclockwise.
 `
     }
 };

--- a/stories/status-indicator/status-indicator.stories.js
+++ b/stories/status-indicator/status-indicator.stories.js
@@ -270,7 +270,7 @@ export const StatusIndicatorLabels = () => `
 <div class="example-container">
 <span style="min-width: 150px;">Top Label :</span>
 <div class="fd-status-indicator fd-status-indicator--critical"  aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="100%" tabindex=0 aria-label="Euro Status Indicator With Labelled On Top" focusable="true" title="100% with label on top">
-	<span class="fd-status-indicator__text--lg fd-status-indicator__text--critical">100%</span>
+	<span class="fd-status-indicator__label--lg">100%</span>
 	<svg id="__shape0__box9-24" class="fd-status-indicator--lg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path25" data-sap-ui="__path25">
 			<defs>
@@ -302,8 +302,8 @@ export const StatusIndicatorLabels = () => `
 </div>
 <div class="example-container">
 	<span style="min-width: 150px;">Bottom Label :</span>
-<div class="fd-status-indicator fd-status-indicator--positive " aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="100%" tabindex=0 aria-label="Euro Status Indicator With Labelled On Bottom" focusable="true" title="100% with label on bottom">
-	<svg id="__shape0__box10-24" data-sap-ui="__shape0-__box21-24" class="fd-status-indicator--lg" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
+<div class="fd-status-indicator fd-status-indicator--positive" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="100%" tabindex=0 aria-label="Euro Status Indicator With Labelled On Bottom" focusable="true" title="100% with label on bottom">
+	<svg id="__shape0__box10-24" class="fd-status-indicator--lg"  data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path26" data-sap-ui="__path26">
 			<defs>
 				<linearGradient id="__path26-gradient" x1="0" y1="1" x2="0" y2="0">
@@ -330,14 +330,14 @@ export const StatusIndicatorLabels = () => `
 			</path>
 		</svg>	
 	</svg>
-	<span class="fd-status-indicator__text--lg fd-status-indicator__text--positive">100%</span>
+	<span class="fd-status-indicator__label--lg">100%</span>
 </div>
 </div>
 <div class="example-container">
 <span style="min-width: 150px;">Left Label :</span>
-<div class="fd-status-indicator fd-status-indicator--critical fd-status-indicator--htext " aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="100%" tabindex=0 aria-label="Euro Status Indicator With Labelled On Left" focusable="true" title="100% with label on left">
-	<span class="fd-status-indicator__text--lg fd-status-indicator__text--critical">100%</span>
-	<svg id="__shape0__box12-24" class="fd-status-indicator--lg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 36 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
+<div class="fd-status-indicator fd-status-indicator--critical fd-status-indicator--horizontal-label" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="100%" tabindex=0 aria-label="Euro Status Indicator With Labelled On Left" focusable="true" title="100% with label on left">
+	<span class="fd-status-indicator__label--lg">100%</span>
+	<svg id="__shape0__box12-24" class="fd-status-indicator--lg"  class=" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 36 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path261" data-sap-ui="__path261">
 			<defs>
 				<linearGradient id="__path261-gradient" x1="0" y1="1" x2="0" y2="0">
@@ -368,7 +368,7 @@ export const StatusIndicatorLabels = () => `
 </div>
 <div class="example-container">
 	<span style="min-width: 150px;">Right Label :</span>
-<div class="fd-status-indicator fd-status-indicator--positive fd-status-indicator--htext"  aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="100%" tabindex=0 aria-label="Euro Status Indicator With Labelled On Right" focusable="true" title="100% with label on right">
+<div class="fd-status-indicator fd-status-indicator--positive fd-status-indicator--horizontal-label"  aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="100%" tabindex=0 aria-label="Euro Status Indicator With Labelled On Right" focusable="true" title="100% with label on right">
 	<svg id="__shape0__box101-24" class="fd-status-indicator--lg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 16 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path262" data-sap-ui="__path262">
 			<defs>
@@ -396,7 +396,7 @@ export const StatusIndicatorLabels = () => `
 			</path>
 		</svg>	
 	</svg>
-	<span class="fd-status-indicator__text--lg fd-status-indicator__text--positive">100%</span>
+	<span class="fd-status-indicator__label--lg">100%</span>
 </div>
 </div>
 


### PR DESCRIPTION

## Related Issue
Closes SAP/fundamental-styles#

## Description
changing the BEM to the status indicator and adding link css

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
fd-status-indicator--lg__text and fd-status-indicator--critical__text. 

### After:
fd-status-indicator__text--lg  fd-status-indicator__text--critical

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [NA] All values are in `rem`
- [NA] Text elements follow the truncation rules
- [NA] hover state of the element follow design spec
- [NA] focus state of the element follow design spec
- [NA] active state of the element follow design spec
- [NA] selected state of the element follow design spec
- [NA] selected hover state of the element follow design spec
- [NA] pressed state of the element follow design spec
- [NA] Responsiveness rules - the component has modifier classes for all breakpoints
- [NA] Includes Compact/Cosy/Tablet design
- [NA] RTL support
2. The code follows fundamental-styles code standards and style
- [NA] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [NA] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [NA] `fd-reset()` mixin is applied to all elements
- [NA] Variables are used, if some value is used more than twice.
- [NA] Checked if current components can be reused, instead of having new code.
3. Testing
- [NA] tested Storybook examples with "CSS Resources" `normalize` option 
- [NA] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [NA] Verified all styles in IE11
- [NA] Updated tests
- [NA] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [NA] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
