### PR TITLE
fix: remove margin from Resizable-Card-Layout item

### DIFF
--- a/.storybook/custom/custom.scss
+++ b/.storybook/custom/custom.scss
@@ -603,19 +603,19 @@ body.sb-show-main {
   .card-one-dimensions {
     width: 40rem;
     height: 16rem;
-    margin: 0 0.5rem 0.5rem 0;
+    margin: 0.5rem;
   }
 
   .card-two-dimensions {
     width: 20rem;
     height: fit-content;
-    margin: 0 0.5rem 0.5rem 0.5rem;
+    margin: 0.5rem;
   }
 
   .card-three-dimensions {
     width: 20rem;
     height: 20rem;
-    margin: 0.5rem 0.5rem 0.5rem 0;
+    margin: 0.5rem;
   }
 
   .card-four-dimensions {

--- a/.storybook/custom/custom.scss
+++ b/.storybook/custom/custom.scss
@@ -600,40 +600,34 @@ body.sb-show-main {
   display: flex;
   flex-wrap: wrap;
 
-  .card-one-dimensions {
-    width: 40rem;
-    height: 16rem;
+  @mixin set-card-dimensions($width: 20rem, $height: 20rem) {
+    width: $width;
+    height: $height;
     margin: 0.5rem;
+  }
+
+  .card-one-dimensions {
+    @include set-card-dimensions(40rem, 16rem);
   }
 
   .card-two-dimensions {
-    width: 20rem;
-    height: fit-content;
-    margin: 0.5rem;
+    @include set-card-dimensions(20rem, fit-content);
   }
 
   .card-three-dimensions {
-    width: 20rem;
-    height: 20rem;
-    margin: 0.5rem;
+    @include set-card-dimensions();
   }
 
   .card-four-dimensions {
-    width: 20rem;
-    height: 35rem;
-    margin: 0.5rem;
+    @include set-card-dimensions(20rem, 35rem);
   }
 
   .card-five-dimensions {
-    width: 40rem;
-    height: 25rem;
-    margin: 0.5rem;
+    @include set-card-dimensions(40rem, 25rem);
   }
 
   .card-six-dimensions {
-    width: 20rem;
-    height: 20rem;
-    margin: 0.5rem;
+    @include set-card-dimensions();
   }
 }
 

--- a/.storybook/custom/custom.scss
+++ b/.storybook/custom/custom.scss
@@ -603,31 +603,37 @@ body.sb-show-main {
   .card-one-dimensions {
     width: 40rem;
     height: 16rem;
+    margin: 0 0.5rem 0.5rem 0;
   }
 
   .card-two-dimensions {
     width: 20rem;
     height: fit-content;
+    margin: 0 0.5rem 0.5rem 0.5rem;
   }
 
   .card-three-dimensions {
     width: 20rem;
     height: 20rem;
+    margin: 0.5rem 0.5rem 0.5rem 0;
   }
 
   .card-four-dimensions {
     width: 20rem;
     height: 35rem;
+    margin: 0.5rem;
   }
 
   .card-five-dimensions {
     width: 40rem;
     height: 25rem;
+    margin: 0.5rem;
   }
 
   .card-six-dimensions {
     width: 20rem;
     height: 20rem;
+    margin: 0.5rem;
   }
 }
 

--- a/src/resizable-card-layout.scss
+++ b/src/resizable-card-layout.scss
@@ -9,25 +9,29 @@ $block: #{$fd-namespace}-resizable-card-layout;
   $fd-resize-handle-width: 0.0625rem;
   $fd-resize-icon-padding: 0.0625rem;
   $fd-border-on-drag: 0.125rem dashed var(--sapContent_DragAndDropActiveColor);
+  $fd-layout-top-margin: 1rem;
+  $fd-layout-default-margin: 0.5rem;
 
   // reduced by 0.5rem as card already have 0.5rem padding
   $fd-resizable-card-padding-x: (
-    sm: 0,
-    md: 0.5rem,
-    lg: 2.5rem,
+    sm: 0.5rem,
+    md: 1rem,
+    lg: 1rem,
+    xl: 3rem
   );
 
   @include fd-reset();
 
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding-left: $fd-layout-default-margin;
+  padding-right: $fd-layout-default-margin;
+  margin-top: $fd-layout-top-margin;
+  position: relative;
 
   &__item {
     @include fd-reset();
     @include fd-flex();
 
     min-width: $fd-resizable-card-min-width;
-    margin: 0.5rem;
     position: relative;
   }
 
@@ -71,6 +75,7 @@ $block: #{$fd-namespace}-resizable-card-layout;
     bottom: 0;
     right: $fd-resize-icon-padding;
     color: var(--sapButton_IconColor);
+    z-index: 2;
 
     @include fd-rtl() {
       transform: rotate(90deg);
@@ -100,6 +105,7 @@ $block: #{$fd-namespace}-resizable-card-layout;
   &__resize {
     &--vertical {
       order: 2;
+      z-index: 2;
       // subtract resize-corner icon font-size/2
       width: $fd-resize-handle-width;
       cursor: ew-resize;
@@ -112,6 +118,7 @@ $block: #{$fd-namespace}-resizable-card-layout;
 
     &--horizontal {
       // subtract resize-corner icon font-size/2
+      z-index: 2;
       width: calc(100% - 0.5rem);
       height: $fd-resize-handle-width;
       position: absolute;

--- a/src/resizable-card-layout.scss
+++ b/src/resizable-card-layout.scss
@@ -11,6 +11,7 @@ $block: #{$fd-namespace}-resizable-card-layout;
   $fd-border-on-drag: 0.125rem dashed var(--sapContent_DragAndDropActiveColor);
   $fd-layout-top-margin: 1rem;
   $fd-layout-default-margin: 0.5rem;
+  $fd-resize-handle-index: 2;
 
   // reduced by 0.5rem as card already have 0.5rem padding
   $fd-resizable-card-padding-x: (
@@ -53,7 +54,7 @@ $block: #{$fd-namespace}-resizable-card-layout;
     position: absolute;
     bottom: 0;
     right: 0;
-    z-index: 2;
+    z-index: $fd-resize-handle-index;
     padding: 0 $fd-resize-icon-padding $fd-resize-icon-padding 0;
 
     @include fd-rtl() {
@@ -75,7 +76,7 @@ $block: #{$fd-namespace}-resizable-card-layout;
     bottom: 0;
     right: $fd-resize-icon-padding;
     color: var(--sapButton_IconColor);
-    z-index: 2;
+    z-index: $fd-resize-handle-index;
 
     @include fd-rtl() {
       transform: rotate(90deg);
@@ -105,7 +106,7 @@ $block: #{$fd-namespace}-resizable-card-layout;
   &__resize {
     &--vertical {
       order: 2;
-      z-index: 2;
+      z-index: $fd-resize-handle-index;
       // subtract resize-corner icon font-size/2
       width: $fd-resize-handle-width;
       cursor: ew-resize;
@@ -118,7 +119,7 @@ $block: #{$fd-namespace}-resizable-card-layout;
 
     &--horizontal {
       // subtract resize-corner icon font-size/2
-      z-index: 2;
+      z-index: $fd-resize-handle-index;
       width: calc(100% - 0.5rem);
       height: $fd-resize-handle-width;
       position: absolute;


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#
Closes #2213 

## Description
1. Margin between cards is handled inside component using script. hence to be removed from styles.
2. added z-index for resize handlers
3. added missing "xl" screen size layout padding

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:


### After:

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- na Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
