### PR TITLE
fix: cleanup unused classes in Notifications and minor code refactoring

### DIFF
--- a/src/notification.scss
+++ b/src/notification.scss
@@ -269,8 +269,6 @@ $block: #{$fd-namespace}-notification;
     }
   }
 
-  // MOBILE view
-
   &--mobile {
     padding: $fd-notification-reset-offset;
 

--- a/src/notification.scss
+++ b/src/notification.scss
@@ -30,6 +30,7 @@ $block: #{$fd-namespace}-notification;
   $fd-notification-padding-right: 1rem;
   $fd-notification-content-offset: 0.75rem;
   $fd-notification-padding-mobile: 0.75rem;
+  $fd-notification-actions-offset: 0.5rem;
   $fd-notification-reset-offset: 0;
 
   // mixins
@@ -165,15 +166,16 @@ $block: #{$fd-namespace}-notification;
       padding-right: $fd-notification-padding-right;
     }
 
-    .#{$fd-namespace}-button {
-      margin-right: 0.5rem;
+    & > * {
+      margin-left: $fd-notification-actions-offset;
 
-      &:last-child {
-        margin-right: 0;
+      &:first-child {
+        margin-left: $fd-notification-reset-offset;
       }
 
       @include fd-rtl() {
-        margin-right: $fd-notification-reset-offset;
+        margin-left: $fd-notification-reset-offset;
+        margin-right: $fd-notification-actions-offset;
       }
     }
   }
@@ -232,10 +234,6 @@ $block: #{$fd-namespace}-notification;
     }
   }
 
-  &--tabs {
-    box-shadow: $fd-notification-box-shadow;
-  }
-
   &--group {
     @include fd-reset();
 
@@ -244,10 +242,6 @@ $block: #{$fd-namespace}-notification;
     .#{$block}__body {
       padding: 1rem 0.5rem 1rem 1rem;
       border-bottom: $fd-notification-border;
-
-      &:last-child {
-        border-bottom: none;
-      }
 
       @include fd-rtl() {
         padding-left: $fd-notification-padding-left;
@@ -299,10 +293,6 @@ $block: #{$fd-namespace}-notification;
       @include fd-rtl() {
         padding-right: $fd-notification-padding-mobile;
         padding-left: $fd-notification-padding-left;
-      }
-
-      .#{$block}__actions--dismiss {
-        display: none;
       }
     }
 

--- a/stories/notification/__snapshots__/notification.stories.storyshot
+++ b/stories/notification/__snapshots__/notification.stories.storyshot
@@ -122,7 +122,7 @@ exports[`Storyshots Components/Notifications Error 1`] = `
             
       <button
         aria-label="Close"
-        class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss"
+        class="fd-button fd-button--transparent fd-button--compact "
       >
         
                 
@@ -258,7 +258,7 @@ exports[`Storyshots Components/Notifications Information 1`] = `
             
       <button
         aria-label="Close"
-        class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss"
+        class="fd-button fd-button--transparent fd-button--compact "
       >
         
                 
@@ -288,7 +288,6 @@ exports[`Storyshots Components/Notifications Mobile 1`] = `
 
 
     <div
-      "=""
       class="fd-notification fd-notification--mobile"
     >
       
@@ -406,7 +405,7 @@ exports[`Storyshots Components/Notifications Mobile 1`] = `
                 
             <div
               aria-hidden="true"
-              class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover"
+              class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow"
               id="popoverA4"
             >
               
@@ -482,7 +481,7 @@ exports[`Storyshots Components/Notifications Mobile 1`] = `
             
           <button
             aria-label="Close"
-            class="fd-button fd-button--transparent fd-notification__actions--dismiss"
+            class="fd-button fd-button--transparent"
           >
             
                 
@@ -517,7 +516,7 @@ exports[`Storyshots Components/Notifications Mobile 1`] = `
       
         
       <ul
-        class="fd-tabs fd-tabs--l fd-notification--tabs"
+        class="fd-tabs fd-tabs--l"
         role="tablist"
       >
         
@@ -539,9 +538,7 @@ exports[`Storyshots Components/Notifications Mobile 1`] = `
             <span
               class="fd-tabs__tag"
             >
-              
-                        By Date
-                    
+              By Date
             </span>
             
                 
@@ -567,9 +564,7 @@ exports[`Storyshots Components/Notifications Mobile 1`] = `
             <span
               class="fd-tabs__tag"
             >
