### PR TITLE
docs: update regular button

### DIFF
--- a/stories/button/__snapshots__/button.stories.storyshot
+++ b/stories/button/__snapshots__/button.stories.storyshot
@@ -22,23 +22,23 @@ exports[`Storyshots Components/Button Button styles 1`] = `
    
         
   <button
-    class="fd-button"
+    class="fd-button fd-button--emphasized"
   >
-    Default Button
+    Primary Button
   </button>
   
         
   <button
-    class="fd-button fd-button--emphasized"
+    class="fd-button"
   >
-    Emphasized Button
+    Secondary Button
   </button>
   
         
   <button
     class="fd-button fd-button--ghost"
   >
-    Ghost Button
+    Secondary Button
   </button>
   
         
@@ -66,7 +66,7 @@ exports[`Storyshots Components/Button Button styles 1`] = `
   <button
     class="fd-button fd-button--transparent"
   >
-    Transparent Button
+    Tertiary Button
   </button>
   
 
@@ -139,26 +139,26 @@ exports[`Storyshots Components/Button Toggle button 1`] = `
   <div
     class="fddocs-container fddocs-button-container"
   >
-     
-    
-    <button
-      class="fd-button"
-    >
-      Default Toggle
-    </button>
     
     
     <button
       class="fd-button fd-button--emphasized"
     >
-      Emphasized Toggle
+      Primary Toggle
+    </button>
+    
+    
+    <button
+      class="fd-button"
+    >
+      Secondary Toggle
     </button>
     
     
     <button
       class="fd-button fd-button--ghost"
     >
-      Ghost Toggle
+      Secondary Toggle
     </button>
     
     
@@ -186,7 +186,7 @@ exports[`Storyshots Components/Button Toggle button 1`] = `
     <button
       class="fd-button fd-button--transparent"
     >
-      Transparent Toggle
+      Tertiary Toggle
     </button>
     
     
@@ -251,23 +251,23 @@ exports[`Storyshots Components/Button Toggle button 1`] = `
      
     
     <button
-      class="fd-button fd-button--toggled"
-    >
-      Default Toggle
-    </button>
-    
-    
-    <button
       class="fd-button fd-button--emphasized fd-button--toggled"
     >
-      Emphasized Toggle
+      Primary Toggle
+    </button>
+        
+    
+    <button
+      class="fd-button fd-button--toggled"
+    >
+      Secondary Toggle
     </button>
     
     
     <button
       class="fd-button fd-button--ghost fd-button--toggled"
     >
-      Ghost Toggle
+      Secondary Toggle
     </button>
     
     
@@ -295,7 +295,7 @@ exports[`Storyshots Components/Button Toggle button 1`] = `
     <button
       class="fd-button fd-button--transparent fd-button--toggled"
     >
-      Transparent Toggle
+      Tertiary Toggle
     </button>
     
     
@@ -360,18 +360,18 @@ exports[`Storyshots Components/Button Toggle button 1`] = `
      
     
     <button
-      class="fd-button fd-button--toggled"
+      class="fd-button fd-button--emphasized fd-button--toggled"
       disabled=""
     >
-      Default Toggle
+      Primary Toggle
     </button>
     
     
     <button
-      class="fd-button fd-button--emphasized fd-button--toggled"
+      class="fd-button fd-button--toggled"
       disabled=""
     >
-      Emphasized Toggle
+      Secondary Toggle
     </button>
     
     
@@ -379,7 +379,7 @@ exports[`Storyshots Components/Button Toggle button 1`] = `
       class="fd-button fd-button--ghost fd-button--toggled"
       disabled=""
     >
-      Ghost Toggle
+      Secondary Toggle
     </button>
     
     
