### PR TITLE
fix: fix the alignment issue between input box and description/unit value for the step input component.

### DIFF
--- a/src/step-input.scss
+++ b/src/step-input.scss
@@ -86,7 +86,7 @@ $block: #{$fd-namespace}-step-input;
 
   &__container {
     display: flex;
-	  align-items: center;
+    align-items: center;
 
     .fd-form-label {
       align-self: auto;

--- a/src/step-input.scss
+++ b/src/step-input.scss
@@ -84,6 +84,15 @@ $block: #{$fd-namespace}-step-input;
     }
   }
 
+  &__container {
+    display: flex;
+	  align-items: center;
+
+    .fd-form-label {
+      align-self: auto;
+    }
+  }
+
   /** Width is different due to different border width  */
   &.is-information,
   &.is-error,

--- a/src/step-input.scss
+++ b/src/step-input.scss
@@ -85,12 +85,7 @@ $block: #{$fd-namespace}-step-input;
   }
 
   &__container {
-    display: flex;
-    align-items: center;
-
-    .fd-form-label {
-      align-self: auto;
-    }
+    @include fd-flex-vertical-center();
   }
 
   /** Width is different due to different border width  */


### PR DESCRIPTION


## Related Issue
Part of SAP/fundamental-ngx#5025

## Description
Changes contains to move move hard coded style from ngx to  style to fix the alignment issue between input box and description.

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:


### After:

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [NA] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