-              
-                        By Type
-                    
+              By Type
             </span>
             
                 
@@ -595,9 +590,7 @@ exports[`Storyshots Components/Notifications Mobile 1`] = `
             <span
               class="fd-tabs__tag"
             >
-              
-                        By Priority
-                    
+              By Priority
             </span>
             
                 
@@ -673,7 +666,7 @@ exports[`Storyshots Components/Notifications Mobile 1`] = `
                     
             <button
               aria-label="Close"
-              class="fd-button fd-button--transparent fd-notification__actions--dismiss"
+              class="fd-button fd-button--transparent"
             >
               
                         
@@ -805,7 +798,7 @@ exports[`Storyshots Components/Notifications Mobile 1`] = `
                         
               <div
                 aria-hidden="true"
-                class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover"
+                class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow"
                 id="popoverA3"
               >
                 
@@ -881,7 +874,7 @@ exports[`Storyshots Components/Notifications Mobile 1`] = `
                     
             <button
               aria-label="Close"
-              class="fd-button fd-button--transparent fd-notification__actions--dismiss"
+              class="fd-button fd-button--transparent"
             >
               
                         
@@ -1012,7 +1005,7 @@ exports[`Storyshots Components/Notifications Mobile 1`] = `
                         
               <div
                 aria-hidden="true"
-                class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover"
+                class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow"
                 id="popoverA2"
               >
                 
@@ -1065,7 +1058,7 @@ exports[`Storyshots Components/Notifications Mobile 1`] = `
                     
             <button
               aria-label="Close"
-              class="fd-button fd-button--transparent fd-notification__actions--dismiss"
+              class="fd-button fd-button--transparent"
             >
               
                         
@@ -1149,7 +1142,7 @@ exports[`Storyshots Components/Notifications Mobile 1`] = `
                     
             <button
               aria-label="Close"
-              class="fd-button fd-button--transparent fd-notification__actions--dismiss"
+              class="fd-button fd-button--transparent"
             >
               
                         
@@ -1281,7 +1274,7 @@ exports[`Storyshots Components/Notifications Mobile 1`] = `
                         
               <div
                 aria-hidden="true"
-                class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover"
+                class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow"
                 id="popoverA42"
               >
                 
@@ -1357,7 +1350,7 @@ exports[`Storyshots Components/Notifications Mobile 1`] = `
                     
             <button
               aria-label="Close"
-              class="fd-button fd-button--transparent fd-notification__actions--dismiss"
+              class="fd-button fd-button--transparent"
             >
               
                         
@@ -1488,7 +1481,7 @@ exports[`Storyshots Components/Notifications Mobile 1`] = `
                         
               <div
                 aria-hidden="true"
-                class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover"
+                class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow"
                 id="popoverA245"
               >
                 
@@ -1541,7 +1534,7 @@ exports[`Storyshots Components/Notifications Mobile 1`] = `
                     
             <button
               aria-label="Close"
-              class="fd-button fd-button--transparent fd-notification__actions--dismiss"
+              class="fd-button fd-button--transparent"
             >
               
                         
@@ -1625,7 +1618,7 @@ exports[`Storyshots Components/Notifications Mobile 1`] = `
                     
             <button
               aria-label="Close"
-              class="fd-button fd-button--transparent fd-notification__actions--dismiss"
+              class="fd-button fd-button--transparent"
             >
               
                         
@@ -1757,7 +1750,7 @@ exports[`Storyshots Components/Notifications Mobile 1`] = `
                         
               <div
                 aria-hidden="true"
-                class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover"
+                class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow"
                 id="popoverA5"
               >
                 
@@ -1833,7 +1826,7 @@ exports[`Storyshots Components/Notifications Mobile 1`] = `
                     
             <button
               aria-label="Close"
-              class="fd-button fd-button--transparent fd-notification__actions--dismiss"
+              class="fd-button fd-button--transparent"
             >
               
                         
@@ -1964,7 +1957,7 @@ exports[`Storyshots Components/Notifications Mobile 1`] = `
                         
               <div
                 aria-hidden="true"
-                class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover"
+                class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow"
                 id="popoverA43212"
               >
                 
@@ -2017,7 +2010,7 @@ exports[`Storyshots Components/Notifications Mobile 1`] = `
                     
             <button
               aria-label="Close"
