### PR TITLE
fix: quick view inherit display for fit in parent block

### DIFF
--- a/src/quick-view.scss
+++ b/src/quick-view.scss
@@ -18,6 +18,7 @@ $fd-quick-view-group-item-indent: 0.75rem;
     }
   }
 
+  display: inherit;
   min-width: 20rem;
 
   > *:first-child {


### PR DESCRIPTION
## Related Issue
Part of SAP/fundamental-ngx#4963

## Description
- Added `display: inherit`

## Screenshots

### Before:
<img src="https://user-images.githubusercontent.com/14160094/119654612-5265a480-be31-11eb-8510-e9d5ece5a82b.png" width="47%" /> <img src="https://user-images.githubusercontent.com/14160094/119654725-6b6e5580-be31-11eb-8dc8-c7a579808a4b.png" width="47%" />

### After:
<img src="https://user-images.githubusercontent.com/14160094/119654828-8771f700-be31-11eb-9d5e-afe08d9e78af.png" width="47%" /> 
