### PR TITLE
fix: show navigation button on hover in carousel content area, carousel component css moved from ngx

### DIFF
--- a/.storybook/custom/custom.scss
+++ b/.storybook/custom/custom.scss
@@ -700,3 +700,8 @@ body.sb-show-main {
 .fddocs-list-height {
   height: 11rem;
 }
+
+.fddocs-horizontal-center {
+  display: flex;
+  justify-content: center;
+}

--- a/.storybook/custom/custom.scss
+++ b/.storybook/custom/custom.scss
@@ -705,3 +705,15 @@ body.sb-show-main {
   display: flex;
   justify-content: center;
 }
+
+.fddoc-carousel-example {
+  margin-bottom: 3rem;
+  width: 30rem;
+  height: 15.5rem;
+}
+
+.fddoc-horizontal-carousel-example {
+  margin-bottom: 3rem;
+  width: 60rem;
+  height: 15.5rem;
+}

--- a/.storybook/custom/custom.scss
+++ b/.storybook/custom/custom.scss
@@ -700,20 +700,3 @@ body.sb-show-main {
 .fddocs-list-height {
   height: 11rem;
 }
-
-.fddocs-horizontal-center {
-  display: flex;
-  justify-content: center;
-}
-
-.fddoc-carousel-example {
-  margin-bottom: 3rem;
-  width: 30rem;
-  height: 15.5rem;
-}
-
-.fddoc-horizontal-carousel-example {
-  margin-bottom: 3rem;
-  width: 60rem;
-  height: 15.5rem;
-}

--- a/src/carousel.scss
+++ b/src/carousel.scss
@@ -21,8 +21,12 @@ $button: #{$fd-namespace}-button;
   @include fd-reset();
   @include fd-flex(column);
 
-  @include fd-focus() {
-    outline: 0.0625rem dotted;
+  @include fd-hover() {
+    .#{$block}__content {
+      .#{$block}__button.#{$button} {
+        display: block;
+      }
+    }
   }
 
   width: 100%;
@@ -44,16 +48,13 @@ $button: #{$fd-namespace}-button;
       margin: 0;
       top: calc(50%);
       transform: translateY(-50%);
+      display: none;
 
       &.#{$block}__button--left {
         left: $fd-carousel-button-content-offset;
 
-        @include fd-focus() {
-          right: auto;
-        }
-
         @include fd-rtl() {
-          left: auto;
+          left: initial;
           right: $fd-carousel-button-content-offset;
         }
       }
@@ -61,12 +62,8 @@ $button: #{$fd-namespace}-button;
       &.#{$block}__button--right {
         right: $fd-carousel-button-content-offset;
 
-        @include fd-focus() {
-          right: auto;
-        }
-
         @include fd-rtl() {
-          right: auto;
+          right: initial;
           left: $fd-carousel-button-content-offset;
         }
       }
@@ -162,6 +159,12 @@ $button: #{$fd-namespace}-button;
         right: -0.25rem;
         height: $fd-carousel-touchable-button-size;
         width: $fd-carousel-touchable-button-size;
+      }
+
+      @include fd-rtl() {
+        & > [class*=sap-icon] {
+          transform: rotate(180deg);
+        }
       }
 
       @include fd-focus() {

--- a/src/carousel.scss
+++ b/src/carousel.scss
@@ -185,7 +185,7 @@ $button: #{$fd-namespace}-button;
 
   &--no-navigation {
     .#{$block}__button.#{$button} {
-      display: none;
+      display: none !important;
     }
   }
 

--- a/src/carousel.scss
+++ b/src/carousel.scss
@@ -72,6 +72,14 @@ $button: #{$fd-namespace}-button;
     &--display {
       overflow: hidden;
     }
+
+    &--horizontal {
+      @include fd-flex();
+    }
+
+    &--error-message {
+      @include fd-flex-center();
+    }
   }
 
   &__item {
@@ -180,12 +188,6 @@ $button: #{$fd-namespace}-button;
           @include after-position-overwrite();
         }
       }
-    }
-  }
-
-  &__horizontal {
-    @include fd-flex-vertical-center() {
-      width: 100%;
     }
   }
 

--- a/src/carousel.scss
+++ b/src/carousel.scss
@@ -185,7 +185,15 @@ $button: #{$fd-namespace}-button;
 
   &--no-navigation {
     .#{$block}__button.#{$button} {
-      display: none !important;
+      display: none;
+    }
+
+    @include fd-hover() {
+      .#{$block}__content {
+        .#{$block}__button.#{$button} {
+          display: none;
+        }
+      }
     }
   }
 

--- a/src/carousel.scss
+++ b/src/carousel.scss
@@ -22,7 +22,7 @@ $button: #{$fd-namespace}-button;
   @include fd-flex(column);
 
   @include fd-focus() {
-    outline: 1px dotted;
+    outline: 0.0625rem dotted;
   }
 
   width: 100%;

--- a/src/carousel.scss
+++ b/src/carousel.scss
@@ -16,10 +16,15 @@ $button: #{$fd-namespace}-button;
 
   @mixin after-position-overwrite() {
     outline-offset: $fd-carousel-button-focus-outline-offset;
+    top: 50%;
   }
 
   @include fd-reset();
   @include fd-flex(column);
+
+  @include fd-focus() {
+    outline: 1px dotted;
+  }
 
   width: 100%;
   min-width: 15.5rem;
@@ -44,8 +49,12 @@ $button: #{$fd-namespace}-button;
       &.#{$block}__button--left {
         left: $fd-carousel-button-content-offset;
 
+        @include fd-focus() {
+          right: auto;
+        }
+
         @include fd-rtl() {
-          left: initial;
+          left: auto;
           right: $fd-carousel-button-content-offset;
         }
       }
@@ -53,11 +62,19 @@ $button: #{$fd-namespace}-button;
       &.#{$block}__button--right {
         right: $fd-carousel-button-content-offset;
 
+        @include fd-focus() {
+          right: auto;
+        }
+
         @include fd-rtl() {
-          right: initial;
+          right: auto;
           left: $fd-carousel-button-content-offset;
         }
       }
+    }
+
+    &--display {
+      overflow: hidden;
     }
   }
 
@@ -148,11 +165,11 @@ $button: #{$fd-namespace}-button;
         width: $fd-carousel-touchable-button-size;
       }
 
-      @include fd-rtl() {
-        & > [class*=sap-icon] {
-          transform: rotate(180deg);
-        }
-      }
+      // @include fd-rtl() {
+      //   & > [class*=sap-icon] {
+      //     transform: rotate(180deg);
+      //   }
+      // }
 
       @include fd-focus() {
         @include after-position-overwrite();
@@ -174,5 +191,12 @@ $button: #{$fd-namespace}-button;
     .#{$block}__button.#{$button} {
       display: none;
     }
+  }
+
+  &--horizontal {
+    @include fd-reset();
+    @include fd-flex-vertical-center();
+
+    width: 100%;
   }
 }

--- a/src/carousel.scss
+++ b/src/carousel.scss
@@ -23,7 +23,7 @@ $button: #{$fd-namespace}-button;
 
   @include fd-hover() {
     .#{$block}__content {
-      .#{$block}__button.#{$button} {
+      .#{$block}__button {
         display: block;
       }
     }
@@ -183,6 +183,12 @@ $button: #{$fd-namespace}-button;
     }
   }
 
+  &__horizontal {
+    @include fd-flex-vertical-center() {
+      width: 100%;
+    }
+  }
+
   &--no-navigation {
     .#{$block}__button.#{$button} {
       display: none;
@@ -190,16 +196,10 @@ $button: #{$fd-namespace}-button;
 
     @include fd-hover() {
       .#{$block}__content {
-        .#{$block}__button.#{$button} {
+        .#{$block}__button {
           display: none;
         }
       }
-    }
-  }
-
-  &--horizontal {
-    @include fd-flex-vertical-center() {
-      width: 100%;
     }
   }
 }

--- a/src/carousel.scss
+++ b/src/carousel.scss
@@ -16,7 +16,6 @@ $button: #{$fd-namespace}-button;
 
   @mixin after-position-overwrite() {
     outline-offset: $fd-carousel-button-focus-outline-offset;
-    top: 50%;
   }
 
   @include fd-reset();
