### PR TITLE
fix: class added for no outer border for table

### DIFF
--- a/src/table.scss
+++ b/src/table.scss
@@ -593,6 +593,10 @@ $block: #{$fd-namespace}-table;
     }
   }
 
+  &--no-border {
+    border: hidden;
+  }
+
   @include fd-rtl() {
     .#{$block}__cell {
       text-align: right;

--- a/src/table.scss
+++ b/src/table.scss
@@ -593,7 +593,7 @@ $block: #{$fd-namespace}-table;
     }
   }
 
-  &--no-border {
+  &--no-outer-border {
     border: hidden;
   }
 

--- a/stories/table/__snapshots__/table.stories.storyshot
+++ b/stories/table/__snapshots__/table.stories.storyshot
@@ -1273,217 +1273,6 @@ exports[`Storyshots Components/Table Borderless 1`] = `
 </section>
 `;
 
-exports[`Storyshots Components/Table Borderless table 1`] = `
-<section>
-  
-
-  <div
-    class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active"
-  >
-    
-    
-    <h4
-      style="margin: 0;"
-    >
-      Table Without Outer Borders
-    </h4>
-    
-    
-    <span
-      class="fd-toolbar__spacer fd-toolbar__spacer--auto"
-    />
-    
-
-  </div>
-  
-
-  <table
-    class="fd-table fd-table--no-border"
-  >
-    
-    
-    <thead
-      class="fd-table__header"
-    >
-      
-        
-      <tr
-        class="fd-table__row"
-      >
-        
-            
-        <th
-          class="fd-table__cell"
-          scope="col"
-        >
-          Column Header
-        </th>
-        
-            
-        <th
-          class="fd-table__cell"
-          scope="col"
-        >
-          Column Header
-        </th>
-        
-            
-        <th
-          class="fd-table__cell"
-          scope="col"
-        >
-          Column Header
-        </th>
-        
-            
-        <th
-          class="fd-table__cell"
-          scope="col"
-        >
-          Column Header
-        </th>
-        
-        
-      </tr>
-      
-    
-    </thead>
-    
-    
-    <tbody
-      class="fd-table__body"
-    >
-      
-        
-      <tr
-        class="fd-table__row"
-      >
-        
-            
-        <td
-          class="fd-table__cell"
-        >
-          <a
-            class="fd-link"
-          >
-            user.name@email.com
-          </a>
-        </td>
-        
-            
-        <td
-          class="fd-table__cell"
-        >
-          First Name
-        </td>
-        
-            
-        <td
-          class="fd-table__cell"
-        >
-          Last Name
-        </td>
-        
-            
-        <td
-          class="fd-table__cell"
-        >
-          01/26/17
-        </td>
-        
-        
-      </tr>
-      
-        
-      <tr
-        class="fd-table__row"
-      >
-        
-            
-        <td
-          class="fd-table__cell"
-        >
-          <a
-            class="fd-link"
-          >
-            user.name@email.com
-          </a>
-        </td>
-        
-            
-        <td
-          class="fd-table__cell"
-        >
-          First Name
-        </td>
-        
-            
-        <td
-          class="fd-table__cell"
-        >
-          Last Name
-        </td>
-        
-            
-        <td
-          class="fd-table__cell"
-        >
-          01/26/17
-        </td>
-        
-        
-      </tr>
-      
-        
-      <tr
-        class="fd-table__row"
-      >
-        
-            
-        <td
-          class="fd-table__cell"
-        >
-          <a
-            class="fd-link"
-          >
-            user.name@email.com
-          </a>
-        </td>
-        
-            
-        <td
-          class="fd-table__cell"
-        >
-          First Name
-        </td>
-        
-            
-        <td
-          class="fd-table__cell"
-        >
-          Last Name
-        </td>
-        
-            
-        <td
-          class="fd-table__cell"
-        >
-          01/26/17
-        </td>
-        
-        
-      </tr>
-      
-    
-    </tbody>
-    
-
-  </table>
-  
-
-</section>
-`;
-
 exports[`Storyshots Components/Table Checkbox (compact) 1`] = `
 <section>
   
@@ -7171,6 +6960,217 @@ exports[`Storyshots Components/Table Navigation indicators 1`] = `
           />
           
             
+        </td>
+        
+        
+      </tr>
+      
+    
+    </tbody>
+    
+
+  </table>
+  
+
+</section>
+`;
+
+exports[`Storyshots Components/Table No outer Border 1`] = `
+<section>
+  
+
+  <div
+    class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active"
+  >
+    
+    
+    <h4
+      style="margin: 0;"
+    >
+      Table Without Outer Borders
+    </h4>
+    
+    
+    <span
+      class="fd-toolbar__spacer fd-toolbar__spacer--auto"
+    />
+    
+
+  </div>
+  
+
+  <table
+    class="fd-table fd-table--no-outer-border"
+  >
+    
+    
+    <thead
+      class="fd-table__header"
+    >
+      
+        
+      <tr
+        class="fd-table__row"
+      >
+        
+            
+        <th
+          class="fd-table__cell"
+          scope="col"
+        >
+          Column Header
+        </th>
+        
+            
+        <th
+          class="fd-table__cell"
+          scope="col"
+        >
+          Column Header
+        </th>
+        
+            
+        <th
+          class="fd-table__cell"
+          scope="col"
+        >
+          Column Header
+        </th>
+        
+            
+        <th
+          class="fd-table__cell"
+          scope="col"
+        >
+          Column Header
+        </th>
+        
+        
+      </tr>
+      
+    
+    </thead>
+    
+    
+    <tbody
+      class="fd-table__body"
+    >
+      
+        
+      <tr
+        class="fd-table__row"
+      >
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          <a
+            class="fd-link"
+          >
+            user.name@email.com
+          </a>
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          First Name
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          Last Name
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          01/26/17
+        </td>
+        
+        
+      </tr>
+      
+        
+      <tr
+        class="fd-table__row"
+      >
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          <a
+            class="fd-link"
+          >
+            user.name@email.com
+          </a>
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          First Name
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          Last Name
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          01/26/17
+        </td>
+        
+        
+      </tr>
+      
+        
+      <tr
+        class="fd-table__row"
+      >
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          <a
+            class="fd-link"
+          >
+            user.name@email.com
+          </a>
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          First Name
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          Last Name
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          01/26/17
         </td>
         
         

--- a/stories/table/__snapshots__/table.stories.storyshot
+++ b/stories/table/__snapshots__/table.stories.storyshot
@@ -1273,6 +1273,217 @@ exports[`Storyshots Components/Table Borderless 1`] = `
 </section>
 `;
 
+exports[`Storyshots Components/Table Borderless table 1`] = `
+<section>
+  
+
+  <div
+    class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active"
+  >
+    
+    
+    <h4
+      style="margin: 0;"
+    >
+      Table Without Outer Borders
+    </h4>
+    
+    
+    <span
+      class="fd-toolbar__spacer fd-toolbar__spacer--auto"
+    />
+    
+
+  </div>
+  
+
+  <table
+    class="fd-table fd-table--no-border"
+  >
+    
+    
+    <thead
+      class="fd-table__header"
+    >
+      
+        
+      <tr
+        class="fd-table__row"
+      >
+        
+            
+        <th
+          class="fd-table__cell"
+          scope="col"
+        >
+          Column Header
+        </th>
+        
+            
+        <th
+          class="fd-table__cell"
+          scope="col"
+        >
+          Column Header
+        </th>
+        
+            
+        <th
+          class="fd-table__cell"
+          scope="col"
+        >
+          Column Header
+        </th>
+        
+            
+        <th
+          class="fd-table__cell"
+          scope="col"
+        >
+          Column Header
+        </th>
+        
+        
+      </tr>
+      
+    
+    </thead>
+    
+    
+    <tbody
+      class="fd-table__body"
+    >
+      
+        
+      <tr
+        class="fd-table__row"
+      >
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          <a
+            class="fd-link"
+          >
+            user.name@email.com
+          </a>
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          First Name
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          Last Name
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          01/26/17
+        </td>
+        
+        
+      </tr>
+      
+        
+      <tr
+        class="fd-table__row"
+      >
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          <a
+            class="fd-link"
+          >
+            user.name@email.com
+          </a>
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          First Name
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          Last Name
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          01/26/17
+        </td>
+        
+        
+      </tr>
+      
+        
+      <tr
+        class="fd-table__row"
+      >
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          <a
+            class="fd-link"
+          >
+            user.name@email.com
+          </a>
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          First Name
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          Last Name
+        </td>
+        
+            
+        <td
+          class="fd-table__cell"
+        >
+          01/26/17
+        </td>
+        
+        
+      </tr>
+      
+    
+    </tbody>
+    
+
+  </table>
+  
+
+</section>
+`;
+
 exports[`Storyshots Components/Table Checkbox (compact) 1`] = `
 <section>
   

--- a/stories/table/table.stories.js
+++ b/stories/table/table.stories.js
@@ -230,12 +230,12 @@ Table can be displayed without borders that separate the columns and rows only, 
     }
 };
 
-export const borderlesstable = () => `
+export const noOuterBorder = () => `
 <div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
     <h4 style="margin: 0;">Table Without Outer Borders</h4>
     <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
 </div>
-<table class="fd-table fd-table--no-border">
+<table class="fd-table fd-table--no-outer-border">
     <thead class="fd-table__header">
         <tr class="fd-table__row">
             <th class="fd-table__cell" scope="col">Column Header</th>
@@ -267,8 +267,8 @@ export const borderlesstable = () => `
 </table>
 `;
 
-borderlesstable.storyName = 'Borderless table';
-borderlesstable.parameters = {
+noOuterBorder.storyName = 'No outer Border';
+noOuterBorder.parameters = {
     docs: {
         storyDescription: `
 Table can be displayed without outer borders, might be needed when used inside some other element. To display a table without outer border, add the \`fd-table--border-less\` modifier class to the main element.

--- a/stories/table/table.stories.js
+++ b/stories/table/table.stories.js
@@ -271,7 +271,7 @@ noOuterBorder.storyName = 'No outer Border';
 noOuterBorder.parameters = {
     docs: {
         storyDescription: `
-Table can be displayed without outer borders, might be needed when used inside some other element. To display a table without outer border, add the \`fd-table--border-less\` modifier class to the main element.
+Table can be displayed without outer borders, might be needed when used inside some other element. To display a table without outer border, add the \`fd-table--no-outer-border\` modifier class to the main element.
     `
     }
 };

