### PR TITLE
fix: table fixed (freeze) column border fix

### DIFF
--- a/src/table.scss
+++ b/src/table.scss
@@ -126,9 +126,12 @@ $block: #{$fd-namespace}-table;
       &--fixed {
         margin-top: -$fd-table-fixed-cell-shift;
         border-top: $fd-table-border;
-        border-right: $fd-table-fixed-cell-border;
         border-left: $fd-table-border;
         height: $fd-table-cozy-cell-height + $fd-table-fixed-cell-shift;
+
+        &-last {
+          border-right: $fd-table-fixed-cell-border;
+        }
 
         @include fd-rtl() {
           border-left: $fd-table-fixed-cell-border;
@@ -229,7 +232,7 @@ $block: #{$fd-namespace}-table;
         background-color: var(--sapList_Hover_Background);
       }
 
-      &:last-of-type {
+      &-last {
         border-right: $fd-table-fixed-cell-border;
       }
 

--- a/src/table.scss
+++ b/src/table.scss
@@ -131,11 +131,11 @@ $block: #{$fd-namespace}-table;
 
         &-last {
           border-right: $fd-table-fixed-cell-border;
-        }
 
-        @include fd-rtl() {
-          border-left: $fd-table-fixed-cell-border;
-          border-right: $fd-table-border;
+          @include fd-rtl() {
+            border-left: $fd-table-fixed-cell-border;
+            border-right: $fd-table-border;
+          }
         }
       }
     }
@@ -234,16 +234,16 @@ $block: #{$fd-namespace}-table;
 
       &-last {
         border-right: $fd-table-fixed-cell-border;
+
+        @include fd-rtl() {
+          border-right: $fd-table-border;
+          border-left: $fd-table-fixed-cell-border;
+        }
       }
 
       @include fd-rtl() {
         left: auto;
         right: 0;
-
-        &:last-of-type {
-          border-right: $fd-table-border;
-          border-left: $fd-table-fixed-cell-border;
-        }
       }
     }
 
@@ -417,6 +417,16 @@ $block: #{$fd-namespace}-table;
   // Modifiers
   &--fixed {
     overflow-x: scroll;
+
+    .#{$block}__header,
+    .#{$block}__body {
+      border-left: none;
+
+      @include fd-rtl() {
+        border-left: $fd-table-border;
+        border-right: none;
+      }
+    }
   }
 
   &--pop-in {

--- a/src/table.scss
+++ b/src/table.scss
@@ -58,6 +58,17 @@ $block: #{$fd-namespace}-table;
     margin: 0;
   }
 
+  @mixin fd-table-fixed-last-cell-border() {
+    &.#{$block}__cell--fixed-last {
+      border-right: $fd-table-fixed-cell-border;
+
+      @include fd-rtl() {
+        border-right: $fd-table-border;
+        border-left: $fd-table-fixed-cell-border;
+      }
+    }
+  }
+
   // LOCAL VARS
   $fd-table-cell-padding: 0.5rem;
   $fd-table-first-cell-padding: 1rem;
@@ -129,14 +140,7 @@ $block: #{$fd-namespace}-table;
         border-left: $fd-table-border;
         height: $fd-table-cozy-cell-height + $fd-table-fixed-cell-shift;
 
-        &-last {
-          border-right: $fd-table-fixed-cell-border;
-
-          @include fd-rtl() {
-            border-left: $fd-table-fixed-cell-border;
-            border-right: $fd-table-border;
-          }
-        }
+        @include fd-table-fixed-last-cell-border();
       }
     }
   }
@@ -232,19 +236,12 @@ $block: #{$fd-namespace}-table;
         background-color: var(--sapList_Hover_Background);
       }
 
-      &-last {
-        border-right: $fd-table-fixed-cell-border;
-
-        @include fd-rtl() {
-          border-right: $fd-table-border;
-          border-left: $fd-table-fixed-cell-border;
-        }
-      }
-
       @include fd-rtl() {
         left: auto;
         right: 0;
       }
+
+      @include fd-table-fixed-last-cell-border();
     }
 
     @include fd-first-child() {

--- a/src/table.scss
+++ b/src/table.scss
@@ -58,17 +58,6 @@ $block: #{$fd-namespace}-table;
     margin: 0;
   }
 