@@ -165,12 +164,6 @@ $button: #{$fd-namespace}-button;
         width: $fd-carousel-touchable-button-size;
       }
 
-      // @include fd-rtl() {
-      //   & > [class*=sap-icon] {
-      //     transform: rotate(180deg);
-      //   }
-      // }
-
       @include fd-focus() {
         @include after-position-overwrite();
       }
@@ -194,9 +187,8 @@ $button: #{$fd-namespace}-button;
   }
 
   &--horizontal {
-    @include fd-reset();
-    @include fd-flex-vertical-center();
-
-    width: 100%;
+    @include fd-flex-vertical-center() {
+      width: 100%;
+    }
   }
 }

--- a/src/carousel.scss
+++ b/src/carousel.scss
@@ -76,10 +76,6 @@ $button: #{$fd-namespace}-button;
     &--horizontal {
       @include fd-flex();
     }
-
-    &--error-message {
-      @include fd-flex-center();
-    }
   }
 
   &__item {

--- a/stories/carousel/__snapshots__/carousel.stories.storyshot
+++ b/stories/carousel/__snapshots__/carousel.stories.storyshot
@@ -685,7 +685,7 @@ exports[`Storyshots Components/Carousel Items in horizontal direction 1`] = `
     
         
     <div
-      class="fd-carousel__content fd-carousel__horizontal"
+      class="fd-carousel__content fd-carousel__content--horizontal"
       style="text-align: center; padding: 1rem; min-height: 15.5rem;"
     >
       
@@ -793,7 +793,8 @@ exports[`Storyshots Components/Carousel Items in horizontal direction 1`] = `
         
                 
         <li
-          class="fd-carousel__page-indicator"
+          aria-label="Displaying item 2 of 3"
+          class="fd-carousel__page-indicator fd-carousel__page-indicator--active"
           data-slide-to="2"
         />
         
@@ -801,31 +802,6 @@ exports[`Storyshots Components/Carousel Items in horizontal direction 1`] = `
         <li
           class="fd-carousel__page-indicator"
           data-slide-to="3"
-        />
-        
-                
-        <li
-          class="fd-carousel__page-indicator"
-          data-slide-to="4"
-        />
-        
-                
-        <li
-          aria-label="Displaying item 2 of 3"
-          class="fd-carousel__page-indicator fd-carousel__page-indicator--active"
-          data-slide-to="5"
-        />
-        
-                
-        <li
-          class="fd-carousel__page-indicator"
-          data-slide-to="6"
-        />
-        
-                
-        <li
-          class="fd-carousel__page-indicator"
-          data-slide-to="7"
         />
         
             
@@ -861,6 +837,116 @@ exports[`Storyshots Components/Carousel Items in horizontal direction 1`] = `
   >
     
         Displaying item 2 of 3
+    
+  </div>
+  
+
+</div>
+`;
+
+exports[`Storyshots Components/Carousel Items loading error 1`] = `
+<div
+  style="display: flex; flex-direction: column; align-items: center; background: #CCD1D1;"
+>
+  
+    
+  <h4>
+    Error in loading items
+  </h4>
+  
+    
+  <div
+    class="fd-carousel fd-carousel--no-navigation"
+    data-ride="carousel"
+    style="margin-bottom: 3rem; max-width: 60rem;"
+  >
+    
+        
+    <div
+      class="fd-carousel__content fd-carousel__content--error-message"
+      style="text-align: center; padding: 1rem; min-height: 15.5rem;"
+    >
+      
+            
+      <div
+        class="docs-column-flex"
+      >
+        
+                
+        <div
+          class="fddocs-horizontal-center"
+        >
+          
+                    
+          <i
+            class="sap-icon--document"
+          />
+          
+                
+        </div>
+        
+                Items could not be loaded
+            
+      </div>
+      
+        
+    </div>
+    
+        
+    <div
+      class="fd-carousel__page-indicator-container"
+    >
+      
+            
+      <button
+        aria-label="Go to previous item"
+        class="fd-button fd-carousel__button fd-carousel__button--left"
+        data-slide="prev"
+      >
+        
+                
+        <i
+          class="sap-icon--slim-arrow-left"
+        />
+        
+            
+      </button>
+      
+            
+      <ol
+        class="fd-carousel__page-indicators"
+      />
+      
+            
+      <button
+        aria-label="Go to next item"
+        class="fd-button fd-carousel__button fd-carousel__button--right"
+        data-slide="next"
+      >
+        
+                
+        <i
+          class="sap-icon--slim-arrow-right"
+        />
+        
+            
+      </button>
+      
+        
+    </div>
+    
+    
+  </div>
+  
+    
+  <div
+    aria-live="polite"
+    id="carousel-12"
+    role="region"
+    style="display: none;"
+  >
+    
+        Error in loading items
     
   </div>
   

--- a/stories/carousel/__snapshots__/carousel.stories.storyshot
+++ b/stories/carousel/__snapshots__/carousel.stories.storyshot
@@ -685,7 +685,7 @@ exports[`Storyshots Components/Carousel Items in horizontal direction 1`] = `
     
         
     <div
-      class="fd-carousel__content fd-carousel--horizontal"
+      class="fd-carousel__content fd-carousel__horizontal"
       style="text-align: center; padding: 1rem; min-height: 15.5rem;"
     >
       
@@ -696,7 +696,7 @@ exports[`Storyshots Components/Carousel Items in horizontal direction 1`] = `
         
                 
         <div
-          aria-label="Carousel Image 4"
+          aria-label="Carousel Image 5"
           role="img"
           style="
                         width:100%;
@@ -719,7 +719,7 @@ exports[`Storyshots Components/Carousel Items in horizontal direction 1`] = `
         
                 
         <div
-          aria-label="Carousel Image 4"
+          aria-label="Carousel Image 6"
           role="img"
           style="
                         width:100%;
@@ -742,7 +742,7 @@ exports[`Storyshots Components/Carousel Items in horizontal direction 1`] = `
         
                 
         <div
-          aria-label="Carousel Image 4"
+          aria-label="Carousel Image 7"
           role="img"
           style="
                         width:100%;
@@ -811,7 +811,7 @@ exports[`Storyshots Components/Carousel Items in horizontal direction 1`] = `
         
                 
         <li
-          aria-label="Displaying item 5 of 7"
+          aria-label="Displaying item 2 of 3"
           class="fd-carousel__page-indicator fd-carousel__page-indicator--active"
           data-slide-to="5"
         />
@@ -860,7 +860,7 @@ exports[`Storyshots Components/Carousel Items in horizontal direction 1`] = `
     style="display: none;"
   >
     
-        Displaying item 1 of 4
+        Displaying item 2 of 3
     
   </div>
   

--- a/stories/carousel/__snapshots__/carousel.stories.storyshot
+++ b/stories/carousel/__snapshots__/carousel.stories.storyshot
@@ -678,32 +678,84 @@ exports[`Storyshots Components/Carousel Items in horizontal direction 1`] = `
   
     
   <div
-    class="fd-carousel"
-    data-ride="carousel"
-    style="margin-bottom: 3rem; max-width: 60rem;"
+    class="fddoc-horizontal-carousel-example"
   >
     
         
     <div
-      class="fd-carousel__content fd-carousel__content--horizontal"
-      style="text-align: center; padding: 1rem; min-height: 15.5rem;"
+      class="fd-carousel"
+      data-ride="carousel"
     >
       
             
       <div
-        class="fd-carousel__item fd-carousel__item--active"
+        class="fd-carousel__content fd-carousel__content--horizontal"
       >
         
                 
         <div
-          aria-label="Carousel Image 5"
-          role="img"
-          style="
-                        width:100%;
-                        background-image: url(assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg);
-                        height: 15.5rem;
-                        background-size:cover;"
+          class="fd-carousel__item fd-carousel__item--active"
         >
+          
+                    
+          <div
+            aria-label="Carousel Image 5"
+            role="img"
+            style="
+                            width:100%;
+                            background-image: url(assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg);
+                            height: 15.5rem;
+                            background-size:cover;"
+          >
+            
+                    
+          </div>
+          
+                
+        </div>
+        
+
+                
+        <div
+          class="fd-carousel__item fd-carousel__item--active"
+        >
+          
+                    
+          <div
+            aria-label="Carousel Image 6"
+            role="img"
+            style="
+                            width:100%;
+                            background-image: url(assets/images/backgrounds/city.jpg);
+                            height: 15.5rem;
+                            background-size:cover;"
+          >
+            
+                    
+          </div>
+          
+                
+        </div>
+        
+
+                
+        <div
+          class="fd-carousel__item fd-carousel__item--active"
+        >
+          
+                    
+          <div
+            aria-label="Carousel Image 7"
+            role="img"
+            style="
+                            width:100%;
+                            background-image: url(assets/images/backgrounds/leaves.jpg);
+                            height: 15.5rem;
+                            background-size:cover;"
+          >
+            
+                    
+          </div>
           
                 
         </div>
@@ -711,116 +763,70 @@ exports[`Storyshots Components/Carousel Items in horizontal direction 1`] = `
             
       </div>
       
-
             
       <div
-        class="fd-carousel__item fd-carousel__item--active"
+        class="fd-carousel__page-indicator-container"
       >
         
                 
-        <div
-          aria-label="Carousel Image 6"
-          role="img"
-          style="
-                        width:100%;
-                        background-image: url(assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg);
-                        height: 15.5rem;
-                        background-size:cover;"
+        <button
+          aria-label="Go to previous item"
+          class="fd-button fd-carousel__button fd-carousel__button--left"
+          data-slide="prev"
         >
           
+                    
+          <i
+            class="sap-icon--slim-arrow-left"
+          />
+          
                 
-        </div>
+        </button>
+        
+                
+        <ol
+          class="fd-carousel__page-indicators"
+        >
+          
+                    
+          <li
+            class="fd-carousel__page-indicator"
+            data-slide-to="1"
+          />
+          
+                    
+          <li
+            aria-label="Displaying item 2 of 3"
+            class="fd-carousel__page-indicator fd-carousel__page-indicator--active"
+            data-slide-to="2"
+          />
+          
+                    
+          <li
+            class="fd-carousel__page-indicator"
+            data-slide-to="3"
+          />
+          
+                
+        </ol>
+        
+                
+        <button
+          aria-label="Go to next item"
+          class="fd-button fd-carousel__button fd-carousel__button--right"
+          data-slide="next"
+        >
+          
+                    
+          <i
+            class="sap-icon--slim-arrow-right"
+          />
+          
+                
+        </button>
         
             
       </div>
-      
-
-            
-      <div
-        class="fd-carousel__item fd-carousel__item--active"
-      >
-        
-                
-        <div
-          aria-label="Carousel Image 7"
-          role="img"
-          style="
-                        width:100%;
-                        background-image: url(assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg);
-                        height: 15.5rem;
-                        background-size:cover;"
-        >
-          
-                
-        </div>
-        
-            
-      </div>
-      
-        
-    </div>
-    
-        
-    <div
-      class="fd-carousel__page-indicator-container"
-    >
-      
-            
-      <button
-        aria-label="Go to previous item"
-        class="fd-button fd-carousel__button fd-carousel__button--left"
-        data-slide="prev"
-      >
-        
-                
-        <i
-          class="sap-icon--slim-arrow-left"
-        />
-        
-            
-      </button>
-      
-            
-      <ol
-        class="fd-carousel__page-indicators"
-      >
-        
-                
-        <li
-          class="fd-carousel__page-indicator"
-          data-slide-to="1"
-        />
-        
-                
-        <li
-          aria-label="Displaying item 2 of 3"
-          class="fd-carousel__page-indicator fd-carousel__page-indicator--active"
-          data-slide-to="2"
-        />
-        
-                
-        <li
-          class="fd-carousel__page-indicator"
-          data-slide-to="3"
-        />
-        
-            
-      </ol>
-      
-            
-      <button
-        aria-label="Go to next item"
-        class="fd-button fd-carousel__button fd-carousel__button--right"
-        data-slide="next"
-      >
-        
-                
-        <i
-          class="sap-icon--slim-arrow-right"
-        />
-        
-            
-      </button>
       
         
     </div>
@@ -856,81 +862,87 @@ exports[`Storyshots Components/Carousel Items loading error 1`] = `
   
     
   <div
-    class="fd-carousel fd-carousel--no-navigation"
-    data-ride="carousel"
-    style="margin-bottom: 3rem; max-width: 60rem;"
+    class="fddoc-carousel-example"
   >
     
         
     <div
-      class="fd-carousel__content fd-carousel__content--error-message"
-      style="text-align: center; padding: 1rem; min-height: 15.5rem;"
+      class="fd-carousel fd-carousel--no-navigation"
+      data-ride="carousel"
     >
       
             
       <div
-        class="docs-column-flex"
+        class="fd-carousel__content fd-carousel__content--error-message"
       >
         
                 
         <div
-          class="fddocs-horizontal-center"
+          class="docs-column-flex"
+        >
+          
+                    
+          <div
+            class="fddocs-horizontal-center"
+          >
+            
+                        
+            <i
+              class="sap-icon--document"
+            />
+            
+                    
+          </div>
+          
+                    Items could not be loaded
+                
+        </div>
+        
+            
+      </div>
+      
+            
+      <div
+        class="fd-carousel__page-indicator-container"
+      >
+        
+                
+        <button
+          aria-label="Go to previous item"
+          class="fd-button fd-carousel__button fd-carousel__button--left"
+          data-slide="prev"
         >
           
                     
           <i
-            class="sap-icon--document"
+            class="sap-icon--slim-arrow-left"
           />
           
                 
-        </div>
+        </button>
         
-                Items could not be loaded
+                
+        <ol
+          class="fd-carousel__page-indicators"
+        />
+        
+                
+        <button
+          aria-label="Go to next item"
+          class="fd-button fd-carousel__button fd-carousel__button--right"
+          data-slide="next"
+        >
+          
+                    
+          <i
+            class="sap-icon--slim-arrow-right"
+          />
+          
+                
+        </button>
+        
             
       </div>
-      
-        
-    </div>
-    
-        
-    <div
-      class="fd-carousel__page-indicator-container"
-    >
-      
-            
-      <button
-        aria-label="Go to previous item"
-        class="fd-button fd-carousel__button fd-carousel__button--left"
-        data-slide="prev"
-      >
-        
-                
-        <i
-          class="sap-icon--slim-arrow-left"
-        />
-        
-            
-      </button>
-      
-            
-      <ol
-        class="fd-carousel__page-indicators"
-      />
-      
-            
-      <button
-        aria-label="Go to next item"
-        class="fd-button fd-carousel__button fd-carousel__button--right"
-        data-slide="next"
-      >
-        
-                
-        <i
-          class="sap-icon--slim-arrow-right"
-        />
-        
-            
-      </button>
       
         
     </div>

--- a/stories/carousel/__snapshots__/carousel.stories.storyshot
+++ b/stories/carousel/__snapshots__/carousel.stories.storyshot
@@ -528,7 +528,7 @@ exports[`Storyshots Components/Carousel Hidden navigation buttons 1`] = `
     
   <div
     aria-live="polite"
-    id="carousel-1"
+    id="carousel-9"
     role="region"
     style="display: none;"
   >
@@ -653,7 +653,209 @@ exports[`Storyshots Components/Carousel Hidden navigation buttons 1`] = `
     
   <div
     aria-live="polite"
-    id="carousel-6"
+    id="carousel-10"
+    role="region"
+    style="display: none;"
+  >
+    
+        Displaying item 1 of 4
+    
+  </div>
+  
+
+</div>
+`;
+
+exports[`Storyshots Components/Carousel Items in horizontal direction 1`] = `
+<div
+  style="display: flex; flex-direction: column; align-items: center; background: #CCD1D1;"
+>
+  
+    
+  <h4>
+    Items in horizontal direction
+  </h4>
+  
+    
+  <div
+    class="fd-carousel"
+    data-ride="carousel"
+    style="margin-bottom: 3rem; max-width: 60rem;"
+  >
+    
+        
+    <div
+      class="fd-carousel__content fd-carousel--horizontal"
+      style="text-align: center; padding: 1rem; min-height: 15.5rem;"
+    >
+      
+            
+      <div
+        class="fd-carousel__item fd-carousel__item--active"
+      >
+        
+                
+        <div
+          aria-label="Carousel Image 4"
+          role="img"
+          style="
+                        width:100%;
+                        background-image: url(assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg);
+                        height: 15.5rem;
+                        background-size:cover;"
+        >
+          
+                
+        </div>
+        
+            
+      </div>
+      
+
+            
+      <div
+        class="fd-carousel__item fd-carousel__item--active"
+      >
+        
+                
+        <div
+          aria-label="Carousel Image 4"
+          role="img"
+          style="
+                        width:100%;
+                        background-image: url(assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg);
+                        height: 15.5rem;
+                        background-size:cover;"
+        >
+          
+                
+        </div>
+        
+            
+      </div>
+      
+
+            
+      <div
+        class="fd-carousel__item fd-carousel__item--active"
+      >
+        
+                
+        <div
+          aria-label="Carousel Image 4"
+          role="img"
+          style="
+                        width:100%;
+                        background-image: url(assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg);
+                        height: 15.5rem;
+                        background-size:cover;"
+        >
+          
+                
+        </div>
+        
+            
+      </div>
+      
+        
+    </div>
+    
+        
+    <div
+      class="fd-carousel__page-indicator-container"
+    >
+      
+            
+      <button
+        aria-label="Go to previous item"
+        class="fd-button fd-carousel__button fd-carousel__button--left"
+        data-slide="prev"
+      >
+        
+                
+        <i
+          class="sap-icon--slim-arrow-left"
+        />
+        
+            
+      </button>
+      
+            
+      <ol
+        class="fd-carousel__page-indicators"
+      >
+        
+                
+        <li
+          class="fd-carousel__page-indicator"
+          data-slide-to="1"
+        />
+        
+                
+        <li
+          class="fd-carousel__page-indicator"
+          data-slide-to="2"
+        />
+        
+                
+        <li
+          class="fd-carousel__page-indicator"
+          data-slide-to="3"
+        />
+        
+                
+        <li
+          class="fd-carousel__page-indicator"
+          data-slide-to="4"
+        />
+        
+                
+        <li
+          aria-label="Displaying item 5 of 7"
+          class="fd-carousel__page-indicator fd-carousel__page-indicator--active"
+          data-slide-to="5"
+        />
+        
+                
+        <li
+          class="fd-carousel__page-indicator"
+          data-slide-to="6"
+        />
+        
+                
+        <li
+          class="fd-carousel__page-indicator"
+          data-slide-to="7"
+        />
+        
+            
+      </ol>
+      
+            
+      <button
+        aria-label="Go to next item"
+        class="fd-button fd-carousel__button fd-carousel__button--right"
+        data-slide="next"
+      >
+        
+                
+        <i
+          class="sap-icon--slim-arrow-right"
+        />
+        
+            
+      </button>
+      
+        
+    </div>
+    
+    
+  </div>
+  
+    
+  <div
+    aria-live="polite"
+    id="carousel-11"
     role="region"
     style="display: none;"
   >

--- a/stories/carousel/__snapshots__/carousel.stories.storyshot
+++ b/stories/carousel/__snapshots__/carousel.stories.storyshot
@@ -668,7 +668,7 @@ exports[`Storyshots Components/Carousel Hidden navigation buttons 1`] = `
 
 exports[`Storyshots Components/Carousel Items in horizontal direction 1`] = `
 <div
-  style="display: flex; flex-direction: column; align-items: center; background: #CCD1D1;"
+  style="display: flex; flex-direction: column; align-items: center; background: #CCD1D1; height: 25rem;"
 >
   
     
@@ -678,84 +678,31 @@ exports[`Storyshots Components/Carousel Items in horizontal direction 1`] = `
   
     
   <div
-    class="fddoc-horizontal-carousel-example"
+    class="fd-carousel"
+    data-ride="carousel"
+    style="max-width: 60rem; max-height: 15.5rem;"
   >
     
         
     <div
-      class="fd-carousel"
-      data-ride="carousel"
+      class="fd-carousel__content fd-carousel__content--horizontal"
     >
       
             
       <div
-        class="fd-carousel__content fd-carousel__content--horizontal"
+        class="fd-carousel__item fd-carousel__item--active"
       >
         
                 
         <div
-          class="fd-carousel__item fd-carousel__item--active"
+          aria-label="Carousel Image 5"
+          role="img"
+          style="
+                        width: 100%;
+                        background-image: url(assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg);
+                        height: 100%;
+                        background-size:cover;"
         >
-          
-                    
-          <div
-            aria-label="Carousel Image 5"
-            role="img"
-            style="
-                            width:100%;
-                            background-image: url(assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg);
-                            height: 15.5rem;
-                            background-size:cover;"
-          >
-            
-                    
-          </div>
-          
-                
-        </div>
-        
-
-                
-        <div
-          class="fd-carousel__item fd-carousel__item--active"
-        >
-          
-                    
-          <div
-            aria-label="Carousel Image 6"
-            role="img"
-            style="
-                            width:100%;
-                            background-image: url(assets/images/backgrounds/city.jpg);
-                            height: 15.5rem;
-                            background-size:cover;"
-          >
-            
-                    
-          </div>
-          
-                
-        </div>
-        
-
-                
-        <div
-          class="fd-carousel__item fd-carousel__item--active"
-        >
-          
-                    
-          <div
-            aria-label="Carousel Image 7"
-            role="img"
-            style="
-                            width:100%;
-                            background-image: url(assets/images/backgrounds/leaves.jpg);
-                            height: 15.5rem;
-                            background-size:cover;"
-          >
-            
-                    
-          </div>
           
                 
         </div>
@@ -763,70 +710,116 @@ exports[`Storyshots Components/Carousel Items in horizontal direction 1`] = `
             
       </div>
       
+
             
       <div
-        class="fd-carousel__page-indicator-container"
+        class="fd-carousel__item fd-carousel__item--active"
       >
         
                 
-        <button
-          aria-label="Go to previous item"
-          class="fd-button fd-carousel__button fd-carousel__button--left"
-          data-slide="prev"
+        <div
+          aria-label="Carousel Image 6"
+          role="img"
+          style="
+                        width: 100%;
+                        background-image: url(assets/images/backgrounds/city.jpg);
+                        height: 100%;
+                        background-size:cover;"
         >
           
-                    
-          <i
-            class="sap-icon--slim-arrow-left"
-          />
-          
                 
-        </button>
-        
-                
-        <ol
-          class="fd-carousel__page-indicators"
-        >
-          
-                    
-          <li
-            class="fd-carousel__page-indicator"
-            data-slide-to="1"
-          />
-          
-                    
-          <li
-            aria-label="Displaying item 2 of 3"
-            class="fd-carousel__page-indicator fd-carousel__page-indicator--active"
-            data-slide-to="2"
-          />
-          
-                    
-          <li
-            class="fd-carousel__page-indicator"
-            data-slide-to="3"
-          />
-          
-                
-        </ol>
-        
-                
-        <button
-          aria-label="Go to next item"
-          class="fd-button fd-carousel__button fd-carousel__button--right"
-          data-slide="next"
-        >
-          
-                    
-          <i
-            class="sap-icon--slim-arrow-right"
-          />
-          
-                
-        </button>
+        </div>
         
             
       </div>
+      
+
+            
+      <div
+        class="fd-carousel__item fd-carousel__item--active"
+      >
+        
+                
+        <div
+          aria-label="Carousel Image 7"
+          role="img"
+          style="
+                        width: 100%;
+                        background-image: url(assets/images/backgrounds/leaves.jpg);
+                        height: 100%;
+                        background-size:cover;"
+        >
+          
+                
+        </div>
+        
+            
+      </div>
+      
+        
+    </div>
+    
+        
+    <div
+      class="fd-carousel__page-indicator-container"
+    >
+      
+            
+      <button
+        aria-label="Go to previous item"
+        class="fd-button fd-carousel__button fd-carousel__button--left"
+        data-slide="prev"
+      >
+        
+                
+        <i
+          class="sap-icon--slim-arrow-left"
+        />
+        
+            
+      </button>
+      
+            
+      <ol
+        class="fd-carousel__page-indicators"
+      >
+        
+                
+        <li
+          class="fd-carousel__page-indicator"
+          data-slide-to="1"
+        />
+        
+                
+        <li
+          aria-label="Displaying item 2 of 3"
+          class="fd-carousel__page-indicator fd-carousel__page-indicator--active"
+          data-slide-to="2"
+        />
+        
+                
+        <li
+          class="fd-carousel__page-indicator"
+          data-slide-to="3"
+        />
+        
+            
+      </ol>
+      
+            
+      <button
+        aria-label="Go to next item"
+        class="fd-button fd-carousel__button fd-carousel__button--right"
+        data-slide="next"
+      >
+        
+                
+        <i
+          class="sap-icon--slim-arrow-right"
+        />
+        
+            
+      </button>
       
         
     </div>
@@ -852,7 +845,7 @@ exports[`Storyshots Components/Carousel Items in horizontal direction 1`] = `
 
 exports[`Storyshots Components/Carousel Items loading error 1`] = `
 <div
-  style="display: flex; flex-direction: column; align-items: center; background: #CCD1D1;"
+  style="display: flex; flex-direction: column; align-items: center; background: #CCD1D1; height: 25rem;"
 >
   
     
@@ -862,87 +855,108 @@ exports[`Storyshots Components/Carousel Items loading error 1`] = `
   
     
   <div
-    class="fddoc-carousel-example"
+    class="fd-carousel fd-carousel--no-navigation"
+    data-ride="carousel"
+    style="max-width: 30rem; max-height: 15.5rem;"
   >
     
         
     <div
-      class="fd-carousel fd-carousel--no-navigation"
-      data-ride="carousel"
+      class="fd-carousel__content fd-carousel__content--error-message"
     >
       
             
       <div
-        class="fd-carousel__content fd-carousel__content--error-message"
+        class="fd-message-page"
       >
         
                 
         <div
-          class="docs-column-flex"
+          class="fd-message-page__container"
         >
           
-                    
+                
           <div
-            class="fddocs-horizontal-center"
+            class="fd-message-page__icon-container"
           >
             
-                        
+                    
             <i
-              class="sap-icon--document"
+              class="sap-icon--document fd-message-page__icon"
+              role="presentation"
+              style="font-size:3rem"
             />
             
-                    
+                
           </div>
           
-                    Items could not be loaded
                 
+          <div
+            aria-live="polite"
+            class="fd-message-page__content"
+            role="status"
+          >
+            
+                    
+            <div
+              class="fd-message-page__title"
+            >
+              
+                        Items could not be loaded
+                    
+            </div>
+            
+                
+          </div>
+          
+            
         </div>
         
-            
+        
       </div>
       
+        
+    </div>
+    
+        
+    <div
+      class="fd-carousel__page-indicator-container"
+    >
+      
             
-      <div
-        class="fd-carousel__page-indicator-container"
+      <button
+        aria-label="Go to previous item"
+        class="fd-button fd-carousel__button fd-carousel__button--left"
+        data-slide="prev"
       >
         
                 
-        <button
-          aria-label="Go to previous item"
-          class="fd-button fd-carousel__button fd-carousel__button--left"
-          data-slide="prev"
-        >
-          
-                    
-          <i
-            class="sap-icon--slim-arrow-left"
-          />
-          
-                
-        </button>
-        
-                
-        <ol
-          class="fd-carousel__page-indicators"
+        <i
+          class="sap-icon--slim-arrow-left"
         />
         
+            
+      </button>
+      
+            
+      <ol
+        class="fd-carousel__page-indicators"
+      />
+      
+            
+      <button
+        aria-label="Go to next item"
+        class="fd-button fd-carousel__button fd-carousel__button--right"
+        data-slide="next"
+      >
+        
                 
-        <button
-          aria-label="Go to next item"
-          class="fd-button fd-carousel__button fd-carousel__button--right"
-          data-slide="next"
-        >
-          
-                    
-          <i
-            class="sap-icon--slim-arrow-right"
-          />
-          
-                
-        </button>
+        <i
+          class="sap-icon--slim-arrow-right"
+        />
         
             
-      </div>
+      </button>
       
         
     </div>

--- a/stories/carousel/__snapshots__/carousel.stories.storyshot
+++ b/stories/carousel/__snapshots__/carousel.stories.storyshot
@@ -884,7 +884,6 @@ exports[`Storyshots Components/Carousel Items loading error 1`] = `
             <i
               class="sap-icon--document fd-message-page__icon"
               role="presentation"
-              style="font-size:3rem"
             />
             
                 

--- a/stories/carousel/__snapshots__/carousel.stories.storyshot
+++ b/stories/carousel/__snapshots__/carousel.stories.storyshot
@@ -862,7 +862,7 @@ exports[`Storyshots Components/Carousel Items loading error 1`] = `
     
         
     <div
-      class="fd-carousel__content fd-carousel__content--error-message"
+      class="fd-carousel__content"
     >
       
             

--- a/stories/carousel/carousel.stories.js
+++ b/stories/carousel/carousel.stories.js
@@ -367,7 +367,6 @@ carouselTop.parameters = {
     }
 };
 
