### PR TITLE
fix: Remove outline from radio button

### DIFF
--- a/src/radio.scss
+++ b/src/radio.scss
@@ -79,6 +79,10 @@ $block: #{$fd-namespace}-radio;
       left: $fd-radio-inner-content-padding;
     }
 
+    @include fd-focus() {
+      outline: none;
+    }
+
     @include fd-hover() {
       &::before {
         background-color: var(--sapField_Hover_Background);


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-styles/issues/2194

## Description
Outline is removed from radio button label

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] focus state of the element follow design spec
2. The code follows fundamental-styles code standards and style
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
3. Testing
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