-  @mixin fd-table-fixed-last-cell-border() {
-    &.#{$block}__cell--fixed-last {
-      border-right: $fd-table-fixed-cell-border;
-
-      @include fd-rtl() {
-        border-right: $fd-table-border;
-        border-left: $fd-table-fixed-cell-border;
-      }
-    }
-  }
-
   // LOCAL VARS
   $fd-table-cell-padding: 0.5rem;
   $fd-table-first-cell-padding: 1rem;
@@ -120,6 +109,18 @@ $block: #{$fd-namespace}-table;
     }
   }
 
+  &__header,
+  &__body {
+    .#{$block}__cell--fixed-last {
+      border-right: $fd-table-fixed-cell-border;
+
+      @include fd-rtl() {
+        border-right: $fd-table-border;
+        border-left: $fd-table-fixed-cell-border;
+      }
+    }
+  }
+
   &__header {
     border-top: $fd-table-border;
     border-left: $fd-table-border;
@@ -139,8 +140,6 @@ $block: #{$fd-namespace}-table;
         border-top: $fd-table-border;
         border-left: $fd-table-border;
         height: $fd-table-cozy-cell-height + $fd-table-fixed-cell-shift;
-
-        @include fd-table-fixed-last-cell-border();
       }
     }
   }
@@ -240,8 +239,6 @@ $block: #{$fd-namespace}-table;
         left: auto;
         right: 0;
       }
