### PR TITLE
fix: Add color to link icon

### DIFF
--- a/src/link.scss
+++ b/src/link.scss
@@ -10,7 +10,7 @@ $block: #{$fd-namespace}-link;
   @include fd-reset();
   @include fd-link();
 
-  @include fd-icon-selector() {
+  @include fd-icon-element-base() {
     text-decoration: var(--fdLink_Text_Decoration);
   }
 


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-styles/issues/2194

## Description

## Screenshots

### Before:
![image](https://user-images.githubusercontent.com/26483208/112827778-16130380-908f-11eb-9888-ad5f59b032ca.png)


### After:
![image](https://user-images.githubusercontent.com/26483208/112827770-13b0a980-908f-11eb-82ac-9f1257dea4b1.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
3. Testing
- [x] Verified all styles in IE11
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [NA] Storybook documentation has been created/updated
- [NA] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
