### PR TITLE
fix: vertically align close button for compact token

### DIFF
--- a/src/token.scss
+++ b/src/token.scss
@@ -103,13 +103,13 @@ $block: #{$fd-namespace}-token;
   @include fd-token-focus();
 
   &--compact {
-    padding: 0 0 $fd-token-compact-padding-vertical $fd-token-compact-padding-horizontal;
+    padding: $fd-token-compact-padding-vertical 0 $fd-token-compact-padding-vertical $fd-token-compact-padding-horizontal;
     height: $fd-token-compact-height;
     min-width: 3rem;
     line-height: 1.125rem;
 
     .#{$block}__close {
-      padding: ($fd-token-compact-padding-vertical * 2) $fd-token-compact-padding-horizontal $fd-token-compact-padding-vertical;
+      padding: $fd-token-compact-padding-vertical $fd-token-compact-padding-horizontal;
       vertical-align: baseline;
       width: $fd-token-compact-close-width;
       min-width: $fd-token-compact-close-width;

--- a/src/token.scss
+++ b/src/token.scss
@@ -109,7 +109,7 @@ $block: #{$fd-namespace}-token;
     line-height: 1.125rem;
 
     .#{$block}__close {
-      padding: $fd-token-compact-padding-vertical $fd-token-compact-padding-horizontal;
+      padding: ($fd-token-compact-padding-vertical * 2) $fd-token-compact-padding-horizontal $fd-token-compact-padding-vertical;
       vertical-align: baseline;
       width: $fd-token-compact-close-width;
       min-width: $fd-token-compact-close-width;


### PR DESCRIPTION
## Related Issue
Closes #1731

## Description
Change close button padding to vertically center the icon inside.

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/6586561/116221012-e1f63580-a755-11eb-830f-fa05d39d9f8f.png)


### After:
![image](https://user-images.githubusercontent.com/6586561/116221072-f5a19c00-a755-11eb-9a26-737246be6aeb.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