-
 export const carouselNoNavigation = () => `<div style="display: flex; flex-direction: column; align-items: center; background: #CCD1D1;">
     <h4>Hiding navigation buttons in page indicator</h4>
     <div 
@@ -414,7 +413,7 @@ export const carouselNoNavigation = () => `<div style="display: flex; flex-direc
             </button>
         </div>
     </div>
-    <div style="display: none;" role="region" id="carousel-1" aria-live="polite">
+    <div style="display: none;" role="region" id="carousel-9" aria-live="polite">
         Displaying item 1 of 4
     </div>
 
@@ -463,7 +462,7 @@ export const carouselNoNavigation = () => `<div style="display: flex; flex-direc
             </button>
         </div>
     </div>
-    <div style="display: none;" role="region" id="carousel-6" aria-live="polite">
+    <div style="display: none;" role="region" id="carousel-10" aria-live="polite">
         Displaying item 1 of 4
     </div>
 </div>
@@ -474,6 +473,103 @@ carouselNoNavigation.parameters = {
     docs: {
         iframeHeight: 900,
         storyDescription: `Carousel can also be displayed without navigation buttons. To hide them, add the <code class="docs-code">fd-carousel--no-navigation</code> modifier class to the <code class="docs-code">fd-carousel</code> class. On touchable devices, the user can navigate with a swipe gesture.
