### PR TITLE
fix: remove readonly attribute from File Uploader input and add examples of  File Uploader input states

### DIFF
--- a/src/file-uploader.scss
+++ b/src/file-uploader.scss
@@ -36,6 +36,7 @@ $fd-file-uploader-padding: 0.25rem;
       background-color: var(--sapField_WarningBackground);
       border-color: var(--sapField_WarningColor);
     }
+
     &.is-information {
       background-color: var(--sapField_InformationBackground);
       border-color: var(--sapField_InformationColor);

--- a/src/file-uploader.scss
+++ b/src/file-uploader.scss
@@ -9,7 +9,7 @@ $fd-file-uploader-padding: 0.25rem;
 .#{$block} {
   @include fd-reset();
   @include fd-flex-vertical-center();
-
+  
   &__input.#{$input} {
     width: auto;
     margin-right: $fd-file-uploader-padding;
@@ -26,13 +26,17 @@ $fd-file-uploader-padding: 0.25rem;
       margin-right: 0;
     }
 
+    &.is-success {
+      background-color: var(--sapField_SuccessBackground);
+      border-color: var(--sapField_SuccessColor);
+    }
+
     &.is-error {
       background-color: var(--sapField_InvalidBackground);
       border-color: var(--sapField_InvalidColor);
     }
 
-    &.is-warning,
-    &.is-alert {
+    &.is-warning {
       background-color: var(--sapField_WarningBackground);
       border-color: var(--sapField_WarningColor);
     }

--- a/src/file-uploader.scss
+++ b/src/file-uploader.scss
@@ -36,6 +36,10 @@ $fd-file-uploader-padding: 0.25rem;
       background-color: var(--sapField_WarningBackground);
       border-color: var(--sapField_WarningColor);
     }
+    &.is-information {
+      background-color: var(--sapField_InformationBackground);
+      border-color: var(--sapField_InformationColor);
+    }
   }
 
   &__hidden {

--- a/src/file-uploader.scss
+++ b/src/file-uploader.scss
@@ -25,6 +25,15 @@ $fd-file-uploader-padding: 0.25rem;
       margin-left: $fd-file-uploader-padding;
       margin-right: 0;
     }
+    &.is-error {
+      background-color: var(--sapField_InvalidBackground);
+      border-color: var(--sapField_InvalidColor);
+    }
+    &.is-warning,
+    &.is-alert {
+      background-color: var(--sapField_WarningBackground);
+      border-color: var(--sapField_WarningColor);
+    }
   }
 
   &__hidden {

--- a/src/file-uploader.scss
+++ b/src/file-uploader.scss
@@ -9,7 +9,7 @@ $fd-file-uploader-padding: 0.25rem;
 .#{$block} {
   @include fd-reset();
   @include fd-flex-vertical-center();
-  
+
   &__input.#{$input} {
     width: auto;
     margin-right: $fd-file-uploader-padding;

--- a/src/file-uploader.scss
+++ b/src/file-uploader.scss
@@ -16,9 +16,15 @@ $fd-file-uploader-padding: 0.25rem;
     background-color: var(--sapField_Background);
     user-select: none;
     cursor: pointer;
+    color: transparent;
+    text-shadow: 0 0 0 var(--sapTextColor);
 
     &::placeholder {
       color: var(--sapTextColor);
+    }
+
+    &:focus{
+      outline: none;
     }
 
     @include fd-rtl() {
@@ -26,25 +32,6 @@ $fd-file-uploader-padding: 0.25rem;
       margin-right: 0;
     }
 
-    &.is-success {
-      background-color: var(--sapField_SuccessBackground);
-      border-color: var(--sapField_SuccessColor);
-    }
-
-    &.is-error {
-      background-color: var(--sapField_InvalidBackground);
-      border-color: var(--sapField_InvalidColor);
-    }
-
-    &.is-warning {
-      background-color: var(--sapField_WarningBackground);
-      border-color: var(--sapField_WarningColor);
-    }
-
-    &.is-information {
-      background-color: var(--sapField_InformationBackground);
-      border-color: var(--sapField_InformationColor);
-    }
   }
 
   &__hidden {

--- a/src/file-uploader.scss
+++ b/src/file-uploader.scss
@@ -23,7 +23,7 @@ $fd-file-uploader-padding: 0.25rem;
       color: var(--sapTextColor);
     }
 
