### PR TITLE
fix: removal of extra margin on the labelled status indicator

### DIFF
--- a/src/status-indicator.scss
+++ b/src/status-indicator.scss
@@ -44,7 +44,7 @@ $color-states: (
   &--horizontal-label {
     @include fd-reset();
 
-    flex-direction: unset;
+    flex-direction: row;
   }
 
   &--link {
@@ -53,13 +53,35 @@ $color-states: (
 
   &__label {
     font-size: $fd-status-indicator-default-font-size;
-    margin: $fd-status-indicator-default-margin;
 
     // sizes
     @each $set-name, $size-set in $fd-status-indicator-sizes {
       &--#{$set-name} {
         font-size: map-get($size-set, 'font-size');
-        margin: map-get($size-set, 'margin');
+        &.#{$block}__label--top {
+          margin-bottom: map-get($size-set, 'margin');
+        }
+        &.#{$block}__label--right {
+          margin-left: map-get($size-set, 'margin');
+
+          @include fd-rtl() {
+            margin-left: 0;
+            margin-right: map-get($size-set, 'margin');
+            transform: matrix(1, 0, 0, 1, 22, 1);
+          }
+        }
+        &.#{$block}__label--left {
+          margin-right: map-get($size-set, 'margin');
+
+          @include fd-rtl() {
+            margin-right: 0;
+            margin-left: map-get($size-set, 'margin');
+            transform: matrix(1, 0, 0, 1, -22, 1);
+          }
+        }
+        &.#{$block}__label--bottom {
+          margin-top: map-get($size-set, 'margin');
+        }
       }
     }
   }

--- a/stories/status-indicator/__snapshots__/status-indicator.stories.storyshot
+++ b/stories/status-indicator/__snapshots__/status-indicator.stories.storyshot
@@ -10,7 +10,7 @@ exports[`Storyshots Components/Status Indicator Fill values 1`] = `
     
 
     <span
-      style="min-width: 150px;"
+      class="fd-form-label"
     >
       Negative Filling :
     </span>
@@ -153,7 +153,7 @@ exports[`Storyshots Components/Status Indicator Fill values 1`] = `
     
 
     <span
-      style="min-width: 150px;"
+      class="fd-form-label"
     >
       Critical Filling :
     </span>
@@ -296,7 +296,7 @@ exports[`Storyshots Components/Status Indicator Fill values 1`] = `
     
 
     <span
-      style="min-width: 150px;"
+      class="fd-form-label"
     >
       Positive Filling :
     </span>
@@ -446,7 +446,7 @@ exports[`Storyshots Components/Status Indicator Sizes 1`] = `
     
 
     <span
-      style="min-width: 150px;"
+      class="fd-form-label"
     >
       Small size :
     </span>
@@ -589,7 +589,7 @@ exports[`Storyshots Components/Status Indicator Sizes 1`] = `
     
 
     <span
-      style="min-width: 150px;"
+      class="fd-form-label"
     >
       Medium size(Default) :
     </span>
@@ -732,7 +732,7 @@ exports[`Storyshots Components/Status Indicator Sizes 1`] = `
     
 
     <span
-      style="min-width: 150px;"
+      class="fd-form-label"
     >
       Large Size :
     </span>
@@ -875,7 +875,7 @@ exports[`Storyshots Components/Status Indicator Sizes 1`] = `
     
 
     <span
-      style="min-width: 150px;"
+      class="fd-form-label"
     >
       Extra Large Size :
     </span>
@@ -1025,7 +1025,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Angular fi
     
 	
     <span
-      style="min-width: 150px;"
+      class="fd-form-label"
     >
       Angular filling 270 degree:
     </span>
@@ -1194,7 +1194,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Angular fi
     
 	
     <span
-      style="min-width: 150px;"
+      class="fd-form-label"
     >
       Angular filling 40 degree:
     </span>
@@ -1363,7 +1363,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Angular fi
     
 	
     <span
-      style="min-width: 150px;"
+      class="fd-form-label"
     >
       Angular filling 98 degree:
     </span>
@@ -1532,7 +1532,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Angular fi
     
 	
     <span
-      style="min-width: 150px;"
+      class="fd-form-label"
     >
       Angular filling 140 degree:
     </span>
@@ -1712,7 +1712,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Label 1`] 
     
 
     <span
-      style="min-width: 150px;"
+      class="fd-form-label"
     >
       Top Label :
     </span>
