### PR TITLE
chore: add 3 new SAP icons

### DIFF
--- a/src/icons/_settings.scss
+++ b/src/icons/_settings.scss
@@ -657,6 +657,9 @@ $fd-icons: (
   feedback: "\e288",
   information: "\e289",
   s4hana: "\e28A",
-  translate: "\e28B"
+  translate: "\e28B",
+  clear-all: "\e28C",
+  command-line-interfaces: "\e28D",
+  icon-sum: "\e28E"
 ) !default;
 /* stylelint-enable */

--- a/src/icons/_settings.scss
+++ b/src/icons/_settings.scss
@@ -660,6 +660,6 @@ $fd-icons: (
   translate: "\e28B",
   clear-all: "\e28C",
   command-line-interfaces: "\e28D",
-  icon-sum: "\e28E"
+  icon-sum: "\e28E",
 ) !default;
 /* stylelint-enable */

--- a/stories/icon/__snapshots__/icon.stories.storyshot
+++ b/stories/icon/__snapshots__/icon.stories.storyshot
@@ -7888,6 +7888,42 @@ exports[`Storyshots Components/Icon Available Icons 1`] = `
     </div>
   </div>
   <br />
+  <div
+    class="fddocs-container--icon"
+  >
+    <span
+      class="sap-icon sap-icon--clear-all"
+      style="font-size:3rem"
+    />
+    <div>
+      .sap-icon--clear-all
+    </div>
+  </div>
+  <br />
+  <div
+    class="fddocs-container--icon"
+  >
+    <span
+      class="sap-icon sap-icon--command-line-interfaces"
+      style="font-size:3rem"
+    />
+    <div>
+      .sap-icon--command-line-interfaces
+    </div>
+  </div>
+  <br />
+  <div
+    class="fddocs-container--icon"
+  >
+    <span
+      class="sap-icon sap-icon--icon-sum"
+      style="font-size:3rem"
+    />
+    <div>
+      .sap-icon--icon-sum
+    </div>
+  </div>
+  <br />
 </div>
 `;
 

--- a/stories/icon/data.json
+++ b/stories/icon/data.json
@@ -656,6 +656,9 @@
         "feedback",
         "information",
         "s4hana",
-        "translate"
+        "translate",
+        "clear-all",
+        "command-line-interfaces",
+        "icon-sum"
     ]
 }


### PR DESCRIPTION


## Description
The latest release of SAP-icons version 4.9 has 3 new icons which the current PR is introducing in Fundamental-styles

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### After:
<img width="946" alt="Screen Shot 2021-03-31 at 1 53 47 PM" src="https://user-images.githubusercontent.com/39598672/113188868-94ef7400-9228-11eb-880e-0f9ae818b2c1.png">



#### Please check whether the PR fulfills the following requirements

3. Testing
- [na] tested Storybook examples with "CSS Resources" `normalize` option 
- [na] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [na] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [na] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