-
-      @include fd-table-fixed-last-cell-border();
     }
 
     @include fd-first-child() {

--- a/stories/table/__snapshots__/table.stories.storyshot
+++ b/stories/table/__snapshots__/table.stories.storyshot
@@ -2193,6 +2193,7 @@ exports[`Storyshots Components/Table Fixed header 1`] = `
         .fd-table--fixed {
            padding-left: 200px;
         }
+
         [dir=rtl] .fd-table--fixed,
         .fd-table--fixed[dir=rtl] {
            padding-left: 0;
@@ -2234,7 +2235,7 @@ exports[`Storyshots Components/Table Fixed header 1`] = `
                
             <th
               aria-haspopup="true"
-              class="fd-table__cell fd-table__cell--fixed"
+              class="fd-table__cell fd-table__cell--fixed fd-table__cell--fixed-last"
               scope="col"
             >
               
@@ -2330,7 +2331,7 @@ exports[`Storyshots Components/Table Fixed header 1`] = `
             
                
             <th
-              class="fd-table__cell fd-table__cell--fixed"
+              class="fd-table__cell fd-table__cell--fixed fd-table__cell--fixed-last"
               scope="row"
             >
               Row header
@@ -2395,7 +2396,7 @@ exports[`Storyshots Components/Table Fixed header 1`] = `
             
                
             <th
-              class="fd-table__cell fd-table__cell--fixed"
+              class="fd-table__cell fd-table__cell--fixed fd-table__cell--fixed-last"
               scope="row"
             >
               Row header
@@ -2460,7 +2461,7 @@ exports[`Storyshots Components/Table Fixed header 1`] = `
             
                
             <th
-              class="fd-table__cell fd-table__cell--fixed"
+              class="fd-table__cell fd-table__cell--fixed fd-table__cell--fixed-last"
               scope="row"
             >
               Row header

--- a/stories/table/table.stories.js
+++ b/stories/table/table.stories.js
@@ -1448,6 +1448,7 @@ export const fixColumnHeader = () => `
         .fd-table--fixed {
            padding-left: 200px;
         }
+
         [dir=rtl] .fd-table--fixed,
         .fd-table--fixed[dir=rtl] {
            padding-left: 0;
@@ -1464,7 +1465,7 @@ export const fixColumnHeader = () => `
       <table class="fd-table">
          <thead class="fd-table__header">
             <tr class="fd-table__row">
-               <th class="fd-table__cell fd-table__cell--fixed"  aria-haspopup="true" scope="col">
+               <th class="fd-table__cell fd-table__cell--fixed fd-table__cell--fixed-last"  aria-haspopup="true" scope="col">
                 Header Column
                </th>
                <th class="fd-table__cell" scope="col">
@@ -1492,7 +1493,7 @@ export const fixColumnHeader = () => `
          </thead>
          <tbody class="fd-table__body">
             <tr class="fd-table__row">
-               <th class="fd-table__cell fd-table__cell--fixed" scope="row">Row header</th>
+               <th class="fd-table__cell fd-table__cell--fixed fd-table__cell--fixed-last" scope="row">Row header</th>
                <td class="fd-table__cell">Lorem ipsum dolor sit amet ipsum</td>
                <td class="fd-table__cell">Lorem ipsum dolor sit amet ipsum</td>
                <td class="fd-table__cell">Lorem ipsum dolor sit amet ipsum</td>
@@ -1502,7 +1503,7 @@ export const fixColumnHeader = () => `
                <td class="fd-table__cell">Lorem ipsum dolor sit amet ipsum</td>
             </tr>
             <tr class="fd-table__row">
-               <th class="fd-table__cell fd-table__cell--fixed" scope="row">Row header</th>
+               <th class="fd-table__cell fd-table__cell--fixed fd-table__cell--fixed-last" scope="row">Row header</th>
                <td class="fd-table__cell">Lorem ipsum dolor sit amet ipsum</td>
                <td class="fd-table__cell">Lorem ipsum dolor sit amet ipsum</td>
                <td class="fd-table__cell">Lorem ipsum dolor sit amet ipsum</td>
@@ -1512,7 +1513,7 @@ export const fixColumnHeader = () => `
                <td class="fd-table__cell">Lorem ipsum dolor sit amet ipsum</td>
             </tr>
             <tr class="fd-table__row">
-               <th class="fd-table__cell fd-table__cell--fixed" scope="row">Row header</th>
+               <th class="fd-table__cell fd-table__cell--fixed fd-table__cell--fixed-last" scope="row">Row header</th>
                <td class="fd-table__cell">Lorem ipsum dolor sit amet ipsum</td>
                <td class="fd-table__cell">Lorem ipsum dolor sit amet ipsum</td>
                <td class="fd-table__cell">Lorem ipsum dolor sit amet ipsum</td>

--- a/stories/table/table.stories.js
+++ b/stories/table/table.stories.js
@@ -1532,9 +1532,11 @@ fixColumnHeader.storyName = 'Fixed header';
 fixColumnHeader.parameters = {
     docs: {
         storyDescription: `
-Table can display columns with a fixed header. To display fixed headers, wrap the table with the \`fd-table--fixed\` modifier class. In addition, add the \`fd-table__cell--fixed\` modifier class to each cell element, it should be propagated to the entire row. 
-        
-        
+Table can display columns with a fixed header.
+To display fixed headers, wrap the table with the \`fd-table--fixed\` modifier class.
+In addition, add the \`fd-table__cell--fixed\` modifier class to each cell element, it should be propagated to the entire row. 
+Then apply \`.fd-table__cell--fixed-last\` to every last fixed cell in every column to have special border after the fixed columns.
+
 It’s important to hardcode the width of the columns, otherwise the cells will be squished.
     `
     }


### PR DESCRIPTION
## Related Issue

Part of https://github.com/SAP/fundamental-ngx/issues/4415

## Description

We have applied a special right border to the last fixed column by `.class:last-of-type` selector. That's working since we have only one fixed column. Basically, that selector should not be applied to the class as it's working with the type (of the element). The additional class created for that purpose. 

## Screenshots

Nothing changed in the examples. It's more like improvements for the future (when we will provide the ability to use multiple fixed columns), for the NGX library (where we do provide multiple fixed columns but there is a special border not shown).

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [X] All values are in `rem`
- [X] Text elements follow the truncation rules
- [X] hover state of the element follow design spec
- [X] focus state of the element follow design spec
- [X] active state of the element follow design spec
- [X] selected state of the element follow design spec
- [X] selected hover state of the element follow design spec
- [X] pressed state of the element follow design spec
- [X] Responsiveness rules - the component has modifier classes for all breakpoints
- [X] Includes Compact/Cosy/Tablet design
- [X] RTL support
2. The code follows fundamental-styles code standards and style
- [X] only one top level `fd-*` class is used in the file
- [X] BEM naming convention is used
- [X] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [X] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [X] `fd-reset()` mixin is applied to all elements
- [X] Variables are used, if some value is used more than twice.
- [X] Checked if current components can be reused, instead of having new code.
3. Testing
- [X] tested Storybook examples with "CSS Resources" `normalize` option 
- [X] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [X] Verified all styles in IE11
- [X] Updated tests
- [X] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [X] Storybook documentation has been created/updated
- [X] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.