### PR TITLE
feat: larger dropdown body

### DIFF
--- a/src/_listDefinitions.scss
+++ b/src/_listDefinitions.scss
@@ -47,6 +47,9 @@ $fd-list-item-counter-spacing: 1rem !default;
 
 $fd-list-rating-indicator-spacing: 0.5rem !default;
 
+$fd-list-dropdown-max-width: 40rem !default;
+$fd-list-dropdown-optional-max-width: 62rem !default;
+
 $semantic-color: (
   "neutral": ("color": var(--sapNeutralTextColor)),
   "positive": ("color": var(--sapPositiveTextColor)),

--- a/src/_listDropdown.scss
+++ b/src/_listDropdown.scss
@@ -1,4 +1,3 @@
-
 @import "./listDefinitions.scss";
 
 .#{$block} {
@@ -19,12 +18,6 @@
         height: auto;
         padding: $fd-dropdown-vertical-compact-padding $fd-list-item-padding-x;
       }
-    }
-
-    .#{$block}__secondary {
-      width: auto;
-      max-width: 15rem;
-      display: contents;
     }
   }
 
@@ -113,14 +106,29 @@
 
   &--dropdown,
   &--multi-input {
+    @mixin list-width-limit($maxWidth: $fd-list-dropdown-max-width) {
+      max-width: $maxWidth;
+
+      .#{$block}__title {
+        max-width: 0.6 * $maxWidth;
+
+        &:first-child:last-child {
+          max-width: $maxWidth;
+        }
+      }
+
+      .#{$block}__secondary {
+        max-width: 0.4 * $maxWidth;
+      }
+
+      // for when dropdown and multi input are used in mobile mode
+      &.#{$block}--mobile {
+        max-width: 100%;
+      }
+    }
+
     display: block;
     min-width: 7rem;
-    max-width: 37.5rem;
-
-    // for when dropdown and multi input are used in mobile mode
-    &.#{$block}--mobile {
-      max-width: 100%;
-    }
 
     .#{$block}__item {
       cursor: pointer;
@@ -142,17 +150,23 @@
       }
     }
 
+    .#{$block}__secondary {
+      width: auto;
+      display: block;
+    }
+
     .#{$block}__title {
       width: auto;
-      max-width: 22.5rem;
-
-      &:first-child:last-child {
-        max-width: 37.5rem;
-      }
     }
+
+    @include list-width-limit($fd-list-dropdown-max-width);
 
     .#{$block}__icon {
       line-height: 1rem;
+    }
+
+    &.#{$block}--large-dropdown {
+      @include list-width-limit($fd-list-dropdown-optional-max-width);
     }
   }
 }

--- a/src/popover.scss
+++ b/src/popover.scss
@@ -194,7 +194,7 @@ $block: #{$fd-namespace}-popover;
 
       &-fill {
         display: block;
-        max-width: 37.5rem;
+        max-width: 40rem;
         width: $fd-popover-full-filled-width;
       }
     }

--- a/stories/select/__snapshots__/select.stories.storyshot
+++ b/stories/select/__snapshots__/select.stories.storyshot
@@ -1927,6 +1927,188 @@ exports[`Storyshots Components/Select Grouping 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/Select Large Select 1`] = `
+<div
+  style="height: 250px"
+>
+  
+    
+  <label
+    class="fd-form-label"
+    id="largeSelectPopoverSizeLabel"
+  >
+    Choose an option
+  </label>
+  <br />
+  
+    
+  <div
+    class="fd-popover"
+  >
+    
+    
+    <div
+      class="fd-popover__control"
+    >
+      
+        
+      <div
+        class="fd-select"
+      >
+        
+            
+        <button
+          aria-expanded="true"
+          aria-haspopup="listbox"
+          aria-labelledby="largeSelectPopoverSizeLabel"
+          class="fd-select__control"
+          id="largeSelectPopoverBodySizeLabelCombobx"
+          onclick="
+                    toggleElAttrs('h0GTKE325', ['aria-hidden']);
+                    toggleElAttrs('matchSelectPopoverBodySizeSelectCombobox', ['aria-expanded']);
+                "
+          tabindex="0"
+        >
+          
+                
+          <span
+            class="fd-select__text-content"
+            id="largeSelectPopoverSizeValue"
+          >
+            Larger Option Than Usual
+          </span>
+          
+                
+          <span
+            class="fd-button fd-button--transparent fd-select__button"
+          >
+            
+                    
+            <i
+              class="sap-icon--slim-arrow-down"
+            />
+            
+                
+          </span>
+          
+            
+        </button>
+        
+        
+      </div>
+      
+    
+    </div>
+    
+    
+    <div
+      aria-hidden="false"
+      class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown"
+      id="h0GGFE325"
+    >
+      
+        
+      <ul
+        aria-activedescendant="largeSelectPopoverBodySizeSelectCombobox-currentlyFocusedItem"
+        aria-labelledby="largeSelectPopoverSizeLabel"
+        class="fd-list fd-list--dropdown fd-list--large-dropdown"
+        role="listbox"
+      >
+        
+            
+        <li
+          aria-selected="true"
+          class="fd-list__item is-selected"
+          id="largeSelectPopoverBodySizeSelectCombobox-currentlyFocusedItem"
+          role="option"
+          tabindex="0"
+        >
+          
+                
+          <span
+            class="fd-list__title"
+          >
+            
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                
+          </span>
+          
+            
+        </li>
+        
+            
+        <li
+          class="fd-list__item"
+          role="option"
+          tabindex="-1"
+        >
+          
+                
+          <span
+            class="fd-list__title"
+          >
+            List item 2
+          </span>
+          
+            
+        </li>
+        
+            
+        <li
+          class="fd-list__item"
+          role="option"
+          tabindex="-1"
+        >
+          
+                
+          <span
+            class="fd-list__title"
+          >
+            List item 3
+          </span>
+          
+            
+        </li>
+        
+            
+        <li
+          class="fd-list__item"
+          role="option"
+          tabindex="-1"
+        >
+          
+                
+          <span
+            class="fd-list__title"
+          >
+            List item 4
+          </span>
+          
+            
+        </li>
+        
+        
+      </ul>
+      
+    
+    </div>
+    
+    
+  </div>
+  
+
+</div>
+`;
+
 exports[`Storyshots Components/Select Mobile 1`] = `
 <div
   class="fd-dialog fd-dialog-docs-static fd-select-docs-max-height fd-dialog--active"
@@ -3686,7 +3868,11 @@ exports[`Storyshots Components/Select Text wrapping 1`] = `
           <span
             class="fd-list__title"
           >
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. 
+            
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore 
+                    et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut 
+                    aliquip ex ea commodo consequat.
+                
           </span>
           
                 

