### PR TITLE
chore: upgrade to theming-base-content version 11.1.28

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,14 +5,14 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "0.17.0-rc.18",
+      "version": "0.17.0-rc.30",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.11.6",
         "@babel/node": "^7.10.5",
         "@babel/plugin-transform-runtime": "^7.11.5",
         "@babel/preset-react": "^7.10.4",
-        "@sap-theming/theming-base-content": "~11.1.27",
+        "@sap-theming/theming-base-content": "~11.1.28",
         "@storybook/addon-a11y": "6.1.21",
         "@storybook/addon-actions": "6.1.21",
         "@storybook/addon-cssresources": "6.1.21",
@@ -4754,9 +4754,10 @@
       }
     },
     "node_modules/@sap-theming/theming-base-content": {
-      "version": "11.1.27",
-      "dev": true,
-      "license": "Apache-2.0"
+      "version": "11.1.28",
+      "resolved": "https://registry.npmjs.org/@sap-theming/theming-base-content/-/theming-base-content-11.1.28.tgz",
+      "integrity": "sha512-ND8WW7ZNkeFx+Hsd50MkpgF8tusyPpXsFkwup30AF0RooAGLAKdQLlzzXg+P1nR9RSd2mf72pJpvg0GDgSCizQ==",
+      "dev": true
     },
     "node_modules/@sideway/address": {
       "version": "4.1.0",
@@ -53930,7 +53931,9 @@
       }
     },
     "@sap-theming/theming-base-content": {
-      "version": "11.1.27",
+      "version": "11.1.28",
+      "resolved": "https://registry.npmjs.org/@sap-theming/theming-base-content/-/theming-base-content-11.1.28.tgz",
+      "integrity": "sha512-ND8WW7ZNkeFx+Hsd50MkpgF8tusyPpXsFkwup30AF0RooAGLAKdQLlzzXg+P1nR9RSd2mf72pJpvg0GDgSCizQ==",
       "dev": true
     },
     "@sideway/address": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@babel/node": "^7.10.5",
     "@babel/plugin-transform-runtime": "^7.11.5",
     "@babel/preset-react": "^7.10.4",
-    "@sap-theming/theming-base-content": "~11.1.27",
+    "@sap-theming/theming-base-content": "~11.1.28",
     "@storybook/addon-a11y": "6.1.21",
     "@storybook/addon-actions": "6.1.21",
     "@storybook/addon-cssresources": "6.1.21",


### PR DESCRIPTION
upgrade to theming-base-content version 11.1.28