### PR TITLE
feat: Icons - add status enumeration

### DIFF
--- a/config/bundlesize.json
+++ b/config/bundlesize.json
@@ -2,7 +2,7 @@
     "files": [
         {
             "path": "./dist/fundamental-styles.css",
-            "maxSize": "94 kB"
+            "maxSize": "100 kB"
         }
     ]
 }

--- a/src/icon.scss
+++ b/src/icon.scss
@@ -9,6 +9,7 @@ $blockTNT: sap-icon-TNT;
 [class*="#{$block}"] {
   @include fd-reset();
   @include fd-icon-base();
+  @include fd-icon-control-enumeration($block);
 
   font-style: normal;
   display: inline-block;
@@ -16,10 +17,12 @@ $blockTNT: sap-icon-TNT;
 
 [class*='#{$blockBusiness}'] {
   @include fd-business-suite-icon-base();
+  @include fd-icon-control-enumeration($blockBusiness);
 }
 
 [class*='#{$blockTNT}'] {
   @include fd-tnt-icon-base();
+  @include fd-icon-control-enumeration($blockTNT);
 }
 
 .#{$block} {

--- a/src/icons/_settings.scss
+++ b/src/icons/_settings.scss
@@ -663,3 +663,15 @@ $fd-icons: (
   icon-sum: "\e28E",
 ) !default;
 /* stylelint-enable */
+
+$fd-icon-control-enumerations: (
+  "default": ("color": var(--sapContent_IconColor), "background-color": var(transparent)),
+  "contrast": ("color": var(--sapContent_ContrastIconColor), "background-color": var(--sapContent_IconColor)),
+  "non-interactive": ("color": var(--sapContent_NonInteractiveIconColor), "background-color": var(--sapContent_NonInteractiveIconColor)),
+  "tile": ("color": var(--sapTile_IconColor), "background-color": var(--sapTile_IconColor)),
+  "marker": ("color": var(--sapContent_MarkerIconColor), "background-color": var(--sapContent_MarkerIconColor)),
+  "critical": ("color": var(--sapCriticalElementColor), "background-color": var(--sapCriticalElementColor)),
+  "negative": ("color": var(--sapNegativeElementColor), "background-color": var(--sapNegativeElementColor)),
+  "neutral": ("color": var(--sapNeutralElementColor), "background-color": var(--sapNeutralElementColor)),
+  "positive": ("color": var(--sapPositiveElementColor), "background-color": var(--sapPositiveElementColor))
+);

--- a/src/mixins/_icons.scss
+++ b/src/mixins/_icons.scss
@@ -96,3 +96,20 @@
     @warn "Unknown `#{$glyph}` in $fd-tnt-icons map";
   }
 }
+
+// Icon Control Enumerations
+
+@mixin fd-icon-control-enumeration($block, $position: 'before') {
+  @each $enumeration-name, $enumeration-value in $fd-icon-control-enumerations {
+    &.#{$block} {
+      &--color-#{$enumeration-name} {
+        color: map_get($enumeration-value, "color");
+      }
+      &--background-#{$enumeration-name} {
+        &::#{$position} {
+          background-color: map_get($enumeration-value, "background-color");
+        }
+      }
+    }
+  }
+}

