### PR TITLE
fix: Carousel - add shadow for hover state for controls [ci visual]

### DIFF
--- a/src/carousel.scss
+++ b/src/carousel.scss
@@ -130,36 +130,42 @@ $button: #{$fd-namespace}-button;
     text-align: center;
   }
 
-  &__button.#{$button} {
-    @include fd-flex-center();
-    @include set-width($fd-carousel-button-size);
-    @include set-height($fd-carousel-button-size);
+  &__button {
+    &.#{$button} {
+      @include fd-flex-center();
+      @include set-width($fd-carousel-button-size);
+      @include set-height($fd-carousel-button-size);
 
-    border-radius: 50%;
-    padding: 0;
-    box-shadow: none;
-    margin: 0.25rem;
+      border-radius: 50%;
+      padding: 0;
+      box-shadow: none;
+      margin: 0.25rem;
 
-    &::before {
-      left: -0.25rem;
-      right: -0.25rem;
-      height: $fd-carousel-touchable-button-size;
-      width: $fd-carousel-touchable-button-size;
-    }
-
-    @include fd-rtl() {
-      & > [class*=sap-icon] {
-        transform: rotate(180deg);
+      &::before {
+        left: -0.25rem;
+        right: -0.25rem;
+        height: $fd-carousel-touchable-button-size;
+        width: $fd-carousel-touchable-button-size;
       }
-    }
 
-    @include fd-focus() {
-      @include after-position-overwrite();
-    }
+      @include fd-rtl() {
+        & > [class*=sap-icon] {
+          transform: rotate(180deg);
+        }
+      }
 
-    @include fd-active() {
-      @include buttonFocus() {
+      @include fd-focus() {
         @include after-position-overwrite();
+      }
+
+      @include fd-hover() {
+        box-shadow: var(--sapContent_Shadow1);
+      }
+
+      @include fd-active() {
+        @include buttonFocus() {
+          @include after-position-overwrite();
+        }
       }
     }
   }


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/1909

## Description
Added shadow for hover state for navigation buttons

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/6586561/116598955-250c0080-a930-11eb-928e-88dc2a4d7908.png)

### After:
![image](https://user-images.githubusercontent.com/6586561/116598968-29d0b480-a930-11eb-98d1-9c77e91ac152.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x]Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
