### PR TITLE
fix: Avatar Group popover control focus & more button color

### DIFF
--- a/src/avatar-group.scss
+++ b/src/avatar-group.scss
@@ -49,6 +49,11 @@ $block: #{$fd-namespace}-avatar-group;
 
   display: flex;
 
+  &__popover-control {
+    @include fd-fiori-focus($fd-focus-outline-offset);
+    @include action-cursor();
+  }
+
   &--individual-type {
     .#{$block}__item {
       @include fd-fiori-focus($fd-focus-outline-offset);
@@ -72,8 +77,6 @@ $block: #{$fd-namespace}-avatar-group;
   }
 
   &__more-button {
-    @include fd-reset();
-
     .#{$block}__button-text {
       font-size: inherit;
 

--- a/stories/avatar-group/__snapshots__/avatar-group.stories.storyshot
+++ b/stories/avatar-group/__snapshots__/avatar-group.stories.storyshot
@@ -28,8 +28,9 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
         
                 
         <span
-          aria-label="Wendy Wallace"
+          alt="Wendy Wallace"
           class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border"
+          role="img"
         >
           WW
         </span>
@@ -44,8 +45,9 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
         
                 
         <span
-          aria-label="Avatar"
+          alt="Simon Doe"
           class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border"
+          role="img"
         >
           
                     
@@ -67,7 +69,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
         
                 
         <span
-          aria-label="John Doe"
+          alt="John Doe"
           class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail"
           role="img"
           style="background-image: url('/assets/images/avatars/1.svg')"
@@ -83,8 +85,9 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
         
                 
         <span
-          aria-label="Endy Wallace"
+          alt="Endy Wallace"
           class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border"
+          role="img"
         >
           EW
         </span>
@@ -99,8 +102,9 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
         
                 
         <span
-          aria-label="Avatar"
+          alt="Whitney Copper"
           class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border"
+          role="img"
         >
           
                     
@@ -122,7 +126,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
         
                 
         <span
-          aria-label="John Doe"
+          alt="John Doe"
           class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail"
           role="img"
           style="background-image: url('/assets/images/avatars/2.svg')"
@@ -214,8 +218,9 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           
                     
           <span
-            aria-label="Wendy Wallace"
+            alt="Wendy Wallace"
             class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border"
+            role="img"
           >
             WW
           </span>
@@ -230,8 +235,9 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           
                     
           <span
-            aria-label="Avatar"
+            alt="Sarah Smith"
             class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border"
+            role="img"
           >
             
                         
@@ -253,7 +259,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           
                     
           <span
-            aria-label="John Doe"
+            alt="John Doe"
             class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail"
             role="img"
             style="background-image: url('/assets/images/avatars/1.svg')"
@@ -269,8 +275,9 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           
                     
           <span
-            aria-label="Endy Wallace"
+            alt="Endy Wallace"
             class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border"
+            role="img"
           >
             EW
           </span>
@@ -285,8 +292,9 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           
                     
           <span
-            aria-label="Avatar"
+            alt="Whitney Bow"
             class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border"
+            role="img"
           >
             
                         
@@ -308,7 +316,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           
                     
           <span
-            aria-label="John Doe"
+            alt="John Doe"
             class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail"
             role="img"
             style="background-image: url('/assets/images/avatars/2.svg')"
@@ -324,8 +332,9 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           
                     
           <span
-            aria-label="Andy Wallace"
+            alt="Andy Wallace"
             class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border"
+            role="img"
           >
             AW
           </span>
@@ -340,8 +349,9 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           
                     
           <span
-            aria-label="Avatar"
+            alt="John Carter"
             class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border"
+            role="img"
           >
             
                         
@@ -363,7 +373,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           
                     
           <span
-            aria-label="John Doe"
+            alt="John Doe"
             class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail"
             role="img"
             style="background-image: url('/assets/images/avatars/3.svg')"
@@ -379,8 +389,9 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           
                     
           <span
-            aria-label="John Moe"
+            alt="John Moe"
             class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border"
+            role="img"
           >
             JM
           </span>
@@ -395,8 +406,9 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           
                     
           <span
-            aria-label="Joe Bloggs"
+            alt="Joe Bloggs"
             class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border"
+            role="img"
           >
             JB
           </span>
@@ -411,8 +423,9 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           
                     
           <span
-            aria-label="Avatar"
+            alt="Simon Swan"
             class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border"
+            role="img"
           >
             
                         
@@ -434,7 +447,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           
                     
           <span
-            aria-label="John Doe"
+            alt="John Doe"
             class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail"
             role="img"
             style="background-image: url('/assets/images/avatars/4.svg')"
@@ -450,8 +463,9 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           
                     
           <span
-            aria-label="Fred Bloggs"
+            alt="Fred Bloggs"
             class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border"
+            role="img"
           >
             FB
           </span>
@@ -466,8 +480,9 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           
                     
           <span
-            aria-label="Jan Alleman"
+            alt="Jan Alleman"
             class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border"
+            role="img"
           >
             JA
           </span>
@@ -514,8 +529,9 @@ exports[`Storyshots Components/Avatar Group Individual Type 1`] = `
         
                 
         <span
-          aria-label="Wendy Wallace"
+          alt="Wendy Wallace"
           class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border"
+          role="img"
         >
           WW
         </span>
@@ -579,8 +595,9 @@ exports[`Storyshots Components/Avatar Group Individual Type 1`] = `
               
                             
               <span
-                aria-label="Wendy Wallace"
+                alt="Jason Smith"
                 class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border"
+                role="img"
               >
                 WW
               </span>
@@ -594,7 +611,7 @@ exports[`Storyshots Components/Avatar Group Individual Type 1`] = `
                 <h5
                   class="fd-title fd-title--h5"
                 >
-                  Wendy Wallace
+                  Jason Smith
                 </h5>
                 
                                 
@@ -741,8 +758,9 @@ exports[`Storyshots Components/Avatar Group Individual Type 1`] = `
         
                
         <span
-          aria-label="Avatar"
+          alt="Wendy Wallace"
           class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border"
+          role="img"
         >
           
                     
@@ -813,8 +831,9 @@ exports[`Storyshots Components/Avatar Group Individual Type 1`] = `
               
                             
               <span
-                aria-label="Wendy Wallace"
+                alt="Wendy Wallace"
                 class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border"
+                role="img"
               >
                 WW
               </span>
@@ -975,7 +994,7 @@ exports[`Storyshots Components/Avatar Group Individual Type 1`] = `
         
                
         <span
-          aria-label="Christian Bow"
+          alt="Christian Bow"
           class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border fd-avatar--thumbnail"
           role="img"
           style="background-image: url('/assets/images/avatars/1.svg')"
@@ -1038,7 +1057,7 @@ exports[`Storyshots Components/Avatar Group Individual Type 1`] = `
               
                             
               <span
-                aria-label="Christian Bow"
+                alt="Christian Bow"
                 class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border fd-avatar--thumbnail"
                 role="img"
                 style="background-image: url('/assets/images/avatars/1.svg')"
@@ -1200,8 +1219,9 @@ exports[`Storyshots Components/Avatar Group Individual Type 1`] = `
         
                
         <span
-          aria-label="Endy Wallace"
+          alt="Endy Wallace"
           class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border"
+          role="img"
         >
           EW
         </span>
@@ -1265,8 +1285,9 @@ exports[`Storyshots Components/Avatar Group Individual Type 1`] = `
               
                             
               <span
-                aria-label="Endy Wallace"
+                alt="Endy Wallace"
                 class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border"
+                role="img"
               >
                 EW
               </span>
@@ -1501,8 +1522,9 @@ exports[`Storyshots Components/Avatar Group Individual Type 1`] = `
             
                         
             <span
-              aria-label="Avatar"
+              alt="Gordon Smith"
               class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border"
+              role="img"
             >
               
                             
@@ -1527,7 +1549,7 @@ exports[`Storyshots Components/Avatar Group Individual Type 1`] = `
             
                         
             <span
-              aria-label="John Doe"
+              alt="John Doe"
               class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border fd-avatar--thumbnail"
               role="img"
               style="background-image: url('/assets/images/avatars/2.svg')"
@@ -1546,8 +1568,9 @@ exports[`Storyshots Components/Avatar Group Individual Type 1`] = `
             
                         
             <span
-              aria-label="John Moe"
+              alt="John Moe"
               class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border"
+              role="img"
             >
               JM
             </span>
@@ -1565,8 +1588,9 @@ exports[`Storyshots Components/Avatar Group Individual Type 1`] = `
             
                         
             <span
-              aria-label="Joe Bloggs"
+              alt="Joe Bloggs"
               class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border"
+              role="img"
             >
               JB
             </span>

--- a/stories/avatar-group/__snapshots__/avatar-group.stories.storyshot
+++ b/stories/avatar-group/__snapshots__/avatar-group.stories.storyshot
@@ -7,18 +7,18 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
   
     
   <div
-    class="fd-popover__control"
+    aria-expanded="false"
+    aria-haspopup="true"
+    aria-label="Has popup type dialog Conjoined avatars, 6 avatars displayed, 8 avatars hidden, activate for complete list"
+    class="fd-popover__control fd-avatar-group__popover-control"
+    onclick="onPopoverClick('popover_avatar-group_tztuj');"
+    role="button"
+    tabindex="0"
   >
     
         
     <div
-      aria-expanded="false"
-      aria-haspopup="true"
-      aria-label="Has popup type dialog Conjoined avatars, 6 avatars displayed, 8 avatars hidden, activate for complete list"
       class="fd-avatar-group fd-avatar-group--group-type fd-avatar-group--m"
-      onclick="onPopoverClick('popover_avatar-group_tztuj');"
-      role="button"
-      tabindex="0"
     >
       
             
@@ -200,13 +200,13 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
         
             
       </div>
-        
+      
         
             
       <div
         class="fd-avatar-group__overflow-body"
       >
-         
+        
                 
         <div
           class="fd-avatar-group__item"
@@ -222,7 +222,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           
                 
         </div>
-                            
+        
                 
         <div
           class="fd-avatar-group__item"
@@ -245,7 +245,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           
                 
         </div>
-            
+        
                 
         <div
           class="fd-avatar-group__item"
@@ -261,7 +261,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           
                 
         </div>
-            
+        
                 
         <div
           class="fd-avatar-group__item"
@@ -277,7 +277,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           
                 
         </div>
-            
+        
                 
         <div
           class="fd-avatar-group__item"
@@ -300,7 +300,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           
                 
         </div>
-            
+        
                 
         <div
           class="fd-avatar-group__item"
@@ -316,7 +316,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           
                 
         </div>
-            
+        
                 
         <div
           class="fd-avatar-group__item"
@@ -332,7 +332,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           
                 
         </div>
-            
+        
                 
         <div
           class="fd-avatar-group__item"
@@ -355,7 +355,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           
                 
         </div>
-            
+        
                 
         <div
           class="fd-avatar-group__item"
@@ -371,7 +371,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           
                 
         </div>
-            
+        
                 
         <div
           class="fd-avatar-group__item"
@@ -387,7 +387,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           
                 
         </div>
-            
+        
                 
         <div
           class="fd-avatar-group__item"
@@ -403,7 +403,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           
                 
         </div>
-            
+        
                 
         <div
           class="fd-avatar-group__item"
@@ -426,7 +426,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           
                 
         </div>
-            
+        
                 
         <div
           class="fd-avatar-group__item"
@@ -442,7 +442,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           
                 
         </div>
-            
+        
                 
         <div
           class="fd-avatar-group__item"
@@ -477,7 +477,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
         
             
       </div>
-       
+      
         
     </div>
     

--- a/stories/avatar-group/__snapshots__/avatar-group.stories.storyshot
+++ b/stories/avatar-group/__snapshots__/avatar-group.stories.storyshot
@@ -31,6 +31,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           alt="Wendy Wallace"
           class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border"
           role="img"
+          title="Wendy Wallace"
         >
           WW
         </span>
@@ -48,6 +49,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           alt="Simon Doe"
           class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border"
           role="img"
+          title="Simon Doe"
         >
           
                     
@@ -73,6 +75,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail"
           role="img"
           style="background-image: url('/assets/images/avatars/1.svg')"
+          title="John Doe"
         />
         
             
@@ -88,6 +91,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           alt="Endy Wallace"
           class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border"
           role="img"
+          title="Endy Wallace"
         >
           EW
         </span>
@@ -105,6 +109,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           alt="Whitney Copper"
           class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border"
           role="img"
+          title="Whitney Copper"
         >
           
                     
@@ -130,6 +135,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
           class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail"
           role="img"
           style="background-image: url('/assets/images/avatars/2.svg')"
+          title="John Doe"
         />
         
             
@@ -221,6 +227,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
             alt="Wendy Wallace"
             class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border"
             role="img"
+            title="Wendy Wallace"
           >
             WW
           </span>
@@ -238,6 +245,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
             alt="Sarah Smith"
             class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border"
             role="img"
+            title="Sarah Smith"
           >
             
                         
@@ -263,6 +271,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
             class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail"
             role="img"
             style="background-image: url('/assets/images/avatars/1.svg')"
+            title="John Doe"
           />
           
                 
@@ -278,6 +287,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
             alt="Endy Wallace"
             class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border"
             role="img"
+            title="Endy Wallace"
           >
             EW
           </span>
@@ -295,6 +305,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
             alt="Whitney Bow"
             class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border"
             role="img"
+            title="Whitney Bow"
           >
             
                         
@@ -320,6 +331,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
             class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail"
             role="img"
             style="background-image: url('/assets/images/avatars/2.svg')"
+            title="John Doe"
           />
           
                 
@@ -335,6 +347,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
             alt="Andy Wallace"
             class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border"
             role="img"
+            title="Andy Wallace"
           >
             AW
           </span>
@@ -352,6 +365,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
             alt="John Carter"
             class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border"
             role="img"
+            title="John Carter"
           >
             
                         
@@ -377,6 +391,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
             class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail"
             role="img"
             style="background-image: url('/assets/images/avatars/3.svg')"
+            title="John Doe"
           />
           
                 
@@ -392,6 +407,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
             alt="John Moe"
             class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border"
             role="img"
+            title="John Moe"
           >
             JM
           </span>
@@ -409,6 +425,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
             alt="Joe Bloggs"
             class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border"
             role="img"
+            title="Joe Bloggs"
           >
             JB
           </span>
@@ -426,6 +443,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
             alt="Simon Swan"
             class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border"
             role="img"
+            title="Simon Swan"
           >
             
                         
@@ -451,6 +469,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
             class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail"
             role="img"
             style="background-image: url('/assets/images/avatars/4.svg')"
+            title="John Doe"
           />
           
                 
@@ -466,6 +485,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
             alt="Fred Bloggs"
             class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border"
             role="img"
+            title="Fred Bloggs"
           >
             FB
           </span>
@@ -483,6 +503,7 @@ exports[`Storyshots Components/Avatar Group Group Type 1`] = `
             alt="Jan Alleman"
             class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border"
             role="img"
+            title="Jan Alleman"
           >
             JA
           </span>
@@ -532,6 +553,7 @@ exports[`Storyshots Components/Avatar Group Individual Type 1`] = `
           alt="Wendy Wallace"
           class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border"
           role="img"
+          title="Wendy Wallace"
         >
           WW
         </span>
@@ -598,6 +620,7 @@ exports[`Storyshots Components/Avatar Group Individual Type 1`] = `
                 alt="Jason Smith"
                 class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border"
                 role="img"
+                title="Jason Smith"
               >
                 WW
               </span>
@@ -758,9 +781,10 @@ exports[`Storyshots Components/Avatar Group Individual Type 1`] = `
         
                
         <span
-          alt="Wendy Wallace"
+          alt="Jason Goldwell"
           class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border"
           role="img"
+          title="Jason Goldwell"
         >
           
                     
@@ -834,6 +858,7 @@ exports[`Storyshots Components/Avatar Group Individual Type 1`] = `
                 alt="Wendy Wallace"
                 class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border"
                 role="img"
+                title="Wendy Wallace"
               >
                 WW
               </span>
@@ -998,6 +1023,7 @@ exports[`Storyshots Components/Avatar Group Individual Type 1`] = `
           class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border fd-avatar--thumbnail"
           role="img"
           style="background-image: url('/assets/images/avatars/1.svg')"
+          title="Christian Bow"
         />
       </div>
       
@@ -1061,6 +1087,7 @@ exports[`Storyshots Components/Avatar Group Individual Type 1`] = `
                 class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border fd-avatar--thumbnail"
                 role="img"
                 style="background-image: url('/assets/images/avatars/1.svg')"
+                title="Christian Bow"
               />
               
                             
@@ -1222,6 +1249,7 @@ exports[`Storyshots Components/Avatar Group Individual Type 1`] = `
           alt="Endy Wallace"
           class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border"
           role="img"
+          title="Endy Wallace"
         >
           EW
         </span>
@@ -1288,6 +1316,7 @@ exports[`Storyshots Components/Avatar Group Individual Type 1`] = `
                 alt="Endy Wallace"
                 class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border"
                 role="img"
+                title="Endy Wallace"
               >
                 EW
               </span>
@@ -1525,6 +1554,7 @@ exports[`Storyshots Components/Avatar Group Individual Type 1`] = `
               alt="Gordon Smith"
               class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border"
               role="img"
+              title="Gordon Smith"
             >
               
                             
@@ -1553,6 +1583,7 @@ exports[`Storyshots Components/Avatar Group Individual Type 1`] = `
               class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border fd-avatar--thumbnail"
               role="img"
               style="background-image: url('/assets/images/avatars/2.svg')"
+              title="John Doe"
             />
             
                     
@@ -1571,6 +1602,7 @@ exports[`Storyshots Components/Avatar Group Individual Type 1`] = `
               alt="John Moe"
               class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border"
               role="img"
+              title="John Moe"
             >
               JM
             </span>
@@ -1591,6 +1623,7 @@ exports[`Storyshots Components/Avatar Group Individual Type 1`] = `
               alt="Joe Bloggs"
               class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border"
               role="img"
+              title="Joe Bloggs"
             >
               JB
             </span>

--- a/stories/avatar-group/avatar-group.stories.js
+++ b/stories/avatar-group/avatar-group.stories.js
@@ -52,7 +52,7 @@ export const individualType = () => `<div class="fd-avatar-group fd-avatar-group
     <div class="fd-popover">
         <div class="fd-popover__control">
             <div class="fd-avatar-group__item" tabindex="0" aria-haspopup="true" aria-expanded="false" onclick="onPopoverClick('popover_avatar_5z28edb');">
-                <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" role="img" alt="Wendy Wallace">WW</span>
+                <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" role="img" alt="Wendy Wallace" title="Wendy Wallace">WW</span>
             </div>
         </div>
         <div class="fd-popover__body" aria-hidden="false" id="popover_avatar_5z28edb">
@@ -66,7 +66,7 @@ export const individualType = () => `<div class="fd-avatar-group fd-avatar-group
                 <div class="fd-quick-view__content">
                     <div class="fd-bar fd-bar--header-with-subheader">
                         <div class="fd-bar__left">
-                            <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" role="img" alt="Jason Smith">WW</span>
+                            <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" role="img" alt="Jason Smith" title="Jason Smith">WW</span>
                             <div class="fd-quick-view__subheader-text">
                                 <h5 class="fd-title fd-title--h5">Jason Smith</h5>
                                 <div class="fd-quick-view__subtitle">Marketing Manager</div>
@@ -97,7 +97,7 @@ export const individualType = () => `<div class="fd-avatar-group fd-avatar-group
     <div class="fd-popover">
         <div class="fd-popover__control">
             <div class="fd-avatar-group__item" tabindex="0" aria-haspopup="true" aria-expanded="false" onclick="onPopoverClick('popover_avatar_spbw4q');">
-               <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" role="img" alt="Wendy Wallace">
+               <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" role="img" alt="Jason Goldwell" title="Jason Goldwell">
                     <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
                 </span>
             </div>
@@ -113,7 +113,7 @@ export const individualType = () => `<div class="fd-avatar-group fd-avatar-group
                 <div class="fd-quick-view__content">
                     <div class="fd-bar fd-bar--header-with-subheader">
                         <div class="fd-bar__left">
-                            <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" role="img" alt="Wendy Wallace">WW</span>
+                            <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" role="img" alt="Wendy Wallace" title="Wendy Wallace">WW</span>
                             <div class="fd-quick-view__subheader-text">
                                 <h5 class="fd-title fd-title--h5">Sarah Parker</h5>
                                 <div class="fd-quick-view__subtitle">Visual Designer</div>
@@ -144,7 +144,7 @@ export const individualType = () => `<div class="fd-avatar-group fd-avatar-group
     <div class="fd-popover">
         <div class="fd-popover__control">
             <div class="fd-avatar-group__item" tabindex="0" aria-haspopup="true" aria-expanded="false" onclick="onPopoverClick('popover_avatar_4ahzcg');">
-               <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/1.svg')" role="img" alt="Christian Bow"></span></div>
+               <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/1.svg')" role="img" alt="Christian Bow" title="Christian Bow"></span></div>
         </div>
         <div class="fd-popover__body" aria-hidden="true" id="popover_avatar_4ahzcg">
             <div class="fd-quick-view">
@@ -157,7 +157,7 @@ export const individualType = () => `<div class="fd-avatar-group fd-avatar-group
                 <div class="fd-quick-view__content">
                     <div class="fd-bar fd-bar--header-with-subheader">
                         <div class="fd-bar__left">
-                            <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/1.svg')" role="img" alt="Christian Bow"></span>
+                            <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/1.svg')" role="img" alt="Christian Bow" title="Christian Bow"></span>
                             <div class="fd-quick-view__subheader-text">
                                 <h5 class="fd-title fd-title--h5">Christian Bow</h5>
                                 <div class="fd-quick-view__subtitle">Marketing Manager</div>
@@ -188,7 +188,7 @@ export const individualType = () => `<div class="fd-avatar-group fd-avatar-group
     <div class="fd-popover">
         <div class="fd-popover__control">
             <div class="fd-avatar-group__item" tabindex="0" aria-haspopup="true" aria-expanded="false" onclick="onPopoverClick('popover_avatar_qc1f1jf');">
-               <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" role="img" alt="Endy Wallace">EW</span>
+               <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" role="img" alt="Endy Wallace" title="Endy Wallace">EW</span>
             </div>
         </div>
         <div class="fd-popover__body" aria-hidden="true" id="popover_avatar_qc1f1jf">
@@ -202,7 +202,7 @@ export const individualType = () => `<div class="fd-avatar-group fd-avatar-group
                 <div class="fd-quick-view__content">
                     <div class="fd-bar fd-bar--header-with-subheader">
                         <div class="fd-bar__left">
-                            <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" role="img" alt="Endy Wallace">EW</span>
+                            <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" role="img" alt="Endy Wallace" title="Endy Wallace">EW</span>
                             <div class="fd-quick-view__subheader-text">
                                 <h5 class="fd-title fd-title--h5">Endy Wallace</h5>
                                 <div class="fd-quick-view__subtitle">Software Developer</div>
@@ -254,18 +254,18 @@ export const individualType = () => `<div class="fd-avatar-group fd-avatar-group
 
                 <div class="fd-avatar-group__overflow-body">
                     <div class="fd-avatar-group__item" tabindex="0" aria-haspopup="true" aria-expanded="false">
-                        <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" role="img" alt="Gordon Smith">
+                        <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" role="img" alt="Gordon Smith" title="Gordon Smith">
                             <i class="fd-avatar__icon sap-icon--washing-machine" role="presentation"></i>
                         </span>
                     </div>
                     <div class="fd-avatar-group__item" tabindex="0" aria-haspopup="true" aria-expanded="false">
-                        <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/2.svg')" role="img" alt="John Doe"></span>
+                        <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/2.svg')" role="img" alt="John Doe" title="John Doe"></span>
                     </div>
                     <div class="fd-avatar-group__item" tabindex="0" aria-haspopup="true" aria-expanded="false">
-                        <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" role="img" alt="John Moe">JM</span>
+                        <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" role="img" alt="John Moe" title="John Moe">JM</span>
                     </div>
                     <div class="fd-avatar-group__item" tabindex="0" aria-haspopup="true" aria-expanded="false">
-                        <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" role="img" alt="Joe Bloggs">JB</span>
+                        <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" role="img" alt="Joe Bloggs" title="Joe Bloggs">JB</span>
                     </div>
                 </div>
             </div>
@@ -292,26 +292,26 @@ export const groupType = () => `<div class="fd-popover">
          onclick="onPopoverClick('popover_avatar-group_tztuj');">
         <div class="fd-avatar-group fd-avatar-group--group-type fd-avatar-group--m">
             <div class="fd-avatar-group__item">
-                <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Wendy Wallace">WW</span>
+                <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Wendy Wallace" title="Wendy Wallace">WW</span>
             </div>
             <div class="fd-avatar-group__item">
-                <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Simon Doe">
+                <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Simon Doe" title="Simon Doe">
                     <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
                 </span>
             </div>
             <div class="fd-avatar-group__item">
-                <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/1.svg')" role="img" alt="John Doe"></span>
+                <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/1.svg')" role="img" alt="John Doe" title="John Doe"></span>
             </div>
             <div class="fd-avatar-group__item">
-                <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Endy Wallace">EW</span>
+                <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Endy Wallace" title="Endy Wallace">EW</span>
             </div>
             <div class="fd-avatar-group__item">
-                <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Whitney Copper">
+                <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Whitney Copper" title="Whitney Copper">
                     <i class="fd-avatar__icon sap-icon--washing-machine" role="presentation"></i>
                 </span>
             </div>
             <div class="fd-avatar-group__item">
-                <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/2.svg')" role="img" alt="John Doe"></span>
+                <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/2.svg')" role="img" alt="John Doe" title="John Doe"></span>
             </div>
         
             <button class="fd-button fd-avatar-group__more-button fd-avatar-group__more-button--m" role="button" tabindex="-1">
@@ -332,57 +332,57 @@ export const groupType = () => `<div class="fd-popover">
         
             <div class="fd-avatar-group__overflow-body">
                 <div class="fd-avatar-group__item">
-                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Wendy Wallace">WW</span>
+                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Wendy Wallace" title="Wendy Wallace">WW</span>
                 </div>
                 <div class="fd-avatar-group__item">
-                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Sarah Smith">
+                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Sarah Smith" title="Sarah Smith">
                         <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
                     </span>
                 </div>
                 <div class="fd-avatar-group__item">
-                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/1.svg')" role="img" alt="John Doe"></span>
+                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/1.svg')" role="img" alt="John Doe" title="John Doe"></span>
                 </div>
                 <div class="fd-avatar-group__item">
-                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Endy Wallace">EW</span>
+                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Endy Wallace" title="Endy Wallace">EW</span>
                 </div>
                 <div class="fd-avatar-group__item">
-                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Whitney Bow">
+                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Whitney Bow" title="Whitney Bow">
                         <i class="fd-avatar__icon sap-icon--washing-machine" role="presentation"></i>
                     </span>
                 </div>
                 <div class="fd-avatar-group__item">
-                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/2.svg')" role="img" alt="John Doe"></span>
+                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/2.svg')" role="img" alt="John Doe" title="John Doe"></span>
                 </div>
                 <div class="fd-avatar-group__item">
-                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Andy Wallace">AW</span>
+                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Andy Wallace" title="Andy Wallace">AW</span>
                 </div>
                 <div class="fd-avatar-group__item">
-                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="John Carter">
+                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="John Carter" title="John Carter">
                         <i class="fd-avatar__icon sap-icon--account" role="presentation"></i>
                     </span>
                 </div>
                 <div class="fd-avatar-group__item">
-                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/3.svg')" role="img" alt="John Doe"></span>
+                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/3.svg')" role="img" alt="John Doe" title="John Doe"></span>
                 </div>
                 <div class="fd-avatar-group__item">
-                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="John Moe">JM</span>
+                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="John Moe" title="John Moe">JM</span>
                 </div>
                 <div class="fd-avatar-group__item">
-                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Joe Bloggs">JB</span>
+                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Joe Bloggs" title="Joe Bloggs">JB</span>
                 </div>
                 <div class="fd-avatar-group__item">
-                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Simon Swan">
+                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Simon Swan" title="Simon Swan">
                         <i class="fd-avatar__icon sap-icon--visits" role="presentation"></i>
                     </span>
                 </div>
                 <div class="fd-avatar-group__item">
-                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/4.svg')" role="img" alt="John Doe"></span>
+                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/4.svg')" role="img" alt="John Doe" title="John Doe"></span>
                 </div>
                 <div class="fd-avatar-group__item">
-                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Fred Bloggs">FB</span>
+                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Fred Bloggs" title="Fred Bloggs">FB</span>
                 </div>
                 <div class="fd-avatar-group__item">
-                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Jan Alleman">JA</span>
+                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Jan Alleman" title="Jan Alleman">JA</span>
                 </div>
             </div>
         </div>

--- a/stories/avatar-group/avatar-group.stories.js
+++ b/stories/avatar-group/avatar-group.stories.js
@@ -52,7 +52,7 @@ export const individualType = () => `<div class="fd-avatar-group fd-avatar-group
     <div class="fd-popover">
         <div class="fd-popover__control">
             <div class="fd-avatar-group__item" tabindex="0" aria-haspopup="true" aria-expanded="false" onclick="onPopoverClick('popover_avatar_5z28edb');">
-                <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" aria-label="Wendy Wallace">WW</span>
+                <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" role="img" alt="Wendy Wallace">WW</span>
             </div>
         </div>
         <div class="fd-popover__body" aria-hidden="false" id="popover_avatar_5z28edb">
@@ -66,9 +66,9 @@ export const individualType = () => `<div class="fd-avatar-group fd-avatar-group
                 <div class="fd-quick-view__content">
                     <div class="fd-bar fd-bar--header-with-subheader">
                         <div class="fd-bar__left">
-                            <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" aria-label="Wendy Wallace">WW</span>
+                            <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" role="img" alt="Jason Smith">WW</span>
                             <div class="fd-quick-view__subheader-text">
-                                <h5 class="fd-title fd-title--h5">Wendy Wallace</h5>
+                                <h5 class="fd-title fd-title--h5">Jason Smith</h5>
                                 <div class="fd-quick-view__subtitle">Marketing Manager</div>
                             </div>
                         </div>
@@ -97,7 +97,7 @@ export const individualType = () => `<div class="fd-avatar-group fd-avatar-group
     <div class="fd-popover">
         <div class="fd-popover__control">
             <div class="fd-avatar-group__item" tabindex="0" aria-haspopup="true" aria-expanded="false" onclick="onPopoverClick('popover_avatar_spbw4q');">
-               <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" aria-label="Avatar">
+               <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" role="img" alt="Wendy Wallace">
                     <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
                 </span>
             </div>
@@ -113,7 +113,7 @@ export const individualType = () => `<div class="fd-avatar-group fd-avatar-group
                 <div class="fd-quick-view__content">
                     <div class="fd-bar fd-bar--header-with-subheader">
                         <div class="fd-bar__left">
-                            <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" aria-label="Wendy Wallace">WW</span>
+                            <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" role="img" alt="Wendy Wallace">WW</span>
                             <div class="fd-quick-view__subheader-text">
                                 <h5 class="fd-title fd-title--h5">Sarah Parker</h5>
                                 <div class="fd-quick-view__subtitle">Visual Designer</div>
@@ -144,7 +144,7 @@ export const individualType = () => `<div class="fd-avatar-group fd-avatar-group
     <div class="fd-popover">
         <div class="fd-popover__control">
             <div class="fd-avatar-group__item" tabindex="0" aria-haspopup="true" aria-expanded="false" onclick="onPopoverClick('popover_avatar_4ahzcg');">
-               <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/1.svg')" role="img" aria-label="Christian Bow"></span></div>
+               <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/1.svg')" role="img" alt="Christian Bow"></span></div>
         </div>
         <div class="fd-popover__body" aria-hidden="true" id="popover_avatar_4ahzcg">
             <div class="fd-quick-view">
@@ -157,7 +157,7 @@ export const individualType = () => `<div class="fd-avatar-group fd-avatar-group
                 <div class="fd-quick-view__content">
                     <div class="fd-bar fd-bar--header-with-subheader">
                         <div class="fd-bar__left">
-                            <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/1.svg')" role="img" aria-label="Christian Bow"></span>
+                            <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/1.svg')" role="img" alt="Christian Bow"></span>
                             <div class="fd-quick-view__subheader-text">
                                 <h5 class="fd-title fd-title--h5">Christian Bow</h5>
                                 <div class="fd-quick-view__subtitle">Marketing Manager</div>
@@ -188,7 +188,7 @@ export const individualType = () => `<div class="fd-avatar-group fd-avatar-group
     <div class="fd-popover">
         <div class="fd-popover__control">
             <div class="fd-avatar-group__item" tabindex="0" aria-haspopup="true" aria-expanded="false" onclick="onPopoverClick('popover_avatar_qc1f1jf');">
-               <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" aria-label="Endy Wallace">EW</span>
+               <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" role="img" alt="Endy Wallace">EW</span>
             </div>
         </div>
         <div class="fd-popover__body" aria-hidden="true" id="popover_avatar_qc1f1jf">
@@ -202,7 +202,7 @@ export const individualType = () => `<div class="fd-avatar-group fd-avatar-group
                 <div class="fd-quick-view__content">
                     <div class="fd-bar fd-bar--header-with-subheader">
                         <div class="fd-bar__left">
-                            <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" aria-label="Endy Wallace">EW</span>
+                            <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" role="img" alt="Endy Wallace">EW</span>
                             <div class="fd-quick-view__subheader-text">
                                 <h5 class="fd-title fd-title--h5">Endy Wallace</h5>
                                 <div class="fd-quick-view__subtitle">Software Developer</div>
@@ -254,18 +254,18 @@ export const individualType = () => `<div class="fd-avatar-group fd-avatar-group
 
                 <div class="fd-avatar-group__overflow-body">
                     <div class="fd-avatar-group__item" tabindex="0" aria-haspopup="true" aria-expanded="false">
-                        <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" aria-label="Avatar">
+                        <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" role="img" alt="Gordon Smith">
                             <i class="fd-avatar__icon sap-icon--washing-machine" role="presentation"></i>
                         </span>
                     </div>
                     <div class="fd-avatar-group__item" tabindex="0" aria-haspopup="true" aria-expanded="false">
-                        <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/2.svg')" role="img" aria-label="John Doe"></span>
+                        <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/2.svg')" role="img" alt="John Doe"></span>
                     </div>
                     <div class="fd-avatar-group__item" tabindex="0" aria-haspopup="true" aria-expanded="false">
-                        <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" aria-label="John Moe">JM</span>
+                        <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" role="img" alt="John Moe">JM</span>
                     </div>
                     <div class="fd-avatar-group__item" tabindex="0" aria-haspopup="true" aria-expanded="false">
-                        <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" aria-label="Joe Bloggs">JB</span>
+                        <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--border" role="img" alt="Joe Bloggs">JB</span>
                     </div>
                 </div>
             </div>
@@ -292,26 +292,26 @@ export const groupType = () => `<div class="fd-popover">
          onclick="onPopoverClick('popover_avatar-group_tztuj');">
         <div class="fd-avatar-group fd-avatar-group--group-type fd-avatar-group--m">
             <div class="fd-avatar-group__item">
-                <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" aria-label="Wendy Wallace">WW</span>
+                <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Wendy Wallace">WW</span>
             </div>
             <div class="fd-avatar-group__item">
-                <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" aria-label="Avatar">
+                <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Simon Doe">
                     <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
                 </span>
             </div>
             <div class="fd-avatar-group__item">
-                <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/1.svg')" role="img" aria-label="John Doe"></span>
+                <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/1.svg')" role="img" alt="John Doe"></span>
             </div>
             <div class="fd-avatar-group__item">
-                <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" aria-label="Endy Wallace">EW</span>
+                <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Endy Wallace">EW</span>
             </div>
             <div class="fd-avatar-group__item">
-                <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" aria-label="Avatar">
+                <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Whitney Copper">
                     <i class="fd-avatar__icon sap-icon--washing-machine" role="presentation"></i>
                 </span>
             </div>
             <div class="fd-avatar-group__item">
-                <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/2.svg')" role="img" aria-label="John Doe"></span>
+                <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/2.svg')" role="img" alt="John Doe"></span>
             </div>
         
             <button class="fd-button fd-avatar-group__more-button fd-avatar-group__more-button--m" role="button" tabindex="-1">
@@ -332,57 +332,57 @@ export const groupType = () => `<div class="fd-popover">
         
             <div class="fd-avatar-group__overflow-body">
                 <div class="fd-avatar-group__item">
-                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" aria-label="Wendy Wallace">WW</span>
+                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Wendy Wallace">WW</span>
                 </div>
                 <div class="fd-avatar-group__item">
-                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" aria-label="Avatar">
+                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Sarah Smith">
                         <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
                     </span>
                 </div>
                 <div class="fd-avatar-group__item">
-                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/1.svg')" role="img" aria-label="John Doe"></span>
+                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/1.svg')" role="img" alt="John Doe"></span>
                 </div>
                 <div class="fd-avatar-group__item">
-                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" aria-label="Endy Wallace">EW</span>
+                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Endy Wallace">EW</span>
                 </div>
                 <div class="fd-avatar-group__item">
-                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" aria-label="Avatar">
+                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Whitney Bow">
                         <i class="fd-avatar__icon sap-icon--washing-machine" role="presentation"></i>
                     </span>
                 </div>
                 <div class="fd-avatar-group__item">
-                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/2.svg')" role="img" aria-label="John Doe"></span>
+                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/2.svg')" role="img" alt="John Doe"></span>
                 </div>
                 <div class="fd-avatar-group__item">
-                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" aria-label="Andy Wallace">AW</span>
+                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Andy Wallace">AW</span>
                 </div>
                 <div class="fd-avatar-group__item">
-                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" aria-label="Avatar">
+                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="John Carter">
                         <i class="fd-avatar__icon sap-icon--account" role="presentation"></i>
                     </span>
                 </div>
                 <div class="fd-avatar-group__item">
-                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/3.svg')" role="img" aria-label="John Doe"></span>
+                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/3.svg')" role="img" alt="John Doe"></span>
                 </div>
                 <div class="fd-avatar-group__item">
-                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" aria-label="John Moe">JM</span>
+                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="John Moe">JM</span>
                 </div>
                 <div class="fd-avatar-group__item">
-                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" aria-label="Joe Bloggs">JB</span>
+                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Joe Bloggs">JB</span>
                 </div>
                 <div class="fd-avatar-group__item">
-                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" aria-label="Avatar">
+                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Simon Swan">
                         <i class="fd-avatar__icon sap-icon--visits" role="presentation"></i>
                     </span>
                 </div>
                 <div class="fd-avatar-group__item">
-                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/4.svg')" role="img" aria-label="John Doe"></span>
+                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/4.svg')" role="img" alt="John Doe"></span>
                 </div>
                 <div class="fd-avatar-group__item">
-                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" aria-label="Fred Bloggs">FB</span>
+                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Fred Bloggs">FB</span>
                 </div>
                 <div class="fd-avatar-group__item">
-                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" aria-label="Jan Alleman">JA</span>
+                    <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" role="img" alt="Jan Alleman">JA</span>
                 </div>
             </div>
         </div>

--- a/stories/avatar-group/avatar-group.stories.js
+++ b/stories/avatar-group/avatar-group.stories.js
@@ -283,14 +283,14 @@ individualType.parameters = {
 
 
 export const groupType = () => `<div class="fd-popover">
-    <div class="fd-popover__control">
-        <div class="fd-avatar-group fd-avatar-group--group-type fd-avatar-group--m"
-             role="button"
-             tabindex="0"
-             aria-label="Has popup type dialog Conjoined avatars, 6 avatars displayed, 8 avatars hidden, activate for complete list"
-             aria-haspopup="true"
-             aria-expanded="false"
-             onclick="onPopoverClick('popover_avatar-group_tztuj');">
+    <div class="fd-popover__control fd-avatar-group__popover-control"
+         role="button"
+         tabindex="0"
+         aria-label="Has popup type dialog Conjoined avatars, 6 avatars displayed, 8 avatars hidden, activate for complete list"
+         aria-haspopup="true"
+         aria-expanded="false"
+         onclick="onPopoverClick('popover_avatar-group_tztuj');">
+        <div class="fd-avatar-group fd-avatar-group--group-type fd-avatar-group--m">
             <div class="fd-avatar-group__item">
                 <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" aria-label="Wendy Wallace">WW</span>
             </div>
@@ -328,63 +328,63 @@ export const groupType = () => `<div class="fd-popover">
                         <div class="fd-bar__element">Team Members (14)</div>
                     </div>
                 </div>
-            </div>  
+            </div>
         
-            <div class="fd-avatar-group__overflow-body"> 
+            <div class="fd-avatar-group__overflow-body">
                 <div class="fd-avatar-group__item">
                     <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" aria-label="Wendy Wallace">WW</span>
-                </div>                    
+                </div>
                 <div class="fd-avatar-group__item">
                     <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" aria-label="Avatar">
                         <i class="fd-avatar__icon sap-icon--money-bills" role="presentation"></i>
                     </span>
-                </div>    
+                </div>
                 <div class="fd-avatar-group__item">
                     <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/1.svg')" role="img" aria-label="John Doe"></span>
-                </div>    
+                </div>
                 <div class="fd-avatar-group__item">
                     <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" aria-label="Endy Wallace">EW</span>
-                </div>    
+                </div>
                 <div class="fd-avatar-group__item">
                     <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" aria-label="Avatar">
                         <i class="fd-avatar__icon sap-icon--washing-machine" role="presentation"></i>
                     </span>
-                </div>    
+                </div>
                 <div class="fd-avatar-group__item">
                     <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/2.svg')" role="img" aria-label="John Doe"></span>
-                </div>    
+                </div>
                 <div class="fd-avatar-group__item">
                     <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" aria-label="Andy Wallace">AW</span>
-                </div>    
+                </div>
                 <div class="fd-avatar-group__item">
                     <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" aria-label="Avatar">
                         <i class="fd-avatar__icon sap-icon--account" role="presentation"></i>
                     </span>
-                </div>    
+                </div>
                 <div class="fd-avatar-group__item">
                     <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/3.svg')" role="img" aria-label="John Doe"></span>
-                </div>    
+                </div>
                 <div class="fd-avatar-group__item">
                     <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" aria-label="John Moe">JM</span>
-                </div>    
+                </div>
                 <div class="fd-avatar-group__item">
                     <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" aria-label="Joe Bloggs">JB</span>
-                </div>    
+                </div>
                 <div class="fd-avatar-group__item">
                     <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" aria-label="Avatar">
                         <i class="fd-avatar__icon sap-icon--visits" role="presentation"></i>
                     </span>
-                </div>    
+                </div>
                 <div class="fd-avatar-group__item">
                     <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/4.svg')" role="img" aria-label="John Doe"></span>
-                </div>    
+                </div>
                 <div class="fd-avatar-group__item">
                     <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" aria-label="Fred Bloggs">FB</span>
                 </div>
                 <div class="fd-avatar-group__item">
                     <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--border" aria-label="Jan Alleman">JA</span>
                 </div>
-            </div> 
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
BREAKING CHANGE: 
- added `.fd-avatar-group__popover-control` class to `.fd-popover__control`
- `role` changed to `img`, added `alt` and `title` instead of `aria-label` for Avatars

## Related Issue
Closes: https://github.com/SAP/fundamental-styles/issues/2240

## Description
Fixed: 
- focus state of popover-control
- text and border color of "more button"

## Screenshots

### Before:
![image](https://user-images.githubusercontent.com/14160094/114707483-f1778680-9d32-11eb-8d25-cca9eb2254ae.png)

### After:
![image](https://user-images.githubusercontent.com/14160094/114707511-f76d6780-9d32-11eb-8268-5f2fa6ac701b.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [n/a] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [n/a] tested Storybook examples with "CSS Resources" `normalize` option 
- [n/a] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [n/a] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