-              class="fd-button fd-button--transparent fd-notification__actions--dismiss"
+              class="fd-button fd-button--transparent"
             >
               
                         
@@ -2134,7 +2127,7 @@ exports[`Storyshots Components/Notifications No Avatar 1`] = `
             
       <button
         aria-label="Close"
-        class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss"
+        class="fd-button fd-button--transparent fd-button--compact "
       >
         
                 
@@ -2162,7 +2155,7 @@ exports[`Storyshots Components/Notifications Notification Group 1`] = `
   
     
   <ul
-    class="fd-tabs fd-tabs--l fd-notification--tabs"
+    class="fd-tabs fd-tabs--l"
     role="tablist"
   >
     
@@ -2325,7 +2318,7 @@ exports[`Storyshots Components/Notifications Notification Group 1`] = `
                 
         <button
           aria-label="Close"
-          class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss"
+          class="fd-button fd-button--transparent fd-button--compact "
         >
           
                     
@@ -2445,7 +2438,7 @@ exports[`Storyshots Components/Notifications Notification Group 1`] = `
                     
           <div
             aria-hidden="true"
-            class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover"
+            class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow"
             id="popoverA5"
           >
             
@@ -2545,7 +2538,7 @@ exports[`Storyshots Components/Notifications Notification Group 1`] = `
                 
         <button
           aria-label="Close"
-          class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss"
+          class="fd-button fd-button--transparent fd-button--compact "
         >
           
                     
@@ -2653,7 +2646,7 @@ exports[`Storyshots Components/Notifications Notification Group 1`] = `
                 
         <button
           aria-label="Close"
-          class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss"
+          class="fd-button fd-button--transparent fd-button--compact "
         >
           
                     
@@ -2760,7 +2753,7 @@ exports[`Storyshots Components/Notifications Notification Group 1`] = `
                 
         <button
           aria-label="Close"
-          class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss"
+          class="fd-button fd-button--transparent fd-button--compact "
         >
           
                     
@@ -2873,7 +2866,7 @@ exports[`Storyshots Components/Notifications Notification Group 1`] = `
                 
         <button
           aria-label="Close"
-          class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss"
+          class="fd-button fd-button--transparent fd-button--compact "
         >
           
                     
@@ -2981,7 +2974,7 @@ exports[`Storyshots Components/Notifications Notification Group 1`] = `
                 
         <button
           aria-label="Close"
-          class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss"
+          class="fd-button fd-button--transparent fd-button--compact "
         >
           
                     
@@ -3072,7 +3065,7 @@ exports[`Storyshots Components/Notifications Notification Group 1`] = `
                 
         <button
           aria-label="Close"
-          class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss"
+          class="fd-button fd-button--transparent fd-button--compact "
         >
           
                     
@@ -3180,7 +3173,7 @@ exports[`Storyshots Components/Notifications Notification Group 1`] = `
                 
         <button
           aria-label="Close"
-          class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss"
+          class="fd-button fd-button--transparent fd-button--compact "
         >
           
                     
@@ -3299,7 +3292,7 @@ exports[`Storyshots Components/Notifications Primary 1`] = `
             
       <button
         aria-label="Close"
-        class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss"
+        class="fd-button fd-button--transparent fd-button--compact "
       >
         
                 
@@ -3442,7 +3435,7 @@ exports[`Storyshots Components/Notifications Warning 1`] = `
             
       <button
         aria-label="Close"
-        class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss"
+        class="fd-button fd-button--transparent fd-button--compact "
       >
         
                 

--- a/stories/notification/notification.stories.js
+++ b/stories/notification/notification.stories.js
@@ -17,7 +17,7 @@ Notifications are used to relay information to the user about a situation or tas
 
 export const primary = () => `<div class="fd-notification">
     <div class="fd-notification__body">
-        <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/3.svg')" role="img"aria-label="John Doe"></span>
+        <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/3.svg')" role="img" aria-label="John Doe"></span>
         <div class="fd-notification__content">
             <div class="fd-notification__header">
                 <div class="fd-notification__indicator fd-notification__indicator--success"></div>
