### PR TITLE
chore: introduce fd-expanded() mixin

### DIFF
--- a/src/input.scss
+++ b/src/input.scss
@@ -28,7 +28,7 @@ $block: #{$fd-namespace}-input;
     z-index: 0;
   }
 
-  &[aria-expanded="true"] {
+  @include fd-expanded() {
     z-index: 4;
   }
 

--- a/src/menu.scss
+++ b/src/menu.scss
@@ -168,10 +168,11 @@ $block: #{$fd-namespace}-menu;
       opacity: var(--sapContent_DisabledOpacity);
     }
 
-    &.has-child.is-expanded,
-    &.has-child[aria-expanded="true"] {
-      &:not(:active):not(.is-active) {
-        @include selected-menu-item();
+    &.has-child {
+      @include fd-expanded() {
+        &:not(:active):not(.is-active) {
+          @include selected-menu-item();
+        }
       }
     }
   }

--- a/src/mixins/_states.scss
+++ b/src/mixins/_states.scss
@@ -139,6 +139,14 @@
   }
 }
 
+// EXPANDED state
+@mixin fd-expanded {
+  &[aria-expanded="true"],
+  &.is-expanded {
+    @content;
+  }
+}
+
 @mixin fd-navigated {
   &.is-navigated {
     @content;

--- a/src/select.scss
+++ b/src/select.scss
@@ -90,8 +90,7 @@ $outline-offset: 0.1875rem;
       }
     }
 
-    &.is-expanded,
-    &[aria-expanded="true"] {
+    @include fd-expanded() {
       .#{$block}__button {
         background-color: $fd-select-button-active-background;
         color: $fd-select-button-active-text-color;

--- a/src/tabs.scss
+++ b/src/tabs.scss
@@ -229,8 +229,7 @@ $block: #{$fd-namespace}-tabs;
       display: none;
     }
 
-    &.is-expanded,
-    &[aria-expanded="true"] {
+    @include fd-expanded() {
       display: block;
     }
   }

--- a/src/textarea.scss
+++ b/src/textarea.scss
@@ -24,7 +24,7 @@ $block: #{$fd-namespace}-textarea;
     z-index: 0;
   }
 
-  &[aria-expanded="true"] {
+  @include fd-expanded() {
     z-index: 4;
   }
 

--- a/src/tree.scss
+++ b/src/tree.scss
@@ -266,8 +266,7 @@ $fd-tree-item-selected-border-bottom: var(--sapList_BorderWidth) solid var(--sap
       margin-right: $fd-tree-expander-size-negative;
     }
 
-    &.is-expanded,
-    &[aria-expanded="true"] {
+    @include fd-expanded() {
       border-bottom: none;
     }
   }


### PR DESCRIPTION
## Related Issue
Closes #1620

## Description
Add `@mixin fd-expanded` and update code accordingly

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x]Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