--- a/stories/select/select.stories.js
+++ b/stories/select/select.stories.js
@@ -879,7 +879,11 @@ export const textWrapping = () => `<div style="height: 300px">
             <li
                 id="textWrappingSelectCombobox-currentlyFocusedItem"
                 class="fd-list__item is-selected" aria-selected="true" role="option" tabindex="0">
-                <span class="fd-list__title">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. </span>
+                <span class="fd-list__title">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore 
+                    et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut 
+                    aliquip ex ea commodo consequat.
+                </span>
                 <span class="fd-list__secondary">A1</span>
             </li>
             <li class="fd-list__item" role="option" tabindex="-1">
@@ -1040,6 +1044,80 @@ matchSelectPopoverBodySize.parameters = {
         iframeHeight: 300,
         storyDescription: `
 Select can be displayed as a popover, using all of its specifications. The default size for the popover body is often longer than the text length. The body can be adjusted to match the text length by adding the \`fd-popover__body—dropdown-fill\` class to \`fd-popover__body\`. See **Popover** for more details.       
+        `
+    }
+};
+
+export const largerSelect = () => `<div style="height: 250px">
+    <label class="fd-form-label" id="largeSelectPopoverSizeLabel">Choose an option</label><br />
+    <div class="fd-popover">
+    <div class="fd-popover__control">
+        <div class="fd-select">
+            <button
+                aria-labelledby="largeSelectPopoverSizeLabel"
+                class="fd-select__control"
+                tabindex="0"
+                id="largeSelectPopoverBodySizeLabelCombobx"
+                onclick="
+                    toggleElAttrs('h0GTKE325', ['aria-hidden']);
+                    toggleElAttrs('matchSelectPopoverBodySizeSelectCombobox', ['aria-expanded']);
+                "
+                aria-expanded="true"
+                aria-haspopup="listbox">
+                <span id="largeSelectPopoverSizeValue" class="fd-select__text-content">Larger Option Than Usual</span>
+                <span class="fd-button fd-button--transparent fd-select__button">
+                    <i class="sap-icon--slim-arrow-down"></i>
+                </span>
+            </button>
+        </div>
+    </div>
+    <div
+        class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--dropdown"
+        aria-hidden="false"
+        id="h0GGFE325">
+        <ul
+            aria-activedescendant="largeSelectPopoverBodySizeSelectCombobox-currentlyFocusedItem"
+            aria-labelledby="largeSelectPopoverSizeLabel"
+            class="fd-list fd-list--dropdown fd-list--large-dropdown"
+            role="listbox">
+            <li
+                id="largeSelectPopoverBodySizeSelectCombobox-currentlyFocusedItem"
+                class="fd-list__item is-selected" aria-selected="true" role="option" tabindex="0">
+                <span class="fd-list__title">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                </span>
+            </li>
+            <li class="fd-list__item" role="option" tabindex="-1">
+                <span class="fd-list__title">List item 2</span>
+            </li>
+            <li class="fd-list__item" role="option" tabindex="-1">
+                <span class="fd-list__title">List item 3</span>
+            </li>
+            <li class="fd-list__item" role="option" tabindex="-1">
+                <span class="fd-list__title">List item 4</span>
+            </li>
+        </ul>
+    </div>
+    </div>
+</div>
+`;
+
+largerSelect.storyName = 'Large Select';
+
+largerSelect.parameters = {
+    docs: {
+        iframeHeight: 300,
+        storyDescription: `
+There is a way to make larger select select body, To achieve it, add \`fd-list--large-dropdown\` to \`fd-list\` element.        
         `
     }
 };


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-styles/issues/2207

## Description
There is applied hcange for max width of default dropdown body.
Due to fiori3 `37,5rem` -> `40rem`.

Also there is added larger dropdown - achieved by class `fd-list--large-dropdown`

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:


### After:

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [NA] hover state of the element follow design spec
- [Na] focus state of the element follow design spec
- [NA] active state of the element follow design spec
- [NA] selected state of the element follow design spec
- [NA] selected hover state of the element follow design spec
- [NA] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
