### PR TITLE
fix: Align borders properly for fixed columns

### DIFF
--- a/src/table.scss
+++ b/src/table.scss
@@ -65,6 +65,7 @@ $block: #{$fd-namespace}-table;
   $fd-table-compact-cell-height: 2rem;
   $fd-table-navigation-icon-width: 2rem;
   $fd-table-condensed-cell-height: 1.5rem;
+  $fd-table-fixed-cell-shift: 0.05rem;
 
   // Thanks to table-cell specification, if the width is set to small value, the cell will have content width
   $fd-table-cell-fit-content-width: 0.5rem;
@@ -121,6 +122,19 @@ $block: #{$fd-namespace}-table;
       height: $fd-table-cozy-cell-height;
       background-color: var(--sapList_HeaderBackground);
       color: var(--sapList_HeaderTextColor);
+
+      &--fixed {
+        margin-top: -$fd-table-fixed-cell-shift;
+        border-top: $fd-table-border;
+        border-right: $fd-table-fixed-cell-border;
+        border-left: $fd-table-border;
+        height: $fd-table-cozy-cell-height + $fd-table-fixed-cell-shift;
+
+        @include fd-rtl() {
+          border-left: $fd-table-fixed-cell-border;
+          border-right: $fd-table-border;
+        }
+      }
     }
   }
 
@@ -206,7 +220,8 @@ $block: #{$fd-namespace}-table;
       position: absolute;
       background-color: inherit;
       border-bottom: $fd-table-border;
-      margin-top: 0.05rem;
+      border-left: $fd-table-border;
+      margin-top: $fd-table-fixed-cell-shift;
 
       @include fd-flex-vertical-center();
 
@@ -223,7 +238,7 @@ $block: #{$fd-namespace}-table;
         right: 0;
 
         &:last-of-type {
-          border-right: none;
+          border-right: $fd-table-border;
           border-left: $fd-table-fixed-cell-border;
         }
       }
@@ -570,6 +585,10 @@ $block: #{$fd-namespace}-table;
     .#{$block}__header {
       .#{$block}__cell {
         height: $fd-table-compact-cell-height;
+
+        &--fixed {
+          height: $fd-table-compact-cell-height + $fd-table-fixed-cell-shift;
+        }
       }
     }
   }

--- a/src/table.scss
+++ b/src/table.scss
@@ -206,7 +206,7 @@ $block: #{$fd-namespace}-table;
       position: absolute;
       background-color: inherit;
       border-bottom: $fd-table-border;
-      margin-top: 0.0375rem;
+      margin-top: 0.05rem;
 
       @include fd-flex-vertical-center();
 

--- a/src/table.scss
+++ b/src/table.scss
@@ -71,7 +71,7 @@ $block: #{$fd-namespace}-table;
 
   $fd-table-basic-background: var(--sapList_Background);
   $fd-table-border: var(--sapList_BorderWidth) solid var(--sapList_BorderColor);
-  $fd-table-fixed-cell-border: 0.125rem var(--sapList_TableFixedBorderColor) solid;
+  $fd-table-fixed-cell-border: var(--sapList_BorderWidth) solid var(--sapList_TableFixedBorderColor);
 
   // BLOCK BASE *******************************************
   // set all BLOCK reset and baseline styles
@@ -206,6 +206,7 @@ $block: #{$fd-namespace}-table;
       position: absolute;
       background-color: inherit;
       border-bottom: $fd-table-border;
+      margin-top: 0.0375rem;
 
       @include fd-flex-vertical-center();
 
@@ -294,6 +295,14 @@ $block: #{$fd-namespace}-table;
         @include fd-selected() {
           @include fd-active() {
             background-color: var(--sapList_Active_Background);
+          }
+        }
+      }
+
+      @include fd-first-child() {
+        .#{$block}__cell {
+          &--fixed {
+            margin-top: 0;
           }
         }
       }


### PR DESCRIPTION
## Related Issue
Closes #1948 

## Description
Change fixed column border width.
Shift fixed columns down so that bottom border would be visible

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/6586561/116218134-e4a35b80-a752-11eb-8bcb-bf59d732e000.png)


### After:
![image](https://user-images.githubusercontent.com/6586561/116556174-dea1ac00-a905-11eb-8efd-0fe421db2058.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
