### PR TITLE
fix: remove unnecessary alignment for breadcrumbs in Dynamic Page

### DIFF
--- a/src/dynamic-page.scss
+++ b/src/dynamic-page.scss
@@ -432,11 +432,6 @@ $block: #{$fd-namespace}-dynamic-page;
   }
 
   &--md {
-
-    .#{$block}__breadcrumb-container {
-      align-items: flex-end;
-    }
-
     .#{$block}__toolbar {
       padding: 0;
     }


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#2362

## Description
`align-items` was applied for the `--md` modifier on breadcrumbs, which is no longer needed as all elements are centre-aligned. This PR removes this unnecessary code.

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
<img width="605" alt="Screenshot 2021-05-17 at 9 46 39 PM" src="https://user-images.githubusercontent.com/53509521/118594477-2b6ef900-b7c7-11eb-86f7-9d97e842e3e5.png">

### After:
<img width="605" alt="Screenshot 2021-05-17 at 9 46 39 PM" src="https://user-images.githubusercontent.com/53509521/118594648-6a04b380-b7c7-11eb-886a-419d14697963.png">

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [n/a] Storybook documentation has been created/updated
- [n/a] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
