### PR TITLE
fix: list docs, focus colors on menu and object list [ci visual]

### DIFF
--- a/src/menu.scss
+++ b/src/menu.scss
@@ -157,6 +157,10 @@ $block: #{$fd-namespace}-menu;
       .#{$block}__addon-after {
         color: var(--sapList_Active_TextColor);
       }
+
+      @include fd-focus() {
+        outline-color: var(--sapContent_ContrastFocusColor);
+      }
     }
 
     @include fd-disabled() {

--- a/src/object-list.scss
+++ b/src/object-list.scss
@@ -21,6 +21,8 @@ $block: #{$fd-namespace}-object-list;
 
     .#{$fd-namespace}-list__link {
       @include fd-active() {
+        background: var(--sapList_Active_Background);
+
         .#{$block}__intro,
         .#{$block}__object-attribute,
         .#{$fd-namespace}-avatar,

--- a/stories/list/standard/standard-list.stories.js
+++ b/stories/list/standard/standard-list.stories.js
@@ -93,7 +93,7 @@ unread.parameters = {
     }
 };
 
-export const interractive = () => `<h4>Interractive Items</h4>
+export const interactive = () => `<h4>Interactive Items</h4>
 <ul class="fd-list" role="list">
   <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
       <span class="fd-list__title">List item 1</span>
@@ -112,14 +112,14 @@ export const interractive = () => `<h4>Interractive Items</h4>
   </li>
 `;
 
-interractive.storyName = 'Interractive';
+interactive.storyName = 'Interactive';
 
-interractive.parameters = {
+interactive.parameters = {
     docs: {
         iframeHeight: 445,
         storyDescription: `
-            The \`fd-list__item--interractive\` will force list item to handle hover and active states. 
-            Usage of this modifier is not needed on \`Selection\`, \`Navigation\` and \`Action\` modes.
+The \`fd-list__item--interractive\` will force list item to handle hover and active states. 
+Usage of this modifier is not needed on \`Selection\`, \`Navigation\` and \`Action\` modes.
         `
     }
 };


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-styles/issues/2194

## Description
There is 
- fixed documentation for list
- Added contrast outline color for menu items, when active
- Added background color for object list, on active 

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
3. Testing
- [x] Verified all styles in IE11
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [NA] Storybook documentation has been created/updated
- [NA] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