-    &:focus{
+    &:focus {
       outline: none;
     }
 
@@ -31,7 +31,6 @@ $fd-file-uploader-padding: 0.25rem;
       margin-left: $fd-file-uploader-padding;
       margin-right: 0;
     }
-
   }
 
   &__hidden {

--- a/src/file-uploader.scss
+++ b/src/file-uploader.scss
@@ -25,10 +25,12 @@ $fd-file-uploader-padding: 0.25rem;
       margin-left: $fd-file-uploader-padding;
       margin-right: 0;
     }
+
     &.is-error {
       background-color: var(--sapField_InvalidBackground);
       border-color: var(--sapField_InvalidColor);
     }
+
     &.is-warning,
     &.is-alert {
       background-color: var(--sapField_WarningBackground);

--- a/stories/file-uploader/__snapshots__/file-uploader.stories.storyshot
+++ b/stories/file-uploader/__snapshots__/file-uploader.stories.storyshot
@@ -204,65 +204,127 @@ exports[`Storyshots Components/File Uploader Status 1`] = `
     class="fd-form-item"
   >
     
-  
+
+
     <label
       class="fd-form-label"
-      id="browse_input4_label"
+      id="browse_input7_label"
     >
-      Upload Document (Error)
+      Upload Document (Success)
     </label>
     
-  
+
     <div
       class="fd-file-uploader"
     >
       
-    
+  
       <input
-        aria-labelledby="browse_input4_label"
+        aria-labelledby="browse_input7_label"
         autocomplete="off"
-        class="fd-input fd-input--compact fd-file-uploader__input is-error"
-        id="browse_input4"
+        class="fd-input fd-input--compact fd-file-uploader__input is-success"
+        id="browse_input7"
         onclick="browseFile('input2');"
         placeholder="Choose a file for upload"
         title="Choose a file for upload"
         type="text"
       />
       
-    
+  
       <button
         aria-label="Select a file for uploading"
         class="fd-button fd-button--compact fd-file-uploader__button"
-        id="file-uploader-button-4"
+        id="file-uploader-button-7"
         onclick="browseFile('input2');"
       >
         Browse...
-    
+  
       </button>
       
-  
+
     </div>
     
-  
+
     <div
       aria-atomic="true"
       aria-live="polite"
       class="fd-file-uploader__hidden"
     />
     
-  
+
     <input
-      aria-labelledby="browse_input4_label"
+      aria-labelledby="browse_input7_label"
       class="fd-file-uploader__hidden"
       hidden=""
-      id="input3"
-      onchange="selectFile(this,'browse_input4')"
+      id="input6"
+      onchange="selectFile(this,'browse_input7')"
       type="file"
     />
     
 
   </div>
   
+
+  <br />
+  
+
+  
+  <label
+    class="fd-form-label"
+    id="browse_input4_label"
+  >
+    Upload Document (Error)
+  </label>
+  
+  
+  <div
+    class="fd-file-uploader"
+  >
+    
+    
+    <input
+      aria-labelledby="browse_input4_label"
+      autocomplete="off"
+      class="fd-input fd-input--compact fd-file-uploader__input is-error"
+      id="browse_input4"
+      onclick="browseFile('input2');"
+      placeholder="Choose a file for upload"
+      title="Choose a file for upload"
+      type="text"
+    />
+    
+    
+    <button
+      aria-label="Select a file for uploading"
+      class="fd-button fd-button--compact fd-file-uploader__button"
+      id="file-uploader-button-4"
+      onclick="browseFile('input2');"
+    >
+      Browse...
+    
+    </button>
+    
+  
+  </div>
+  
+  
+  <div
+    aria-atomic="true"
+    aria-live="polite"
+    class="fd-file-uploader__hidden"
+  />
+  
+  
+  <input
+    aria-labelledby="browse_input4_label"
+    class="fd-file-uploader__hidden"
+    hidden=""
+    id="input3"
+    onchange="selectFile(this,'browse_input4')"
+    type="file"
+  />
+  
+
 
   <br />
   

--- a/stories/file-uploader/__snapshots__/file-uploader.stories.storyshot
+++ b/stories/file-uploader/__snapshots__/file-uploader.stories.storyshot
@@ -163,6 +163,7 @@ exports[`Storyshots Components/File Uploader Default 1`] = `
     />
     
     
+    
     <button
       aria-label="Select a file for uploading"
       class="fd-button"

--- a/stories/file-uploader/__snapshots__/file-uploader.stories.storyshot
+++ b/stories/file-uploader/__snapshots__/file-uploader.stories.storyshot
@@ -25,7 +25,6 @@ exports[`Storyshots Components/File Uploader After Selecting 1`] = `
       class="fd-input fd-file-uploader__input"
       id="browse_input2"
       onclick="browseFile('input1');"
-      readonly=""
       title="document.pdf"
       type="text"
       value="document.pdf"
@@ -94,7 +93,6 @@ exports[`Storyshots Components/File Uploader Compact 1`] = `
       id="browse_input3"
       onclick="browseFile('input2');"
       placeholder="Choose a file for upload"
-      readonly=""
       title="Choose a file for upload"
       type="text"
     />
@@ -160,7 +158,6 @@ exports[`Storyshots Components/File Uploader Default 1`] = `
       id="browse_input1"
       onclick="browseFile('input1');"
       placeholder="Choose a file for upload"
-      readonly=""
       title="Choose a file for upload"
       type="text"
     />
@@ -228,7 +225,6 @@ exports[`Storyshots Components/File Uploader Status 1`] = `
         id="browse_input4"
         onclick="browseFile('input2');"
         placeholder="Choose a file for upload"
-        readonly=""
         title="Choose a file for upload"
         type="text"
       />
@@ -291,7 +287,6 @@ exports[`Storyshots Components/File Uploader Status 1`] = `
       id="browse_input5"
       onclick="browseFile('input2');"
       placeholder="Choose a file for upload"
-      readonly=""
       title="Choose a file for upload"
       type="text"
     />
@@ -352,7 +347,6 @@ exports[`Storyshots Components/File Uploader Status 1`] = `
       id="browse_input3"
       onclick="browseFile('input2');"
       placeholder="Choose a file for upload"
-      readonly=""
       title="Choose a file for upload"
       type="text"
     />

--- a/stories/file-uploader/__snapshots__/file-uploader.stories.storyshot
+++ b/stories/file-uploader/__snapshots__/file-uploader.stories.storyshot
@@ -200,3 +200,195 @@ exports[`Storyshots Components/File Uploader Default 1`] = `
 
 </div>
 `;
+
+exports[`Storyshots Components/File Uploader Status 1`] = `
+<section>
+  <div
+    class="fd-form-item"
+  >
+    
+  
+    <label
+      class="fd-form-label"
+      id="browse_input4_label"
+    >
+      Upload Document (Error)
+    </label>
+    
+  
+    <div
+      class="fd-file-uploader"
+    >
+      
+    
+      <input
+        aria-labelledby="browse_input4_label"
+        autocomplete="off"
+        class="fd-input fd-input--compact fd-file-uploader__input is-error"
+        id="browse_input4"
+        onclick="browseFile('input2');"
+        placeholder="Choose a file for upload"
+        readonly=""
+        title="Choose a file for upload"
+        type="text"
+      />
+      
+    
+      <button
+        aria-label="Select a file for uploading"
+        class="fd-button fd-button--compact fd-file-uploader__button"
+        id="file-uploader-button-4"
+        onclick="browseFile('input2');"
+      >
+        Browse...
+    
+      </button>
+      
+  
+    </div>
+    
+  
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      class="fd-file-uploader__hidden"
+    />
+    
+  
+    <input
+      aria-labelledby="browse_input4_label"
+      class="fd-file-uploader__hidden"
+      hidden=""
+      id="input3"
+      onchange="selectFile(this,'browse_input4')"
+      type="file"
+    />
+    
+
+  </div>
+  
+
+  <br />
+  
+
+  <label
+    class="fd-form-label"
+    id="browse_input5_label"
+  >
+    Upload Document (Warning)
+  </label>
+  
+  
+  <div
+    class="fd-file-uploader"
+  >
+    
+    
+    <input
+      aria-labelledby="browse_input5_label"
+      autocomplete="off"
+      class="fd-input fd-input--compact fd-file-uploader__input is-warning"
+      id="browse_input5"
+      onclick="browseFile('input2');"
+      placeholder="Choose a file for upload"
+      readonly=""
+      title="Choose a file for upload"
+      type="text"
+    />
+    
+    
+    <button
+      aria-label="Select a file for uploading"
+      class="fd-button fd-button--compact fd-file-uploader__button"
+      id="file-uploader-button-5"
+      onclick="browseFile('input2');"
+    >
+      Browse...
+    
+    </button>
+    
+  
+  </div>
+  
+  
+  <div
+    aria-atomic="true"
+    aria-live="polite"
+    class="fd-file-uploader__hidden"
+  />
+  
+  
+  <input
+    aria-labelledby="browse_input5_label"
+    class="fd-file-uploader__hidden"
+    hidden=""
+    id="input4"
+    onchange="selectFile(this,'browse_input5')"
+    type="file"
+  />
+  
+
+
+  <br />
+  
+
+  <label
+    class="fd-form-label"
+    id="browse_input6_label"
+  >
+    Upload Document (Information)
+  </label>
+  
+  
+  <div
+    class="fd-file-uploader"
+  >
+    
+    
+    <input
+      aria-labelledby="browse_input6_label"
+      autocomplete="off"
+      class="fd-input fd-input--compact fd-file-uploader__input is-information"
+      id="browse_input3"
+      onclick="browseFile('input2');"
+      placeholder="Choose a file for upload"
+      readonly=""
+      title="Choose a file for upload"
+      type="text"
+    />
+    
+    
+    <button
+      aria-label="Select a file for uploading"
+      class="fd-button fd-button--compact fd-file-uploader__button"
+      id="file-uploader-button-6"
+      onclick="browseFile('input2');"
+    >
+      Browse...
+    
+    </button>
+    
+  
+  </div>
+  
+  
+  <div
+    aria-atomic="true"
+    aria-live="polite"
+    class="fd-file-uploader__hidden"
+  />
+  
+  
+  <input
+    aria-labelledby="browse_input6_label"
+    class="fd-file-uploader__hidden"
+    hidden=""
+    id="input5"
+    onchange="selectFile(this,'browse_input6')"
+    type="file"
+  />
+  
+
+
+</section>
+`;

--- a/stories/file-uploader/file-uploader.stories.js
+++ b/stories/file-uploader/file-uploader.stories.js
@@ -28,7 +28,7 @@ export const primary = () => `<div class="fd-form-item">
       id="browse_input1"
       autocomplete="off"
       placeholder="Choose a file for upload"
-      readonly>
+      >
     <button
       class="fd-button"
       onclick="browseFile('input1');"
@@ -67,7 +67,7 @@ export const selected = () => `<div class="fd-form-item">
       id="browse_input2" 
       autocomplete="off"
       value="document.pdf"
-      readonly>
+      >
     <button 
       class="fd-button"
       onclick="browseFile('input1');" 
@@ -107,7 +107,7 @@ export const compact = () => `<div class="fd-form-item">
       title="Choose a file for upload"  
       placeholder="Choose a file for upload"
       autocomplete="off"
-      readonly>
+      >
     <button
       class="fd-button fd-button--compact fd-file-uploader__button"  
       onclick="browseFile('input2');"
@@ -146,7 +146,7 @@ export const status = () => `<div class="fd-form-item">
       title="Choose a file for upload"  
       placeholder="Choose a file for upload"
       autocomplete="off"
-      readonly>
+      >
     <button
       class="fd-button fd-button--compact fd-file-uploader__button"  
       onclick="browseFile('input2');"
@@ -175,7 +175,7 @@ export const status = () => `<div class="fd-form-item">
       title="Choose a file for upload"  
       placeholder="Choose a file for upload"
       autocomplete="off"
-      readonly>
+      >
     <button
       class="fd-button fd-button--compact fd-file-uploader__button"  
       onclick="browseFile('input2');"
@@ -204,7 +204,7 @@ export const status = () => `<div class="fd-form-item">
       title="Choose a file for upload"  
       placeholder="Choose a file for upload"
       autocomplete="off"
-      readonly>
+      >
     <button
       class="fd-button fd-button--compact fd-file-uploader__button"  
       onclick="browseFile('input2');"

--- a/stories/file-uploader/file-uploader.stories.js
+++ b/stories/file-uploader/file-uploader.stories.js
@@ -29,6 +29,7 @@ export const primary = () => `<div class="fd-form-item">
       autocomplete="off"
       placeholder="Choose a file for upload"
       >
+    
     <button
       class="fd-button"
       onclick="browseFile('input1');"

--- a/stories/file-uploader/file-uploader.stories.js
+++ b/stories/file-uploader/file-uploader.stories.js
@@ -227,6 +227,6 @@ export const status = () => `<div class="fd-form-item">
 status.parameters = {
     docs: {
         iframeHeight: 250,
-        storyDescription: 'For Status File Uploader apply the `--compact` modifier to the button and input elements.'
+        storyDescription: 'For Status File Uploader apply the corresponding status class `is-success, is-error, is-warning, is-information ` modifier to the input element.'
     }
 };

--- a/stories/file-uploader/file-uploader.stories.js
+++ b/stories/file-uploader/file-uploader.stories.js
@@ -131,3 +131,73 @@ compact.parameters = {
         storyDescription: 'For compact File Uploader apply the `--compact` modifier to the button and input elements.'
     }
 };