@@ -32,7 +32,7 @@ export const primary = () => `<div class="fd-notification">
         </div>
         <div class="fd-notification__actions">
             <button class="fd-button fd-button--compact">Open</button>
-            <button class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss" aria-label="Close">
+            <button class="fd-button fd-button--transparent fd-button--compact " aria-label="Close">
                 <i class="sap-icon--decline"></i>
             </button>
         </div>
@@ -64,7 +64,7 @@ export const noAvatar = () => `<div class="fd-notification">
         </div>
         <div class="fd-notification__actions">
             <button class="fd-button fd-button--compact">Open</button>
-            <button class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss" aria-label="Close">
+            <button class="fd-button fd-button--transparent fd-button--compact " aria-label="Close">
                 <i class="sap-icon--decline"></i>
             </button>
         </div>
@@ -90,7 +90,7 @@ export const information = () => `<div class="fd-notification">
       </button>
     </div>
     <div class="fd-notification__body fd-notification__body--message">
-        <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/3.svg')" role="img"aria-label="John Doe"></span>
+        <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/3.svg')" role="img" aria-label="John Doe"></span>
         <div class="fd-notification__content">
             <div class="fd-notification__header">
                 <h2 class="fd-notification__title fd-notification__title--unread">You have new items</h2>
@@ -103,7 +103,7 @@ export const information = () => `<div class="fd-notification">
         </div>
         <div class="fd-notification__actions">
             <button class="fd-button fd-button--compact">Open</button>
-            <button class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss" aria-label="Close">
+            <button class="fd-button fd-button--transparent fd-button--compact " aria-label="Close">
                 <i class="sap-icon--decline"></i>
             </button>
         </div>
@@ -129,7 +129,7 @@ export const warning = () => `<div class="fd-notification">
       </button>
     </div>
     <div class="fd-notification__body fd-notification__body--message">
-       <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/3.svg')" role="img"aria-label="John Doe"></span>
+       <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/3.svg')" role="img" aria-label="John Doe"></span>
         <div class="fd-notification__content">
             <div class="fd-notification__header">
               <h2 class="fd-notification__title fd-notification__title--unread">You have new items</h2>
@@ -143,7 +143,7 @@ export const warning = () => `<div class="fd-notification">
         </div>
         <div class="fd-notification__actions">
             <button class="fd-button fd-button--compact">Open</button>
-            <button class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss" aria-label="Close">
+            <button class="fd-button fd-button--transparent fd-button--compact " aria-label="Close">
                 <i class="sap-icon--decline"></i>
             </button>
         </div>
@@ -169,7 +169,7 @@ export const error = () => `<div class="fd-notification">
           </button>
     </div>
     <div class="fd-notification__body fd-notification__body--message">
-        <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/3.svg')" role="img"aria-label="John Doe"></span>
+        <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/3.svg')" role="img" aria-label="John Doe"></span>
         <div class="fd-notification__content">
           <div class="fd-notification__header">
             <h2 class="fd-notification__title fd-notification__title--unread">You have new items</h2>
@@ -183,7 +183,7 @@ export const error = () => `<div class="fd-notification">
         </div>
         <div class="fd-notification__actions">
             <button class="fd-button fd-button--compact">Open</button>
-            <button class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss" aria-label="Close">
+            <button class="fd-button fd-button--transparent fd-button--compact " aria-label="Close">
                 <i class="sap-icon--decline"></i>
             </button>
         </div>
@@ -200,7 +200,7 @@ Notifications can display error alerts by adding the <code>fd-message-strip fd-m
 };
 
 export const notificationGroup = () => `<div class="fd-notification fd-notification--group">
-    <ul class="fd-tabs fd-tabs--l fd-notification--tabs" role="tablist">
+    <ul class="fd-tabs fd-tabs--l" role="tablist">
         <li role="tab" class="fd-tabs__item" aria-selected="true">
             <a 
                 class="fd-tabs__link"
@@ -245,13 +245,13 @@ export const notificationGroup = () => `<div class="fd-notification fd-notificat
             </div>
             <div class="fd-notification__actions">
                 <button class="fd-button fd-button--compact">Accept All</button>
-                <button class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss" aria-label="Close">
+                <button class="fd-button fd-button--transparent fd-button--compact " aria-label="Close">
                     <i class="sap-icon--decline"></i>
                 </button>
             </div>
         </div>
         <div class="fd-notification__body">
-            <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" role="img"aria-label="John Doe">JD</span>
+            <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" role="img" aria-label="John Doe">JD</span>
             <div class="fd-notification__content">
                 <div class="fd-notification__header">
                     <div class="fd-notification__indicator fd-notification__indicator--warning"></div>
