### PR TITLE
chore: added class for focusable avatar in Avatar Group

### DIFF
--- a/src/avatar-group.scss
+++ b/src/avatar-group.scss
@@ -49,7 +49,8 @@ $block: #{$fd-namespace}-avatar-group;
 
   display: flex;
 
-  &__popover-control {
+  &__popover-control,
+  &__focusable-avatar {
     @include fd-fiori-focus($fd-focus-outline-offset);
     @include action-cursor();
   }


### PR DESCRIPTION
## Related Issue
Related to https://github.com/SAP/fundamental-ngx/pull/5074

## Description
- Additional class for Avatar which could be focusable 


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [n/a] All values are in `rem`
- [n/a] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [n/a] active state of the element follow design spec
- [n/a] selected state of the element follow design spec
- [n/a] selected hover state of the element follow design spec
- [n/a] pressed state of the element follow design spec
- [n/a] Responsiveness rules - the component has modifier classes for all breakpoints
- [n/a] Includes Compact/Cosy/Tablet design
- [n/a] RTL support
2. The code follows fundamental-styles code standards and style
- [n/a] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [n/a] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [n/a] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [n/a] `fd-reset()` mixin is applied to all elements
- [n/a] Variables are used, if some value is used more than twice.
- [n/a] Checked if current components can be reused, instead of having new code.
3. Testing
- [n/a] tested Storybook examples with "CSS Resources" `normalize` option 
- [n/a] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [n/a] Verified all styles in IE11
- [n/a] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [n/a] Storybook documentation has been created/updated
- [n/a] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