+
+
+
+export const status = () => `<div class="fd-form-item">
+  <label class="fd-form-label" id="browse_input3_label" >Upload Document (Error)</label>
+  <div class="fd-file-uploader">
+    <input
+      aria-labelledby="browse_input3_label"
+      class="fd-input fd-input--compact fd-file-uploader__input is-error" 
+      onclick="browseFile('input2');" 
+      id="browse_input3" 
+      type="text"
+      title="Choose a file for upload"  
+      placeholder="Choose a file for upload"
+      autocomplete="off"
+      readonly>
+    <button
+      class="fd-button fd-button--compact fd-file-uploader__button"  
+      onclick="browseFile('input2');"
+      id="file-uploader-button-3" 
+      aria-label="Select a file for uploading">Browse...
+    </button>
+  </div>
+  <div class="fd-file-uploader__hidden" aria-live="polite" aria-atomic="true"></div>
+  <input
+    aria-labelledby="browse_input3_label"
+    hidden
+    id="input2"
+    class="fd-file-uploader__hidden"
+    type="file"
+    onchange="selectFile(this,'browse_input3')">
+</div>
+<br/>
+<label class="fd-form-label" id="browse_input3_label" >Upload Document (Warning)</label>
+  <div class="fd-file-uploader">
+    <input
+      aria-labelledby="browse_input3_label"
+      class="fd-input fd-input--compact fd-file-uploader__input is-warning" 
+      onclick="browseFile('input2');" 
+      id="browse_input3" 
+      type="text"
+      title="Choose a file for upload"  
+      placeholder="Choose a file for upload"
+      autocomplete="off"
+      readonly>
+    <button
+      class="fd-button fd-button--compact fd-file-uploader__button"  
+      onclick="browseFile('input2');"
+      id="file-uploader-button-3" 
+      aria-label="Select a file for uploading">Browse...
+    </button>
+  </div>
+  <div class="fd-file-uploader__hidden" aria-live="polite" aria-atomic="true"></div>
+  <input
+    aria-labelledby="browse_input3_label"
+    hidden
+    id="input2"
+    class="fd-file-uploader__hidden"
+    type="file"
+    onchange="selectFile(this,'browse_input3')">
+</div>
+`;
+
+
+status.parameters = {
+    docs: {
+        iframeHeight: 250,
+        storyDescription: 'For Status File Uploader apply the `--compact` modifier to the button and input elements.'
+    }
+};

