### PR TITLE
fix: form grid aligns items vertically to the top

### DIFF
--- a/src/form-label.scss
+++ b/src/form-label.scss
@@ -105,4 +105,12 @@ $block: #{$fd-namespace}-form-label;
     justify-content: space-between;
     align-items: center;
   }
+
+  &--horizontal {
+    line-height: 2.8rem;
+  }
+
+  &--compact {
+    line-height: 2rem;
+  }
 }

--- a/src/form-label.scss
+++ b/src/form-label.scss
@@ -105,12 +105,4 @@ $block: #{$fd-namespace}-form-label;
     justify-content: space-between;
     align-items: center;
   }
-
-  &--horizontal {
-    line-height: 2.8rem;
-  }
-
-  &--compact {
-    line-height: 2rem;
-  }
 }

--- a/src/form-layout-grid.scss
+++ b/src/form-layout-grid.scss
@@ -31,10 +31,8 @@ $cols: 11;
     }
 
     .#{$blockRow} {
-      align-items: center;
       margin-top: 0;
       margin-bottom: 0.625rem;
-
       .#{$blockCol} {
         padding: 0 0.25rem;
         overflow: hidden;
@@ -192,9 +190,19 @@ $cols: 11;
 @media (min-width: 1440px) {
   .#{$blockContainer}.#{$block}-container {
     .#{$blockRow} {
+      align-items: start;
+
       .#{$blockCol} {
         .fd-form-label {
           padding-bottom: 0;
+
+          &--horizontal {
+            line-height: 2.8rem;
+          }
+
+          &--compact {
+            line-height: 2rem;
+          }
         }
 
         @for $n from 0 through $cols {

--- a/src/form-layout-grid.scss
+++ b/src/form-layout-grid.scss
@@ -195,14 +195,6 @@ $cols: 11;
       .#{$blockCol} {
         .fd-form-label {
           padding-bottom: 0;
-
-          &--horizontal {
-            line-height: 2.8rem;
-          }
-
-          &--compact {
-            line-height: 2rem;
-          }
         }
 
         @for $n from 0 through $cols {

--- a/src/form-layout-grid.scss
+++ b/src/form-layout-grid.scss
@@ -31,8 +31,14 @@ $cols: 11;
     }
 
     .#{$blockRow} {
+      align-items: center;
       margin-top: 0;
       margin-bottom: 0.625rem;
+
+      &--top {
+        align-items: start;
+      }
+
       .#{$blockCol} {
         padding: 0 0.25rem;
         overflow: hidden;
@@ -190,8 +196,6 @@ $cols: 11;
 @media (min-width: 1440px) {
   .#{$blockContainer}.#{$block}-container {
     .#{$blockRow} {
-      align-items: start;
-
       .#{$blockCol} {
         .fd-form-label {
           padding-bottom: 0;

--- a/stories/form-grid/__snapshots__/form-grid.stories.storyshot
+++ b/stories/form-grid/__snapshots__/form-grid.stories.storyshot
@@ -192,7 +192,7 @@ exports[`Storyshots Components/Forms/Form Grid Compact form 1`] = `
       
           
       <label
-        class="fd-form-label"
+        class="fd-form-label fd-form-label--compact"
         for="input-13-compact"
       >
         Default Input:
@@ -232,7 +232,7 @@ exports[`Storyshots Components/Forms/Form Grid Compact form 1`] = `
       
           
       <label
-        class="fd-form-label fd-form-label--required"
+        class="fd-form-label fd-form-label--compact fd-form-label--required"
         for="input-13b-compact"
       >
         Required Input: 
@@ -274,7 +274,7 @@ exports[`Storyshots Components/Forms/Form Grid Compact form 1`] = `
       
           
       <label
-        class="fd-form-label"
+        class="fd-form-label fd-form-label--compact"
         id="groupLabel-compact"
       >
         2 Inputs: 
@@ -358,7 +358,7 @@ exports[`Storyshots Components/Forms/Form Grid Default [L] 1`] = `
       
       
       <label
-        class="fd-form-label"
+        class="fd-form-label fd-form-label--horizontal"
         for="input-6-name"
       >
         Name:
@@ -400,7 +400,7 @@ exports[`Storyshots Components/Forms/Form Grid Default [L] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--required"
+        class="fd-form-label fd-form-label--horizontal fd-form-label--required"
         for="input-6-street"
       >
         Street/No.: 
@@ -476,7 +476,7 @@ exports[`Storyshots Components/Forms/Form Grid Default [L] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--required"
+        class="fd-form-label fd-form-label--horizontal fd-form-label--required"
         for="input-6-zip"
       >
         ZIP Code/City: 
@@ -552,7 +552,7 @@ exports[`Storyshots Components/Forms/Form Grid Default [L] 1`] = `
       
       
       <label
-        class="fd-form-label"
+        class="fd-form-label fd-form-label--horizontal"
         for="input-6-country"
       >
         Country:
@@ -653,7 +653,7 @@ exports[`Storyshots Components/Forms/Form Grid Default [M] 1`] = `
       
       
       <label
-        class="fd-form-label"
+        class="fd-form-label fd-form-label--horizontal"
         for="input-2-name"
       >
         Name:
@@ -695,7 +695,7 @@ exports[`Storyshots Components/Forms/Form Grid Default [M] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--required"
+        class="fd-form-label fd-form-label--horizontal fd-form-label--required"
         for="input-2-street"
       >
         Street/No.: 
@@ -771,7 +771,7 @@ exports[`Storyshots Components/Forms/Form Grid Default [M] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--required"
+        class="fd-form-label  fd-form-label--horizontal fd-form-label--required"
         for="input-2-zip"
       >
         ZIP Code/City: 
@@ -847,7 +847,7 @@ exports[`Storyshots Components/Forms/Form Grid Default [M] 1`] = `
       
       
       <label
-        class="fd-form-label"
+        class="fd-form-label fd-form-label--horizontal"
         for="input-2-country"
       >
         Country:
@@ -947,7 +947,7 @@ exports[`Storyshots Components/Forms/Form Grid Default [XL] 1`] = `
       
       
       <label
-        class="fd-form-label"
+        class="fd-form-label fd-form-label--horizontal"
         for="input-9-name"
       >
         Name:
@@ -989,7 +989,7 @@ exports[`Storyshots Components/Forms/Form Grid Default [XL] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--required"
+        class="fd-form-label fd-form-label--horizontal fd-form-label--required"
         for="input-9-street"
       >
         Street/No.: 
@@ -1065,7 +1065,7 @@ exports[`Storyshots Components/Forms/Form Grid Default [XL] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--required"
+        class="fd-form-label fd-form-label--horizontal fd-form-label--required"
         for="input-9-zip"
       >
         ZIP Code/City: 
@@ -1141,7 +1141,7 @@ exports[`Storyshots Components/Forms/Form Grid Default [XL] 1`] = `
       
       
       <label
-        class="fd-form-label"
+        class="fd-form-label fd-form-label--horizontal"
         for="input-9-country"
       >
         Country:
@@ -1251,7 +1251,7 @@ exports[`Storyshots Components/Forms/Form Grid Double form [XL] 1`] = `
           
           
           <label
-            class="fd-form-label"
+            class="fd-form-label fd-form-label--horizontal"
             for="input-11-name"
           >
             Name:
@@ -1293,7 +1293,7 @@ exports[`Storyshots Components/Forms/Form Grid Double form [XL] 1`] = `
           
           
           <label
-            class="fd-form-label fd-form-label--required"
+            class="fd-form-label fd-form-label--horizontal fd-form-label--required"
             for="input-11-street"
           >
             Street/No.: 
@@ -1369,7 +1369,7 @@ exports[`Storyshots Components/Forms/Form Grid Double form [XL] 1`] = `
           
           
           <label
-            class="fd-form-label fd-form-label--required"
+            class="fd-form-label fd-form-label--horizontal fd-form-label--required"
             for="input-11-zip"
           >
             ZIP Code/City: 
@@ -1445,7 +1445,7 @@ exports[`Storyshots Components/Forms/Form Grid Double form [XL] 1`] = `
           
           
           <label
-            class="fd-form-label"
+            class="fd-form-label fd-form-label--horizontal"
             for="input-11-country"
           >
             Country:
@@ -1543,7 +1543,7 @@ exports[`Storyshots Components/Forms/Form Grid Double form [XL] 1`] = `
           
           
           <label
-            class="fd-form-label"
+            class="fd-form-label fd-form-label--horizontal"
             for="input-11a-name"
           >
             Name:
@@ -1585,7 +1585,7 @@ exports[`Storyshots Components/Forms/Form Grid Double form [XL] 1`] = `
           
           
           <label
-            class="fd-form-label fd-form-label--required"
+            class="fd-form-label fd-form-label--horizontal fd-form-label--required"
             for="input-11a-street"
           >
             Street/No.: 
@@ -1661,7 +1661,7 @@ exports[`Storyshots Components/Forms/Form Grid Double form [XL] 1`] = `
           
           
           <label
-            class="fd-form-label fd-form-label--required"
+            class="fd-form-label fd-form-label--horizontal fd-form-label--required"
             for="input-11a-zip"
           >
             ZIP Code/City: 
@@ -1737,7 +1737,7 @@ exports[`Storyshots Components/Forms/Form Grid Double form [XL] 1`] = `
           
           
           <label
-            class="fd-form-label"
+            class="fd-form-label fd-form-label--horizontal"
             for="input-11a-country"
           >
             Country:
@@ -1843,7 +1843,7 @@ exports[`Storyshots Components/Forms/Form Grid Full screen [M] 1`] = `
       
       
       <label
-        class="fd-form-label"
+        class="fd-form-label fd-form-label--horizontal"
         for="input-4-name"
       >
         Name:
@@ -1885,7 +1885,7 @@ exports[`Storyshots Components/Forms/Form Grid Full screen [M] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--required"
+        class="fd-form-label fd-form-label--horizontal fd-form-label--required"
         for="input-4-street"
       >
         Street/No.: 
@@ -1961,7 +1961,7 @@ exports[`Storyshots Components/Forms/Form Grid Full screen [M] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--required"
+        class="fd-form-label fd-form-label--horizontal fd-form-label--required"
         for="input-4-zip"
       >
         ZIP Code/City: 
@@ -2037,7 +2037,7 @@ exports[`Storyshots Components/Forms/Form Grid Full screen [M] 1`] = `
       
       
       <label
-        class="fd-form-label"
+        class="fd-form-label fd-form-label--horizontal"
         for="input-4-country"
       >
         Country:
@@ -2434,7 +2434,7 @@ exports[`Storyshots Components/Forms/Form Grid Long label [M] 1`] = `
       
       
       <label
-        class="fd-form-label"
+        class="fd-form-label fd-form-label--horizontal"
         for="input-5-name"
       >
         Name:
@@ -2476,7 +2476,7 @@ exports[`Storyshots Components/Forms/Form Grid Long label [M] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--required"
+        class="fd-form-label  fd-form-label--horizontal fd-form-label--required"
         for="input-5-street"
       >
         Street/No.: 
@@ -2552,7 +2552,7 @@ exports[`Storyshots Components/Forms/Form Grid Long label [M] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--required"
+        class="fd-form-label fd-form-label--horizontal fd-form-label--required"
         for="input-5-zip"
       >
         ZIP Code/City: 
@@ -2628,7 +2628,7 @@ exports[`Storyshots Components/Forms/Form Grid Long label [M] 1`] = `
       
       
       <label
-        class="fd-form-label"
+        class="fd-form-label fd-form-label--horizontal"
         for="input-5-country"
       >
         Country:
@@ -3327,46 +3327,6 @@ exports[`Storyshots Components/Forms/Form Grid Multiple form [XL] 1`] = `
       class="fd-col fd-col-xl--4 fd-col--wrap"
     >
       
-      
-      <div
-        class="fd-row"
-      >
-        
-        
-        <div
-          class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12"
-        >
-          
-          
-          <label
-            class="fd-form-label"
-            for="input-12-name"
-          >
-            Name:
-          </label>
-          
-        
-        </div>
-        
-        
-        <div
-          class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--12"
-        >
-          
-          
-          <input
-            class="fd-input"
-            id="input-12-name"
-            placeholder="Enter First and Last Name"
-            type="text"
-            value="Amelia Perry"
-          />
-          
-        
-        </div>
-        
-      
-      </div>
       
 
       
@@ -4594,7 +4554,7 @@ exports[`Storyshots Components/Forms/Form Grid Single form [L] 1`] = `
       
       
       <label
-        class="fd-form-label"
+        class="fd-form-label fd-form-label--horizontal"
         for="input-7-name"
       >
         Name:
@@ -4631,12 +4591,12 @@ exports[`Storyshots Components/Forms/Form Grid Single form [L] 1`] = `
     
     
     <div
-      class="fd-col  fd-col-md--2 fd-col-lg--3"
+      class="fd-col fd-col-md--2 fd-col-lg--3"
     >
       
       
       <label
-        class="fd-form-label fd-form-label--required"
+        class="fd-form-label fd-form-label--horizontal fd-form-label--required"
         for="input-7-street"
       >
         Street/No.: 
@@ -4712,7 +4672,7 @@ exports[`Storyshots Components/Forms/Form Grid Single form [L] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--required"
+        class="fd-form-label fd-form-label--horizontal fd-form-label--required"
         for="input-7-zip"
       >
         ZIP Code/City: 
@@ -4788,7 +4748,7 @@ exports[`Storyshots Components/Forms/Form Grid Single form [L] 1`] = `
       
       
       <label
-        class="fd-form-label"
+        class="fd-form-label fd-form-label--horizontal"
         for="input-7-country"
       >
         Country:
@@ -4887,7 +4847,7 @@ exports[`Storyshots Components/Forms/Form Grid Single form [XL] 1`] = `
       
       
       <label
-        class="fd-form-label"
+        class="fd-form-label fd-form-label--horizontal"
         for="input-10-name"
       >
         Name:
@@ -4929,7 +4889,7 @@ exports[`Storyshots Components/Forms/Form Grid Single form [XL] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--required"
+        class="fd-form-label fd-form-label--horizontal fd-form-label--required"
         for="input-10-street"
       >
         Street/No.: 
@@ -5005,7 +4965,7 @@ exports[`Storyshots Components/Forms/Form Grid Single form [XL] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--required"
+        class="fd-form-label fd-form-label--horizontal fd-form-label--required"
         for="input-10-zip"
       >
         ZIP Code/City: 
@@ -5081,7 +5041,7 @@ exports[`Storyshots Components/Forms/Form Grid Single form [XL] 1`] = `
       
       
       <label
-        class="fd-form-label"
+        class="fd-form-label fd-form-label--horizontal"
         for="input-10-country"
       >
         Country:
@@ -5441,7 +5401,7 @@ exports[`Storyshots Components/Forms/Form Grid Split screen [M] 1`] = `
       
       
       <label
-        class="fd-form-label"
+        class="fd-form-label fd-form-label--horizontal"
         for="input-3-name"
       >
         Name:
@@ -5483,7 +5443,7 @@ exports[`Storyshots Components/Forms/Form Grid Split screen [M] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--required"
+        class="fd-form-label fd-form-label--horizontal fd-form-label--required"
         for="input-3-street"
       >
         Street/No.: 
@@ -5559,7 +5519,7 @@ exports[`Storyshots Components/Forms/Form Grid Split screen [M] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--required"
+        class="fd-form-label fd-form-label--horizontal fd-form-label--required"
         for="input-3-zip"
       >
         ZIP Code/City: 
@@ -5635,7 +5595,7 @@ exports[`Storyshots Components/Forms/Form Grid Split screen [M] 1`] = `
       
       
       <label
-        class="fd-form-label"
+        class="fd-form-label fd-form-label--horizontal"
         for="input-3-country"
       >
         Country:

--- a/stories/form-grid/__snapshots__/form-grid.stories.storyshot
+++ b/stories/form-grid/__snapshots__/form-grid.stories.storyshot
@@ -192,7 +192,7 @@ exports[`Storyshots Components/Forms/Form Grid Compact form 1`] = `
       
           
       <label
-        class="fd-form-label fd-form-label--compact"
+        class="fd-form-label"
         for="input-13-compact"
       >
         Default Input:
@@ -232,7 +232,7 @@ exports[`Storyshots Components/Forms/Form Grid Compact form 1`] = `
       
           
       <label
-        class="fd-form-label fd-form-label--compact fd-form-label--required"
+        class="fd-form-label fd-form-label--required"
         for="input-13b-compact"
       >
         Required Input: 
@@ -274,7 +274,7 @@ exports[`Storyshots Components/Forms/Form Grid Compact form 1`] = `
       
           
       <label
-        class="fd-form-label fd-form-label--compact"
+        class="fd-form-label"
         id="groupLabel-compact"
       >
         2 Inputs: 
@@ -358,7 +358,7 @@ exports[`Storyshots Components/Forms/Form Grid Default [L] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--horizontal"
+        class="fd-form-label"
         for="input-6-name"
       >
         Name:
@@ -400,7 +400,7 @@ exports[`Storyshots Components/Forms/Form Grid Default [L] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--horizontal fd-form-label--required"
+        class="fd-form-label fd-form-label--required"
         for="input-6-street"
       >
         Street/No.: 
@@ -476,7 +476,7 @@ exports[`Storyshots Components/Forms/Form Grid Default [L] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--horizontal fd-form-label--required"
+        class="fd-form-label fd-form-label--required"
         for="input-6-zip"
       >
         ZIP Code/City: 
@@ -552,7 +552,7 @@ exports[`Storyshots Components/Forms/Form Grid Default [L] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--horizontal"
+        class="fd-form-label"
         for="input-6-country"
       >
         Country:
@@ -653,7 +653,7 @@ exports[`Storyshots Components/Forms/Form Grid Default [M] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--horizontal"
+        class="fd-form-label"
         for="input-2-name"
       >
         Name:
@@ -695,7 +695,7 @@ exports[`Storyshots Components/Forms/Form Grid Default [M] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--horizontal fd-form-label--required"
+        class="fd-form-label fd-form-label--required"
         for="input-2-street"
       >
         Street/No.: 
@@ -771,7 +771,7 @@ exports[`Storyshots Components/Forms/Form Grid Default [M] 1`] = `
       
       
       <label
-        class="fd-form-label  fd-form-label--horizontal fd-form-label--required"
+        class="fd-form-label fd-form-label--required"
         for="input-2-zip"
       >
         ZIP Code/City: 
@@ -847,7 +847,7 @@ exports[`Storyshots Components/Forms/Form Grid Default [M] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--horizontal"
+        class="fd-form-label"
         for="input-2-country"
       >
         Country:
@@ -947,7 +947,7 @@ exports[`Storyshots Components/Forms/Form Grid Default [XL] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--horizontal"
+        class="fd-form-label"
         for="input-9-name"
       >
         Name:
@@ -989,7 +989,7 @@ exports[`Storyshots Components/Forms/Form Grid Default [XL] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--horizontal fd-form-label--required"
+        class="fd-form-label fd-form-label--required"
         for="input-9-street"
       >
         Street/No.: 
@@ -1065,7 +1065,7 @@ exports[`Storyshots Components/Forms/Form Grid Default [XL] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--horizontal fd-form-label--required"
+        class="fd-form-label fd-form-label--required"
         for="input-9-zip"
       >
         ZIP Code/City: 
@@ -1141,7 +1141,7 @@ exports[`Storyshots Components/Forms/Form Grid Default [XL] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--horizontal"
+        class="fd-form-label"
         for="input-9-country"
       >
         Country:
@@ -1251,7 +1251,7 @@ exports[`Storyshots Components/Forms/Form Grid Double form [XL] 1`] = `
           
           
           <label
-            class="fd-form-label fd-form-label--horizontal"
+            class="fd-form-label"
             for="input-11-name"
           >
             Name:
@@ -1293,7 +1293,7 @@ exports[`Storyshots Components/Forms/Form Grid Double form [XL] 1`] = `
           
           
           <label
-            class="fd-form-label fd-form-label--horizontal fd-form-label--required"
+            class="fd-form-label fd-form-label--required"
             for="input-11-street"
           >
             Street/No.: 
@@ -1369,7 +1369,7 @@ exports[`Storyshots Components/Forms/Form Grid Double form [XL] 1`] = `
           
           
           <label
-            class="fd-form-label fd-form-label--horizontal fd-form-label--required"
+            class="fd-form-label fd-form-label--required"
             for="input-11-zip"
           >
             ZIP Code/City: 
@@ -1445,7 +1445,7 @@ exports[`Storyshots Components/Forms/Form Grid Double form [XL] 1`] = `
           
           
           <label
-            class="fd-form-label fd-form-label--horizontal"
+            class="fd-form-label"
             for="input-11-country"
           >
             Country:
@@ -1543,7 +1543,7 @@ exports[`Storyshots Components/Forms/Form Grid Double form [XL] 1`] = `
           
           
           <label
-            class="fd-form-label fd-form-label--horizontal"
+            class="fd-form-label"
             for="input-11a-name"
           >
             Name:
@@ -1585,7 +1585,7 @@ exports[`Storyshots Components/Forms/Form Grid Double form [XL] 1`] = `
           
           
           <label
-            class="fd-form-label fd-form-label--horizontal fd-form-label--required"
+            class="fd-form-label fd-form-label--required"
             for="input-11a-street"
           >
             Street/No.: 
@@ -1661,7 +1661,7 @@ exports[`Storyshots Components/Forms/Form Grid Double form [XL] 1`] = `
           
           
           <label
-            class="fd-form-label fd-form-label--horizontal fd-form-label--required"
+            class="fd-form-label fd-form-label--required"
             for="input-11a-zip"
           >
             ZIP Code/City: 
@@ -1737,7 +1737,7 @@ exports[`Storyshots Components/Forms/Form Grid Double form [XL] 1`] = `
           
           
           <label
-            class="fd-form-label fd-form-label--horizontal"
+            class="fd-form-label"
             for="input-11a-country"
           >
             Country:
@@ -1843,7 +1843,7 @@ exports[`Storyshots Components/Forms/Form Grid Full screen [M] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--horizontal"
+        class="fd-form-label"
         for="input-4-name"
       >
         Name:
@@ -1885,7 +1885,7 @@ exports[`Storyshots Components/Forms/Form Grid Full screen [M] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--horizontal fd-form-label--required"
+        class="fd-form-label fd-form-label--required"
         for="input-4-street"
       >
         Street/No.: 
@@ -1961,7 +1961,7 @@ exports[`Storyshots Components/Forms/Form Grid Full screen [M] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--horizontal fd-form-label--required"
+        class="fd-form-label fd-form-label--required"
         for="input-4-zip"
       >
         ZIP Code/City: 
@@ -2037,7 +2037,7 @@ exports[`Storyshots Components/Forms/Form Grid Full screen [M] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--horizontal"
+        class="fd-form-label"
         for="input-4-country"
       >
         Country:
@@ -2434,7 +2434,7 @@ exports[`Storyshots Components/Forms/Form Grid Long label [M] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--horizontal"
+        class="fd-form-label"
         for="input-5-name"
       >
         Name:
@@ -2476,7 +2476,7 @@ exports[`Storyshots Components/Forms/Form Grid Long label [M] 1`] = `
       
       
       <label
-        class="fd-form-label  fd-form-label--horizontal fd-form-label--required"
+        class="fd-form-label fd-form-label--required"
         for="input-5-street"
       >
         Street/No.: 
@@ -2552,7 +2552,7 @@ exports[`Storyshots Components/Forms/Form Grid Long label [M] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--horizontal fd-form-label--required"
+        class="fd-form-label fd-form-label--required"
         for="input-5-zip"
       >
         ZIP Code/City: 
@@ -2628,7 +2628,7 @@ exports[`Storyshots Components/Forms/Form Grid Long label [M] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--horizontal"
+        class="fd-form-label"
         for="input-5-country"
       >
         Country:
@@ -3319,7 +3319,7 @@ exports[`Storyshots Components/Forms/Form Grid Multiple form [XL] 1`] = `
   
   
   <div
-    class="fd-row"
+    class="fd-row fd-row--top"
   >
     
     
@@ -4554,7 +4554,7 @@ exports[`Storyshots Components/Forms/Form Grid Single form [L] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--horizontal"
+        class="fd-form-label"
         for="input-7-name"
       >
         Name:
@@ -4596,7 +4596,7 @@ exports[`Storyshots Components/Forms/Form Grid Single form [L] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--horizontal fd-form-label--required"
+        class="fd-form-label fd-form-label--required"
         for="input-7-street"
       >
         Street/No.: 
@@ -4667,12 +4667,12 @@ exports[`Storyshots Components/Forms/Form Grid Single form [L] 1`] = `
     
     
     <div
-      class="fd-col  fd-col-md--2 fd-col-lg--3"
+      class="fd-col fd-col-md--2 fd-col-lg--3"
     >
       
       
       <label
-        class="fd-form-label fd-form-label--horizontal fd-form-label--required"
+        class="fd-form-label fd-form-label--required"
         for="input-7-zip"
       >
         ZIP Code/City: 
@@ -4748,7 +4748,7 @@ exports[`Storyshots Components/Forms/Form Grid Single form [L] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--horizontal"
+        class="fd-form-label"
         for="input-7-country"
       >
         Country:
@@ -4847,7 +4847,7 @@ exports[`Storyshots Components/Forms/Form Grid Single form [XL] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--horizontal"
+        class="fd-form-label"
         for="input-10-name"
       >
         Name:
@@ -4889,7 +4889,7 @@ exports[`Storyshots Components/Forms/Form Grid Single form [XL] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--horizontal fd-form-label--required"
+        class="fd-form-label fd-form-label--required"
         for="input-10-street"
       >
         Street/No.: 
@@ -4965,7 +4965,7 @@ exports[`Storyshots Components/Forms/Form Grid Single form [XL] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--horizontal fd-form-label--required"
+        class="fd-form-label fd-form-label--required"
         for="input-10-zip"
       >
         ZIP Code/City: 
@@ -5041,7 +5041,7 @@ exports[`Storyshots Components/Forms/Form Grid Single form [XL] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--horizontal"
+        class="fd-form-label"
         for="input-10-country"
       >
         Country:
@@ -5401,7 +5401,7 @@ exports[`Storyshots Components/Forms/Form Grid Split screen [M] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--horizontal"
+        class="fd-form-label"
         for="input-3-name"
       >
         Name:
@@ -5443,7 +5443,7 @@ exports[`Storyshots Components/Forms/Form Grid Split screen [M] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--horizontal fd-form-label--required"
+        class="fd-form-label fd-form-label--required"
         for="input-3-street"
       >
         Street/No.: 
@@ -5519,7 +5519,7 @@ exports[`Storyshots Components/Forms/Form Grid Split screen [M] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--horizontal fd-form-label--required"
+        class="fd-form-label fd-form-label--required"
         for="input-3-zip"
       >
         ZIP Code/City: 
@@ -5595,7 +5595,7 @@ exports[`Storyshots Components/Forms/Form Grid Split screen [M] 1`] = `
       
       
       <label
-        class="fd-form-label fd-form-label--horizontal"
+        class="fd-form-label"
         for="input-3-country"
       >
         Country:

--- a/stories/form-grid/form-grid.stories.js
+++ b/stories/form-grid/form-grid.stories.js
@@ -109,7 +109,7 @@ Empty grid columns | 0 | There are no empty spaces on the right of the fields.
 export const mSizeDefault = () => `<div class="fd-container fd-form-layout-grid-container" style="max-width:1024px">
   <div class="fd-row">
     <div class="fd-col fd-col-md--2 fd-col-lg--4">
-      <label class="fd-form-label fd-form-label--horizontal" for="input-2-name">Name:</label>
+      <label class="fd-form-label" for="input-2-name">Name:</label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--8">
       <input class="fd-input" type="text" id="input-2-name" placeholder="Enter First and Last Name" value="Amelia Perry">
@@ -118,7 +118,7 @@ export const mSizeDefault = () => `<div class="fd-container fd-form-layout-grid-
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--2 fd-col-lg--4">
-      <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-2-street">Street/No.: </label>
+      <label class="fd-form-label fd-form-label--required" for="input-2-street">Street/No.: </label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--8">
       <div class="fd-row">
@@ -134,7 +134,7 @@ export const mSizeDefault = () => `<div class="fd-container fd-form-layout-grid-
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--2  fd-col-lg--4">
-      <label class="fd-form-label  fd-form-label--horizontal fd-form-label--required" for="input-2-zip">ZIP Code/City: </label>
+      <label class="fd-form-label fd-form-label--required" for="input-2-zip">ZIP Code/City: </label>
     </div>
     <div class="fd-col fd-col-md--10  fd-col-lg--8">
       <div class="fd-row">
@@ -150,7 +150,7 @@ export const mSizeDefault = () => `<div class="fd-container fd-form-layout-grid-
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--2  fd-col-lg--4">
-      <label class="fd-form-label fd-form-label--horizontal" for="input-2-country">Country:</label>
+      <label class="fd-form-label" for="input-2-country">Country:</label>
     </div>
     <div class="fd-col fd-col-md--10  fd-col-lg--8">
       <div class="fd-popover" style="width:100%">
@@ -182,7 +182,7 @@ mSizeDefault.parameters = {
     docs: {
         iframeHeight: 370,
         storyDescription: `
-The default medium form grid uses a single-column layout. The labels are positioned in the same row as the corresponding input field or value by adding the --horizontal modifier on the fd-form-label class. and form groups are positioned below each other.
+The default medium form grid uses a single-column layout. The labels are positioned in the same row as the corresponding input field or value, and form groups are positioned below each other.
 
 ####Label-field ratio
 The default medium form grid is organized into a **2:10:0** label-field ratio. 
@@ -200,7 +200,7 @@ Empty grid columns | 0 | There are no empty spaces on the right of the fields.
 export const mSizeSplitScreen = () => `<div class="fd-container fd-form-layout-grid-container" style="max-width:1024px">
   <div class="fd-row">
     <div class="fd-col fd-col-md--4  fd-col-lg--4">
-      <label class="fd-form-label fd-form-label--horizontal" for="input-3-name">Name:</label>
+      <label class="fd-form-label" for="input-3-name">Name:</label>
     </div>
     <div class="fd-col fd-col-md--7  fd-col-lg--8 fd-col-md--offset-after--1">
       <input class="fd-input" type="text" id="input-3-name" placeholder="Enter First and Last Name" value="Amelia Perry">
@@ -209,7 +209,7 @@ export const mSizeSplitScreen = () => `<div class="fd-container fd-form-layout-g
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--4  fd-col-lg--4">
-      <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-3-street">Street/No.: </label>
+      <label class="fd-form-label fd-form-label--required" for="input-3-street">Street/No.: </label>
     </div>
     <div class="fd-col fd-col-md--7  fd-col-lg--8 fd-col-md--offset-after--1">
       <div class="fd-row">
@@ -225,7 +225,7 @@ export const mSizeSplitScreen = () => `<div class="fd-container fd-form-layout-g
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--4  fd-col-lg--4">
-      <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-3-zip">ZIP Code/City: </label>
+      <label class="fd-form-label fd-form-label--required" for="input-3-zip">ZIP Code/City: </label>
     </div>
     <div class="fd-col fd-col-md--7  fd-col-lg--8 fd-col-md--offset-after--1">
       <div class="fd-row">
@@ -241,7 +241,7 @@ export const mSizeSplitScreen = () => `<div class="fd-container fd-form-layout-g
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--4  fd-col-lg--4">
-      <label class="fd-form-label fd-form-label--horizontal" for="input-3-country">Country:</label>
+      <label class="fd-form-label" for="input-3-country">Country:</label>
     </div>
     <div class="fd-col fd-col-md--7  fd-col-lg--8 fd-col-md--offset-after--1">
       <div class="fd-popover" style="width:100%">
@@ -273,8 +273,7 @@ mSizeSplitScreen.parameters = {
     docs: {
         iframeHeight: 370,
         storyDescription: `
-When the form is positioned in the details part of a split screen, the medium form grid should use a label-field ratio of 4:7:1.The labels are positioned in the same row as
-the corresponding input field or value by adding the --horizontal modifier on the fd-form-label class
+When the form is positioned in the details part of a split screen, the medium form grid should use a label-field ratio of 4:7:1.
 
 ####Label-field ratio
 The medium form grid is organized into a **4:7:1** label-field ratio for split-screen views. 
@@ -293,7 +292,7 @@ Empty grid columns | 1 | There is one empty space on the right of the field.
 export const mSizeFullScreenApp = () => `<div class="fd-container fd-form-layout-grid-container" style="max-width:1024px">
   <div class="fd-row">
     <div class="fd-col fd-col-md--3  fd-col-lg--4">
-      <label class="fd-form-label fd-form-label--horizontal" for="input-4-name">Name:</label>
+      <label class="fd-form-label" for="input-4-name">Name:</label>
     </div>
     <div class="fd-col fd-col-md--5  fd-col-lg--8 fd-col-md--offset-after--4">
       <input class="fd-input" type="text" id="input-4-name" placeholder="Enter First and Last Name" value="Amelia Perry">
@@ -302,7 +301,7 @@ export const mSizeFullScreenApp = () => `<div class="fd-container fd-form-layout
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--3  fd-col-lg--4">
-      <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-4-street">Street/No.: </label>
+      <label class="fd-form-label fd-form-label--required" for="input-4-street">Street/No.: </label>
     </div>
     <div class="fd-col fd-col-md--5  fd-col-lg--8 fd-col-md--offset-after--4">
       <div class="fd-row">
@@ -318,7 +317,7 @@ export const mSizeFullScreenApp = () => `<div class="fd-container fd-form-layout
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--3  fd-col-lg--4">
-      <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-4-zip">ZIP Code/City: </label>
+      <label class="fd-form-label fd-form-label--required" for="input-4-zip">ZIP Code/City: </label>
     </div>
     <div class="fd-col fd-col-md--5  fd-col-lg--8 fd-col-md--offset-after--4">
       <div class="fd-row">
@@ -334,7 +333,7 @@ export const mSizeFullScreenApp = () => `<div class="fd-container fd-form-layout
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--3  fd-col-lg--4">
-      <label class="fd-form-label fd-form-label--horizontal" for="input-4-country">Country:</label>
+      <label class="fd-form-label" for="input-4-country">Country:</label>
     </div>
     <div class="fd-col fd-col-md--5  fd-col-lg--8 fd-col-md--offset-after--4">
       <div class="fd-popover" style="width:100%">
@@ -367,8 +366,6 @@ mSizeFullScreenApp.parameters = {
         iframeHeight: 450,
         storyDescription: `
 If the form is being viewed in a full-screen app, the medium form grid should use a single-column layout.
-The labels are positioned in the same row as the corresponding input field or value by adding the --horizontal modifier on the fd-form-label class.
-
 ####Label-field ratio
 The medium form grid is organized into a **3:5:4** label-field ratio for full-screen views. 
         
@@ -385,7 +382,7 @@ Empty grid columns | 4 | There are four empty spaces on the right of the field.
 export const mSizeFullScreenAppLongLabel = () => `<div class="fd-container fd-form-layout-grid-container" style="max-width:1024px">
   <div class="fd-row">
     <div class="fd-col fd-col-md--4 fd-col-lg--3">
-      <label class="fd-form-label fd-form-label--horizontal" for="input-5-name">Name:</label>
+      <label class="fd-form-label" for="input-5-name">Name:</label>
     </div>
     <div class="fd-col fd-col-md--8 fd-col-lg--5 fd-col--offset-after--4">
       <input class="fd-input" type="text" id="input-5-name" placeholder="Enter First and Last Name" value="Amelia Perry">
@@ -394,7 +391,7 @@ export const mSizeFullScreenAppLongLabel = () => `<div class="fd-container fd-fo
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--4 fd-col-lg--3">
-      <label class="fd-form-label  fd-form-label--horizontal fd-form-label--required" for="input-5-street">Street/No.: </label>
+      <label class="fd-form-label fd-form-label--required" for="input-5-street">Street/No.: </label>
     </div>
     <div class="fd-col fd-col-md--8 fd-col-lg--5 fd-col--offset-after--4">
       <div class="fd-row">
@@ -410,7 +407,7 @@ export const mSizeFullScreenAppLongLabel = () => `<div class="fd-container fd-fo
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--4 fd-col-lg--3">
-      <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-5-zip">ZIP Code/City: </label>
+      <label class="fd-form-label fd-form-label--required" for="input-5-zip">ZIP Code/City: </label>
     </div>
     <div class="fd-col fd-col-md--8 fd-col-lg--5 fd-col--offset-after--4">
       <div class="fd-row">
@@ -426,7 +423,7 @@ export const mSizeFullScreenAppLongLabel = () => `<div class="fd-container fd-fo
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--4 fd-col-lg--3">
-      <label class="fd-form-label fd-form-label--horizontal" for="input-5-country">Country:</label>
+      <label class="fd-form-label" for="input-5-country">Country:</label>
     </div>
     <div class="fd-col fd-col-md--8 fd-col-lg--5 fd-col--offset-after--4">
       <div class="fd-popover" style="width:100%">
@@ -459,9 +456,8 @@ mSizeFullScreenAppLongLabel.parameters = {
         iframeHeight: 450,
         storyDescription: `
 The medium form width can go down to 601 px, providing insufficient space for longer labels and fields. If long labels or input values are necessary, use the label-field ratio of 4:8:0.
-The labels are positioned in the same row as the corresponding input field or value by adding the --horizontal modifier on the fd-form-label class.
-
 ####Label-field ratio
+
 The medium form grid is organized into a **3:5:4** label-field ratio to accommodate long labels and fields. 
 
 Components | Grid columns | Description
@@ -477,7 +473,7 @@ Empty grid columns | 0 | There is no empty space on the right of the field.
 export const lSizeDefault = () => `<div class="fd-container fd-form-layout-grid-container" style="max-width:1440px">
   <div class="fd-row">
     <div class="fd-col fd-col-md--2 fd-col-lg--4">
-      <label class="fd-form-label fd-form-label--horizontal" for="input-6-name">Name:</label>
+      <label class="fd-form-label" for="input-6-name">Name:</label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--8">
       <input class="fd-input" type="text" id="input-6-name" placeholder="Enter First and Last Name" value="Amelia Perry">
@@ -486,7 +482,7 @@ export const lSizeDefault = () => `<div class="fd-container fd-form-layout-grid-
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--2 fd-col-lg--4">
-      <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-6-street">Street/No.: </label>
+      <label class="fd-form-label fd-form-label--required" for="input-6-street">Street/No.: </label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--8">
       <div class="fd-row">
@@ -502,7 +498,7 @@ export const lSizeDefault = () => `<div class="fd-container fd-form-layout-grid-
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--2 fd-col-lg--4">
-      <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-6-zip">ZIP Code/City: </label>
+      <label class="fd-form-label fd-form-label--required" for="input-6-zip">ZIP Code/City: </label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--8">
       <div class="fd-row">
@@ -518,7 +514,7 @@ export const lSizeDefault = () => `<div class="fd-container fd-form-layout-grid-
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--2 fd-col-lg--4">
-      <label class="fd-form-label fd-form-label--horizontal" for="input-6-country">Country:</label>
+      <label class="fd-form-label" for="input-6-country">Country:</label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--8">
       <div class="fd-popover" style="width:100%">
@@ -550,11 +546,9 @@ lSizeDefault.parameters = {
     docs: {
         iframeHeight: 500,
         storyDescription: `
-The default large form grid uses a two-column layout. The form groups are placed side-by-side, displaying all information on one screen to avoid scrolling. 
-In these columns, the labels are positioned in the same row adding the --horizontal modifier on the fd-form-label class.
-Therefore, the form groups adopt the Z layout, directing users’ attention to each row instead of columns.
-
+The default large form grid uses a two-column layout. The form groups are placed side-by-side, displaying all information on one screen to avoid scrolling. In these columns, the labels are positioned in the same row as the corresponding input field or value. Therefore, the form groups adopt the Z layout, directing users’ attention to each row instead of columns.
 ####Label-field ratio
+
 The default large form grid is organized into a **4:8:0** label-field ratio. 
 
 Components | Grid columns | Description
@@ -570,7 +564,7 @@ Empty grid columns | 0 | There is no empty space on the right of the field.
 export const lSizeSingleFormGroup = () => `<div class="fd-container fd-form-layout-grid-container" style="max-width:1440px">
   <div class="fd-row">
     <div class="fd-col fd-col-md--2 fd-col-lg--3">
-      <label class="fd-form-label fd-form-label--horizontal" for="input-7-name">Name:</label>
+      <label class="fd-form-label" for="input-7-name">Name:</label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--5 fd-col-lg--offset-after--4">
       <input class="fd-input" type="text" id="input-7-name" placeholder="Enter First and Last Name" value="Amelia Perry">
@@ -579,7 +573,7 @@ export const lSizeSingleFormGroup = () => `<div class="fd-container fd-form-layo
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--2 fd-col-lg--3">
-      <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-7-street">Street/No.: </label>
+      <label class="fd-form-label fd-form-label--required" for="input-7-street">Street/No.: </label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--5 fd-col-lg--offset-after--4">
       <div class="fd-row">
@@ -594,8 +588,8 @@ export const lSizeSingleFormGroup = () => `<div class="fd-container fd-form-layo
   </div>
 
   <div class="fd-row">
-    <div class="fd-col  fd-col-md--2 fd-col-lg--3">
-      <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-7-zip">ZIP Code/City: </label>
+    <div class="fd-col fd-col-md--2 fd-col-lg--3">
+      <label class="fd-form-label fd-form-label--required" for="input-7-zip">ZIP Code/City: </label>
     </div>
     <div class="fd-col  fd-col-md--10 fd-col-lg--5 fd-col-lg--offset-after--4">
       <div class="fd-row">
@@ -611,7 +605,7 @@ export const lSizeSingleFormGroup = () => `<div class="fd-container fd-form-layo
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--2 fd-col-lg--3">
-      <label class="fd-form-label fd-form-label--horizontal" for="input-7-country">Country:</label>
+      <label class="fd-form-label" for="input-7-country">Country:</label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--5 fd-col-lg--offset-after--4">
       <div class="fd-popover" style="width:100%">
@@ -643,8 +637,7 @@ lSizeSingleFormGroup.parameters = {
         iframeHeight: 530,
         storyDescription: `
 If the form contains a single form group, you can use a single-column layout.
-The labels are positioned in the same row as the corresponding input field or value by adding the --horizontal
-modifier on the fd-form-label class.
+
 
 ####Label-field ratio
 The large form grid is organized into a **3:5:4** label-field ratio for single form groups.
@@ -824,7 +817,7 @@ Empty grid columns | 0 | There are no empty spaces on the right of the fields.
 export const xlDefault = () => `<div class="fd-container fd-form-layout-grid-container">
   <div class="fd-row">
     <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
-      <label class="fd-form-label fd-form-label--horizontal" for="input-9-name">Name:</label>
+      <label class="fd-form-label" for="input-9-name">Name:</label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--8">
       <input class="fd-input" type="text" id="input-9-name" placeholder="Enter First and Last Name" value="Amelia Perry">
@@ -833,7 +826,7 @@ export const xlDefault = () => `<div class="fd-container fd-form-layout-grid-con
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
-      <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-9-street">Street/No.: </label>
+      <label class="fd-form-label fd-form-label--required" for="input-9-street">Street/No.: </label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--8">
       <div class="fd-row">
@@ -849,7 +842,7 @@ export const xlDefault = () => `<div class="fd-container fd-form-layout-grid-con
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
-      <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-9-zip">ZIP Code/City: </label>
+      <label class="fd-form-label fd-form-label--required" for="input-9-zip">ZIP Code/City: </label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--8">
       <div class="fd-row">
@@ -865,7 +858,7 @@ export const xlDefault = () => `<div class="fd-container fd-form-layout-grid-con
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
-      <label class="fd-form-label fd-form-label--horizontal" for="input-9-country">Country:</label>
+      <label class="fd-form-label" for="input-9-country">Country:</label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--8">
       <div class="fd-popover" style="width:100%">
@@ -897,9 +890,9 @@ xlDefault.parameters = {
     docs: {
         iframeHeight: 500,
         storyDescription: `
-The default extra-large form grid uses a two-column layout. The form groups are placed side-by-side, displaying all information on one screen to avoid scrolling. In these columns, the labels are positioned in the same row as the corresponding input field or value by adding the --horizontal modifier on the fd-form-label class. The form groups adopt the Z layout.
-
+The default extra-large form grid uses a two-column layout. The form groups are placed side-by-side, displaying all information on one screen to avoid scrolling. In these columns, the labels are positioned in the same row as the corresponding input field or value. The form groups adopt the Z layout.
 ####Label-field ratio
+
 The default extra-large form grid is organized into a **4:8:0** label-field ratio. Technically, the value is set to -1 and inherits the value of size large, see also the development hint below.
 
 Components | Grid columns | Description
@@ -916,7 +909,7 @@ Empty grid columns | 0 | There are no empty spaces on the right of the fields.
 export const xlSingleFormGroup = () => `<div class="fd-container fd-form-layout-grid-container">
   <div class="fd-row">
     <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--3">
-      <label class="fd-form-label fd-form-label--horizontal" for="input-10-name">Name:</label>
+      <label class="fd-form-label" for="input-10-name">Name:</label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--5 fd-col-xl--offset-after--4">
       <input class="fd-input" type="text" id="input-10-name" placeholder="Enter First and Last Name" value="Amelia Perry">
@@ -925,7 +918,7 @@ export const xlSingleFormGroup = () => `<div class="fd-container fd-form-layout-
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--3">
-      <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-10-street">Street/No.: </label>
+      <label class="fd-form-label fd-form-label--required" for="input-10-street">Street/No.: </label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--5 fd-col-xl--offset-after--4">
       <div class="fd-row">
@@ -941,7 +934,7 @@ export const xlSingleFormGroup = () => `<div class="fd-container fd-form-layout-
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--3">
-      <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-10-zip">ZIP Code/City: </label>
+      <label class="fd-form-label fd-form-label--required" for="input-10-zip">ZIP Code/City: </label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--5 fd-col-xl--offset-after--4">
       <div class="fd-row">
@@ -957,7 +950,7 @@ export const xlSingleFormGroup = () => `<div class="fd-container fd-form-layout-
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--3">
-      <label class="fd-form-label fd-form-label--horizontal" for="input-10-country">Country:</label>
+      <label class="fd-form-label" for="input-10-country">Country:</label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--5 fd-col-xl--offset-after-4">
       <div class="fd-popover" style="width:100%">
@@ -990,7 +983,6 @@ xlSingleFormGroup.parameters = {
         iframeHeight: 500,
         storyDescription: `
 If the form contains a single form group, you can use a single-column layout.
-The labels are positioned in the same row as the corresponding input field or value by adding the --horizontal modifier on the fd-form-label class.
 
 ####Label-field ratio
 The extra-large form grid is organized into a **3:5:4** label-field ratio for single form groups.
@@ -1012,7 +1004,7 @@ export const xlDoubleFormGroup = () => `<div class="fd-container fd-form-layout-
     <div class="fd-col fd-col-xl--6 fd-col--wrap">
       <div class="fd-row">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
-          <label class="fd-form-label fd-form-label--horizontal" for="input-11-name">Name:</label>
+          <label class="fd-form-label" for="input-11-name">Name:</label>
         </div>
         <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--8">
           <input class="fd-input" type="text" id="input-11-name" placeholder="Enter First and Last Name" value="Amelia Perry">
@@ -1021,7 +1013,7 @@ export const xlDoubleFormGroup = () => `<div class="fd-container fd-form-layout-
 
       <div class="fd-row">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
-          <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-11-street">Street/No.: </label>
+          <label class="fd-form-label fd-form-label--required" for="input-11-street">Street/No.: </label>
         </div>
         <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--8">
           <div class="fd-row">
@@ -1037,7 +1029,7 @@ export const xlDoubleFormGroup = () => `<div class="fd-container fd-form-layout-
 
       <div class="fd-row">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
-          <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-11-zip">ZIP Code/City: </label>
+          <label class="fd-form-label fd-form-label--required" for="input-11-zip">ZIP Code/City: </label>
         </div>
         <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--8">
           <div class="fd-row">
@@ -1053,7 +1045,7 @@ export const xlDoubleFormGroup = () => `<div class="fd-container fd-form-layout-
 
       <div class="fd-row">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
-          <label class="fd-form-label fd-form-label--horizontal" for="input-11-country">Country:</label>
+          <label class="fd-form-label" for="input-11-country">Country:</label>
         </div>
         <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--8">
           <div class="fd-popover" style="width:100%">
@@ -1080,7 +1072,7 @@ export const xlDoubleFormGroup = () => `<div class="fd-container fd-form-layout-
     <div class="fd-col fd-col-xl--6 fd-col--wrap">
       <div class="fd-row">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
-          <label class="fd-form-label fd-form-label--horizontal" for="input-11a-name">Name:</label>
+          <label class="fd-form-label" for="input-11a-name">Name:</label>
         </div>
         <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--8">
           <input class="fd-input" type="text" id="input-11a-name" placeholder="Enter First and Last Name" value="Amelia Perry">
@@ -1089,7 +1081,7 @@ export const xlDoubleFormGroup = () => `<div class="fd-container fd-form-layout-
 
       <div class="fd-row">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
-          <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-11a-street">Street/No.: </label>
+          <label class="fd-form-label fd-form-label--required" for="input-11a-street">Street/No.: </label>
         </div>
         <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--8">
           <div class="fd-row">
@@ -1105,7 +1097,7 @@ export const xlDoubleFormGroup = () => `<div class="fd-container fd-form-layout-
 
       <div class="fd-row">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
-          <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-11a-zip">ZIP Code/City: </label>
+          <label class="fd-form-label fd-form-label--required" for="input-11a-zip">ZIP Code/City: </label>
         </div>
         <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--8">
           <div class="fd-row">
@@ -1121,7 +1113,7 @@ export const xlDoubleFormGroup = () => `<div class="fd-container fd-form-layout-
 
       <div class="fd-row">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
-          <label class="fd-form-label fd-form-label--horizontal" for="input-11a-country">Country:</label>
+          <label class="fd-form-label" for="input-11a-country">Country:</label>
         </div>
         <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--8">
           <div class="fd-popover" style="width:100%">
@@ -1155,7 +1147,6 @@ xlDoubleFormGroup.parameters = {
         iframeHeight: 650,
         storyDescription: `
 If the form contains multiple form groups, you can use a two-column layout.
-The labels are positioned in the same row as the corresponding input field or value by adding the --horizontal modifier on the fd-form-label class.
 
 ####Label-field ratio
 The extra-large form grid is organized into a **4:8:0** label-field ratio for double form groups.
@@ -1171,7 +1162,7 @@ Empty grid columns | 0 | There are no empty spaces on the right of the fields.
 };
 
 export const xlMultipleFormGroup = () => `<div class="fd-container fd-form-layout-grid-container">
-  <div class="fd-row">
+  <div class="fd-row fd-row--top">
     <div class="fd-col fd-col-xl--4 fd-col--wrap">
       
 
@@ -1382,7 +1373,7 @@ xlMultipleFormGroup.parameters = {
     docs: {
         iframeHeight: 850,
         storyDescription: `
-If the form contains multiple form groups, you can use a three-column layout.
+If the form contains multiple form groups, you can use a three-column layout.fd-row--top class will organize all the elements evenly on screen.
 
 ####Label-field ratio
 The extra-large form grid is organized into a **12:12:0** label-field ratio for multiple form groups.
@@ -1400,7 +1391,7 @@ Empty grid columns | 0 | There is no empty space on the right of the field.
 export const compactLayout = () => `<div class="fd-container fd-form-layout-grid-container">
     <div class="fd-row">
         <div class="fd-col fd-col--4">
-          <label class="fd-form-label fd-form-label--compact" for="input-13-compact">Default Input:</label>
+          <label class="fd-form-label" for="input-13-compact">Default Input:</label>
         </div>
         <div class="fd-col fd-col--7">
             <input class="fd-input fd-input--compact" type="text" id="input-13-compact" placeholder="Field placeholder text">
@@ -1408,7 +1399,7 @@ export const compactLayout = () => `<div class="fd-container fd-form-layout-grid
     </div>
     <div class="fd-row">
         <div class="fd-col fd-col--4">
-          <label class="fd-form-label fd-form-label--compact fd-form-label--required" for="input-13b-compact">Required Input: </label>
+          <label class="fd-form-label fd-form-label--required" for="input-13b-compact">Required Input: </label>
         </div>
         <div class="fd-col fd-col--7">
             <input class="fd-input fd-input--compact" type="text" id="input-13b-compact" placeholder="Field placeholder text">
@@ -1416,7 +1407,7 @@ export const compactLayout = () => `<div class="fd-container fd-form-layout-grid
     </div>
     <div class="fd-row" role="group" aria-labelledby="groupLabel-compact">
         <div class="fd-col fd-col--4">
-          <label class="fd-form-label fd-form-label--compact"  id="groupLabel-compact">2 Inputs: </label>
+          <label class="fd-form-label"  id="groupLabel-compact">2 Inputs: </label>
         </div>
         <div class="fd-col fd-col--7">
             <div class="fd-row">
@@ -1437,8 +1428,7 @@ compactLayout.parameters = {
     docs: {
         iframeHeight: 200,
         storyDescription: `
-To display the form using a compact layout, add the \`--compact\` modifier on the \`fd-input\` class.
-The labels are positioned in the same row as the corresponding input field or value by adding the --compact modifier on the fd-form-label class.`
+To display the form using a compact layout, add the \`--compact\` modifier on the \`fd-input\` class.`
     }
 };
 

--- a/stories/form-grid/form-grid.stories.js
+++ b/stories/form-grid/form-grid.stories.js
@@ -109,7 +109,7 @@ Empty grid columns | 0 | There are no empty spaces on the right of the fields.
 export const mSizeDefault = () => `<div class="fd-container fd-form-layout-grid-container" style="max-width:1024px">
   <div class="fd-row">
     <div class="fd-col fd-col-md--2 fd-col-lg--4">
-      <label class="fd-form-label" for="input-2-name">Name:</label>
+      <label class="fd-form-label fd-form-label--horizontal" for="input-2-name">Name:</label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--8">
       <input class="fd-input" type="text" id="input-2-name" placeholder="Enter First and Last Name" value="Amelia Perry">
@@ -118,7 +118,7 @@ export const mSizeDefault = () => `<div class="fd-container fd-form-layout-grid-
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--2 fd-col-lg--4">
-      <label class="fd-form-label fd-form-label--required" for="input-2-street">Street/No.: </label>
+      <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-2-street">Street/No.: </label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--8">
       <div class="fd-row">
@@ -134,7 +134,7 @@ export const mSizeDefault = () => `<div class="fd-container fd-form-layout-grid-
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--2  fd-col-lg--4">
-      <label class="fd-form-label fd-form-label--required" for="input-2-zip">ZIP Code/City: </label>
+      <label class="fd-form-label  fd-form-label--horizontal fd-form-label--required" for="input-2-zip">ZIP Code/City: </label>
     </div>
     <div class="fd-col fd-col-md--10  fd-col-lg--8">
       <div class="fd-row">
@@ -150,7 +150,7 @@ export const mSizeDefault = () => `<div class="fd-container fd-form-layout-grid-
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--2  fd-col-lg--4">
-      <label class="fd-form-label" for="input-2-country">Country:</label>
+      <label class="fd-form-label fd-form-label--horizontal" for="input-2-country">Country:</label>
     </div>
     <div class="fd-col fd-col-md--10  fd-col-lg--8">
       <div class="fd-popover" style="width:100%">
@@ -182,7 +182,7 @@ mSizeDefault.parameters = {
     docs: {
         iframeHeight: 370,
         storyDescription: `
-The default medium form grid uses a single-column layout. The labels are positioned in the same row as the corresponding input field or value, and form groups are positioned below each other.
+The default medium form grid uses a single-column layout. The labels are positioned in the same row as the corresponding input field or value by adding the --horizontal modifier on the fd-form-label class. and form groups are positioned below each other.
 
 ####Label-field ratio
 The default medium form grid is organized into a **2:10:0** label-field ratio. 
@@ -200,7 +200,7 @@ Empty grid columns | 0 | There are no empty spaces on the right of the fields.
 export const mSizeSplitScreen = () => `<div class="fd-container fd-form-layout-grid-container" style="max-width:1024px">
   <div class="fd-row">
     <div class="fd-col fd-col-md--4  fd-col-lg--4">
-      <label class="fd-form-label" for="input-3-name">Name:</label>
+      <label class="fd-form-label fd-form-label--horizontal" for="input-3-name">Name:</label>
     </div>
     <div class="fd-col fd-col-md--7  fd-col-lg--8 fd-col-md--offset-after--1">
       <input class="fd-input" type="text" id="input-3-name" placeholder="Enter First and Last Name" value="Amelia Perry">
@@ -209,7 +209,7 @@ export const mSizeSplitScreen = () => `<div class="fd-container fd-form-layout-g
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--4  fd-col-lg--4">
-      <label class="fd-form-label fd-form-label--required" for="input-3-street">Street/No.: </label>
+      <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-3-street">Street/No.: </label>
     </div>
     <div class="fd-col fd-col-md--7  fd-col-lg--8 fd-col-md--offset-after--1">
       <div class="fd-row">
@@ -225,7 +225,7 @@ export const mSizeSplitScreen = () => `<div class="fd-container fd-form-layout-g
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--4  fd-col-lg--4">
-      <label class="fd-form-label fd-form-label--required" for="input-3-zip">ZIP Code/City: </label>
+      <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-3-zip">ZIP Code/City: </label>
     </div>
     <div class="fd-col fd-col-md--7  fd-col-lg--8 fd-col-md--offset-after--1">
       <div class="fd-row">
@@ -241,7 +241,7 @@ export const mSizeSplitScreen = () => `<div class="fd-container fd-form-layout-g
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--4  fd-col-lg--4">
-      <label class="fd-form-label" for="input-3-country">Country:</label>
+      <label class="fd-form-label fd-form-label--horizontal" for="input-3-country">Country:</label>
     </div>
     <div class="fd-col fd-col-md--7  fd-col-lg--8 fd-col-md--offset-after--1">
       <div class="fd-popover" style="width:100%">
@@ -273,7 +273,8 @@ mSizeSplitScreen.parameters = {
     docs: {
         iframeHeight: 370,
         storyDescription: `
-When the form is positioned in the details part of a split screen, the medium form grid should use a label-field ratio of 4:7:1.
+When the form is positioned in the details part of a split screen, the medium form grid should use a label-field ratio of 4:7:1.The labels are positioned in the same row as
+the corresponding input field or value by adding the --horizontal modifier on the fd-form-label class
 
 ####Label-field ratio
 The medium form grid is organized into a **4:7:1** label-field ratio for split-screen views. 
@@ -292,7 +293,7 @@ Empty grid columns | 1 | There is one empty space on the right of the field.
 export const mSizeFullScreenApp = () => `<div class="fd-container fd-form-layout-grid-container" style="max-width:1024px">
   <div class="fd-row">
     <div class="fd-col fd-col-md--3  fd-col-lg--4">
-      <label class="fd-form-label" for="input-4-name">Name:</label>
+      <label class="fd-form-label fd-form-label--horizontal" for="input-4-name">Name:</label>
     </div>
     <div class="fd-col fd-col-md--5  fd-col-lg--8 fd-col-md--offset-after--4">
       <input class="fd-input" type="text" id="input-4-name" placeholder="Enter First and Last Name" value="Amelia Perry">
@@ -301,7 +302,7 @@ export const mSizeFullScreenApp = () => `<div class="fd-container fd-form-layout
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--3  fd-col-lg--4">
-      <label class="fd-form-label fd-form-label--required" for="input-4-street">Street/No.: </label>
+      <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-4-street">Street/No.: </label>
     </div>
     <div class="fd-col fd-col-md--5  fd-col-lg--8 fd-col-md--offset-after--4">
       <div class="fd-row">
@@ -317,7 +318,7 @@ export const mSizeFullScreenApp = () => `<div class="fd-container fd-form-layout
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--3  fd-col-lg--4">
-      <label class="fd-form-label fd-form-label--required" for="input-4-zip">ZIP Code/City: </label>
+      <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-4-zip">ZIP Code/City: </label>
     </div>
     <div class="fd-col fd-col-md--5  fd-col-lg--8 fd-col-md--offset-after--4">
       <div class="fd-row">
@@ -333,7 +334,7 @@ export const mSizeFullScreenApp = () => `<div class="fd-container fd-form-layout
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--3  fd-col-lg--4">
-      <label class="fd-form-label" for="input-4-country">Country:</label>
+      <label class="fd-form-label fd-form-label--horizontal" for="input-4-country">Country:</label>
     </div>
     <div class="fd-col fd-col-md--5  fd-col-lg--8 fd-col-md--offset-after--4">
       <div class="fd-popover" style="width:100%">
@@ -366,6 +367,7 @@ mSizeFullScreenApp.parameters = {
         iframeHeight: 450,
         storyDescription: `
 If the form is being viewed in a full-screen app, the medium form grid should use a single-column layout.
+The labels are positioned in the same row as the corresponding input field or value by adding the --horizontal modifier on the fd-form-label class.
 
 ####Label-field ratio
 The medium form grid is organized into a **3:5:4** label-field ratio for full-screen views. 
@@ -383,7 +385,7 @@ Empty grid columns | 4 | There are four empty spaces on the right of the field.
 export const mSizeFullScreenAppLongLabel = () => `<div class="fd-container fd-form-layout-grid-container" style="max-width:1024px">
   <div class="fd-row">
     <div class="fd-col fd-col-md--4 fd-col-lg--3">
-      <label class="fd-form-label" for="input-5-name">Name:</label>
+      <label class="fd-form-label fd-form-label--horizontal" for="input-5-name">Name:</label>
     </div>
     <div class="fd-col fd-col-md--8 fd-col-lg--5 fd-col--offset-after--4">
       <input class="fd-input" type="text" id="input-5-name" placeholder="Enter First and Last Name" value="Amelia Perry">
@@ -392,7 +394,7 @@ export const mSizeFullScreenAppLongLabel = () => `<div class="fd-container fd-fo
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--4 fd-col-lg--3">
-      <label class="fd-form-label fd-form-label--required" for="input-5-street">Street/No.: </label>
+      <label class="fd-form-label  fd-form-label--horizontal fd-form-label--required" for="input-5-street">Street/No.: </label>
     </div>
     <div class="fd-col fd-col-md--8 fd-col-lg--5 fd-col--offset-after--4">
       <div class="fd-row">
@@ -408,7 +410,7 @@ export const mSizeFullScreenAppLongLabel = () => `<div class="fd-container fd-fo
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--4 fd-col-lg--3">
-      <label class="fd-form-label fd-form-label--required" for="input-5-zip">ZIP Code/City: </label>
+      <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-5-zip">ZIP Code/City: </label>
     </div>
     <div class="fd-col fd-col-md--8 fd-col-lg--5 fd-col--offset-after--4">
       <div class="fd-row">
@@ -424,7 +426,7 @@ export const mSizeFullScreenAppLongLabel = () => `<div class="fd-container fd-fo
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--4 fd-col-lg--3">
-      <label class="fd-form-label" for="input-5-country">Country:</label>
+      <label class="fd-form-label fd-form-label--horizontal" for="input-5-country">Country:</label>
     </div>
     <div class="fd-col fd-col-md--8 fd-col-lg--5 fd-col--offset-after--4">
       <div class="fd-popover" style="width:100%">
@@ -457,6 +459,7 @@ mSizeFullScreenAppLongLabel.parameters = {
         iframeHeight: 450,
         storyDescription: `
 The medium form width can go down to 601 px, providing insufficient space for longer labels and fields. If long labels or input values are necessary, use the label-field ratio of 4:8:0.
+The labels are positioned in the same row as the corresponding input field or value by adding the --horizontal modifier on the fd-form-label class.
 
 ####Label-field ratio
 The medium form grid is organized into a **3:5:4** label-field ratio to accommodate long labels and fields. 
@@ -474,7 +477,7 @@ Empty grid columns | 0 | There is no empty space on the right of the field.
 export const lSizeDefault = () => `<div class="fd-container fd-form-layout-grid-container" style="max-width:1440px">
   <div class="fd-row">
     <div class="fd-col fd-col-md--2 fd-col-lg--4">
-      <label class="fd-form-label" for="input-6-name">Name:</label>
+      <label class="fd-form-label fd-form-label--horizontal" for="input-6-name">Name:</label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--8">
       <input class="fd-input" type="text" id="input-6-name" placeholder="Enter First and Last Name" value="Amelia Perry">
@@ -483,7 +486,7 @@ export const lSizeDefault = () => `<div class="fd-container fd-form-layout-grid-
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--2 fd-col-lg--4">
-      <label class="fd-form-label fd-form-label--required" for="input-6-street">Street/No.: </label>
+      <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-6-street">Street/No.: </label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--8">
       <div class="fd-row">
@@ -499,7 +502,7 @@ export const lSizeDefault = () => `<div class="fd-container fd-form-layout-grid-
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--2 fd-col-lg--4">
-      <label class="fd-form-label fd-form-label--required" for="input-6-zip">ZIP Code/City: </label>
+      <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-6-zip">ZIP Code/City: </label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--8">
       <div class="fd-row">
@@ -515,7 +518,7 @@ export const lSizeDefault = () => `<div class="fd-container fd-form-layout-grid-
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--2 fd-col-lg--4">
-      <label class="fd-form-label" for="input-6-country">Country:</label>
+      <label class="fd-form-label fd-form-label--horizontal" for="input-6-country">Country:</label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--8">
       <div class="fd-popover" style="width:100%">
@@ -547,7 +550,9 @@ lSizeDefault.parameters = {
     docs: {
         iframeHeight: 500,
         storyDescription: `
-The default large form grid uses a two-column layout. The form groups are placed side-by-side, displaying all information on one screen to avoid scrolling. In these columns, the labels are positioned in the same row as the corresponding input field or value. Therefore, the form groups adopt the Z layout, directing users’ attention to each row instead of columns.
+The default large form grid uses a two-column layout. The form groups are placed side-by-side, displaying all information on one screen to avoid scrolling. 
+In these columns, the labels are positioned in the same row adding the --horizontal modifier on the fd-form-label class.
+Therefore, the form groups adopt the Z layout, directing users’ attention to each row instead of columns.
 
 ####Label-field ratio
 The default large form grid is organized into a **4:8:0** label-field ratio. 
@@ -565,7 +570,7 @@ Empty grid columns | 0 | There is no empty space on the right of the field.
 export const lSizeSingleFormGroup = () => `<div class="fd-container fd-form-layout-grid-container" style="max-width:1440px">
   <div class="fd-row">
     <div class="fd-col fd-col-md--2 fd-col-lg--3">
-      <label class="fd-form-label" for="input-7-name">Name:</label>
+      <label class="fd-form-label fd-form-label--horizontal" for="input-7-name">Name:</label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--5 fd-col-lg--offset-after--4">
       <input class="fd-input" type="text" id="input-7-name" placeholder="Enter First and Last Name" value="Amelia Perry">
@@ -573,8 +578,8 @@ export const lSizeSingleFormGroup = () => `<div class="fd-container fd-form-layo
   </div>
 
   <div class="fd-row">
-    <div class="fd-col  fd-col-md--2 fd-col-lg--3">
-      <label class="fd-form-label fd-form-label--required" for="input-7-street">Street/No.: </label>
+    <div class="fd-col fd-col-md--2 fd-col-lg--3">
+      <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-7-street">Street/No.: </label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--5 fd-col-lg--offset-after--4">
       <div class="fd-row">
@@ -590,7 +595,7 @@ export const lSizeSingleFormGroup = () => `<div class="fd-container fd-form-layo
 
   <div class="fd-row">
     <div class="fd-col  fd-col-md--2 fd-col-lg--3">
-      <label class="fd-form-label fd-form-label--required" for="input-7-zip">ZIP Code/City: </label>
+      <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-7-zip">ZIP Code/City: </label>
     </div>
     <div class="fd-col  fd-col-md--10 fd-col-lg--5 fd-col-lg--offset-after--4">
       <div class="fd-row">
@@ -606,7 +611,7 @@ export const lSizeSingleFormGroup = () => `<div class="fd-container fd-form-layo
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--2 fd-col-lg--3">
-      <label class="fd-form-label" for="input-7-country">Country:</label>
+      <label class="fd-form-label fd-form-label--horizontal" for="input-7-country">Country:</label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--5 fd-col-lg--offset-after--4">
       <div class="fd-popover" style="width:100%">
@@ -638,6 +643,8 @@ lSizeSingleFormGroup.parameters = {
         iframeHeight: 530,
         storyDescription: `
 If the form contains a single form group, you can use a single-column layout.
+The labels are positioned in the same row as the corresponding input field or value by adding the --horizontal
+modifier on the fd-form-label class.
 
 ####Label-field ratio
 The large form grid is organized into a **3:5:4** label-field ratio for single form groups.
@@ -817,7 +824,7 @@ Empty grid columns | 0 | There are no empty spaces on the right of the fields.
 export const xlDefault = () => `<div class="fd-container fd-form-layout-grid-container">
   <div class="fd-row">
     <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
-      <label class="fd-form-label" for="input-9-name">Name:</label>
+      <label class="fd-form-label fd-form-label--horizontal" for="input-9-name">Name:</label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--8">
       <input class="fd-input" type="text" id="input-9-name" placeholder="Enter First and Last Name" value="Amelia Perry">
@@ -826,7 +833,7 @@ export const xlDefault = () => `<div class="fd-container fd-form-layout-grid-con
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
-      <label class="fd-form-label fd-form-label--required" for="input-9-street">Street/No.: </label>
+      <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-9-street">Street/No.: </label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--8">
       <div class="fd-row">
@@ -842,7 +849,7 @@ export const xlDefault = () => `<div class="fd-container fd-form-layout-grid-con
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
-      <label class="fd-form-label fd-form-label--required" for="input-9-zip">ZIP Code/City: </label>
+      <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-9-zip">ZIP Code/City: </label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--8">
       <div class="fd-row">
@@ -858,7 +865,7 @@ export const xlDefault = () => `<div class="fd-container fd-form-layout-grid-con
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
-      <label class="fd-form-label" for="input-9-country">Country:</label>
+      <label class="fd-form-label fd-form-label--horizontal" for="input-9-country">Country:</label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--8">
       <div class="fd-popover" style="width:100%">
@@ -890,7 +897,7 @@ xlDefault.parameters = {
     docs: {
         iframeHeight: 500,
         storyDescription: `
-The default extra-large form grid uses a two-column layout. The form groups are placed side-by-side, displaying all information on one screen to avoid scrolling. In these columns, the labels are positioned in the same row as the corresponding input field or value. The form groups adopt the Z layout.
+The default extra-large form grid uses a two-column layout. The form groups are placed side-by-side, displaying all information on one screen to avoid scrolling. In these columns, the labels are positioned in the same row as the corresponding input field or value by adding the --horizontal modifier on the fd-form-label class. The form groups adopt the Z layout.
 
 ####Label-field ratio
 The default extra-large form grid is organized into a **4:8:0** label-field ratio. Technically, the value is set to -1 and inherits the value of size large, see also the development hint below.
@@ -909,7 +916,7 @@ Empty grid columns | 0 | There are no empty spaces on the right of the fields.
 export const xlSingleFormGroup = () => `<div class="fd-container fd-form-layout-grid-container">
   <div class="fd-row">
     <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--3">
-      <label class="fd-form-label" for="input-10-name">Name:</label>
+      <label class="fd-form-label fd-form-label--horizontal" for="input-10-name">Name:</label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--5 fd-col-xl--offset-after--4">
       <input class="fd-input" type="text" id="input-10-name" placeholder="Enter First and Last Name" value="Amelia Perry">
@@ -918,7 +925,7 @@ export const xlSingleFormGroup = () => `<div class="fd-container fd-form-layout-
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--3">
-      <label class="fd-form-label fd-form-label--required" for="input-10-street">Street/No.: </label>
+      <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-10-street">Street/No.: </label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--5 fd-col-xl--offset-after--4">
       <div class="fd-row">
@@ -934,7 +941,7 @@ export const xlSingleFormGroup = () => `<div class="fd-container fd-form-layout-
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--3">
-      <label class="fd-form-label fd-form-label--required" for="input-10-zip">ZIP Code/City: </label>
+      <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-10-zip">ZIP Code/City: </label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--5 fd-col-xl--offset-after--4">
       <div class="fd-row">
@@ -950,7 +957,7 @@ export const xlSingleFormGroup = () => `<div class="fd-container fd-form-layout-
 
   <div class="fd-row">
     <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--3">
-      <label class="fd-form-label" for="input-10-country">Country:</label>
+      <label class="fd-form-label fd-form-label--horizontal" for="input-10-country">Country:</label>
     </div>
     <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--5 fd-col-xl--offset-after-4">
       <div class="fd-popover" style="width:100%">
@@ -983,6 +990,7 @@ xlSingleFormGroup.parameters = {
         iframeHeight: 500,
         storyDescription: `
 If the form contains a single form group, you can use a single-column layout.
+The labels are positioned in the same row as the corresponding input field or value by adding the --horizontal modifier on the fd-form-label class.
 
 ####Label-field ratio
 The extra-large form grid is organized into a **3:5:4** label-field ratio for single form groups.
@@ -1004,7 +1012,7 @@ export const xlDoubleFormGroup = () => `<div class="fd-container fd-form-layout-
     <div class="fd-col fd-col-xl--6 fd-col--wrap">
       <div class="fd-row">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
-          <label class="fd-form-label" for="input-11-name">Name:</label>
+          <label class="fd-form-label fd-form-label--horizontal" for="input-11-name">Name:</label>
         </div>
         <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--8">
           <input class="fd-input" type="text" id="input-11-name" placeholder="Enter First and Last Name" value="Amelia Perry">
@@ -1013,7 +1021,7 @@ export const xlDoubleFormGroup = () => `<div class="fd-container fd-form-layout-
 
       <div class="fd-row">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
-          <label class="fd-form-label fd-form-label--required" for="input-11-street">Street/No.: </label>
+          <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-11-street">Street/No.: </label>
         </div>
         <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--8">
           <div class="fd-row">
@@ -1029,7 +1037,7 @@ export const xlDoubleFormGroup = () => `<div class="fd-container fd-form-layout-
 
       <div class="fd-row">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
-          <label class="fd-form-label fd-form-label--required" for="input-11-zip">ZIP Code/City: </label>
+          <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-11-zip">ZIP Code/City: </label>
         </div>
         <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--8">
           <div class="fd-row">
@@ -1045,7 +1053,7 @@ export const xlDoubleFormGroup = () => `<div class="fd-container fd-form-layout-
 
       <div class="fd-row">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
-          <label class="fd-form-label" for="input-11-country">Country:</label>
+          <label class="fd-form-label fd-form-label--horizontal" for="input-11-country">Country:</label>
         </div>
         <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--8">
           <div class="fd-popover" style="width:100%">
@@ -1072,7 +1080,7 @@ export const xlDoubleFormGroup = () => `<div class="fd-container fd-form-layout-
     <div class="fd-col fd-col-xl--6 fd-col--wrap">
       <div class="fd-row">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
-          <label class="fd-form-label" for="input-11a-name">Name:</label>
+          <label class="fd-form-label fd-form-label--horizontal" for="input-11a-name">Name:</label>
         </div>
         <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--8">
           <input class="fd-input" type="text" id="input-11a-name" placeholder="Enter First and Last Name" value="Amelia Perry">
@@ -1081,7 +1089,7 @@ export const xlDoubleFormGroup = () => `<div class="fd-container fd-form-layout-
 
       <div class="fd-row">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
-          <label class="fd-form-label fd-form-label--required" for="input-11a-street">Street/No.: </label>
+          <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-11a-street">Street/No.: </label>
         </div>
         <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--8">
           <div class="fd-row">
@@ -1097,7 +1105,7 @@ export const xlDoubleFormGroup = () => `<div class="fd-container fd-form-layout-
 
       <div class="fd-row">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
-          <label class="fd-form-label fd-form-label--required" for="input-11a-zip">ZIP Code/City: </label>
+          <label class="fd-form-label fd-form-label--horizontal fd-form-label--required" for="input-11a-zip">ZIP Code/City: </label>
         </div>
         <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--8">
           <div class="fd-row">
@@ -1113,7 +1121,7 @@ export const xlDoubleFormGroup = () => `<div class="fd-container fd-form-layout-
 
       <div class="fd-row">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
-          <label class="fd-form-label" for="input-11a-country">Country:</label>
+          <label class="fd-form-label fd-form-label--horizontal" for="input-11a-country">Country:</label>
         </div>
         <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--8">
           <div class="fd-popover" style="width:100%">
@@ -1147,6 +1155,7 @@ xlDoubleFormGroup.parameters = {
         iframeHeight: 650,
         storyDescription: `
 If the form contains multiple form groups, you can use a two-column layout.
+The labels are positioned in the same row as the corresponding input field or value by adding the --horizontal modifier on the fd-form-label class.
 
 ####Label-field ratio
 The extra-large form grid is organized into a **4:8:0** label-field ratio for double form groups.
@@ -1164,14 +1173,7 @@ Empty grid columns | 0 | There are no empty spaces on the right of the fields.
 export const xlMultipleFormGroup = () => `<div class="fd-container fd-form-layout-grid-container">
   <div class="fd-row">
     <div class="fd-col fd-col-xl--4 fd-col--wrap">
-      <div class="fd-row">
-        <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
-          <label class="fd-form-label" for="input-12-name">Name:</label>
-        </div>
-        <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--12">
-          <input class="fd-input" type="text" id="input-12-name" placeholder="Enter First and Last Name" value="Amelia Perry">
-        </div>
-      </div>
+      
 
       <div class="fd-row">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
@@ -1398,7 +1400,7 @@ Empty grid columns | 0 | There is no empty space on the right of the field.
 export const compactLayout = () => `<div class="fd-container fd-form-layout-grid-container">
     <div class="fd-row">
         <div class="fd-col fd-col--4">
-          <label class="fd-form-label" for="input-13-compact">Default Input:</label>
+          <label class="fd-form-label fd-form-label--compact" for="input-13-compact">Default Input:</label>
         </div>
         <div class="fd-col fd-col--7">
             <input class="fd-input fd-input--compact" type="text" id="input-13-compact" placeholder="Field placeholder text">
@@ -1406,7 +1408,7 @@ export const compactLayout = () => `<div class="fd-container fd-form-layout-grid
     </div>
     <div class="fd-row">
         <div class="fd-col fd-col--4">
-          <label class="fd-form-label fd-form-label--required" for="input-13b-compact">Required Input: </label>
+          <label class="fd-form-label fd-form-label--compact fd-form-label--required" for="input-13b-compact">Required Input: </label>
         </div>
         <div class="fd-col fd-col--7">
             <input class="fd-input fd-input--compact" type="text" id="input-13b-compact" placeholder="Field placeholder text">
@@ -1414,7 +1416,7 @@ export const compactLayout = () => `<div class="fd-container fd-form-layout-grid
     </div>
     <div class="fd-row" role="group" aria-labelledby="groupLabel-compact">
         <div class="fd-col fd-col--4">
-          <label class="fd-form-label"  id="groupLabel-compact">2 Inputs: </label>
+          <label class="fd-form-label fd-form-label--compact"  id="groupLabel-compact">2 Inputs: </label>
         </div>
         <div class="fd-col fd-col--7">
             <div class="fd-row">
@@ -1435,7 +1437,8 @@ compactLayout.parameters = {
     docs: {
         iframeHeight: 200,
         storyDescription: `
-To display the form using a compact layout, add the \`--compact\` modifier on the \`fd-input\` class.`
+To display the form using a compact layout, add the \`--compact\` modifier on the \`fd-input\` class.
+The labels are positioned in the same row as the corresponding input field or value by adding the --compact modifier on the fd-form-label class.`
     }
 };
 


### PR DESCRIPTION
## Related Issue
Closes  #2262 

## Description

BREAKING CHANGE:
Added a new modifier class to fd-row to achieve even alignment of its elements:`fd-row--top` in a form. 

Form Grid aligns items vertically to the center when according to the guideline it should align to the top.

*When you have more than one column and the number of the fields is not equal for each column fields are aligned to the middle instead of to the top*:

![image](https://user-images.githubusercontent.com/3263744/114849311-4b865380-9de8-11eb-8f63-a382457034bf.png)


*According to the guideline it should be aligned to the top*:

![image](https://user-images.githubusercontent.com/3263744/114849463-72448a00-9de8-11eb-870f-7dde4c1cb9b9.png)

## Screenshots


### Before:

![image](https://user-images.githubusercontent.com/3263744/114849311-4b865380-9de8-11eb-8f63-a382457034bf.png)

### After:

![image](https://user-images.githubusercontent.com/3263744/114849463-72448a00-9de8-11eb-870f-7dde4c1cb9b9.png)
#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