--- a/stories/icon/BusinessSuiteInAppSymbols/__snapshots__/iconBusinessSuite.stories.storyshot
+++ b/stories/icon/BusinessSuiteInAppSymbols/__snapshots__/iconBusinessSuite.stories.storyshot
@@ -2563,6 +2563,73 @@ exports[`Storyshots Components/Icons/BusinessSuiteInAppSymbol Icons Business Sui
 </div>
 `;
 
+exports[`Storyshots Components/Icons/BusinessSuiteInAppSymbol Icons Colors 1`] = `
+<section>
+  
+ 
+  <span
+    class="sap-icon-businessSuiteInAppSymbols sap-icon-businessSuiteInAppSymbols--heart"
+    style="font-size:5rem"
+  />
+  
+ 
+  <span
+    class="sap-icon-businessSuiteInAppSymbols sap-icon-businessSuiteInAppSymbols--heart sap-icon-businessSuiteInAppSymbols--color-default"
+    style="font-size:5rem"
+  />
+  
+ 
+  <span
+    class="sap-icon-businessSuiteInAppSymbols sap-icon-businessSuiteInAppSymbols--heart sap-icon-businessSuiteInAppSymbols--color-contrast sap-icon-businessSuiteInAppSymbols--background-contrast"
+    style="font-size:5rem"
+  />
+  
+ 
+  <span
+    class="sap-icon-businessSuiteInAppSymbols sap-icon-businessSuiteInAppSymbols--heart sap-icon-businessSuiteInAppSymbols--color-non-interactive"
+    style="font-size:5rem"
+  />
+  
+ 
+  <span
+    class="sap-icon-businessSuiteInAppSymbols sap-icon-businessSuiteInAppSymbols--heart sap-icon-businessSuiteInAppSymbols--color-tile"
+    style="font-size:5rem"
+  />
+  
+ 
+  <span
+    class="sap-icon-businessSuiteInAppSymbols sap-icon-businessSuiteInAppSymbols--heart sap-icon-businessSuiteInAppSymbols--color-marker"
+    style="font-size:5rem"
+  />
+  
+ 
+  <span
+    class="sap-icon-businessSuiteInAppSymbols sap-icon-businessSuiteInAppSymbols--heart sap-icon-businessSuiteInAppSymbols--color-critical"
+    style="font-size:5rem"
+  />
+  
+ 
+  <span
+    class="sap-icon-businessSuiteInAppSymbols sap-icon-businessSuiteInAppSymbols--heart sap-icon-businessSuiteInAppSymbols--color-negative"
+    style="font-size:5rem"
+  />
+  
+ 
+  <span
+    class="sap-icon-businessSuiteInAppSymbols sap-icon-businessSuiteInAppSymbols--heart sap-icon-businessSuiteInAppSymbols--color-neutral"
+    style="font-size:5rem"
+  />
+  
+ 
+  <span
+    class="sap-icon-businessSuiteInAppSymbols sap-icon-businessSuiteInAppSymbols--heart sap-icon-businessSuiteInAppSymbols--color-positive"
+    style="font-size:5rem"
+  />
+  
+ 
+</section>
+`;
+
 exports[`Storyshots Components/Icons/BusinessSuiteInAppSymbol Icons Sizes 1`] = `
 <section>
   

--- a/stories/icon/BusinessSuiteInAppSymbols/iconBusinessSuite.stories.js
+++ b/stories/icon/BusinessSuiteInAppSymbols/iconBusinessSuite.stories.js
@@ -8,7 +8,7 @@ export default {
 ##Usage
 **Use the icon if:**
 
-- You want to display an icon for illustrative purposes only, without interaction states, acting as a non-interactive icon/pictogram. 
+- You want to display an icon for illustrative purposes only, without interaction states, acting as a non-interactive icon/pictogram.
 - You intend to pair the icon with another method of communication i.e. with text or a tooltip.
 
 
@@ -35,6 +35,34 @@ sizes.parameters = {
     }
 };
 
+/**
+ * There are different semantic statuses that can be applied to the icon by adding a modifier class.
+ *
+ * | **Status**      | **Modifier class**               |
+ * | --------------: | :------------------------------- |
+ * | Default         | ` sap-icon-businessSuiteInAppSymbols--color-default`        |
+ * | Contrast        | ` sap-icon-businessSuiteInAppSymbols--color-contrast`       |
+ * | Non-interactive | ` sap-icon-businessSuiteInAppSymbols--color-non-interactive`|
+ * | Tile            | ` sap-icon-businessSuiteInAppSymbols--color-tile`           |
+ * | Marker          | ` sap-icon-businessSuiteInAppSymbols--color-marker`         |
+ * | Critical        | ` sap-icon-businessSuiteInAppSymbols--color-critical`       |
+ * | Negative        | ` sap-icon-businessSuiteInAppSymbols--color-negative`       |
+ * | Neutral         | ` sap-icon-businessSuiteInAppSymbols--color-neutral`        |
+ * | Positive        | ` sap-icon-businessSuiteInAppSymbols--color-positive`       |
+ */
+
+export const colors = () => `
+ <span class="sap-icon-businessSuiteInAppSymbols sap-icon-businessSuiteInAppSymbols--heart" style="font-size:5rem"></span>
+ <span class="sap-icon-businessSuiteInAppSymbols sap-icon-businessSuiteInAppSymbols--heart sap-icon-businessSuiteInAppSymbols--color-default" style="font-size:5rem"></span>
+ <span class="sap-icon-businessSuiteInAppSymbols sap-icon-businessSuiteInAppSymbols--heart sap-icon-businessSuiteInAppSymbols--color-contrast sap-icon-businessSuiteInAppSymbols--background-contrast" style="font-size:5rem"></span>
+ <span class="sap-icon-businessSuiteInAppSymbols sap-icon-businessSuiteInAppSymbols--heart sap-icon-businessSuiteInAppSymbols--color-non-interactive" style="font-size:5rem"></span>
+ <span class="sap-icon-businessSuiteInAppSymbols sap-icon-businessSuiteInAppSymbols--heart sap-icon-businessSuiteInAppSymbols--color-tile" style="font-size:5rem"></span>
+ <span class="sap-icon-businessSuiteInAppSymbols sap-icon-businessSuiteInAppSymbols--heart sap-icon-businessSuiteInAppSymbols--color-marker" style="font-size:5rem"></span>
+ <span class="sap-icon-businessSuiteInAppSymbols sap-icon-businessSuiteInAppSymbols--heart sap-icon-businessSuiteInAppSymbols--color-critical" style="font-size:5rem"></span>
+ <span class="sap-icon-businessSuiteInAppSymbols sap-icon-businessSuiteInAppSymbols--heart sap-icon-businessSuiteInAppSymbols--color-negative" style="font-size:5rem"></span>
+ <span class="sap-icon-businessSuiteInAppSymbols sap-icon-businessSuiteInAppSymbols--heart sap-icon-businessSuiteInAppSymbols--color-neutral" style="font-size:5rem"></span>
+ <span class="sap-icon-businessSuiteInAppSymbols sap-icon-businessSuiteInAppSymbols--heart sap-icon-businessSuiteInAppSymbols--color-positive" style="font-size:5rem"></span>
+ `;
 
 export const businessSuiteIcons = () => {
     const div = document.createElement('div');

--- a/stories/icon/SAPIcons/__snapshots__/icon.stories.storyshot
+++ b/stories/icon/SAPIcons/__snapshots__/icon.stories.storyshot
@@ -7927,6 +7927,73 @@ exports[`Storyshots Components/Icons/SAP Icons Available Icons 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/Icons/SAP Icons Colors 1`] = `
+<section>
+  
+
+  <span
+    class="sap-icon sap-icon--cart"
+    style="font-size:5rem"
+  />
+  
+
+  <span
+    class="sap-icon sap-icon--cart sap-icon--color-default"
+    style="font-size:5rem"
+  />
+  
+
+  <span
+    class="sap-icon sap-icon--cart sap-icon--color-contrast sap-icon--background-contrast"
+    style="font-size:5rem"
+  />
+  
+
+  <span
+    class="sap-icon sap-icon--cart sap-icon--color-non-interactive"
+    style="font-size:5rem"
+  />
+  
+
+  <span
+    class="sap-icon sap-icon--cart sap-icon--color-tile"
+    style="font-size:5rem"
+  />
+  
+
+  <span
+    class="sap-icon sap-icon--cart sap-icon--color-marker"
+    style="font-size:5rem"
+  />
+  
+
+  <span
+    class="sap-icon sap-icon--cart sap-icon--color-critical"
+    style="font-size:5rem"
+  />
+  
+
+  <span
+    class="sap-icon sap-icon--cart sap-icon--color-negative"
+    style="font-size:5rem"
+  />
+  
+
+  <span
+    class="sap-icon sap-icon--cart sap-icon--color-neutral"
+    style="font-size:5rem"
+  />
+  
+
+  <span
+    class="sap-icon sap-icon--cart sap-icon--color-positive"
+    style="font-size:5rem"
+  />
+  
+
+</section>
+`;
+
 exports[`Storyshots Components/Icons/SAP Icons Sizes 1`] = `
 <section>
   

--- a/stories/icon/SAPIcons/icon.stories.js
+++ b/stories/icon/SAPIcons/icon.stories.js
@@ -8,7 +8,7 @@ export default {
 ##Usage
 **Use the icon if:**
 
-- You want to display an icon for illustrative purposes only, without interaction states, acting as a non-interactive icon/pictogram. 
+- You want to display an icon for illustrative purposes only, without interaction states, acting as a non-interactive icon/pictogram.
 - You intend to pair the icon with another method of communication i.e. with text or a tooltip.
 
 
@@ -34,6 +34,35 @@ sizes.parameters = {
         storyDescription: 'Icons don’t have predefined sizes because they align with the font size value. They are vector graphics, meaning they can be easily resized without compromising their appearance. And because icons are essentially a font, there are unlimited sizes.'
     }
 };
+
+/**
+ * There are different semantic statuses that can be applied to the icon by adding a modifier class.
+ *
+ * | **Status**      | **Modifier class**               |
+ * | --------------: | :------------------------------- |
+ * | Default         | `sap-icon--color-default`        |
+ * | Contrast        | `sap-icon--color-contrast`       |
+ * | Non-interactive | `sap-icon--color-non-interactive`|
+ * | Tile            | `sap-icon--color-tile`           |
+ * | Marker          | `sap-icon--color-marker`         |
+ * | Critical        | `sap-icon--color-critical`       |
+ * | Negative        | `sap-icon--color-negative`       |
+ * | Neutral         | `sap-icon--color-neutral`        |
+ * | Positive        | `sap-icon--color-positive`       |
+ */
+
+export const colors = () => `
+<span class="sap-icon sap-icon--cart" style="font-size:5rem"></span>
+<span class="sap-icon sap-icon--cart sap-icon--color-default" style="font-size:5rem"></span>
+<span class="sap-icon sap-icon--cart sap-icon--color-contrast sap-icon--background-contrast" style="font-size:5rem"></span>
+<span class="sap-icon sap-icon--cart sap-icon--color-non-interactive" style="font-size:5rem"></span>
+<span class="sap-icon sap-icon--cart sap-icon--color-tile" style="font-size:5rem"></span>
+<span class="sap-icon sap-icon--cart sap-icon--color-marker" style="font-size:5rem"></span>
+<span class="sap-icon sap-icon--cart sap-icon--color-critical" style="font-size:5rem"></span>
+<span class="sap-icon sap-icon--cart sap-icon--color-negative" style="font-size:5rem"></span>
+<span class="sap-icon sap-icon--cart sap-icon--color-neutral" style="font-size:5rem"></span>
+<span class="sap-icon sap-icon--cart sap-icon--color-positive" style="font-size:5rem"></span>
+`;
 
 export const availableIcons = () => {
     const div = document.createElement('div');

--- a/stories/icon/TNTIcons/__snapshots__/iconTnt.stories.storyshot
+++ b/stories/icon/TNTIcons/__snapshots__/iconTnt.stories.storyshot
@@ -1,5 +1,72 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Storyshots Components/Icons/TNT Icons Colors 1`] = `
+<section>
+  
+ 
+  <span
+    class="sap-icon-TNT sap-icon-TNT--exceptions"
+    style="font-size:5rem"
+  />
+  
+ 
+  <span
+    class="sap-icon-TNT sap-icon-TNT--exceptions sap-icon-TNT--color-default"
+    style="font-size:5rem"
+  />
+  
+ 
+  <span
+    class="sap-icon-TNT sap-icon-TNT--exceptions sap-icon-TNT--color-contrast sap-icon-TNT--background-contrast"
+    style="font-size:5rem"
+  />
+  
+ 
+  <span
+    class="sap-icon-TNT sap-icon-TNT--exceptions sap-icon-TNT--color-non-interactive"
+    style="font-size:5rem"
+  />
+  
+ 
+  <span
+    class="sap-icon-TNT sap-icon-TNT--exceptions sap-icon-TNT--color-tile"
+    style="font-size:5rem"
+  />
+  
+ 
+  <span
+    class="sap-icon-TNT sap-icon-TNT--exceptions sap-icon-TNT--color-marker"
+    style="font-size:5rem"
+  />
+  
+ 
+  <span
+    class="sap-icon-TNT sap-icon-TNT--exceptions sap-icon-TNT--color-critical"
+    style="font-size:5rem"
+  />
+  
+ 
+  <span
+    class="sap-icon-TNT sap-icon-TNT--exceptions sap-icon-TNT--color-negative"
+    style="font-size:5rem"
+  />
+  
+ 
+  <span
+    class="sap-icon-TNT sap-icon-TNT--exceptions sap-icon-TNT--color-neutral"
+    style="font-size:5rem"
+  />
+  
+ 
+  <span
+    class="sap-icon-TNT sap-icon-TNT--exceptions sap-icon-TNT--color-positive"
+    style="font-size:5rem"
+  />
+  
+ 
+</section>
+`;
+
 exports[`Storyshots Components/Icons/TNT Icons Sizes 1`] = `
 <section>
   

--- a/stories/icon/TNTIcons/iconTnt.stories.js
+++ b/stories/icon/TNTIcons/iconTnt.stories.js
@@ -8,7 +8,7 @@ export default {
 ##Usage
 **Use the icon if:**
 
-- You want to display an icon for illustrative purposes only, without interaction states, acting as a non-interactive icon/pictogram. 
+- You want to display an icon for illustrative purposes only, without interaction states, acting as a non-interactive icon/pictogram.
 - You intend to pair the icon with another method of communication i.e. with text or a tooltip.
 
 
@@ -34,6 +34,35 @@ sizes.parameters = {
         storyDescription: 'Icons don’t have predefined sizes because they align with the font size value. They are vector graphics, meaning they can be easily resized without compromising their appearance. And because icons are essentially a font, there are unlimited sizes.'
     }
 };
+
+/**
+ * There are different semantic statuses that can be applied to the icon by adding a modifier class.
+ *
+ * | **Status**      | **Modifier class**               |
+ * | --------------: | :------------------------------- |
+ * | Default         | ` sap-icon-TNT--color-default`        |
+ * | Contrast        | ` sap-icon-TNT--color-contrast`       |
+ * | Non-interactive | ` sap-icon-TNT--color-non-interactive`|
+ * | Tile            | ` sap-icon-TNT--color-tile`           |
+ * | Marker          | ` sap-icon-TNT--color-marker`         |
+ * | Critical        | ` sap-icon-TNT--color-critical`       |
+ * | Negative        | ` sap-icon-TNT--color-negative`       |
+ * | Neutral         | ` sap-icon-TNT--color-neutral`        |
+ * | Positive        | ` sap-icon-TNT--color-positive`       |
+ */
+
+export const colors = () => `
+ <span class="sap-icon-TNT sap-icon-TNT--exceptions" style="font-size:5rem"></span>
+ <span class="sap-icon-TNT sap-icon-TNT--exceptions sap-icon-TNT--color-default" style="font-size:5rem"></span>
+ <span class="sap-icon-TNT sap-icon-TNT--exceptions sap-icon-TNT--color-contrast sap-icon-TNT--background-contrast" style="font-size:5rem"></span>
+ <span class="sap-icon-TNT sap-icon-TNT--exceptions sap-icon-TNT--color-non-interactive" style="font-size:5rem"></span>
+ <span class="sap-icon-TNT sap-icon-TNT--exceptions sap-icon-TNT--color-tile" style="font-size:5rem"></span>
+ <span class="sap-icon-TNT sap-icon-TNT--exceptions sap-icon-TNT--color-marker" style="font-size:5rem"></span>
+ <span class="sap-icon-TNT sap-icon-TNT--exceptions sap-icon-TNT--color-critical" style="font-size:5rem"></span>
+ <span class="sap-icon-TNT sap-icon-TNT--exceptions sap-icon-TNT--color-negative" style="font-size:5rem"></span>
+ <span class="sap-icon-TNT sap-icon-TNT--exceptions sap-icon-TNT--color-neutral" style="font-size:5rem"></span>
+ <span class="sap-icon-TNT sap-icon-TNT--exceptions sap-icon-TNT--color-positive" style="font-size:5rem"></span>
+ `;
 
 export const tntIcons = () => {
     const div = document.createElement('div');


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/1894

## Description
Add status indicators for icons

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).
![image](https://user-images.githubusercontent.com/6586561/116550796-db0b2680-a8ff-11eb-913b-a99b4122a3fa.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
