### PR TITLE
feat: implement vertical nav

### DIFF
--- a/.storybook/static/preview-head.js
+++ b/.storybook/static/preview-head.js
@@ -383,16 +383,11 @@ function collectionHas(a, b) { //helper function (see below)
     return false;
 }
 
-function toggleCondensedVerticalNavSubmenu(event, source) {
-    let button;
-    if (source === 'child') {
-        button = event.target.parentElement.parentElement.parentElement.parentElement;
-    }
-    else if (source === 'parent') {
-        button = event.target;
-        if (button.tagName.toLowerCase() !== 'li') {
-            button = event.target.parentNode;
-        }
+function toggleCondensedVerticalNavSubmenu(event) {
+    let button = event.target;
+
+    while (button.id !== 'parentCalendarButton') {
+        button = button.parentNode;
     }
 
     if(!button.classList.contains('is-expanded')) {

--- a/.storybook/static/preview-head.js
+++ b/.storybook/static/preview-head.js
@@ -376,10 +376,23 @@ function toggleNestedListSubmenu(event) {
     }
 }
 
-function toggleCondensedVerticalNavSubmenu(event) {
-    let button = event.target;
-    if (button.tagName.toLowerCase() !== 'li') {
-        button = event.target.parentNode;
+function collectionHas(a, b) { //helper function (see below)
+    for(var i = 0, len = a.length; i < len; i ++) {
+        if(a[i] == b) return true;
+    }
+    return false;
+}
+
+function toggleCondensedVerticalNavSubmenu(event, source) {
+    let button;
+    if (source === 'child') {
+        button = event.target.parentElement.parentElement.parentElement.parentElement;
+    }
+    else if (source === 'parent') {
+        button = event.target;
+        if (button.tagName.toLowerCase() !== 'li') {
+            button = event.target.parentNode;
+        }
     }
 
     if(!button.classList.contains('is-expanded')) {

--- a/.storybook/static/preview-head.js
+++ b/.storybook/static/preview-head.js
@@ -384,6 +384,7 @@ function toggleVerticalNavSubmenu(event) {
     let arrowIcon = button.querySelector('.fd-list__navigation-item__arrow');
 
     if(arrowIcon && arrowIcon.classList.contains('is-expanded')) {
+        button.classList.remove('is-expanded');
         arrowIcon.classList.add('sap-icon--navigation-right-arrow');
         arrowIcon.classList.remove('sap-icon--navigation-down-arrow');
         arrowIcon.classList.remove('is-expanded');
@@ -392,6 +393,7 @@ function toggleVerticalNavSubmenu(event) {
             second.style.display = 'none';
         });
     } else if (arrowIcon) {
+        button.classList.add('is-expanded');
         arrowIcon.classList.remove('sap-icon--navigation-right-arrow');
         arrowIcon.classList.add('sap-icon--navigation-down-arrow');
         arrowIcon.classList.add('is-expanded');

--- a/.storybook/static/preview-head.js
+++ b/.storybook/static/preview-head.js
@@ -375,3 +375,29 @@ function toggleNestedListSubmenu(event) {
         icon.classList = 'sap-icon--navigation-down-arrow';
     }
 }
+
+function toggleVerticalNavSubmenu(event) {
+    let button = event.target;
+    if (button.tagName.toLowerCase() !== 'li') {
+        button = event.target.parentNode;
+    }
+    let arrowIcon = button.querySelector('.fd-list__navigation-item__arrow');
+
+    if(arrowIcon && arrowIcon.classList.contains('is-expanded')) {
+        arrowIcon.classList.add('sap-icon--navigation-right-arrow');
+        arrowIcon.classList.remove('sap-icon--navigation-down-arrow');
+        arrowIcon.classList.remove('is-expanded');
+        const seconds = arrowIcon.parentElement.getElementsByTagName('ul');
+        seconds.forEach(second => {
+            second.style.display = 'none';
+        });
+    } else if (arrowIcon) {
+        arrowIcon.classList.remove('sap-icon--navigation-right-arrow');
+        arrowIcon.classList.add('sap-icon--navigation-down-arrow');
+        arrowIcon.classList.add('is-expanded');
+        const seconds = arrowIcon.parentElement.getElementsByTagName('ul');
+        seconds.forEach(second => {
+            second.style.display = 'block';
+        });
+    }
+}

--- a/.storybook/static/preview-head.js
+++ b/.storybook/static/preview-head.js
@@ -376,6 +376,19 @@ function toggleNestedListSubmenu(event) {
     }
 }
 
+function toggleCondensedVerticalNavSubmenu(event) {
+    let button = event.target;
+    if (button.tagName.toLowerCase() !== 'li') {
+        button = event.target.parentNode;
+    }
+
+    if(!button.classList.contains('is-expanded')) {
+        button.classList.add('is-expanded');
+    } else if(button.classList.contains('is-expanded')) {
+        button.classList.remove('is-expanded');
+    }
+}
+
 function toggleVerticalNavSubmenu(event) {
     let button = event.target;
     if (button.tagName.toLowerCase() !== 'li') {
@@ -385,21 +398,13 @@ function toggleVerticalNavSubmenu(event) {
 
     if(arrowIcon && arrowIcon.classList.contains('is-expanded')) {
         button.classList.remove('is-expanded');
+        arrowIcon.classList.remove('is-expanded');
         arrowIcon.classList.add('sap-icon--navigation-right-arrow');
         arrowIcon.classList.remove('sap-icon--navigation-down-arrow');
-        arrowIcon.classList.remove('is-expanded');
-        const seconds = arrowIcon.parentElement.getElementsByTagName('ul');
-        seconds.forEach(second => {
-            second.style.display = 'none';
-        });
     } else if (arrowIcon) {
         button.classList.add('is-expanded');
+        arrowIcon.classList.add('is-expanded');
         arrowIcon.classList.remove('sap-icon--navigation-right-arrow');
         arrowIcon.classList.add('sap-icon--navigation-down-arrow');
-        arrowIcon.classList.add('is-expanded');
-        const seconds = arrowIcon.parentElement.getElementsByTagName('ul');
-        seconds.forEach(second => {
-            second.style.display = 'block';
-        });
     }
 }

--- a/.storybook/static/preview-head.js
+++ b/.storybook/static/preview-head.js
@@ -407,7 +407,7 @@ function toggleVerticalNavSubmenu(event) {
     if (button.tagName.toLowerCase() !== 'li') {
         button = event.target.parentNode;
     }
-    let arrowIcon = button.querySelector('.fd-list__navigation-item__arrow');
+    let arrowIcon = button.querySelector('.fd-list__navigation-item-arrow');
 
     if(arrowIcon && arrowIcon.classList.contains('is-expanded')) {
         button.classList.remove('is-expanded');

--- a/config/bundlesize.json
+++ b/config/bundlesize.json
@@ -2,7 +2,7 @@
     "files": [
         {
             "path": "./dist/fundamental-styles.css",
-            "maxSize": "94 kB"
+            "maxSize": "100 kB"
         }
     ]
 }

--- a/src/_listNavigationItem.scss
+++ b/src/_listNavigationItem.scss
@@ -1,14 +1,18 @@
-@import "./listDefinitions.scss";
+@import './listDefinitions.scss';
 
-$fd-list-navigation-item-height: 2.75rem;
+$fd-list-navigation-item-height: 2.75rem !default;
+$fd-list-navigation-item-indicator-spacing: 0.3125rem !default;
+$fd-list-navigation-item-text-spacing: 2.5rem !default;
 
 .#{$block} {
   list-style-type: none;
   background: var(--sapList_AlternatingBackground);
 
   .#{$block}__navigation-item-indicator {
+    @include fd-reset();
+
     &::after {
-      content: "";
+      content: '';
       width: 0.1875rem;
       display: inline-block;
       position: absolute;
@@ -18,7 +22,7 @@ $fd-list-navigation-item-height: 2.75rem;
       background-color: var(--sapSelectedColor);
       color: var(--sapSelectedColor);
       border-radius: var(--sapField_BorderCornerRadius);
-      margin-right: 0.3125rem;
+      margin-right: $fd-list-navigation-item-indicator-spacing;
     }
 
     @include fd-rtl() {
@@ -26,7 +30,7 @@ $fd-list-navigation-item-height: 2.75rem;
         right: unset;
         margin-right: 0;
         left: 0;
-        margin-left: 0.3125rem;
+        margin-left: $fd-list-navigation-item-indicator-spacing;
       }
     }
   }
@@ -34,39 +38,30 @@ $fd-list-navigation-item-height: 2.75rem;
   &__navigation-item {
     @include fd-reset();
     @include fd-fiori-focus();
+    @include set-paddings-x(0.5rem, 1rem);
 
     background: transparent;
     height: $fd-list-navigation-item-height;
-    width: auto;
-    padding-left: 0.5rem;
-    padding-right: 1rem;
     position: relative;
-
-    @include fd-rtl() {
-      padding-right: 0.5rem;
-      padding-left: 1rem;
-    }
 
     .fd-list {
       display: none;
     }
 
     &--expandable {
-      margin-top: 0.25rem;
-      margin-bottom: 0.25rem;
+      margin: 0.25rem 0;
     }
 
     &.is-expanded {
-      margin-left: 0.25rem;
-      margin-right: 0.25rem;
+      @include set-margins-x(0.25rem, 0.25rem);
+
       border-radius: var(--sapElement_BorderCornerRadius);
       box-shadow: var(--sapContent_Shadow0);
-      height: auto;
+      height: 100%;
       overflow: hidden;
 
       .#{$block}__navigation-item {
-        width: auto;
-
+        width: 100%;
         .#{$block}__navigation-item-indicator {
           &::after {
             margin-right: 0;
@@ -83,54 +78,36 @@ $fd-list-navigation-item-height: 2.75rem;
           @include fd-reset();
 
           vertical-align: middle;
-          line-height: 2.75rem;
+          line-height: $fd-list-navigation-item-height;
           color: var(--sapContent_LabelColor);
           font-size: var(--sapFontSize);
-          margin-left: 2.5rem;
+          margin-left: $fd-list-navigation-item-text-spacing;
 
           @include fd-rtl() {
-            margin-right: 2.5rem;
+            margin-right: $fd-list-navigation-item-text-spacing;
             margin-left: 0;
           }
         }
       }
 
       .#{$block}__navigation-item-text {
-        padding-left: 0;
-
-        @include fd-rtl() {
-          padding-right: 0;
-        }
+        @include set-padding-left();
       }
 
       .#{$block}__navigation-item-icon {
-        padding-right: 0.5rem;
-
-        @include fd-rtl() {
-          padding-right: 0;
-          padding-left: 0.5rem;
-        }
+        @include set-padding-right(0.5rem);
       }
 
       .#{$block} {
-        margin-right: -1rem;
-        margin-left: -0.5rem;
+        @include set-margins-x(-0.5rem, -1rem);
+
         width: auto;
         display: block;
-
-        @include fd-rtl() {
-          margin-left: -1rem;
-          margin-right: -0.5rem;
-        }
       }
 
       .#{$block}__navigation-item-indicator {
         &::after {
-          margin-right: 0;
-
-          @include fd-rtl() {
-            margin-left: 0;
-          }
+          @include set-margin-right();
         }
       }
     }
@@ -156,16 +133,10 @@ $fd-list-navigation-item-height: 2.75rem;
     }
 
     &--condensed {
+      @include set-paddings-x();
+
       position: relative;
       width: 3.25rem;
-      padding-left: 0;
-      padding-right: 0;
-
-      @include fd-rtl() {
-        width: 3.25rem;
-        padding-left: 0;
-        padding-right: 0;
-      }
 
       .#{$block}__navigation-item-popover {
         &--first-level,
@@ -180,10 +151,10 @@ $fd-list-navigation-item-height: 2.75rem;
       }
 
       .#{$block}__navigation-item-icon {
+        @include set-margins-x(0.5rem, 0.5rem);
+
         height: $fd-list-navigation-item-height;
         line-height: $fd-list-navigation-item-height;
-        margin-left: 0.5rem;
-        margin-right: 0.5rem;
       }
 
       &.is-expanded {
@@ -192,13 +163,7 @@ $fd-list-navigation-item-height: 2.75rem;
         visibility: hidden;
 
         .#{$block}__navigation-item {
-          width: auto;
-          margin-left: 0;
-
-          @include fd-rtl() {
-            margin-left: 0;
-            margin-right: 0;
-          }
+          @include set-margins-x();
         }
 
         .#{$block}__navigation-item--condensed {
@@ -227,15 +192,8 @@ $fd-list-navigation-item-height: 2.75rem;
             }
 
             .#{$block}__navigation-item-text {
-              padding-left: 0;
-              margin-left: 0;
-
-              @include fd-rtl() {
-                padding-left: 0;
-                padding-right: 0;
-                margin-left: 0;
-                margin-right: 0;
-              }
+              @include set-margin-left();
+              @include set-padding-left();
             }
           }
 
@@ -245,6 +203,7 @@ $fd-list-navigation-item-height: 2.75rem;
             width: 14.325rem;
             border-bottom-right-radius: 0;
             z-index: 3;
+            height: 100%;
 
             @include fd-rtl() {
               border-bottom-left-radius: 0;
@@ -266,27 +225,16 @@ $fd-list-navigation-item-height: 2.75rem;
               right: 3.25rem;
             }
 
-            .fd-list {
-              .#{$block}__navigation-item {
-                .#{$block}__navigation-item-text {
-                  margin-left: 1rem;
+            .#{$block}__navigation-item {
+              .#{$block}__navigation-item-text {
+                @include set-margin-left(1rem);
+              }
 
-                  @include fd-rtl() {
-                    margin-left: 0;
-                    margin-right: 1rem;
-                  }
-                }
+              .#{$block}__navigation-item-indicator {
+                &::after {
+                  @include set-margin-right();
 
-                .#{$block}__navigation-item-indicator {
-                  &::after {
-                    margin-right: 0;
-                    display: inline-block;
-
-                    @include fd-rtl() {
-                      margin-right: 0;
-                      margin-left: 0;
-                    }
-                  }
+                  display: inline-block;
                 }
               }
             }
@@ -313,7 +261,7 @@ $fd-list-navigation-item-height: 2.75rem;
 
         &::before {
           display: inline-block;
-          content: "";
+          content: '';
           min-width: 0;
           min-height: 0;
           margin-right: 0.75rem;
@@ -337,7 +285,7 @@ $fd-list-navigation-item-height: 2.75rem;
 
     &-icon {
       font-size: 1rem;
-      font-family: "SAP-icons";
+      font-family: 'SAP-icons';
       height: $fd-list-navigation-item-height;
       line-height: $fd-list-navigation-item-height;
       width: 2.25rem;
@@ -347,21 +295,17 @@ $fd-list-navigation-item-height: 2.75rem;
     }
 
     &-text {
+      @include set-padding-left(0.25rem);
+
       font-size: var(--sapFontLargeSize);
       font-family: var(--sapFontFamily);
       color: var(--sapList_TextColor);
-      padding-left: 0.25rem;
       max-width: 9rem;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
       display: inline-block;
       line-height: $fd-list-navigation-item-height;
-
-      @include fd-rtl() {
-        padding-left: 0;
-        padding-right: 0.25rem;
-      }
     }
 
     &-arrow {
@@ -374,7 +318,7 @@ $fd-list-navigation-item-height: 2.75rem;
       position: absolute;
       right: 0;
       line-height: $fd-list-navigation-item-height;
-      font-family: "SAP-icons";
+      font-family: 'SAP-icons';
       font-size: 1rem;
       color: var(--sapContent_NonInteractiveIconColor);
       background-color: transparent;

--- a/src/_listNavigationItem.scss
+++ b/src/_listNavigationItem.scss
@@ -1,5 +1,7 @@
 @import "./listDefinitions.scss";
 
+$fd-list-navigation-item-height: 2.75rem;
+
 .#{$block} {
   list-style-type: none;
   background: var(--sapList_AlternatingBackground);
@@ -18,14 +20,24 @@
       border-radius: var(--sapField_BorderCornerRadius);
       margin-right: 0.3125rem;
     }
+
+    @include fd-rtl() {
+      &::after {
+        right: unset;
+        margin-right: 0;
+        left: 0;
+        margin-left: 0.3125rem;
+      }
+    }
   }
 
   &__navigation-item {
+    @include fd-reset();
     @include fd-fiori-focus();
 
     background: transparent;
-    height: 2.75rem;
-    width: 13.5rem;
+    height: $fd-list-navigation-item-height;
+    width: auto;
     padding-left: 0.5rem;
     padding-right: 1rem;
     position: relative;
@@ -34,25 +46,67 @@
       display: none;
     }
 
+    &--expandable {
+      margin-top: 0.25rem;
+      margin-bottom: 0.25rem;
+    }
+
     &.is-expanded {
-      height: auto;
+      margin-left: 0.25rem;
+      margin-right: 0.25rem;
       border-radius: var(--sapElement_BorderCornerRadius);
       box-shadow: var(--sapContent_Shadow0);
-      width: 13rem;
-      margin: 0.25rem;
+      height: auto;
       overflow: hidden;
+
+      .#{$block}__navigation-item {
+        width: auto;
+
+        .#{$block}__navigation-item-indicator {
+          &::after {
+            margin-right: 0;
+          }
+
+          @include fd-rtl() {
+            &::after {
+              margin-left: 0;
+            }
+          }
+        }
+
+        .#{$block}__navigation-item-text {
+          color: var(--sapContent_LabelColor);
+          font-size: var(--sapFontSize);
+          margin-left: 2.5rem;
+
+          @include fd-rtl() {
+            margin-right: 2.5rem;
+            margin-left: 0;
+          }
+        }
+      }
 
       .#{$block}__navigation-item-text {
         padding-left: 0.25rem;
+
+        @include fd-rtl() {
+          padding-left: 0;
+          padding-right: 0.25rem;
+        }
       }
 
       .#{$block}__navigation-item-icon {
         padding-right: 0.5rem;
+
+        @include fd-rtl() {
+          padding-right: 0;
+          padding-left: 0.5rem;
+        }
       }
 
       .#{$block} {
-        margin-left: -0.5rem;
         margin-right: -1rem;
+        margin-left: -0.5rem;
         width: auto;
         display: block;
       }
@@ -60,6 +114,10 @@
       .#{$block}__navigation-item-indicator {
         &::after {
           margin-right: 0;
+
+          @include fd-rtl() {
+            margin-left: 0;
+          }
         }
       }
     }
@@ -67,16 +125,6 @@
     &.is-expanded > .#{$block}__navigation-item-indicator {
       &::after {
         display: none;
-      }
-    }
-
-    &--second {
-      width: auto;
-
-      .#{$block}__navigation-item-text {
-        color: var(--sapContent_LabelColor);
-        font-size: var(--sapFontSize);
-        margin-left: 2.5rem;
       }
     }
 
@@ -90,7 +138,7 @@
       }
     }
 
-    .#{$block}__navigation-item--second.#{$block}__navigation-item--indicated .#{$block}__navigation-item-text {
+    .#{$block}__navigation-item--indicated .#{$block}__navigation-item-text {
       color: var(--sapSelectedColor);
     }
 
@@ -100,9 +148,15 @@
       padding-left: 0;
       padding-right: 0;
 
+      @include fd-rtl() {
+        width: 3.25rem;
+        padding-left: 0;
+        padding-right: 0;
+      }
+
       .#{$block}__navigation-item-popover {
-        &--first,
-        &--second {
+        &--first-level,
+        &--second-level {
           display: none;
           background: var(--sapList_AlternatingBackground);
         }
@@ -113,16 +167,10 @@
       }
 
       .#{$block}__navigation-item-icon {
-        height: 2.75rem;
-        line-height: 2.75rem;
+        height: $fd-list-navigation-item-height;
+        line-height: $fd-list-navigation-item-height;
         margin-left: 0.5rem;
         margin-right: 0.5rem;
-      }
-
-      .#{$block}__navigation-item--second {
-        display: none;
-        width: auto;
-        margin-left: 0;
       }
 
       &.is-expanded {
@@ -130,56 +178,105 @@
         margin: 0;
         visibility: hidden;
 
-        .#{$block}__navigation-item--condensed {
+        .#{$block}__navigation-item {
           width: auto;
+          margin-left: 0;
 
+          @include fd-rtl() {
+            margin-left: 0;
+            margin-right: 0;
+          }
+        }
+
+        .#{$block}__navigation-item--condensed {
           .#{$block}__navigation-item-icon {
+            margin-left: 0;
             padding-left: 0.875rem;
+
+            @include fd-rtl() {
+              margin-right: 0;
+              margin-left: 0.5rem;
+              padding-right: 0.875rem;
+            }
           }
         }
 
         .#{$block}__navigation-item-popover {
-          &--first,
-          &--second {
+          &--first-level,
+          &--second-level {
             overflow: hidden;
             display: block;
 
-            .#{$block}__navigation-item-text {
-              padding-left: 0;
+            .fd-list {
+              width: 100%;
+              display: inline-block;
+              margin: 0 auto;
             }
 
-            .#{$block}__navigation-item--second {
-              display: block;
-              width: 11.4rem;
-              padding-left: 0.5rem;
+            .#{$block}__navigation-item-text {
+              padding-left: 0;
+              margin-left: 0;
 
-              .#{$block}__navigation-item-text {
-                margin-left: 1rem;
-              }
-
-              .#{$block}__navigation-item-indicator {
-                &::after {
-                  margin-right: 0;
-                  display: inline-block;
-                }
+              @include fd-rtl() {
+                padding-left: 0;
+                padding-right: 0;
+                margin-left: 0;
+                margin-right: 0;
               }
             }
           }
 
-          &--first {
+          &--first-level {
             top: 0;
             left: 0.325rem;
             width: 14.325rem;
             border-bottom-right-radius: 0;
             z-index: 3;
+
+            @include fd-rtl() {
+              border-bottom-left-radius: 0;
+              border-bottom-right-radius: var(--sapElement_BorderCornerRadius);
+              left: unset;
+              right: 0.325rem;
+            }
           }
 
-          &--second {
+          &--second-level {
             border-top-right-radius: 0;
             border-top-left-radius: 0;
-            top: 2.75rem;
+            top: $fd-list-navigation-item-height;
             left: 3.25rem;
             width: 11.4rem;
+
+            @include fd-rtl() {
+              left: unset;
+              right: 3.25rem;
+            }
+
+            .fd-list {
+              .#{$block}__navigation-item {
+                .#{$block}__navigation-item-text {
+                  margin-left: 1rem;
+
+                  @include fd-rtl() {
+                    margin-left: 0;
+                    margin-right: 1rem;
+                  }
+                }
+
+                .#{$block}__navigation-item-indicator {
+                  &::after {
+                    margin-right: 0;
+                    display: inline-block;
+
+                    @include fd-rtl() {
+                      margin-right: 0;
+                      margin-left: 0;
+                    }
+                  }
+                }
+              }
+            }
           }
         }
 
@@ -214,6 +311,13 @@
           right: 0;
           bottom: 0;
           position: absolute;
+
+          @include fd-rtl() {
+            right: unset;
+            margin-right: 0;
+            margin-left: 0.75rem;
+            left: 0;
+          }
         }
       }
     }
@@ -221,8 +325,8 @@
     &-icon {
       font-size: 1rem;
       font-family: "SAP-icons";
-      height: 2.75rem;
-      line-height: 2.75rem;
+      height: $fd-list-navigation-item-height;
+      line-height: $fd-list-navigation-item-height;
       width: 2.25rem;
       color: var(--sapContent_NonInteractiveIconColor);
       vertical-align: top;
@@ -234,12 +338,17 @@
       font-family: var(--sapFontFamily);
       color: var(--sapList_TextColor);
       padding-left: 0.5rem;
-      max-width: 8.5rem;
+      max-width: 8rem;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
       display: inline-block;
-      line-height: 2.75rem;
+      line-height: $fd-list-navigation-item-height;
+
+      @include fd-rtl() {
+        padding-left: 0;
+        padding-right: 0.5rem;
+      }
     }
 
     &-arrow {
@@ -247,15 +356,21 @@
       @include fd-button-reset();
       @include fd-fiori-focus();
 
-      height: 2.75rem;
+      height: $fd-list-navigation-item-height;
       width: 2.75rem;
       position: absolute;
       right: 0;
-      line-height: 2.75rem;
+      line-height: $fd-list-navigation-item-height;
       font-family: "SAP-icons";
       font-size: 1rem;
       color: var(--sapContent_NonInteractiveIconColor);
       background-color: transparent;
+
+      @include fd-rtl() {
+        right: unset;
+        left: 0;
+        transform: scaleX(-1);
+      }
     }
   }
 

--- a/src/_listNavigationItem.scss
+++ b/src/_listNavigationItem.scss
@@ -3,21 +3,34 @@
 .#{$block} {
   list-style-type: none;
 
-  &--navigation-item {
+  &__navigation-item {
     background: var(--sapList_AlternatingBackground);
     height: 2.75rem;
-    width: 15rem;
+    width: 13.5rem;
     padding-left: 0.5rem;
     padding-right: 1rem;
 
+    &--second {
+      width: 13rem;
+      .#{$block}__navigation-item__text {
+        font-size: var(--sapFontSize);
+        color: var(--sapContent_LabelColor);
+        margin-left: 2rem;
+      }
+    }
+
     &--condensed {
+      position: relative;
       width: 3.25rem;
 
-      .#{$block}--navigation-item__text {
+      .#{$block}__navigation-item__text {
         display: none;
       }
 
-      .#{$block}--navigation-item__arrow {
+      .#{$block}__navigation-item__arrow {
+        width: 0;
+        height: 0;
+
         &::before {
           content: "";
           min-width: 0;
@@ -33,7 +46,7 @@
         }
       }
 
-      .#{$block}--navigation-item__icon {
+      .#{$block}__navigation-item__icon {
         margin-left: 0.5rem;
         margin-right: 0.5rem;
       }
@@ -70,11 +83,12 @@
       font-family: "SAP-icons";
       font-size: 1rem;
       color: var(--sapContent_NonInteractiveIconColor);
+      text-align: end;
     }
   }
 
-  &--navigation-item,
-  &--navigation-item--condensed {
+  &__navigation-item,
+  &__navigation-item--condensed {
     @include fd-hover() {
       background: var(--sapList_Hover_Background);
     }

--- a/src/_listNavigationItem.scss
+++ b/src/_listNavigationItem.scss
@@ -351,7 +351,7 @@ $fd-list-navigation-item-height: 2.75rem;
       font-family: var(--sapFontFamily);
       color: var(--sapList_TextColor);
       padding-left: 0.25rem;
-      max-width: 8rem;
+      max-width: 9rem;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;

--- a/src/_listNavigationItem.scss
+++ b/src/_listNavigationItem.scss
@@ -21,6 +21,8 @@
   }
 
   &__navigation-item {
+    @include fd-fiori-focus();
+
     background: transparent;
     height: 2.75rem;
     width: 13.5rem;
@@ -34,7 +36,6 @@
 
     &.is-expanded {
       height: auto;
-      min-height: 2.75rem;
       border-radius: var(--sapElement_BorderCornerRadius);
       box-shadow: var(--sapContent_Shadow0);
       width: 13rem;
@@ -49,15 +50,17 @@
         padding-right: 0.5rem;
       }
 
-      .#{$block}__navigation-item-arrow {
-        margin-right: -0.375rem;
-      }
-
       .#{$block} {
         margin-left: -0.5rem;
         margin-right: -1rem;
         width: auto;
         display: block;
+      }
+
+      .#{$block}__navigation-item-indicator {
+        &::after {
+          margin-right: 0;
+        }
       }
     }
 
@@ -94,6 +97,8 @@
     &--condensed {
       position: relative;
       width: 3.25rem;
+      padding-left: 0;
+      padding-right: 0;
 
       .#{$block}__navigation-item-popover {
         &--first,
@@ -121,8 +126,16 @@
       }
 
       &.is-expanded {
+        overflow: visible;
+        margin: 0;
+        visibility: hidden;
+
         .#{$block}__navigation-item--condensed {
           width: auto;
+
+          .#{$block}__navigation-item-icon {
+            padding-left: 0.875rem;
+          }
         }
 
         .#{$block}__navigation-item-popover {
@@ -137,6 +150,8 @@
 
             .#{$block}__navigation-item--second {
               display: block;
+              width: 11.4rem;
+              padding-left: 0.5rem;
 
               .#{$block}__navigation-item-text {
                 margin-left: 1rem;
@@ -157,11 +172,6 @@
             width: 14.325rem;
             border-bottom-right-radius: 0;
             z-index: 3;
-
-            .#{$block}__navigation-item-icon {
-              margin-left: 0.175rem;
-              margin-right: 0.175rem;
-            }
           }
 
           &--second {
@@ -189,8 +199,7 @@
       }
 
       .#{$block}__navigation-item-arrow {
-        width: 0;
-        height: 0;
+        width: 100%;
 
         &::before {
           display: inline-block;
@@ -225,7 +234,7 @@
       font-family: var(--sapFontFamily);
       color: var(--sapList_TextColor);
       padding-left: 0.5rem;
-      max-width: 9rem;
+      max-width: 8.5rem;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -234,13 +243,19 @@
     }
 
     &-arrow {
+      @include fd-reset();
+      @include fd-button-reset();
+      @include fd-fiori-focus();
+
       height: 2.75rem;
+      width: 2.75rem;
+      position: absolute;
+      right: 0;
       line-height: 2.75rem;
-      float: right;
       font-family: "SAP-icons";
       font-size: 1rem;
       color: var(--sapContent_NonInteractiveIconColor);
-      text-align: end;
+      background-color: transparent;
     }
   }
 

--- a/src/_listNavigationItem.scss
+++ b/src/_listNavigationItem.scss
@@ -30,16 +30,59 @@
     }
 
     &--second {
+      /**
+       the next three lines are a hack to extend the edges of the second item to the edge of the is-expanded container,
+       which I believe is the original intention of the specs but this is not 100% clear
+       */
       padding: 0;
+      width: 14.6rem;
+      margin-left: -0.42rem;
 
       .#{$block}__navigation-item__text {
-        font-size: var(--sapFontSize);
         color: var(--sapContent_LabelColor);
-        margin-left: 2.5rem;
+        font-size: var(--sapFontSize);
+        margin-left: 2.92rem;
       }
 
       &:last-child {
         border-bottom: 0.0625rem solid var(--sapTile_BorderColor);
+      }
+    }
+
+    &--indicated {
+      position: relative;
+      color: var(--sapSelectedColor);
+
+      .#{$block}__navigation-item__indicator {
+        &::after {
+          content: "";
+          width: 0.1875rem;
+          display: inline-block;
+          position: absolute;
+          right: 0;
+          top: 0.5625rem; // (height of nav item - height of indicator) / 2
+          height: 1.625rem;
+          background-color: var(--sapSelectedColor);
+          color: var(--sapSelectedColor);
+          border-radius: var(--sapField_BorderCornerRadius);
+          margin-right: 0.3125rem;
+        }
+      }
+
+      .#{$block}__navigation-item__text,
+      .#{$block}__navigation-item__icon,
+      .#{$block}__navigation-item__arrow {
+        color: var(--sapSelectedColor);
+      }
+    }
+
+    .#{$block}__navigation-item--second .#{$block}__navigation-item--indicated .#{$block}__navigation-item__text {
+      color: var(--sapSelectedColor);
+    }
+
+    .#{$block}__navigation-item--second .#{$block}__navigation-item--indicated .#{$block}__navigation-item__indicator {
+      &::after {
+        margin-right: 0.125rem;
       }
     }
 

--- a/src/_listNavigationItem.scss
+++ b/src/_listNavigationItem.scss
@@ -3,12 +3,29 @@
 .#{$block} {
   list-style-type: none;
 
+  .#{$block}__navigation-item__indicator {
+    &::after {
+      content: "";
+      width: 0.1875rem;
+      display: inline-block;
+      position: absolute;
+      right: 0;
+      top: 0.5625rem; // (height of nav item - height of indicator) / 2
+      height: 1.625rem;
+      background-color: var(--sapSelectedColor);
+      color: var(--sapSelectedColor);
+      border-radius: var(--sapField_BorderCornerRadius);
+      margin-right: 0.3125rem;
+    }
+  }
+
   &__navigation-item {
     background: var(--sapList_AlternatingBackground);
     min-height: 2.75rem;
     width: 13.5rem;
     padding-left: 0.5rem;
     padding-right: 1rem;
+    position: relative;
 
     &.is-expanded {
       border-radius: var(--sapElement_BorderCornerRadius);
@@ -26,6 +43,12 @@
 
       .#{$block}__navigation-item__arrow {
         padding-left: 2.125rem;
+      }
+    }
+
+    &.is-expanded > .#{$block}__navigation-item__indicator {
+      &::after {
+        display: none;
       }
     }
 
@@ -50,24 +73,7 @@
     }
 
     &--indicated {
-      position: relative;
       color: var(--sapSelectedColor);
-
-      .#{$block}__navigation-item__indicator {
-        &::after {
-          content: "";
-          width: 0.1875rem;
-          display: inline-block;
-          position: absolute;
-          right: 0;
-          top: 0.5625rem; // (height of nav item - height of indicator) / 2
-          height: 1.625rem;
-          background-color: var(--sapSelectedColor);
-          color: var(--sapSelectedColor);
-          border-radius: var(--sapField_BorderCornerRadius);
-          margin-right: 0.3125rem;
-        }
-      }
 
       .#{$block}__navigation-item__text,
       .#{$block}__navigation-item__icon,
@@ -76,11 +82,11 @@
       }
     }
 
-    .#{$block}__navigation-item--second .#{$block}__navigation-item--indicated .#{$block}__navigation-item__text {
+    .#{$block}__navigation-item--second.#{$block}__navigation-item--indicated .#{$block}__navigation-item__text {
       color: var(--sapSelectedColor);
     }
 
-    .#{$block}__navigation-item--second .#{$block}__navigation-item--indicated .#{$block}__navigation-item__indicator {
+    .#{$block}__navigation-item--second.#{$block}__navigation-item--indicated .#{$block}__navigation-item__indicator {
       &::after {
         margin-right: 0.125rem;
       }

--- a/src/_listNavigationItem.scss
+++ b/src/_listNavigationItem.scss
@@ -3,7 +3,7 @@
 .#{$block} {
   list-style-type: none;
 
-  .#{$block}__navigation-item__indicator {
+  .#{$block}__navigation-item-indicator {
     &::after {
       content: "";
       width: 0.1875rem;
@@ -37,15 +37,15 @@
       width: 13.25rem;
       margin: 0.25rem auto;
 
-      .#{$block}__navigation-item__text {
+      .#{$block}__navigation-item-text {
         padding-left: 0.375rem;
       }
 
-      .#{$block}__navigation-item__icon {
+      .#{$block}__navigation-item-icon {
         padding-right: 0.25rem;
       }
 
-      .#{$block}__navigation-item__arrow {
+      .#{$block}__navigation-item-arrow {
         padding-left: 2.125rem;
       }
 
@@ -54,7 +54,7 @@
       }
     }
 
-    &.is-expanded > .#{$block}__navigation-item__indicator {
+    &.is-expanded > .#{$block}__navigation-item-indicator {
       &::after {
         display: none;
       }
@@ -69,7 +69,7 @@
       width: 14.6rem;
       margin-left: -0.42rem;
 
-      .#{$block}__navigation-item__text {
+      .#{$block}__navigation-item-text {
         color: var(--sapContent_LabelColor);
         font-size: var(--sapFontSize);
         margin-left: 2.92rem;
@@ -83,18 +83,18 @@
     &--indicated {
       color: var(--sapSelectedColor);
 
-      .#{$block}__navigation-item__text,
-      .#{$block}__navigation-item__icon,
-      .#{$block}__navigation-item__arrow {
+      .#{$block}__navigation-item-text,
+      .#{$block}__navigation-item-icon,
+      .#{$block}__navigation-item-arrow {
         color: var(--sapSelectedColor);
       }
     }
 
-    .#{$block}__navigation-item--second.#{$block}__navigation-item--indicated .#{$block}__navigation-item__text {
+    .#{$block}__navigation-item--second.#{$block}__navigation-item--indicated .#{$block}__navigation-item-text {
       color: var(--sapSelectedColor);
     }
 
-    .#{$block}__navigation-item--second.#{$block}__navigation-item--indicated .#{$block}__navigation-item__indicator {
+    .#{$block}__navigation-item--second.#{$block}__navigation-item--indicated .#{$block}__navigation-item-indicator {
       &::after {
         margin-right: 0.125rem;
       }
@@ -104,45 +104,98 @@
       position: relative;
       width: 3.25rem;
 
-      .#{$block}__navigation-item__text {
+      .#{$block}__navigation-item-popover {
+        &--first, &--second {
+          display: none;
+          background: var(--sapList_AlternatingBackground);
+        }
+      }
+
+      .#{$block}__navigation-item-text {
         display: none;
       }
 
       .#{$block}__navigation-item--second {
         display: none;