@@ -411,7 +411,7 @@ exports[`Storyshots Components/Button Toggle button 1`] = `
       class="fd-button fd-button--transparent fd-button--toggled"
       disabled=""
     >
-      Transparent Toggle
+      Tertiary Toggle
     </button>
     
     

--- a/stories/button/button.stories.js
+++ b/stories/button/button.stories.js
@@ -41,40 +41,38 @@ export const primary = () => `
  */
 
 export const types = () => `<div class="fddocs-container fddocs-button-container"> 
-        <button class="fd-button">Default Button</button>
-        <button class="fd-button fd-button--emphasized">Emphasized Button</button>
-        <button class="fd-button fd-button--ghost">Ghost Button</button>
+        <button class="fd-button fd-button--emphasized">Primary Button</button>
+        <button class="fd-button">Secondary Button</button>
+        <button class="fd-button fd-button--ghost">Secondary Button</button>
         <button class="fd-button fd-button--positive">Positive Button</button>
         <button class="fd-button fd-button--negative">Negative Button</button>
         <button class="fd-button fd-button--attention">Attention Button</button>
-        <button class="fd-button fd-button--transparent">Transparent Button</button>
+        <button class="fd-button fd-button--transparent">Tertiary Button</button>
 </div>`;
 
 types.storyName = 'Button styles';
 types.parameters = {
     docs: {
-        storyDescription: `    
-- **Default button** is used for neutral or informative (secondary) actions.
-- **Emphasized button** is used to indicate the primary action on the screen.
-- **Ghost button** is used to trigger secondary actions. If a page already has a primary action, but you also need to highlight the most important action in a content toolbar, use the ghost style.
+        storyDescription: `
+- **Primary button** is used to indicate the primary actions on the screen.
+- **Secondary button** is used for neutral or informative (secondary) actions. If a page already has a primary action, but you also need to highlight the most important action in a content toolbar, use the ghost style.
 - **Positive button** is used to trigger positive semantic actions, such as _Accept_ and should always be accompanied by text.
 - **Negative button** is used to trigger negative semantic actions, such as _Reject_ and should always be accompanied by text.
 - **Attention button** is used to trigger a semantic action that needs attention and should always be accompanied by text.
-- **Transparent button** is used to trigger a negative path action within a header or footer bar, and secondary actions in toolbars.
-        
+- **Tertiary button** is used to trigger a negative path action within a header or footer bar, and secondary actions in toolbars.
 `
     }
 };
 
 export const toggle = () => `<h4>Inactive state of toggle button</h4>
-<div class="fddocs-container fddocs-button-container"> 
-    <button class="fd-button">Default Toggle</button>
-    <button class="fd-button fd-button--emphasized">Emphasized Toggle</button>
-    <button class="fd-button fd-button--ghost">Ghost Toggle</button>
+<div class="fddocs-container fddocs-button-container">
+    <button class="fd-button fd-button--emphasized">Primary Toggle</button>
+    <button class="fd-button">Secondary Toggle</button>
+    <button class="fd-button fd-button--ghost">Secondary Toggle</button>
     <button class="fd-button fd-button--positive">Positive Toggle</button>
     <button class="fd-button fd-button--negative">Negative Toggle</button>
     <button class="fd-button fd-button--attention">Attention Toggle</button>
-    <button class="fd-button fd-button--transparent">Transparent Toggle</button>
+    <button class="fd-button fd-button--transparent">Tertiary Toggle</button>
     <button class="fd-button fd-button--menu">
         <span class="fd-button__text">Action Button</span>
         <i class="sap-icon--slim-arrow-down"></i>
@@ -86,13 +84,13 @@ export const toggle = () => `<h4>Inactive state of toggle button</h4>
 </div>
 <h4>Active (toggled) state of toggle button</h4>
 <div class="fddocs-container fddocs-button-container"> 
-    <button class="fd-button fd-button--toggled">Default Toggle</button>
-    <button class="fd-button fd-button--emphasized fd-button--toggled">Emphasized Toggle</button>
-    <button class="fd-button fd-button--ghost fd-button--toggled">Ghost Toggle</button>
+    <button class="fd-button fd-button--emphasized fd-button--toggled">Primary Toggle</button>    
+    <button class="fd-button fd-button--toggled">Secondary Toggle</button>
+    <button class="fd-button fd-button--ghost fd-button--toggled">Secondary Toggle</button>
     <button class="fd-button fd-button--positive fd-button--toggled">Positive Toggle</button>
     <button class="fd-button fd-button--negative fd-button--toggled">Negative Toggle</button>
     <button class="fd-button fd-button--attention fd-button--toggled">Attention Toggle</button>
-    <button class="fd-button fd-button--transparent fd-button--toggled">Transparent Toggle</button>
+    <button class="fd-button fd-button--transparent fd-button--toggled">Tertiary Toggle</button>
     <button class="fd-button fd-button--menu fd-button--toggled">
         <span class="fd-button__text">Action Button</span>
         <i class="sap-icon--slim-arrow-down"></i>
@@ -104,13 +102,13 @@ export const toggle = () => `<h4>Inactive state of toggle button</h4>
 </div>
 <h4>Disabled Toggle button in active state</h4>
 <div class="fddocs-container fddocs-button-container"> 
-    <button class="fd-button fd-button--toggled" disabled>Default Toggle</button>
-    <button class="fd-button fd-button--emphasized fd-button--toggled" disabled>Emphasized Toggle</button>
-    <button class="fd-button fd-button--ghost fd-button--toggled" disabled>Ghost Toggle</button>
+    <button class="fd-button fd-button--emphasized fd-button--toggled" disabled>Primary Toggle</button>
+    <button class="fd-button fd-button--toggled" disabled>Secondary Toggle</button>
+    <button class="fd-button fd-button--ghost fd-button--toggled" disabled>Secondary Toggle</button>
     <button class="fd-button fd-button--positive fd-button--toggled" disabled>Positive Toggle</button>
     <button class="fd-button fd-button--negative fd-button--toggled" disabled>Negative Toggle</button>
     <button class="fd-button fd-button--attention fd-button--toggled" disabled>Attention Toggle</button>
-    <button class="fd-button fd-button--transparent fd-button--toggled" disabled>Transparent Toggle</button>
+    <button class="fd-button fd-button--transparent fd-button--toggled" disabled>Tertiary Toggle</button>
     <button class="fd-button fd-button--menu fd-button--toggled" aria-disabled="true" disabled>
         <span class="fd-button__text">Action Button</span>
         <i class="sap-icon--slim-arrow-down"></i>
@@ -550,3 +548,4 @@ Note: For the text to be read out loud by screen readers, a helper text has been
 `
     }
 };
+


### PR DESCRIPTION
part of #2327 

This is a new PR duplicate of https://github.com/SAP/fundamental-styles/pull/2387 originally by @hanjunt - reopening this PR on a separate branch due to rebase commit message reword not cooperating with the new lint commit hooks.

All text below from @hanjunt :
Update documentation for buttons

## Related Issue
Part of SAP/fundamental-styles#2327 - Documentation Requests:Button

## Description
"Fundamental buttons should be renamed to Primary/Secondary/Tertiary"
You can find the request at https://github.com/SAP/fundamental-styles/issues/2327 under ```Documentation Requests: Button```

## Screenshots
![Screen Shot 2021-05-26 at 11 21 46 AM](https://user-images.githubusercontent.com/46663585/119686842-b88ffe80-be14-11eb-8ac1-9e055f66ace5.png)
![Screen Shot 2021-05-26 at 11 22 29 AM](https://user-images.githubusercontent.com/46663585/119686846-b9289500-be14-11eb-969b-30563d06c400.png)


### Before:


### After:

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
