### PR TITLE
fix: add fix for the Popover alignment in Avatar Group component

### DIFF
--- a/src/mixins/_popover.scss
+++ b/src/mixins/_popover.scss
@@ -1,6 +1,6 @@
 @import "mixins";
 
-$fd-popover-body-shadow-offset: var(--sapGroup_BorderWidth) !default;
+$fd-popover-body-shadow-offset: calc(#{var(--sapGroup_BorderWidth)} + 0.4275rem) !default;
 $fd-popover-background-color: var(--sapGroup_ContentBackground) !default;
 $fd-popover-border-radius: var(--sapElement_BorderCornerRadius) !default;
 $fd-popover-box-shadow-no-arrow: var(--sapContent_Shadow1) !default;


### PR DESCRIPTION
## Related Issue
Part of SAP/fundamental-styles#2153

## Description
Fix position for popover body 

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
https://user-images.githubusercontent.com/4380815/108005485-d86a8780-6fc6-11eb-9f0a-d0d91f6d454f.png
![image](https://user-images.githubusercontent.com/2508127/112306041-a8866200-8c9f-11eb-9349-892f4c2c7d66.png)

### After:
![image](https://user-images.githubusercontent.com/2508127/112306060-b1773380-8c9f-11eb-8edf-11ceb134ba3e.png)
![image](https://user-images.githubusercontent.com/2508127/112306074-b3d98d80-8c9f-11eb-96e8-d48e3d69de87.png)
![image](https://user-images.githubusercontent.com/2508127/112306092-b63be780-8c9f-11eb-886f-c27be83ff135.png)


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [ ] Includes Compact/Cosy/Tablet design
- [ ] RTL support
- [ ] tested Storybook examples with "CSS Resources" `normalize` option 
- [ ] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [ ] Verified all styles in IE11
- [ ] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)