+        width: auto;
+        margin-left: 0;
       }
 
       &.is-expanded {
-        width: 17.625rem;
-
-        .#{$block}__navigation-item__text {
-          display: inline;
+        .#{$block}__navigation-item--condensed {
+          width: auto;
         }
 
-        .#{$block}__navigation-item--second {
-          width: 14.375rem;
-          left: 3.25rem;
-          display: block;
+        .#{$block}__navigation-item-popover {
+          &--first, &--second {
+            overflow: hidden;
+            display: block;
 
-          .#{$block}__navigation-item__indicator {
-            &::after {
-              display: inline-block;
+            .#{$block}__navigation-item-text {
+              padding-left: 0;
+            }
+
+            .#{$block}__navigation-item--second {
+              display: block;
+
+              .#{$block}__navigation-item-text {
+                margin-left: 1rem;
+              }
+
+              .#{$block}__navigation-item-indicator {
+                &::after {
+                  margin-right: 0;
+                  display: inline-block;
+                }
+              }
+            }
+          }
+
+          &--first {
+            top: 0;
+            left: 0.325rem;
+            width: 14.325rem;
+            border-bottom-right-radius: 0;
+            z-index: 3;
+
+            .#{$block}__navigation-item-icon {
+              margin-left: 0.175rem;
+              margin-right: 0.175rem;
+            }
+          }
+
+          &--second {
+            border-top-right-radius: 0;
+            border-top-left-radius: 0;
+            top: 2.75rem;
+            left: 3.25rem;
+            width: 11.4rem;
+/**
+            &::before {
+              content: "";
+              position: absolute;
+              border-top-left-radius: $fd-popover-border-radius;
+              box-shadow: $fd-popover-box-shadow;
             }
           }
         }
+*/
+        .#{$block}__navigation-item-text {
+          display: inline;
+        }
 
-        .#{$block}__navigation-item__arrow {
+        .#{$block}__navigation-item-arrow {
           display: none;
         }
 
-        .#{$block}__navigation-item__indicator {
+        .#{$block}__navigation-item-indicator {
           &::after {
             display: none;
           }
         }
       }
 
-      .#{$block}__navigation-item__arrow {
+      .#{$block}__navigation-item-arrow {
         width: 0;
         height: 0;
 
@@ -162,13 +215,13 @@
         }
       }
 
-      .#{$block}__navigation-item__icon {
+      .#{$block}__navigation-item-icon {
         margin-left: 0.5rem;
         margin-right: 0.5rem;
       }
     }
 
-    &__icon {
+    &-icon {
       font-size: 1rem;
       font-family: "SAP-icons";
       height: 2.75rem;
@@ -179,7 +232,7 @@
       text-align: center;
     }
 
-    &__text {
+    &-text {
       font-size: var(--sapFontLargeSize);
       font-family: var(--sapFontFamily);
       color: var(--sapList_TextColor);
@@ -191,7 +244,7 @@
       line-height: 2.75rem;
     }
 
-    &__arrow {
+    &-arrow {
       width: 2.75rem;
       height: 2.75rem;
       line-height: 2.75rem;
@@ -213,8 +266,8 @@
       background: var(--sapList_Active_Background);
       color: var(--sapContent_ContrastTextColor);
 
-      &__icon,
-      &__arrow,
+      &-icon,
+      &-arrow,
       &__navigation-indicator {
         color: var(--sapContent_ContrastIconColor);
       }

--- a/src/_listNavigationItem.scss
+++ b/src/_listNavigationItem.scss
@@ -61,6 +61,9 @@
     }
 
     &--second {
+      border-bottom-right-radius: 0.25rem;
+      border-bottom-left-radius: 0.25rem;
+
       /**
        the next three lines are a hack to extend the edges of the second item to the edge of the is-expanded container,
        which I believe is the original intention of the specs but this is not 100% clear
@@ -105,7 +108,8 @@
       width: 3.25rem;
 
       .#{$block}__navigation-item-popover {
-        &--first, &--second {
+        &--first,
+        &--second {
           display: none;
           background: var(--sapList_AlternatingBackground);
         }
@@ -127,7 +131,8 @@
         }
 
         .#{$block}__navigation-item-popover {
-          &--first, &--second {
+          &--first,
+          &--second {
             overflow: hidden;
             display: block;
 
@@ -170,16 +175,9 @@
             top: 2.75rem;
             left: 3.25rem;
             width: 11.4rem;
-/**
-            &::before {
-              content: "";
-              position: absolute;
-              border-top-left-radius: $fd-popover-border-radius;
-              box-shadow: $fd-popover-box-shadow;
-            }
           }
         }
-*/
+
         .#{$block}__navigation-item-text {
           display: inline;
         }

--- a/src/_listNavigationItem.scss
+++ b/src/_listNavigationItem.scss
@@ -1,0 +1,93 @@
+@import "./listDefinitions.scss";
+
+.#{$block} {
+  list-style-type: none;
+
+  &--navigation-item {
+    background: var(--sapList_AlternatingBackground);
+    height: 2.75rem;
+    width: 15rem;
+    padding-left: 0.5rem;
+    padding-right: 1rem;
+
+    &--condensed {
+      width: 3.25rem;
+
+      .#{$block}--navigation-item__text {
+        display: none;
+      }
+
+      .#{$block}--navigation-item__arrow {
+        &::before {
+          content: "";
+          min-width: 0;
+          min-height: 0;
+          margin-right: 0.75rem;
+          margin-bottom: 0.5625rem;
+          border-style: solid;
+          border-width: 0.25rem 0.25rem 0 0;
+          border-color: transparent var(--sapContent_NonInteractiveIconColor) transparent transparent;
+          right: 0;
+          bottom: 0;
+          position: absolute;
+        }
+      }
+
+      .#{$block}--navigation-item__icon {
+        margin-left: 0.5rem;
+        margin-right: 0.5rem;
+      }
+    }
+
+    &__icon {
+      font-size: 1rem;
+      font-family: "SAP-icons";
+      height: 2.75rem;
+      line-height: 2.75rem;
+      width: 2.25rem;
+      color: var(--sapContent_NonInteractiveIconColor);
+      vertical-align: middle;
+      text-align: center;
+    }
+
+    &__text {
+      font-size: var(--sapFontLargeSize);
+      font-family: var(--sapFontFamily);
+      color: var(--sapList_TextColor);
+      padding-left: 0.5rem;
+      width: 100%;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      line-height: 2.75rem;
+    }
+
+    &__arrow {
+      width: 2.75rem;
+      height: 2.75rem;
+      line-height: 2.75rem;
+      float: right;
+      font-family: "SAP-icons";
+      font-size: 1rem;
+      color: var(--sapContent_NonInteractiveIconColor);
+    }
+  }
+
+  &--navigation-item,
+  &--navigation-item--condensed {
+    @include fd-hover() {
+      background: var(--sapList_Hover_Background);
+    }
+
+    @include fd-pressed() {
+      background: var(--sapList_Active_Background);
+      color: var(--sapContent_ContrastTextColor);
+
+      &__icon,
+      &__arrow,
+      &__navigation-indicator {
+        color: var(--sapContent_ContrastIconColor);
+      }
+    }
+  }
+}

--- a/src/_listNavigationItem.scss
+++ b/src/_listNavigationItem.scss
@@ -42,6 +42,11 @@ $fd-list-navigation-item-height: 2.75rem;
     padding-right: 1rem;
     position: relative;
 
+    @include fd-rtl() {
+      padding-right: 0.5rem;
+      padding-left: 1rem;
+    }
+
     .fd-list {
       display: none;
     }
@@ -75,6 +80,10 @@ $fd-list-navigation-item-height: 2.75rem;
         }
 
         .#{$block}__navigation-item-text {
+          @include fd-reset();
+
+          vertical-align: middle;
+          line-height: 2.75rem;
           color: var(--sapContent_LabelColor);
           font-size: var(--sapFontSize);
           margin-left: 2.5rem;
@@ -87,11 +96,10 @@ $fd-list-navigation-item-height: 2.75rem;
       }
 
       .#{$block}__navigation-item-text {
-        padding-left: 0.25rem;
+        padding-left: 0;
 
         @include fd-rtl() {
-          padding-left: 0;
-          padding-right: 0.25rem;
+          padding-right: 0;
         }
       }
 
@@ -109,6 +117,11 @@ $fd-list-navigation-item-height: 2.75rem;
         margin-left: -0.5rem;
         width: auto;
         display: block;
+
+        @include fd-rtl() {
+          margin-left: -1rem;
+          margin-right: -0.5rem;
+        }
       }
 
       .#{$block}__navigation-item-indicator {
@@ -337,7 +350,7 @@ $fd-list-navigation-item-height: 2.75rem;
       font-size: var(--sapFontLargeSize);
       font-family: var(--sapFontFamily);
       color: var(--sapList_TextColor);
-      padding-left: 0.5rem;
+      padding-left: 0.25rem;
       max-width: 8rem;
       white-space: nowrap;
       overflow: hidden;
@@ -347,7 +360,7 @@ $fd-list-navigation-item-height: 2.75rem;
 
       @include fd-rtl() {
         padding-left: 0;
-        padding-right: 0.5rem;
+        padding-right: 0.25rem;
       }
     }
 

--- a/src/_listNavigationItem.scss
+++ b/src/_listNavigationItem.scss
@@ -5,17 +5,41 @@
 
   &__navigation-item {
     background: var(--sapList_AlternatingBackground);
-    height: 2.75rem;
+    min-height: 2.75rem;
     width: 13.5rem;
     padding-left: 0.5rem;
     padding-right: 1rem;
 
+    &.is-expanded {
+      border-radius: var(--sapElement_BorderCornerRadius);
+      box-shadow: inset 0 0 0 0.0625rem var(--sapTile_BorderColor);
+      width: 13.25rem;
+      margin: 0.25rem auto;
+
+      .#{$block}__navigation-item__text {
+        padding-left: 0.375rem;
+      }
+
+      .#{$block}__navigation-item__icon {
+        padding-right: 0.25rem;
+      }
+
+      .#{$block}__navigation-item__arrow {
+        padding-left: 2.125rem;
+      }
+    }
+
     &--second {
-      width: 13rem;
+      padding: 0;
+
       .#{$block}__navigation-item__text {
         font-size: var(--sapFontSize);
         color: var(--sapContent_LabelColor);
-        margin-left: 2rem;
+        margin-left: 2.5rem;
+      }
+
+      &:last-child {
+        border-bottom: 0.0625rem solid var(--sapTile_BorderColor);
       }
     }
 

--- a/src/_listNavigationItem.scss
+++ b/src/_listNavigationItem.scss
@@ -108,9 +108,37 @@
         display: none;
       }
 
+      .#{$block}__navigation-item--second {
+        display: none;
+      }
+
       &.is-expanded {
-        .#{$block}__navigation-item__arrow, .#{$block}__navigation-item__indicator {
+        width: 17.625rem;
+
+        .#{$block}__navigation-item__text {
+          display: inline;
+        }
+
+        .#{$block}__navigation-item--second {
+          width: 14.375rem;
+          left: 3.25rem;
+          display: block;
+
+          .#{$block}__navigation-item__indicator {
+            &::after {
+              display: inline-block;
+            }
+          }
+        }
+
+        .#{$block}__navigation-item__arrow {
           display: none;
+        }
+
+        .#{$block}__navigation-item__indicator {
+          &::after {
+            display: none;
+          }
         }
       }
 

--- a/src/_listNavigationItem.scss
+++ b/src/_listNavigationItem.scss
@@ -27,6 +27,10 @@
     padding-right: 1rem;
     position: relative;
 
+    .fd-list {
+      display: none;
+    }
+
     &.is-expanded {
       border-radius: var(--sapElement_BorderCornerRadius);
       box-shadow: inset 0 0 0 0.0625rem var(--sapTile_BorderColor);
@@ -43,6 +47,10 @@
 
       .#{$block}__navigation-item__arrow {
         padding-left: 2.125rem;
+      }
+
+      .fd-list {
+        display: block;
       }
     }
 
@@ -100,11 +108,18 @@
         display: none;
       }
 
+      &.is-expanded {
+        .#{$block}__navigation-item__arrow, .#{$block}__navigation-item__indicator {
+          display: none;
+        }
+      }
+
       .#{$block}__navigation-item__arrow {
         width: 0;
         height: 0;
 
         &::before {
+          display: inline-block;
           content: "";
           min-width: 0;
           min-height: 0;

--- a/src/_listNavigationItem.scss
+++ b/src/_listNavigationItem.scss
@@ -2,6 +2,7 @@
 
 .#{$block} {
   list-style-type: none;
+  background: var(--sapList_AlternatingBackground);
 
   .#{$block}__navigation-item-indicator {
     &::after {
@@ -20,8 +21,8 @@
   }
 
   &__navigation-item {
-    background: var(--sapList_AlternatingBackground);
-    min-height: 2.75rem;
+    background: transparent;
+    height: 2.75rem;
     width: 13.5rem;
     padding-left: 0.5rem;
     padding-right: 1rem;
@@ -32,24 +33,30 @@
     }
 
     &.is-expanded {
+      height: auto;
+      min-height: 2.75rem;
       border-radius: var(--sapElement_BorderCornerRadius);
-      box-shadow: inset 0 0 0 0.0625rem var(--sapTile_BorderColor);
-      width: 13.25rem;
-      margin: 0.25rem auto;
+      box-shadow: var(--sapContent_Shadow0);
+      width: 13rem;
+      margin: 0.25rem;
+      overflow: hidden;
 
       .#{$block}__navigation-item-text {
-        padding-left: 0.375rem;
+        padding-left: 0.25rem;
       }
 
       .#{$block}__navigation-item-icon {
-        padding-right: 0.25rem;
+        padding-right: 0.5rem;
       }
 
       .#{$block}__navigation-item-arrow {
-        padding-left: 2.125rem;
+        margin-right: -0.375rem;
       }
 
-      .fd-list {
+      .#{$block} {
+        margin-left: -0.5rem;
+        margin-right: -1rem;
+        width: auto;
         display: block;
       }
     }
@@ -61,25 +68,12 @@
     }
 
     &--second {
-      border-bottom-right-radius: 0.25rem;
-      border-bottom-left-radius: 0.25rem;
-
-      /**
-       the next three lines are a hack to extend the edges of the second item to the edge of the is-expanded container,
-       which I believe is the original intention of the specs but this is not 100% clear
-       */
-      padding: 0;
-      width: 14.6rem;
-      margin-left: -0.42rem;
+      width: auto;
 
       .#{$block}__navigation-item-text {
         color: var(--sapContent_LabelColor);
         font-size: var(--sapFontSize);
-        margin-left: 2.92rem;
-      }
-
-      &:last-child {
-        border-bottom: 0.0625rem solid var(--sapTile_BorderColor);
+        margin-left: 2.5rem;
       }
     }
 
@@ -97,12 +91,6 @@
       color: var(--sapSelectedColor);
     }
 
-    .#{$block}__navigation-item--second.#{$block}__navigation-item--indicated .#{$block}__navigation-item-indicator {
-      &::after {
-        margin-right: 0.125rem;
-      }
-    }
-
     &--condensed {
       position: relative;
       width: 3.25rem;
@@ -117,6 +105,13 @@
 
       .#{$block}__navigation-item-text {
         display: none;
+      }
+
+      .#{$block}__navigation-item-icon {
+        height: 2.75rem;
+        line-height: 2.75rem;
+        margin-left: 0.5rem;
+        margin-right: 0.5rem;
       }
 
       .#{$block}__navigation-item--second {
@@ -212,11 +207,6 @@
           position: absolute;
         }
       }
-
-      .#{$block}__navigation-item-icon {
-        margin-left: 0.5rem;
-        margin-right: 0.5rem;
-      }
     }
 
     &-icon {
@@ -226,7 +216,7 @@
       line-height: 2.75rem;
       width: 2.25rem;
       color: var(--sapContent_NonInteractiveIconColor);
-      vertical-align: middle;
+      vertical-align: top;
       text-align: center;
     }
 
@@ -235,15 +225,15 @@
       font-family: var(--sapFontFamily);
       color: var(--sapList_TextColor);
       padding-left: 0.5rem;
-      width: 100%;
+      max-width: 9rem;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+      display: inline-block;
       line-height: 2.75rem;
     }
 
     &-arrow {
-      width: 2.75rem;
       height: 2.75rem;
       line-height: 2.75rem;
       float: right;

--- a/src/_listNavigationItemIndication.scss
+++ b/src/_listNavigationItemIndication.scss
@@ -1,0 +1,75 @@
+@import "./listDefinitions.scss";
+
+$vertical-nav-block: #{$fd-namespace}-vertical-nav;
+
+.#{$vertical-nav-block} {
+  &--navigation-indication {
+
+    .#{$block}__navigation-item {
+      &::after {
+        min-width: $fd-list-navigation-indicator-width - 1rem;
+        content: '';
+      }
+    }
+
+    .#{$block}__navigation-item.#{$block}__navigation-item--link {
+      &::after {
+        content: none;
+      }
+
+      padding-right: 0;
+
+      @include fd-rtl() {
+        padding-left: 0;
+        padding-right: initial;
+      }
+    }
+
+    .#{$block}__link {
+      &::after {
+        min-width: $fd-list-navigation-indicator-width;
+        content: '';
+      }
+
+      &--navigation-indicator {
+        &::after {
+          @include fd-flex-center();
+
+          height: 100%;
+          font-family: "SAP-icons";
+          content: '\e1ed';
+          color: var(--sapContent_NonInteractiveIconColor);
+          font-size: var(--sapFontSmallSize);
+          text-decoration: none;
+          text-transform: none;
+        }
+
+        @include fd-rtl() {
+          &::after {
+            content: '\e1ee';
+          }
+        }
+      }
+    }
+
+    .#{$block}__icon {
+      &:last-child {
+        margin: 0;
+      }
+
+      @include fd-rtl() {
+        &:last-child {
+          margin: 0;
+        }
+      }
+    }
+
+    .is-navigated {
+      box-shadow: $fd-list-navigation-navigator-bar-right;
+
+      @include fd-rtl() {
+        box-shadow: $fd-list-navigation-navigator-bar-left;
+      }
+    }
+  }
+}

--- a/src/_nested-list.scss
+++ b/src/_nested-list.scss
@@ -73,7 +73,7 @@ $button: #{$fd-namespace}-button;
     @include fd-reset();
 
     background: var(--sapList_Background);
