### PR TITLE
fix: avatar zoom icon issues

### DIFF
--- a/src/avatar.scss
+++ b/src/avatar.scss
@@ -65,11 +65,9 @@ $block: #{$fd-namespace}-avatar;
 
   &__icon {
     @include fd-icon-element-base() {
-      // Added in order to trully center the icon inside it's container
-      display: flex;
-      align-content: center;
-      justify-content: center;
-      align-items: center;
+      @include fd-flex-center() {
+        align-content: center;
+      }
     }
   }
 

--- a/src/avatar.scss
+++ b/src/avatar.scss
@@ -64,7 +64,13 @@ $block: #{$fd-namespace}-avatar;
   }
 
   &__icon {
-    @include fd-icon-element-base();
+    @include fd-icon-element-base() {
+      // Added in order to trully center the icon inside it's container
+      display: flex;
+      align-content: center;
+      justify-content: center;
+      align-items: center;
+    }
   }
 
   // BLOCK MODIFIERS ************
@@ -136,12 +142,20 @@ $block: #{$fd-namespace}-avatar;
           font-size: map_get($size-set, "beforeFontSize");
           width: map_get($size-set, "zoomIconDimensions");
           height: map_get($size-set, "zoomIconDimensions");
-          bottom: map_get($size-set, "offset");
-          right: map_get($size-set, "offset");
+        }
+      }
 
-          @include fd-rtl() {
-            right: auto;
-            left: map_get($size-set, "offset");
+      // Do not modify alignment of the icon if it's circle avatar
+      &:not(.#{$block}--circle) {
+        .#{$block}__zoom-icon {
+          @include fd-icon-selector() {
+            bottom: map_get($size-set, "offset");
+            right: map_get($size-set, "offset");
+
+            @include fd-rtl() {
+              right: auto;
+              left: map_get($size-set, "offset");
+            }
           }
         }
       }


### PR DESCRIPTION
## Related Issue
Closes #2111

## Description
Fixed:
* Position of the zoom icon for circle avatar
* Vertical centering for the icons and text inside avatar

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/6586561/116120286-0d324380-a6c8-11eb-863b-6b4f2bf564c9.png)

### After:
![image](https://user-images.githubusercontent.com/6586561/116120415-2d620280-a6c8-11eb-9f7a-0dfcc9f238f9.png)


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x]hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x]`fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