+`
+    }
+};
+
+export const horizontalCarousel = () => `<div style="display: flex; flex-direction: column; align-items: center; background: #CCD1D1;">
+    <h4>Items in horizontal direction</h4>
+    <div
+        class="fd-carousel"
+        data-ride="carousel"
+        style="margin-bottom: 3rem; max-width: 60rem;">
+        <div class="fd-carousel__content fd-carousel--horizontal" style="text-align: center; padding: 1rem; min-height: 15.5rem;">
+            <div class="fd-carousel__item fd-carousel__item--active">
+                <div
+                    style="
+                        width:100%;
+                        background-image: url(assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg);
+                        height: 15.5rem;
+                        background-size:cover;"
+                    role="img"
+                    aria-label="Carousel Image 4">
+                </div>
+            </div>
+
+            <div class="fd-carousel__item fd-carousel__item--active">
+                <div
+                    style="
+                        width:100%;
+                        background-image: url(assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg);
+                        height: 15.5rem;
+                        background-size:cover;"
+                    role="img"
+                    aria-label="Carousel Image 4">
+                </div>
+            </div>
+
+            <div class="fd-carousel__item fd-carousel__item--active">
+                <div
+                    style="
+                        width:100%;
+                        background-image: url(assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg);
+                        height: 15.5rem;
+                        background-size:cover;"
+                    role="img"
+                    aria-label="Carousel Image 4">
+                </div>
+            </div>
+        </div>
+        <div class="fd-carousel__page-indicator-container">
+            <button
+                class="fd-button fd-carousel__button fd-carousel__button--left"
+                data-slide="prev"
+                aria-label="Go to previous item">
+                <i class="sap-icon--slim-arrow-left"></i>
+            </button>
+            <ol class="fd-carousel__page-indicators">
+                <li
+                    data-slide-to="1"
+                    class="fd-carousel__page-indicator"></li>
+                <li
+                    data-slide-to="2"
+                    class="fd-carousel__page-indicator"></li>
+                <li
+                    data-slide-to="3"
+                    class="fd-carousel__page-indicator"></li>
+                <li
+                    data-slide-to="4"
+                    class="fd-carousel__page-indicator"></li>
+                <li
+                    data-slide-to="5"
+                    aria-label="Displaying item 5 of 7"
+                    class="fd-carousel__page-indicator fd-carousel__page-indicator--active"></li>
+                <li
+                    data-slide-to="6"
+                    class="fd-carousel__page-indicator"></li>
+                <li
+                    data-slide-to="7"
+                    class="fd-carousel__page-indicator"></li>
+            </ol>
+            <button
+                class="fd-button fd-carousel__button fd-carousel__button--right"
+                data-slide="next"
+                aria-label="Go to next item">
+                <i class="sap-icon--slim-arrow-right"></i>
+            </button>
+        </div>
+    </div>
+    <div style="display: none;" role="region" id="carousel-11" aria-live="polite">
+        Displaying item 1 of 4
+    </div>
+</div>
+`;
+
+horizontalCarousel.storyName = 'Items in horizontal direction';
+horizontalCarousel.parameters = {
+    docs: {
+        iframeHeight: 900,
+        storyDescription: `Carousel will have items which will spread horizontally and will be visible on navigation. For translation to work, all items should be in DOM.
 `
     }
 };

--- a/stories/carousel/carousel.stories.js
+++ b/stories/carousel/carousel.stories.js
@@ -479,72 +479,73 @@ carouselNoNavigation.parameters = {
 
 export const horizontalCarousel = () => `<div style="display: flex; flex-direction: column; align-items: center; background: #CCD1D1;">
     <h4>Items in horizontal direction</h4>
