### PR TITLE
fix: Slider - fix ticks for windows [ci visual]

### DIFF
--- a/src/slider.scss
+++ b/src/slider.scss
@@ -51,7 +51,7 @@ $handle-hit-area-mobile-dimensions: 2.75rem;
 
     position: absolute;
     width: 100%;
-    top: -0.4rem;
+    top: calc((-1rem + var(--fdSlider_Track_Height)) / 2);
   }
 
   &__ticks {
@@ -78,12 +78,11 @@ $handle-hit-area-mobile-dimensions: 2.75rem;
     @include fd-reset();
 
     position: relative;
-    width: 0.0625rem;
+    border-left: 0.0625rem solid var(--sapField_BorderColor);
     height: var(--fdSlider_Tick_Height);
-    background-color: var(--sapField_BorderColor);
 
     &--in-range {
-      background-color: var(--fdSlider_Track_Active_Border);
+      border-color: var(--fdSlider_Track_Active_Border);
     }
   }
 


### PR DESCRIPTION
## Related Issue
Closes https://github.com/sap/fundamental-ngx/issues/4604

## Description
Fixed slider ticks for windows

## Screenshots
### Before:
![image](https://user-images.githubusercontent.com/32538291/107199978-1ee74180-6a1d-11eb-9864-28d5cf92fbd9.png)

### After:
<img width="650" alt="Screenshot 2021-05-21 at 13 51 58" src="https://user-images.githubusercontent.com/8318592/119126482-beb06480-ba3b-11eb-8ea7-110abb264f22.png">

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [X] All values are in `rem`
- [X] Text elements follow the truncation rules
- [X] hover state of the element follow design spec
- [X] focus state of the element follow design spec
- [X] active state of the element follow design spec
- [X] selected state of the element follow design spec
- [X] selected hover state of the element follow design spec
- [X] pressed state of the element follow design spec
- [X] Responsiveness rules - the component has modifier classes for all breakpoints
- [X] Includes Compact/Cosy/Tablet design
- [X] RTL support
2. The code follows fundamental-styles code standards and style
- [X] only one top level `fd-*` class is used in the file
- [X] BEM naming convention is used
- [X] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [X] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [X] `fd-reset()` mixin is applied to all elements
- [X] Variables are used, if some value is used more than twice.
- [X] Checked if current components can be reused, instead of having new code.
3. Testing
- [X] tested Storybook examples with "CSS Resources" `normalize` option 
- [X] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [X] Verified all styles in IE11
- [X] Updated tests
- [X] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [X] Storybook documentation has been created/updated
- [X] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