-    text-shadow: var(--fdSideNav_Text_Shadow);
+    text-shadow: var(--fdVerticalNav_Text_Shadow);
 
     &:first-child {
       .#{$block}__link,

--- a/src/fundamental-styles.scss
+++ b/src/fundamental-styles.scss
@@ -68,6 +68,7 @@
 @import "./tokenizer";
 @import "./toolbar";
 @import "./tree";
+@import "./vertical-nav";
 @import "./helpers";
 @import "./info-label";
 @import "./step-input";

--- a/src/list.scss
+++ b/src/list.scss
@@ -3,6 +3,7 @@
 @import "./listByline.scss";
 @import "./listNavigation.scss";
 @import "./listNavigationItem.scss";
+@import "./listNavigationItemIndication.scss";
 @import "./listNavigationIndication.scss";
 @import "./listSelection.scss";
 @import "./listItemCounter";

--- a/src/list.scss
+++ b/src/list.scss
@@ -2,6 +2,7 @@
 @import "./listDropdown.scss";
 @import "./listByline.scss";
 @import "./listNavigation.scss";
+@import "./listNavigationItem.scss";
 @import "./listNavigationIndication.scss";
 @import "./listSelection.scss";
 @import "./listItemCounter";

--- a/src/mixins/_mixins.scss
+++ b/src/mixins/_mixins.scss
@@ -1,4 +1,4 @@
-@import "states";
+@import 'states';
 
 // utils
 @mixin fd-reset {
@@ -38,7 +38,7 @@
 
 @mixin fd-clearfix {
   &::after {
-    content: "";
+    content: '';
     display: table;
     clear: both;
   }
@@ -99,7 +99,7 @@
       border-width: 0 $width $height $width;
 
       @if $varcolor {
-        @include fd-var-color("border-bottom-color", $foreground-color, $varcolor);
+        @include fd-var-color('border-bottom-color', $foreground-color, $varcolor);
       } @else {
         border-bottom-color: $foreground-color;
       }
@@ -111,7 +111,7 @@
       border-bottom-color: $background-color;
 
       @if $varcolor {
-        @include fd-var-color("border-left-color", $foreground-color, $varcolor);
+        @include fd-var-color('border-left-color', $foreground-color, $varcolor);
       } @else {
         border-left-color: $foreground-color;
       }
@@ -121,7 +121,7 @@
       border-width: $height $width 0 $width;
 
       @if $varcolor {
-        @include fd-var-color("border-top-color", $foreground-color, $varcolor);
+        @include fd-var-color('border-top-color', $foreground-color, $varcolor);
       } @else {
         border-top-color: $foreground-color;
       }
@@ -133,7 +133,7 @@
       border-bottom-color: $background-color;
 
       @if $varcolor {
-        @include fd-var-color("border-right-color", $foreground-color, $varcolor);
+        @include fd-var-color('border-right-color', $foreground-color, $varcolor);
       } @else {
         border-right-color: $foreground-color;
       }
@@ -196,8 +196,8 @@
 
 @mixin fd-rtl {
   @at-root {
-    [dir="rtl"] &,
-    &[dir="rtl"] {
+    [dir='rtl'] &,
+    &[dir='rtl'] {
       @content;
     }
   }
@@ -272,13 +272,13 @@
 
   &::before {
     position: absolute;
-    content: "...";
+    content: '...';
     right: 0;
     bottom: 1px;
   }
 
   &::after {
-    content: "";
+    content: '';
     position: absolute;
     right: 0;
     width: 1em;
@@ -373,20 +373,20 @@
 }
 
 @mixin fd-icon-overwrite {
-  &[class*=sap-icon] {
+  &[class*='sap-icon'] {
     @content;
   }
 }
 
 @mixin fd-icon-before-overwrite {
-  &[class*=sap-icon]::before,
+  &[class*='sap-icon']::before,
   &::before {
     @content;
   }
 }
 
 @mixin fd-icon-after-overwrite {
-  &[class*=sap-icon]::after,
+  &[class*='sap-icon']::after,
   &::after {
     @content;
   }
@@ -405,8 +405,8 @@
 }
 
 @mixin fd-icon-selector() {
-  [class*="sap-icon"],
-  &[class*="sap-icon"] {
+  [class*='sap-icon'],
+  &[class*='sap-icon'] {
     @content;
   }
 }
@@ -430,4 +430,60 @@
   overflow: hidden;
   white-space: normal;
   text-overflow: ellipsis;
+}
+
+@mixin set-margins-x($left: 0, $right: 0) {
+  margin-left: $left;
+  margin-right: $right;
+
+  @include fd-rtl() {
+    margin-right: $left;
+    margin-left: $right;
+  }
+}
+
+@mixin set-margin-left($left: 0) {
+  margin-left: $left;
+
+  @include fd-rtl() {
+    margin-right: $left;
+    margin-left: 0;
+  }
+}
+
+@mixin set-margin-right($right: 0) {
+  margin-right: $right;
+
+  @include fd-rtl() {
+    margin-right: 0;
+    margin-left: $right;
+  }
+}
+
+@mixin set-paddings-x($left: 0, $right: 0) {
+  padding-left: $left;
+  padding-right: $right;
+
+  @include fd-rtl() {
+    padding-right: $left;
+    padding-left: $right;
+  }
+}
+
+@mixin set-padding-left($left: 0) {
+  padding-left: $left;
+
+  @include fd-rtl() {
+    padding-right: $left;
+    padding-left: 0;
+  }
+}
+
+@mixin set-padding-right($right: 0) {
+  padding-right: $right;
+
+  @include fd-rtl() {
+    padding-right: 0;
+    padding-left: $right;
+  }
 }

--- a/src/theming/sap_fiori_3.scss
+++ b/src/theming/sap_fiori_3.scss
@@ -74,8 +74,11 @@
   /* Token */
   --fdToken_Text_Shadow: none;
 
-  /* Side-Nav */
+  /* TODO: DEPRECATED Side-Nav */
   --fdSideNav_Text_Shadow: none;
+
+  /* Vertical-Nav */
+  --fdVerticalNav_Text_Shadow: none;
 
   /* Time */
   --fdTime_Text_Shadow: none;

--- a/src/theming/sap_fiori_3_dark.scss
+++ b/src/theming/sap_fiori_3_dark.scss
@@ -74,8 +74,11 @@
   /* Token */
   --fdToken_Text_Shadow: none;
 
-  /* Side-Nav */
+  /* TODO: DEPRECATED Side-Nav */
   --fdSideNav_Text_Shadow: none;
+
+  /* Vertical-Nav */
+  --fdVerticalNav_Text_Shadow: none;
 
   /* Time */
   --fdTime_Text_Shadow: none;

--- a/src/theming/sap_fiori_3_hcb.scss
+++ b/src/theming/sap_fiori_3_hcb.scss
@@ -74,8 +74,11 @@
   /* Token */
   --fdToken_Text_Shadow: 0 0 0.125rem #000;
 
-  /* Side-Nav */
+  /* TODO: DEPRECATED Side-Nav */
   --fdSideNav_Text_Shadow: 0 0 0.125rem #000;
+
+  /* Vertical-Nav */
+  --fdVerticalNav_Text_Shadow: 0 0 0.125rem #000;
 
   /* Time */
   --fdTime_Text_Shadow: 0 0 0.125rem #000;

--- a/src/theming/sap_fiori_3_hcw.scss
+++ b/src/theming/sap_fiori_3_hcw.scss
@@ -74,8 +74,11 @@
   /* Token */
   --fdToken_Text_Shadow: none;
 
-  /* Side-Nav */
+  /* TODO: DEPRECATED Side-Nav */
   --fdSideNav_Text_Shadow: none;
+
+  /* Vertical-Nav */
+  --fdVerticalNav_Text_Shadow: none;
 
   /* Time */
   --fdTime_Text_Shadow: none;

--- a/src/theming/sap_fiori_3_light_dark.scss
+++ b/src/theming/sap_fiori_3_light_dark.scss
@@ -74,8 +74,11 @@
   /* Token */
   --fdToken_Text_Shadow: none;
 
-  /* Side-Nav */
+  /* TODO: DEPRECATED Side-Nav */
   --fdSideNav_Text_Shadow: none;
+
+  /* Vertical-Nav */
+  --fdVerticalNav_Text_Shadow: none;
 
   /* Time */
   --fdTime_Text_Shadow: none;

--- a/src/vertical-nav.scss
+++ b/src/vertical-nav.scss
@@ -15,6 +15,7 @@ $has-child-content-arrow-margin: 0.125rem;
   flex-direction: column;
   justify-content: space-between;
   text-shadow: var(--fdVerticalNav_Text_Shadow);
+  box-shadow: var(--sapContent_Shadow0);
   height: 100%;
 
   &__skip-link {

--- a/src/vertical-nav.scss
+++ b/src/vertical-nav.scss
@@ -9,8 +9,6 @@ $has-child-content-arrow-margin: 0.125rem;
 
   background-color: var(--sapList_AlternatingBackground);
   width: 15rem;
-  border-right: var(--sapList_BorderWidth) solid;
-  border-right-color: var(--sapGroup_ContentBorderColor);
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -58,10 +56,6 @@ $has-child-content-arrow-margin: 0.125rem;
     width: 3.25rem;
 
     @include fd-rtl() {
-      border-right: none;
-      border-left: var(--sapList_BorderWidth) solid;
-      border-left-color: var(--sapGroup_ContentBorderColor);
-
       &.#{$block}--condensed {
         width: 2.75rem;
       }

--- a/src/vertical-nav.scss
+++ b/src/vertical-nav.scss
@@ -1,0 +1,69 @@
+@import "./new-settings";
+@import "./mixins";
+
+$block: #{$fd-namespace}-vertical-nav;
+$has-child-content-arrow-margin: 0.125rem;
+
+.#{$block} {
+  @include fd-reset();
+
+  background-color: var(--sapList_AlternatingBackground);
+  width: 15rem;
+  border-right: var(--sapList_BorderWidth) solid;
+  border-right-color: var(--sapGroup_ContentBorderColor);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  text-shadow: var(--fdVerticalNav_Text_Shadow);
+  height: 100%;
+
+  &__skip-link {
+    @include fd-reset();
+    @include fd-screen-reader-only();
+
+    &:focus {
+      @include fd-link();
+
+      position: static;
+      width: auto;
+      height: auto;
+    }
+  }
+
+  &__group-header {
+    @include fd-reset();
+
+    height: 2.75rem;
+    background: var(--sapList_GroupHeaderBackground);
+    border-bottom: var(--sapList_BorderWidth) solid var(--sapList_GroupHeaderBorderColor);
+    color: var(--sapList_GroupHeaderTextColor);
+    display: flex;
+    align-items: flex-end;
+    font-size: var(--sapFontSize);
+    font-weight: bold;
+    line-height: 2rem;
+    padding-right: 1rem;
+    padding-left: 1rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  &__main-navigation {
+    @include fd-reset();
+  }
+
+  &--condensed {
+    width: 3.25rem;
+
+    @include fd-rtl() {
+      border-right: none;
+      border-left: var(--sapList_BorderWidth) solid;
+      border-left-color: var(--sapGroup_ContentBorderColor);
+
+      &.#{$block}--condensed {
+        width: 2.75rem;
+      }
+    }
+  }
+}

--- a/src/vertical-nav.scss
+++ b/src/vertical-nav.scss
@@ -2,35 +2,24 @@
 @import "./mixins";
 
 $block: #{$fd-namespace}-vertical-nav;
-$has-child-content-arrow-margin: 0.125rem;
 
 .#{$block} {
   @include fd-reset();
 
+  @include fd-flex(column) {
+    justify-content: space-between;
+  }
+
   background-color: var(--sapList_AlternatingBackground);
   width: 15rem;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
   text-shadow: var(--fdVerticalNav_Text_Shadow);
   box-shadow: var(--sapContent_Shadow0);
   height: 100%;
 
-  &__skip-link {
-    @include fd-reset();
-    @include fd-screen-reader-only();
-
-    &:focus {
-      @include fd-link();
-
-      position: static;
-      width: auto;
-      height: auto;
-    }
-  }
-
   &__group-header {
     @include fd-reset();
+    @include fd-ellipsis();
+    @include set-paddings-x(1rem);
 
     height: 2.75rem;
     background: var(--sapList_GroupHeaderBackground);
@@ -41,11 +30,6 @@ $has-child-content-arrow-margin: 0.125rem;
     font-size: var(--sapFontSize);
     font-weight: bold;
     line-height: 2rem;
-    padding-right: 1rem;
-    padding-left: 1rem;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
 
   &__main-navigation {

--- a/src/vertical-nav.scss
+++ b/src/vertical-nav.scss
@@ -54,11 +54,5 @@ $has-child-content-arrow-margin: 0.125rem;
 
   &--condensed {
     width: 3.25rem;
-
-    @include fd-rtl() {
-      &.#{$block}--condensed {
-        width: 2.75rem;
-      }
-    }
   }
 }

--- a/stories/side-navigation/side-navigation.stories.js
+++ b/stories/side-navigation/side-navigation.stories.js
@@ -2,7 +2,7 @@ export default {
     title: 'Components/Side Navigation',
     parameters: {
         description: `
-The side navigation area can be used to display navigation structures with up to two levels and contains links that change the content area. The side navigation consists of two container sections: the **main navigation section** (top-aligned) with links used to navigate within the user’s current work context, and the **utility section** (bottom-aligned) that contains links to additional information. Both of these sections use a nested list to display navigation items.
+**DEPRECATED**. This component will be deprecated in favor of the vertical navigation component. The side navigation area can be used to display navigation structures with up to two levels and contains links that change the content area. The side navigation consists of two container sections: the **main navigation section** (top-aligned) with links used to navigate within the user’s current work context, and the **utility section** (bottom-aligned) that contains links to additional information. Both of these sections use a nested list to display navigation items.
 
 ##Usage      
 **Use the side navigation if:**

--- a/stories/vertical-navigation/__snapshots__/vertical-navigation.stories.storyshot
+++ b/stories/vertical-navigation/__snapshots__/vertical-navigation.stories.storyshot
@@ -7,13 +7,13 @@ exports[`Storyshots Components/Vertical Navigation Condensed 1`] = `
   
     
   <nav
-    aria-label="Main Menu"
+    aria-label="Main Menu 2"
     class="fd-vertical-nav__main-navigation"
   >
     
         
     <ul
-      aria-label="Main Menu List"
+      aria-label="Main Menu List 2"
       class="fd-list"
     >
       
@@ -26,6 +26,7 @@ exports[`Storyshots Components/Vertical Navigation Condensed 1`] = `
                 
         <i
           class="fd-list__navigation-item-icon sap-icon--home"
+          role="presentation"
         />
         
                 
@@ -47,6 +48,7 @@ exports[`Storyshots Components/Vertical Navigation Condensed 1`] = `
                 
         <i
           class="fd-list__navigation-item-icon sap-icon--calendar"
+          role="presentation"
         />
         
                 
@@ -68,6 +70,7 @@ exports[`Storyshots Components/Vertical Navigation Condensed 1`] = `
                 
         <i
           class="fd-list__navigation-item-icon sap-icon--customer"
+          role="presentation"
         />
         
                 
@@ -89,6 +92,7 @@ exports[`Storyshots Components/Vertical Navigation Condensed 1`] = `
                 
         <i
           class="fd-list__navigation-item-icon sap-icon--shipping-status"
+          role="presentation"
         />
         
                 
@@ -137,6 +141,7 @@ exports[`Storyshots Components/Vertical Navigation Default 1`] = `
                 
         <i
           class="fd-list__navigation-item-icon sap-icon--home"
+          role="presentation"
         />
         
                 
@@ -158,6 +163,7 @@ exports[`Storyshots Components/Vertical Navigation Default 1`] = `
                 
         <i
           class="fd-list__navigation-item-icon sap-icon--calendar"
+          role="presentation"
         />
         
                 
@@ -225,6 +231,7 @@ exports[`Storyshots Components/Vertical Navigation Default 1`] = `
                 
         <i
           class="fd-list__navigation-item-icon sap-icon--customer"
+          role="presentation"
         />
         
                 
@@ -236,7 +243,7 @@ exports[`Storyshots Components/Vertical Navigation Default 1`] = `
         
                 
         <button
-          aria-label="Expand submenu"
+          aria-label="Expand second submenu"
           class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"
         />
         
@@ -292,6 +299,7 @@ exports[`Storyshots Components/Vertical Navigation Default 1`] = `
                 
         <i
           class="fd-list__navigation-item-icon sap-icon--shipping-status"
+          role="presentation"
         />
         
                 
@@ -322,13 +330,13 @@ exports[`Storyshots Components/Vertical Navigation Navigation Indication 1`] = `
     
     
     <nav
-      aria-label="Main Menu"
+      aria-label="Main Menu 3"
       class="fd-vertical-nav__main-navigation"
     >
       
         
       <ul
-        aria-label="Main Menu List"
+        aria-label="Main Menu List 3"
         class="fd-list"
       >
         
@@ -341,6 +349,7 @@ exports[`Storyshots Components/Vertical Navigation Navigation Indication 1`] = `
                 
           <i
             class="fd-list__navigation-item-icon sap-icon--home"
+            role="presentation"
           />
           
                 
@@ -362,6 +371,7 @@ exports[`Storyshots Components/Vertical Navigation Navigation Indication 1`] = `
                 
           <i
             class="fd-list__navigation-item-icon sap-icon--calendar"
+            role="presentation"
           />
           
                 
@@ -373,7 +383,7 @@ exports[`Storyshots Components/Vertical Navigation Navigation Indication 1`] = `
           
                 
           <button
-            aria-label="Expand submenu"
+            aria-label="Expand second submenu 3"
             class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"
           />
           
@@ -449,13 +459,13 @@ exports[`Storyshots Components/Vertical Navigation Navigation Indication 1`] = `
     
     
     <nav
-      aria-label="Main Menu"
+      aria-label="Main Menu 4"
       class="fd-vertical-nav__main-navigation"
     >
       
         
       <ul
-        aria-label="Main Menu List"
+        aria-label="Main Menu List 4"
         class="fd-list"
       >
         
@@ -468,6 +478,7 @@ exports[`Storyshots Components/Vertical Navigation Navigation Indication 1`] = `
                 
           <i
             class="fd-list__navigation-item-icon sap-icon--home"
+            role="presentation"
           />
           
                 
@@ -490,11 +501,12 @@ exports[`Storyshots Components/Vertical Navigation Navigation Indication 1`] = `
                 
           <i
             class="fd-list__navigation-item-icon sap-icon--calendar"
+            role="presentation"
           />
           
                 
           <button
-            aria-label="Expand submenu"
+            aria-label="Expand second submenu 4"
             class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow"
           />
               
@@ -523,6 +535,7 @@ exports[`Storyshots Components/Vertical Navigation Navigation Indication 1`] = `
                             
                 <i
                   class="fd-list__navigation-item-icon sap-icon--calendar"
+                  role="presentation"
                 />
                 
                             
@@ -545,7 +558,7 @@ exports[`Storyshots Components/Vertical Navigation Navigation Indication 1`] = `
           <div
             aria-hidden="false"
             class="fd-popover__body fd-popover__body--left fd-popover__body--no-arrow fd-list__navigation-item-popover--second-level"
-            id="popoverA1"
+            id="popoverA2"
           >
             
                     
@@ -608,6 +621,7 @@ exports[`Storyshots Components/Vertical Navigation Navigation Indication 1`] = `
                 
           <i
             class="fd-list__navigation-item-icon sap-icon--customer"
+            role="presentation"
           />
           
                 
@@ -629,6 +643,7 @@ exports[`Storyshots Components/Vertical Navigation Navigation Indication 1`] = `
                 
           <i
             class="fd-list__navigation-item-icon sap-icon--shipping-status"
+            role="presentation"
           />
           
                 
@@ -661,13 +676,13 @@ exports[`Storyshots Components/Vertical Navigation Text Only 1`] = `
   
     
   <nav
-    aria-label="Main Menu"
+    aria-label="Main Menu 3"
     class="fd-vertical-nav__main-navigation"
   >
     
         
     <ul
-      aria-label="Main Menu List"
+      aria-label="Main Menu List 3"
       class="fd-list"
     >
       
@@ -702,7 +717,7 @@ exports[`Storyshots Components/Vertical Navigation Text Only 1`] = `
         
                 
         <button
-          aria-label="Expand submenu"
+          aria-label="Expand second submenu 3"
           class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"
         />
         
@@ -764,7 +779,7 @@ exports[`Storyshots Components/Vertical Navigation Text Only 1`] = `
         
                 
         <button
-          aria-label="Expand submenu"
+          aria-label="Expand third submenu 2"
           class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"
         />
         

--- a/stories/vertical-navigation/__snapshots__/vertical-navigation.stories.storyshot
+++ b/stories/vertical-navigation/__snapshots__/vertical-navigation.stories.storyshot
@@ -13,13 +13,14 @@ exports[`Storyshots Components/Vertical Navigation Condensed 1`] = `
     
         
     <ul
-      aria-label="Main Menu"
+      aria-label="Main Menu List"
       class="fd-list"
     >
       
             
       <li
-        class="fd-list__navigation-item--condensed"
+        class="fd-list__navigation-item fd-list__navigation-item--condensed"
+        tabindex="0"
       >
         
                 
@@ -39,7 +40,8 @@ exports[`Storyshots Components/Vertical Navigation Condensed 1`] = `
       
             
       <li
-        class="fd-list__navigation-item--condensed"
+        class="fd-list__navigation-item fd-list__navigation-item--condensed"
+        tabindex="0"
       >
         
                 
@@ -59,7 +61,8 @@ exports[`Storyshots Components/Vertical Navigation Condensed 1`] = `
       
             
       <li
-        class="fd-list__navigation-item--condensed"
+        class="fd-list__navigation-item fd-list__navigation-item--condensed"
+        tabindex="0"
       >
         
                 
@@ -79,7 +82,8 @@ exports[`Storyshots Components/Vertical Navigation Condensed 1`] = `
       
             
       <li
-        class="fd-list__navigation-item--condensed"
+        class="fd-list__navigation-item fd-list__navigation-item--condensed"
+        tabindex="0"
       >
         
                 
@@ -120,13 +124,14 @@ exports[`Storyshots Components/Vertical Navigation Default 1`] = `
     
         
     <ul
-      aria-label="Main Menu"
+      aria-label="Main Menu List"
       class="fd-list"
     >
       
             
       <li
         class="fd-list__navigation-item"
+        tabindex="0"
       >
         
                 
@@ -159,11 +164,11 @@ exports[`Storyshots Components/Vertical Navigation Default 1`] = `
         <span
           class="fd-list__navigation-item-text"
         >
-          Calendar
+          Calendar Calendar Calendar Calendar Calendar Calendar 
         </span>
         
                 
-        <i
+        <button
           class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"
         />
         
@@ -175,6 +180,7 @@ exports[`Storyshots Components/Vertical Navigation Default 1`] = `
                     
           <li
             class="fd-list__navigation-item fd-list__navigation-item--second"
+            tabindex="0"
           >
             
                         
@@ -190,13 +196,14 @@ exports[`Storyshots Components/Vertical Navigation Default 1`] = `
                     
           <li
             class="fd-list__navigation-item fd-list__navigation-item--second"
+            tabindex="0"
           >
             
                         
             <span
               class="fd-list__navigation-item-text"
             >
-              Second level item 2
+              Second level item 2 Second level item 2 Second level item 2 Second level item 2 Second level item 2 
             </span>
             
                     
@@ -227,7 +234,7 @@ exports[`Storyshots Components/Vertical Navigation Default 1`] = `
         </span>
         
                 
-        <i
+        <button
           class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"
         />
         
@@ -239,6 +246,7 @@ exports[`Storyshots Components/Vertical Navigation Default 1`] = `
                     
           <li
             class="fd-list__navigation-item fd-list__navigation-item--second"
+            tabindex="0"
           >
             
                         
@@ -254,6 +262,7 @@ exports[`Storyshots Components/Vertical Navigation Default 1`] = `
                     
           <li
             class="fd-list__navigation-item fd-list__navigation-item--second"
+            tabindex="0"
           >
             
                         
@@ -275,6 +284,7 @@ exports[`Storyshots Components/Vertical Navigation Default 1`] = `
             
       <li
         class="fd-list__navigation-item"
+        tabindex="0"
       >
         
                 
@@ -316,13 +326,14 @@ exports[`Storyshots Components/Vertical Navigation Navigation Indication 1`] = `
       
         
       <ul
-        aria-label="Main Menu"
+        aria-label="Main Menu List"
         class="fd-list"
       >
         
             
         <li
           class="fd-list__navigation-item"
+          tabindex="0"
         >
           
                 
@@ -359,7 +370,7 @@ exports[`Storyshots Components/Vertical Navigation Navigation Indication 1`] = `
           </span>
           
                 
-          <i
+          <button
             class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"
           />
           
@@ -391,6 +402,7 @@ exports[`Storyshots Components/Vertical Navigation Navigation Indication 1`] = `
                     
             <li
               class="fd-list__navigation-item fd-list__navigation-item--second"
+              tabindex="0"
             >
               
                         
@@ -440,13 +452,14 @@ exports[`Storyshots Components/Vertical Navigation Navigation Indication 1`] = `
       
         
       <ul
-        aria-label="Main Menu"
+        aria-label="Main Menu List"
         class="fd-list"
       >
         
             
         <li
-          class="fd-list__navigation-item--condensed"
+          class="fd-list__navigation-item fd-list__navigation-item--condensed"
+          tabindex="0"
         >
           
                 
@@ -466,8 +479,9 @@ exports[`Storyshots Components/Vertical Navigation Navigation Indication 1`] = `
         
             
         <li
-          class="fd-list__navigation-item--condensed"
-          onclick="toggleCondensedVerticalNavSubmenu(event, 'parent')"
+          class="fd-list__navigation-item fd-list__navigation-item--condensed"
+          id="parentCalendarButton"
+          onclick="toggleCondensedVerticalNavSubmenu(event)"
         >
           
                 
@@ -476,7 +490,7 @@ exports[`Storyshots Components/Vertical Navigation Navigation Indication 1`] = `
           />
           
                 
-          <i
+          <button
             class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow"
           />
               
@@ -499,8 +513,7 @@ exports[`Storyshots Components/Vertical Navigation Navigation Indication 1`] = `
               
                         
               <li
-                class="fd-list__navigation-item--condensed"
-                onclick="toggleCondensedVerticalNavSubmenu(event, 'child')"
+                class="fd-list__navigation-item fd-list__navigation-item--condensed"
               >
                 
                             
@@ -538,7 +551,8 @@ exports[`Storyshots Components/Vertical Navigation Navigation Indication 1`] = `
               
                         
               <li
-                class="fd-list__navigation-item--condensed fd-list__navigation-item--second fd-list__navigation-item--indicated"
+                class="fd-list__navigation-item fd-list__navigation-item--condensed fd-list__navigation-item--second fd-list__navigation-item--indicated"
+                tabindex="0"
               >
                 
                             
@@ -558,7 +572,8 @@ exports[`Storyshots Components/Vertical Navigation Navigation Indication 1`] = `
               
                         
               <li
-                class="fd-list__navigation-item--condensed fd-list__navigation-item--second"
+                class="fd-list__navigation-item fd-list__navigation-item--condensed fd-list__navigation-item--second"
+                tabindex="0"
               >
                 
                             
@@ -582,7 +597,8 @@ exports[`Storyshots Components/Vertical Navigation Navigation Indication 1`] = `
         
             
         <li
-          class="fd-list__navigation-item--condensed"
+          class="fd-list__navigation-item fd-list__navigation-item--condensed"
+          tabindex="0"
         >
           
                 
@@ -602,7 +618,8 @@ exports[`Storyshots Components/Vertical Navigation Navigation Indication 1`] = `
         
             
         <li
-          class="fd-list__navigation-item--condensed"
+          class="fd-list__navigation-item fd-list__navigation-item--condensed"
+          tabindex="0"
         >
           
                 
@@ -646,13 +663,14 @@ exports[`Storyshots Components/Vertical Navigation Text Only 1`] = `
     
         
     <ul
-      aria-label="Main Menu"
+      aria-label="Main Menu List"
       class="fd-list"
     >
       
             
       <li
         class="fd-list__navigation-item"
+        tabindex="0"
       >
         
                 
@@ -679,7 +697,7 @@ exports[`Storyshots Components/Vertical Navigation Text Only 1`] = `
         </span>
         
                 
-        <i
+        <button
           class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"
         />
         
@@ -691,6 +709,7 @@ exports[`Storyshots Components/Vertical Navigation Text Only 1`] = `
                     
           <li
             class="fd-list__navigation-item fd-list__navigation-item--second"
+            tabindex="0"
           >
             
                         
@@ -706,6 +725,7 @@ exports[`Storyshots Components/Vertical Navigation Text Only 1`] = `
                     
           <li
             class="fd-list__navigation-item fd-list__navigation-item--second"
+            tabindex="0"
           >
             
                         
@@ -738,7 +758,7 @@ exports[`Storyshots Components/Vertical Navigation Text Only 1`] = `
         </span>
         
                 
-        <i
+        <button
           class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"
         />
         
@@ -750,6 +770,7 @@ exports[`Storyshots Components/Vertical Navigation Text Only 1`] = `
                     
           <li
             class="fd-list__navigation-item fd-list__navigation-item--second"
+            tabindex="0"
           >
             
                         
@@ -765,6 +786,7 @@ exports[`Storyshots Components/Vertical Navigation Text Only 1`] = `
                     
           <li
             class="fd-list__navigation-item fd-list__navigation-item--second"
+            tabindex="0"
           >
             
                         
@@ -786,6 +808,7 @@ exports[`Storyshots Components/Vertical Navigation Text Only 1`] = `
             
       <li
         class="fd-list__navigation-item"
+        tabindex="0"
       >
         
                 

--- a/stories/vertical-navigation/__snapshots__/vertical-navigation.stories.storyshot
+++ b/stories/vertical-navigation/__snapshots__/vertical-navigation.stories.storyshot
@@ -1,0 +1,4885 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Components/Vertical Navigation Complex (compact) 1`] = `
+<div
+  class="fd-vertical-nav"
+>
+  
+    
+  <a
+    class="fd-vertical-nav__skip-link"
+    href="#content"
+  >
+    Skip navigation
+  </a>
+  
+    
+  <div
+    class="fd-vertical-nav__group-header"
+    id="EX500H1"
+  >
+    
+        Group Header 1
+    
+  </div>
+  
+    
+  <nav
+    aria-label="Main Menu"
+    class="fd-vertical-nav__main-navigation"
+  >
+    
+        
+    <ul
+      aria-labelledby="EX500H1"
+      class="fd-nested-list fd-nested-list--compact"
+    >
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <i
+            class="fd-nested-list__icon sap-icon--home"
+            role="presentation"
+          />
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link is-selected"
+          href="#"
+        >
+          
+                    
+          <i
+            class="fd-nested-list__icon sap-icon--calendar"
+            role="presentation"
+          />
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <div
+          class="fd-nested-list__content has-child"
+        >
+          
+                    
+          <a
+            class="fd-nested-list__link"
+            href="#"
+          >
+            
+                        
+            <i
+              class="fd-nested-list__icon sap-icon--employee"
+              role="presentation"
+            />
+            
+                        
+            <span
+              class="fd-nested-list__title"
+            >
+              Level 1 Item
+            </span>
+            
+                    
+          </a>
+          
+                    
+          <button
+            aria-controls="EX500L2"
+            aria-expanded="false"
+            aria-haspopup="true"
+            aria-label="Expand submenu"
+            class="fd-button fd-nested-list__button"
+            onclick="toggleNestedListSubmenu(event)"
+          >
+            
+                        
+            <i
+              class="sap-icon--navigation-right-arrow"
+              role="presentation"
+            />
+                
+                    
+          </button>
+          
+                
+        </div>
+        
+                
+        <ul
+          aria-hidden="true"
+          class="fd-nested-list fd-nested-list--text-only level-2"
+          id="EX500L2"
+        >
+          
+                    
+          <li
+            class="fd-nested-list__item"
+          >
+            
+                        
+            <a
+              class="fd-nested-list__link"
+              href="#"
+            >
+              
+                            
+              <span
+                class="fd-nested-list__title"
+              >
+                Level 2 Item
+              </span>
+              
+                        
+            </a>
+            
+                    
+          </li>
+          
+                    
+          <li
+            class="fd-nested-list__item"
+          >
+            
+                        
+            <a
+              class="fd-nested-list__link"
+              href="#"
+            >
+              
+                            
+              <span
+                class="fd-nested-list__title"
+              >
+                Level 2 Item
+              </span>
+              
+                        
+            </a>
+            
+                    
+          </li>
+          
+                    
+          <li
+            class="fd-nested-list__item"
+          >
+            
+                        
+            <a
+              class="fd-nested-list__link"
+              href="#"
+            >
+              
+                            
+              <span
+                class="fd-nested-list__title"
+              >
+                Level 2 Item
+              </span>
+              
+                        
+            </a>
+            
+                    
+          </li>
+          
+                
+        </ul>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <i
+            class="fd-nested-list__icon sap-icon--activities"
+            role="presentation"
+          />
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+        
+    </ul>
+    
+        
+    <div
+      class="fd-vertical-nav__group-header"
+      id="EX500H2"
+    >
+      
+                Group Header 2
+        
+    </div>
+    
+        
+    <ul
+      aria-labelledby="EX500H2"
+      class="fd-nested-list fd-nested-list--compact"
+    >
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <i
+            class="fd-nested-list__icon sap-icon--bar-chart"
+            role="presentation"
+          />
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+        
+    </ul>
+    
+    
+  </nav>
+  
+    
+  <nav
+    aria-label="Utility Menu"
+    class="fd-vertical-nav__utility"
+  >
+    
+        
+    <ul
+      aria-label="Utility Menu"
+      class="fd-nested-list fd-nested-list--compact"
+    >
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <i
+            class="fd-nested-list__icon sap-icon--compare"
+            role="presentation"
+          />
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <i
+            class="fd-nested-list__icon sap-icon--chain-link"
+            role="presentation"
+          />
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+        
+    </ul>
+    
+    
+  </nav>
+  
+
+</div>
+`;
+
+exports[`Storyshots Components/Vertical Navigation Complex 1`] = `
+<div
+  class="fd-vertical-nav"
+>
+  
+    
+  <a
+    class="fd-vertical-nav__skip-link"
+    href="#content"
+  >
+    Skip navigation
+  </a>
+  
+    
+  <div
+    class="fd-vertical-nav__group-header"
+    id="EX400H1"
+  >
+    
+        Group Header 1
+    
+  </div>
+  
+    
+  <nav
+    aria-label="Main Menu"
+    class="fd-vertical-nav__main-navigation"
+  >
+    
+        
+    <ul
+      aria-labelledby="EX400H1"
+      class="fd-nested-list "
+    >
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <i
+            class="fd-nested-list__icon sap-icon--home"
+            role="presentation"
+          />
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <i
+            class="fd-nested-list__icon sap-icon--calendar"
+            role="presentation"
+          />
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <div
+          class="fd-nested-list__content is-selected has-child"
+        >
+          
+                    
+          <a
+            class="fd-nested-list__link"
+            href="#"
+          >
+            
+                        
+            <i
+              class="fd-nested-list__icon sap-icon--employee"
+              role="presentation"
+            />
+            
+                        
+            <span
+              class="fd-nested-list__title"
+            >
+              Level 1 Item
+            </span>
+            
+                    
+          </a>
+          
+                    
+          <button
+            aria-controls="EX400L2"
+            aria-expanded="false"
+            aria-haspopup="true"
+            aria-label="Expand submenu"
+            class="fd-button fd-nested-list__button"
+            onclick="toggleNestedListSubmenu(event)"
+          >
+            
+                        
+            <i
+              class="sap-icon--navigation-right-arrow"
+              role="presentation"
+            />
+                
+                    
+          </button>
+          
+                
+        </div>
+        
+                
+        <ul
+          aria-hidden="true"
+          class="fd-nested-list fd-nested-list--text-only level-2"
+          id="EX400L2"
+        >
+          
+                    
+          <li
+            class="fd-nested-list__item"
+          >
+            
+                        
+            <a
+              class="fd-nested-list__link"
+              href="#"
+            >
+              
+                            
+              <span
+                class="fd-nested-list__title"
+              >
+                Level 2 Item
+              </span>
+              
+                        
+            </a>
+            
+                    
+          </li>
+          
+                    
+          <li
+            class="fd-nested-list__item"
+          >
+            
+                        
+            <a
+              class="fd-nested-list__link is-selected"
+              href="#"
+            >
+              
+                            
+              <span
+                class="fd-nested-list__title"
+              >
+                Level 2 Item
+              </span>
+              
+                        
+            </a>
+            
+                    
+          </li>
+          
+                    
+          <li
+            class="fd-nested-list__item"
+          >
+            
+                        
+            <a
+              class="fd-nested-list__link"
+              href="#"
+            >
+              
+                            
+              <span
+                class="fd-nested-list__title"
+              >
+                Level 2 Item
+              </span>
+              
+                        
+            </a>
+            
+                    
+          </li>
+          
+                
+        </ul>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <i
+            class="fd-nested-list__icon sap-icon--activities"
+            role="presentation"
+          />
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+        
+    </ul>
+    
+        
+    <div
+      class="fd-vertical-nav__group-header"
+      id="EX400H2"
+    >
+      
+            Group Header 2
+        
+    </div>
+    
+        
+    <ul
+      aria-labelledby="EX400H2"
+      class="fd-nested-list"
+    >
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <i
+            class="fd-nested-list__icon sap-icon--bar-chart"
+            role="presentation"
+          />
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+        
+    </ul>
+    
+    
+  </nav>
+  
+    
+  <nav
+    aria-label="Utility Menu"
+    class="fd-vertical-nav__utility"
+  >
+    
+        
+    <ul
+      aria-label="Utility Menu"
+      class="fd-nested-list"
+    >
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <i
+            class="fd-nested-list__icon sap-icon--compare"
+            role="presentation"
+          />
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <i
+            class="fd-nested-list__icon sap-icon--chain-link"
+            role="presentation"
+          />
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+        
+    </ul>
+    
+    
+  </nav>
+  
+
+</div>
+`;
+
+exports[`Storyshots Components/Vertical Navigation Condensed (compact) 1`] = `
+<nav
+  class="fd-vertical-nav fd-vertical-nav--condensed"
+>
+  
+    
+  <a
+    class="fd-vertical-nav__skip-link"
+    href="#content"
+  >
+    Skip navigation
+  </a>
+  
+    
+  <div
+    class="fd-vertical-nav__main-navigation"
+  >
+    
+        
+    <ul
+      class="fd-nested-list fd-nested-list--compact"
+    >
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <i
+            class="fd-nested-list__icon sap-icon--home"
+            role="presentation"
+          />
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <i
+            class="fd-nested-list__icon sap-icon--calendar"
+            role="presentation"
+          />
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <div
+          class="fd-nested-list__content is-selected has-child"
+        >
+          
+                    
+          <button
+            aria-controls="EX600L2"
+            aria-expanded="false"
+            aria-haspopup="true"
+            aria-label="Expand submenu"
+            class="fd-nested-list__link"
+          >
+            
+                        
+            <i
+              class="fd-nested-list__icon sap-icon--employee"
+              role="presentation"
+            />
+            
+                        
+            <span
+              class="fd-nested-list__title"
+            >
+              Level 1 Item
+            </span>
+            
+                    
+          </button>
+          
+                
+        </div>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <i
+            class="fd-nested-list__icon sap-icon--activities"
+            role="presentation"
+          />
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <i
+            class="fd-nested-list__icon sap-icon--bar-chart"
+            role="presentation"
+          />
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+        
+    </ul>
+    
+    
+  </div>
+  
+    
+  <div
+    class="fd-vertical-nav__utility"
+  >
+    
+        
+    <ul
+      aria-label="Utility Menu"
+      class="fd-nested-list fd-nested-list--compact"
+    >
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <i
+            class="fd-nested-list__icon sap-icon--compare"
+            role="presentation"
+          />
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <i
+            class="fd-nested-list__icon sap-icon--chain-link"
+            role="presentation"
+          />
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+        
+    </ul>
+    
+    
+  </div>
+  
+
+</nav>
+`;
+
+exports[`Storyshots Components/Vertical Navigation Condensed 1`] = `
+<nav
+  class="fd-vertical-nav fd-vertical-nav--condensed"
+>
+  
+    
+  <a
+    class="fd-vertical-nav__skip-link"
+    href="#content"
+  >
+    Skip navigation
+  </a>
+  
+    
+  <div
+    class="fd-vertical-nav__main-navigation"
+  >
+    
+        
+    <ul
+      class="fd-nested-list"
+    >
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <i
+            aria-label="Level 1 Item"
+            class="fd-nested-list__icon sap-icon--home"
+          />
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <i
+            aria-label="Level 1 Item"
+            class="fd-nested-list__icon sap-icon--calendar"
+          />
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <div
+          class="fd-nested-list__content is-selected has-child"
+        >
+          
+                    
+          <button
+            aria-controls="EX500L2"
+            aria-expanded="false"
+            aria-haspopup="true"
+            aria-label="Expand submenu"
+            class="fd-nested-list__link"
+          >
+            
+                        
+            <i
+              class="fd-nested-list__icon sap-icon--employee"
+              role="presentation"
+            />
+            
+                        
+            <span
+              class="fd-nested-list__title"
+            >
+              Level 1 Item
+            </span>
+            
+                    
+          </button>
+          
+                
+        </div>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <i
+            aria-label="Level 1 Item"
+            class="fd-nested-list__icon sap-icon--activities"
+          />
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <i
+            aria-label="Level 1 Item"
+            class="fd-nested-list__icon sap-icon--bar-chart"
+          />
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+        
+    </ul>
+    
+    
+  </div>
+  
+    
+  <div
+    aria-label="Utility Menu"
+    class="fd-vertical-nav__utility"
+  >
+    
+        
+    <ul
+      class="fd-nested-list"
+    >
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <i
+            aria-label="Level 1 Item"
+            class="fd-nested-list__icon sap-icon--compare"
+          />
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <i
+            aria-label="Level 1 Item"
+            class="fd-nested-list__icon sap-icon--chain-link"
+          />
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+        
+    </ul>
+    
+    
+  </div>
+  
+
+</nav>
+`;
+
+exports[`Storyshots Components/Vertical Navigation Default 1`] = `
+<div
+  class="fd-vertical-nav"
+>
+  
+    
+  <a
+    class="fd-vertical-nav__skip-link"
+    href="#content"
+  >
+    Skip navigation
+  </a>
+  
+    
+  <nav
+    aria-label="Main Menu"
+    class="fd-vertical-nav__main-navigation"
+  >
+    
+        
+    <ul
+      aria-label="Main Menu"
+      class="fd-nested-list fd-nested-list--text-only"
+    >
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+        >
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link is-selected"
+        >
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+        >
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+        >
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+        
+    </ul>
+    
+    
+  </nav>
+  
+    
+  <nav
+    aria-label="Utility Menu"
+    class="fd-vertical-nav__utility"
+  >
+    
+        
+    <ul
+      aria-label="Utility Menu"
+      class="fd-nested-list fd-nested-list--text-only"
+    >
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+        >
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+        >
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+        
+    </ul>
+    
+    
+  </nav>
+  
+
+</div>
+`;
+
+exports[`Storyshots Components/Vertical Navigation Group 1`] = `
+<div
+  class="fd-vertical-nav"
+>
+  
+    
+  <a
+    class="fd-vertical-nav__skip-link"
+    href="#content"
+  >
+    Skip navigation
+  </a>
+  
+    
+  <nav
+    aria-label="Main Menu"
+    class="fd-vertical-nav__main-navigation"
+  >
+    
+        
+    <ul
+      class="fd-nested-list fd-nested-list--text-only"
+    >
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link is-selected"
+          href="#"
+        >
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+                  
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <div
+          class="fd-nested-list__content has-child"
+        >
+          
+                    
+          <a
+            class="fd-nested-list__link"
+            href="#"
+          >
+            
+                        
+            <span
+              class="fd-nested-list__title"
+            >
+              Level 1 Item
+            </span>
+            
+                    
+          </a>
+          
+                    
+          <button
+            aria-controls="EX100L2"
+            aria-expanded="false"
+            aria-haspopup="true"
+            aria-label="Expand submenu"
+            class="fd-button fd-nested-list__button"
+            onclick="toggleNestedListSubmenu(event)"
+          >
+            
+                        
+            <i
+              class="sap-icon--navigation-right-arrow"
+              role="presentation"
+            />
+                
+                    
+          </button>
+          
+                
+        </div>
+        
+                
+        <ul
+          aria-hidden="true"
+          class="fd-nested-list level-2"
+          id="EX100L2"
+        >
+          
+                    
+          <li
+            class="fd-nested-list__item"
+          >
+            
+                        
+            <a
+              class="fd-nested-list__link"
+              href="#"
+            >
+              
+                            
+              <span
+                class="fd-nested-list__title"
+              >
+                Level 2 Item
+              </span>
+              
+                        
+            </a>
+            
+                    
+          </li>
+          
+                    
+          <li
+            class="fd-nested-list__item"
+          >
+            
+                        
+            <a
+              class="fd-nested-list__link"
+              href="#"
+            >
+              
+                            
+              <span
+                class="fd-nested-list__title"
+              >
+                Level 2 Item
+              </span>
+              
+                        
+            </a>
+            
+                    
+          </li>
+          
+                    
+          <li
+            class="fd-nested-list__item"
+          >
+            
+                        
+            <a
+              class="fd-nested-list__link"
+              href="#"
+            >
+              
+                            
+              <span
+                class="fd-nested-list__title"
+              >
+                Level 2 Item
+              </span>
+              
+                        
+            </a>
+            
+                    
+          </li>
+          
+                
+        </ul>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+        
+    </ul>
+    
+    
+  </nav>
+  
+    
+  <nav
+    aria-label="Utility Menu"
+    class="fd-vertical-nav__utility"
+  >
+    
+        
+    <ul
+      aria-label="Utility Menu"
+      class="fd-nested-list fd-nested-list--text-only"
+    >
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+        
+    </ul>
+    
+    
+  </nav>
+  
+
+</div>
+`;
+
+exports[`Storyshots Components/Vertical Navigation Icons 1`] = `
+<div
+  class="fd-vertical-nav"
+>
+  
+    
+  <a
+    class="fd-vertical-nav__skip-link"
+    href="#content"
+  >
+    Skip navigation
+  </a>
+  
+    
+  <nav
+    aria-label="Main Menu"
+    class="fd-vertical-nav__main-navigation"
+  >
+    
+        
+    <ul
+      class="fd-nested-list"
+    >
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <i
+            class="fd-nested-list__icon sap-icon--home"
+            role="presentation"
+          />
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link is-selected"
+          href="#"
+        >
+          
+                    
+          <i
+            class="fd-nested-list__icon sap-icon--calendar"
+            role="presentation"
+          />
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <i
+            class="fd-nested-list__icon sap-icon--employee"
+            role="presentation"
+          />
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <i
+            class="fd-nested-list__icon sap-icon--activities"
+            role="presentation"
+          />
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+        
+    </ul>
+    
+    
+  </nav>
+  
+    
+  <nav
+    aria-label="Utility Menu"
+    class="fd-vertical-nav__utility"
+  >
+    
+        
+    <ul
+      class="fd-nested-list"
+    >
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <i
+            class="fd-nested-list__icon sap-icon--compare"
+            role="presentation"
+          />
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#"
+        >
+          
+                    
+          <i
+            class="fd-nested-list__icon sap-icon--chain-link"
+            role="presentation"
+          />
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+        
+    </ul>
+    
+    
+  </nav>
+  
+
+</div>
+`;
+
+exports[`Storyshots Components/Vertical Navigation Nested List With Group Headers 1`] = `
+<ul
+  class="fd-nested-list"
+>
+  
+    
+  <li
+    class="fd-nested-list__group-header"
+  >
+    
+        Group Header 1
+    
+  </li>
+  
+    
+  <li
+    class="fd-nested-list__item"
+  >
+    
+        
+    <a
+      class="fd-nested-list__link"
+      href="#/"
+    >
+      
+            
+      <i
+        class="fd-nested-list__icon sap-icon--home"
+        role="presentation"
+      />
+      
+            
+      <span
+        class="fd-nested-list__title"
+      >
+        Level 1 Item
+      </span>
+      
+        
+    </a>
+    
+    
+  </li>
+  
+    
+  <li
+    class="fd-nested-list__item"
+  >
+    
+        
+    <a
+      class="fd-nested-list__link is-selected"
+      href="#/"
+    >
+      
+            
+      <i
+        class="fd-nested-list__icon sap-icon--calendar"
+        role="presentation"
+      />
+      
+            
+      <span
+        class="fd-nested-list__title"
+      >
+        Level 1 Item
+      </span>
+      
+        
+    </a>
+    
+    
+  </li>
+  
+    
+  <li
+    class="fd-nested-list__item"
+  >
+    
+	   
+    <div
+      class="fd-nested-list__content has-child"
+      tabindex="0"
+    >
+      
+			
+      <a
+        class="fd-nested-list__link"
+        href="#"
+        tabindex="-1"
+      >
+        
+				
+        <i
+          class="fd-nested-list__icon sap-icon--employee"
+          role="presentation"
+        />
+        
+				
+        <span
+          class="fd-nested-list__title"
+        >
+          Level 1 Item
+        </span>
+        
+			
+      </a>
+      
+            
+      <button
+        aria-controls="EX400L222"
+        aria-expanded="true"
+        aria-haspopup="true"
+        aria-label="Expand submenu"
+        class="fd-button fd-nested-list__button"
+      >
+        
+                
+        <i
+          class="sap-icon--navigation-right-arrow"
+          role="presentation"
+        />
+            
+            
+      </button>
+      
+		
+    </div>
+    
+        
+    <ul
+      aria-hidden="false"
+      class="fd-nested-list fd-nested-list--text-only level-2"
+      id="EX400L222"
+    >
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#/"
+        >
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 2 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+			   
+        <div
+          class="fd-nested-list__content has-child"
+          tabindex="0"
+        >
+          
+					
+          <a
+            class="fd-nested-list__link"
+            href="#"
+            tabindex="-1"
+          >
+            
+						
+            <span
+              class="fd-nested-list__title"
+            >
+              Level 2 Item
+            </span>
+            
+					
+          </a>
+          
+                    
+          <button
+            aria-controls="EX400L3"
+            aria-expanded="true"
+            aria-haspopup="true"
+            aria-label="Expand submenu"
+            class="fd-button fd-nested-list__button"
+          >
+            
+                        
+            <i
+              class="sap-icon--navigation-right-arrow"
+              role="presentation"
+            />
+                
+                    
+          </button>
+          
+				
+        </div>
+        
+                
+        <ul
+          aria-hidden="false"
+          class="fd-nested-list fd-nested-list--text-only level-3"
+          id="EX400L3"
+        >
+          
+                    
+          <li
+            class="fd-nested-list__item"
+          >
+            
+                        
+            <a
+              class="fd-nested-list__link"
+              href="#/"
+            >
+              
+                            
+              <span
+                class="fd-nested-list__title"
+              >
+                Level 3 Item
+              </span>
+              
+                        
+            </a>
+            
+                    
+          </li>
+          
+                    
+          <li
+            class="fd-nested-list__item"
+          >
+            
+					   
+            <div
+              class="fd-nested-list__content has-child"
+              tabindex="0"
+            >
+              
+							
+              <a
+                class="fd-nested-list__link"
+                href="#"
+                tabindex="-1"
+              >
+                
+								
+                <span
+                  class="fd-nested-list__title"
+                >
+                  Level 3 Item
+                </span>
+                
+							
+              </a>
+              
+                            
+              <button
+                aria-controls="EX400L4"
+                aria-expanded="true"
+                aria-haspopup="true"
+                aria-label="Expand submenu"
+                class="fd-button fd-nested-list__button"
+              >
+                
+                                
+                <i
+                  class="sap-icon--navigation-right-arrow"
+                  role="presentation"
+                />
+                    
+                            
+              </button>
+              
+						
+            </div>
+            
+                        
+            <ul
+              aria-hidden="false"
+              class="fd-nested-list fd-nested-list--text-only level-4"
+              id="EX400L4"
+            >
+              
+                            
+              <li
+                class="fd-nested-list__item"
+              >
+                
+                                
+                <a
+                  class="fd-nested-list__link"
+                  href="#/"
+                >
+                  
+                                    
+                  <span
+                    class="fd-nested-list__title"
+                  >
+                    Level 4 Item
+                  </span>
+                  
+                                
+                </a>
+                
+                            
+              </li>
+              
+                            
+              <li
+                class="fd-nested-list__item"
+              >
+                
+                                
+                <a
+                  class="fd-nested-list__link"
+                  href="#/"
+                >
+                  
+                                    
+                  <span
+                    class="fd-nested-list__title"
+                  >
+                    Level 4 Item
+                  </span>
+                  
+                                
+                </a>
+                
+                            
+              </li>
+              
+                            
+              <li
+                class="fd-nested-list__item"
+              >
+                
+                                
+                <a
+                  class="fd-nested-list__link"
+                  href="#/"
+                >
+                  
+                                    
+                  <span
+                    class="fd-nested-list__title"
+                  >
+                    Level 4 Item
+                  </span>
+                  
+                                
+                </a>
+                
+                            
+              </li>
+              
+                        
+            </ul>
+            
+                    
+          </li>
+          
+                    
+          <li
+            class="fd-nested-list__item"
+          >
+            
+                        
+            <a
+              class="fd-nested-list__link"
+              href="#/"
+            >
+              
+                            
+              <span
+                class="fd-nested-list__title"
+              >
+                Level 3 Item
+              </span>
+              
+                        
+            </a>
+            
+                    
+          </li>
+          
+                
+        </ul>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#/"
+        >
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 2 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+        
+    </ul>
+    
+    
+  </li>
+  
+    
+  <li
+    class="fd-nested-list__item"
+  >
+    
+        
+    <a
+      class="fd-nested-list__link"
+      href="#/"
+    >
+      
+            
+      <i
+        class="fd-nested-list__icon sap-icon--activities"
+        role="presentation"
+      />
+      
+            
+      <span
+        class="fd-nested-list__title"
+      >
+        Level 1 Item
+      </span>
+      
+        
+    </a>
+    
+    
+  </li>
+  
+    
+  <li
+    class="fd-nested-list__group-header"
+  >
+    
+        Group Header 2
+    
+  </li>
+  
+    
+  <li
+    class="fd-nested-list__item"
+  >
+    
+        
+    <a
+      class="fd-nested-list__link"
+      href="#/"
+    >
+      
+            
+      <i
+        class="fd-nested-list__icon sap-icon--bar-chart"
+        role="presentation"
+      />
+      
+            
+      <span
+        class="fd-nested-list__title"
+      >
+        Level 1 Item
+      </span>
+      
+        
+    </a>
+    
+    
+  </li>
+  
+    
+  <li
+    class="fd-nested-list__item"
+  >
+    
+        
+    <a
+      class="fd-nested-list__link"
+      href="#/"
+    >
+      
+            
+      <span
+        class="fd-nested-list__title"
+      >
+        Level 1 Item
+      </span>
+      
+        
+    </a>
+    
+    
+  </li>
+  
+
+</ul>
+`;
+
+exports[`Storyshots Components/Vertical Navigation Nested List With Group Headers Compact Mode 1`] = `
+<ul
+  class="fd-nested-list fd-nested-list--compact"
+>
+  
+    
+  <li
+    class="fd-nested-list__group-header"
+  >
+    
+        Group Header 1
+    
+  </li>
+  
+    
+  <li
+    class="fd-nested-list__item"
+  >
+    
+        
+    <a
+      class="fd-nested-list__link"
+      href="#/"
+    >
+      
+            
+      <i
+        class="fd-nested-list__icon sap-icon--home"
+        role="presentation"
+      />
+      
+            
+      <span
+        class="fd-nested-list__title"
+      >
+        Level 1 Item
+      </span>
+      
+        
+    </a>
+    
+    
+  </li>
+  
+    
+  <li
+    class="fd-nested-list__item"
+  >
+    
+        
+    <a
+      class="fd-nested-list__link is-selected"
+      href="#/"
+    >
+      
+            
+      <i
+        class="fd-nested-list__icon sap-icon--calendar"
+        role="presentation"
+      />
+      
+            
+      <span
+        class="fd-nested-list__title"
+      >
+        Level 1 Item
+      </span>
+      
+        
+    </a>
+    
+    
+  </li>
+  
+    
+  <li
+    class="fd-nested-list__item"
+  >
+    
+	   
+    <div
+      class="fd-nested-list__content has-child"
+      tabindex="0"
+    >
+      
+			
+      <a
+        class="fd-nested-list__link"
+        href="#"
+        tabindex="-1"
+      >
+        
+            	
+        <i
+          class="fd-nested-list__icon sap-icon--employee"
+          role="presentation"
+        />
+        
+				
+        <span
+          class="fd-nested-list__title"
+        >
+          Level 1 Item
+        </span>
+        
+			
+      </a>
+      
+            
+      <button
+        aria-controls="EX500L2"
+        aria-expanded="true"
+        aria-haspopup="true"
+        aria-label="Expand submenu"
+        class="fd-button fd-nested-list__button"
+      >
+        
+                
+        <i
+          class="sap-icon--navigation-right-arrow"
+          role="presentation"
+        />
+            
+            
+      </button>
+      
+		
+    </div>
+    
+        
+    <ul
+      aria-hidden="false"
+      class="fd-nested-list fd-nested-list--text-only level-2"
+      id="EX500L2"
+    >
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#/"
+        >
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 2 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+			   
+        <div
+          class="fd-nested-list__content has-child"
+          tabindex="0"
+        >
+          
+					
+          <a
+            class="fd-nested-list__link"
+            href="#"
+            tabindex="-1"
+          >
+            
+						
+            <span
+              class="fd-nested-list__title"
+            >
+              Level 2 Item
+            </span>
+            
+					
+          </a>
+          
+                    
+          <button
+            aria-controls="EX500L3"
+            aria-expanded="true"
+            aria-haspopup="true"
+            aria-label="Expand submenu"
+            class="fd-button fd-nested-list__button"
+          >
+            
+                        
+            <i
+              class="sap-icon--navigation-right-arrow"
+              role="presentation"
+            />
+                
+                    
+          </button>
+          
+				
+        </div>
+        
+                
+        <ul
+          aria-hidden="false"
+          class="fd-nested-list fd-nested-list--text-only level-3"
+          id="EX500L3"
+        >
+          
+                    
+          <li
+            class="fd-nested-list__item"
+          >
+            
+                        
+            <a
+              class="fd-nested-list__link"
+              href="#/"
+            >
+              
+                            
+              <span
+                class="fd-nested-list__title"
+              >
+                Level 3 Item
+              </span>
+              
+                        
+            </a>
+            
+                    
+          </li>
+          
+                    
+          <li
+            class="fd-nested-list__item"
+          >
+            
+					   
+            <div
+              class="fd-nested-list__content has-child"
+              tabindex="0"
+            >
+              
+							
+              <a
+                class="fd-nested-list__link"
+                href="#"
+                tabindex="-1"
+              >
+                
+								
+                <span
+                  class="fd-nested-list__title"
+                >
+                  Level 3 Item
+                </span>
+                
+							
+              </a>
+              
+                            
+              <button
+                aria-controls="EX500L4"
+                aria-expanded="true"
+                aria-haspopup="true"
+                aria-label="Expand submenu"
+                class="fd-button fd-nested-list__button"
+              >
+                
+                                
+                <i
+                  class="sap-icon--navigation-right-arrow"
+                  role="presentation"
+                />
+                    
+                            
+              </button>
+              
+						
+            </div>
+            
+                        
+            <ul
+              aria-hidden="false"
+              class="fd-nested-list fd-nested-list--text-only level-4"
+              id="EX500L4"
+            >
+              
+                            
+              <li
+                class="fd-nested-list__item"
+              >
+                
+                                
+                <a
+                  class="fd-nested-list__link"
+                  href="#/"
+                >
+                  
+                                    
+                  <span
+                    class="fd-nested-list__title"
+                  >
+                    Level 4 Item
+                  </span>
+                  
+                                
+                </a>
+                
+                            
+              </li>
+              
+                            
+              <li
+                class="fd-nested-list__item"
+              >
+                
+                                
+                <a
+                  class="fd-nested-list__link"
+                  href="#/"
+                >
+                  
+                                    
+                  <span
+                    class="fd-nested-list__title"
+                  >
+                    Level 4 Item
+                  </span>
+                  
+                                
+                </a>
+                
+                            
+              </li>
+              
+                            
+              <li
+                class="fd-nested-list__item"
+              >
+                
+                                
+                <a
+                  class="fd-nested-list__link"
+                  href="#/"
+                >
+                  
+                                    
+                  <span
+                    class="fd-nested-list__title"
+                  >
+                    Level 4 Item
+                  </span>
+                  
+                                
+                </a>
+                
+                            
+              </li>
+              
+                        
+            </ul>
+            
+                    
+          </li>
+          
+                    
+          <li
+            class="fd-nested-list__item"
+          >
+            
+                        
+            <a
+              class="fd-nested-list__link"
+              href="#/"
+            >
+              
+                            
+              <span
+                class="fd-nested-list__title"
+              >
+                Level 3 Item
+              </span>
+              
+                        
+            </a>
+            
+                    
+          </li>
+          
+                
+        </ul>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#/"
+        >
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 2 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+        
+    </ul>
+    
+    
+  </li>
+  
+    
+  <li
+    class="fd-nested-list__item"
+  >
+    
+        
+    <a
+      class="fd-nested-list__link"
+      href="#/"
+    >
+      
+            
+      <i
+        class="fd-nested-list__icon sap-icon--activities"
+        role="presentation"
+      />
+      
+            
+      <span
+        class="fd-nested-list__title"
+      >
+        Level 1 Item
+      </span>
+      
+        
+    </a>
+    
+    
+  </li>
+  
+    
+  <li
+    class="fd-nested-list__group-header"
+  >
+    
+        Group Header 2
+    
+  </li>
+  
+    
+  <li
+    class="fd-nested-list__item"
+  >
+    
+        
+    <a
+      class="fd-nested-list__link"
+      href="#/"
+    >
+      
+            
+      <i
+        class="fd-nested-list__icon sap-icon--bar-chart"
+        role="presentation"
+      />
+      
+            
+      <span
+        class="fd-nested-list__title"
+      >
+        Level 1 Item
+      </span>
+      
+        
+    </a>
+    
+    
+  </li>
+  
+    
+  <li
+    class="fd-nested-list__item"
+  >
+    
+        
+    <a
+      class="fd-nested-list__link"
+      href="#/"
+    >
+      
+            
+      <span
+        class="fd-nested-list__title"
+      >
+        Level 1 Item
+      </span>
+      
+        
+    </a>
+    
+    
+  </li>
+  
+
+</ul>
+`;
+
+exports[`Storyshots Components/Vertical Navigation Nested List With Icons Only In First Level 1`] = `
+<ul
+  class="fd-nested-list"
+>
+  
+    
+  <li
+    class="fd-nested-list__item"
+  >
+    
+        
+    <a
+      class="fd-nested-list__link"
+      href="#/"
+    >
+      
+            
+      <i
+        class="fd-nested-list__icon sap-icon--home"
+        role="presentation"
+      />
+      
+            
+      <span
+        class="fd-nested-list__title"
+      >
+        Level 1 Item
+      </span>
+      
+        
+    </a>
+    
+    
+  </li>
+  
+    
+  <li
+    class="fd-nested-list__item"
+  >
+    
+        
+    <a
+      class="fd-nested-list__link is-selected"
+      href="#/"
+    >
+      
+            
+      <i
+        class="fd-nested-list__icon sap-icon--calendar"
+        role="presentation"
+      />
+      
+            
+      <span
+        class="fd-nested-list__title"
+      >
+        Level 1 Item
+      </span>
+      
+        
+    </a>
+    
+    
+  </li>
+  
+    
+  <li
+    class="fd-nested-list__item"
+  >
+    
+	   
+    <div
+      class="fd-nested-list__content has-child is-expanded"
+      tabindex="0"
+    >
+      
+			
+      <a
+        class="fd-nested-list__link"
+        href="#"
+        tabindex="-1"
+      >
+        
+				
+        <i
+          class="fd-nested-list__icon sap-icon--employee"
+          role="presentation"
+        />
+        
+				
+        <span
+          class="fd-nested-list__title"
+        >
+          Level 1 Item
+        </span>
+        
+			
+      </a>
+      
+            
+      <button
+        aria-controls="EX300L2"
+        aria-expanded="true"
+        aria-haspopup="true"
+        aria-label="Expand submenu"
+        class="fd-button fd-nested-list__button"
+      >
+        
+                
+        <i
+          class="sap-icon--navigation-right-arrow"
+          role="presentation"
+        />
+            
+            
+      </button>
+      
+		
+    </div>
+    
+        
+    <ul
+      aria-hidden="false"
+      class="fd-nested-list fd-nested-list--text-only level-2"
+      id="EX300L2"
+    >
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#/"
+        >
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 2 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+			   
+        <div
+          class="fd-nested-list__content has-child"
+          tabindex="0"
+        >
+          
+					
+          <a
+            class="fd-nested-list__link"
+            href="#"
+            tabindex="-1"
+          >
+            
+						
+            <span
+              class="fd-nested-list__title"
+            >
+              Level 2 Item
+            </span>
+            
+					
+          </a>
+          
+                    
+          <button
+            aria-controls="EX300L3"
+            aria-expanded="true"
+            aria-haspopup="true"
+            aria-label="Expand submenu"
+            class="fd-button fd-nested-list__button"
+          >
+            
+                        
+            <i
+              class="sap-icon--navigation-right-arrow"
+              role="presentation"
+            />
+                
+                    
+          </button>
+          
+				
+        </div>
+        
+                
+        <ul
+          aria-hidden="false"
+          class="fd-nested-list fd-nested-list--text-only level-3"
+          id="EX300L3"
+        >
+          
+                    
+          <li
+            class="fd-nested-list__item"
+          >
+            
+                        
+            <a
+              class="fd-nested-list__link"
+              href="#/"
+            >
+              
+                            
+              <span
+                class="fd-nested-list__title"
+              >
+                Level 3 Item
+              </span>
+              
+                        
+            </a>
+            
+                    
+          </li>
+          
+                    
+          <li
+            class="fd-nested-list__item"
+          >
+            
+					   
+            <div
+              class="fd-nested-list__content has-child"
+              tabindex="0"
+            >
+              
+							
+              <a
+                class="fd-nested-list__link"
+                href="#"
+                tabindex="-1"
+              >
+                
+								
+                <span
+                  class="fd-nested-list__title"
+                >
+                  Level 3 Item
+                </span>
+                
+							
+              </a>
+              
+                            
+              <button
+                aria-controls="EX300L4"
+                aria-expanded="true"
+                aria-haspopup="true"
+                aria-label="Expand submenu"
+                class="fd-button fd-nested-list__button"
+              >
+                
+                                
+                <i
+                  class="sap-icon--navigation-right-arrow"
+                  role="presentation"
+                />
+                    
+                            
+              </button>
+              
+						
+            </div>
+            
+                        
+            <ul
+              aria-hidden="false"
+              class="fd-nested-list fd-nested-list--text-only level-4"
+              id="EX300L4"
+            >
+              
+                            
+              <li
+                class="fd-nested-list__item"
+              >
+                
+                                
+                <a
+                  class="fd-nested-list__link"
+                  href="#/"
+                >
+                  
+                                    
+                  <span
+                    class="fd-nested-list__title"
+                  >
+                    Level 4 Item
+                  </span>
+                  
+                                
+                </a>
+                
+                            
+              </li>
+              
+                            
+              <li
+                class="fd-nested-list__item"
+              >
+                
+                                
+                <a
+                  class="fd-nested-list__link"
+                  href="#/"
+                >
+                  
+                                    
+                  <span
+                    class="fd-nested-list__title"
+                  >
+                    Level 4 Item
+                  </span>
+                  
+                                
+                </a>
+                
+                            
+              </li>
+              
+                            
+              <li
+                class="fd-nested-list__item"
+              >
+                
+                                
+                <a
+                  class="fd-nested-list__link"
+                  href="#/"
+                >
+                  
+                                    
+                  <span
+                    class="fd-nested-list__title"
+                  >
+                    Level 4 Item
+                  </span>
+                  
+                                
+                </a>
+                
+                            
+              </li>
+              
+                        
+            </ul>
+            
+                    
+          </li>
+          
+                    
+          <li
+            class="fd-nested-list__item"
+          >
+            
+                        
+            <a
+              class="fd-nested-list__link"
+              href="#/"
+            >
+              
+                            
+              <span
+                class="fd-nested-list__title"
+              >
+                Level 3 Item
+              </span>
+              
+                        
+            </a>
+            
+                    
+          </li>
+          
+                
+        </ul>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#/"
+        >
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 2 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+        
+    </ul>
+    
+    
+  </li>
+  
+    
+  <li
+    class="fd-nested-list__item"
+  >
+    
+        
+    <a
+      class="fd-nested-list__link"
+      href="#/"
+    >
+      
+            
+      <i
+        class="fd-nested-list__icon sap-icon--activities"
+        role="presentation"
+      />
+      
+            
+      <span
+        class="fd-nested-list__title"
+      >
+        Level 1 Item
+      </span>
+      
+        
+    </a>
+    
+    
+  </li>
+  
+    
+  <li
+    class="fd-nested-list__item"
+  >
+    
+        
+    <a
+      class="fd-nested-list__link"
+      href="#/"
+    >
+      
+            
+      <i
+        class="fd-nested-list__icon sap-icon--bar-chart"
+        role="presentation"
+      />
+      
+            
+      <span
+        class="fd-nested-list__title"
+      >
+        Level 1 Item
+      </span>
+      
+        
+    </a>
+    
+    
+  </li>
+  
+    
+  <li
+    class="fd-nested-list__item"
+  >
+    
+        
+    <a
+      class="fd-nested-list__link"
+      href="#/"
+    >
+      
+            
+      <span
+        class="fd-nested-list__title"
+      >
+        Level 1 Item
+      </span>
+      
+        
+    </a>
+    
+    
+  </li>
+  
+
+</ul>
+`;
+
+exports[`Storyshots Components/Vertical Navigation Nested List Without Icons 1`] = `
+<ul
+  class="fd-nested-list fd-nested-list--text-only"
+>
+  
+    
+  <li
+    class="fd-nested-list__item"
+  >
+    
+        
+    <a
+      class="fd-nested-list__link"
+      href="#/"
+    >
+      
+            
+      <span
+        class="fd-nested-list__title"
+      >
+        Level 1 Item
+      </span>
+      
+        
+    </a>
+    
+    
+  </li>
+  
+    
+  <li
+    class="fd-nested-list__item"
+  >
+    
+        
+    <a
+      class="fd-nested-list__link is-selected"
+      href="#/"
+    >
+      
+            
+      <span
+        class="fd-nested-list__title"
+      >
+        Level 1 Item
+      </span>
+      
+        
+    </a>
+    
+    
+  </li>
+  
+    
+  <li
+    class="fd-nested-list__item"
+  >
+    
+	    
+    <div
+      class="fd-nested-list__content has-child is-expanded"
+    >
+      
+			
+      <a
+        class="fd-nested-list__link"
+        href="#"
+      >
+        
+				
+        <span
+          class="fd-nested-list__title"
+        >
+          Level 1 Item
+        </span>
+        
+            
+      </a>
+      
+            
+      <button
+        aria-controls="EX100L25"
+        aria-expanded="true"
+        aria-haspopup="true"
+        aria-label="Expand submenu"
+        class="fd-button fd-nested-list__button"
+      >
+        
+                    
+        <i
+          class="sap-icon--navigation-right-arrow"
+          role="presentation"
+        />
+            
+            
+      </button>
+      
+		
+    </div>
+    
+        
+    <ul
+      aria-hidden="false"
+      class="fd-nested-list level-2"
+      id="EX100L25"
+    >
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#/"
+        >
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 2 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+			   
+        <div
+          class="fd-nested-list__content has-child"
+          tabindex="0"
+        >
+          
+					
+          <a
+            class="fd-nested-list__link"
+            href="#"
+            tabindex="-1"
+          >
+            
+						
+            <span
+              class="fd-nested-list__title"
+            >
+              Level 2 Item
+            </span>
+            
+                    
+          </a>
+          
+                    
+          <button
+            aria-controls="EX100L35"
+            aria-expanded="true"
+            aria-haspopup="true"
+            aria-label="Expand submenu"
+            class="fd-button fd-nested-list__button"
+          >
+            
+                        
+            <i
+              class="sap-icon--navigation-right-arrow"
+              role="presentation"
+            />
+                
+                    
+          </button>
+          
+				
+        </div>
+        
+                
+        <ul
+          aria-hidden="false"
+          class="fd-nested-list level-3"
+          id="EX100L35"
+        >
+          
+                    
+          <li
+            class="fd-nested-list__item"
+          >
+            
+                        
+            <a
+              class="fd-nested-list__link"
+              href="#/"
+            >
+              
+                            
+              <span
+                class="fd-nested-list__title"
+              >
+                Level 3 Item
+              </span>
+              
+                        
+            </a>
+            
+                    
+          </li>
+          
+                    
+          <li
+            class="fd-nested-list__item"
+          >
+            
+					   
+            <div
+              class="fd-nested-list__content has-child"
+              tabindex="0"
+            >
+              
+							
+              <a
+                class="fd-nested-list__link"
+                href="#"
+                tabindex="-1"
+              >
+                
+								
+                <span
+                  class="fd-nested-list__title"
+                >
+                  Level 3 Item
+                </span>
+                
+							
+              </a>
+              
+                            
+              <button
+                aria-controls="EX100L45"
+                aria-expanded="true"
+                aria-haspopup="true"
+                aria-label="Expand submenu"
+                class="fd-button fd-nested-list__button"
+              >
+                
+                                
+                <i
+                  class="sap-icon--navigation-right-arrow"
+                  role="presentation"
+                />
+                    
+                            
+              </button>
+              
+						
+            </div>
+            
+                        
+            <ul
+              aria-hidden="false"
+              class="fd-nested-list level-4"
+              id="EX100L45"
+            >
+              
+                            
+              <li
+                class="fd-nested-list__item"
+              >
+                
+                                
+                <a
+                  class="fd-nested-list__link"
+                  href="#/"
+                >
+                  
+                                    
+                  <span
+                    class="fd-nested-list__title"
+                  >
+                    Level 4 Item
+                  </span>
+                  
+                                
+                </a>
+                
+                            
+              </li>
+              
+                            
+              <li
+                class="fd-nested-list__item"
+              >
+                
+							   
+                <div
+                  class="fd-nested-list__content has-child"
+                  tabindex="0"
+                >
+                  
+									
+                  <a
+                    class="fd-nested-list__link"
+                    href="#"
+                    tabindex="-1"
+                  >
+                    
+										
+                    <span
+                      class="fd-nested-list__title"
+                    >
+                      Level 4 Item
+                    </span>
+                    
+									
+                  </a>
+                  
+                                    
+                  <button
+                    aria-controls="EX100L55"
+                    aria-expanded="true"
+                    aria-haspopup="true"
+                    aria-label="Expand submenu"
+                    class="fd-button fd-nested-list__button"
+                  >
+                    
+                                        
+                    <i
+                      class="sap-icon--navigation-right-arrow"
+                      role="presentation"
+                    />
+                        
+                                    
+                  </button>
+                  
+								
+                </div>
+                
+                                
+                <ul
+                  aria-hidden="false"
+                  class="fd-nested-list level-5"
+                  id="EX100L55"
+                >
+                  
+                                    
+                  <li
+                    class="fd-nested-list__item"
+                  >
+                    
+                                        
+                    <a
+                      class="fd-nested-list__link"
+                      href="#/"
+                    >
+                      
+                                            
+                      <span
+                        class="fd-nested-list__title"
+                      >
+                        Level 5 Item
+                      </span>
+                      
+                                        
+                    </a>
+                    
+                                    
+                  </li>
+                  
+                                    
+                  <li
+                    class="fd-nested-list__item"
+                  >
+                    
+									   
+                    <div
+                      class="fd-nested-list__content has-child"
+                      tabindex="0"
+                    >
+                      
+											
+                      <a
+                        class="fd-nested-list__link"
+                        href="#"
+                        tabindex="-1"
+                      >
+                        
+												
+                        <span
+                          class="fd-nested-list__title"
+                        >
+                          Level 5 Item
+                        </span>
+                        
+											
+                      </a>
+                      
+                                            
+                      <button
+                        aria-controls="EX100L65"
+                        aria-expanded="true"
+                        aria-haspopup="true"
+                        aria-label="Expand submenu"
+                        class="fd-button fd-nested-list__button"
+                      >
+                        
+                                                
+                        <i
+                          class="sap-icon--navigation-right-arrow"
+                          role="presentation"
+                        />
+                        
+                                            
+                      </button>
+                      
+										
+                    </div>
+                    
+                                        
+                    <ul
+                      aria-hidden="false"
+                      class="fd-nested-list level-6"
+                      id="EX100L65"
+                    >
+                      
+                                            
+                      <li
+                        class="fd-nested-list__item"
+                      >
+                        
+                                                
+                        <a
+                          class="fd-nested-list__link"
+                          href="#/"
+                        >
+                          
+                                                    
+                          <span
+                            class="fd-nested-list__title"
+                          >
+                            Level 6 Item
+                          </span>
+                          
+                                                
+                        </a>
+                        
+                                            
+                      </li>
+                      
+                                            
+                      <li
+                        class="fd-nested-list__item"
+                      >
+                        
+                                                
+                        <a
+                          class="fd-nested-list__link"
+                          href="#/"
+                        >
+                          
+                                                    
+                          <span
+                            class="fd-nested-list__title"
+                          >
+                            Level 6 Item
+                          </span>
+                          
+                                                
+                        </a>
+                        
+                                            
+                      </li>
+                      
+                                            
+                      <li
+                        class="fd-nested-list__item"
+                      >
+                        
+                                                
+                        <a
+                          class="fd-nested-list__link"
+                          href="#/"
+                        >
+                          
+                                                    
+                          <span
+                            class="fd-nested-list__title"
+                          >
+                            Level 6 Item
+                          </span>
+                          
+                                                
+                        </a>
+                        
+                                            
+                      </li>
+                      
+                                        
+                    </ul>
+                    
+                                    
+                  </li>
+                  
+                                    
+                  <li
+                    class="fd-nested-list__item"
+                  >
+                    
+                                        
+                    <a
+                      class="fd-nested-list__link"
+                      href="#/"
+                    >
+                      
+                                            
+                      <span
+                        class="fd-nested-list__title"
+                      >
+                        Level 5 Item
+                      </span>
+                      
+                                        
+                    </a>
+                    
+                                    
+                  </li>
+                  
+                                
+                </ul>
+                
+                            
+              </li>
+              
+                            
+              <li
+                class="fd-nested-list__item"
+              >
+                
+                                
+                <a
+                  class="fd-nested-list__link"
+                  href="#/"
+                >
+                  
+                                    
+                  <span
+                    class="fd-nested-list__title"
+                  >
+                    Level 4 Item
+                  </span>
+                  
+                                
+                </a>
+                
+                            
+              </li>
+              
+                        
+            </ul>
+            
+                    
+          </li>
+          
+                    
+          <li
+            class="fd-nested-list__item"
+          >
+            
+                        
+            <a
+              class="fd-nested-list__link"
+              href="#/"
+            >
+              
+                            
+              <span
+                class="fd-nested-list__title"
+              >
+                Level 3 Item
+              </span>
+              
+                        
+            </a>
+            
+                    
+          </li>
+          
+                
+        </ul>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#/"
+        >
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 2 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+        
+    </ul>
+    
+    
+  </li>
+  
+    
+  <li
+    class="fd-nested-list__item"
+  >
+    
+        
+    <a
+      class="fd-nested-list__link"
+      href="#/"
+    >
+      
+            
+      <span
+        class="fd-nested-list__title"
+      >
+        Level 1 Item
+      </span>
+      
+        
+    </a>
+    
+    
+  </li>
+  
+    
+  <li
+    class="fd-nested-list__item"
+  >
+    
+        
+    <a
+      class="fd-nested-list__link"
+      href="#/"
+    >
+      
+            
+      <span
+        class="fd-nested-list__title"
+      >
+        Level 1 Item
+      </span>
+      
+        
+    </a>
+    
+    
+  </li>
+  
+
+</ul>
+`;
+
+exports[`Storyshots Components/Vertical Navigation Nested List Without Links 1`] = `
+<ul
+  class="fd-nested-list fd-nested-list--compact"
+>
+  
+    
+  <li
+    class="fd-nested-list__group-header"
+  >
+    
+        Group Header 1
+    
+  </li>
+  
+    
+  <li
+    class="fd-nested-list__item"
+  >
+    
+        
+    <div
+      class="fd-nested-list__content"
+    >
+      
+            
+      <i
+        class="fd-nested-list__icon sap-icon--home"
+        role="presentation"
+      />
+      
+            
+      <span
+        class="fd-nested-list__title"
+      >
+        Level 1 Item
+      </span>
+      
+        
+    </div>
+    
+    
+  </li>
+  
+    
+  <li
+    class="fd-nested-list__item"
+  >
+    
+        
+    <div
+      class="fd-nested-list__content is-selected"
+    >
+      
+            
+      <i
+        class="fd-nested-list__icon sap-icon--calendar"
+        role="presentation"
+      />
+      
+            
+      <span
+        class="fd-nested-list__title"
+      >
+        Level 1 Item
+      </span>
+      
+        
+    </div>
+    
+    
+  </li>
+  
+    
+  <li
+    class="fd-nested-list__item"
+  >
+    
+	   
+    <div
+      class="fd-nested-list__content has-child"
+      tabindex="0"
+    >
+      
+            
+      <i
+        class="fd-nested-list__icon sap-icon--employee"
+        role="presentation"
+      />
+      
+			
+      <span
+        class="fd-nested-list__title"
+      >
+        Level 1 Item
+      </span>
+      
+            
+      <button
+        aria-controls="EX600L2"
+        aria-expanded="true"
+        aria-haspopup="true"
+        aria-label="Expand submenu"
+        class="fd-button fd-nested-list__button"
+      >
+        
+                
+        <i
+          class="sap-icon--navigation-right-arrow"
+          role="presentation"
+        />
+            
+            
+      </button>
+      
+		
+    </div>
+    
+        
+    <ul
+      aria-hidden="false"
+      class="fd-nested-list fd-nested-list--text-only level-2"
+      id="EX600L2"
+    >
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <div
+          class="fd-nested-list__content"
+        >
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 2 Item
+          </span>
+          
+                
+        </div>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+			   
+        <div
+          class="fd-nested-list__content has-child"
+          tabindex="0"
+        >
+          
+					
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 2 Item
+          </span>
+          
+                    
+          <button
+            aria-controls="EX600L3"
+            aria-expanded="true"
+            aria-haspopup="true"
+            aria-label="Expand submenu"
+            class="fd-button fd-nested-list__button"
+          >
+            
+                        
+            <i
+              class="sap-icon--navigation-right-arrow"
+              role="presentation"
+            />
+                
+                    
+          </button>
+          
+				
+        </div>
+        
+                
+        <ul
+          aria-hidden="false"
+          class="fd-nested-list fd-nested-list--text-only level-3"
+          id="EX600L3"
+        >
+          
+                    
+          <li
+            class="fd-nested-list__item"
+          >
+            
+                        
+            <div
+              class="fd-nested-list__content"
+            >
+              
+                            
+              <span
+                class="fd-nested-list__title"
+              >
+                Level 3 Item
+              </span>
+              
+                        
+            </div>
+            
+                    
+          </li>
+          
+                    
+          <li
+            class="fd-nested-list__item"
+          >
+            
+					   
+            <div
+              class="fd-nested-list__content has-child"
+              tabindex="0"
+            >
+              
+							
+              <span
+                class="fd-nested-list__title"
+              >
+                Level 3 Item
+              </span>
+              
+                            
+              <button
+                aria-controls="EX600L4"
+                aria-expanded="true"
+                aria-haspopup="true"
+                aria-label="Expand submenu"
+                class="fd-button fd-nested-list__button"
+              >
+                
+                                
+                <i
+                  class="sap-icon--navigation-right-arrow"
+                  role="presentation"
+                />
+                    
+                            
+              </button>
+              
+						
+            </div>
+            
+                        
+            <ul
+              aria-hidden="false"
+              class="fd-nested-list fd-nested-list--text-only level-4"
+              id="EX600L4"
+            >
+              
+                            
+              <li
+                class="fd-nested-list__item"
+              >
+                
+                                
+                <div
+                  class="fd-nested-list__content"
+                >
+                  
+                                    
+                  <span
+                    class="fd-nested-list__title"
+                  >
+                    Level 4 Item
+                  </span>
+                  
+                                
+                </div>
+                
+                            
+              </li>
+              
+                            
+              <li
+                class="fd-nested-list__item"
+              >
+                
+                                
+                <div
+                  class="fd-nested-list__content"
+                >
+                  
+                                    
+                  <span
+                    class="fd-nested-list__title"
+                  >
+                    Level 4 Item
+                  </span>
+                  
+                                
+                </div>
+                
+                            
+              </li>
+              
+                            
+              <li
+                class="fd-nested-list__item"
+              >
+                
+                                
+                <div
+                  class="fd-nested-list__content"
+                >
+                  
+                                    
+                  <span
+                    class="fd-nested-list__title"
+                  >
+                    Level 4 Item
+                  </span>
+                  
+                                
+                </div>
+                
+                            
+              </li>
+              
+                        
+            </ul>
+            
+                    
+          </li>
+          
+                    
+          <li
+            class="fd-nested-list__item"
+          >
+            
+                        
+            <div
+              class="fd-nested-list__content"
+            >
+              
+                            
+              <span
+                class="fd-nested-list__title"
+              >
+                Level 3 Item
+              </span>
+              
+                        
+            </div>
+            
+                    
+          </li>
+          
+                
+        </ul>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <div
+          class="fd-nested-list__content"
+        >
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 2 Item
+          </span>
+          
+                
+        </div>
+        
+            
+      </li>
+      
+        
+    </ul>
+    
+    
+  </li>
+  
+    
+  <li
+    class="fd-nested-list__item"
+  >
+    
+        
+    <div
+      class="fd-nested-list__content"
+    >
+      
+            
+      <i
+        class="fd-nested-list__icon sap-icon--activities"
+        role="presentation"
+      />
+      
+            
+      <span
+        class="fd-nested-list__title"
+      >
+        Level 1 Item
+      </span>
+      
+        
+    </div>
+    
+    
+  </li>
+  
+    
+  <li
+    class="fd-nested-list__group-header"
+  >
+    
+        Group Header 2
+    
+  </li>
+  
+    
+  <li
+    class="fd-nested-list__item"
+  >
+    
+        
+    <div
+      class="fd-nested-list__content"
+    >
+      
+            
+      <i
+        class="fd-nested-list__icon sap-icon--bar-chart"
+        role="presentation"
+      />
+      
+            
+      <span
+        class="fd-nested-list__title"
+      >
+        Level 1 Item
+      </span>
+      
+        
+    </div>
+    
+    
+  </li>
+  
+    
+  <li
+    class="fd-nested-list__item"
+  >
+    
+        
+    <div
+      class="fd-nested-list__content"
+    >
+      
+            
+      <span
+        class="fd-nested-list__title"
+      >
+        Level 1 Item
+      </span>
+      
+        
+    </div>
+    
+    
+  </li>
+  
+
+</ul>
+`;

--- a/stories/vertical-navigation/__snapshots__/vertical-navigation.stories.storyshot
+++ b/stories/vertical-navigation/__snapshots__/vertical-navigation.stories.storyshot
@@ -1,1409 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots Components/Vertical Navigation Complex (compact) 1`] = `
-<div
-  class="fd-vertical-nav"
->
-  
-    
-  <a
-    class="fd-vertical-nav__skip-link"
-    href="#content"
-  >
-    Skip navigation
-  </a>
-  
-    
-  <div
-    class="fd-vertical-nav__group-header"
-    id="EX500H1"
-  >
-    
-        Group Header 1
-    
-  </div>
-  
-    
-  <nav
-    aria-label="Main Menu"
-    class="fd-vertical-nav__main-navigation"
-  >
-    
-        
-    <ul
-      aria-labelledby="EX500H1"
-      class="fd-nested-list fd-nested-list--compact"
-    >
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#"
-        >
-          
-                    
-          <i
-            class="fd-nested-list__icon sap-icon--home"
-            role="presentation"
-          />
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link is-selected"
-          href="#"
-        >
-          
-                    
-          <i
-            class="fd-nested-list__icon sap-icon--calendar"
-            role="presentation"
-          />
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <div
-          class="fd-nested-list__content has-child"
-        >
-          
-                    
-          <a
-            class="fd-nested-list__link"
-            href="#"
-          >
-            
-                        
-            <i
-              class="fd-nested-list__icon sap-icon--employee"
-              role="presentation"
-            />
-            
-                        
-            <span
-              class="fd-nested-list__title"
-            >
-              Level 1 Item
-            </span>
-            
-                    
-          </a>
-          
-                    
-          <button
-            aria-controls="EX500L2"
-            aria-expanded="false"
-            aria-haspopup="true"
-            aria-label="Expand submenu"
-            class="fd-button fd-nested-list__button"
-            onclick="toggleNestedListSubmenu(event)"
-          >
-            
-                        
-            <i
-              class="sap-icon--navigation-right-arrow"
-              role="presentation"
-            />
-                
-                    
-          </button>
-          
-                
-        </div>
-        
-                
-        <ul
-          aria-hidden="true"
-          class="fd-nested-list fd-nested-list--text-only level-2"
-          id="EX500L2"
-        >
-          
-                    
-          <li
-            class="fd-nested-list__item"
-          >
-            
-                        
-            <a
-              class="fd-nested-list__link"
-              href="#"
-            >
-              
-                            
-              <span
-                class="fd-nested-list__title"
-              >
-                Level 2 Item
-              </span>
-              
-                        
-            </a>
-            
-                    
-          </li>
-          
-                    
-          <li
-            class="fd-nested-list__item"
-          >
-            
-                        
-            <a
-              class="fd-nested-list__link"
-              href="#"
-            >
-              
-                            
-              <span
-                class="fd-nested-list__title"
-              >
-                Level 2 Item
-              </span>
-              
-                        
-            </a>
-            
-                    
-          </li>
-          
-                    
-          <li
-            class="fd-nested-list__item"
-          >
-            
-                        
-            <a
-              class="fd-nested-list__link"
-              href="#"
-            >
-              
-                            
-              <span
-                class="fd-nested-list__title"
-              >
-                Level 2 Item
-              </span>
-              
-                        
-            </a>
-            
-                    
-          </li>
-          
-                
-        </ul>
-        
-            
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#"
-        >
-          
-                    
-          <i
-            class="fd-nested-list__icon sap-icon--activities"
-            role="presentation"
-          />
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-        
-    </ul>
-    
-        
-    <div
-      class="fd-vertical-nav__group-header"
-      id="EX500H2"
-    >
-      
-                Group Header 2
-        
-    </div>
-    
-        
-    <ul
-      aria-labelledby="EX500H2"
-      class="fd-nested-list fd-nested-list--compact"
-    >
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#"
-        >
-          
-                    
-          <i
-            class="fd-nested-list__icon sap-icon--bar-chart"
-            role="presentation"
-          />
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#"
-        >
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-        
-    </ul>
-    
-    
-  </nav>
-  
-    
-  <nav
-    aria-label="Utility Menu"
-    class="fd-vertical-nav__utility"
-  >
-    
-        
-    <ul
-      aria-label="Utility Menu"
-      class="fd-nested-list fd-nested-list--compact"
-    >
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#"
-        >
-          
-                    
-          <i
-            class="fd-nested-list__icon sap-icon--compare"
-            role="presentation"
-          />
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#"
-        >
-          
-                    
-          <i
-            class="fd-nested-list__icon sap-icon--chain-link"
-            role="presentation"
-          />
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-        
-    </ul>
-    
-    
-  </nav>
-  
-
-</div>
-`;
-
-exports[`Storyshots Components/Vertical Navigation Complex 1`] = `
-<div
-  class="fd-vertical-nav"
->
-  
-    
-  <a
-    class="fd-vertical-nav__skip-link"
-    href="#content"
-  >
-    Skip navigation
-  </a>
-  
-    
-  <div
-    class="fd-vertical-nav__group-header"
-    id="EX400H1"
-  >
-    
-        Group Header 1
-    
-  </div>
-  
-    
-  <nav
-    aria-label="Main Menu"
-    class="fd-vertical-nav__main-navigation"
-  >
-    
-        
-    <ul
-      aria-labelledby="EX400H1"
-      class="fd-nested-list "
-    >
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#"
-        >
-          
-                    
-          <i
-            class="fd-nested-list__icon sap-icon--home"
-            role="presentation"
-          />
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#"
-        >
-          
-                    
-          <i
-            class="fd-nested-list__icon sap-icon--calendar"
-            role="presentation"
-          />
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <div
-          class="fd-nested-list__content is-selected has-child"
-        >
-          
-                    
-          <a
-            class="fd-nested-list__link"
-            href="#"
-          >
-            
-                        
-            <i
-              class="fd-nested-list__icon sap-icon--employee"
-              role="presentation"
-            />
-            
-                        
-            <span
-              class="fd-nested-list__title"
-            >
-              Level 1 Item
-            </span>
-            
-                    
-          </a>
-          
-                    
-          <button
-            aria-controls="EX400L2"
-            aria-expanded="false"
-            aria-haspopup="true"
-            aria-label="Expand submenu"
-            class="fd-button fd-nested-list__button"
-            onclick="toggleNestedListSubmenu(event)"
-          >
-            
-                        
-            <i
-              class="sap-icon--navigation-right-arrow"
-              role="presentation"
-            />
-                
-                    
-          </button>
-          
-                
-        </div>
-        
-                
-        <ul
-          aria-hidden="true"
-          class="fd-nested-list fd-nested-list--text-only level-2"
-          id="EX400L2"
-        >
-          
-                    
-          <li
-            class="fd-nested-list__item"
-          >
-            
-                        
-            <a
-              class="fd-nested-list__link"
-              href="#"
-            >
-              
-                            
-              <span
-                class="fd-nested-list__title"
-              >
-                Level 2 Item
-              </span>
-              
-                        
-            </a>
-            
-                    
-          </li>
-          
-                    
-          <li
-            class="fd-nested-list__item"
-          >
-            
-                        
-            <a
-              class="fd-nested-list__link is-selected"
-              href="#"
-            >
-              
-                            
-              <span
-                class="fd-nested-list__title"
-              >
-                Level 2 Item
-              </span>
-              
-                        
-            </a>
-            
-                    
-          </li>
-          
-                    
-          <li
-            class="fd-nested-list__item"
-          >
-            
-                        
-            <a
-              class="fd-nested-list__link"
-              href="#"
-            >
-              
-                            
-              <span
-                class="fd-nested-list__title"
-              >
-                Level 2 Item
-              </span>
-              
-                        
-            </a>
-            
-                    
-          </li>
-          
-                
-        </ul>
-        
-            
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#"
-        >
-          
-                    
-          <i
-            class="fd-nested-list__icon sap-icon--activities"
-            role="presentation"
-          />
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-        
-    </ul>
-    
-        
-    <div
-      class="fd-vertical-nav__group-header"
-      id="EX400H2"
-    >
-      
-            Group Header 2
-        
-    </div>
-    
-        
-    <ul
-      aria-labelledby="EX400H2"
-      class="fd-nested-list"
-    >
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#"
-        >
-          
-                    
-          <i
-            class="fd-nested-list__icon sap-icon--bar-chart"
-            role="presentation"
-          />
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#"
-        >
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-        
-    </ul>
-    
-    
-  </nav>
-  
-    
-  <nav
-    aria-label="Utility Menu"
-    class="fd-vertical-nav__utility"
-  >
-    
-        
-    <ul
-      aria-label="Utility Menu"
-      class="fd-nested-list"
-    >
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#"
-        >
-          
-                    
-          <i
-            class="fd-nested-list__icon sap-icon--compare"
-            role="presentation"
-          />
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#"
-        >
-          
-                    
-          <i
-            class="fd-nested-list__icon sap-icon--chain-link"
-            role="presentation"
-          />
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-        
-    </ul>
-    
-    
-  </nav>
-  
-
-</div>
-`;
-
-exports[`Storyshots Components/Vertical Navigation Condensed (compact) 1`] = `
-<nav
-  class="fd-vertical-nav fd-vertical-nav--condensed"
->
-  
-    
-  <a
-    class="fd-vertical-nav__skip-link"
-    href="#content"
-  >
-    Skip navigation
-  </a>
-  
-    
-  <div
-    class="fd-vertical-nav__main-navigation"
-  >
-    
-        
-    <ul
-      class="fd-nested-list fd-nested-list--compact"
-    >
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#"
-        >
-          
-                    
-          <i
-            class="fd-nested-list__icon sap-icon--home"
-            role="presentation"
-          />
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#"
-        >
-          
-                    
-          <i
-            class="fd-nested-list__icon sap-icon--calendar"
-            role="presentation"
-          />
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <div
-          class="fd-nested-list__content is-selected has-child"
-        >
-          
-                    
-          <button
-            aria-controls="EX600L2"
-            aria-expanded="false"
-            aria-haspopup="true"
-            aria-label="Expand submenu"
-            class="fd-nested-list__link"
-          >
-            
-                        
-            <i
-              class="fd-nested-list__icon sap-icon--employee"
-              role="presentation"
-            />
-            
-                        
-            <span
-              class="fd-nested-list__title"
-            >
-              Level 1 Item
-            </span>
-            
-                    
-          </button>
-          
-                
-        </div>
-        
-            
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#"
-        >
-          
-                    
-          <i
-            class="fd-nested-list__icon sap-icon--activities"
-            role="presentation"
-          />
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#"
-        >
-          
-                    
-          <i
-            class="fd-nested-list__icon sap-icon--bar-chart"
-            role="presentation"
-          />
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-        
-    </ul>
-    
-    
-  </div>
-  
-    
-  <div
-    class="fd-vertical-nav__utility"
-  >
-    
-        
-    <ul
-      aria-label="Utility Menu"
-      class="fd-nested-list fd-nested-list--compact"
-    >
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#"
-        >
-          
-                    
-          <i
-            class="fd-nested-list__icon sap-icon--compare"
-            role="presentation"
-          />
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#"
-        >
-          
-                    
-          <i
-            class="fd-nested-list__icon sap-icon--chain-link"
-            role="presentation"
-          />
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-        
-    </ul>
-    
-    
-  </div>
-  
-
-</nav>
-`;
-
 exports[`Storyshots Components/Vertical Navigation Condensed 1`] = `
-<nav
+<div
   class="fd-vertical-nav fd-vertical-nav--condensed"
 >
-  
-    
-  <a
-    class="fd-vertical-nav__skip-link"
-    href="#content"
-  >
-    Skip navigation
-  </a>
-  
-    
-  <div
-    class="fd-vertical-nav__main-navigation"
-  >
-    
-        
-    <ul
-      class="fd-nested-list"
-    >
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#"
-        >
-          
-                    
-          <i
-            aria-label="Level 1 Item"
-            class="fd-nested-list__icon sap-icon--home"
-          />
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#"
-        >
-          
-                    
-          <i
-            aria-label="Level 1 Item"
-            class="fd-nested-list__icon sap-icon--calendar"
-          />
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <div
-          class="fd-nested-list__content is-selected has-child"
-        >
-          
-                    
-          <button
-            aria-controls="EX500L2"
-            aria-expanded="false"
-            aria-haspopup="true"
-            aria-label="Expand submenu"
-            class="fd-nested-list__link"
-          >
-            
-                        
-            <i
-              class="fd-nested-list__icon sap-icon--employee"
-              role="presentation"
-            />
-            
-                        
-            <span
-              class="fd-nested-list__title"
-            >
-              Level 1 Item
-            </span>
-            
-                    
-          </button>
-          
-                
-        </div>
-        
-            
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#"
-        >
-          
-                    
-          <i
-            aria-label="Level 1 Item"
-            class="fd-nested-list__icon sap-icon--activities"
-          />
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#"
-        >
-          
-                    
-          <i
-            aria-label="Level 1 Item"
-            class="fd-nested-list__icon sap-icon--bar-chart"
-          />
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-        
-    </ul>
-    
-    
-  </div>
-  
-    
-  <div
-    aria-label="Utility Menu"
-    class="fd-vertical-nav__utility"
-  >
-    
-        
-    <ul
-      class="fd-nested-list"
-    >
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#"
-        >
-          
-                    
-          <i
-            aria-label="Level 1 Item"
-            class="fd-nested-list__icon sap-icon--compare"
-          />
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#"
-        >
-          
-                    
-          <i
-            aria-label="Level 1 Item"
-            class="fd-nested-list__icon sap-icon--chain-link"
-          />
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-        
-    </ul>
-    
-    
-  </div>
-  
-
-</nav>
-`;
-
-exports[`Storyshots Components/Vertical Navigation Default 1`] = `
-<div
-  class="fd-vertical-nav"
->
-  
-    
-  <a
-    class="fd-vertical-nav__skip-link"
-    href="#content"
-  >
-    Skip navigation
-  </a>
   
     
   <nav
@@ -1414,161 +14,85 @@ exports[`Storyshots Components/Vertical Navigation Default 1`] = `
         
     <ul
       aria-label="Main Menu"
-      class="fd-nested-list fd-nested-list--text-only"
+      class="fd-list"
     >
       
             
       <li
-        class="fd-nested-list__item"
+        class="fd-list__navigation-item--condensed"
       >
         
                 
-        <a
-          class="fd-nested-list__link"
-        >
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
+        <i
+          class="fd-list__navigation-item-icon sap-icon--home"
+        />
+        
                 
-        </a>
+        <span
+          class="fd-list__navigation-item-text"
+        >
+          Overview
+        </span>
         
             
       </li>
       
             
       <li
-        class="fd-nested-list__item"
+        class="fd-list__navigation-item--condensed"
       >
         
                 
-        <a
-          class="fd-nested-list__link is-selected"
-        >
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
+        <i
+          class="fd-list__navigation-item-icon sap-icon--calendar"
+        />
+        
                 
-        </a>
+        <span
+          class="fd-list__navigation-item-text"
+        >
+          Calendar
+        </span>
         
             
       </li>
       
             
       <li
-        class="fd-nested-list__item"
+        class="fd-list__navigation-item--condensed"
       >
         
                 
-        <a
-          class="fd-nested-list__link"
-        >
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
+        <i
+          class="fd-list__navigation-item-icon sap-icon--customer"
+        />
+        
                 
-        </a>
+        <span
+          class="fd-list__navigation-item-text"
+        >
+          Customers
+        </span>
         
             
       </li>
       
             
       <li
-        class="fd-nested-list__item"
+        class="fd-list__navigation-item--condensed"
       >
         
                 
-        <a
-          class="fd-nested-list__link"
+        <i
+          class="fd-list__navigation-item-icon sap-icon--shipping-status"
+        />
+        
+                
+        <span
+          class="fd-list__navigation-item-text"
         >
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-        
-    </ul>
-    
-    
-  </nav>
-  
-    
-  <nav
-    aria-label="Utility Menu"
-    class="fd-vertical-nav__utility"
-  >
-    
-        
-    <ul
-      aria-label="Utility Menu"
-      class="fd-nested-list fd-nested-list--text-only"
-    >
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-        >
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-        >
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
+          Deliveries
+        </span>
         
             
       </li>
@@ -1583,18 +107,10 @@ exports[`Storyshots Components/Vertical Navigation Default 1`] = `
 </div>
 `;
 
-exports[`Storyshots Components/Vertical Navigation Group 1`] = `
+exports[`Storyshots Components/Vertical Navigation Default 1`] = `
 <div
   class="fd-vertical-nav"
 >
-  
-    
-  <a
-    class="fd-vertical-nav__skip-link"
-    href="#content"
-  >
-    Skip navigation
-  </a>
   
     
   <nav
@@ -1604,180 +120,84 @@ exports[`Storyshots Components/Vertical Navigation Group 1`] = `
     
         
     <ul
-      class="fd-nested-list fd-nested-list--text-only"
+      aria-label="Main Menu"
+      class="fd-list"
     >
       
             
       <li
-        class="fd-nested-list__item"
+        class="fd-list__navigation-item"
       >
         
                 
-        <a
-          class="fd-nested-list__link"
-          href="#"
-        >
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
+        <i
+          class="fd-list__navigation-item-icon sap-icon--home"
+        />
+        
                 
-        </a>
+        <span
+          class="fd-list__navigation-item-text"
+        >
+          Overview
+        </span>
         
             
       </li>
       
             
       <li
-        class="fd-nested-list__item"
+        class="fd-list__navigation-item is-expanded"
+        onclick="toggleVerticalNavSubmenu(event)"
       >
         
                 
-        <a
-          class="fd-nested-list__link is-selected"
-          href="#"
+        <i
+          class="fd-list__navigation-item-icon sap-icon--calendar"
+        />
+        
+                
+        <span
+          class="fd-list__navigation-item-text"
+        >
+          Calendar
+        </span>
+        
+                
+        <i
+          class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"
+        />
+        
+                
+        <ul
+          class="fd-list"
         >
           
                     
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-                  
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <div
-          class="fd-nested-list__content has-child"
-        >
-          
-                    
-          <a
-            class="fd-nested-list__link"
-            href="#"
+          <li
+            class="fd-list__navigation-item fd-list__navigation-item--second"
           >
             
                         
             <span
-              class="fd-nested-list__title"
+              class="fd-list__navigation-item-text"
             >
-              Level 1 Item
+              Second level item 1
             </span>
             
                     
-          </a>
-          
-                    
-          <button
-            aria-controls="EX100L2"
-            aria-expanded="false"
-            aria-haspopup="true"
-            aria-label="Expand submenu"
-            class="fd-button fd-nested-list__button"
-            onclick="toggleNestedListSubmenu(event)"
-          >
-            
-                        
-            <i
-              class="sap-icon--navigation-right-arrow"
-              role="presentation"
-            />
-                
-                    
-          </button>
-          
-                
-        </div>
-        
-                
-        <ul
-          aria-hidden="true"
-          class="fd-nested-list level-2"
-          id="EX100L2"
-        >
-          
-                    
-          <li
-            class="fd-nested-list__item"
-          >
-            
-                        
-            <a
-              class="fd-nested-list__link"
-              href="#"
-            >
-              
-                            
-              <span
-                class="fd-nested-list__title"
-              >
-                Level 2 Item
-              </span>
-              
-                        
-            </a>
-            
-                    
           </li>
           
                     
           <li
-            class="fd-nested-list__item"
+            class="fd-list__navigation-item fd-list__navigation-item--second"
           >
             
                         
-            <a
-              class="fd-nested-list__link"
-              href="#"
+            <span
+              class="fd-list__navigation-item-text"
             >
-              
-                            
-              <span
-                class="fd-nested-list__title"
-              >
-                Level 2 Item
-              </span>
-              
-                        
-            </a>
-            
-                    
-          </li>
-          
-                    
-          <li
-            class="fd-nested-list__item"
-          >
-            
-                        
-            <a
-              class="fd-nested-list__link"
-              href="#"
-            >
-              
-                            
-              <span
-                class="fd-nested-list__title"
-              >
-                Level 2 Item
-              </span>
-              
-                        
-            </a>
+              Second level item 2
+            </span>
             
                     
           </li>
@@ -1790,114 +210,84 @@ exports[`Storyshots Components/Vertical Navigation Group 1`] = `
       
             
       <li
-        class="fd-nested-list__item"
+        class="fd-list__navigation-item is-expanded"
+        onclick="toggleVerticalNavSubmenu(event)"
       >
         
                 
-        <a
-          class="fd-nested-list__link"
-          href="#"
+        <i
+          class="fd-list__navigation-item-icon sap-icon--customer"
+        />
+        
+                
+        <span
+          class="fd-list__navigation-item-text"
+        >
+          Customers
+        </span>
+        
+                
+        <i
+          class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"
+        />
+        
+                
+        <ul
+          class="fd-list"
         >
           
                     
-          <span
-            class="fd-nested-list__title"
+          <li
+            class="fd-list__navigation-item fd-list__navigation-item--second"
           >
-            Level 1 Item
-          </span>
+            
+                        
+            <span
+              class="fd-list__navigation-item-text"
+            >
+              Second level item 1
+            </span>
+            
+                    
+          </li>
+          
+                    
+          <li
+            class="fd-list__navigation-item fd-list__navigation-item--second"
+          >
+            
+                        
+            <span
+              class="fd-list__navigation-item-text"
+            >
+              Second level item 2
+            </span>
+            
+                    
+          </li>
           
                 
-        </a>
+        </ul>
         
             
       </li>
       
             
       <li
-        class="fd-nested-list__item"
+        class="fd-list__navigation-item"
       >
         
                 
-        <a
-          class="fd-nested-list__link"
-          href="#"
+        <i
+          class="fd-list__navigation-item-icon sap-icon--shipping-status"
+        />
+        
+                
+        <span
+          class="fd-list__navigation-item-text"
         >
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-        
-    </ul>
-    
-    
-  </nav>
-  
-    
-  <nav
-    aria-label="Utility Menu"
-    class="fd-vertical-nav__utility"
-  >
-    
-        
-    <ul
-      aria-label="Utility Menu"
-      class="fd-nested-list fd-nested-list--text-only"
-    >
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#"
-        >
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#"
-        >
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
+          Deliveries
+        </span>
         
             
       </li>
@@ -1912,18 +302,341 @@ exports[`Storyshots Components/Vertical Navigation Group 1`] = `
 </div>
 `;
 
-exports[`Storyshots Components/Vertical Navigation Icons 1`] = `
+exports[`Storyshots Components/Vertical Navigation Navigation Indication 1`] = `
+<section>
+  <div
+    class="fd-vertical-nav"
+  >
+    
+    
+    <nav
+      aria-label="Main Menu"
+      class="fd-vertical-nav__main-navigation"
+    >
+      
+        
+      <ul
+        aria-label="Main Menu"
+        class="fd-list"
+      >
+        
+            
+        <li
+          class="fd-list__navigation-item"
+        >
+          
+                
+          <i
+            class="fd-list__navigation-item-icon sap-icon--home"
+          />
+          
+                
+          <span
+            class="fd-list__navigation-item-text"
+          >
+            Overview
+          </span>
+          
+            
+        </li>
+        
+            
+        <li
+          class="fd-list__navigation-item is-expanded"
+          onclick="toggleVerticalNavSubmenu(event)"
+        >
+          
+                
+          <i
+            class="fd-list__navigation-item-icon sap-icon--calendar"
+          />
+          
+                
+          <span
+            class="fd-list__navigation-item-text"
+          >
+            Calendar
+          </span>
+          
+                
+          <i
+            class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"
+          />
+          
+                
+          <ul
+            class="fd-list"
+          >
+            
+                    
+            <li
+              class="fd-list__navigation-item fd-list__navigation-item--second fd-list__navigation-item--indicated"
+            >
+              
+                        
+              <span
+                class="fd-list__navigation-item-text"
+              >
+                Second level item 1
+              </span>
+              
+                        
+              <span
+                class="fd-list__navigation-item-indicator"
+              />
+              
+                    
+            </li>
+            
+                    
+            <li
+              class="fd-list__navigation-item fd-list__navigation-item--second"
+            >
+              
+                        
+              <span
+                class="fd-list__navigation-item-text"
+              >
+                Second level item 2
+              </span>
+              
+                    
+            </li>
+            
+                
+          </ul>
+          
+                
+          <span
+            class="fd-list__navigation-item-indicator"
+          />
+          
+            
+        </li>
+        
+        
+      </ul>
+      
+    
+    </nav>
+    
+
+  </div>
+  
+
+  <br />
+  <br />
+  
+
+  <div
+    class="fd-vertical-nav fd-vertical-nav--condensed"
+  >
+    
+    
+    <nav
+      aria-label="Main Menu"
+      class="fd-vertical-nav__main-navigation"
+    >
+      
+        
+      <ul
+        aria-label="Main Menu"
+        class="fd-list"
+      >
+        
+            
+        <li
+          class="fd-list__navigation-item--condensed"
+        >
+          
+                
+          <i
+            class="fd-list__navigation-item-icon sap-icon--home"
+          />
+          
+                
+          <span
+            class="fd-list__navigation-item-text"
+          >
+            Overview
+          </span>
+          
+            
+        </li>
+        
+            
+        <li
+          class="fd-list__navigation-item--condensed"
+          onclick="toggleCondensedVerticalNavSubmenu(event, 'parent')"
+        >
+          
+                
+          <i
+            class="fd-list__navigation-item-icon sap-icon--calendar"
+          />
+          
+                
+          <i
+            class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow"
+          />
+              
+                
+          <span
+            class="fd-list__navigation-item-indicator"
+          />
+          
+                
+          <div
+            aria-hidden="false"
+            class="fd-popover__body fd-popover__body--left fd-popover__body--no-arrow fd-list__navigation-item-popover--first"
+            id="popoverA1"
+          >
+            
+                    
+            <ul
+              class="fd-list"
+            >
+              
+                        
+              <li
+                class="fd-list__navigation-item--condensed"
+                onclick="toggleCondensedVerticalNavSubmenu(event, 'child')"
+              >
+                
+                            
+                <i
+                  class="fd-list__navigation-item-icon sap-icon--calendar"
+                />
+                
+                            
+                <span
+                  class="fd-list__navigation-item-text"
+                >
+                  Calendar
+                </span>
+                
+                        
+              </li>
+              
+                    
+            </ul>
+            
+                
+          </div>
+          
+                
+          <div
+            aria-hidden="false"
+            class="fd-popover__body fd-popover__body--left fd-popover__body--no-arrow fd-list__navigation-item-popover--second"
+            id="popoverA1"
+          >
+            
+                    
+            <ul
+              class="fd-list"
+            >
+              
+                        
+              <li
+                class="fd-list__navigation-item--condensed fd-list__navigation-item--second fd-list__navigation-item--indicated"
+              >
+                
+                            
+                <span
+                  class="fd-list__navigation-item-text"
+                >
+                  Second level item 1
+                </span>
+                
+                            
+                <span
+                  class="fd-list__navigation-item-indicator"
+                />
+                
+                        
+              </li>
+              
+                        
+              <li
+                class="fd-list__navigation-item--condensed fd-list__navigation-item--second"
+              >
+                
+                            
+                <span
+                  class="fd-list__navigation-item-text"
+                >
+                  Second level item 2
+                </span>
+                
+                        
+              </li>
+              
+                    
+            </ul>
+            
+                
+          </div>
+          
+            
+        </li>
+        
+            
+        <li
+          class="fd-list__navigation-item--condensed"
+        >
+          
+                
+          <i
+            class="fd-list__navigation-item-icon sap-icon--customer"
+          />
+          
+                
+          <span
+            class="fd-list__navigation-item-text"
+          >
+            Customers
+          </span>
+          
+            
+        </li>
+        
+            
+        <li
+          class="fd-list__navigation-item--condensed"
+        >
+          
+                
+          <i
+            class="fd-list__navigation-item-icon sap-icon--shipping-status"
+          />
+          
+                
+          <span
+            class="fd-list__navigation-item-text"
+          >
+            Deliveries
+          </span>
+          
+            
+        </li>
+        
+        
+      </ul>
+      
+    
+    </nav>
+    
+
+  </div>
+  
+
+</section>
+`;
+
+exports[`Storyshots Components/Vertical Navigation Text Only 1`] = `
 <div
   class="fd-vertical-nav"
 >
-  
-    
-  <a
-    class="fd-vertical-nav__skip-link"
-    href="#content"
-  >
-    Skip navigation
-  </a>
   
     
   <nav
@@ -1933,202 +646,154 @@ exports[`Storyshots Components/Vertical Navigation Icons 1`] = `
     
         
     <ul
-      class="fd-nested-list"
+      aria-label="Main Menu"
+      class="fd-list"
     >
       
             
       <li
-        class="fd-nested-list__item"
+        class="fd-list__navigation-item"
       >
         
                 
-        <a
-          class="fd-nested-list__link"
-          href="#"
+        <span
+          class="fd-list__navigation-item-text"
         >
-          
-                    
-          <i
-            class="fd-nested-list__icon sap-icon--home"
-            role="presentation"
-          />
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
+          Overview
+        </span>
         
             
       </li>
       
             
       <li
-        class="fd-nested-list__item"
+        class="fd-list__navigation-item is-expanded"
+        onclick="toggleVerticalNavSubmenu(event)"
       >
         
                 
-        <a
-          class="fd-nested-list__link is-selected"
-          href="#"
+        <span
+          class="fd-list__navigation-item-text"
+        >
+          Calendar
+        </span>
+        
+                
+        <i
+          class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"
+        />
+        
+                
+        <ul
+          class="fd-list"
         >
           
                     
-          <i
-            class="fd-nested-list__icon sap-icon--calendar"
-            role="presentation"
-          />
+          <li
+            class="fd-list__navigation-item fd-list__navigation-item--second"
+          >
+            
+                        
+            <span
+              class="fd-list__navigation-item-text"
+            >
+              Second level item 1
+            </span>
+            
+                    
+          </li>
           
                     
-          <span
-            class="fd-nested-list__title"
+          <li
+            class="fd-list__navigation-item fd-list__navigation-item--second"
           >
-            Level 1 Item
-          </span>
+            
+                        
+            <span
+              class="fd-list__navigation-item-text"
+            >
+              Second level item 2
+            </span>
+            
+                    
+          </li>
           
                 
-        </a>
+        </ul>
         
             
       </li>
       
             
       <li
-        class="fd-nested-list__item"
+        class="fd-list__navigation-item is-expanded"
+        onclick="toggleVerticalNavSubmenu(event)"
       >
         
                 
-        <a
-          class="fd-nested-list__link"
-          href="#"
+        <span
+          class="fd-list__navigation-item-text"
+        >
+          Customers
+        </span>
+        
+                
+        <i
+          class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"
+        />
+        
+                
+        <ul
+          class="fd-list"
         >
           
                     
-          <i
-            class="fd-nested-list__icon sap-icon--employee"
-            role="presentation"
-          />
+          <li
+            class="fd-list__navigation-item fd-list__navigation-item--second"
+          >
+            
+                        
+            <span
+              class="fd-list__navigation-item-text"
+            >
+              Second level item 1
+            </span>
+            
+                    
+          </li>
           
                     
-          <span
-            class="fd-nested-list__title"
+          <li
+            class="fd-list__navigation-item fd-list__navigation-item--second"
           >
-            Level 1 Item
-          </span>
+            
+                        
+            <span
+              class="fd-list__navigation-item-text"
+            >
+              Second level item 2
+            </span>
+            
+                    
+          </li>
           
                 
-        </a>
+        </ul>
         
             
       </li>
       
             
       <li
-        class="fd-nested-list__item"
+        class="fd-list__navigation-item"
       >
         
                 
-        <a
-          class="fd-nested-list__link"
-          href="#"
+        <span
+          class="fd-list__navigation-item-text"
         >
-          
-                    
-          <i
-            class="fd-nested-list__icon sap-icon--activities"
-            role="presentation"
-          />
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-        
-    </ul>
-    
-    
-  </nav>
-  
-    
-  <nav
-    aria-label="Utility Menu"
-    class="fd-vertical-nav__utility"
-  >
-    
-        
-    <ul
-      class="fd-nested-list"
-    >
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#"
-        >
-          
-                    
-          <i
-            class="fd-nested-list__icon sap-icon--compare"
-            role="presentation"
-          />
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#"
-        >
-          
-                    
-          <i
-            class="fd-nested-list__icon sap-icon--chain-link"
-            role="presentation"
-          />
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
-                
-        </a>
+          Deliveries
+        </span>
         
             
       </li>
@@ -2141,2745 +806,4 @@ exports[`Storyshots Components/Vertical Navigation Icons 1`] = `
   
 
 </div>
-`;
-
-exports[`Storyshots Components/Vertical Navigation Nested List With Group Headers 1`] = `
-<ul
-  class="fd-nested-list"
->
-  
-    
-  <li
-    class="fd-nested-list__group-header"
-  >
-    
-        Group Header 1
-    
-  </li>
-  
-    
-  <li
-    class="fd-nested-list__item"
-  >
-    
-        
-    <a
-      class="fd-nested-list__link"
-      href="#/"
-    >
-      
-            
-      <i
-        class="fd-nested-list__icon sap-icon--home"
-        role="presentation"
-      />
-      
-            
-      <span
-        class="fd-nested-list__title"
-      >
-        Level 1 Item
-      </span>
-      
-        
-    </a>
-    
-    
-  </li>
-  
-    
-  <li
-    class="fd-nested-list__item"
-  >
-    
-        
-    <a
-      class="fd-nested-list__link is-selected"
-      href="#/"
-    >
-      
-            
-      <i
-        class="fd-nested-list__icon sap-icon--calendar"
-        role="presentation"
-      />
-      
-            
-      <span
-        class="fd-nested-list__title"
-      >
-        Level 1 Item
-      </span>
-      
-        
-    </a>
-    
-    
-  </li>
-  
-    
-  <li
-    class="fd-nested-list__item"
-  >
-    
-	   
-    <div
-      class="fd-nested-list__content has-child"
-      tabindex="0"
-    >
-      
-			
-      <a
-        class="fd-nested-list__link"
-        href="#"
-        tabindex="-1"
-      >
-        
-				
-        <i
-          class="fd-nested-list__icon sap-icon--employee"
-          role="presentation"
-        />
-        
-				
-        <span
-          class="fd-nested-list__title"
-        >
-          Level 1 Item
-        </span>
-        
-			
-      </a>
-      
-            
-      <button
-        aria-controls="EX400L222"
-        aria-expanded="true"
-        aria-haspopup="true"
-        aria-label="Expand submenu"
-        class="fd-button fd-nested-list__button"
-      >
-        
-                
-        <i
-          class="sap-icon--navigation-right-arrow"
-          role="presentation"
-        />
-            
-            
-      </button>
-      
-		
-    </div>
-    
-        
-    <ul
-      aria-hidden="false"
-      class="fd-nested-list fd-nested-list--text-only level-2"
-      id="EX400L222"
-    >
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#/"
-        >
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 2 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-			   
-        <div
-          class="fd-nested-list__content has-child"
-          tabindex="0"
-        >
-          
-					
-          <a
-            class="fd-nested-list__link"
-            href="#"
-            tabindex="-1"
-          >
-            
-						
-            <span
-              class="fd-nested-list__title"
-            >
-              Level 2 Item
-            </span>
-            
-					
-          </a>
-          
-                    
-          <button
-            aria-controls="EX400L3"
-            aria-expanded="true"
-            aria-haspopup="true"
-            aria-label="Expand submenu"
-            class="fd-button fd-nested-list__button"
-          >
-            
-                        
-            <i
-              class="sap-icon--navigation-right-arrow"
-              role="presentation"
-            />
-                
-                    
-          </button>
-          
-				
-        </div>
-        
-                
-        <ul
-          aria-hidden="false"
-          class="fd-nested-list fd-nested-list--text-only level-3"
-          id="EX400L3"
-        >
-          
-                    
-          <li
-            class="fd-nested-list__item"
-          >
-            
-                        
-            <a
-              class="fd-nested-list__link"
-              href="#/"
-            >
-              
-                            
-              <span
-                class="fd-nested-list__title"
-              >
-                Level 3 Item
-              </span>
-              
-                        
-            </a>
-            
-                    
-          </li>
-          
-                    
-          <li
-            class="fd-nested-list__item"
-          >
-            
-					   
-            <div
-              class="fd-nested-list__content has-child"
-              tabindex="0"
-            >
-              
-							
-              <a
-                class="fd-nested-list__link"
-                href="#"
-                tabindex="-1"
-              >
-                
-								
-                <span
-                  class="fd-nested-list__title"
-                >
-                  Level 3 Item
-                </span>
-                
-							
-              </a>
-              
-                            
-              <button
-                aria-controls="EX400L4"
-                aria-expanded="true"
-                aria-haspopup="true"
-                aria-label="Expand submenu"
-                class="fd-button fd-nested-list__button"
-              >
-                
-                                
-                <i
-                  class="sap-icon--navigation-right-arrow"
-                  role="presentation"
-                />
-                    
-                            
-              </button>
-              
-						
-            </div>
-            
-                        
-            <ul
-              aria-hidden="false"
-              class="fd-nested-list fd-nested-list--text-only level-4"
-              id="EX400L4"
-            >
-              
-                            
-              <li
-                class="fd-nested-list__item"
-              >
-                
-                                
-                <a
-                  class="fd-nested-list__link"
-                  href="#/"
-                >
-                  
-                                    
-                  <span
-                    class="fd-nested-list__title"
-                  >
-                    Level 4 Item
-                  </span>
-                  
-                                
-                </a>
-                
-                            
-              </li>
-              
-                            
-              <li
-                class="fd-nested-list__item"
-              >
-                
-                                
-                <a
-                  class="fd-nested-list__link"
-                  href="#/"
-                >
-                  
-                                    
-                  <span
-                    class="fd-nested-list__title"
-                  >
-                    Level 4 Item
-                  </span>
-                  
-                                
-                </a>
-                
-                            
-              </li>
-              
-                            
-              <li
-                class="fd-nested-list__item"
-              >
-                
-                                
-                <a
-                  class="fd-nested-list__link"
-                  href="#/"
-                >
-                  
-                                    
-                  <span
-                    class="fd-nested-list__title"
-                  >
-                    Level 4 Item
-                  </span>
-                  
-                                
-                </a>
-                
-                            
-              </li>
-              
-                        
-            </ul>
-            
-                    
-          </li>
-          
-                    
-          <li
-            class="fd-nested-list__item"
-          >
-            
-                        
-            <a
-              class="fd-nested-list__link"
-              href="#/"
-            >
-              
-                            
-              <span
-                class="fd-nested-list__title"
-              >
-                Level 3 Item
-              </span>
-              
-                        
-            </a>
-            
-                    
-          </li>
-          
-                
-        </ul>
-        
-            
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#/"
-        >
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 2 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-        
-    </ul>
-    
-    
-  </li>
-  
-    
-  <li
-    class="fd-nested-list__item"
-  >
-    
-        
-    <a
-      class="fd-nested-list__link"
-      href="#/"
-    >
-      
-            
-      <i
-        class="fd-nested-list__icon sap-icon--activities"
-        role="presentation"
-      />
-      
-            
-      <span
-        class="fd-nested-list__title"
-      >
-        Level 1 Item
-      </span>
-      
-        
-    </a>
-    
-    
-  </li>
-  
-    
-  <li
-    class="fd-nested-list__group-header"
-  >
-    
-        Group Header 2
-    
-  </li>
-  
-    
-  <li
-    class="fd-nested-list__item"
-  >
-    
-        
-    <a
-      class="fd-nested-list__link"
-      href="#/"
-    >
-      
-            
-      <i
-        class="fd-nested-list__icon sap-icon--bar-chart"
-        role="presentation"
-      />
-      
-            
-      <span
-        class="fd-nested-list__title"
-      >
-        Level 1 Item
-      </span>
-      
-        
-    </a>
-    
-    
-  </li>
-  
-    
-  <li
-    class="fd-nested-list__item"
-  >
-    
-        
-    <a
-      class="fd-nested-list__link"
-      href="#/"
-    >
-      
-            
-      <span
-        class="fd-nested-list__title"
-      >
-        Level 1 Item
-      </span>
-      
-        
-    </a>
-    
-    
-  </li>
-  
-
-</ul>
-`;
-
-exports[`Storyshots Components/Vertical Navigation Nested List With Group Headers Compact Mode 1`] = `
-<ul
-  class="fd-nested-list fd-nested-list--compact"
->
-  
-    
-  <li
-    class="fd-nested-list__group-header"
-  >
-    
-        Group Header 1
-    
-  </li>
-  
-    
-  <li
-    class="fd-nested-list__item"
-  >
-    
-        
-    <a
-      class="fd-nested-list__link"
-      href="#/"
-    >
-      
-            
-      <i
-        class="fd-nested-list__icon sap-icon--home"
-        role="presentation"
-      />
-      
-            
-      <span
-        class="fd-nested-list__title"
-      >
-        Level 1 Item
-      </span>
-      
-        
-    </a>
-    
-    
-  </li>
-  
-    
-  <li
-    class="fd-nested-list__item"
-  >
-    
-        
-    <a
-      class="fd-nested-list__link is-selected"
-      href="#/"
-    >
-      
-            
-      <i
-        class="fd-nested-list__icon sap-icon--calendar"
-        role="presentation"
-      />
-      
-            
-      <span
-        class="fd-nested-list__title"
-      >
-        Level 1 Item
-      </span>
-      
-        
-    </a>
-    
-    
-  </li>
-  
-    
-  <li
-    class="fd-nested-list__item"
-  >
-    
-	   
-    <div
-      class="fd-nested-list__content has-child"
-      tabindex="0"
-    >
-      
-			
-      <a
-        class="fd-nested-list__link"
-        href="#"
-        tabindex="-1"
-      >
-        
-            	
-        <i
-          class="fd-nested-list__icon sap-icon--employee"
-          role="presentation"
-        />
-        
-				
-        <span
-          class="fd-nested-list__title"
-        >
-          Level 1 Item
-        </span>
-        
-			
-      </a>
-      
-            
-      <button
-        aria-controls="EX500L2"
-        aria-expanded="true"
-        aria-haspopup="true"
-        aria-label="Expand submenu"
-        class="fd-button fd-nested-list__button"
-      >
-        
-                
-        <i
-          class="sap-icon--navigation-right-arrow"
-          role="presentation"
-        />
-            
-            
-      </button>
-      
-		
-    </div>
-    
-        
-    <ul
-      aria-hidden="false"
-      class="fd-nested-list fd-nested-list--text-only level-2"
-      id="EX500L2"
-    >
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#/"
-        >
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 2 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-			   
-        <div
-          class="fd-nested-list__content has-child"
-          tabindex="0"
-        >
-          
-					
-          <a
-            class="fd-nested-list__link"
-            href="#"
-            tabindex="-1"
-          >
-            
-						
-            <span
-              class="fd-nested-list__title"
-            >
-              Level 2 Item
-            </span>
-            
-					
-          </a>
-          
-                    
-          <button
-            aria-controls="EX500L3"
-            aria-expanded="true"
-            aria-haspopup="true"
-            aria-label="Expand submenu"
-            class="fd-button fd-nested-list__button"
-          >
-            
-                        
-            <i
-              class="sap-icon--navigation-right-arrow"
-              role="presentation"
-            />
-                
-                    
-          </button>
-          
-				
-        </div>
-        
-                
-        <ul
-          aria-hidden="false"
-          class="fd-nested-list fd-nested-list--text-only level-3"
-          id="EX500L3"
-        >
-          
-                    
-          <li
-            class="fd-nested-list__item"
-          >
-            
-                        
-            <a
-              class="fd-nested-list__link"
-              href="#/"
-            >
-              
-                            
-              <span
-                class="fd-nested-list__title"
-              >
-                Level 3 Item
-              </span>
-              
-                        
-            </a>
-            
-                    
-          </li>
-          
-                    
-          <li
-            class="fd-nested-list__item"
-          >
-            
-					   
-            <div
-              class="fd-nested-list__content has-child"
-              tabindex="0"
-            >
-              
-							
-              <a
-                class="fd-nested-list__link"
-                href="#"
-                tabindex="-1"
-              >
-                
-								
-                <span
-                  class="fd-nested-list__title"
-                >
-                  Level 3 Item
-                </span>
-                
-							
-              </a>
-              
-                            
-              <button
-                aria-controls="EX500L4"
-                aria-expanded="true"
-                aria-haspopup="true"
-                aria-label="Expand submenu"
-                class="fd-button fd-nested-list__button"
-              >
-                
-                                
-                <i
-                  class="sap-icon--navigation-right-arrow"
-                  role="presentation"
-                />
-                    
-                            
-              </button>
-              
-						
-            </div>
-            
-                        
-            <ul
-              aria-hidden="false"
-              class="fd-nested-list fd-nested-list--text-only level-4"
-              id="EX500L4"
-            >
-              
-                            
-              <li
-                class="fd-nested-list__item"
-              >
-                
-                                
-                <a
-                  class="fd-nested-list__link"
-                  href="#/"
-                >
-                  
-                                    
-                  <span
-                    class="fd-nested-list__title"
-                  >
-                    Level 4 Item
-                  </span>
-                  
-                                
-                </a>
-                
-                            
-              </li>
-              
-                            
-              <li
-                class="fd-nested-list__item"
-              >
-                
-                                
-                <a
-                  class="fd-nested-list__link"
-                  href="#/"
-                >
-                  
-                                    
-                  <span
-                    class="fd-nested-list__title"
-                  >
-                    Level 4 Item
-                  </span>
-                  
-                                
-                </a>
-                
-                            
-              </li>
-              
-                            
-              <li
-                class="fd-nested-list__item"
-              >
-                
-                                
-                <a
-                  class="fd-nested-list__link"
-                  href="#/"
-                >
-                  
-                                    
-                  <span
-                    class="fd-nested-list__title"
-                  >
-                    Level 4 Item
-                  </span>
-                  
-                                
-                </a>
-                
-                            
-              </li>
-              
-                        
-            </ul>
-            
-                    
-          </li>
-          
-                    
-          <li
-            class="fd-nested-list__item"
-          >
-            
-                        
-            <a
-              class="fd-nested-list__link"
-              href="#/"
-            >
-              
-                            
-              <span
-                class="fd-nested-list__title"
-              >
-                Level 3 Item
-              </span>
-              
-                        
-            </a>
-            
-                    
-          </li>
-          
-                
-        </ul>
-        
-            
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#/"
-        >
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 2 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-        
-    </ul>
-    
-    
-  </li>
-  
-    
-  <li
-    class="fd-nested-list__item"
-  >
-    
-        
-    <a
-      class="fd-nested-list__link"
-      href="#/"
-    >
-      
-            
-      <i
-        class="fd-nested-list__icon sap-icon--activities"
-        role="presentation"
-      />
-      
-            
-      <span
-        class="fd-nested-list__title"
-      >
-        Level 1 Item
-      </span>
-      
-        
-    </a>
-    
-    
-  </li>
-  
-    
-  <li
-    class="fd-nested-list__group-header"
-  >
-    
-        Group Header 2
-    
-  </li>
-  
-    
-  <li
-    class="fd-nested-list__item"
-  >
-    
-        
-    <a
-      class="fd-nested-list__link"
-      href="#/"
-    >
-      
-            
-      <i
-        class="fd-nested-list__icon sap-icon--bar-chart"
-        role="presentation"
-      />
-      
-            
-      <span
-        class="fd-nested-list__title"
-      >
-        Level 1 Item
-      </span>
-      
-        
-    </a>
-    
-    
-  </li>
-  
-    
-  <li
-    class="fd-nested-list__item"
-  >
-    
-        
-    <a
-      class="fd-nested-list__link"
-      href="#/"
-    >
-      
-            
-      <span
-        class="fd-nested-list__title"
-      >
-        Level 1 Item
-      </span>
-      
-        
-    </a>
-    
-    
-  </li>
-  
-
-</ul>
-`;
-
-exports[`Storyshots Components/Vertical Navigation Nested List With Icons Only In First Level 1`] = `
-<ul
-  class="fd-nested-list"
->
-  
-    
-  <li
-    class="fd-nested-list__item"
-  >
-    
-        
-    <a
-      class="fd-nested-list__link"
-      href="#/"
-    >
-      
-            
-      <i
-        class="fd-nested-list__icon sap-icon--home"
-        role="presentation"
-      />
-      
-            
-      <span
-        class="fd-nested-list__title"
-      >
-        Level 1 Item
-      </span>
-      
-        
-    </a>
-    
-    
-  </li>
-  
-    
-  <li
-    class="fd-nested-list__item"
-  >
-    
-        
-    <a
-      class="fd-nested-list__link is-selected"
-      href="#/"
-    >
-      
-            
-      <i
-        class="fd-nested-list__icon sap-icon--calendar"
-        role="presentation"
-      />
-      
-            
-      <span
-        class="fd-nested-list__title"
-      >
-        Level 1 Item
-      </span>
-      
-        
-    </a>
-    
-    
-  </li>
-  
-    
-  <li
-    class="fd-nested-list__item"
-  >
-    
-	   
-    <div
-      class="fd-nested-list__content has-child is-expanded"
-      tabindex="0"
-    >
-      
-			
-      <a
-        class="fd-nested-list__link"
-        href="#"
-        tabindex="-1"
-      >
-        
-				
-        <i
-          class="fd-nested-list__icon sap-icon--employee"
-          role="presentation"
-        />
-        
-				
-        <span
-          class="fd-nested-list__title"
-        >
-          Level 1 Item
-        </span>
-        
-			
-      </a>
-      
-            
-      <button
-        aria-controls="EX300L2"
-        aria-expanded="true"
-        aria-haspopup="true"
-        aria-label="Expand submenu"
-        class="fd-button fd-nested-list__button"
-      >
-        
-                
-        <i
-          class="sap-icon--navigation-right-arrow"
-          role="presentation"
-        />
-            
-            
-      </button>
-      
-		
-    </div>
-    
-        
-    <ul
-      aria-hidden="false"
-      class="fd-nested-list fd-nested-list--text-only level-2"
-      id="EX300L2"
-    >
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#/"
-        >
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 2 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-			   
-        <div
-          class="fd-nested-list__content has-child"
-          tabindex="0"
-        >
-          
-					
-          <a
-            class="fd-nested-list__link"
-            href="#"
-            tabindex="-1"
-          >
-            
-						
-            <span
-              class="fd-nested-list__title"
-            >
-              Level 2 Item
-            </span>
-            
-					
-          </a>
-          
-                    
-          <button
-            aria-controls="EX300L3"
-            aria-expanded="true"
-            aria-haspopup="true"
-            aria-label="Expand submenu"
-            class="fd-button fd-nested-list__button"
-          >
-            
-                        
-            <i
-              class="sap-icon--navigation-right-arrow"
-              role="presentation"
-            />
-                
-                    
-          </button>
-          
-				
-        </div>
-        
-                
-        <ul
-          aria-hidden="false"
-          class="fd-nested-list fd-nested-list--text-only level-3"
-          id="EX300L3"
-        >
-          
-                    
-          <li
-            class="fd-nested-list__item"
-          >
-            
-                        
-            <a
-              class="fd-nested-list__link"
-              href="#/"
-            >
-              
-                            
-              <span
-                class="fd-nested-list__title"
-              >
-                Level 3 Item
-              </span>
-              
-                        
-            </a>
-            
-                    
-          </li>
-          
-                    
-          <li
-            class="fd-nested-list__item"
-          >
-            
-					   
-            <div
-              class="fd-nested-list__content has-child"
-              tabindex="0"
-            >
-              
-							
-              <a
-                class="fd-nested-list__link"
-                href="#"
-                tabindex="-1"
-              >
-                
-								
-                <span
-                  class="fd-nested-list__title"
-                >
-                  Level 3 Item
-                </span>
-                
-							
-              </a>
-              
-                            
-              <button
-                aria-controls="EX300L4"
-                aria-expanded="true"
-                aria-haspopup="true"
-                aria-label="Expand submenu"
-                class="fd-button fd-nested-list__button"
-              >
-                
-                                
-                <i
-                  class="sap-icon--navigation-right-arrow"
-                  role="presentation"
-                />
-                    
-                            
-              </button>
-              
-						
-            </div>
-            
-                        
-            <ul
-              aria-hidden="false"
-              class="fd-nested-list fd-nested-list--text-only level-4"
-              id="EX300L4"
-            >
-              
-                            
-              <li
-                class="fd-nested-list__item"
-              >
-                
-                                
-                <a
-                  class="fd-nested-list__link"
-                  href="#/"
-                >
-                  
-                                    
-                  <span
-                    class="fd-nested-list__title"
-                  >
-                    Level 4 Item
-                  </span>
-                  
-                                
-                </a>
-                
-                            
-              </li>
-              
-                            
-              <li
-                class="fd-nested-list__item"
-              >
-                
-                                
-                <a
-                  class="fd-nested-list__link"
-                  href="#/"
-                >
-                  
-                                    
-                  <span
-                    class="fd-nested-list__title"
-                  >
-                    Level 4 Item
-                  </span>
-                  
-                                
-                </a>
-                
-                            
-              </li>
-              
-                            
-              <li
-                class="fd-nested-list__item"
-              >
-                
-                                
-                <a
-                  class="fd-nested-list__link"
-                  href="#/"
-                >
-                  
-                                    
-                  <span
-                    class="fd-nested-list__title"
-                  >
-                    Level 4 Item
-                  </span>
-                  
-                                
-                </a>
-                
-                            
-              </li>
-              
-                        
-            </ul>
-            
-                    
-          </li>
-          
-                    
-          <li
-            class="fd-nested-list__item"
-          >
-            
-                        
-            <a
-              class="fd-nested-list__link"
-              href="#/"
-            >
-              
-                            
-              <span
-                class="fd-nested-list__title"
-              >
-                Level 3 Item
-              </span>
-              
-                        
-            </a>
-            
-                    
-          </li>
-          
-                
-        </ul>
-        
-            
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#/"
-        >
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 2 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-        
-    </ul>
-    
-    
-  </li>
-  
-    
-  <li
-    class="fd-nested-list__item"
-  >
-    
-        
-    <a
-      class="fd-nested-list__link"
-      href="#/"
-    >
-      
-            
-      <i
-        class="fd-nested-list__icon sap-icon--activities"
-        role="presentation"
-      />
-      
-            
-      <span
-        class="fd-nested-list__title"
-      >
-        Level 1 Item
-      </span>
-      
-        
-    </a>
-    
-    
-  </li>
-  
-    
-  <li
-    class="fd-nested-list__item"
-  >
-    
-        
-    <a
-      class="fd-nested-list__link"
-      href="#/"
-    >
-      
-            
-      <i
-        class="fd-nested-list__icon sap-icon--bar-chart"
-        role="presentation"
-      />
-      
-            
-      <span
-        class="fd-nested-list__title"
-      >
-        Level 1 Item
-      </span>
-      
-        
-    </a>
-    
-    
-  </li>
-  
-    
-  <li
-    class="fd-nested-list__item"
-  >
-    
-        
-    <a
-      class="fd-nested-list__link"
-      href="#/"
-    >
-      
-            
-      <span
-        class="fd-nested-list__title"
-      >
-        Level 1 Item
-      </span>
-      
-        
-    </a>
-    
-    
-  </li>
-  
-
-</ul>
-`;
-
-exports[`Storyshots Components/Vertical Navigation Nested List Without Icons 1`] = `
-<ul
-  class="fd-nested-list fd-nested-list--text-only"
->
-  
-    
-  <li
-    class="fd-nested-list__item"
-  >
-    
-        
-    <a
-      class="fd-nested-list__link"
-      href="#/"
-    >
-      
-            
-      <span
-        class="fd-nested-list__title"
-      >
-        Level 1 Item
-      </span>
-      
-        
-    </a>
-    
-    
-  </li>
-  
-    
-  <li
-    class="fd-nested-list__item"
-  >
-    
-        
-    <a
-      class="fd-nested-list__link is-selected"
-      href="#/"
-    >
-      
-            
-      <span
-        class="fd-nested-list__title"
-      >
-        Level 1 Item
-      </span>
-      
-        
-    </a>
-    
-    
-  </li>
-  
-    
-  <li
-    class="fd-nested-list__item"
-  >
-    
-	    
-    <div
-      class="fd-nested-list__content has-child is-expanded"
-    >
-      
-			
-      <a
-        class="fd-nested-list__link"
-        href="#"
-      >
-        
-				
-        <span
-          class="fd-nested-list__title"
-        >
-          Level 1 Item
-        </span>
-        
-            
-      </a>
-      
-            
-      <button
-        aria-controls="EX100L25"
-        aria-expanded="true"
-        aria-haspopup="true"
-        aria-label="Expand submenu"
-        class="fd-button fd-nested-list__button"
-      >
-        
-                    
-        <i
-          class="sap-icon--navigation-right-arrow"
-          role="presentation"
-        />
-            
-            
-      </button>
-      
-		
-    </div>
-    
-        
-    <ul
-      aria-hidden="false"
-      class="fd-nested-list level-2"
-      id="EX100L25"
-    >
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#/"
-        >
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 2 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-			   
-        <div
-          class="fd-nested-list__content has-child"
-          tabindex="0"
-        >
-          
-					
-          <a
-            class="fd-nested-list__link"
-            href="#"
-            tabindex="-1"
-          >
-            
-						
-            <span
-              class="fd-nested-list__title"
-            >
-              Level 2 Item
-            </span>
-            
-                    
-          </a>
-          
-                    
-          <button
-            aria-controls="EX100L35"
-            aria-expanded="true"
-            aria-haspopup="true"
-            aria-label="Expand submenu"
-            class="fd-button fd-nested-list__button"
-          >
-            
-                        
-            <i
-              class="sap-icon--navigation-right-arrow"
-              role="presentation"
-            />
-                
-                    
-          </button>
-          
-				
-        </div>
-        
-                
-        <ul
-          aria-hidden="false"
-          class="fd-nested-list level-3"
-          id="EX100L35"
-        >
-          
-                    
-          <li
-            class="fd-nested-list__item"
-          >
-            
-                        
-            <a
-              class="fd-nested-list__link"
-              href="#/"
-            >
-              
-                            
-              <span
-                class="fd-nested-list__title"
-              >
-                Level 3 Item
-              </span>
-              
-                        
-            </a>
-            
-                    
-          </li>
-          
-                    
-          <li
-            class="fd-nested-list__item"
-          >
-            
-					   
-            <div
-              class="fd-nested-list__content has-child"
-              tabindex="0"
-            >
-              
-							
-              <a
-                class="fd-nested-list__link"
-                href="#"
-                tabindex="-1"
-              >
-                
-								
-                <span
-                  class="fd-nested-list__title"
-                >
-                  Level 3 Item
-                </span>
-                
-							
-              </a>
-              
-                            
-              <button
-                aria-controls="EX100L45"
-                aria-expanded="true"
-                aria-haspopup="true"
-                aria-label="Expand submenu"
-                class="fd-button fd-nested-list__button"
-              >
-                
-                                
-                <i
-                  class="sap-icon--navigation-right-arrow"
-                  role="presentation"
-                />
-                    
-                            
-              </button>
-              
-						
-            </div>
-            
-                        
-            <ul
-              aria-hidden="false"
-              class="fd-nested-list level-4"
-              id="EX100L45"
-            >
-              
-                            
-              <li
-                class="fd-nested-list__item"
-              >
-                
-                                
-                <a
-                  class="fd-nested-list__link"
-                  href="#/"
-                >
-                  
-                                    
-                  <span
-                    class="fd-nested-list__title"
-                  >
-                    Level 4 Item
-                  </span>
-                  
-                                
-                </a>
-                
-                            
-              </li>
-              
-                            
-              <li
-                class="fd-nested-list__item"
-              >
-                
-							   
-                <div
-                  class="fd-nested-list__content has-child"
-                  tabindex="0"
-                >
-                  
-									
-                  <a
-                    class="fd-nested-list__link"
-                    href="#"
-                    tabindex="-1"
-                  >
-                    
-										
-                    <span
-                      class="fd-nested-list__title"
-                    >
-                      Level 4 Item
-                    </span>
-                    
-									
-                  </a>
-                  
-                                    
-                  <button
-                    aria-controls="EX100L55"
-                    aria-expanded="true"
-                    aria-haspopup="true"
-                    aria-label="Expand submenu"
-                    class="fd-button fd-nested-list__button"
-                  >
-                    
-                                        
-                    <i
-                      class="sap-icon--navigation-right-arrow"
-                      role="presentation"
-                    />
-                        
-                                    
-                  </button>
-                  
-								
-                </div>
-                
-                                
-                <ul
-                  aria-hidden="false"
-                  class="fd-nested-list level-5"
-                  id="EX100L55"
-                >
-                  
-                                    
-                  <li
-                    class="fd-nested-list__item"
-                  >
-                    
-                                        
-                    <a
-                      class="fd-nested-list__link"
-                      href="#/"
-                    >
-                      
-                                            
-                      <span
-                        class="fd-nested-list__title"
-                      >
-                        Level 5 Item
-                      </span>
-                      
-                                        
-                    </a>
-                    
-                                    
-                  </li>
-                  
-                                    
-                  <li
-                    class="fd-nested-list__item"
-                  >
-                    
-									   
-                    <div
-                      class="fd-nested-list__content has-child"
-                      tabindex="0"
-                    >
-                      
-											
-                      <a
-                        class="fd-nested-list__link"
-                        href="#"
-                        tabindex="-1"
-                      >
-                        
-												
-                        <span
-                          class="fd-nested-list__title"
-                        >
-                          Level 5 Item
-                        </span>
-                        
-											
-                      </a>
-                      
-                                            
-                      <button
-                        aria-controls="EX100L65"
-                        aria-expanded="true"
-                        aria-haspopup="true"
-                        aria-label="Expand submenu"
-                        class="fd-button fd-nested-list__button"
-                      >
-                        
-                                                
-                        <i
-                          class="sap-icon--navigation-right-arrow"
-                          role="presentation"
-                        />
-                        
-                                            
-                      </button>
-                      
-										
-                    </div>
-                    
-                                        
-                    <ul
-                      aria-hidden="false"
-                      class="fd-nested-list level-6"
-                      id="EX100L65"
-                    >
-                      
-                                            
-                      <li
-                        class="fd-nested-list__item"
-                      >
-                        
-                                                
-                        <a
-                          class="fd-nested-list__link"
-                          href="#/"
-                        >
-                          
-                                                    
-                          <span
-                            class="fd-nested-list__title"
-                          >
-                            Level 6 Item
-                          </span>
-                          
-                                                
-                        </a>
-                        
-                                            
-                      </li>
-                      
-                                            
-                      <li
-                        class="fd-nested-list__item"
-                      >
-                        
-                                                
-                        <a
-                          class="fd-nested-list__link"
-                          href="#/"
-                        >
-                          
-                                                    
-                          <span
-                            class="fd-nested-list__title"
-                          >
-                            Level 6 Item
-                          </span>
-                          
-                                                
-                        </a>
-                        
-                                            
-                      </li>
-                      
-                                            
-                      <li
-                        class="fd-nested-list__item"
-                      >
-                        
-                                                
-                        <a
-                          class="fd-nested-list__link"
-                          href="#/"
-                        >
-                          
-                                                    
-                          <span
-                            class="fd-nested-list__title"
-                          >
-                            Level 6 Item
-                          </span>
-                          
-                                                
-                        </a>
-                        
-                                            
-                      </li>
-                      
-                                        
-                    </ul>
-                    
-                                    
-                  </li>
-                  
-                                    
-                  <li
-                    class="fd-nested-list__item"
-                  >
-                    
-                                        
-                    <a
-                      class="fd-nested-list__link"
-                      href="#/"
-                    >
-                      
-                                            
-                      <span
-                        class="fd-nested-list__title"
-                      >
-                        Level 5 Item
-                      </span>
-                      
-                                        
-                    </a>
-                    
-                                    
-                  </li>
-                  
-                                
-                </ul>
-                
-                            
-              </li>
-              
-                            
-              <li
-                class="fd-nested-list__item"
-              >
-                
-                                
-                <a
-                  class="fd-nested-list__link"
-                  href="#/"
-                >
-                  
-                                    
-                  <span
-                    class="fd-nested-list__title"
-                  >
-                    Level 4 Item
-                  </span>
-                  
-                                
-                </a>
-                
-                            
-              </li>
-              
-                        
-            </ul>
-            
-                    
-          </li>
-          
-                    
-          <li
-            class="fd-nested-list__item"
-          >
-            
-                        
-            <a
-              class="fd-nested-list__link"
-              href="#/"
-            >
-              
-                            
-              <span
-                class="fd-nested-list__title"
-              >
-                Level 3 Item
-              </span>
-              
-                        
-            </a>
-            
-                    
-          </li>
-          
-                
-        </ul>
-        
-            
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#/"
-        >
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 2 Item
-          </span>
-          
-                
-        </a>
-        
-            
-      </li>
-      
-        
-    </ul>
-    
-    
-  </li>
-  
-    
-  <li
-    class="fd-nested-list__item"
-  >
-    
-        
-    <a
-      class="fd-nested-list__link"
-      href="#/"
-    >
-      
-            
-      <span
-        class="fd-nested-list__title"
-      >
-        Level 1 Item
-      </span>
-      
-        
-    </a>
-    
-    
-  </li>
-  
-    
-  <li
-    class="fd-nested-list__item"
-  >
-    
-        
-    <a
-      class="fd-nested-list__link"
-      href="#/"
-    >
-      
-            
-      <span
-        class="fd-nested-list__title"
-      >
-        Level 1 Item
-      </span>
-      
-        
-    </a>
-    
-    
-  </li>
-  
-
-</ul>
-`;
-
-exports[`Storyshots Components/Vertical Navigation Nested List Without Links 1`] = `
-<ul
-  class="fd-nested-list fd-nested-list--compact"
->
-  
-    
-  <li
-    class="fd-nested-list__group-header"
-  >
-    
-        Group Header 1
-    
-  </li>
-  
-    
-  <li
-    class="fd-nested-list__item"
-  >
-    
-        
-    <div
-      class="fd-nested-list__content"
-    >
-      
-            
-      <i
-        class="fd-nested-list__icon sap-icon--home"
-        role="presentation"
-      />
-      
-            
-      <span
-        class="fd-nested-list__title"
-      >
-        Level 1 Item
-      </span>
-      
-        
-    </div>
-    
-    
-  </li>
-  
-    
-  <li
-    class="fd-nested-list__item"
-  >
-    
-        
-    <div
-      class="fd-nested-list__content is-selected"
-    >
-      
-            
-      <i
-        class="fd-nested-list__icon sap-icon--calendar"
-        role="presentation"
-      />
-      
-            
-      <span
-        class="fd-nested-list__title"
-      >
-        Level 1 Item
-      </span>
-      
-        
-    </div>
-    
-    
-  </li>
-  
-    
-  <li
-    class="fd-nested-list__item"
-  >
-    
-	   
-    <div
-      class="fd-nested-list__content has-child"
-      tabindex="0"
-    >
-      
-            
-      <i
-        class="fd-nested-list__icon sap-icon--employee"
-        role="presentation"
-      />
-      
-			
-      <span
-        class="fd-nested-list__title"
-      >
-        Level 1 Item
-      </span>
-      
-            
-      <button
-        aria-controls="EX600L2"
-        aria-expanded="true"
-        aria-haspopup="true"
-        aria-label="Expand submenu"
-        class="fd-button fd-nested-list__button"
-      >
-        
-                
-        <i
-          class="sap-icon--navigation-right-arrow"
-          role="presentation"
-        />
-            
-            
-      </button>
-      
-		
-    </div>
-    
-        
-    <ul
-      aria-hidden="false"
-      class="fd-nested-list fd-nested-list--text-only level-2"
-      id="EX600L2"
-    >
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <div
-          class="fd-nested-list__content"
-        >
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 2 Item
-          </span>
-          
-                
-        </div>
-        
-            
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-			   
-        <div
-          class="fd-nested-list__content has-child"
-          tabindex="0"
-        >
-          
-					
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 2 Item
-          </span>
-          
-                    
-          <button
-            aria-controls="EX600L3"
-            aria-expanded="true"
-            aria-haspopup="true"
-            aria-label="Expand submenu"
-            class="fd-button fd-nested-list__button"
-          >
-            
-                        
-            <i
-              class="sap-icon--navigation-right-arrow"
-              role="presentation"
-            />
-                
-                    
-          </button>
-          
-				
-        </div>
-        
-                
-        <ul
-          aria-hidden="false"
-          class="fd-nested-list fd-nested-list--text-only level-3"
-          id="EX600L3"
-        >
-          
-                    
-          <li
-            class="fd-nested-list__item"
-          >
-            
-                        
-            <div
-              class="fd-nested-list__content"
-            >
-              
-                            
-              <span
-                class="fd-nested-list__title"
-              >
-                Level 3 Item
-              </span>
-              
-                        
-            </div>
-            
-                    
-          </li>
-          
-                    
-          <li
-            class="fd-nested-list__item"
-          >
-            
-					   
-            <div
-              class="fd-nested-list__content has-child"
-              tabindex="0"
-            >
-              
-							
-              <span
-                class="fd-nested-list__title"
-              >
-                Level 3 Item
-              </span>
-              
-                            
-              <button
-                aria-controls="EX600L4"
-                aria-expanded="true"
-                aria-haspopup="true"
-                aria-label="Expand submenu"
-                class="fd-button fd-nested-list__button"
-              >
-                
-                                
-                <i
-                  class="sap-icon--navigation-right-arrow"
-                  role="presentation"
-                />
-                    
-                            
-              </button>
-              
-						
-            </div>
-            
-                        
-            <ul
-              aria-hidden="false"
-              class="fd-nested-list fd-nested-list--text-only level-4"
-              id="EX600L4"
-            >
-              
-                            
-              <li
-                class="fd-nested-list__item"
-              >
-                
-                                
-                <div
-                  class="fd-nested-list__content"
-                >
-                  
-                                    
-                  <span
-                    class="fd-nested-list__title"
-                  >
-                    Level 4 Item
-                  </span>
-                  
-                                
-                </div>
-                
-                            
-              </li>
-              
-                            
-              <li
-                class="fd-nested-list__item"
-              >
-                
-                                
-                <div
-                  class="fd-nested-list__content"
-                >
-                  
-                                    
-                  <span
-                    class="fd-nested-list__title"
-                  >
-                    Level 4 Item
-                  </span>
-                  
-                                
-                </div>
-                
-                            
-              </li>
-              
-                            
-              <li
-                class="fd-nested-list__item"
-              >
-                
-                                
-                <div
-                  class="fd-nested-list__content"
-                >
-                  
-                                    
-                  <span
-                    class="fd-nested-list__title"
-                  >
-                    Level 4 Item
-                  </span>
-                  
-                                
-                </div>
-                
-                            
-              </li>
-              
-                        
-            </ul>
-            
-                    
-          </li>
-          
-                    
-          <li
-            class="fd-nested-list__item"
-          >
-            
-                        
-            <div
-              class="fd-nested-list__content"
-            >
-              
-                            
-              <span
-                class="fd-nested-list__title"
-              >
-                Level 3 Item
-              </span>
-              
-                        
-            </div>
-            
-                    
-          </li>
-          
-                
-        </ul>
-        
-            
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item"
-      >
-        
-                
-        <div
-          class="fd-nested-list__content"
-        >
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 2 Item
-          </span>
-          
-                
-        </div>
-        
-            
-      </li>
-      
-        
-    </ul>
-    
-    
-  </li>
-  
-    
-  <li
-    class="fd-nested-list__item"
-  >
-    
-        
-    <div
-      class="fd-nested-list__content"
-    >
-      
-            
-      <i
-        class="fd-nested-list__icon sap-icon--activities"
-        role="presentation"
-      />
-      
-            
-      <span
-        class="fd-nested-list__title"
-      >
-        Level 1 Item
-      </span>
-      
-        
-    </div>
-    
-    
-  </li>
-  
-    
-  <li
-    class="fd-nested-list__group-header"
-  >
-    
-        Group Header 2
-    
-  </li>
-  
-    
-  <li
-    class="fd-nested-list__item"
-  >
-    
-        
-    <div
-      class="fd-nested-list__content"
-    >
-      
-            
-      <i
-        class="fd-nested-list__icon sap-icon--bar-chart"
-        role="presentation"
-      />
-      
-            
-      <span
-        class="fd-nested-list__title"
-      >
-        Level 1 Item
-      </span>
-      
-        
-    </div>
-    
-    
-  </li>
-  
-    
-  <li
-    class="fd-nested-list__item"
-  >
-    
-        
-    <div
-      class="fd-nested-list__content"
-    >
-      
-            
-      <span
-        class="fd-nested-list__title"
-      >
-        Level 1 Item
-      </span>
-      
-        
-    </div>
-    
-    
-  </li>
-  
-
-</ul>
 `;

--- a/stories/vertical-navigation/__snapshots__/vertical-navigation.stories.storyshot
+++ b/stories/vertical-navigation/__snapshots__/vertical-navigation.stories.storyshot
@@ -169,6 +169,7 @@ exports[`Storyshots Components/Vertical Navigation Default 1`] = `
         
                 
         <button
+          aria-label="Expand submenu"
           class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"
         />
         
@@ -235,6 +236,7 @@ exports[`Storyshots Components/Vertical Navigation Default 1`] = `
         
                 
         <button
+          aria-label="Expand submenu"
           class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"
         />
         
@@ -371,6 +373,7 @@ exports[`Storyshots Components/Vertical Navigation Navigation Indication 1`] = `
           
                 
           <button
+            aria-label="Expand submenu"
             class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"
           />
           
@@ -491,6 +494,7 @@ exports[`Storyshots Components/Vertical Navigation Navigation Indication 1`] = `
           
                 
           <button
+            aria-label="Expand submenu"
             class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow"
           />
               
@@ -698,6 +702,7 @@ exports[`Storyshots Components/Vertical Navigation Text Only 1`] = `
         
                 
         <button
+          aria-label="Expand submenu"
           class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"
         />
         
@@ -759,6 +764,7 @@ exports[`Storyshots Components/Vertical Navigation Text Only 1`] = `
         
                 
         <button
+          aria-label="Expand submenu"
           class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"
         />
         

--- a/stories/vertical-navigation/__snapshots__/vertical-navigation.stories.storyshot
+++ b/stories/vertical-navigation/__snapshots__/vertical-navigation.stories.storyshot
@@ -151,7 +151,7 @@ exports[`Storyshots Components/Vertical Navigation Default 1`] = `
       
             
       <li
-        class="fd-list__navigation-item is-expanded"
+        class="fd-list__navigation-item fd-list__navigation-item--expandable is-expanded"
         onclick="toggleVerticalNavSubmenu(event)"
       >
         
@@ -179,7 +179,7 @@ exports[`Storyshots Components/Vertical Navigation Default 1`] = `
           
                     
           <li
-            class="fd-list__navigation-item fd-list__navigation-item--second"
+            class="fd-list__navigation-item"
             tabindex="0"
           >
             
@@ -195,7 +195,7 @@ exports[`Storyshots Components/Vertical Navigation Default 1`] = `
           
                     
           <li
-            class="fd-list__navigation-item fd-list__navigation-item--second"
+            class="fd-list__navigation-item"
             tabindex="0"
           >
             
@@ -217,7 +217,7 @@ exports[`Storyshots Components/Vertical Navigation Default 1`] = `
       
             
       <li
-        class="fd-list__navigation-item is-expanded"
+        class="fd-list__navigation-item fd-list__navigation-item--expandable is-expanded"
         onclick="toggleVerticalNavSubmenu(event)"
       >
         
@@ -245,7 +245,7 @@ exports[`Storyshots Components/Vertical Navigation Default 1`] = `
           
                     
           <li
-            class="fd-list__navigation-item fd-list__navigation-item--second"
+            class="fd-list__navigation-item"
             tabindex="0"
           >
             
@@ -261,7 +261,7 @@ exports[`Storyshots Components/Vertical Navigation Default 1`] = `
           
                     
           <li
-            class="fd-list__navigation-item fd-list__navigation-item--second"
+            class="fd-list__navigation-item"
             tabindex="0"
           >
             
@@ -353,7 +353,7 @@ exports[`Storyshots Components/Vertical Navigation Navigation Indication 1`] = `
         
             
         <li
-          class="fd-list__navigation-item is-expanded"
+          class="fd-list__navigation-item fd-list__navigation-item--expandable is-expanded"
           onclick="toggleVerticalNavSubmenu(event)"
         >
           
@@ -381,7 +381,7 @@ exports[`Storyshots Components/Vertical Navigation Navigation Indication 1`] = `
             
                     
             <li
-              class="fd-list__navigation-item fd-list__navigation-item--second fd-list__navigation-item--indicated"
+              class="fd-list__navigation-item fd-list__navigation-item--indicated"
             >
               
                         
@@ -401,7 +401,7 @@ exports[`Storyshots Components/Vertical Navigation Navigation Indication 1`] = `
             
                     
             <li
-              class="fd-list__navigation-item fd-list__navigation-item--second"
+              class="fd-list__navigation-item"
               tabindex="0"
             >
               
@@ -502,7 +502,7 @@ exports[`Storyshots Components/Vertical Navigation Navigation Indication 1`] = `
                 
           <div
             aria-hidden="false"
-            class="fd-popover__body fd-popover__body--left fd-popover__body--no-arrow fd-list__navigation-item-popover--first"
+            class="fd-popover__body fd-popover__body--left fd-popover__body--no-arrow fd-list__navigation-item-popover--first-level"
             id="popoverA1"
           >
             
@@ -540,7 +540,7 @@ exports[`Storyshots Components/Vertical Navigation Navigation Indication 1`] = `
                 
           <div
             aria-hidden="false"
-            class="fd-popover__body fd-popover__body--left fd-popover__body--no-arrow fd-list__navigation-item-popover--second"
+            class="fd-popover__body fd-popover__body--left fd-popover__body--no-arrow fd-list__navigation-item-popover--second-level"
             id="popoverA1"
           >
             
@@ -551,7 +551,7 @@ exports[`Storyshots Components/Vertical Navigation Navigation Indication 1`] = `
               
                         
               <li
-                class="fd-list__navigation-item fd-list__navigation-item--condensed fd-list__navigation-item--second fd-list__navigation-item--indicated"
+                class="fd-list__navigation-item fd-list__navigation-item--condensed fd-list__navigation-item--indicated"
                 tabindex="0"
               >
                 
@@ -572,7 +572,7 @@ exports[`Storyshots Components/Vertical Navigation Navigation Indication 1`] = `
               
                         
               <li
-                class="fd-list__navigation-item fd-list__navigation-item--condensed fd-list__navigation-item--second"
+                class="fd-list__navigation-item fd-list__navigation-item--condensed"
                 tabindex="0"
               >
                 
@@ -685,7 +685,7 @@ exports[`Storyshots Components/Vertical Navigation Text Only 1`] = `
       
             
       <li
-        class="fd-list__navigation-item is-expanded"
+        class="fd-list__navigation-item fd-list__navigation-item--expandable is-expanded"
         onclick="toggleVerticalNavSubmenu(event)"
       >
         
@@ -708,7 +708,7 @@ exports[`Storyshots Components/Vertical Navigation Text Only 1`] = `
           
                     
           <li
-            class="fd-list__navigation-item fd-list__navigation-item--second"
+            class="fd-list__navigation-item"
             tabindex="0"
           >
             
@@ -724,7 +724,7 @@ exports[`Storyshots Components/Vertical Navigation Text Only 1`] = `
           
                     
           <li
-            class="fd-list__navigation-item fd-list__navigation-item--second"
+            class="fd-list__navigation-item"
             tabindex="0"
           >
             
@@ -746,7 +746,7 @@ exports[`Storyshots Components/Vertical Navigation Text Only 1`] = `
       
             
       <li
-        class="fd-list__navigation-item is-expanded"
+        class="fd-list__navigation-item fd-list__navigation-item--expandable is-expanded"
         onclick="toggleVerticalNavSubmenu(event)"
       >
         
@@ -769,7 +769,7 @@ exports[`Storyshots Components/Vertical Navigation Text Only 1`] = `
           
                     
           <li
-            class="fd-list__navigation-item fd-list__navigation-item--second"
+            class="fd-list__navigation-item"
             tabindex="0"
           >
             
@@ -785,7 +785,7 @@ exports[`Storyshots Components/Vertical Navigation Text Only 1`] = `
           
                     
           <li
-            class="fd-list__navigation-item fd-list__navigation-item--second"
+            class="fd-list__navigation-item"
             tabindex="0"
           >
             

--- a/stories/vertical-navigation/vertical-navigation.stories.js
+++ b/stories/vertical-navigation/vertical-navigation.stories.js
@@ -13,11 +13,11 @@ The vertical navigation area can be used to display navigation structures with u
 export const cozy = () => `<div class="fd-vertical-nav">
     <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu">
         <ul class="fd-list" aria-label="Main Menu">
-            <li class="fd-list__navigation-item">
+            <!--li class="fd-list__navigation-item">
                 <i class="fd-list__navigation-item__icon sap-icon--home"></i>
                 <span class="fd-list__navigation-item__text">Overview</span>
-            </li>
-            <li class="fd-list__navigation-item" onclick="toggleVerticalNavSubmenu(event)">
+            </li-->
+            <li class="fd-list__navigation-item is-expanded" onclick="toggleVerticalNavSubmenu(event)">
                 <i class="fd-list__navigation-item__icon sap-icon--calendar"></i>
                 <span class="fd-list__navigation-item__text">Calendar</span>
                 <i class="fd-list__navigation-item__arrow sap-icon--navigation-down-arrow is-expanded"></i>
@@ -30,7 +30,7 @@ export const cozy = () => `<div class="fd-vertical-nav">
                     </li>
                 </ul>
             </li>
-            <li class="fd-list__navigation-item" onclick="toggleVerticalNavSubmenu(event)">
+            <li class="fd-list__navigation-item is-expanded" onclick="toggleVerticalNavSubmenu(event)">
                 <i class="fd-list__navigation-item__icon sap-icon--customer"></i>
                 <span class="fd-list__navigation-item__text">Customers</span>
                 <i class="fd-list__navigation-item__arrow sap-icon--navigation-down-arrow is-expanded"></i>
@@ -43,10 +43,10 @@ export const cozy = () => `<div class="fd-vertical-nav">
                     </li>
                 </ul>
             </li>
-            <li class="fd-list__navigation-item">
+            <!--li class="fd-list__navigation-item">
                 <i class="fd-list__navigation-item__icon sap-icon--shipping-status"></i>
                 <span class="fd-list__navigation-item__text">Deliveries</span>
-            </li>
+            </li-->
         </ul>
     </nav>
 </div>

--- a/stories/vertical-navigation/vertical-navigation.stories.js
+++ b/stories/vertical-navigation/vertical-navigation.stories.js
@@ -1,0 +1,58 @@
+export default {
+    title: 'Components/Vertical Navigation',
+    parameters: {
+        description: `
+The vertical navigation area can be used to display navigation structures with up to two levels and contains links that change the content area.
+        `,
+
+        tags: ['f3', 'a11y', 'theme'],
+        components: ['vertical-nav', 'button', 'icon', 'list']
+    }
+};
+
+export const cozy = () => `<div class="fd-vertical-nav">
+    <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu">
+        <ul class="fd-list" aria-label="Main Menu">
+            <li class="fd-list--navigation-item">
+                <i class="fd-list--navigation-item__icon sap-icon--bell"></i>
+                <span class="fd-list--navigation-item__text">Level 1 Item</span>
+                <i class="fd-list--navigation-item__arrow sap-icon--navigation-right-arrow"></i>    
+            </li>
+        </ul>
+    </nav>
+</div>
+`;
+
+cozy.storyName = 'Default';
+
+cozy.parameters = {
+    docs: {
+        iframeHeight: 400,
+        storyDescription: `
+The default vertical navigation is comprised of several navigation list items.
+        `
+    }
+};
+
+export const condensed = () => `<div class="fd-vertical-nav--condensed">
+    <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu">
+        <ul class="fd-list" aria-label="Main Menu">
+            <li class="fd-list--navigation-item--condensed">
+                <i class="fd-list--navigation-item__icon sap-icon--bell"></i>
+                <i class="fd-list--navigation-item__arrow sap-icon--navigation-right-arrow"></i>    
+            </li>
+        </ul>
+    </nav>
+</div>
+`;
+
+condensed.storyName = 'Condensed';
+
+condensed.parameters = {
+    docs: {
+        iframeHeight: 400,
+        storyDescription: `
+The condensed vertical navigation.
+        `
+    }
+};

--- a/stories/vertical-navigation/vertical-navigation.stories.js
+++ b/stories/vertical-navigation/vertical-navigation.stories.js
@@ -33,19 +33,19 @@ Side navigation can be viewed in three different states:
 export const cozy = () => `<div class="fd-vertical-nav">
     <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu">
         <ul class="fd-list" aria-label="Main Menu List">
-            <li class="fd-list__navigation-item">
+            <li class="fd-list__navigation-item" tabindex="0">
                 <i class="fd-list__navigation-item-icon sap-icon--home"></i>
                 <span class="fd-list__navigation-item-text">Overview</span>
             </li>
             <li class="fd-list__navigation-item is-expanded" onclick="toggleVerticalNavSubmenu(event)">
                 <i class="fd-list__navigation-item-icon sap-icon--calendar"></i>
                 <span class="fd-list__navigation-item-text">Calendar Calendar Calendar Calendar Calendar Calendar </span>
-                <i class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"></i>
+                <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"></button>
                 <ul class="fd-list">
-                    <li class="fd-list__navigation-item fd-list__navigation-item--second">
+                    <li class="fd-list__navigation-item fd-list__navigation-item--second" tabindex="0">
                         <span class="fd-list__navigation-item-text">Second level item 1</span>
                     </li>
-                    <li class="fd-list__navigation-item fd-list__navigation-item--second">
+                    <li class="fd-list__navigation-item fd-list__navigation-item--second" tabindex="0">
                         <span class="fd-list__navigation-item-text">Second level item 2 Second level item 2 Second level item 2 Second level item 2 Second level item 2 </span>
                     </li>
                 </ul>
@@ -53,17 +53,17 @@ export const cozy = () => `<div class="fd-vertical-nav">
             <li class="fd-list__navigation-item is-expanded" onclick="toggleVerticalNavSubmenu(event)">
                 <i class="fd-list__navigation-item-icon sap-icon--customer"></i>
                 <span class="fd-list__navigation-item-text">Customers</span>
-                <i class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"></i>
+                <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"></button>
                 <ul class="fd-list">
-                    <li class="fd-list__navigation-item fd-list__navigation-item--second">
+                    <li class="fd-list__navigation-item fd-list__navigation-item--second" tabindex="0">
                         <span class="fd-list__navigation-item-text">Second level item 1</span>
                     </li>
-                    <li class="fd-list__navigation-item fd-list__navigation-item--second">
+                    <li class="fd-list__navigation-item fd-list__navigation-item--second" tabindex="0">
                         <span class="fd-list__navigation-item-text">Second level item 2</span>
                     </li>
                 </ul>
             </li>
-            <li class="fd-list__navigation-item">
+            <li class="fd-list__navigation-item" tabindex="0">
                 <i class="fd-list__navigation-item-icon sap-icon--shipping-status"></i>
                 <span class="fd-list__navigation-item-text">Deliveries</span>
             </li>
@@ -86,19 +86,19 @@ The default vertical navigation is comprised of several navigation list items.
 export const condensed = () => `<div class="fd-vertical-nav fd-vertical-nav--condensed">
     <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu">
         <ul class="fd-list" aria-label="Main Menu List">
-            <li class="fd-list__navigation-item--condensed">
+            <li class="fd-list__navigation-item fd-list__navigation-item--condensed" tabindex="0">
                 <i class="fd-list__navigation-item-icon sap-icon--home"></i>
                 <span class="fd-list__navigation-item-text">Overview</span>
             </li>
-            <li class="fd-list__navigation-item--condensed">
+            <li class="fd-list__navigation-item fd-list__navigation-item--condensed" tabindex="0">
                 <i class="fd-list__navigation-item-icon sap-icon--calendar"></i>
                 <span class="fd-list__navigation-item-text">Calendar</span>
             </li>
-            <li class="fd-list__navigation-item--condensed">
+            <li class="fd-list__navigation-item fd-list__navigation-item--condensed" tabindex="0">
                 <i class="fd-list__navigation-item-icon sap-icon--customer"></i>
                 <span class="fd-list__navigation-item-text">Customers</span>
             </li>
-            <li class="fd-list__navigation-item--condensed">
+            <li class="fd-list__navigation-item fd-list__navigation-item--condensed" tabindex="0">
                 <i class="fd-list__navigation-item-icon sap-icon--shipping-status"></i>
                 <span class="fd-list__navigation-item-text">Deliveries</span>
             </li>
@@ -121,34 +121,34 @@ In condensed mode, only icons are shown unless some navigation items have second
 export const text = () => `<div class="fd-vertical-nav">
     <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu">
         <ul class="fd-list" aria-label="Main Menu List">
-            <li class="fd-list__navigation-item">
+            <li class="fd-list__navigation-item" tabindex="0">
                 <span class="fd-list__navigation-item-text">Overview</span>
             </li>
             <li class="fd-list__navigation-item is-expanded" onclick="toggleVerticalNavSubmenu(event)">
                 <span class="fd-list__navigation-item-text">Calendar</span>
-                <i class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"></i>
+                <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"></button>
                 <ul class="fd-list">
-                    <li class="fd-list__navigation-item fd-list__navigation-item--second">
+                    <li class="fd-list__navigation-item fd-list__navigation-item--second" tabindex="0">
                         <span class="fd-list__navigation-item-text">Second level item 1</span>
                     </li>
-                    <li class="fd-list__navigation-item fd-list__navigation-item--second">
+                    <li class="fd-list__navigation-item fd-list__navigation-item--second" tabindex="0">
                         <span class="fd-list__navigation-item-text">Second level item 2</span>
                     </li>
                 </ul>
             </li>
             <li class="fd-list__navigation-item is-expanded" onclick="toggleVerticalNavSubmenu(event)">
                 <span class="fd-list__navigation-item-text">Customers</span>
-                <i class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"></i>
+                <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"></button>
                 <ul class="fd-list">
-                    <li class="fd-list__navigation-item fd-list__navigation-item--second">
+                    <li class="fd-list__navigation-item fd-list__navigation-item--second" tabindex="0">
                         <span class="fd-list__navigation-item-text">Second level item 1</span>
                     </li>
-                    <li class="fd-list__navigation-item fd-list__navigation-item--second">
+                    <li class="fd-list__navigation-item fd-list__navigation-item--second" tabindex="0">
                         <span class="fd-list__navigation-item-text">Second level item 2</span>
                     </li>
                 </ul>
             </li>
-            <li class="fd-list__navigation-item">
+            <li class="fd-list__navigation-item" tabindex="0">
                 <span class="fd-list__navigation-item-text">Deliveries</span>
             </li>
         </ul>
@@ -170,20 +170,20 @@ A vertical navigation list does not need to have icons. However this is only ava
 export const indication = () => `<div class="fd-vertical-nav">
     <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu">
         <ul class="fd-list" aria-label="Main Menu List">
-            <li class="fd-list__navigation-item">
+            <li class="fd-list__navigation-item" tabindex="0">
                 <i class="fd-list__navigation-item-icon sap-icon--home"></i>
                 <span class="fd-list__navigation-item-text">Overview</span>
             </li>
             <li class="fd-list__navigation-item is-expanded" onclick="toggleVerticalNavSubmenu(event)">
                 <i class="fd-list__navigation-item-icon sap-icon--calendar"></i>
                 <span class="fd-list__navigation-item-text">Calendar</span>
-                <i class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"></i>
+                <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"></button>
                 <ul class="fd-list">
                     <li class="fd-list__navigation-item fd-list__navigation-item--second fd-list__navigation-item--indicated">
                         <span class="fd-list__navigation-item-text">Second level item 1</span>
                         <span class="fd-list__navigation-item-indicator"></span>
                     </li>
-                    <li class="fd-list__navigation-item fd-list__navigation-item--second">
+                    <li class="fd-list__navigation-item fd-list__navigation-item--second" tabindex="0">
                         <span class="fd-list__navigation-item-text">Second level item 2</span>
                     </li>
                 </ul>
@@ -196,17 +196,17 @@ export const indication = () => `<div class="fd-vertical-nav">
 <div class="fd-vertical-nav fd-vertical-nav--condensed">
     <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu">
         <ul class="fd-list" aria-label="Main Menu List">
-            <li class="fd-list__navigation-item--condensed">
+            <li class="fd-list__navigation-item fd-list__navigation-item--condensed" tabindex="0">
                 <i class="fd-list__navigation-item-icon sap-icon--home"></i>
                 <span class="fd-list__navigation-item-text">Overview</span>
             </li>
-            <li class="fd-list__navigation-item--condensed" onclick="toggleCondensedVerticalNavSubmenu(event, 'parent')">
+            <li class="fd-list__navigation-item fd-list__navigation-item--condensed" id="parentCalendarButton" onclick="toggleCondensedVerticalNavSubmenu(event)">
                 <i class="fd-list__navigation-item-icon sap-icon--calendar"></i>
-                <i class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow"></i>    
+                <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow"></button>    
                 <span class="fd-list__navigation-item-indicator"></span>
                 <div class="fd-popover__body fd-popover__body--left fd-popover__body--no-arrow fd-list__navigation-item-popover--first" aria-hidden="false" id="popoverA1">
                     <ul class="fd-list">
-                        <li class="fd-list__navigation-item--condensed" onclick="toggleCondensedVerticalNavSubmenu(event, 'child')">
+                        <li class="fd-list__navigation-item fd-list__navigation-item--condensed">
                             <i class="fd-list__navigation-item-icon sap-icon--calendar"></i>
                             <span class="fd-list__navigation-item-text">Calendar</span>
                         </li>
@@ -214,21 +214,21 @@ export const indication = () => `<div class="fd-vertical-nav">
                 </div>
                 <div class="fd-popover__body fd-popover__body--left fd-popover__body--no-arrow fd-list__navigation-item-popover--second" aria-hidden="false" id="popoverA1">
                     <ul class="fd-list">
-                        <li class="fd-list__navigation-item--condensed fd-list__navigation-item--second fd-list__navigation-item--indicated">
+                        <li class="fd-list__navigation-item fd-list__navigation-item--condensed fd-list__navigation-item--second fd-list__navigation-item--indicated" tabindex="0">
                             <span class="fd-list__navigation-item-text">Second level item 1</span>
                             <span class="fd-list__navigation-item-indicator"></span>
                         </li>
-                        <li class="fd-list__navigation-item--condensed fd-list__navigation-item--second">
+                        <li class="fd-list__navigation-item fd-list__navigation-item--condensed fd-list__navigation-item--second" tabindex="0">
                             <span class="fd-list__navigation-item-text">Second level item 2</span>
                         </li>
                     </ul>
                 </div>
             </li>
-            <li class="fd-list__navigation-item--condensed">
+            <li class="fd-list__navigation-item fd-list__navigation-item--condensed" tabindex="0">
                 <i class="fd-list__navigation-item-icon sap-icon--customer"></i>
                 <span class="fd-list__navigation-item-text">Customers</span>
             </li>
-            <li class="fd-list__navigation-item--condensed">
+            <li class="fd-list__navigation-item fd-list__navigation-item--condensed" tabindex="0">
                 <i class="fd-list__navigation-item-icon sap-icon--shipping-status"></i>
                 <span class="fd-list__navigation-item-text">Deliveries</span>
             </li>

--- a/stories/vertical-navigation/vertical-navigation.stories.js
+++ b/stories/vertical-navigation/vertical-navigation.stories.js
@@ -39,14 +39,14 @@ export const cozy = () => `<div class="fd-vertical-nav">
             </li>
             <li class="fd-list__navigation-item is-expanded" onclick="toggleVerticalNavSubmenu(event)">
                 <i class="fd-list__navigation-item-icon sap-icon--calendar"></i>
-                <span class="fd-list__navigation-item-text">Calendar</span>
+                <span class="fd-list__navigation-item-text">Calendar Calendar Calendar Calendar Calendar Calendar </span>
                 <i class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"></i>
                 <ul class="fd-list">
                     <li class="fd-list__navigation-item fd-list__navigation-item--second">
                         <span class="fd-list__navigation-item-text">Second level item 1</span>
                     </li>
                     <li class="fd-list__navigation-item fd-list__navigation-item--second">
-                        <span class="fd-list__navigation-item-text">Second level item 2</span>
+                        <span class="fd-list__navigation-item-text">Second level item 2 Second level item 2 Second level item 2 Second level item 2 Second level item 2 </span>
                     </li>
                 </ul>
             </li>

--- a/stories/vertical-navigation/vertical-navigation.stories.js
+++ b/stories/vertical-navigation/vertical-navigation.stories.js
@@ -141,15 +141,15 @@ export const indication = () => `<div class="fd-vertical-nav">
 <div class="fd-vertical-nav fd-vertical-nav--condensed">
     <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu">
         <ul class="fd-list" aria-label="Main Menu">
-            <li class="fd-list__navigation-item--condensed fd-list__navigation-item--indicated">
+            <li class="fd-list__navigation-item--condensed">
                 <i class="fd-list__navigation-item__icon sap-icon--home"></i>
                 <span class="fd-list__navigation-item__text">Overview</span>
-                <span class="fd-list__navigation-item__indicator"></span>
             </li>
-            <li class="fd-list__navigation-item--condensed">
+            <li class="fd-list__navigation-item--condensed" onclick="toggleCondensedVerticalNavSubmenu(event)">
                 <i class="fd-list__navigation-item__icon sap-icon--calendar"></i>
                 <span class="fd-list__navigation-item__text">Calendar</span>
-                <i class="fd-list__navigation-item__arrow sap-icon--navigation-down-arrow is-expanded"></i>    
+                <i class="fd-list__navigation-item__arrow sap-icon--navigation-down-arrow"></i>    
+                <span class="fd-list__navigation-item__indicator"></span>
             </li>
         </ul>
     </nav>
@@ -177,12 +177,12 @@ export const condensed = () => `<div class="fd-vertical-nav fd-vertical-nav--con
             <li class="fd-list__navigation-item--condensed">
                 <i class="fd-list__navigation-item__icon sap-icon--calendar"></i>
                 <span class="fd-list__navigation-item__text">Calendar</span>
-                <i class="fd-list__navigation-item__arrow sap-icon--navigation-down-arrow is-expanded"></i>    
+                <i class="fd-list__navigation-item__arrow sap-icon--navigation-down-arrow"></i>    
             </li>
             <li class="fd-list__navigation-item--condensed">
                 <i class="fd-list__navigation-item__icon sap-icon--customer"></i>
                 <span class="fd-list__navigation-item__text">Customers</span>
-                <i class="fd-list__navigation-item__arrow sap-icon--navigation-down-arrow is-expanded"></i>    
+                <i class="fd-list__navigation-item__arrow sap-icon--navigation-down-arrow"></i>    
             </li>
             <li class="fd-list__navigation-item--condensed">
                 <i class="fd-list__navigation-item__icon sap-icon--shipping-status"></i>

--- a/stories/vertical-navigation/vertical-navigation.stories.js
+++ b/stories/vertical-navigation/vertical-navigation.stories.js
@@ -150,6 +150,15 @@ export const indication = () => `<div class="fd-vertical-nav">
                 <span class="fd-list__navigation-item__text">Calendar</span>
                 <i class="fd-list__navigation-item__arrow sap-icon--navigation-down-arrow"></i>    
                 <span class="fd-list__navigation-item__indicator"></span>
+                <ul class="fd-list">
+                    <li class="fd-list__navigation-item fd-list__navigation-item--second fd-list__navigation-item--indicated">
+                        <span class="fd-list__navigation-item__text">Second level item 1</span>
+                        <span class="fd-list__navigation-item__indicator"></span>
+                    </li>
+                    <li class="fd-list__navigation-item fd-list__navigation-item--second">
+                        <span class="fd-list__navigation-item__text">Second level item 2</span>
+                    </li>
+                </ul>
             </li>
         </ul>
     </nav>

--- a/stories/vertical-navigation/vertical-navigation.stories.js
+++ b/stories/vertical-navigation/vertical-navigation.stories.js
@@ -37,28 +37,28 @@ export const cozy = () => `<div class="fd-vertical-nav">
                 <i class="fd-list__navigation-item-icon sap-icon--home"></i>
                 <span class="fd-list__navigation-item-text">Overview</span>
             </li>
-            <li class="fd-list__navigation-item is-expanded" onclick="toggleVerticalNavSubmenu(event)">
+            <li class="fd-list__navigation-item fd-list__navigation-item--expandable is-expanded" onclick="toggleVerticalNavSubmenu(event)">
                 <i class="fd-list__navigation-item-icon sap-icon--calendar"></i>
                 <span class="fd-list__navigation-item-text">Calendar Calendar Calendar Calendar Calendar Calendar </span>
                 <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"></button>
                 <ul class="fd-list">
-                    <li class="fd-list__navigation-item fd-list__navigation-item--second" tabindex="0">
+                    <li class="fd-list__navigation-item" tabindex="0">
                         <span class="fd-list__navigation-item-text">Second level item 1</span>
                     </li>
-                    <li class="fd-list__navigation-item fd-list__navigation-item--second" tabindex="0">
+                    <li class="fd-list__navigation-item" tabindex="0">
                         <span class="fd-list__navigation-item-text">Second level item 2 Second level item 2 Second level item 2 Second level item 2 Second level item 2 </span>
                     </li>
                 </ul>
             </li>
-            <li class="fd-list__navigation-item is-expanded" onclick="toggleVerticalNavSubmenu(event)">
+            <li class="fd-list__navigation-item fd-list__navigation-item--expandable is-expanded" onclick="toggleVerticalNavSubmenu(event)">
                 <i class="fd-list__navigation-item-icon sap-icon--customer"></i>
                 <span class="fd-list__navigation-item-text">Customers</span>
                 <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"></button>
                 <ul class="fd-list">
-                    <li class="fd-list__navigation-item fd-list__navigation-item--second" tabindex="0">
+                    <li class="fd-list__navigation-item" tabindex="0">
                         <span class="fd-list__navigation-item-text">Second level item 1</span>
                     </li>
-                    <li class="fd-list__navigation-item fd-list__navigation-item--second" tabindex="0">
+                    <li class="fd-list__navigation-item" tabindex="0">
                         <span class="fd-list__navigation-item-text">Second level item 2</span>
                     </li>
                 </ul>
@@ -124,26 +124,26 @@ export const text = () => `<div class="fd-vertical-nav">
             <li class="fd-list__navigation-item" tabindex="0">
                 <span class="fd-list__navigation-item-text">Overview</span>
             </li>
-            <li class="fd-list__navigation-item is-expanded" onclick="toggleVerticalNavSubmenu(event)">
+            <li class="fd-list__navigation-item fd-list__navigation-item--expandable is-expanded" onclick="toggleVerticalNavSubmenu(event)">
                 <span class="fd-list__navigation-item-text">Calendar</span>
                 <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"></button>
                 <ul class="fd-list">
-                    <li class="fd-list__navigation-item fd-list__navigation-item--second" tabindex="0">
+                    <li class="fd-list__navigation-item" tabindex="0">
                         <span class="fd-list__navigation-item-text">Second level item 1</span>
                     </li>
-                    <li class="fd-list__navigation-item fd-list__navigation-item--second" tabindex="0">
+                    <li class="fd-list__navigation-item" tabindex="0">
                         <span class="fd-list__navigation-item-text">Second level item 2</span>
                     </li>
                 </ul>
             </li>
-            <li class="fd-list__navigation-item is-expanded" onclick="toggleVerticalNavSubmenu(event)">
+            <li class="fd-list__navigation-item fd-list__navigation-item--expandable is-expanded" onclick="toggleVerticalNavSubmenu(event)">
                 <span class="fd-list__navigation-item-text">Customers</span>
                 <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"></button>
                 <ul class="fd-list">
-                    <li class="fd-list__navigation-item fd-list__navigation-item--second" tabindex="0">
+                    <li class="fd-list__navigation-item" tabindex="0">
                         <span class="fd-list__navigation-item-text">Second level item 1</span>
                     </li>
-                    <li class="fd-list__navigation-item fd-list__navigation-item--second" tabindex="0">
+                    <li class="fd-list__navigation-item" tabindex="0">
                         <span class="fd-list__navigation-item-text">Second level item 2</span>
                     </li>
                 </ul>
@@ -174,16 +174,16 @@ export const indication = () => `<div class="fd-vertical-nav">
                 <i class="fd-list__navigation-item-icon sap-icon--home"></i>
                 <span class="fd-list__navigation-item-text">Overview</span>
             </li>
-            <li class="fd-list__navigation-item is-expanded" onclick="toggleVerticalNavSubmenu(event)">
+            <li class="fd-list__navigation-item fd-list__navigation-item--expandable is-expanded" onclick="toggleVerticalNavSubmenu(event)">
                 <i class="fd-list__navigation-item-icon sap-icon--calendar"></i>
                 <span class="fd-list__navigation-item-text">Calendar</span>
                 <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"></button>
                 <ul class="fd-list">
-                    <li class="fd-list__navigation-item fd-list__navigation-item--second fd-list__navigation-item--indicated">
+                    <li class="fd-list__navigation-item fd-list__navigation-item--indicated">
                         <span class="fd-list__navigation-item-text">Second level item 1</span>
                         <span class="fd-list__navigation-item-indicator"></span>
                     </li>
-                    <li class="fd-list__navigation-item fd-list__navigation-item--second" tabindex="0">
+                    <li class="fd-list__navigation-item" tabindex="0">
                         <span class="fd-list__navigation-item-text">Second level item 2</span>
                     </li>
                 </ul>
@@ -204,7 +204,7 @@ export const indication = () => `<div class="fd-vertical-nav">
                 <i class="fd-list__navigation-item-icon sap-icon--calendar"></i>
                 <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow"></button>    
                 <span class="fd-list__navigation-item-indicator"></span>
-                <div class="fd-popover__body fd-popover__body--left fd-popover__body--no-arrow fd-list__navigation-item-popover--first" aria-hidden="false" id="popoverA1">
+                <div class="fd-popover__body fd-popover__body--left fd-popover__body--no-arrow fd-list__navigation-item-popover--first-level" aria-hidden="false" id="popoverA1">
                     <ul class="fd-list">
                         <li class="fd-list__navigation-item fd-list__navigation-item--condensed">
                             <i class="fd-list__navigation-item-icon sap-icon--calendar"></i>
@@ -212,13 +212,13 @@ export const indication = () => `<div class="fd-vertical-nav">
                         </li>
                     </ul>
                 </div>
-                <div class="fd-popover__body fd-popover__body--left fd-popover__body--no-arrow fd-list__navigation-item-popover--second" aria-hidden="false" id="popoverA1">
+                <div class="fd-popover__body fd-popover__body--left fd-popover__body--no-arrow fd-list__navigation-item-popover--second-level" aria-hidden="false" id="popoverA1">
                     <ul class="fd-list">
-                        <li class="fd-list__navigation-item fd-list__navigation-item--condensed fd-list__navigation-item--second fd-list__navigation-item--indicated" tabindex="0">
+                        <li class="fd-list__navigation-item fd-list__navigation-item--condensed fd-list__navigation-item--indicated" tabindex="0">
                             <span class="fd-list__navigation-item-text">Second level item 1</span>
                             <span class="fd-list__navigation-item-indicator"></span>
                         </li>
-                        <li class="fd-list__navigation-item fd-list__navigation-item--condensed fd-list__navigation-item--second" tabindex="0">
+                        <li class="fd-list__navigation-item fd-list__navigation-item--condensed" tabindex="0">
                             <span class="fd-list__navigation-item-text">Second level item 2</span>
                         </li>
                     </ul>

--- a/stories/vertical-navigation/vertical-navigation.stories.js
+++ b/stories/vertical-navigation/vertical-navigation.stories.js
@@ -2,7 +2,27 @@ export default {
     title: 'Components/Vertical Navigation',
     parameters: {
         description: `
-The vertical navigation area can be used to display navigation structures with up to two levels and contains links that change the content area.
+The side navigation area can be used to display navigation structures with up to two levels. It contains links that change the content area. The side navigation area has three visual states: off-canvas, medium and large. Depending on the device context, two of these states are used per device.
+
+##Usage      
+**Use the vertical navigation if:**
+
+- You need to display global navigation structures of up to two levels.
+- Your scenarios are in the tooling or administration space.
+- If you want the entries to change as though they are dynamic content.
+
+**Do not use the vertical navigation if:**
+
+- Your scenarios are not in the tooling or administration space.
+
+##States
+Side navigation can be viewed in three different states:
+
+- **Expanded:** everything is shown; icons and/or text.
+- **Condensed:** only icons are shown; text-only condensed state is not supported.
+- **Off-canvas:** side navigation is completely off-screen, and can be triggered via the menu icon in the shellbar.
+
+**Note:** It is recommend to use only two states per device.
         `,
 
         tags: ['f3', 'a11y', 'theme'],
@@ -93,7 +113,7 @@ condensed.parameters = {
     docs: {
         iframeHeight: 400,
         storyDescription: `
-The condensed vertical navigation.
+In condensed mode, only icons are shown unless some navigation items have second levels and the second level is expanded.
         `
     }
 };
@@ -223,7 +243,7 @@ indication.parameters = {
     docs: {
         iframeHeight: 700,
         storyDescription: `
-The vertical navigation list can display navigation indication in several ways.
+All the possible combinations of navigation indication are visualized below. When a second level item has been navigated to and the second list has been collapsed, the indicator is shown on the right of the corresponding first level item, but the text and icon color do not change.
         `
     }
 };

--- a/stories/vertical-navigation/vertical-navigation.stories.js
+++ b/stories/vertical-navigation/vertical-navigation.stories.js
@@ -40,7 +40,7 @@ export const cozy = () => `<div class="fd-vertical-nav">
             <li class="fd-list__navigation-item fd-list__navigation-item--expandable is-expanded" onclick="toggleVerticalNavSubmenu(event)">
                 <i class="fd-list__navigation-item-icon sap-icon--calendar"></i>
                 <span class="fd-list__navigation-item-text">Calendar Calendar Calendar Calendar Calendar Calendar </span>
-                <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"></button>
+                <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded" aria-label="Expand submenu"></button>
                 <ul class="fd-list">
                     <li class="fd-list__navigation-item" tabindex="0">
                         <span class="fd-list__navigation-item-text">Second level item 1</span>
@@ -53,7 +53,7 @@ export const cozy = () => `<div class="fd-vertical-nav">
             <li class="fd-list__navigation-item fd-list__navigation-item--expandable is-expanded" onclick="toggleVerticalNavSubmenu(event)">
                 <i class="fd-list__navigation-item-icon sap-icon--customer"></i>
                 <span class="fd-list__navigation-item-text">Customers</span>
-                <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"></button>
+                <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded" aria-label="Expand submenu"></button>
                 <ul class="fd-list">
                     <li class="fd-list__navigation-item" tabindex="0">
                         <span class="fd-list__navigation-item-text">Second level item 1</span>
@@ -126,7 +126,7 @@ export const text = () => `<div class="fd-vertical-nav">
             </li>
             <li class="fd-list__navigation-item fd-list__navigation-item--expandable is-expanded" onclick="toggleVerticalNavSubmenu(event)">
                 <span class="fd-list__navigation-item-text">Calendar</span>
-                <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"></button>
+                <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded" aria-label="Expand submenu"></button>
                 <ul class="fd-list">
                     <li class="fd-list__navigation-item" tabindex="0">
                         <span class="fd-list__navigation-item-text">Second level item 1</span>
@@ -138,7 +138,7 @@ export const text = () => `<div class="fd-vertical-nav">
             </li>
             <li class="fd-list__navigation-item fd-list__navigation-item--expandable is-expanded" onclick="toggleVerticalNavSubmenu(event)">
                 <span class="fd-list__navigation-item-text">Customers</span>
-                <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"></button>
+                <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded" aria-label="Expand submenu"></button>
                 <ul class="fd-list">
                     <li class="fd-list__navigation-item" tabindex="0">
                         <span class="fd-list__navigation-item-text">Second level item 1</span>
@@ -177,7 +177,7 @@ export const indication = () => `<div class="fd-vertical-nav">
             <li class="fd-list__navigation-item fd-list__navigation-item--expandable is-expanded" onclick="toggleVerticalNavSubmenu(event)">
                 <i class="fd-list__navigation-item-icon sap-icon--calendar"></i>
                 <span class="fd-list__navigation-item-text">Calendar</span>
-                <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"></button>
+                <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded" aria-label="Expand submenu"></button>
                 <ul class="fd-list">
                     <li class="fd-list__navigation-item fd-list__navigation-item--indicated">
                         <span class="fd-list__navigation-item-text">Second level item 1</span>
@@ -202,7 +202,7 @@ export const indication = () => `<div class="fd-vertical-nav">
             </li>
             <li class="fd-list__navigation-item fd-list__navigation-item--condensed" id="parentCalendarButton" onclick="toggleCondensedVerticalNavSubmenu(event)">
                 <i class="fd-list__navigation-item-icon sap-icon--calendar"></i>
-                <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow"></button>    
+                <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow" aria-label="Expand submenu"></button>    
                 <span class="fd-list__navigation-item-indicator"></span>
                 <div class="fd-popover__body fd-popover__body--left fd-popover__body--no-arrow fd-list__navigation-item-popover--first-level" aria-hidden="false" id="popoverA1">
                     <ul class="fd-list">

--- a/stories/vertical-navigation/vertical-navigation.stories.js
+++ b/stories/vertical-navigation/vertical-navigation.stories.js
@@ -32,7 +32,7 @@ Side navigation can be viewed in three different states:
 
 export const cozy = () => `<div class="fd-vertical-nav">
     <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu">
-        <ul class="fd-list" aria-label="Main Menu">
+        <ul class="fd-list" aria-label="Main Menu List">
             <li class="fd-list__navigation-item">
                 <i class="fd-list__navigation-item-icon sap-icon--home"></i>
                 <span class="fd-list__navigation-item-text">Overview</span>
@@ -85,7 +85,7 @@ The default vertical navigation is comprised of several navigation list items.
 
 export const condensed = () => `<div class="fd-vertical-nav fd-vertical-nav--condensed">
     <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu">
-        <ul class="fd-list" aria-label="Main Menu">
+        <ul class="fd-list" aria-label="Main Menu List">
             <li class="fd-list__navigation-item--condensed">
                 <i class="fd-list__navigation-item-icon sap-icon--home"></i>
                 <span class="fd-list__navigation-item-text">Overview</span>
@@ -120,7 +120,7 @@ In condensed mode, only icons are shown unless some navigation items have second
 
 export const text = () => `<div class="fd-vertical-nav">
     <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu">
-        <ul class="fd-list" aria-label="Main Menu">
+        <ul class="fd-list" aria-label="Main Menu List">
             <li class="fd-list__navigation-item">
                 <span class="fd-list__navigation-item-text">Overview</span>
             </li>
@@ -169,7 +169,7 @@ A vertical navigation list does not need to have icons. However this is only ava
 
 export const indication = () => `<div class="fd-vertical-nav">
     <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu">
-        <ul class="fd-list" aria-label="Main Menu">
+        <ul class="fd-list" aria-label="Main Menu List">
             <li class="fd-list__navigation-item">
                 <i class="fd-list__navigation-item-icon sap-icon--home"></i>
                 <span class="fd-list__navigation-item-text">Overview</span>
@@ -195,7 +195,7 @@ export const indication = () => `<div class="fd-vertical-nav">
 <br/><br/>
 <div class="fd-vertical-nav fd-vertical-nav--condensed">
     <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu">
-        <ul class="fd-list" aria-label="Main Menu">
+        <ul class="fd-list" aria-label="Main Menu List">
             <li class="fd-list__navigation-item--condensed">
                 <i class="fd-list__navigation-item-icon sap-icon--home"></i>
                 <span class="fd-list__navigation-item-text">Overview</span>

--- a/stories/vertical-navigation/vertical-navigation.stories.js
+++ b/stories/vertical-navigation/vertical-navigation.stories.js
@@ -13,10 +13,10 @@ The vertical navigation area can be used to display navigation structures with u
 export const cozy = () => `<div class="fd-vertical-nav">
     <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu">
         <ul class="fd-list" aria-label="Main Menu">
-            <!--li class="fd-list__navigation-item">
+            <li class="fd-list__navigation-item">
                 <i class="fd-list__navigation-item__icon sap-icon--home"></i>
                 <span class="fd-list__navigation-item__text">Overview</span>
-            </li-->
+            </li>
             <li class="fd-list__navigation-item is-expanded" onclick="toggleVerticalNavSubmenu(event)">
                 <i class="fd-list__navigation-item__icon sap-icon--calendar"></i>
                 <span class="fd-list__navigation-item__text">Calendar</span>
@@ -43,10 +43,10 @@ export const cozy = () => `<div class="fd-vertical-nav">
                     </li>
                 </ul>
             </li>
-            <!--li class="fd-list__navigation-item">
+            <li class="fd-list__navigation-item">
                 <i class="fd-list__navigation-item__icon sap-icon--shipping-status"></i>
                 <span class="fd-list__navigation-item__text">Deliveries</span>
-            </li-->
+            </li>
         </ul>
     </nav>
 </div>
@@ -59,6 +59,109 @@ cozy.parameters = {
         iframeHeight: 700,
         storyDescription: `
 The default vertical navigation is comprised of several navigation list items.
+        `
+    }
+};
+
+export const text = () => `<div class="fd-vertical-nav">
+    <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu">
+        <ul class="fd-list" aria-label="Main Menu">
+            <li class="fd-list__navigation-item">
+                <span class="fd-list__navigation-item__text">Overview</span>
+            </li>
+            <li class="fd-list__navigation-item is-expanded" onclick="toggleVerticalNavSubmenu(event)">
+                <span class="fd-list__navigation-item__text">Calendar</span>
+                <i class="fd-list__navigation-item__arrow sap-icon--navigation-down-arrow is-expanded"></i>
+                <ul class="fd-list">
+                    <li class="fd-list__navigation-item fd-list__navigation-item--second">
+                        <span class="fd-list__navigation-item__text">Second level item 1</span>
+                    </li>
+                    <li class="fd-list__navigation-item fd-list__navigation-item--second">
+                        <span class="fd-list__navigation-item__text">Second level item 2</span>
+                    </li>
+                </ul>
+            </li>
+            <li class="fd-list__navigation-item is-expanded" onclick="toggleVerticalNavSubmenu(event)">
+                <span class="fd-list__navigation-item__text">Customers</span>
+                <i class="fd-list__navigation-item__arrow sap-icon--navigation-down-arrow is-expanded"></i>
+                <ul class="fd-list">
+                    <li class="fd-list__navigation-item fd-list__navigation-item--second">
+                        <span class="fd-list__navigation-item__text">Second level item 1</span>
+                    </li>
+                    <li class="fd-list__navigation-item fd-list__navigation-item--second">
+                        <span class="fd-list__navigation-item__text">Second level item 2</span>
+                    </li>
+                </ul>
+            </li>
+            <li class="fd-list__navigation-item">
+                <span class="fd-list__navigation-item__text">Deliveries</span>
+            </li>
+        </ul>
+    </nav>
+</div>
+`;
+
+text.storyName = 'Text Only';
+
+text.parameters = {
+    docs: {
+        iframeHeight: 700,
+        storyDescription: `
+A vertical navigation list does not need to have icons. However this is only available in expanded mode.
+        `
+    }
+};
+
+export const indication = () => `<div class="fd-vertical-nav">
+    <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu">
+        <ul class="fd-list" aria-label="Main Menu">
+            <li class="fd-list__navigation-item">
+                <i class="fd-list__navigation-item__icon sap-icon--home"></i>
+                <span class="fd-list__navigation-item__text">Overview</span>
+            </li>
+            <li class="fd-list__navigation-item is-expanded" onclick="toggleVerticalNavSubmenu(event)">
+                <i class="fd-list__navigation-item__icon sap-icon--calendar"></i>
+                <span class="fd-list__navigation-item__text">Calendar</span>
+                <i class="fd-list__navigation-item__arrow sap-icon--navigation-down-arrow is-expanded"></i>
+                <ul class="fd-list">
+                    <li class="fd-list__navigation-item fd-list__navigation-item--second fd-list__navigation-item--indicated">
+                        <span class="fd-list__navigation-item__text">Second level item 1</span>
+                        <span class="fd-list__navigation-item__indicator"></span>
+                    </li>
+                    <li class="fd-list__navigation-item fd-list__navigation-item--second">
+                        <span class="fd-list__navigation-item__text">Second level item 2</span>
+                    </li>
+                </ul>
+            </li>
+        </ul>
+    </nav>
+</div>
+<br/><br/>
+<div class="fd-vertical-nav fd-vertical-nav--condensed">
+    <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu">
+        <ul class="fd-list" aria-label="Main Menu">
+            <li class="fd-list__navigation-item--condensed fd-list__navigation-item--indicated">
+                <i class="fd-list__navigation-item__icon sap-icon--home"></i>
+                <span class="fd-list__navigation-item__text">Overview</span>
+                        <span class="fd-list__navigation-item__indicator"></span>
+            </li>
+            <li class="fd-list__navigation-item--condensed">
+                <i class="fd-list__navigation-item__icon sap-icon--calendar"></i>
+                <span class="fd-list__navigation-item__text">Calendar</span>
+                <i class="fd-list__navigation-item__arrow sap-icon--navigation-down-arrow is-expanded"></i>    
+            </li>
+        </ul>
+    </nav>
+</div>
+`;
+
+indication.storyName = 'Navigation Indication';
+
+indication.parameters = {
+    docs: {
+        iframeHeight: 700,
+        storyDescription: `
+The vertical navigation list can display navigation indication in several ways.
         `
     }
 };

--- a/stories/vertical-navigation/vertical-navigation.stories.js
+++ b/stories/vertical-navigation/vertical-navigation.stories.js
@@ -132,6 +132,7 @@ export const indication = () => `<div class="fd-vertical-nav">
                         <span class="fd-list__navigation-item__text">Second level item 2</span>
                     </li>
                 </ul>
+                <span class="fd-list__navigation-item__indicator"></span>
             </li>
         </ul>
     </nav>
@@ -143,7 +144,7 @@ export const indication = () => `<div class="fd-vertical-nav">
             <li class="fd-list__navigation-item--condensed fd-list__navigation-item--indicated">
                 <i class="fd-list__navigation-item__icon sap-icon--home"></i>
                 <span class="fd-list__navigation-item__text">Overview</span>
-                        <span class="fd-list__navigation-item__indicator"></span>
+                <span class="fd-list__navigation-item__indicator"></span>
             </li>
             <li class="fd-list__navigation-item--condensed">
                 <i class="fd-list__navigation-item__icon sap-icon--calendar"></i>

--- a/stories/vertical-navigation/vertical-navigation.stories.js
+++ b/stories/vertical-navigation/vertical-navigation.stories.js
@@ -34,11 +34,11 @@ export const cozy = () => `<div class="fd-vertical-nav">
     <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu">
         <ul class="fd-list" aria-label="Main Menu List">
             <li class="fd-list__navigation-item" tabindex="0">
-                <i class="fd-list__navigation-item-icon sap-icon--home"></i>
+                <i role="presentation" class="fd-list__navigation-item-icon sap-icon--home"></i>
                 <span class="fd-list__navigation-item-text">Overview</span>
             </li>
             <li class="fd-list__navigation-item fd-list__navigation-item--expandable is-expanded" onclick="toggleVerticalNavSubmenu(event)">
-                <i class="fd-list__navigation-item-icon sap-icon--calendar"></i>
+                <i role="presentation" class="fd-list__navigation-item-icon sap-icon--calendar"></i>
                 <span class="fd-list__navigation-item-text">Calendar Calendar Calendar Calendar Calendar Calendar </span>
                 <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded" aria-label="Expand submenu"></button>
                 <ul class="fd-list">
@@ -51,9 +51,9 @@ export const cozy = () => `<div class="fd-vertical-nav">
                 </ul>
             </li>
             <li class="fd-list__navigation-item fd-list__navigation-item--expandable is-expanded" onclick="toggleVerticalNavSubmenu(event)">
-                <i class="fd-list__navigation-item-icon sap-icon--customer"></i>
+                <i role="presentation" class="fd-list__navigation-item-icon sap-icon--customer"></i>
                 <span class="fd-list__navigation-item-text">Customers</span>
-                <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded" aria-label="Expand submenu"></button>
+                <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded" aria-label="Expand second submenu"></button>
                 <ul class="fd-list">
                     <li class="fd-list__navigation-item" tabindex="0">
                         <span class="fd-list__navigation-item-text">Second level item 1</span>
@@ -64,7 +64,7 @@ export const cozy = () => `<div class="fd-vertical-nav">
                 </ul>
             </li>
             <li class="fd-list__navigation-item" tabindex="0">
-                <i class="fd-list__navigation-item-icon sap-icon--shipping-status"></i>
+                <i role="presentation" class="fd-list__navigation-item-icon sap-icon--shipping-status"></i>
                 <span class="fd-list__navigation-item-text">Deliveries</span>
             </li>
         </ul>
@@ -84,22 +84,22 @@ The default vertical navigation is comprised of several navigation list items.
 };
 
 export const condensed = () => `<div class="fd-vertical-nav fd-vertical-nav--condensed">
-    <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu">
-        <ul class="fd-list" aria-label="Main Menu List">
+    <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu 2">
+        <ul class="fd-list" aria-label="Main Menu List 2">
             <li class="fd-list__navigation-item fd-list__navigation-item--condensed" tabindex="0">
-                <i class="fd-list__navigation-item-icon sap-icon--home"></i>
+                <i role="presentation" class="fd-list__navigation-item-icon sap-icon--home"></i>
                 <span class="fd-list__navigation-item-text">Overview</span>
             </li>
             <li class="fd-list__navigation-item fd-list__navigation-item--condensed" tabindex="0">
-                <i class="fd-list__navigation-item-icon sap-icon--calendar"></i>
+                <i role="presentation" class="fd-list__navigation-item-icon sap-icon--calendar"></i>
                 <span class="fd-list__navigation-item-text">Calendar</span>
             </li>
             <li class="fd-list__navigation-item fd-list__navigation-item--condensed" tabindex="0">
-                <i class="fd-list__navigation-item-icon sap-icon--customer"></i>
+                <i role="presentation" class="fd-list__navigation-item-icon sap-icon--customer"></i>
                 <span class="fd-list__navigation-item-text">Customers</span>
             </li>
             <li class="fd-list__navigation-item fd-list__navigation-item--condensed" tabindex="0">
-                <i class="fd-list__navigation-item-icon sap-icon--shipping-status"></i>
+                <i role="presentation" class="fd-list__navigation-item-icon sap-icon--shipping-status"></i>
                 <span class="fd-list__navigation-item-text">Deliveries</span>
             </li>
         </ul>
@@ -119,14 +119,14 @@ In condensed mode, only icons are shown unless some navigation items have second
 };
 
 export const text = () => `<div class="fd-vertical-nav">
-    <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu">
-        <ul class="fd-list" aria-label="Main Menu List">
+    <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu 3">
+        <ul class="fd-list" aria-label="Main Menu List 3">
             <li class="fd-list__navigation-item" tabindex="0">
                 <span class="fd-list__navigation-item-text">Overview</span>
             </li>
             <li class="fd-list__navigation-item fd-list__navigation-item--expandable is-expanded" onclick="toggleVerticalNavSubmenu(event)">
                 <span class="fd-list__navigation-item-text">Calendar</span>
-                <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded" aria-label="Expand submenu"></button>
+                <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded" aria-label="Expand second submenu 3"></button>
                 <ul class="fd-list">
                     <li class="fd-list__navigation-item" tabindex="0">
                         <span class="fd-list__navigation-item-text">Second level item 1</span>
@@ -138,7 +138,7 @@ export const text = () => `<div class="fd-vertical-nav">
             </li>
             <li class="fd-list__navigation-item fd-list__navigation-item--expandable is-expanded" onclick="toggleVerticalNavSubmenu(event)">
                 <span class="fd-list__navigation-item-text">Customers</span>
-                <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded" aria-label="Expand submenu"></button>
+                <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded" aria-label="Expand third submenu 2"></button>
                 <ul class="fd-list">
                     <li class="fd-list__navigation-item" tabindex="0">
                         <span class="fd-list__navigation-item-text">Second level item 1</span>
@@ -168,16 +168,16 @@ A vertical navigation list does not need to have icons. However this is only ava
 };
 
 export const indication = () => `<div class="fd-vertical-nav">
-    <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu">
-        <ul class="fd-list" aria-label="Main Menu List">
+    <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu 3">
+        <ul class="fd-list" aria-label="Main Menu List 3">
             <li class="fd-list__navigation-item" tabindex="0">
-                <i class="fd-list__navigation-item-icon sap-icon--home"></i>
+                <i role="presentation" class="fd-list__navigation-item-icon sap-icon--home"></i>
                 <span class="fd-list__navigation-item-text">Overview</span>
             </li>
             <li class="fd-list__navigation-item fd-list__navigation-item--expandable is-expanded" onclick="toggleVerticalNavSubmenu(event)">
-                <i class="fd-list__navigation-item-icon sap-icon--calendar"></i>
+                <i role="presentation" class="fd-list__navigation-item-icon sap-icon--calendar"></i>
                 <span class="fd-list__navigation-item-text">Calendar</span>
-                <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded" aria-label="Expand submenu"></button>
+                <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded" aria-label="Expand second submenu 3"></button>
                 <ul class="fd-list">
                     <li class="fd-list__navigation-item fd-list__navigation-item--indicated">
                         <span class="fd-list__navigation-item-text">Second level item 1</span>
@@ -194,25 +194,25 @@ export const indication = () => `<div class="fd-vertical-nav">
 </div>
 <br/><br/>
 <div class="fd-vertical-nav fd-vertical-nav--condensed">
-    <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu">
-        <ul class="fd-list" aria-label="Main Menu List">
+    <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu 4">
+        <ul class="fd-list" aria-label="Main Menu List 4">
             <li class="fd-list__navigation-item fd-list__navigation-item--condensed" tabindex="0">
-                <i class="fd-list__navigation-item-icon sap-icon--home"></i>
+                <i role="presentation" class="fd-list__navigation-item-icon sap-icon--home"></i>
                 <span class="fd-list__navigation-item-text">Overview</span>
             </li>
             <li class="fd-list__navigation-item fd-list__navigation-item--condensed" id="parentCalendarButton" onclick="toggleCondensedVerticalNavSubmenu(event)">
-                <i class="fd-list__navigation-item-icon sap-icon--calendar"></i>
-                <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow" aria-label="Expand submenu"></button>    
+                <i role="presentation" class="fd-list__navigation-item-icon sap-icon--calendar"></i>
+                <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow" aria-label="Expand second submenu 4"></button>    
                 <span class="fd-list__navigation-item-indicator"></span>
                 <div class="fd-popover__body fd-popover__body--left fd-popover__body--no-arrow fd-list__navigation-item-popover--first-level" aria-hidden="false" id="popoverA1">
                     <ul class="fd-list">
                         <li class="fd-list__navigation-item fd-list__navigation-item--condensed">
-                            <i class="fd-list__navigation-item-icon sap-icon--calendar"></i>
+                            <i role="presentation" class="fd-list__navigation-item-icon sap-icon--calendar"></i>
                             <span class="fd-list__navigation-item-text">Calendar</span>
                         </li>
                     </ul>
                 </div>
-                <div class="fd-popover__body fd-popover__body--left fd-popover__body--no-arrow fd-list__navigation-item-popover--second-level" aria-hidden="false" id="popoverA1">
+                <div class="fd-popover__body fd-popover__body--left fd-popover__body--no-arrow fd-list__navigation-item-popover--second-level" aria-hidden="false" id="popoverA2">
                     <ul class="fd-list">
                         <li class="fd-list__navigation-item fd-list__navigation-item--condensed fd-list__navigation-item--indicated" tabindex="0">
                             <span class="fd-list__navigation-item-text">Second level item 1</span>
@@ -225,11 +225,11 @@ export const indication = () => `<div class="fd-vertical-nav">
                 </div>
             </li>
             <li class="fd-list__navigation-item fd-list__navigation-item--condensed" tabindex="0">
-                <i class="fd-list__navigation-item-icon sap-icon--customer"></i>
+                <i role="presentation" class="fd-list__navigation-item-icon sap-icon--customer"></i>
                 <span class="fd-list__navigation-item-text">Customers</span>
             </li>
             <li class="fd-list__navigation-item fd-list__navigation-item--condensed" tabindex="0">
-                <i class="fd-list__navigation-item-icon sap-icon--shipping-status"></i>
+                <i role="presentation" class="fd-list__navigation-item-icon sap-icon--shipping-status"></i>
                 <span class="fd-list__navigation-item-text">Deliveries</span>
             </li>
         </ul>

--- a/stories/vertical-navigation/vertical-navigation.stories.js
+++ b/stories/vertical-navigation/vertical-navigation.stories.js
@@ -6,7 +6,7 @@ The vertical navigation area can be used to display navigation structures with u
         `,
 
         tags: ['f3', 'a11y', 'theme'],
-        components: ['vertical-nav', 'button', 'icon', 'list']
+        components: ['vertical-nav', 'button', 'icon', 'list', 'popover']
     }
 };
 
@@ -14,38 +14,38 @@ export const cozy = () => `<div class="fd-vertical-nav">
     <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu">
         <ul class="fd-list" aria-label="Main Menu">
             <li class="fd-list__navigation-item">
-                <i class="fd-list__navigation-item__icon sap-icon--home"></i>
-                <span class="fd-list__navigation-item__text">Overview</span>
+                <i class="fd-list__navigation-item-icon sap-icon--home"></i>
+                <span class="fd-list__navigation-item-text">Overview</span>
             </li>
             <li class="fd-list__navigation-item is-expanded" onclick="toggleVerticalNavSubmenu(event)">
-                <i class="fd-list__navigation-item__icon sap-icon--calendar"></i>
-                <span class="fd-list__navigation-item__text">Calendar</span>
-                <i class="fd-list__navigation-item__arrow sap-icon--navigation-down-arrow is-expanded"></i>
+                <i class="fd-list__navigation-item-icon sap-icon--calendar"></i>
+                <span class="fd-list__navigation-item-text">Calendar</span>
+                <i class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"></i>
                 <ul class="fd-list">
                     <li class="fd-list__navigation-item fd-list__navigation-item--second">
-                        <span class="fd-list__navigation-item__text">Second level item 1</span>
+                        <span class="fd-list__navigation-item-text">Second level item 1</span>
                     </li>
                     <li class="fd-list__navigation-item fd-list__navigation-item--second">
-                        <span class="fd-list__navigation-item__text">Second level item 2</span>
+                        <span class="fd-list__navigation-item-text">Second level item 2</span>
                     </li>
                 </ul>
             </li>
             <li class="fd-list__navigation-item is-expanded" onclick="toggleVerticalNavSubmenu(event)">
-                <i class="fd-list__navigation-item__icon sap-icon--customer"></i>
-                <span class="fd-list__navigation-item__text">Customers</span>
-                <i class="fd-list__navigation-item__arrow sap-icon--navigation-down-arrow is-expanded"></i>
+                <i class="fd-list__navigation-item-icon sap-icon--customer"></i>
+                <span class="fd-list__navigation-item-text">Customers</span>
+                <i class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"></i>
                 <ul class="fd-list">
                     <li class="fd-list__navigation-item fd-list__navigation-item--second">
-                        <span class="fd-list__navigation-item__text">Second level item 1</span>
+                        <span class="fd-list__navigation-item-text">Second level item 1</span>
                     </li>
                     <li class="fd-list__navigation-item fd-list__navigation-item--second">
-                        <span class="fd-list__navigation-item__text">Second level item 2</span>
+                        <span class="fd-list__navigation-item-text">Second level item 2</span>
                     </li>
                 </ul>
             </li>
             <li class="fd-list__navigation-item">
-                <i class="fd-list__navigation-item__icon sap-icon--shipping-status"></i>
-                <span class="fd-list__navigation-item__text">Deliveries</span>
+                <i class="fd-list__navigation-item-icon sap-icon--shipping-status"></i>
+                <span class="fd-list__navigation-item-text">Deliveries</span>
             </li>
         </ul>
     </nav>
@@ -63,38 +63,73 @@ The default vertical navigation is comprised of several navigation list items.
     }
 };
 
+export const condensed = () => `<div class="fd-vertical-nav fd-vertical-nav--condensed">
+    <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu">
+        <ul class="fd-list" aria-label="Main Menu">
+            <li class="fd-list__navigation-item--condensed">
+                <i class="fd-list__navigation-item-icon sap-icon--home"></i>
+                <span class="fd-list__navigation-item-text">Overview</span>
+            </li>
+            <li class="fd-list__navigation-item--condensed">
+                <i class="fd-list__navigation-item-icon sap-icon--calendar"></i>
+                <span class="fd-list__navigation-item-text">Calendar</span>
+            </li>
+            <li class="fd-list__navigation-item--condensed">
+                <i class="fd-list__navigation-item-icon sap-icon--customer"></i>
+                <span class="fd-list__navigation-item-text">Customers</span>
+            </li>
+            <li class="fd-list__navigation-item--condensed">
+                <i class="fd-list__navigation-item-icon sap-icon--shipping-status"></i>
+                <span class="fd-list__navigation-item-text">Deliveries</span>
+            </li>
+        </ul>
+    </nav>
+</div>
+`;
+
+condensed.storyName = 'Condensed';
+
+condensed.parameters = {
+    docs: {
+        iframeHeight: 400,
+        storyDescription: `
+The condensed vertical navigation.
+        `
+    }
+};
+
 export const text = () => `<div class="fd-vertical-nav">
     <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu">
         <ul class="fd-list" aria-label="Main Menu">
             <li class="fd-list__navigation-item">
-                <span class="fd-list__navigation-item__text">Overview</span>
+                <span class="fd-list__navigation-item-text">Overview</span>
             </li>
             <li class="fd-list__navigation-item is-expanded" onclick="toggleVerticalNavSubmenu(event)">
-                <span class="fd-list__navigation-item__text">Calendar</span>
-                <i class="fd-list__navigation-item__arrow sap-icon--navigation-down-arrow is-expanded"></i>
+                <span class="fd-list__navigation-item-text">Calendar</span>
+                <i class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"></i>
                 <ul class="fd-list">
                     <li class="fd-list__navigation-item fd-list__navigation-item--second">
-                        <span class="fd-list__navigation-item__text">Second level item 1</span>
+                        <span class="fd-list__navigation-item-text">Second level item 1</span>
                     </li>
                     <li class="fd-list__navigation-item fd-list__navigation-item--second">
-                        <span class="fd-list__navigation-item__text">Second level item 2</span>
+                        <span class="fd-list__navigation-item-text">Second level item 2</span>
                     </li>
                 </ul>
             </li>
             <li class="fd-list__navigation-item is-expanded" onclick="toggleVerticalNavSubmenu(event)">
-                <span class="fd-list__navigation-item__text">Customers</span>
-                <i class="fd-list__navigation-item__arrow sap-icon--navigation-down-arrow is-expanded"></i>
+                <span class="fd-list__navigation-item-text">Customers</span>
+                <i class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"></i>
                 <ul class="fd-list">
                     <li class="fd-list__navigation-item fd-list__navigation-item--second">
-                        <span class="fd-list__navigation-item__text">Second level item 1</span>
+                        <span class="fd-list__navigation-item-text">Second level item 1</span>
                     </li>
                     <li class="fd-list__navigation-item fd-list__navigation-item--second">
-                        <span class="fd-list__navigation-item__text">Second level item 2</span>
+                        <span class="fd-list__navigation-item-text">Second level item 2</span>
                     </li>
                 </ul>
             </li>
             <li class="fd-list__navigation-item">
-                <span class="fd-list__navigation-item__text">Deliveries</span>
+                <span class="fd-list__navigation-item-text">Deliveries</span>
             </li>
         </ul>
     </nav>
@@ -116,23 +151,23 @@ export const indication = () => `<div class="fd-vertical-nav">
     <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu">
         <ul class="fd-list" aria-label="Main Menu">
             <li class="fd-list__navigation-item">
-                <i class="fd-list__navigation-item__icon sap-icon--home"></i>
-                <span class="fd-list__navigation-item__text">Overview</span>
+                <i class="fd-list__navigation-item-icon sap-icon--home"></i>
+                <span class="fd-list__navigation-item-text">Overview</span>
             </li>
             <li class="fd-list__navigation-item is-expanded" onclick="toggleVerticalNavSubmenu(event)">
-                <i class="fd-list__navigation-item__icon sap-icon--calendar"></i>
-                <span class="fd-list__navigation-item__text">Calendar</span>
-                <i class="fd-list__navigation-item__arrow sap-icon--navigation-down-arrow is-expanded"></i>
+                <i class="fd-list__navigation-item-icon sap-icon--calendar"></i>
+                <span class="fd-list__navigation-item-text">Calendar</span>
+                <i class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded"></i>
                 <ul class="fd-list">
                     <li class="fd-list__navigation-item fd-list__navigation-item--second fd-list__navigation-item--indicated">
-                        <span class="fd-list__navigation-item__text">Second level item 1</span>
-                        <span class="fd-list__navigation-item__indicator"></span>
+                        <span class="fd-list__navigation-item-text">Second level item 1</span>
+                        <span class="fd-list__navigation-item-indicator"></span>
                     </li>
                     <li class="fd-list__navigation-item fd-list__navigation-item--second">
-                        <span class="fd-list__navigation-item__text">Second level item 2</span>
+                        <span class="fd-list__navigation-item-text">Second level item 2</span>
                     </li>
                 </ul>
-                <span class="fd-list__navigation-item__indicator"></span>
+                <span class="fd-list__navigation-item-indicator"></span>
             </li>
         </ul>
     </nav>
@@ -142,23 +177,40 @@ export const indication = () => `<div class="fd-vertical-nav">
     <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu">
         <ul class="fd-list" aria-label="Main Menu">
             <li class="fd-list__navigation-item--condensed">
-                <i class="fd-list__navigation-item__icon sap-icon--home"></i>
-                <span class="fd-list__navigation-item__text">Overview</span>
+                <i class="fd-list__navigation-item-icon sap-icon--home"></i>
+                <span class="fd-list__navigation-item-text">Overview</span>
             </li>
-            <li class="fd-list__navigation-item--condensed" onclick="toggleCondensedVerticalNavSubmenu(event)">
-                <i class="fd-list__navigation-item__icon sap-icon--calendar"></i>
-                <span class="fd-list__navigation-item__text">Calendar</span>
-                <i class="fd-list__navigation-item__arrow sap-icon--navigation-down-arrow"></i>    
-                <span class="fd-list__navigation-item__indicator"></span>
-                <ul class="fd-list">
-                    <li class="fd-list__navigation-item fd-list__navigation-item--second fd-list__navigation-item--indicated">
-                        <span class="fd-list__navigation-item__text">Second level item 1</span>
-                        <span class="fd-list__navigation-item__indicator"></span>
-                    </li>
-                    <li class="fd-list__navigation-item fd-list__navigation-item--second">
-                        <span class="fd-list__navigation-item__text">Second level item 2</span>
-                    </li>
-                </ul>
+            <li class="fd-list__navigation-item--condensed" onclick="toggleCondensedVerticalNavSubmenu(event, 'parent')">
+                <i class="fd-list__navigation-item-icon sap-icon--calendar"></i>
+                <i class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow"></i>    
+                <span class="fd-list__navigation-item-indicator"></span>
+                <div class="fd-popover__body fd-popover__body--left fd-popover__body--no-arrow fd-list__navigation-item-popover--first" aria-hidden="false" id="popoverA1">
+                    <ul class="fd-list">
+                        <li class="fd-list__navigation-item--condensed" onclick="toggleCondensedVerticalNavSubmenu(event, 'child')">
+                            <i class="fd-list__navigation-item-icon sap-icon--calendar"></i>
+                            <span class="fd-list__navigation-item-text">Calendar</span>
+                        </li>
+                    </ul>
+                </div>
+                <div class="fd-popover__body fd-popover__body--left fd-popover__body--no-arrow fd-list__navigation-item-popover--second" aria-hidden="false" id="popoverA1">
+                    <ul class="fd-list">
+                        <li class="fd-list__navigation-item--condensed fd-list__navigation-item--second fd-list__navigation-item--indicated">
+                            <span class="fd-list__navigation-item-text">Second level item 1</span>
+                            <span class="fd-list__navigation-item-indicator"></span>
+                        </li>
+                        <li class="fd-list__navigation-item--condensed fd-list__navigation-item--second">
+                            <span class="fd-list__navigation-item-text">Second level item 2</span>
+                        </li>
+                    </ul>
+                </div>
+            </li>
+            <li class="fd-list__navigation-item--condensed">
+                <i class="fd-list__navigation-item-icon sap-icon--customer"></i>
+                <span class="fd-list__navigation-item-text">Customers</span>
+            </li>
+            <li class="fd-list__navigation-item--condensed">
+                <i class="fd-list__navigation-item-icon sap-icon--shipping-status"></i>
+                <span class="fd-list__navigation-item-text">Deliveries</span>
             </li>
         </ul>
     </nav>
@@ -172,43 +224,6 @@ indication.parameters = {
         iframeHeight: 700,
         storyDescription: `
 The vertical navigation list can display navigation indication in several ways.
-        `
-    }
-};
-
-export const condensed = () => `<div class="fd-vertical-nav fd-vertical-nav--condensed">
-    <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu">
-        <ul class="fd-list" aria-label="Main Menu">
-            <li class="fd-list__navigation-item--condensed">
-                <i class="fd-list__navigation-item__icon sap-icon--home"></i>
-                <span class="fd-list__navigation-item__text">Overview</span>
-            </li>
-            <li class="fd-list__navigation-item--condensed">
-                <i class="fd-list__navigation-item__icon sap-icon--calendar"></i>
-                <span class="fd-list__navigation-item__text">Calendar</span>
-                <i class="fd-list__navigation-item__arrow sap-icon--navigation-down-arrow"></i>    
-            </li>
-            <li class="fd-list__navigation-item--condensed">
-                <i class="fd-list__navigation-item__icon sap-icon--customer"></i>
-                <span class="fd-list__navigation-item__text">Customers</span>
-                <i class="fd-list__navigation-item__arrow sap-icon--navigation-down-arrow"></i>    
-            </li>
-            <li class="fd-list__navigation-item--condensed">
-                <i class="fd-list__navigation-item__icon sap-icon--shipping-status"></i>
-                <span class="fd-list__navigation-item__text">Deliveries</span>
-            </li>
-        </ul>
-    </nav>
-</div>
-`;
-
-condensed.storyName = 'Condensed';
-
-condensed.parameters = {
-    docs: {
-        iframeHeight: 400,
-        storyDescription: `
-The condensed vertical navigation.
         `
     }
 };

--- a/stories/vertical-navigation/vertical-navigation.stories.js
+++ b/stories/vertical-navigation/vertical-navigation.stories.js
@@ -13,10 +13,39 @@ The vertical navigation area can be used to display navigation structures with u
 export const cozy = () => `<div class="fd-vertical-nav">
     <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu">
         <ul class="fd-list" aria-label="Main Menu">
-            <li class="fd-list--navigation-item">
-                <i class="fd-list--navigation-item__icon sap-icon--bell"></i>
-                <span class="fd-list--navigation-item__text">Level 1 Item</span>
-                <i class="fd-list--navigation-item__arrow sap-icon--navigation-right-arrow"></i>    
+            <li class="fd-list__navigation-item">
+                <i class="fd-list__navigation-item__icon sap-icon--home"></i>
+                <span class="fd-list__navigation-item__text">Overview</span>
+            </li>
+            <li class="fd-list__navigation-item" onclick="toggleVerticalNavSubmenu(event)">
+                <i class="fd-list__navigation-item__icon sap-icon--calendar"></i>
+                <span class="fd-list__navigation-item__text">Calendar</span>
+                <i class="fd-list__navigation-item__arrow sap-icon--navigation-down-arrow is-expanded"></i>
+                <ul class="fd-list">
+                    <li class="fd-list__navigation-item fd-list__navigation-item--second">
+                        <span class="fd-list__navigation-item__text">Second level item 1</span>
+                    </li>
+                    <li class="fd-list__navigation-item fd-list__navigation-item--second">
+                        <span class="fd-list__navigation-item__text">Second level item 2</span>
+                    </li>
+                </ul>
+            </li>
+            <li class="fd-list__navigation-item" onclick="toggleVerticalNavSubmenu(event)">
+                <i class="fd-list__navigation-item__icon sap-icon--customer"></i>
+                <span class="fd-list__navigation-item__text">Customers</span>
+                <i class="fd-list__navigation-item__arrow sap-icon--navigation-down-arrow is-expanded"></i>
+                <ul class="fd-list">
+                    <li class="fd-list__navigation-item fd-list__navigation-item--second">
+                        <span class="fd-list__navigation-item__text">Second level item 1</span>
+                    </li>
+                    <li class="fd-list__navigation-item fd-list__navigation-item--second">
+                        <span class="fd-list__navigation-item__text">Second level item 2</span>
+                    </li>
+                </ul>
+            </li>
+            <li class="fd-list__navigation-item">
+                <i class="fd-list__navigation-item__icon sap-icon--shipping-status"></i>
+                <span class="fd-list__navigation-item__text">Deliveries</span>
             </li>
         </ul>
     </nav>
@@ -27,19 +56,33 @@ cozy.storyName = 'Default';
 
 cozy.parameters = {
     docs: {
-        iframeHeight: 400,
+        iframeHeight: 700,
         storyDescription: `
 The default vertical navigation is comprised of several navigation list items.
         `
     }
 };
 
-export const condensed = () => `<div class="fd-vertical-nav--condensed">
+export const condensed = () => `<div class="fd-vertical-nav fd-vertical-nav--condensed">
     <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu">
         <ul class="fd-list" aria-label="Main Menu">
-            <li class="fd-list--navigation-item--condensed">
-                <i class="fd-list--navigation-item__icon sap-icon--bell"></i>
-                <i class="fd-list--navigation-item__arrow sap-icon--navigation-right-arrow"></i>    
+            <li class="fd-list__navigation-item--condensed">
+                <i class="fd-list__navigation-item__icon sap-icon--home"></i>
+                <span class="fd-list__navigation-item__text">Overview</span>
+            </li>
+            <li class="fd-list__navigation-item--condensed">
+                <i class="fd-list__navigation-item__icon sap-icon--calendar"></i>
+                <span class="fd-list__navigation-item__text">Calendar</span>
+                <i class="fd-list__navigation-item__arrow sap-icon--navigation-down-arrow is-expanded"></i>    
+            </li>
+            <li class="fd-list__navigation-item--condensed">
+                <i class="fd-list__navigation-item__icon sap-icon--customer"></i>
+                <span class="fd-list__navigation-item__text">Customers</span>
+                <i class="fd-list__navigation-item__arrow sap-icon--navigation-down-arrow is-expanded"></i>    
+            </li>
+            <li class="fd-list__navigation-item--condensed">
+                <i class="fd-list__navigation-item__icon sap-icon--shipping-status"></i>
+                <span class="fd-list__navigation-item__text">Deliveries</span>
             </li>
         </ul>
     </nav>


### PR DESCRIPTION
closes #2211 

## Description
Implements the vertical navigation and deprecates side navigation

## Screenshots
### After:
![Screen Shot 2021-04-28 at 9 06 26 AM](https://user-images.githubusercontent.com/2471874/116427228-14a93800-a801-11eb-8d97-e5880d39929a.png)
![Screen Shot 2021-04-28 at 9 06 13 AM](https://user-images.githubusercontent.com/2471874/116427230-1541ce80-a801-11eb-9ede-81cc89888269.png)
![Screen Shot 2021-04-28 at 9 06 08 AM](https://user-images.githubusercontent.com/2471874/116427234-1541ce80-a801-11eb-94e1-d15a6723303d.png)
![Screen Shot 2021-04-28 at 9 06 03 AM](https://user-images.githubusercontent.com/2471874/116427237-15da6500-a801-11eb-82fe-c4bf9c422b7c.png)


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