@@ -1731,7 +1731,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Label 1`] 
       
 	
       <span
-        class="fd-status-indicator__label fd-status-indicator__label--lg"
+        class="fd-status-indicator__label fd-status-indicator__label--lg fd-status-indicator__label--top"
       >
         100%
       </span>
@@ -1862,7 +1862,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Label 1`] 
     
 	
     <span
-      style="min-width: 150px;"
+      class="fd-form-label"
     >
       Bottom Label :
     </span>
@@ -1994,7 +1994,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Label 1`] 
       
 	
       <span
-        class="fd-status-indicator__label fd-status-indicator__label--lg"
+        class="fd-status-indicator__label fd-status-indicator__label--lg fd-status-indicator__label--bottom"
       >
         100%
       </span>
@@ -2012,7 +2012,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Label 1`] 
     
 
     <span
-      style="min-width: 150px;"
+      class="fd-form-label"
     >
       Left Label :
     </span>
@@ -2031,7 +2031,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Label 1`] 
       
 	
       <span
-        class="fd-status-indicator__label fd-status-indicator__label--lg"
+        class="fd-status-indicator__label fd-status-indicator__label--lg fd-status-indicator__label--left"
       >
         100%
       </span>
@@ -2162,7 +2162,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Label 1`] 
     
 	
     <span
-      style="min-width: 150px;"
+      class="fd-form-label"
     >
       Right Label :
     </span>
@@ -2294,7 +2294,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Label 1`] 
       
 	
       <span
-        class="fd-status-indicator__label fd-status-indicator__label--lg"
+        class="fd-status-indicator__label fd-status-indicator__label--lg fd-status-indicator__label--right"
       >
         100%
       </span>
@@ -2320,7 +2320,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Linear fil
     
 	
     <span
-      style="min-width: 150px;"
+      class="fd-form-label"
     >
       Left to Right fill :
     </span>
@@ -2488,7 +2488,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Linear fil
     
 	
     <span
-      style="min-width: 150px;"
+      class="fd-form-label"
     >
       Bottom to Top fill
     </span>
@@ -2663,7 +2663,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Radial fil
     
 	
     <span
-      style="min-width: 150px;"
+      class="fd-form-label"
     >
       Radial Clock filling:
     </span>
@@ -2829,7 +2829,7 @@ exports[`Storyshots Components/Status Indicator Status Indicator With Radial fil
     
 	
     <span
-      style="min-width: 150px;"
+      class="fd-form-label"
     >
       Radial Counter Clock filling:
     </span>

