### PR TITLE
fix: Avatar group - do not overlay outer shadow with inner component's shadow [ci visual]

### DIFF
--- a/src/popover.scss
+++ b/src/popover.scss
@@ -102,6 +102,11 @@ $block: #{$fd-namespace}-popover;
       z-index: $fd-popover-z-index + 1;
     }
 
+    // Inner shadows can affect outer shadow. This will discard such behavior
+    > * {
+      overflow: hidden;
+    }
+
     > *:first-child {
       border-top-right-radius: $fd-popover-border-radius;
       border-top-left-radius: $fd-popover-border-radius;

--- a/src/popover.scss
+++ b/src/popover.scss
@@ -104,7 +104,9 @@ $block: #{$fd-namespace}-popover;
 
     // Inner shadows can affect outer shadow. This will discard such behavior
     > * {
-      overflow: hidden;
+      &:not(.#{$block}__wrapper) {
+        overflow: hidden;
+      }
     }
 
     > *:first-child {

--- a/stories/popover/__snapshots__/popover.stories.storyshot
+++ b/stories/popover/__snapshots__/popover.stories.storyshot
@@ -1231,93 +1231,93 @@ exports[`Storyshots Components/Popover Body variants 1`] = `
                     
           </div>
           
-                
-        </header>
-        
-                
-        <div
-          class="fd-bar fd-bar--cozy fd-bar--subheader"
-        >
-          
-                        
+                    
           <div
-            class="fd-bar__middle"
+            class="fd-bar fd-bar--cozy fd-bar--subheader"
           >
             
-                            
+                        
             <div
-              class="fd-bar__element"
+              class="fd-bar__middle"
             >
               
-                                
+                            
               <div
-                class="fd-form-item"
+                class="fd-bar__element"
               >
                 
-                                    
+                                
                 <div
-                  aria-label="Group label"
-                  class="fd-segmented-button"
-                  role="group"
+                  class="fd-form-item"
                 >
                   
-                                        
-                  <button
-                    aria-label="email"
-                    aria-pressed="true"
-                    class="fd-button fd-button--compact"
-                  >
-                    
-                                            
-                    <i
-                      class="sap-icon--email"
-                    />
-                    
-                                        
-                  </button>
-                  
-                                        
-                  <button
-                    aria-label="phone"
-                    class="fd-button fd-button--compact"
-                  >
-                    
-                                            
-                    <i
-                      class="sap-icon--iphone"
-                    />
-                    
-                                        
-                  </button>
-                  
-                                        
-                  <button
-                    aria-label="notifications"
-                    class="fd-button fd-button--compact"
-                  >
-                    
-                                            
-                    <i
-                      class="sap-icon--notification-2"
-                    />
-                    
-                                        
-                  </button>
-                  
                                     
+                  <div
+                    aria-label="Group label"
+                    class="fd-segmented-button"
+                    role="group"
+                  >
+                    
+                                        
+                    <button
+                      aria-label="email"
+                      aria-pressed="true"
+                      class="fd-button fd-button--compact"
+                    >
+                      
+                                            
+                      <i
+                        class="sap-icon--email"
+                      />
+                      
+                                        
+                    </button>
+                    
+                                        
+                    <button
+                      aria-label="phone"
+                      class="fd-button fd-button--compact"
+                    >
+                      
+                                            
+                      <i
+                        class="sap-icon--iphone"
+                      />
+                      
+                                        
+                    </button>
+                    
+                                        
+                    <button
+                      aria-label="notifications"
+                      class="fd-button fd-button--compact"
+                    >
+                      
+                                            
+                      <i
+                        class="sap-icon--notification-2"
+                      />
+                      
+                                        
+                    </button>
+                    
+                                    
+                  </div>
+                  
+                                
                 </div>
                 
-                                
+                            
               </div>
               
-                            
+                        
             </div>
             
-                        
+                    
           </div>
           
-                    
-        </div>
+                
+        </header>
         
                 
         <div

--- a/stories/popover/popover.stories.js
+++ b/stories/popover/popover.stories.js
@@ -1,17 +1,17 @@
 export default {
     title: 'Components/Popover',
     parameters: {
-        description: `The popover displays additional information for an object in a compact way without leaving the page. The component contains two essential elements: the control (trigger) and body (content). It can also be paired with a **Menu**, whereas the menu button would trigger a dropdown (body). 
+        description: `The popover displays additional information for an object in a compact way without leaving the page. The component contains two essential elements: the control (trigger) and body (content). It can also be paired with a **Menu**, whereas the menu button would trigger a dropdown (body).
 
-##Usage   
+##Usage
 **Use a popover if:**
-        
+
 - You need to define your own structure.
 - You want to show UI elements that are not available with the quick view.
 
 
 **Do not use a popover if:**
-        
+
 - The objects are in a master list (in this case, the details are shown in the details area).
 
 
@@ -19,7 +19,7 @@ export default {
 - As a general rule, it is suggested that one popover be revealed on the page at any given time. Opening one popover should close all others to prevent multiple layers and collisions of several popovers.
 - Show status information as text fields in a content group. You can use semantic text colors.
 - You can define a height for the popover. If the content exceeds the height, a scroll bar is displayed.
-        
+
 `,
         docs: { iframeHeight: 350 },
         tags: ['f3', 'a11y', 'theme'],
@@ -187,7 +187,7 @@ Alignment.parameters = {
 Alignment | Modifier class
 :------------- | :-----------------
 Left | (default)
-Right | \`fd-popover__body--right\`   
+Right | \`fd-popover__body--right\`
         ` }
 };
 
@@ -395,8 +395,7 @@ export const variants = () => `<div class="fddocs-container">
                             </div>
                         </div>
                     </div>
-                </header>
-                <div class="fd-bar fd-bar--cozy fd-bar--subheader">
+                    <div class="fd-bar fd-bar--cozy fd-bar--subheader">
                         <div class="fd-bar__middle">
                             <div class="fd-bar__element">
                                 <div class="fd-form-item">
@@ -415,6 +414,7 @@ export const variants = () => `<div class="fddocs-container">
                             </div>
                         </div>
                     </div>
+                </header>
                 <div style="margin: 20px 80px;">
                     <span
                         class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--thumbnail"
@@ -451,9 +451,9 @@ Variant | Modifier class | Description
 :------ | :------------- | :---------------
 Header | \`fd-popover__body-header\` | To display a header with text.
 Footer | \`fd-popover__body-footer\` | To display a footer with actions.
-Header, subheader and footer | \`fd-popover__body-header\` containing \`fd-bar fd-bar--header-with-subheader\` and \`fd-bar fd-bar--subheader\` | This variant uses the **Bar** component. 
+Header, subheader and footer | \`fd-popover__body-header\` containing \`fd-bar fd-bar--header-with-subheader\` and \`fd-bar fd-bar--subheader\` | This variant uses the **Bar** component.
 Cozy mode | \`fd-bar--cozy\` | Add this modifier class to the header area where \`fd-bar\` is used.
-        
+
         ` }
 };
 


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/2153

## Description
Add `overflow: hidden` for inner elements of `fd-popover__body` which will prevent inner component's shadow to overlay outer one.

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/6586561/116597205-fd1b9d80-a92d-11eb-8fc2-293b25ff6540.png)


### After:
![image](https://user-images.githubusercontent.com/6586561/116597226-03aa1500-a92e-11eb-92cc-6e42e061c733.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