--- a/stories/table/table.stories.js
+++ b/stories/table/table.stories.js
@@ -230,6 +230,52 @@ Table can be displayed without borders that separate the columns and rows only, 
     }
 };
 
+export const borderlesstable = () => `
+<div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
+    <h4 style="margin: 0;">Table Without Outer Borders</h4>
+    <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
+</div>
+<table class="fd-table fd-table--no-border">
+    <thead class="fd-table__header">
+        <tr class="fd-table__row">
+            <th class="fd-table__cell" scope="col">Column Header</th>
+            <th class="fd-table__cell" scope="col">Column Header</th>
+            <th class="fd-table__cell" scope="col">Column Header</th>
+            <th class="fd-table__cell" scope="col">Column Header</th>
+        </tr>
+    </thead>
+    <tbody class="fd-table__body">
+        <tr class="fd-table__row">
+            <td class="fd-table__cell"><a class="fd-link">user.name@email.com</a></td>
+            <td class="fd-table__cell">First Name</td>
+            <td class="fd-table__cell">Last Name</td>
+            <td class="fd-table__cell">01/26/17</td>
+        </tr>
+        <tr class="fd-table__row">
+            <td class="fd-table__cell"><a class="fd-link">user.name@email.com</a></td>
+            <td class="fd-table__cell">First Name</td>
+            <td class="fd-table__cell">Last Name</td>
+            <td class="fd-table__cell">01/26/17</td>
+        </tr>
+        <tr class="fd-table__row">
+            <td class="fd-table__cell"><a class="fd-link">user.name@email.com</a></td>
+            <td class="fd-table__cell">First Name</td>
+            <td class="fd-table__cell">Last Name</td>
+            <td class="fd-table__cell">01/26/17</td>
+        </tr>
+    </tbody>
+</table>
+`;
+
+borderlesstable.storyName = 'Borderless table';
+borderlesstable.parameters = {
+    docs: {
+        storyDescription: `
+Table can be displayed without outer borders, might be needed when used inside some other element. To display a table without outer border, add the \`fd-table--border-less\` modifier class to the main element.
+    `
+    }
+};
+
 export const footer = () => `
 <div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
     <h4 style="margin: 0;">Table With Footer Cozy Mode</h4>


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#2360

## Description
A table can be displayed inside a card, and that time outer border of the table should not visible, otherwise it will reserve some space. This PR adds fd-tabel-no border class inside table-component which hides the outer border when applied.

Requirement coming from below comment:
https://github.com/SAP/fundamental-ngx/pull/5015#pullrequestreview-657228575

## Screenshots

### Before:
<img width="928" alt="before" src="https://user-images.githubusercontent.com/57661487/118605903-675c8b00-b7d4-11eb-9a30-4188575e45c1.png">


### After:
<img width="932" alt="after" src="https://user-images.githubusercontent.com/57661487/118605919-6b88a880-b7d4-11eb-8edd-f156373d0092.png">

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- na Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
