### PR TITLE
feat: add Extended Busy Indicator

### DIFF
--- a/src/busy-indicator.scss
+++ b/src/busy-indicator.scss
@@ -3,6 +3,7 @@
 @import "./mixins";
 
 $block: #{$fd-namespace}-busy-indicator;
+$message-toast: #{$fd-namespace}-message-toast;
 $fd-dots-color: var(--sapContent_IconColor);
 $fd-dots-color-contrast: var(--sapContent_ContrastIconColor);
 // default sizes
@@ -23,6 +24,29 @@ $fd-dots-size-l: 2rem;
   display: block;
   font-size: 0;
   color: $fd-dots-color;
+}
+
+.#{$block}-extended {
+  @include fd-flex-center() {
+    flex-direction: column;
+  };
+
+  &.#{$message-toast} {
+    width: 23.125rem;
+    max-width: 23.125rem;
+    box-shadow: var(--sapContent_Shadow2);
+    text-shadow: var(--sapContent_TextShadow);
+    background-color: var(--sapPageFooter_Background);
+  }
+
+  &__label {
+    @include fd-reset();
+
+    display: block;
+    color: var(--sapPageFooter_TextColor);
+    margin-top: 1rem;
+    text-align: center;
+  }
 }
 
 .#{$block}.contrast,

--- a/stories/busy-indicator/__snapshots__/busy-indicator.stories.storyshot
+++ b/stories/busy-indicator/__snapshots__/busy-indicator.stories.storyshot
@@ -34,6 +34,16 @@ exports[`Storyshots Components/Busy Indicator Contrast Mode 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/Busy Indicator Extended Busy Indicator 1`] = `
+
+
+`;
+
+exports[`Storyshots Components/Busy Indicator Extended Busy Indicator Inside Message Toast 1`] = `
+
+
+`;
+
 exports[`Storyshots Components/Busy Indicator Standard 1`] = `
 <div
   style="text-align: center"

--- a/stories/busy-indicator/busy-indicator.stories.js
+++ b/stories/busy-indicator/busy-indicator.stories.js
@@ -26,7 +26,7 @@ The ongoing operation only covers part of a screen that has multiple controls, a
 - You need to block the screen because the user is not supposed to start another operation. In this case, use the **Busy Dialog** component.
         `,
         tags: ['f3', 'a11y', 'theme'],
-        components: ['busy-indicator']
+        components: ['busy-indicator', 'message-toast']
     }
 };
 
@@ -69,5 +69,41 @@ contrastMode.parameters = {
     docs: {
         iframeHeight: 200,
         storyDescription: 'The busy indicator also comes in contrast mode and displays white dots against a dark background. To apply contrast mode, add <code>contrast</code> into the element i.e. <code>fd-busy-indicator--m contrast</code>.'
+    }
+};
+
+export const extendedBusyIndicator = () => `
+<div class="fd-busy-indicator-extended">
+    <div class="fd-busy-indicator fd-busy-indicator--l" aria-hidden="false" aria-label="Loading">
+        <div class="fd-busy-indicator--circle-0"></div>
+        <div class="fd-busy-indicator--circle-1"></div>
+        <div class="fd-busy-indicator--circle-2"></div>
+    </div>
+    <div class="fd-busy-indicator-extended__label">loading data...</div>
+</div>`;
+
+extendedBusyIndicator.parameters = {
+    docs: {
+        iframeHeight: 200,
+        storyDescription:
+            'If more information needs to be displayed with the loading animation, it is replaced by the Extended Busy Indicator <code>fd-busy-indicator-extended</code>. The additional information is wrapped in an element with <code>fd-busy-indicator-extended\\_\\_label</code> class.'
+    }
+};
+
+export const extendedBusyIndicatorInsideMessageToast = () => `
+<div class="fd-message-toast fd-busy-indicator-extended">
+    <div class="fd-busy-indicator fd-busy-indicator--l" aria-hidden="false" aria-label="Loading">
+        <div class="fd-busy-indicator--circle-0"></div>
+        <div class="fd-busy-indicator--circle-1"></div>
+        <div class="fd-busy-indicator--circle-2"></div>
+    </div>
+    <div class="fd-busy-indicator-extended__label">loading data...</div>
+</div>`;
+
+extendedBusyIndicatorInsideMessageToast.parameters = {
+    docs: {
+        iframeHeight: 200,
+        storyDescription:
+            'At the Page level the Busy Indicator should always be placed in a container. The simplest form of container will be centred on the page and inherit the color values from Message Toast.'
     }
 };


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#2338

## Description
add extended busy indicator with label and inside a message toast

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