-    <div
-        class="fd-carousel"
-        data-ride="carousel"
-        style="margin-bottom: 3rem; max-width: 60rem;">
-        <div class="fd-carousel__content fd-carousel__content--horizontal" style="text-align: center; padding: 1rem; min-height: 15.5rem;">
-            <div class="fd-carousel__item fd-carousel__item--active">
-                <div
-                    style="
-                        width:100%;
-                        background-image: url(assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg);
-                        height: 15.5rem;
-                        background-size:cover;"
-                    role="img"
-                    aria-label="Carousel Image 5">
+    <div class="fddoc-horizontal-carousel-example">
+        <div
+            class="fd-carousel"
+            data-ride="carousel">
+            <div class="fd-carousel__content fd-carousel__content--horizontal">
+                <div class="fd-carousel__item fd-carousel__item--active">
+                    <div
+                        style="
+                            width:100%;
+                            background-image: url(assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg);
+                            height: 15.5rem;
+                            background-size:cover;"
+                        role="img"
+                        aria-label="Carousel Image 5">
+                    </div>
                 </div>
-            </div>
 
-            <div class="fd-carousel__item fd-carousel__item--active">
-                <div
-                    style="
-                        width:100%;
-                        background-image: url(assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg);
-                        height: 15.5rem;
-                        background-size:cover;"
-                    role="img"
-                    aria-label="Carousel Image 6">
+                <div class="fd-carousel__item fd-carousel__item--active">
+                    <div
+                        style="
+                            width:100%;
+                            background-image: url(assets/images/backgrounds/city.jpg);
+                            height: 15.5rem;
+                            background-size:cover;"
+                        role="img"
+                        aria-label="Carousel Image 6">
+                    </div>
                 </div>