--- a/stories/status-indicator/status-indicator.stories.js
+++ b/stories/status-indicator/status-indicator.stories.js
@@ -9,13 +9,13 @@ It allows users to fill the content on a numeric scale, typically from 1 (lowest
 Use the status indicator in Grids, tables, or in a dialog box.
         `,
         tags: ['f3', 'a11y', 'theme'],
-        components: ['status-indicator']
+        components: ['status-indicator', 'form-label']
     }
 };
 
 export const Sizes = () => `
 <div class="example-container">
-<span style="min-width: 150px;">Small size :</span>
+<span class="fd-form-label">Small size :</span>
 <div class="fd-status-indicator fd-status-indicator--negative fd-status-indicator--sm" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="35%" tabindex=0 aria-label=" Euro Status Indicator small size" focusable="true" title="35% with small size">
 	<svg id="__shape0__box1-24" class="fd-status-indicator__svg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path1" data-sap-ui="__path1">
@@ -47,7 +47,7 @@ export const Sizes = () => `
 </div>
 </div>
 <div class="example-container">
-<span style="min-width: 150px;">Medium size(Default) :</span>
+<span class="fd-form-label">Medium size(Default) :</span>
 <div class="fd-status-indicator fd-status-indicator--critical fd-status-indicator--md" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="50%" tabindex=0 aria-label="Euro Status Indicator Medium default size" focusable="true" title="50% with default medium size">
 	<svg id="__shape0__box2-24" class="fd-status-indicator__svg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path11" data-sap-ui="__path11">
@@ -79,7 +79,7 @@ export const Sizes = () => `
 </div>
 </div>
 <div class="example-container">
-<span style="min-width: 150px;">Large Size :</span>
+<span class="fd-form-label">Large Size :</span>
 <div class="fd-status-indicator fd-status-indicator--positive fd-status-indicator--lg" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="80%" tabindex=0 aria-label="Euro Status Indicator large size" focusable="true" title="80% with large size">
 	<svg id="__shape0__box3-24" class="fd-status-indicator__svg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path12" data-sap-ui="__path12">
@@ -111,7 +111,7 @@ export const Sizes = () => `
 </div>
 </div>
 <div class="example-container">
-<span style="min-width: 150px;">Extra Large Size :</span>
+<span class="fd-form-label">Extra Large Size :</span>
 <div class="fd-status-indicator fd-status-indicator--xl" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="0%" tabindex=0 aria-label="Euro Status Indicator Extra Large size" focusable="true" title="0% with size extra large">
 	<svg id="__shape0__box4-24" class="fd-status-indicator__svg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path13" data-sap-ui="__path13">
@@ -159,7 +159,7 @@ Sizes.parameters = {
 
 export const fillValues = () => `
 <div  class="example-container">
-<span style="min-width: 150px;">Negative Filling :</span>
+<span class="fd-form-label">Negative Filling :</span>
 <div class="fd-status-indicator fd-status-indicator--negative fd-status-indicator--lg" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="35%" tabindex=0 aria-label="Euro Status Indicator With Negative Filling" focusable="true" title="35% fill with negative color">
 	<svg id="__shape0__box5-24" class="fd-status-indicator__svg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path21" data-sap-ui="__path21">
@@ -191,7 +191,7 @@ export const fillValues = () => `
 </div>
 </div>
 <div class="example-container">
-<span style="min-width: 150px;">Critical Filling :</span>
+<span class="fd-form-label">Critical Filling :</span>
 <div class="fd-status-indicator fd-status-indicator--critical fd-status-indicator--lg" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="60%" tabindex=0 aria-label="Euro Status Indicator With Critical Filling" focusable="true" title="60% with critical color filling">
 	<svg id="__shape0__box6-24" class="fd-status-indicator__svg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path22" data-sap-ui="__path22">
@@ -223,7 +223,7 @@ export const fillValues = () => `
 </div>
 </div>
 <div class="example-container">
-<span style="min-width: 150px;">Positive Filling :</span>
+<span class="fd-form-label">Positive Filling :</span>
 <div class="fd-status-indicator fd-status-indicator--positive fd-status-indicator--lg" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="100%" tabindex=0 aria-label="Euro Status Indicator With Positive Filling" focusable="true" title="100% with Positive color filling">
 	<svg id="__shape0__box7-24" class="fd-status-indicator__svg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path23" data-sap-ui="__path23">
@@ -268,9 +268,9 @@ modifier class together with the \`fd-status-indicator\` class.
 
 export const StatusIndicatorLabels = () => `
 <div class="example-container">
-<span style="min-width: 150px;">Top Label :</span>
+<span class="fd-form-label">Top Label :</span>
 <div class="fd-status-indicator fd-status-indicator--critical fd-status-indicator--lg"  aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="100%" tabindex=0 aria-label="Euro Status Indicator With Labelled On Top" focusable="true" title="100% with label on top">
-	<span class="fd-status-indicator__label fd-status-indicator__label--lg">100%</span>
+	<span class="fd-status-indicator__label fd-status-indicator__label--lg fd-status-indicator__label--top">100%</span>
 	<svg id="__shape0__box9-24" class="fd-status-indicator__svg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path25" data-sap-ui="__path25">
 			<defs>
@@ -301,7 +301,7 @@ export const StatusIndicatorLabels = () => `
 </div>
 </div>
 <div class="example-container">
-	<span style="min-width: 150px;">Bottom Label :</span>
+	<span class="fd-form-label">Bottom Label :</span>
 <div class="fd-status-indicator fd-status-indicator--positive fd-status-indicator--lg" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="100%" tabindex=0 aria-label="Euro Status Indicator With Labelled On Bottom" focusable="true" title="100% with label on bottom">
 	<svg id="__shape0__box10-24" class="fd-status-indicator__svg"  data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path26" data-sap-ui="__path26">
@@ -330,13 +330,13 @@ export const StatusIndicatorLabels = () => `
 			</path>
 		</svg>	
 	</svg>
-	<span class="fd-status-indicator__label fd-status-indicator__label--lg">100%</span>
+	<span class="fd-status-indicator__label fd-status-indicator__label--lg fd-status-indicator__label--bottom">100%</span>
 </div>
 </div>
 <div class="example-container">
-<span style="min-width: 150px;">Left Label :</span>
+<span class="fd-form-label">Left Label :</span>
 <div class="fd-status-indicator fd-status-indicator--critical fd-status-indicator--horizontal-label fd-status-indicator--lg" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="100%" tabindex=0 aria-label="Euro Status Indicator With Labelled On Left" focusable="true" title="100% with label on left">
-	<span class="fd-status-indicator__label fd-status-indicator__label--lg">100%</span>
+	<span class="fd-status-indicator__label fd-status-indicator__label--lg fd-status-indicator__label--left">100%</span>
 	<svg id="__shape0__box12-24" class="fd-status-indicator__svg"  class=" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 36 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path261" data-sap-ui="__path261">
 			<defs>
@@ -367,7 +367,7 @@ export const StatusIndicatorLabels = () => `
 </div>
 </div>
 <div class="example-container">
-	<span style="min-width: 150px;">Right Label :</span>
+	<span class="fd-form-label">Right Label :</span>
 <div class="fd-status-indicator fd-status-indicator--positive fd-status-indicator--horizontal-label fd-status-indicator--lg"  aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="100%" tabindex=0 aria-label="Euro Status Indicator With Labelled On Right" focusable="true" title="100% with label on right">
 	<svg id="__shape0__box101-24" class="fd-status-indicator__svg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 16 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path262" data-sap-ui="__path262">
@@ -396,7 +396,7 @@ export const StatusIndicatorLabels = () => `
 			</path>
 		</svg>	
 	</svg>
-	<span class="fd-status-indicator__label fd-status-indicator__label--lg">100%</span>
+	<span class="fd-status-indicator__label fd-status-indicator__label--lg fd-status-indicator__label--right">100%</span>
 </div>
 </div>
 
@@ -414,7 +414,7 @@ modifier class for defining the font size and colour of the Label together with 
 
 export const StatusIndicatorLinearFilling = () => `
 <div class="example-container">
-	<span style="min-width: 150px;">Left to Right fill :</span>
+	<span class="fd-form-label">Left to Right fill :</span>
 <div class="fd-status-indicator fd-status-indicator--negative fd-status-indicator--lg" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="80%" tabindex=0 aria-label="Euro status indicator animated left to right filling " focusable="true" title="80% fill from left to right">
 	<svg id="__shape0__box32a-24" class="fd-status-indicator__svg"  data-sap-ui="__shape0-__box32-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path32a" data-sap-ui="__path32a">
@@ -451,7 +451,7 @@ export const StatusIndicatorLinearFilling = () => `
 </div>
 </div>
 <div class="example-container">
-	<span style="min-width: 150px;">Bottom to Top fill</span>
+	<span class="fd-form-label">Bottom to Top fill</span>
 <div class="fd-status-indicator fd-status-indicator--negative fd-status-indicator--lg" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="80%" tabindex=0 aria-label="Euro status indicator animated bottom up filling" focusable="true" title="80% fill from bottom to top">
 	<svg id="__shape0__box33-24" class="fd-status-indicator__svg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path33" data-sap-ui="__path33">
@@ -645,7 +645,7 @@ StatusIndicatorCoreoGraphy.parameters = {
 
 export const StatusIndicatorRadialFilling = () => `
 <div class="example-container">
-	<span style="min-width: 150px;">Radial Clock filling:</span>
+	<span class="fd-form-label">Radial Clock filling:</span>
 <div class="fd-status-indicator fd-status-indicator--negative fd-status-indicator--xl" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="30%" tabindex=0 aria-label="Euro Status Indicator Radial clockwise filling" focusable="true" title="30% radial filling with clockwise">
 	<svg id="__shape0__box34-24" data-sap-ui="__shape0-__box21-24" class="fd-status-indicator__svg"  version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path34" data-sap-ui="__path34">
@@ -679,7 +679,7 @@ export const StatusIndicatorRadialFilling = () => `
 </div>
 
 <div class="example-container">
-	<span style="min-width: 150px;">Radial Counter Clock filling:</span>
+	<span class="fd-form-label">Radial Counter Clock filling:</span>
 <div class="fd-status-indicator fd-status-indicator--negative fd-status-indicator--xl" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="30%" tabindex=0 aria-label="Euro Status Indicator Radial clockwise filling" focusable="true" title="30% radial filling with counterclockwise">
 	<svg id="__shape0__box35-24" data-sap-ui="__shape0-__box21-24" version="1.1" class="fd-status-indicator__svg" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path35" data-sap-ui="__path35">
@@ -724,7 +724,7 @@ To display Radial filling instead of default bottom to top approach type of stat
 
 export const StatusIndicatorAngularFilling = () => `
 <div class="example-container">
-	<span style="min-width: 150px;">Angular filling 270 degree:</span>
+	<span class="fd-form-label">Angular filling 270 degree:</span>
 <div class="fd-status-indicator fd-status-indicator--positive fd-status-indicator--xl" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="80%" tabindex=0 aria-label="Euro Status Indicator Angled filling at 270 degree" focusable="true"  title="80% angled filling in 270 degree">
 	<svg id="__shape0__box36-24" class="fd-status-indicator__svg"  data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path36" data-sap-ui="__path6">
@@ -762,7 +762,7 @@ export const StatusIndicatorAngularFilling = () => `
 </div>
 
 <div class="example-container">
-	<span style="min-width: 150px;">Angular filling 40 degree:</span>
+	<span class="fd-form-label">Angular filling 40 degree:</span>
 <div class="fd-status-indicator fd-status-indicator--critical fd-status-indicator--xl" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="50%" tabindex=0 aria-label="Euro Status Indicator Angled filling at 40 degree" focusable="true"  title="50% angled filling in 40 degree">
 	<svg id="__shape0__box37-24" class="fd-status-indicator__svg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path37" data-sap-ui="__path37">
@@ -800,7 +800,7 @@ export const StatusIndicatorAngularFilling = () => `
 </div>
 
 <div class="example-container">
-	<span style="min-width: 150px;">Angular filling 98 degree:</span>
+	<span class="fd-form-label">Angular filling 98 degree:</span>
 <div class="fd-status-indicator fd-status-indicator--positive fd-status-indicator--xl" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="50%" tabindex=0 aria-label="Euro Status Indicator Angled filling at 98 degree" focusable="true"  title="50% angled filling in 98 degree">
 	<svg id="__shape0__box38-24" class="fd-status-indicator__svg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path38" data-sap-ui="__path38">
@@ -838,7 +838,7 @@ export const StatusIndicatorAngularFilling = () => `
 </div>
 
 <div class="example-container">
-	<span style="min-width: 150px;">Angular filling 140 degree:</span>
+	<span class="fd-form-label">Angular filling 140 degree:</span>
 <div class="fd-status-indicator fd-status-indicator--negative fd-status-indicator--xl" aria-roledescription="Status Indicator" role="progressbar" aria-valuetext="40%" tabindex=0 aria-label="Euro Status Indicator Angled filling at 140 degree" focusable="true"  title="40% angled filling in 140 degree">
 	<svg id="__shape0__box39-24" class="fd-status-indicator__svg" data-sap-ui="__shape0-__box21-24" version="1.1" xlmns="http://www.w3.org/2000/svg" viewBox="0 0 26 25" preserveAspectRatio="xMidYMid meet" x="0" y="0" width="100%" height="100%">
 		<svg xlmns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" overflow="visible" id="__path39" data-sap-ui="__path39">


### PR DESCRIPTION

## Related Issue
Closes: https://github.com/SAP/fundamental-styles/issues/2331

## Description
Removal of extra margin on the labelled status indicator

## Screenshots

### Before:
<img width="619" alt="116866104-76660980-ac28-11eb-8415-3606b75d2b1b" src="https://user-images.githubusercontent.com/53534379/118957158-e8a35180-b97d-11eb-85f2-45808cd1d305.png">


### After:

<img width="455" alt="Screenshot 2021-05-20 at 3 13 49 PM" src="https://user-images.githubusercontent.com/53534379/118957311-0a043d80-b97e-11eb-84ef-e1c255895d84.png">


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [N/A]  All values are in `rem`
- [N/A]  Text elements follow the truncation rules
- [N/A] hover state of the element follow design spec
- [N/A] focus state of the element follow design spec
- [N/A] active state of the element follow design spec
- [N/A] selected state of the element follow design spec
- [N/A] selected hover state of the element follow design spec
- [N/A] pressed state of the element follow design spec
- [N/A] Responsiveness rules - the component has modifier classes for all breakpoints
- [N/A] Includes Compact/Cosy/Tablet design
- [N/A] RTL support
2. The code follows fundamental-styles code standards and style
- [N/A] only one top level `fd-*` class is used in the file
- [N/A] BEM naming convention is used
- [N/A] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [N/A] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [N/A] `fd-reset()` mixin is applied to all elements
- [N/A] Variables are used, if some value is used more than twice.
- [N/A] Checked if current components can be reused, instead of having new code.
3. Testing
- [N/A] tested Storybook examples with "CSS Resources" `normalize` option 
- [N/A] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [N/A] Verified all styles in IE11
- [N/A] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [N/A] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
