### PR TITLE
fix: move card styles from ngx to styles

### DIFF
--- a/src/card.scss
+++ b/src/card.scss
@@ -231,6 +231,11 @@ $fd-card-default-body-background-color: var(--sapTile_Background) !default;
     @include fd-reset();
 
     color: var(--sapTile_TitleTextColor);
+
+    @include fd-rtl() {
+      direction: ltr;
+      text-align: right;
+    }
   }
 
   &__second-subtitle {
@@ -352,6 +357,8 @@ $fd-card-default-body-background-color: var(--sapTile_Background) !default;
   }
 
   &--table {
+    border: hidden;
+
     &.#{$block}--compact {
       .#{$block}__content {
         padding-bottom: 0.5rem;
@@ -363,5 +370,12 @@ $fd-card-default-body-background-color: var(--sapTile_Background) !default;
     .#{$block}__content {
       padding: 1rem;
     }
+  }
+
+  &__loader {
+    @include fd-reset();
+    @include fd-flex-center();
+
+    min-height: 5rem;
   }
 }

--- a/src/numeric-content.scss
+++ b/src/numeric-content.scss
@@ -56,6 +56,11 @@ $fd-numeric-content-elements-spacing-s: 0.5rem !default;
 
   .#{$block}__kpi {
     font-size: 1.5rem;
+
+    @include fd-rtl() {
+      direction: ltr;
+      text-align: right;
+    }
   }
 
   @content;


### PR DESCRIPTION
## Related Issue
closes #1729 

## Description
Currently fundamental-ngx card component has some styles present in fundamental-ngx, which can be moved to fundamental-styles.

## Screenshots
### Before:
![Screenshot 2021-04-07 at 2 29 39 PM](https://user-images.githubusercontent.com/57661487/113840481-57ea2b00-97ae-11eb-892f-c7907f3fcfd9.png)

![Screenshot 2021-04-07 at 2 29 13 PM](https://user-images.githubusercontent.com/57661487/113840531-66384700-97ae-11eb-9797-c701c38d8687.png)

### After:
Negative sign placed correctly
![Screenshot 2021-04-07 at 2 32 39 PM](https://user-images.githubusercontent.com/57661487/113840497-5caedf00-97ae-11eb-827c-71a7ca0f68b3.png)

Table border removed
![Screenshot 2021-04-07 at 2 35 36 PM](https://user-images.githubusercontent.com/57661487/113840665-8b2cba00-97ae-11eb-877d-c064d3ca8536.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- na Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