-            </div>
 
-            <div class="fd-carousel__item fd-carousel__item--active">
-                <div
-                    style="
-                        width:100%;
-                        background-image: url(assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg);
-                        height: 15.5rem;
-                        background-size:cover;"
-                    role="img"
-                    aria-label="Carousel Image 7">
+                <div class="fd-carousel__item fd-carousel__item--active">
+                    <div
+                        style="
+                            width:100%;
+                            background-image: url(assets/images/backgrounds/leaves.jpg);
+                            height: 15.5rem;
+                            background-size:cover;"
+                        role="img"
+                        aria-label="Carousel Image 7">
+                    </div>
                 </div>
             </div>
-        </div>
-        <div class="fd-carousel__page-indicator-container">
-            <button
-                class="fd-button fd-carousel__button fd-carousel__button--left"
-                data-slide="prev"
-                aria-label="Go to previous item">
-                <i class="sap-icon--slim-arrow-left"></i>
-            </button>
-            <ol class="fd-carousel__page-indicators">
-                <li
-                    data-slide-to="1"
-                    class="fd-carousel__page-indicator"></li>
-                <li
-                    data-slide-to="2"
-                    aria-label="Displaying item 2 of 3"
-                    class="fd-carousel__page-indicator fd-carousel__page-indicator--active"></li>
-                <li
-                    data-slide-to="3"
-                    class="fd-carousel__page-indicator"></li>
-            </ol>
-            <button
-                class="fd-button fd-carousel__button fd-carousel__button--right"
-                data-slide="next"
-                aria-label="Go to next item">
-                <i class="sap-icon--slim-arrow-right"></i>
-            </button>
+            <div class="fd-carousel__page-indicator-container">
+                <button
+                    class="fd-button fd-carousel__button fd-carousel__button--left"
+                    data-slide="prev"
+                    aria-label="Go to previous item">
+                    <i class="sap-icon--slim-arrow-left"></i>
+                </button>
+                <ol class="fd-carousel__page-indicators">
+                    <li
+                        data-slide-to="1"
+                        class="fd-carousel__page-indicator"></li>
+                    <li
+                        data-slide-to="2"
+                        aria-label="Displaying item 2 of 3"
+                        class="fd-carousel__page-indicator fd-carousel__page-indicator--active"></li>
+                    <li
+                        data-slide-to="3"
+                        class="fd-carousel__page-indicator"></li>
+                </ol>
+                <button
+                    class="fd-button fd-carousel__button fd-carousel__button--right"
+                    data-slide="next"
+                    aria-label="Go to next item">
+                    <i class="sap-icon--slim-arrow-right"></i>
+                </button>
+            </div>
         </div>
     </div>
     <div style="display: none;" role="region" id="carousel-11" aria-live="polite">
