### PR TITLE
chore: migrate "add fallback plugin" and "remove font variables" to postCSS v.8

### DIFF
--- a/config/postcss-add-fallback.js
+++ b/config/postcss-add-fallback.js
@@ -36,8 +36,10 @@ module.exports = () => {
         Once(root) {
             let params = new Map();
             let deltaParams = new Map();
+
             // remove file extension (.css)
             let fileName = root.source.input.file.replace(/\.[^/.]+$/, '');
+
             // turn file name into array
             fileName = fileName.split('-');
 

--- a/config/postcss-add-fallback.js
+++ b/config/postcss-add-fallback.js
@@ -1,5 +1,3 @@
-
-const postcss = require('postcss');
 const fs = require('fs');
 const arrayUniq = require('array-uniq');
 const supportedThemes = require('./constants');
@@ -32,29 +30,35 @@ const applyFallback = (root, parameterMap) => {
     });
 };
 
-module.exports = postcss.plugin('add fallback plugin', function() {
-    let params = new Map();
-    let deltaParams = new Map();
-    return function(root) {
-        // remove file extension (.css)
-        let fileName = root.source.input.file.replace(/\.[^/.]+$/, '');
-        // turn file name into array
-        fileName = fileName.split('-');
+module.exports = () => {
+    return {
+        postcssPlugin: 'add fallback plugin',
+        Once(root) {
+            let params = new Map();
+            let deltaParams = new Map();
+            // remove file extension (.css)
+            let fileName = root.source.input.file.replace(/\.[^/.]+$/, '');
+            // turn file name into array
+            fileName = fileName.split('-');
 
-        // set default to sap_fiori_3
-        let sourceParams = fs.readFileSync('node_modules/@sap-theming/theming-base-content/content/Base/baseLib/sap_fiori_3/css_variables.css').toString();
-        let sourceDeltaParams = fs.readFileSync('dist/theming/sap_fiori_3.css').toString();
+            // set default to sap_fiori_3
+            let sourceParams = fs.readFileSync('node_modules/@sap-theming/theming-base-content/content/Base/baseLib/sap_fiori_3/css_variables.css').toString();
+            let sourceDeltaParams = fs.readFileSync('dist/theming/sap_fiori_3.css').toString();
 
-        if (supportedThemes.indexOf(fileName[fileName.length - 1]) > -1) {
-            sourceParams = fs.readFileSync(`node_modules/@sap-theming/theming-base-content/content/Base/baseLib/${fileName[fileName.length - 1]}/css_variables.css`).toString();
-            sourceDeltaParams = fs.readFileSync(`dist/theming/${fileName[fileName.length - 1]}.css`).toString();
+            if (supportedThemes.indexOf(fileName[fileName.length - 1]) > -1) {
+                sourceParams = fs.readFileSync(`node_modules/@sap-theming/theming-base-content/content/Base/baseLib/${fileName[fileName.length - 1]}/css_variables.css`).toString();
+                sourceDeltaParams = fs.readFileSync(`dist/theming/${fileName[fileName.length - 1]}.css`).toString();
+            }
+
+            params = findCSSVars(sourceParams);
+            deltaParams = findCSSVars(sourceDeltaParams);
+
+            // these cannot be combined as part of the same map due to delta variables referencing sap-variables
+            applyFallback(root, deltaParams);
+            applyFallback(root, params);
         }
-
-        params = findCSSVars(sourceParams);
-        deltaParams = findCSSVars(sourceDeltaParams);
-
-        // these cannot be combined as part of the same map due to delta variables referencing sap-variables
-        applyFallback(root, deltaParams);
-        applyFallback(root, params);
     };
-});
+};
+
+
+module.exports.postcss = true;

--- a/config/postcss-remove-fonts.js
+++ b/config/postcss-remove-fonts.js
@@ -1,12 +1,15 @@
-const postcss = require('postcss');
-
-module.exports = postcss.plugin('remove font variables', function() {
-    return function(root) {
-        root.walkDecls(decl => {
-            const regex = /--sapFontUrl_([a-zA-Z-_0-9])+/g;
-            if (decl.prop.match(regex)) {
-                decl.remove();
-            }
-        });
+module.exports = () => {
+    return {
+        postcssPlugin: 'remove font variables',
+        Once(root) {
+            root.walkDecls(decl => {
+                const regex = /--sapFontUrl_([a-zA-Z-_0-9])+/g;
+                if (decl.prop.match(regex)) {
+                    decl.remove();
+                }
+            });
+        }
     };
-});
+};
+
+module.exports.postcss = true;

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "node-sass": "^5.0.0",
     "normalize.css": "^8.0.1",
     "npm-run-all": "^4.1.5",
-    "postcss": "^8.2.6",
     "postcss-banner": "^3.0.2",
     "postcss-clean": "^1.2.2",
     "postcss-cli": "^8.3.1",
@@ -110,6 +109,9 @@
     "stylelint-scss": "^3.19.0",
     "tocbot": "^4.12.2",
     "webpack-merge": "^5.7.3"
+  },
+  "peerDependencies": {
+    "postcss": "^8.2.6"
   },
   "directories": {
     "storybook-testing": "storybook-testing"

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "node-sass": "^5.0.0",
     "normalize.css": "^8.0.1",
     "npm-run-all": "^4.1.5",
+    "postcss": "^8.2.6",
     "postcss-banner": "^3.0.2",
     "postcss-clean": "^1.2.2",
     "postcss-cli": "^8.3.1",
@@ -109,9 +110,6 @@
     "stylelint-scss": "^3.19.0",
     "tocbot": "^4.12.2",
     "webpack-merge": "^5.7.3"
-  },
-  "peerDependencies": {
-    "postcss": "^8.2.6"
   },
   "directories": {
     "storybook-testing": "storybook-testing"


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#2122

## Description
- Moved PostCSS 8 to peerDependencies in package.json;
- Replaced `module.exports = postcss.plugin(name, creator)` with `module.exports = creator`;
- Returned an object with postcssPlugin property containing a plugin name and the Once method;
- Moved plugin code to the Once method;
- Added `module.exports.postcss = true` to the end of the file;
- Removed postcss imports
