### PR TITLE
fix: add padding for user menu subheader

### DIFF
--- a/src/user-menu.scss
+++ b/src/user-menu.scss
@@ -34,6 +34,7 @@ $block: #{$fd-namespace}-user-menu;
 
     width: 100%;
     margin-bottom: 1rem;
+    padding: 0 1rem;
   }
 
   &__user-name {


### PR DESCRIPTION
## Related Issue
Fixed https://github.com/SAP/fundamental-styles/issues/2287

## Description
Added padding for user menu subheader

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [X] All values are in `rem`
- [X] Text elements follow the truncation rules
- [X] hover state of the element follow design spec
- [X] focus state of the element follow design spec
- [X] active state of the element follow design spec
- [X] selected state of the element follow design spec
- [X] selected hover state of the element follow design spec
- [X] pressed state of the element follow design spec
- [X] Responsiveness rules - the component has modifier classes for all breakpoints
- [X] Includes Compact/Cosy/Tablet design
- [X] RTL support
2. The code follows fundamental-styles code standards and style
- [X] only one top level `fd-*` class is used in the file
- [X] BEM naming convention is used
- [X] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [X] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [X] `fd-reset()` mixin is applied to all elements
- [X] Variables are used, if some value is used more than twice.
- [X] Checked if current components can be reused, instead of having new code.
3. Testing
- [X] tested Storybook examples with "CSS Resources" `normalize` option 
- [X] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [X] Verified all styles in IE11
- [X] Updated tests
- [X] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [X] Storybook documentation has been created/updated
- [X] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