@@ -269,7 +269,7 @@ export const notificationGroup = () => `<div class="fd-notification fd-notificat
                             <i class="sap-icon--overflow"></i>
                         </button>
                     </div>
-                    <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover" aria-hidden="true" id="popoverA5">
+                    <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow" aria-hidden="true" id="popoverA5">
                         <nav class="fd-menu" id="">
                             <ul class="fd-menu__list fd-menu__list--no-shadow">
                                 <li class="fd-menu__item">
@@ -292,13 +292,13 @@ export const notificationGroup = () => `<div class="fd-notification fd-notificat
                     </div>
                 </div>
 
-                <button class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss" aria-label="Close">
+                <button class="fd-button fd-button--transparent fd-button--compact " aria-label="Close">
                     <i class="sap-icon--decline"></i>
                 </button>
             </div>
         </div>
         <div class="fd-notification__body">
-            <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/3.svg')" role="img"aria-label="John Doe"></span>
+            <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/3.svg')" role="img" aria-label="John Doe"></span>
             <div class="fd-notification__content">
                 <div class="fd-notification__header">
                 <div class="fd-notification__indicator fd-notification__indicator--success"></div>
@@ -314,13 +314,13 @@ export const notificationGroup = () => `<div class="fd-notification fd-notificat
             <div class="fd-notification__actions">
                 <button class="fd-button fd-button--compact">Open</button>
 
-                <button class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss" aria-label="Close">
+                <button class="fd-button fd-button--transparent fd-button--compact " aria-label="Close">
                     <i class="sap-icon--decline"></i>
                 </button>
             </div>
         </div>
         <div class="fd-notification__body">
-            <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/3.svg')" role="img"aria-label="John Doe"></span>
+            <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/3.svg')" role="img" aria-label="John Doe"></span>
             <div class="fd-notification__content">
                 <div class="fd-notification__header">
                 <div class="fd-notification__indicator fd-notification__indicator--error"></div>
@@ -335,7 +335,7 @@ export const notificationGroup = () => `<div class="fd-notification fd-notificat
             </div>
             <div class="fd-notification__actions">
                 <button class="fd-button fd-button--compact">Open</button>
-                <button class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss" aria-label="Close">
+                <button class="fd-button fd-button--transparent fd-button--compact " aria-label="Close">
                     <i class="sap-icon--decline"></i>
                 </button>
             </div>
@@ -358,13 +358,13 @@ export const notificationGroup = () => `<div class="fd-notification fd-notificat
             </div>
             <div class="fd-notification__actions">
                 <button class="fd-button fd-button--compact">Accept All</button>
-                <button class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss" aria-label="Close">
+                <button class="fd-button fd-button--transparent fd-button--compact " aria-label="Close">
                     <i class="sap-icon--decline"></i>
                 </button>
             </div>
         </div>
         <div class="fd-notification__body">
-            <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/3.svg')" role="img"aria-label="John Doe"></span>
+            <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/3.svg')" role="img" aria-label="John Doe"></span>
             <div class="fd-notification__content">
                 <div class="fd-notification__header">
                 <div class="fd-notification__indicator fd-notification__indicator--success"></div>
@@ -380,7 +380,7 @@ export const notificationGroup = () => `<div class="fd-notification fd-notificat
             <div class="fd-notification__actions">
                 <button class="fd-button fd-button--compact">Open</button>
 
-                <button class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss" aria-label="Close">
+                <button class="fd-button fd-button--transparent fd-button--compact " aria-label="Close">
                     <i class="sap-icon--decline"></i>
                 </button>
             </div>
@@ -399,13 +399,13 @@ export const notificationGroup = () => `<div class="fd-notification fd-notificat
             </div>
             <div class="fd-notification__actions">
                 <button class="fd-button fd-button--compact">Accept All</button>
-                <button class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss" aria-label="Close">
+                <button class="fd-button fd-button--transparent fd-button--compact " aria-label="Close">
                     <i class="sap-icon--decline"></i>
                 </button>
             </div>
         </div>
         <div class="fd-notification__body">
-            <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/3.svg')" role="img"aria-label="John Doe"></span>
+            <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/3.svg')" role="img" aria-label="John Doe"></span>
             <div class="fd-notification__content">
                 <div class="fd-notification__header">
                 <div class="fd-notification__indicator fd-notification__indicator--success"></div>
@@ -421,7 +421,7 @@ export const notificationGroup = () => `<div class="fd-notification fd-notificat
             <div class="fd-notification__actions">
                 <button class="fd-button fd-button--compact">Open</button>
 