@@ -557,39 +558,40 @@ horizontalCarousel.storyName = 'Items in horizontal direction';
 horizontalCarousel.parameters = {
     docs: {
         iframeHeight: 900,
-        storyDescription: `Carousel will have items which will spread horizontally and will be visible on navigation. For translation to work, all items should be in DOM.
+        storyDescription: `Carousel will have items which will spread horizontally and will be visible on navigation. For translate animation effect to work, all items should be in DOM.
 `
     }
 };
 
 export const error = () => `<div style="display: flex; flex-direction: column; align-items: center; background: #CCD1D1;">
     <h4>Error in loading items</h4>
-    <div
-        class="fd-carousel fd-carousel--no-navigation"
-        data-ride="carousel"
-        style="margin-bottom: 3rem; max-width: 60rem;">
-        <div class="fd-carousel__content fd-carousel__content--error-message" style="text-align: center; padding: 1rem; min-height: 15.5rem;">
-            <div class="docs-column-flex">
-                <div class="fddocs-horizontal-center">
-                    <i class="sap-icon--document"></i>
+    <div class="fddoc-carousel-example">
+        <div
+            class="fd-carousel fd-carousel--no-navigation"
+            data-ride="carousel">
+            <div class="fd-carousel__content fd-carousel__content--error-message">
+                <div class="docs-column-flex">
+                    <div class="fddocs-horizontal-center">
+                        <i class="sap-icon--document"></i>
+                    </div>
+                    Items could not be loaded
                 </div>
-                Items could not be loaded
             </div>
-        </div>
-        <div class="fd-carousel__page-indicator-container">
-            <button 
-                class="fd-button fd-carousel__button fd-carousel__button--left"
-                data-slide="prev"
-                aria-label="Go to previous item">
-                <i class="sap-icon--slim-arrow-left"></i>
-            </button>
-            <ol class="fd-carousel__page-indicators"></ol>
-            <button 
-                class="fd-button fd-carousel__button fd-carousel__button--right"
-                data-slide="next"
-                aria-label="Go to next item">
-                <i class="sap-icon--slim-arrow-right"></i>
-            </button>
+            <div class="fd-carousel__page-indicator-container">
+                <button 
+                    class="fd-button fd-carousel__button fd-carousel__button--left"
+                    data-slide="prev"
+                    aria-label="Go to previous item">
+                    <i class="sap-icon--slim-arrow-left"></i>
+                </button>
+                <ol class="fd-carousel__page-indicators"></ol>
+                <button 
+                    class="fd-button fd-carousel__button fd-carousel__button--right"
+                    data-slide="next"
+                    aria-label="Go to next item">
+                    <i class="sap-icon--slim-arrow-right"></i>
+                </button>
+            </div>
         </div>
     </div>
     <div style="display: none;" role="region" id="carousel-12" aria-live="polite">

--- a/stories/carousel/carousel.stories.js
+++ b/stories/carousel/carousel.stories.js
@@ -483,7 +483,7 @@ export const horizontalCarousel = () => `<div style="display: flex; flex-directi
         class="fd-carousel"
         data-ride="carousel"
         style="margin-bottom: 3rem; max-width: 60rem;">
-        <div class="fd-carousel__content fd-carousel--horizontal" style="text-align: center; padding: 1rem; min-height: 15.5rem;">
+        <div class="fd-carousel__content fd-carousel__horizontal" style="text-align: center; padding: 1rem; min-height: 15.5rem;">
             <div class="fd-carousel__item fd-carousel__item--active">
                 <div
                     style="
@@ -492,7 +492,7 @@ export const horizontalCarousel = () => `<div style="display: flex; flex-directi
                         height: 15.5rem;
                         background-size:cover;"
                     role="img"
-                    aria-label="Carousel Image 4">
+                    aria-label="Carousel Image 5">
                 </div>
             </div>
 
@@ -504,7 +504,7 @@ export const horizontalCarousel = () => `<div style="display: flex; flex-directi
                         height: 15.5rem;
                         background-size:cover;"
                     role="img"
-                    aria-label="Carousel Image 4">
+                    aria-label="Carousel Image 6">
                 </div>
             </div>
 
@@ -516,7 +516,7 @@ export const horizontalCarousel = () => `<div style="display: flex; flex-directi
                         height: 15.5rem;
                         background-size:cover;"
                     role="img"
-                    aria-label="Carousel Image 4">
+                    aria-label="Carousel Image 7">
                 </div>
             </div>
         </div>
@@ -542,7 +542,7 @@ export const horizontalCarousel = () => `<div style="display: flex; flex-directi
                     class="fd-carousel__page-indicator"></li>
                 <li
                     data-slide-to="5"
-                    aria-label="Displaying item 5 of 7"
+                    aria-label="Displaying item 2 of 3"
                     class="fd-carousel__page-indicator fd-carousel__page-indicator--active"></li>
                 <li
                     data-slide-to="6"
@@ -560,7 +560,7 @@ export const horizontalCarousel = () => `<div style="display: flex; flex-directi
         </div>
     </div>
     <div style="display: none;" role="region" id="carousel-11" aria-live="polite">
-        Displaying item 1 of 4
+        Displaying item 2 of 3
     </div>
 </div>
 `;

--- a/stories/carousel/carousel.stories.js
+++ b/stories/carousel/carousel.stories.js
@@ -483,7 +483,7 @@ export const horizontalCarousel = () => `<div style="display: flex; flex-directi
         class="fd-carousel"
         data-ride="carousel"
         style="margin-bottom: 3rem; max-width: 60rem;">
-        <div class="fd-carousel__content fd-carousel__horizontal" style="text-align: center; padding: 1rem; min-height: 15.5rem;">
+        <div class="fd-carousel__content fd-carousel__content--horizontal" style="text-align: center; padding: 1rem; min-height: 15.5rem;">
             <div class="fd-carousel__item fd-carousel__item--active">
                 <div
                     style="
@@ -533,22 +533,10 @@ export const horizontalCarousel = () => `<div style="display: flex; flex-directi
                     class="fd-carousel__page-indicator"></li>
                 <li
                     data-slide-to="2"
-                    class="fd-carousel__page-indicator"></li>
-                <li
-                    data-slide-to="3"
-                    class="fd-carousel__page-indicator"></li>
-                <li
-                    data-slide-to="4"
-                    class="fd-carousel__page-indicator"></li>
-                <li
-                    data-slide-to="5"
                     aria-label="Displaying item 2 of 3"
                     class="fd-carousel__page-indicator fd-carousel__page-indicator--active"></li>
                 <li
-                    data-slide-to="6"
-                    class="fd-carousel__page-indicator"></li>
-                <li
-                    data-slide-to="7"
+                    data-slide-to="3"
                     class="fd-carousel__page-indicator"></li>
             </ol>
             <button
@@ -570,6 +558,51 @@ horizontalCarousel.parameters = {
     docs: {
         iframeHeight: 900,
         storyDescription: `Carousel will have items which will spread horizontally and will be visible on navigation. For translation to work, all items should be in DOM.
+`
+    }
+};
+
+export const error = () => `<div style="display: flex; flex-direction: column; align-items: center; background: #CCD1D1;">
+    <h4>Error in loading items</h4>
+    <div
+        class="fd-carousel fd-carousel--no-navigation"
+        data-ride="carousel"
+        style="margin-bottom: 3rem; max-width: 60rem;">
+        <div class="fd-carousel__content fd-carousel__content--error-message" style="text-align: center; padding: 1rem; min-height: 15.5rem;">
+            <div class="docs-column-flex">
+                <div class="fddocs-horizontal-center">
+                    <i class="sap-icon--document"></i>
+                </div>
+                Items could not be loaded
+            </div>
+        </div>
+        <div class="fd-carousel__page-indicator-container">
+            <button 
+                class="fd-button fd-carousel__button fd-carousel__button--left"
+                data-slide="prev"
+                aria-label="Go to previous item">
+                <i class="sap-icon--slim-arrow-left"></i>
+            </button>
+            <ol class="fd-carousel__page-indicators"></ol>
+            <button 
+                class="fd-button fd-carousel__button fd-carousel__button--right"
+                data-slide="next"
+                aria-label="Go to next item">
+                <i class="sap-icon--slim-arrow-right"></i>
+            </button>
+        </div>
+    </div>
+    <div style="display: none;" role="region" id="carousel-12" aria-live="polite">
+        Error in loading items
+    </div>
+</div>
+`;
+
+error.storyName = 'Items loading error';
+error.parameters = {
+    docs: {
+        iframeHeight: 900,
+        storyDescription: `Error message can be disaplyed when items could not be loaded.
 `
     }
 };

--- a/stories/carousel/carousel.stories.js
+++ b/stories/carousel/carousel.stories.js
@@ -572,7 +572,7 @@ export const error = () => `<div style="display: flex; flex-direction: column; a
             <div class="fd-message-page">
                 <div class="fd-message-page__container">
                 <div class="fd-message-page__icon-container">
-                    <i role="presentation" class="sap-icon--document fd-message-page__icon" style="font-size:3rem"></i>
+                    <i role="presentation" class="sap-icon--document fd-message-page__icon"></i>
                 </div>
                 <div role="status" aria-live="polite" class="fd-message-page__content">
                     <div class="fd-message-page__title">
@@ -608,7 +608,7 @@ error.storyName = 'Items loading error';
 error.parameters = {
     docs: {
         iframeHeight: 900,
-        storyDescription: `Error message can be disaplyed when items could not be loaded.
+        storyDescription: `Error message can be disaplyed when items could not be loaded. Error message can be composed using Message page component.
 `
     }
 };

--- a/stories/carousel/carousel.stories.js
+++ b/stories/carousel/carousel.stories.js
@@ -26,7 +26,7 @@ To ensure that the carousel is accessible, a div element with class <code class=
 
 `,
         tags: ['f3', 'a11y', 'theme', 'development'],
-        components: ['carousel', 'button', 'icon']
+        components: ['carousel', 'button', 'icon', 'message-page', 'link']
     }
 };
 
@@ -477,75 +477,74 @@ carouselNoNavigation.parameters = {
     }
 };
 
-export const horizontalCarousel = () => `<div style="display: flex; flex-direction: column; align-items: center; background: #CCD1D1;">
+export const horizontalCarousel = () => `<div style="display: flex; flex-direction: column; align-items: center; background: #CCD1D1; height: 25rem;">
     <h4>Items in horizontal direction</h4>
-    <div class="fddoc-horizontal-carousel-example">
-        <div
-            class="fd-carousel"
-            data-ride="carousel">
-            <div class="fd-carousel__content fd-carousel__content--horizontal">
-                <div class="fd-carousel__item fd-carousel__item--active">
-                    <div
-                        style="
-                            width:100%;
-                            background-image: url(assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg);
-                            height: 15.5rem;
-                            background-size:cover;"
-                        role="img"
-                        aria-label="Carousel Image 5">
-                    </div>
-                </div>
-
-                <div class="fd-carousel__item fd-carousel__item--active">
-                    <div
-                        style="
-                            width:100%;
-                            background-image: url(assets/images/backgrounds/city.jpg);
-                            height: 15.5rem;
-                            background-size:cover;"
-                        role="img"
-                        aria-label="Carousel Image 6">
-                    </div>
-                </div>
-
-                <div class="fd-carousel__item fd-carousel__item--active">
-                    <div
-                        style="
-                            width:100%;
-                            background-image: url(assets/images/backgrounds/leaves.jpg);
-                            height: 15.5rem;
-                            background-size:cover;"
-                        role="img"
-                        aria-label="Carousel Image 7">
-                    </div>
+    <div
+        class="fd-carousel"
+        style="max-width: 60rem; max-height: 15.5rem;"
+        data-ride="carousel">
+        <div class="fd-carousel__content fd-carousel__content--horizontal">
+            <div class="fd-carousel__item fd-carousel__item--active">
+                <div
+                    style="
+                        width: 100%;
+                        background-image: url(assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg);
+                        height: 100%;
+                        background-size:cover;"
+                    role="img"
+                    aria-label="Carousel Image 5">
                 </div>
             </div>
-            <div class="fd-carousel__page-indicator-container">
-                <button
-                    class="fd-button fd-carousel__button fd-carousel__button--left"
-                    data-slide="prev"
-                    aria-label="Go to previous item">
-                    <i class="sap-icon--slim-arrow-left"></i>
-                </button>
-                <ol class="fd-carousel__page-indicators">
-                    <li
-                        data-slide-to="1"
-                        class="fd-carousel__page-indicator"></li>
-                    <li
-                        data-slide-to="2"
-                        aria-label="Displaying item 2 of 3"
-                        class="fd-carousel__page-indicator fd-carousel__page-indicator--active"></li>
-                    <li
-                        data-slide-to="3"
-                        class="fd-carousel__page-indicator"></li>
-                </ol>
-                <button
-                    class="fd-button fd-carousel__button fd-carousel__button--right"
-                    data-slide="next"
-                    aria-label="Go to next item">
-                    <i class="sap-icon--slim-arrow-right"></i>
-                </button>
+
+            <div class="fd-carousel__item fd-carousel__item--active">
+                <div
+                    style="
+                        width: 100%;
+                        background-image: url(assets/images/backgrounds/city.jpg);
+                        height: 100%;
+                        background-size:cover;"
+                    role="img"
+                    aria-label="Carousel Image 6">
+                </div>
             </div>
+
+            <div class="fd-carousel__item fd-carousel__item--active">
+                <div
+                    style="
+                        width: 100%;
+                        background-image: url(assets/images/backgrounds/leaves.jpg);
+                        height: 100%;
+                        background-size:cover;"
+                    role="img"
+                    aria-label="Carousel Image 7">
+                </div>
+            </div>
+        </div>
+        <div class="fd-carousel__page-indicator-container">
+            <button
+                class="fd-button fd-carousel__button fd-carousel__button--left"
+                data-slide="prev"
+                aria-label="Go to previous item">
+                <i class="sap-icon--slim-arrow-left"></i>
+            </button>
+            <ol class="fd-carousel__page-indicators">
+                <li
+                    data-slide-to="1"
+                    class="fd-carousel__page-indicator"></li>
+                <li
+                    data-slide-to="2"
+                    aria-label="Displaying item 2 of 3"
+                    class="fd-carousel__page-indicator fd-carousel__page-indicator--active"></li>
+                <li
+                    data-slide-to="3"
+                    class="fd-carousel__page-indicator"></li>
+            </ol>
+            <button
+                class="fd-button fd-carousel__button fd-carousel__button--right"
+                data-slide="next"
+                aria-label="Go to next item">
+                <i class="sap-icon--slim-arrow-right"></i>
+            </button>
         </div>
     </div>
     <div style="display: none;" role="region" id="carousel-11" aria-live="polite">
@@ -563,35 +562,40 @@ horizontalCarousel.parameters = {
     }
 };
 