--- a/stories/file-uploader/file-uploader.stories.js
+++ b/stories/file-uploader/file-uploader.stories.js
@@ -135,13 +135,13 @@ compact.parameters = {
 
 
 export const status = () => `<div class="fd-form-item">
-  <label class="fd-form-label" id="browse_input3_label" >Upload Document (Error)</label>
+  <label class="fd-form-label" id="browse_input4_label" >Upload Document (Error)</label>
   <div class="fd-file-uploader">
     <input
-      aria-labelledby="browse_input3_label"
+      aria-labelledby="browse_input4_label"
       class="fd-input fd-input--compact fd-file-uploader__input is-error" 
       onclick="browseFile('input2');" 
-      id="browse_input3" 
+      id="browse_input4" 
       type="text"
       title="Choose a file for upload"  
       placeholder="Choose a file for upload"
@@ -150,25 +150,54 @@ export const status = () => `<div class="fd-form-item">
     <button
       class="fd-button fd-button--compact fd-file-uploader__button"  
       onclick="browseFile('input2');"
-      id="file-uploader-button-3" 
+      id="file-uploader-button-4" 
       aria-label="Select a file for uploading">Browse...
     </button>
   </div>
   <div class="fd-file-uploader__hidden" aria-live="polite" aria-atomic="true"></div>
   <input
-    aria-labelledby="browse_input3_label"
+    aria-labelledby="browse_input4_label"
     hidden
-    id="input2"
+    id="input3"
     class="fd-file-uploader__hidden"
     type="file"
-    onchange="selectFile(this,'browse_input3')">
+    onchange="selectFile(this,'browse_input4')">
 </div>
 <br/>
-<label class="fd-form-label" id="browse_input3_label" >Upload Document (Warning)</label>
+<label class="fd-form-label" id="browse_input5_label" >Upload Document (Warning)</label>
   <div class="fd-file-uploader">
     <input
-      aria-labelledby="browse_input3_label"
+      aria-labelledby="browse_input5_label"
       class="fd-input fd-input--compact fd-file-uploader__input is-warning" 
+      onclick="browseFile('input2');" 
+      id="browse_input5" 
+      type="text"
+      title="Choose a file for upload"  
+      placeholder="Choose a file for upload"
+      autocomplete="off"
+      readonly>
+    <button
+      class="fd-button fd-button--compact fd-file-uploader__button"  
+      onclick="browseFile('input2');"
+      id="file-uploader-button-5" 
+      aria-label="Select a file for uploading">Browse...
+    </button>
+  </div>
+  <div class="fd-file-uploader__hidden" aria-live="polite" aria-atomic="true"></div>
+  <input
+    aria-labelledby="browse_input5_label"
+    hidden
+    id="input4"
+    class="fd-file-uploader__hidden"
+    type="file"
+    onchange="selectFile(this,'browse_input5')">
+</div>
+<br/>
+<label class="fd-form-label" id="browse_input6_label" >Upload Document (Information)</label>
+  <div class="fd-file-uploader">
+    <input
+      aria-labelledby="browse_input6_label"
+      class="fd-input fd-input--compact fd-file-uploader__input is-information" 
       onclick="browseFile('input2');" 
       id="browse_input3" 
       type="text"
@@ -179,18 +208,18 @@ export const status = () => `<div class="fd-form-item">
     <button
       class="fd-button fd-button--compact fd-file-uploader__button"  
       onclick="browseFile('input2');"
-      id="file-uploader-button-3" 
+      id="file-uploader-button-6" 
       aria-label="Select a file for uploading">Browse...
     </button>
   </div>
   <div class="fd-file-uploader__hidden" aria-live="polite" aria-atomic="true"></div>
   <input
-    aria-labelledby="browse_input3_label"
+    aria-labelledby="browse_input6_label"
     hidden
-    id="input2"
+    id="input5"
     class="fd-file-uploader__hidden"
     type="file"
-    onchange="selectFile(this,'browse_input3')">
+    onchange="selectFile(this,'browse_input6')">
 </div>
 `;
 

--- a/stories/file-uploader/file-uploader.stories.js
+++ b/stories/file-uploader/file-uploader.stories.js
@@ -135,6 +135,37 @@ compact.parameters = {
 
 
 export const status = () => `<div class="fd-form-item">
+
+<label class="fd-form-label" id="browse_input7_label" >Upload Document (Success)</label>
+<div class="fd-file-uploader">
+  <input
+    aria-labelledby="browse_input7_label"
+    class="fd-input fd-input--compact fd-file-uploader__input is-success" 
+    onclick="browseFile('input2');" 
+    id="browse_input7" 
+    type="text"
+    title="Choose a file for upload"  
+    placeholder="Choose a file for upload"
+    autocomplete="off"
+    >
+  <button
+    class="fd-button fd-button--compact fd-file-uploader__button"  
+    onclick="browseFile('input2');"
+    id="file-uploader-button-7" 
+    aria-label="Select a file for uploading">Browse...
+  </button>
+</div>
+<div class="fd-file-uploader__hidden" aria-live="polite" aria-atomic="true"></div>
+<input
+  aria-labelledby="browse_input7_label"
+  hidden
+  id="input6"
+  class="fd-file-uploader__hidden"
+  type="file"
+  onchange="selectFile(this,'browse_input7')">
+</div>
+<br/>
+
   <label class="fd-form-label" id="browse_input4_label" >Upload Document (Error)</label>
   <div class="fd-file-uploader">
     <input


### PR DESCRIPTION
## Related Issue
Part of https://github.com/SAP/fundamental-ngx/issues/5025

## Description
- removed `readonly` attribute from File Uploader input and added some css rules associated with this move (text shadow and focus)
- introduced examples in the documentation of File Uploader with error, success, information and warning states.

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:


### After:

![image](https://user-images.githubusercontent.com/53512176/115233362-6e40a100-a135-11eb-850b-057f3f1ec698.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [NA] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
