### PR TITLE
fix: provide focus for avatar and icon components

### DIFF
--- a/src/avatar.scss
+++ b/src/avatar.scss
@@ -49,6 +49,12 @@ $block: #{$fd-namespace}-avatar;
   background-position: 50%;
   border-radius: var(--sapElement_BorderCornerRadius);
 
+  @include fd-focus() {
+    outline-width: var(--sapContent_FocusWidth);
+    outline-color: var(--sapContent_FocusColor);
+    outline-style: var(--sapContent_FocusStyle);
+  }
+
   // BLOCK ELEMENTS ************
   // zoom icon
   &__zoom-icon {

--- a/src/avatar.scss
+++ b/src/avatar.scss
@@ -49,11 +49,7 @@ $block: #{$fd-namespace}-avatar;
   background-position: 50%;
   border-radius: var(--sapElement_BorderCornerRadius);
 
-  @include fd-focus() {
-    outline-width: var(--sapContent_FocusWidth);
-    outline-color: var(--sapContent_FocusColor);
-    outline-style: var(--sapContent_FocusStyle);
-  }
+  @include fd-fiori-focus(0);
 
   // BLOCK ELEMENTS ************
   // zoom icon

--- a/src/icon.scss
+++ b/src/icon.scss
@@ -13,6 +13,12 @@ $blockTNT: sap-icon-TNT;
 
   font-style: normal;
   display: inline-block;
+
+  @include fd-focus() {
+    outline-width: var(--sapContent_FocusWidth);
+    outline-color: var(--sapContent_FocusColor);
+    outline-style: var(--sapContent_FocusStyle);
+  }
 }
 
 [class*='#{$blockBusiness}'] {

--- a/src/icon.scss
+++ b/src/icon.scss
@@ -14,11 +14,7 @@ $blockTNT: sap-icon-TNT;
   font-style: normal;
   display: inline-block;
 
-  @include fd-focus() {
-    outline-width: var(--sapContent_FocusWidth);
-    outline-color: var(--sapContent_FocusColor);
-    outline-style: var(--sapContent_FocusStyle);
-  }
+  @include fd-fiori-focus(0);
 }
 
 [class*='#{$blockBusiness}'] {

--- a/src/mixins/_states.scss
+++ b/src/mixins/_states.scss
@@ -51,7 +51,10 @@
 @mixin fd-fiori-focus($offset: -0.1875rem) {
   &:focus,
   &.is-focus {
-    outline-offset: $offset;
+    @if $offset != 0 {
+      outline-offset: $offset;
+    }
+
     outline-width: var(--sapContent_FocusWidth);
     outline-color: var(--sapContent_FocusColor);
     outline-style: var(--sapContent_FocusStyle);

--- a/stories/avatar/__snapshots__/avatar.stories.storyshot
+++ b/stories/avatar/__snapshots__/avatar.stories.storyshot
@@ -476,6 +476,7 @@ exports[`Storyshots Components/Avatar Icon 1`] = `
   <span
     class="fd-avatar fd-avatar--xs"
     role="presentation"
+    tabindex="0"
   >
     
     

--- a/stories/avatar/avatar.stories.js
+++ b/stories/avatar/avatar.stories.js
@@ -34,7 +34,7 @@ Do not use avatar if:
 };
 
 export const icon = () => `
-<span class="fd-avatar fd-avatar--xs" role="presentation">
+<span class="fd-avatar fd-avatar--xs" role="presentation" tabindex="0">
     <i role="presentation" class="fd-avatar__icon sap-icon--washing-machine"></i>
 </span>
 <span class="fd-avatar fd-avatar--s" role="presentation">

--- a/stories/icon/SAPIcons/__snapshots__/icon.stories.storyshot
+++ b/stories/icon/SAPIcons/__snapshots__/icon.stories.storyshot
@@ -7934,6 +7934,7 @@ exports[`Storyshots Components/Icons/SAP Icons Colors 1`] = `
   <span
     class="sap-icon sap-icon--cart"
     style="font-size:5rem"
+    tabindex="0"
   />
   
 

--- a/stories/icon/SAPIcons/icon.stories.js
+++ b/stories/icon/SAPIcons/icon.stories.js
@@ -52,7 +52,7 @@ sizes.parameters = {
  */
 
 export const colors = () => `
-<span class="sap-icon sap-icon--cart" style="font-size:5rem"></span>
+<span class="sap-icon sap-icon--cart" style="font-size:5rem" tabindex="0"></span>
 <span class="sap-icon sap-icon--cart sap-icon--color-default" style="font-size:5rem"></span>
 <span class="sap-icon sap-icon--cart sap-icon--color-contrast sap-icon--background-contrast" style="font-size:5rem"></span>
 <span class="sap-icon sap-icon--cart sap-icon--color-non-interactive" style="font-size:5rem"></span>


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles #2443 

## Description
Providing focus options for icon and avatar components when used with tabindex for accessibility purpose.


### Before:
No Focus 
<img width="418" alt="2021-06-14_22-50-05" src="https://user-images.githubusercontent.com/53487468/121932842-f7a1d780-cd62-11eb-938a-46de82a3c120.png">




### After:

Displaying focus when tabindex="0"
<img width="424" alt="2021-06-14_22-50-20" src="https://user-images.githubusercontent.com/53487468/121932881-025c6c80-cd63-11eb-9b9d-0b6114ef69ab.png">


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