-export const error = () => `<div style="display: flex; flex-direction: column; align-items: center; background: #CCD1D1;">
+export const error = () => `<div style="display: flex; flex-direction: column; align-items: center; background: #CCD1D1; height: 25rem;">
     <h4>Error in loading items</h4>
-    <div class="fddoc-carousel-example">
-        <div
-            class="fd-carousel fd-carousel--no-navigation"
-            data-ride="carousel">
-            <div class="fd-carousel__content fd-carousel__content--error-message">
-                <div class="docs-column-flex">
-                    <div class="fddocs-horizontal-center">
-                        <i class="sap-icon--document"></i>
+    <div
+        class="fd-carousel fd-carousel--no-navigation"
+        style="max-width: 30rem; max-height: 15.5rem;"
+        data-ride="carousel">
+        <div class="fd-carousel__content fd-carousel__content--error-message">
+            <div class="fd-message-page">
+                <div class="fd-message-page__container">
+                <div class="fd-message-page__icon-container">
+                    <i role="presentation" class="sap-icon--document fd-message-page__icon" style="font-size:3rem"></i>
+                </div>
+                <div role="status" aria-live="polite" class="fd-message-page__content">
+                    <div class="fd-message-page__title">
+                        Items could not be loaded
                     </div>
-                    Items could not be loaded
                 </div>
             </div>
-            <div class="fd-carousel__page-indicator-container">
-                <button 
-                    class="fd-button fd-carousel__button fd-carousel__button--left"
-                    data-slide="prev"
-                    aria-label="Go to previous item">
-                    <i class="sap-icon--slim-arrow-left"></i>
-                </button>
-                <ol class="fd-carousel__page-indicators"></ol>
-                <button 
-                    class="fd-button fd-carousel__button fd-carousel__button--right"
-                    data-slide="next"
-                    aria-label="Go to next item">
-                    <i class="sap-icon--slim-arrow-right"></i>
-                </button>
-            </div>
+        </div>
+        </div>
+        <div class="fd-carousel__page-indicator-container">
+            <button 
+                class="fd-button fd-carousel__button fd-carousel__button--left"
+                data-slide="prev"
+                aria-label="Go to previous item">
+                <i class="sap-icon--slim-arrow-left"></i>
+            </button>
+            <ol class="fd-carousel__page-indicators"></ol>
+            <button 
+                class="fd-button fd-carousel__button fd-carousel__button--right"
+                data-slide="next"
+                aria-label="Go to next item">
+                <i class="sap-icon--slim-arrow-right"></i>
+            </button>
         </div>
     </div>
     <div style="display: none;" role="region" id="carousel-12" aria-live="polite">

--- a/stories/carousel/carousel.stories.js
+++ b/stories/carousel/carousel.stories.js
@@ -568,7 +568,7 @@ export const error = () => `<div style="display: flex; flex-direction: column; a
         class="fd-carousel fd-carousel--no-navigation"
         style="max-width: 30rem; max-height: 15.5rem;"
         data-ride="carousel">
-        <div class="fd-carousel__content fd-carousel__content--error-message">
+        <div class="fd-carousel__content">
             <div class="fd-message-page">
                 <div class="fd-message-page__container">
                 <div class="fd-message-page__icon-container">


### PR DESCRIPTION
## Related Issue
Related to Issue SAP/fundamental-ngx#5025

## Description
Moving css present for carousel component in Ngx to styles.
navigation button in content area will be visible on hover on carousel.

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:


### After:

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [NA] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