-                <button class="fd-button fd-button--transparent fd-button--compact fd-notification__actions--dismiss" aria-label="Close">
+                <button class="fd-button fd-button--transparent fd-button--compact " aria-label="Close">
                     <i class="sap-icon--decline"></i>
                 </button>
             </div>
@@ -439,9 +439,9 @@ notificationGroup.parameters = {
 
 export const mobile = () => `<div style="heigt: 200px; max-width: 20rem">
 
-<div class="fd-notification fd-notification--mobile"">
+<div class="fd-notification fd-notification--mobile">
     <div class="fd-notification__body">
-        <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/3.svg')" role="img"aria-label="John Doe"></span>
+        <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/3.svg')" role="img" aria-label="John Doe"></span>
         <div class="fd-notification__content">
             <div class="fd-notification__header">
                 <div class="fd-notification__indicator fd-notification__indicator--success"></div>
@@ -461,7 +461,7 @@ export const mobile = () => `<div style="heigt: 200px; max-width: 20rem">
                          <i class="sap-icon--overflow"></i>
                     </button>
                 </div>
-                <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover" aria-hidden="true" id="popoverA4">
+                <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow" aria-hidden="true" id="popoverA4">
                     <nav class="fd-menu" id="">
                         <ul class="fd-menu__list fd-menu__list--no-shadow">
                             <li class="fd-menu__item">
@@ -478,7 +478,7 @@ export const mobile = () => `<div style="heigt: 200px; max-width: 20rem">
                     </nav>
                 </div>
             </div>
-            <button class="fd-button fd-button--transparent fd-notification__actions--dismiss" aria-label="Close">
+            <button class="fd-button fd-button--transparent" aria-label="Close">
                 <i class="sap-icon--decline"></i>
             </button>
         </div>
@@ -487,15 +487,13 @@ export const mobile = () => `<div style="heigt: 200px; max-width: 20rem">
 </div>
 <div style="heigt: 200px; max-width: 20rem">
     <div class="fd-notification fd-notification--mobile fd-notification--group">
-        <ul class="fd-tabs fd-tabs--l fd-notification--tabs" role="tablist">
+        <ul class="fd-tabs fd-tabs--l" role="tablist">
             <li role="tab" aria-selected="true" class="fd-tabs__item">
                 <a 
                     class="fd-tabs__link" 
                     aria-controls="notifP300" 
                     href="#notifP300">
-                    <span class="fd-tabs__tag">
-                        By Date
-                    </span>
+                    <span class="fd-tabs__tag">By Date</span>
                 </a>
             </li>
             <li role="tab" class="fd-tabs__item">
@@ -503,9 +501,7 @@ export const mobile = () => `<div style="heigt: 200px; max-width: 20rem">
                     class="fd-tabs__link" 
                     aria-controls="notifP301" 
                     href="#notifP301">
-                    <span class="fd-tabs__tag">
-                        By Type
-                    </span>
+                    <span class="fd-tabs__tag">By Type</span>
                 </a>
             </li>
             <li role="tab" class="fd-tabs__item">
@@ -513,9 +509,7 @@ export const mobile = () => `<div style="heigt: 200px; max-width: 20rem">
                     class="fd-tabs__link"
                     aria-controls="notifP302" 
                     href="#notifP302">
-                    <span class="fd-tabs__tag">
-                        By Priority
-                    </span>
+                    <span class="fd-tabs__tag">By Priority</span>
                 </a>
             </li>
         </ul>
@@ -531,13 +525,13 @@ export const mobile = () => `<div style="heigt: 200px; max-width: 20rem">
                     </div>
                 </div>
                 <div class="fd-notification__actions">
-                    <button class="fd-button fd-button--transparent fd-notification__actions--dismiss" aria-label="Close">
+                    <button class="fd-button fd-button--transparent" aria-label="Close">
                         <i class="sap-icon--decline"></i>
                     </button>
                 </div>
             </div>
             <div class="fd-notification__body">
-                <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" role="img"aria-label="John Doe">JD</span>
+                <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" role="img" aria-label="John Doe">JD</span>
                 <div class="fd-notification__content">
                     <div class="fd-notification__header">
                         <div class="fd-notification__indicator fd-notification__indicator--warning"></div>
@@ -557,7 +551,7 @@ export const mobile = () => `<div style="heigt: 200px; max-width: 20rem">
                                 <i class="sap-icon--overflow"></i>
                             </button>
                         </div>
-                        <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover" aria-hidden="true" id="popoverA3">
+                        <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow" aria-hidden="true" id="popoverA3">
                             <nav class="fd-menu" id="">
                                 <ul class="fd-menu__list fd-menu__list--no-shadow">
                                     <li class="fd-menu__item">
@@ -574,13 +568,13 @@ export const mobile = () => `<div style="heigt: 200px; max-width: 20rem">
                             </nav>
                         </div>
                     </div>
-                    <button class="fd-button fd-button--transparent fd-notification__actions--dismiss" aria-label="Close">
+                    <button class="fd-button fd-button--transparent" aria-label="Close">
                         <i class="sap-icon--decline"></i>
                     </button>
                 </div>
             </div>
             <div class="fd-notification__body">
-                <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/3.svg')" role="img"aria-label="John Doe"></span>
+                <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/3.svg')" role="img" aria-label="John Doe"></span>
                 <div class="fd-notification__content">
                     <div class="fd-notification__header">
                     <div class="fd-notification__indicator fd-notification__indicator--success"></div>
@@ -600,7 +594,7 @@ export const mobile = () => `<div style="heigt: 200px; max-width: 20rem">
                                 <i class="sap-icon--overflow"></i>
                             </button>
                         </div>
-                        <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover" aria-hidden="true" id="popoverA2">
+                        <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow" aria-hidden="true" id="popoverA2">
                             <nav class="fd-menu" id="">
                                 <ul class="fd-menu__list fd-menu__list--no-shadow">
                                     <li class="fd-menu__item">
@@ -612,7 +606,7 @@ export const mobile = () => `<div style="heigt: 200px; max-width: 20rem">
                             </nav>
                         </div>
                     </div>
-                    <button class="fd-button fd-button--transparent fd-notification__actions--dismiss" aria-label="Close">
+                    <button class="fd-button fd-button--transparent" aria-label="Close">
                         <i class="sap-icon--decline"></i>
                     </button>
                 </div>
@@ -630,13 +624,13 @@ export const mobile = () => `<div style="heigt: 200px; max-width: 20rem">
                     </div>
                 </div>
                 <div class="fd-notification__actions">
-                    <button class="fd-button fd-button--transparent fd-notification__actions--dismiss" aria-label="Close">
+                    <button class="fd-button fd-button--transparent" aria-label="Close">
                         <i class="sap-icon--decline"></i>
                     </button>
                 </div>
             </div>
             <div class="fd-notification__body">
-                <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" role="img"aria-label="John Doe">JD</span>
+                <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" role="img" aria-label="John Doe">JD</span>
                 <div class="fd-notification__content">
                     <div class="fd-notification__header">
                         <div class="fd-notification__indicator fd-notification__indicator--warning"></div>
@@ -656,7 +650,7 @@ export const mobile = () => `<div style="heigt: 200px; max-width: 20rem">
                                 <i class="sap-icon--overflow"></i>
                             </button>
                         </div>
-                        <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover" aria-hidden="true" id="popoverA42">
+                        <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow" aria-hidden="true" id="popoverA42">
                             <nav class="fd-menu" id="">
                                 <ul class="fd-menu__list fd-menu__list--no-shadow">
                                     <li class="fd-menu__item">
@@ -673,13 +667,13 @@ export const mobile = () => `<div style="heigt: 200px; max-width: 20rem">
                             </nav>
                         </div>
                     </div>
-                    <button class="fd-button fd-button--transparent fd-notification__actions--dismiss" aria-label="Close">
+                    <button class="fd-button fd-button--transparent" aria-label="Close">
                         <i class="sap-icon--decline"></i>
                     </button>
                 </div>
             </div>
             <div class="fd-notification__body">
-                <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/3.svg')" role="img"aria-label="John Doe"></span>
+                <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/3.svg')" role="img" aria-label="John Doe"></span>
                 <div class="fd-notification__content">
                     <div class="fd-notification__header">
                     <div class="fd-notification__indicator fd-notification__indicator--success"></div>
@@ -699,7 +693,7 @@ export const mobile = () => `<div style="heigt: 200px; max-width: 20rem">
                                 <i class="sap-icon--overflow"></i>
                             </button>
                         </div>
-                        <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover" aria-hidden="true" id="popoverA245">
+                        <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow" aria-hidden="true" id="popoverA245">
                             <nav class="fd-menu" id="">
                                 <ul class="fd-menu__list fd-menu__list--no-shadow">
                                     <li class="fd-menu__item">
@@ -711,7 +705,7 @@ export const mobile = () => `<div style="heigt: 200px; max-width: 20rem">
                             </nav>
                         </div>
                     </div>
-                    <button class="fd-button fd-button--transparent fd-notification__actions--dismiss" aria-label="Close">
+                    <button class="fd-button fd-button--transparent" aria-label="Close">
                         <i class="sap-icon--decline"></i>
                     </button>
                 </div>
@@ -729,13 +723,13 @@ export const mobile = () => `<div style="heigt: 200px; max-width: 20rem">
                     </div>
                 </div>
                 <div class="fd-notification__actions">
-                    <button class="fd-button fd-button--transparent fd-notification__actions--dismiss" aria-label="Close">
+                    <button class="fd-button fd-button--transparent" aria-label="Close">
                         <i class="sap-icon--decline"></i>
                     </button>
                 </div>
             </div>
             <div class="fd-notification__body">
-                <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" role="img"aria-label="John Doe">JD</span>
+                <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" role="img" aria-label="John Doe">JD</span>
                 <div class="fd-notification__content">
                     <div class="fd-notification__header">
                         <div class="fd-notification__indicator fd-notification__indicator--warning"></div>
@@ -755,7 +749,7 @@ export const mobile = () => `<div style="heigt: 200px; max-width: 20rem">
                                 <i class="sap-icon--overflow"></i>
                             </button>
                         </div>
-                        <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover" aria-hidden="true" id="popoverA5">
+                        <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow" aria-hidden="true" id="popoverA5">
                             <nav class="fd-menu" id="">
                                 <ul class="fd-menu__list fd-menu__list--no-shadow">
                                     <li class="fd-menu__item">
@@ -772,13 +766,13 @@ export const mobile = () => `<div style="heigt: 200px; max-width: 20rem">
                             </nav>
                         </div>
                     </div>
-                    <button class="fd-button fd-button--transparent fd-notification__actions--dismiss" aria-label="Close">
+                    <button class="fd-button fd-button--transparent" aria-label="Close">
                         <i class="sap-icon--decline"></i>
                     </button>
                 </div>
             </div>
             <div class="fd-notification__body">
-                <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/3.svg')" role="img"aria-label="John Doe"></span>
+                <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/3.svg')" role="img" aria-label="John Doe"></span>
                 <div class="fd-notification__content">
                     <div class="fd-notification__header">
                     <div class="fd-notification__indicator fd-notification__indicator--success"></div>
@@ -798,7 +792,7 @@ export const mobile = () => `<div style="heigt: 200px; max-width: 20rem">
                                 <i class="sap-icon--overflow"></i>
                             </button>
                         </div>
-                        <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow fd-notification__actions--popover" aria-hidden="true" id="popoverA43212">
+                        <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow" aria-hidden="true" id="popoverA43212">
                             <nav class="fd-menu" id="">
                                 <ul class="fd-menu__list fd-menu__list--no-shadow">
                                     <li class="fd-menu__item">
@@ -810,7 +804,7 @@ export const mobile = () => `<div style="heigt: 200px; max-width: 20rem">
                             </nav>
                         </div>
                     </div>
-                    <button class="fd-button fd-button--transparent fd-notification__actions--dismiss" aria-label="Close">
+                    <button class="fd-button fd-button--transparent" aria-label="Close">
                         <i class="sap-icon--decline"></i>
                     </button>
                 </div>


### PR DESCRIPTION
## Related Issue
NA

## Description
- removed unused and unnecessary classes
- deleted the rule that removes the border bottom from the last notification in the notification list/group
- added margin for every child inside actions, not only for buttons as we can have a popover 
- fixed the RTL rules for the actions

BREAKING CHANGE:
- removed classes: `fd-notification__actions--dismiss`, `fd-notification--tabs` and `fd-notification__actions--popover`

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] RTL support
2. The code follows fundamental-styles code standards and style
NA
3. Testing
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
