### PR TITLE
fix: checkbox make square smaller in order for browser to evenly move it from the center

### DIFF
--- a/src/checkbox.scss
+++ b/src/checkbox.scss
@@ -121,7 +121,8 @@ $block: #{$fd-namespace}-checkbox;
 
   &:indeterminate + .#{$block}__label--compact::before {
     content: "\e17b";
-    font-size: 0.5625rem;
+    font-size: 0.5rem;
+    padding: 0;
   }
 
   // states

--- a/src/checkbox.scss
+++ b/src/checkbox.scss
@@ -115,14 +115,12 @@ $block: #{$fd-namespace}-checkbox;
 
   &:indeterminate + .#{$block}__label::before {
     content: "\e17b";
-    font-size: 0.8125rem;
-    padding-top: 0.0625rem;
+    font-size: 0.75rem;
   }
 
   &:indeterminate + .#{$block}__label--compact::before {
     content: "\e17b";
     font-size: 0.5rem;
-    padding: 0;
   }
 
   // states

--- a/src/checkbox.scss
+++ b/src/checkbox.scss
@@ -120,7 +120,7 @@ $block: #{$fd-namespace}-checkbox;
 
   &:indeterminate + .#{$block}__label--compact::before {
     content: "\e17b";
-    font-size: 0.5rem;
+    font-size: 0.6rem;
   }
 
   // states


### PR DESCRIPTION
## Related Issue
Closes #2152 

## Description
Make square smaller for compact checkbox, that way browser could evenly center it vertically and horizontally.

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/6586561/116234085-d2321d80-a764-11eb-837a-b6efffd6d714.png)


### After:
![image](https://user-images.githubusercontent.com/6586561/116234115-dc541c00-a764-11eb-8391-1ccd65977871.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
