### PR TITLE
feat: introduce new Icon Tab Bar component

### DIFF
--- a/config/bundlesize.json
+++ b/config/bundlesize.json
@@ -2,7 +2,7 @@
     "files": [
         {
             "path": "./dist/fundamental-styles.css",
-            "maxSize": "100 kB"
+            "maxSize": "110 kB"
         }
     ]
 }

--- a/src/_listNavigationItem.scss
+++ b/src/_listNavigationItem.scss
@@ -37,7 +37,7 @@ $fd-list-second-level-popover-position: 3.25rem !default;
   &__navigation-item {
     @include fd-reset();
     @include fd-fiori-focus();
-    @include set-paddings-x(0.5rem, 1rem);
+    @include fd-set-paddings-x(0.5rem, 1rem);
 
     background: transparent;
     height: $fd-list-navigation-item-height;
@@ -52,7 +52,7 @@ $fd-list-second-level-popover-position: 3.25rem !default;
     }
 
     &.is-expanded {
-      @include set-margins-x(0.25rem, 0.25rem);
+      @include fd-set-margins-x(0.25rem, 0.25rem);
 
       border-radius: var(--sapElement_BorderCornerRadius);
       box-shadow: var(--sapContent_Shadow0);
@@ -90,15 +90,15 @@ $fd-list-second-level-popover-position: 3.25rem !default;
       }
 
       .#{$block}__navigation-item-text {
-        @include set-padding-left();
+        @include fd-set-padding-left();
       }
 
       .#{$block}__navigation-item-icon {
-        @include set-padding-right(0.5rem);
+        @include fd-set-padding-right(0.5rem);
       }
 
       .#{$block} {
-        @include set-margins-x(-0.5rem, -1rem);
+        @include fd-set-margins-x(-0.5rem, -1rem);
 
         width: auto;
         display: block;
@@ -106,7 +106,7 @@ $fd-list-second-level-popover-position: 3.25rem !default;
 
       .#{$block}__navigation-item-indicator {
         &::after {
-          @include set-margin-right();
+          @include fd-set-margin-right();
         }
       }
     }
@@ -132,7 +132,7 @@ $fd-list-second-level-popover-position: 3.25rem !default;
     }
 
     &--condensed {
-      @include set-paddings-x();
+      @include fd-set-paddings-x();
 
       position: relative;
       width: 3.25rem;
@@ -150,20 +150,20 @@ $fd-list-second-level-popover-position: 3.25rem !default;
       }
 
       .#{$block}__navigation-item-icon {
-        @include set-margins-x(0.5rem, 0.5rem);
+        @include fd-set-margins-x(0.5rem, 0.5rem);
 
         height: $fd-list-navigation-item-height;
         line-height: $fd-list-navigation-item-height;
       }
 
       &.is-expanded {
-        @include set-margins-x();
+        @include fd-set-margins-x();
 
         overflow: visible;
         visibility: hidden;
 
         .#{$block}__navigation-item {
-          @include set-margins-x();
+          @include fd-set-margins-x();
         }
 
         .#{$block}__navigation-item--condensed {
@@ -192,8 +192,8 @@ $fd-list-second-level-popover-position: 3.25rem !default;
             }
 
             .#{$block}__navigation-item-text {
-              @include set-margin-left();
-              @include set-padding-left();
+              @include fd-set-margin-left();
+              @include fd-set-padding-left();
             }
           }
 
@@ -227,12 +227,12 @@ $fd-list-second-level-popover-position: 3.25rem !default;
 
             .#{$block}__navigation-item {
               .#{$block}__navigation-item-text {
-                @include set-margin-left(1rem);
+                @include fd-set-margin-left(1rem);
               }
 
               .#{$block}__navigation-item-indicator {
                 &::after {
-                  @include set-margin-right();
+                  @include fd-set-margin-right();
 
                   display: inline-block;
                 }
@@ -295,7 +295,7 @@ $fd-list-second-level-popover-position: 3.25rem !default;
     }
 
     &-text {
-      @include set-padding-left(0.25rem);
+      @include fd-set-padding-left(0.25rem);
 
       font-size: var(--sapFontLargeSize);
       font-family: var(--sapFontFamily);

--- a/src/fundamental-styles.scss
+++ b/src/fundamental-styles.scss
@@ -79,3 +79,4 @@
 @import "./dynamic-side-content";
 @import "./page-footer";
 @import "./fixed-card-layout.scss";
+@import "./icon-tab-bar.scss";

--- a/src/icon-tab-bar.scss
+++ b/src/icon-tab-bar.scss
@@ -1,0 +1,1002 @@
+@import './mixins';
+
+$block: fd-icon-tab-bar;
+$fd-icon-tab-bar-icon-spacing: 0.188rem !default;
+$fd-icon-tab-bar-list-padding-right: 1rem !default;
+$fd-icon-tab-bar-icon-circle-size: 2.75rem !default;
+$fd-icon-tab-bar-icon-separator-size: 1rem !default;
+$fd-icon-tab-bar-border-thickness: 0.0625rem !default;
+$fd-icon-tab-bar-filter-container-height: 2rem !default;
+$fd-icon-tab-bar-single-click-arrow-size: 1rem !default;
+$fd-icon-tab-bar-icon-circle-size-compact: 2rem !default;
+$fd-icon-tab-bar-multi-click-button-size: 1.5rem !default;
+$fd-icon-tab-bar-tablist-border: var(--sapContent_HeaderShadow);
+$fd-icon-tab-bar-filter-container-top-offset: 1.625rem !default;
+$fd-icon-tab-bar-overflow-button-border-radius: 0.75rem !default;
+$fd-icon-tab-bar-overflow-button-focus-offset: 0.0625rem !default;
+$fd-icon-tab-bar-filter-container-top-offset-compact: 1.375rem !default;
+
+$fd-icon-tab-bar-responsive-paddings: (
+  'sm':  ('padding': 0 1rem),
+  'md':  ('padding': 0 2rem),
+  'lg':  ('padding': 0 2rem),
+  'xl':  ('padding': 0 3rem),
+  'xxl': ('padding': 0 3rem)
+);
+
+$fd-icon-tab-bar-semantic-values: (
+  'negative':  (
+    'icon': '\e1ec',
+    'iconColor': var(--sapNegativeElementColor),
+    'color': var(--fdIcon_Tab_Bar_Semantic_Color_Negative),
+    'badgeColor': var(--fdIcon_Tab_Bar_Semantic_Badge_Color_Negative),
+    'backgroundColor': var(--fdIcon_Tab_Bar_Semantic_Background_Color_Negative)
+  ),
+  'positive':  (
+    'icon': '\e1c1',
+    'iconColor': var(--sapPositiveElementColor),
+    'color': var(--fdIcon_Tab_Bar_Semantic_Color_Positive),
+    'badgeColor': var(--fdIcon_Tab_Bar_Semantic_Badge_Color_Positive),
+    'backgroundColor': var(--fdIcon_Tab_Bar_Semantic_Background_Color_Positive)
+  ),
+  'critical':  (
+    'icon': '\e053',
+    'iconColor': var(--sapCriticalElementColor),
+    'color': var(--fdIcon_Tab_Bar_Semantic_Color_Critical),
+    'badgeColor': var(--fdIcon_Tab_Bar_Semantic_Badge_Color_Critical),
+    'backgroundColor': var(--fdIcon_Tab_Bar_Semantic_Background_Color_Critical)
+  ),
+  'informative':  (
+    'icon': '\e289',
+    'iconColor': var(--sapInformativeElementColor),
+    'color': var(--fdIcon_Tab_Bar_Semantic_Color_Informative),
+    'badgeColor': var(--fdIcon_Tab_Bar_Semantic_Badge_Color_Informative),
+    'backgroundColor': var(--fdIcon_Tab_Bar_Semantic_Background_Color_Informative)
+  )
+);
+
+@mixin fd-icon-tab-bar-selection-bar() {
+  position: relative;
+
+  &::after {
+    left: 0;
+    bottom: 0;
+    content: '';
+    width: 100%;
+    position: absolute;
+    display: inline-block;
+    border-radius: 0.125rem 0.125rem 0 0;
+    transition: all $fd-animation-speed ease-in;
+    height: var(--fdIcon_Tab_Bar_Selection_Bar_Height);
+    background: var(--fdIcon_Tab_Bar_Selection_Bar_Color);
+  }
+}
+
+@mixin fd-icon-tab-bar-set-circle-size($size) {
+  width: $size;
+  height: $size;
+  border-radius: 50%;
+}
+
+@mixin fd-icon-tab-bar-reset-icon() {
+  margin: 0;
+  content: none;
+}
+
+@mixin fd-icon-tab-bar-process-selection-bar-width($iconSize) {
+  &::after {
+    width: $iconSize + 2 * $fd-icon-tab-bar-icon-spacing;
+  }
+}
+
+@mixin fd-icon-tab-bar-set-overflow-state-colors($borderColor, $backgroundColor, $textColor, $iconColor) {
+  background: $backgroundColor;
+  border: $fd-icon-tab-bar-border-thickness solid $borderColor;
+
+  .#{$block}__overflow-text {
+    color: $textColor;
+  }
+
+  [class*='sap-icon'] {
+    font-size: 1rem;
+    color: $iconColor;
+  }
+}
+
+@mixin apply-responsive-paddings($padding) {
+  .#{$block}__header {
+    padding: 0 $padding;
+  }
+}
+
+%fd-icon-tab-bar-text {
+  @include fd-reset();
+
+  line-height: 1rem;
+  white-space: nowrap;
+  color: var(--sapContent_LabelColor);
+}
+
+%semantic-icon-base {
+  speak: none;
+  font-size: 0.75rem;
+  font-family: 'SAP-icons';
+  -webkit-font-smoothing: antialiased;
+  display: var(--fdIcon_Tab_Bar_Semantic_Icon_Display);
+}
+
+%semantic-icon-extended {
+  margin: 0;
+  bottom: 0;
+  width: 0.75rem;
+  position: absolute;
+}
+
+%semantic-icon-reset {
+  &::before {
+    @include fd-icon-tab-bar-reset-icon();
+  }
+}
+
+%fd-tabs-focus {
+  outline-style: var(--sapContent_FocusStyle);
+  outline-width: var(--sapContent_FocusWidth);
+  outline-color: var(--sapContent_FocusColor);
+}
+
+@mixin fd-icon-tab-bar-semantic-item() {
+  @each $set-name, $set-params in $fd-icon-tab-bar-semantic-values {
+    $semantic-icon-margin: 0.5rem;
+    $semantic-icon-position: -0.9rem;
+
+    &--#{$set-name} {
+      .#{$block}__tag {
+        color: map_get($set-params, 'color');
+
+        &::before {
+          @extend %semantic-icon-base;
+
+          margin-right: $semantic-icon-margin;
+          content: map_get($set-params, 'icon');
+          color: map_get($set-params, 'iconColor');
+        }
+
+        @include fd-rtl() {
+          @extend %semantic-icon-reset;
+
+          &::after {
+            @extend %semantic-icon-base;
+
+            margin-left: $semantic-icon-margin;
+            content: map_get($set-params, 'icon');
+            color: map_get($set-params, 'iconColor');
+          }
+        }
+      }
+
+      .#{$block}__tab {
+        @include fd-selected() {
+          &::after {
+            background: map_get($set-params, 'color');
+          }
+
+          .#{$block}__tag {
+            color: map_get($set-params, 'color');
+          }
+
+          .#{$block}__icon {
+            background-color: map_get($set-params, 'backgroundColor');
+          }
+        }
+      }
+
+      .#{$block}__icon {
+        @include fd-icon-selector() {
+          color: map_get($set-params, 'color');
+        }
+
+        position: relative;
+        border-color: map_get($set-params, 'color');
+
+        &::before {
+          @extend %semantic-icon-base;
+          @extend %semantic-icon-extended;
+
+          right: $semantic-icon-position;
+          content: map_get($set-params, 'icon');
+          color: map_get($set-params, 'iconColor');
+        }
+
+        @include fd-rtl() {
+          @extend %semantic-icon-reset;
+
+          &::after {
+            @extend %semantic-icon-base;
+            @extend %semantic-icon-extended;
+
+            right: auto;
+            left: $semantic-icon-position;
+            content: map_get($set-params, 'icon');
+            color: map_get($set-params, 'iconColor');
+          }
+        }
+      }
+
+      .#{$block}__badge {
+        background: map_get($set-params, 'badgeColor');
+
+        &::after {
+          background: map_get($set-params, 'badgeColor');
+        }
+      }
+    }
+  }
+}
+
+.#{$block} {
+  @include fd-reset();
+
+  &__header {
+    @include fd-reset();
+    @include fd-flex-vertical-center();
+
+    list-style: none;
+    box-shadow: var(--sapContent_HeaderShadow);
+    background: var(--sapObjectHeader_Background);
+  }
+
+  &__panel {
+    background: var(--sapBackgroundColor);
+  }
+
+  &__item {
+    @include fd-reset();
+    @include fd-set-margin-right(2rem);
+    @include fd-icon-tab-bar-semantic-item();
+    @include fd-flex-vertical-center();
+
+    &--single-click {
+      .#{$block}__tab {
+        flex-direction: row;
+        align-items: center;
+
+        @include fd-focus() {
+          .#{$block}__tab-container {
+            @extend %fd-tabs-focus;
+          }
+
+          .#{$block}__tag {
+            outline: none;
+          }
+        }
+      }
+    }
+
+    &--multi-click {
+      @include fd-flex-center();
+
+      position: relative;
+
+      .#{$block}__button {
+        @include fd-reset-margins();
+        @include fd-reset-paddings();
+
+        width: $fd-icon-tab-bar-multi-click-button-size;
+        height: $fd-icon-tab-bar-multi-click-button-size;
+        min-width: $fd-icon-tab-bar-multi-click-button-size;
+      }
+
+      .#{$block}__popover {
+        @include fd-set-position-right(0);
+
+        top: 0;
+        position: absolute;
+      }
+
+      .#{$block}__tab {
+        @include fd-selected() {
+          @include fd-set-paddings-x(0.188rem, 2.188rem);
+        }
+
+        .#{$block}__badge {
+          @include fd-set-position-right(1.625rem);
+        }
+      }
+    }
+  }
+
+  &__button-container {
+    @include fd-reset();
+    @include fd-flex-center();
+
+    width: 2rem;
+    height: 2.75rem;
+  }
+
+  &__tab {
+    @include fd-reset();
+
+    @include fd-flex(column) {
+      align-items: flex-start;
+    }
+
+    @include fd-selected() {
+      @include fd-icon-tab-bar-selection-bar();
+
+      @include fd-rtl() {
+        &::after {
+          left: auto;
+          right: 0;
+        }
+      }
+
+      .#{$block}__tag {
+        color: var(--fdIcon_Tab_Bar_Selection_Color);
+      }
+
+      .#{$block}__icon {
+        @include fd-icon-selector() {
+          color: var(--sapContent_ContrastIconColor);
+        }
+
+        background-color: var(--sapSelectedColor);
+      }
+    }
+
+    @include fd-focus() {
+      box-shadow: none;
+      outline: none;
+
+      .#{$block}__tag,
+      .#{$block}__icon,
+      .#{$block}__container--filter {
+        @extend %fd-tabs-focus;
+      }
+    }
+
+    cursor: pointer;
+    min-width: 2rem;
+    position: relative;
+    text-decoration: none;
+    padding: 0.875rem 0.188rem;
+  }
+
+  &__tab-container {
+    @include fd-reset();
+    @include fd-flex-center();
+  }
+
+  &__arrow {
+    @include fd-reset();
+    @include fd-flex-center();
+    @include fd-set-margin-left(0.375rem);
+
+    width: $fd-icon-tab-bar-single-click-arrow-size;
+    height: $fd-icon-tab-bar-single-click-arrow-size;
+  }
+
+  &__tag {
+    @extend %fd-icon-tab-bar-text;
+  }
+
+  &__counter {
+    @extend %fd-icon-tab-bar-text;
+
+    margin-bottom: 0.125rem;
+  }
+
+  &__icon {
+    @include fd-reset();
+    @include fd-flex-center();
+    @include fd-set-margins-x-equal($fd-icon-tab-bar-icon-spacing);
+    @include fd-icon-tab-bar-set-circle-size($fd-icon-tab-bar-icon-circle-size);
+
+    @include fd-icon-selector() {
+      font-size: 1.25rem;
+      color: var(--sapContent_IconColor);
+    }
+
+    border-radius: 50%;
+    border: $fd-icon-tab-bar-border-thickness solid var(--fdIcon_Tab_Bar_Icon_Border_Color);
+  }
+
+  &__details {
+    @include fd-reset();
+
+    @include fd-flex(column) {
+      align-items: flex-start;
+      justify-content: flex-end;
+    }
+
+    @include fd-set-paddings-x(0.125rem, 0.25rem);
+    @include fd-set-paddings-y(0.375rem, 0.25rem);
+
+    max-width: 7.5rem;
+    height: $fd-icon-tab-bar-icon-circle-size;
+  }
+
+  &__label {
+    @include fd-reset();
+    @include fd-ellipsis();
+
+    line-height: 0.875rem;
+    font-size: var(--sapFontSmallSize);
+    color: var(--sapContent_LabelColor);
+  }
+
+  &__separator {
+    @include fd-reset();
+    @include fd-set-paddings-x-equal(0.5rem);
+
+    @include fd-icon-selector() {
+      font-size: 1rem;
+      color: var(--sapContent_NonInteractiveIconColor);
+
+      @include fd-rtl() {
+        transform: rotate(180deg);
+      }
+    }
+  }
+
+  &__container {
+    @include fd-reset();
+
+    position: relative;
+
+    .#{$block}__badge {
+      @include fd-icon-tab-bar-set-circle-size(0.5rem);
+      @include fd-set-position-right($fd-icon-tab-bar-icon-spacing);
+
+      top: 0;
+      border: 0.125rem solid var(--sapObjectHeader_Background);
+    }
+
+    .#{$block}__counter {
+      @include fd-set-position-left($fd-icon-tab-bar-icon-circle-size);
+
+      top: 0;
+      position: absolute;
+    }
+
+    &--filter {
+      @include fd-flex-vertical-center();
+
+      height: $fd-icon-tab-bar-filter-container-height;
+      $separator-position: -1 * (0.5rem + $fd-icon-tab-bar-border-thickness);
+
+      &::after {
+        padding: 0;
+        content: '';
+        position: absolute;
+        right: $separator-position;
+        width: $fd-icon-tab-bar-border-thickness;
+        background: var(--sapGroup_TitleBorderColor);
+        height: $fd-icon-tab-bar-filter-container-height;
+      }
+
+      @include fd-rtl() {
+        &::after {
+          right: auto;
+          left: $separator-position;
+        }
+      }
+    }
+  }
+
+  &__filter-label,
+  &__filter-counter {
+    @include fd-reset();
+
+    font-size: var(--sapFontSmallSize);
+    color: var(--sapContent_LabelColor);
+  }
+
+  &__filter-counter {
+    @include fd-set-margin-right(0.5rem);
+
+    font-size: 1.5rem;
+  }
+
+  &__overflow {
+    @include fd-reset();
+    @include fd-flex-vertical-center();
+    @include fd-set-paddings-x-equal(0.5rem);
+    @include fd-icon-tab-bar-set-overflow-state-colors(
+      var(--sapButton_BorderColor),
+      var(--sapButton_Background),
+      var(--sapButton_TextColor),
+      var(--sapButton_IconColor)
+    );
+
+    @include fd-hover() {
+      @include fd-icon-tab-bar-set-overflow-state-colors(
+        var(--sapButton_Hover_BorderColor),
+        var(--sapButton_Hover_Background),
+        var(--sapButton_Hover_TextColor),
+        var(--sapButton_Hover_TextColor)
+      );
+    }
+
+    @include fd-active() {
+      @include fd-icon-tab-bar-set-overflow-state-colors(
+        var(--sapButton_Active_BorderColor),
+        var(--sapButton_Active_Background),
+        var(--sapButton_Active_TextColor),
+        var(--sapButton_Active_TextColor)
+      );
+    }
+
+    @include fd-focus() {
+      outline: none;
+
+      &::after {
+        content: '';
+        display: block;
+        position: absolute;
+        top: $fd-icon-tab-bar-overflow-button-focus-offset;
+        left: $fd-icon-tab-bar-overflow-button-focus-offset;
+        right: $fd-icon-tab-bar-overflow-button-focus-offset;
+        bottom: $fd-icon-tab-bar-overflow-button-focus-offset;
+        border-radius: $fd-icon-tab-bar-overflow-button-border-radius;
+        border: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
+      }
+
+      @include fd-active() {
+        &::after {
+          border: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_ContrastFocusColor);
+        }
+      }
+    }
+
+    height: 1.5rem;
+    cursor: pointer;
+    position: relative;
+    border-radius: $fd-icon-tab-bar-overflow-button-border-radius;
+
+    &-text {
+      @include fd-reset();
+      @include fd-set-margin-right(0.375rem);
+
+      line-height: 1.5rem;
+    }
+  }
+
+  &__badge {
+    @include fd-reset();
+    @include fd-flex-center();
+    @include fd-icon-tab-bar-set-circle-size(0.375rem);
+    @include fd-set-position-right(-1 * ($fd-icon-tab-bar-border-thickness + $fd-icon-tab-bar-icon-spacing));
+
+    top: 0.75rem;
+    position: absolute;
+    box-sizing: content-box;
+    background: var(--fdIcon_Tab_Bar_Badge_Color);
+    border: $fd-icon-tab-bar-border-thickness solid var(--sapObjectHeader_Background);
+
+    &--animated {
+      transform: scale(0);
+      animation-name: pulseAppear, pulseDisappear;
+      animation-duration: 1500ms, 750ms;
+      animation-delay: 0ms, 1500ms;
+      animation-timing-function: ease-in, ease-out;
+      animation-iteration-count: 1, 1;
+
+      &::after {
+        @include fd-icon-tab-bar-set-circle-size(0.75rem);
+
+        opacity: 0;
+        content: '';
+        position: absolute;
+        transform: scale(0);
+        animation: pulseAfter 1000ms ease-in;
+        animation-delay: 1000ms;
+        animation-iteration-count: 1;
+        background: var(--sapContent_BadgeBackground);
+      }
+
+      @keyframes pulseAppear {
+        0% {
+          transform: scale(0.25);
+        }
+
+        64% {
+          transform: scale(1.25);
+        }
+
+        71% {
+          transform: scale(1);
+        }
+
+        100% {
+          transform: scale(1);
+        }
+      }
+
+      @keyframes pulseDisappear {
+        from {
+          transform: scale(1);
+        }
+
+        to {
+          transform: scale(0);
+        }
+      }
+
+      @keyframes pulseAfter {
+        0% {
+          transform: scale(0);
+          opacity: 0;
+        }
+
+        71% {
+          transform: scale(1);
+          opacity: 0.2;
+        }
+
+        80% {
+          transform: scale(1.17);
+          opacity: 0.2;
+        }
+
+        86% {
+          transform: scale(1.33);
+          opacity: 0.1;
+        }
+
+        93% {
+          transform: scale(1.5);
+          opacity: 0;
+        }
+
+        100% {
+          transform: scale(0);
+          opacity: 0;
+        }
+      }
+    }
+  }
+
+  &__line-separator {
+    @include fd-reset();
+
+    width: 100%;
+
+    &::after {
+      content: '';
+      display: block;
+      margin-top: 0.25rem;
+      border-bottom: 0.063rem solid var(--sapGroup_TitleBorderColor);
+    }
+  }
+
+  &__icon-separator {
+    @include fd-reset();
+
+    @include fd-flex-vertical-bottom() {
+      justify-content: center;
+    }
+
+    height: $fd-icon-tab-bar-icon-separator-size;
+
+    [class*='sap-icon'] {
+      width: $fd-icon-tab-bar-icon-separator-size;
+      height: $fd-icon-tab-bar-icon-separator-size;
+      font-size: $fd-icon-tab-bar-icon-separator-size;
+      line-height: $fd-icon-tab-bar-icon-separator-size;
+    }
+
+    @include fd-rtl() {
+      [class*='sap-icon'] {
+        transform: rotate(180deg);
+      }
+    }
+  }
+
+  &__list {
+    .#{$block}__list-item {
+      @for $i from 1 through 10 {
+        $offset: (($i - 1) * 0.5rem) + $fd-icon-tab-bar-list-padding-right;
+
+        &[aria-level="#{$i}"] {
+          & > * {
+            @include fd-set-paddings-x($offset, $fd-icon-tab-bar-list-padding-right);
+          }
+
+          & + .#{$block}__line-separator {
+            @include fd-set-paddings-x($offset, $fd-icon-tab-bar-list-padding-right);
+          }
+        }
+      }
+
+      span {
+        flex: 0 1 auto;
+      }
+
+      .#{$block}__badge {
+        position: static;
+        margin-bottom: 0.625rem;
+      }
+    }
+
+    .#{$block}__line-separator:first-child {
+      @include fd-set-paddings-x-equal($fd-icon-tab-bar-list-padding-right);
+
+      &::after {
+        margin-top: 0.75rem;
+      }
+    }
+
+    .#{$block}__icon-separator:first-child {
+      @include fd-set-paddings-x-equal($fd-icon-tab-bar-list-padding-right);
+
+      height: 2rem;
+    }
+  }
+
+  // MODIFIERS
+  &--transparent {
+    .#{$block}__header {
+      background: transparent;
+    }
+
+    .#{$block}__panel {
+      background: transparent;
+    }
+  }
+
+  &--translucent {
+    .#{$block}__header {
+      background: var(--sapObjectHeader_Background);
+    }
+
+    .#{$block}__panel {
+      background: var(--sapGroup_ContentBackground);
+    }
+  }
+
+  &--compact {
+    .#{$block}__icon {
+      @include fd-icon-tab-bar-set-circle-size($fd-icon-tab-bar-icon-circle-size-compact);
+
+      @include fd-icon-selector() {
+        font-size: 1rem;
+      }
+    }
+
+    .#{$block}__container {
+      .#{$block}__badge {
+        @include fd-icon-tab-bar-set-circle-size(0.375rem);
+      }
+
+      .#{$block}__counter {
+        @include fd-set-position-left($fd-icon-tab-bar-icon-circle-size-compact);
+      }
+    }
+  }
+
+  &--counters {
+    .#{$block}__tab {
+      height: 3.875rem;
+      justify-content: flex-end;
+    }
+
+    .#{$block}__badge {
+      top: 2rem - $fd-icon-tab-bar-border-thickness;
+    }
+  }
+
+  &--icon-only {
+    .#{$block}__tab {
+      @include fd-reset-paddings();
+      @include fd-set-paddings-y-equal(1rem);
+      @include fd-set-margins-x-equal(0.75rem);
+
+      position: relative;
+      flex-direction: row;
+    }
+
+    .#{$block}__item {
+      @include fd-set-margins-x-equal(0.25rem);
+
+      &:first-child {
+        @include fd-reset-margins();
+        @include fd-set-margin-right(0.25rem);
+
+        .#{$block}__tab {
+          @include fd-reset-margins-x();
+          @include fd-set-margin-right(0.75rem);
+        }
+      }
+    }
+
+    .#{$block}__container {
+      .#{$block}__badge {
+        $badgePosition: $fd-icon-tab-bar-icon-spacing + $fd-icon-tab-bar-border-thickness;
+
+        @include fd-set-position-right($badgePosition);
+      }
+
+      .#{$block}__counter {
+        @include fd-set-position-left($fd-icon-tab-bar-icon-circle-size + $fd-icon-tab-bar-icon-spacing);
+      }
+    }
+
+    &.#{$block}--compact {
+      .#{$block}__container {
+        .#{$block}__counter {
+          @include fd-set-position-left($fd-icon-tab-bar-icon-circle-size-compact + $fd-icon-tab-bar-icon-spacing);
+        }
+
+        .#{$block}__badge {
+          @include fd-set-position-right(0.188rem);
+        }
+      }
+    }
+  }
+
+  &--icon {
+    .#{$block}__item {
+      @include fd-reset-margins();
+
+      @each $set-name, $set-params in $fd-icon-tab-bar-semantic-values {
+        &--#{$set-name} {
+          .#{$block}__icon::before {
+            @include fd-icon-tab-bar-reset-icon();
+          }
+
+          @include fd-rtl() {
+            .#{$block}__icon::after {
+              @include fd-icon-tab-bar-reset-icon();
+            }
+          }
+
+          .#{$block}__label {
+            color: map_get($set-params, 'color');
+
+            &::before {
+              @extend %semantic-icon-base;
+
+              margin-right: 0.5rem;
+              content: map_get($set-params, 'icon');
+              color: map_get($set-params, 'iconColor');
+            }
+
+            @include fd-rtl() {
+              &::before {
+                @include fd-icon-tab-bar-reset-icon();
+              }
+
+              &::after {
+                @extend %semantic-icon-base;
+
+                margin-left: 0.5rem;
+                content: map_get($set-params, 'icon');
+                color: map_get($set-params, 'iconColor');
+              }
+            }
+          }
+        }
+      }
+    }
+
+    .#{$block}__tab {
+      @include fd-reset-paddings();
+      @include fd-set-paddings-y-equal(1rem);
+      @include fd-icon-tab-bar-process-selection-bar-width($fd-icon-tab-bar-icon-circle-size);
+
+      flex-direction: row;
+    }
+
+    .#{$block}__counter {
+      margin-bottom: 0;
+      line-height: 0.875rem;
+      font-size: var(--sapFontSmallSize);
+
+      & + .#{$block}__label {
+        margin-top: 0.375rem;
+      }
+    }
+
+    &.#{$block}--compact {
+      .#{$block}__details {
+        @include fd-reset-paddings-y();
+
+        height: $fd-icon-tab-bar-icon-circle-size-compact;
+      }
+
+      .#{$block}__tab {
+        @include fd-icon-tab-bar-process-selection-bar-width($fd-icon-tab-bar-icon-circle-size-compact);
+      }
+
+      .#{$block}__counter {
+        & + .#{$block}__label {
+          margin-top: 0.25rem;
+        }
+      }
+    }
+  }
+
+  &--process {
+    .#{$block}__item {
+      @include fd-reset-margins-x();
+    }
+  }
+
+  &--filter {
+    .#{$block}__item {
+      @include fd-set-margins-x-equal(0.25rem);
+
+      &:first-child {
+        @include fd-set-margins-x(0, 1.063rem);
+
+        .#{$block}__tab {
+          @include fd-set-paddings-y($fd-icon-tab-bar-filter-container-top-offset, 1.875rem);
+
+          position: relative;
+        }
+      }
+
+      &:nth-child(2) {
+        @include fd-reset-margins();
+        @include fd-set-margin-right(0.25rem);
+      }
+    }
+
+    .#{$block}__tab {
+      @include fd-reset-margins-x();
+      @include fd-set-paddings-x-equal(0.188rem);
+      @include fd-set-paddings-y(0.875rem, 0.625rem);
+
+      position: relative;
+      align-items: center;
+    }
+
+    .#{$block}__icon {
+      @include fd-reset-margins-x();
+    }
+
+    .#{$block}__label {
+      width: 5rem;
+      text-align: center;
+      margin-top: 0.375rem;
+    }
+
+    &.#{$block}--compact {
+      .#{$block}__item:first-child {
+        .#{$block}__tab {
+          @include fd-set-paddings-y-equal($fd-icon-tab-bar-filter-container-top-offset-compact);
+        }
+      }
+
+      .#{$block}__badge {
+        @include fd-set-position-right(0.063rem);
+      }
+    }
+  }
+
+  @each $set-name, $set-padding in $fd-icon-tab-bar-responsive-paddings {
+    &--#{$set-name} {
+      .#{$block}__header {
+        padding: map_get($set-padding, 'padding');
+      }
+    }
+  }
+
+  &--responsive-paddings {
+    @media (max-width: 599px) {
+      @include apply-responsive-paddings(1rem);
+    }
+
+    @media (min-width: 600px) and (max-width: 1023px) {
+      @include apply-responsive-paddings(2rem);
+    }
+
+    @media (min-width: 1024px) and (max-width: 1439px) {
+      @include apply-responsive-paddings(2rem);
+    }
+
+    @media (min-width: 1440px) {
+      @include apply-responsive-paddings(3rem);
+    }
+  }
+}

--- a/src/mixins/_mixins.scss
+++ b/src/mixins/_mixins.scss
@@ -432,7 +432,21 @@
   text-overflow: ellipsis;
 }
 
-@mixin set-margins-x($left: 0, $right: 0) {
+@mixin fd-reset-margins() {
+  margin: 0;
+}
+
+@mixin fd-reset-margins-x() {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+@mixin fd-reset-margins-y() {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+@mixin fd-set-margins-x($left: 0, $right: 0) {
   margin-left: $left;
   margin-right: $right;
 
@@ -442,7 +456,22 @@
   }
 }
 
-@mixin set-margin-left($left: 0) {
+@mixin fd-set-margins-x-equal($value: 0) {
+  margin-left: $value;
+  margin-right: $value;
+}
+
+@mixin fd-set-margins-y($top: 0, $bottom: 0) {
+  margin-top: $top;
+  margin-bottom: $bottom;
+}
+
+@mixin fd-set-margins-y-equal($value: 0) {
+  margin-top: $value;
+  margin-bottom: $value;
+}
+
+@mixin fd-set-margin-left($left: 0) {
   margin-left: $left;
 
   @include fd-rtl() {
@@ -451,7 +480,7 @@
   }
 }
 
-@mixin set-margin-right($right: 0) {
+@mixin fd-set-margin-right($right: 0) {
   margin-right: $right;
 
   @include fd-rtl() {
@@ -460,7 +489,21 @@
   }
 }
 
-@mixin set-paddings-x($left: 0, $right: 0) {
+@mixin fd-reset-paddings() {
+  padding: 0;
+}
+
+@mixin fd-reset-paddings-x() {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+@mixin fd-reset-paddings-y() {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+@mixin fd-set-paddings-x($left: 0, $right: 0) {
   padding-left: $left;
   padding-right: $right;
 
@@ -470,7 +513,22 @@
   }
 }
 
-@mixin set-padding-left($left: 0) {
+@mixin fd-set-paddings-x-equal($value: 0) {
+  padding-left: $value;
+  padding-right: $value;
+}
+
+@mixin fd-set-paddings-y($top: 0, $bottom: 0) {
+  padding-top: $top;
+  padding-bottom: $bottom;
+}
+
+@mixin fd-set-paddings-y-equal($value: 0) {
+  padding-top: $value;
+  padding-bottom: $value;
+}
+
+@mixin fd-set-padding-left($left: 0) {
   padding-left: $left;
 
   @include fd-rtl() {
@@ -479,7 +537,7 @@
   }
 }
 
-@mixin set-padding-right($right: 0) {
+@mixin fd-set-padding-right($right: 0) {
   padding-right: $right;
 
   @include fd-rtl() {
@@ -488,10 +546,25 @@
   }
 }
 
-/*
-   Fully expanded pseudo element
-   Requires parent to have specified position
-*/
+@mixin fd-set-position-right($right) {
+  right: $right;
+
+  @include fd-rtl() {
+    right: auto;
+    left: $right;
+  }
+}
+
+@mixin fd-set-position-left($left) {
+  left: $left;
+
+  @include fd-rtl() {
+    left: auto;
+    right: $left;
+  }
+}
+
+/* Fully expanded pseudo element. Requires parent to have specified position */
 @mixin fd-pseudo-expand($position: "before") {
   &::#{$position} {
     content: "";

--- a/src/theming/sap_fiori_3.scss
+++ b/src/theming/sap_fiori_3.scss
@@ -206,4 +206,24 @@
   --fdSlide_Tile_Indicator_Active_Dot_Color: var(--sapTile_TitleTextColor);
   --fdSlide_Tile_Indicator_Dot_Border: none;
   --fdSlide_Tile_Indicator_Active_Dot_Border: none;
+
+  /* Icon Tab Bar */
+  --fdIcon_Tab_Bar_Selection_Bar_Height: 0.188rem;
+  --fdIcon_Tab_Bar_Selection_Color: var(--sapSelectedColor);
+  --fdIcon_Tab_Bar_Selection_Bar_Color: var(--sapSelectedColor);
+  --fdIcon_Tab_Bar_Icon_Border_Color: var(--sapSelectedColor);
+  --fdIcon_Tab_Bar_Semantic_Icon_Display: none;
+  --fdIcon_Tab_Bar_Semantic_Color_Positive: var(--sapPositiveElementColor);
+  --fdIcon_Tab_Bar_Semantic_Color_Negative: var(--sapNegativeElementColor);
+  --fdIcon_Tab_Bar_Semantic_Color_Critical: var(--sapCriticalElementColor);
+  --fdIcon_Tab_Bar_Semantic_Color_Informative: var(--sapInformativeElementColor);
+  --fdIcon_Tab_Bar_Semantic_Background_Color_Positive: var(--sapPositiveElementColor);
+  --fdIcon_Tab_Bar_Semantic_Background_Color_Negative: var(--sapNegativeElementColor);
+  --fdIcon_Tab_Bar_Semantic_Background_Color_Critical: var(--sapCriticalElementColor);
+  --fdIcon_Tab_Bar_Semantic_Background_Color_Informative: var(--sapInformativeElementColor);
+  --fdIcon_Tab_Bar_Badge_Color: var(--sapContent_BadgeBackground);
+  --fdIcon_Tab_Bar_Semantic_Badge_Color_Positive: var(--sapPositiveElementColor);
+  --fdIcon_Tab_Bar_Semantic_Badge_Color_Negative: var(--sapNegativeElementColor);
+  --fdIcon_Tab_Bar_Semantic_Badge_Color_Critical: var(--sapCriticalElementColor);
+  --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapInformativeElementColor);
 }

--- a/src/theming/sap_fiori_3_dark.scss
+++ b/src/theming/sap_fiori_3_dark.scss
@@ -205,4 +205,24 @@
   --fdSlide_Tile_Indicator_Active_Dot_Color: var(--sapTile_TitleTextColor);
   --fdSlide_Tile_Indicator_Dot_Border: none;
   --fdSlide_Tile_Indicator_Active_Dot_Border: none;
+
+  /* Icon Tab Bar */
+  --fdIcon_Tab_Bar_Selection_Bar_Height: 0.188rem;
+  --fdIcon_Tab_Bar_Selection_Color: var(--sapSelectedColor);
+  --fdIcon_Tab_Bar_Selection_Bar_Color: var(--sapSelectedColor);
+  --fdIcon_Tab_Bar_Icon_Border_Color: var(--sapSelectedColor);
+  --fdIcon_Tab_Bar_Semantic_Icon_Display: none;
+  --fdIcon_Tab_Bar_Semantic_Color_Positive: var(--sapPositiveElementColor);
+  --fdIcon_Tab_Bar_Semantic_Color_Negative: var(--sapNegativeElementColor);
+  --fdIcon_Tab_Bar_Semantic_Color_Critical: var(--sapCriticalElementColor);
+  --fdIcon_Tab_Bar_Semantic_Color_Informative: var(--sapInformativeElementColor);
+  --fdIcon_Tab_Bar_Semantic_Background_Color_Positive: var(--sapPositiveElementColor);
+  --fdIcon_Tab_Bar_Semantic_Background_Color_Negative: var(--sapNegativeElementColor);
+  --fdIcon_Tab_Bar_Semantic_Background_Color_Critical: var(--sapCriticalElementColor);
+  --fdIcon_Tab_Bar_Semantic_Background_Color_Informative: var(--sapInformativeElementColor);
+  --fdIcon_Tab_Bar_Badge_Color: var(--sapContent_BadgeBackground);
+  --fdIcon_Tab_Bar_Semantic_Badge_Color_Positive: var(--sapPositiveElementColor);
+  --fdIcon_Tab_Bar_Semantic_Badge_Color_Negative: var(--sapNegativeElementColor);
+  --fdIcon_Tab_Bar_Semantic_Badge_Color_Critical: var(--sapCriticalElementColor);
+  --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapInformativeElementColor);
 }

--- a/src/theming/sap_fiori_3_hcb.scss
+++ b/src/theming/sap_fiori_3_hcb.scss
@@ -205,4 +205,24 @@
   --fdSlide_Tile_Indicator_Active_Dot_Color: var(--sapContent_NonInteractiveIconColor);
   --fdSlide_Tile_Indicator_Dot_Border: solid 0.0625rem var(--sapContent_NonInteractiveIconColor);
   --fdSlide_Tile_Indicator_Active_Dot_Border: solid 0.0625rem var(--sapContent_NonInteractiveIconColor);
+
+  /* Icon Tab Bar */
+  --fdIcon_Tab_Bar_Selection_Bar_Height: 0.313rem;
+  --fdIcon_Tab_Bar_Selection_Color: var(--sapGroup_TitleTextColor);
+  --fdIcon_Tab_Bar_Selection_Bar_Color: var(--sapList_SelectionBorderColor);
+  --fdIcon_Tab_Bar_Icon_Border_Color: var(--sapList_SelectionBorderColor);
+  --fdIcon_Tab_Bar_Semantic_Icon_Display: inline;
+  --fdIcon_Tab_Bar_Semantic_Color_Positive: var(--sapContent_LabelColor);
+  --fdIcon_Tab_Bar_Semantic_Color_Negative: var(--sapContent_LabelColor);
+  --fdIcon_Tab_Bar_Semantic_Color_Critical: var(--sapContent_LabelColor);
+  --fdIcon_Tab_Bar_Semantic_Color_Informative: var(--sapContent_LabelColor);
+  --fdIcon_Tab_Bar_Semantic_Background_Color_Positive: var(--sapSelectedColor);
+  --fdIcon_Tab_Bar_Semantic_Background_Color_Negative: var(--sapSelectedColor);
+  --fdIcon_Tab_Bar_Semantic_Background_Color_Critical: var(--sapSelectedColor);
+  --fdIcon_Tab_Bar_Semantic_Background_Color_Informative: var(--sapSelectedColor);
+  --fdIcon_Tab_Bar_Badge_Color: var(--sapContent_IconColor);
+  --fdIcon_Tab_Bar_Semantic_Badge_Color_Positive: var(--sapContent_IconColor);
+  --fdIcon_Tab_Bar_Semantic_Badge_Color_Negative: var(--sapContent_IconColor);
+  --fdIcon_Tab_Bar_Semantic_Badge_Color_Critical: var(--sapContent_IconColor);
+  --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapContent_IconColor);
 }

--- a/src/theming/sap_fiori_3_hcw.scss
+++ b/src/theming/sap_fiori_3_hcw.scss
@@ -205,4 +205,24 @@
   --fdSlide_Tile_Indicator_Active_Dot_Color: var(--sapContent_NonInteractiveIconColor);
   --fdSlide_Tile_Indicator_Dot_Border: solid 0.0625rem var(--sapContent_NonInteractiveIconColor);
   --fdSlide_Tile_Indicator_Active_Dot_Border: solid 0.0625rem var(--sapContent_NonInteractiveIconColor);
+
+  /* Icon Tab Bar */
+  --fdIcon_Tab_Bar_Selection_Bar_Height: 0.313rem;
+  --fdIcon_Tab_Bar_Selection_Color: var(--sapGroup_TitleTextColor);
+  --fdIcon_Tab_Bar_Selection_Bar_Color: var(--sapList_SelectionBorderColor);
+  --fdIcon_Tab_Bar_Icon_Border_Color: var(--sapList_SelectionBorderColor);
+  --fdIcon_Tab_Bar_Semantic_Icon_Display: inline;
+  --fdIcon_Tab_Bar_Semantic_Color_Positive: var(--sapContent_LabelColor);
+  --fdIcon_Tab_Bar_Semantic_Color_Negative: var(--sapContent_LabelColor);
+  --fdIcon_Tab_Bar_Semantic_Color_Critical: var(--sapContent_LabelColor);
+  --fdIcon_Tab_Bar_Semantic_Color_Informative: var(--sapContent_LabelColor);
+  --fdIcon_Tab_Bar_Semantic_Background_Color_Positive: var(--sapSelectedColor);
+  --fdIcon_Tab_Bar_Semantic_Background_Color_Negative: var(--sapSelectedColor);
+  --fdIcon_Tab_Bar_Semantic_Background_Color_Critical: var(--sapSelectedColor);
+  --fdIcon_Tab_Bar_Semantic_Background_Color_Informative: var(--sapSelectedColor);
+  --fdIcon_Tab_Bar_Badge_Color: var(--sapContent_IconColor);
+  --fdIcon_Tab_Bar_Semantic_Badge_Color_Positive: var(--sapContent_IconColor);
+  --fdIcon_Tab_Bar_Semantic_Badge_Color_Negative: var(--sapContent_IconColor);
+  --fdIcon_Tab_Bar_Semantic_Badge_Color_Critical: var(--sapContent_IconColor);
+  --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapContent_IconColor);
 }

--- a/src/theming/sap_fiori_3_light_dark.scss
+++ b/src/theming/sap_fiori_3_light_dark.scss
@@ -205,4 +205,24 @@
   --fdSlide_Tile_Indicator_Active_Dot_Color: var(--sapTile_TitleTextColor);
   --fdSlide_Tile_Indicator_Dot_Border: none;
   --fdSlide_Tile_Indicator_Active_Dot_Border: none;
+
+  /* Icon Tab Bar */
+  --fdIcon_Tab_Bar_Selection_Bar_Height: 0.188rem;
+  --fdIcon_Tab_Bar_Selection_Color: var(--sapSelectedColor);
+  --fdIcon_Tab_Bar_Selection_Bar_Color: var(--sapSelectedColor);
+  --fdIcon_Tab_Bar_Icon_Border_Color: var(--sapSelectedColor);
+  --fdIcon_Tab_Bar_Semantic_Icon_Display: none;
+  --fdIcon_Tab_Bar_Semantic_Color_Positive: var(--sapPositiveElementColor);
+  --fdIcon_Tab_Bar_Semantic_Color_Negative: var(--sapNegativeElementColor);
+  --fdIcon_Tab_Bar_Semantic_Color_Critical: var(--sapCriticalElementColor);
+  --fdIcon_Tab_Bar_Semantic_Color_Informative: var(--sapInformativeElementColor);
+  --fdIcon_Tab_Bar_Semantic_Background_Color_Positive: var(--sapPositiveElementColor);
+  --fdIcon_Tab_Bar_Semantic_Background_Color_Negative: var(--sapNegativeElementColor);
+  --fdIcon_Tab_Bar_Semantic_Background_Color_Critical: var(--sapCriticalElementColor);
+  --fdIcon_Tab_Bar_Semantic_Background_Color_Informative: var(--sapInformativeElementColor);
+  --fdIcon_Tab_Bar_Badge_Color: var(--sapContent_BadgeBackground);
+  --fdIcon_Tab_Bar_Semantic_Badge_Color_Positive: var(--sapPositiveElementColor);
+  --fdIcon_Tab_Bar_Semantic_Badge_Color_Negative: var(--sapNegativeElementColor);
+  --fdIcon_Tab_Bar_Semantic_Badge_Color_Critical: var(--sapCriticalElementColor);
+  --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapInformativeElementColor);
 }

--- a/src/vertical-nav.scss
+++ b/src/vertical-nav.scss
@@ -19,7 +19,7 @@ $block: #{$fd-namespace}-vertical-nav;
   &__group-header {
     @include fd-reset();
     @include fd-ellipsis();
-    @include set-paddings-x(1rem);
+    @include fd-set-paddings-x(1rem);
 
     height: 2.75rem;
     background: var(--sapList_GroupHeaderBackground);

--- a/stories/icon-tab-bar/__snapshots__/icon-tab-bar.stories.storyshot
+++ b/stories/icon-tab-bar/__snapshots__/icon-tab-bar.stories.storyshot
@@ -1,0 +1,6309 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Components/Icon Tab Bar Badges 1`] = `
+<section>
+  <div
+    class="fd-icon-tab-bar"
+  >
+    
+    
+    <ul
+      class="fd-icon-tab-bar__header"
+      role="tablist"
+    >
+        
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#section11"
+          id="tab1"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 1
+          </span>
+          
+                
+          <span
+            class="fd-icon-tab-bar__badge"
+          />
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          aria-selected="true"
+          class="fd-icon-tab-bar__tab"
+          href="#section12"
+          id="tab2"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 2
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#section13"
+          id="tab3"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 3
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+    
+    </ul>
+    
+
+  </div>
+  
+
+
+  <br />
+  <br />
+  
+
+  <div
+    class="fd-icon-tab-bar"
+  >
+    
+    
+    <ul
+      class="fd-icon-tab-bar__header"
+      role="tablist"
+    >
+        
+        
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--positive"
+        role="presentation"
+      >
+        
+            
+        <a
+          aria-selected="true"
+          class="fd-icon-tab-bar__tab"
+          href="#section21"
+          id="tab4"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 1
+          </span>
+          
+                
+          <span
+            class="fd-icon-tab-bar__badge"
+          />
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--negative"
+        role="presentation"
+      >
+        
+            
+        <a
+          aria-selected="true"
+          class="fd-icon-tab-bar__tab"
+          href="#section22"
+          id="tab5"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 2
+          </span>
+          
+                
+          <span
+            class="fd-icon-tab-bar__badge"
+          />
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--critical"
+        role="presentation"
+      >
+        
+            
+        <a
+          aria-selected="true"
+          class="fd-icon-tab-bar__tab"
+          href="#section23"
+          id="tab6"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 3
+          </span>
+          
+                
+          <span
+            class="fd-icon-tab-bar__badge"
+          />
+           
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--informative"
+        role="presentation"
+      >
+        
+            
+        <a
+          aria-selected="true"
+          class="fd-icon-tab-bar__tab"
+          href="#section24"
+          id="tab7"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 4
+          </span>
+          
+                
+          <span
+            class="fd-icon-tab-bar__badge"
+          />
+          
+            
+        </a>
+        
+        
+      </li>
+      
+    
+    </ul>
+    
+
+  </div>
+  
+
+
+  <br />
+  <br />
+  
+
+  <div
+    class="fd-icon-tab-bar fd-icon-tab-bar--counters"
+  >
+    
+    
+    <ul
+      class="fd-icon-tab-bar__header"
+      role="tablist"
+    >
+        
+        
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--positive"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#section41"
+          id="tab8"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 1
+          </span>
+          
+                
+          <span
+            class="fd-icon-tab-bar__badge"
+          />
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--negative"
+        role="presentation"
+      >
+        
+            
+        <a
+          aria-selected="true"
+          class="fd-icon-tab-bar__tab"
+          href="#section42"
+          id="tab9"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__counter"
+          >
+            23
+          </span>
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 2
+          </span>
+          
+                
+          <span
+            class="fd-icon-tab-bar__badge"
+          />
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--critical"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#section43"
+          id="tab10"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__counter"
+          >
+            10
+          </span>
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 3
+          </span>
+          
+                
+          <span
+            class="fd-icon-tab-bar__badge"
+          />
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--informative"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#section44"
+          id="tab11"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__counter"
+          >
+            10
+          </span>
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 4
+          </span>
+          
+                
+          <span
+            class="fd-icon-tab-bar__badge"
+          />
+          
+            
+        </a>
+        
+        
+      </li>
+      
+    
+    </ul>
+     
+
+  </div>
+  
+
+  <br />
+  <br />
+  
+
+  <div
+    class="fd-icon-tab-bar fd-icon-tab-bar--icon-only"
+  >
+    
+  
+    <ul
+      class="fd-icon-tab-bar__header"
+      role="tablist"
+    >
+      
+    
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--positive"
+        role="presentation"
+      >
+        
+      
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab12"
+          role="tab"
+        >
+          
+        
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+          
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--history"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+          
+            <span
+              class="fd-icon-tab-bar__badge fd-icon-tab-bar__badge--animated"
+            />
+            
+          
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              2
+            </span>
+            
+        
+          </div>
+          
+      
+        </a>
+        
+    
+      </li>
+      
+    
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--negative"
+        role="presentation"
+      >
+        
+      
+        <a
+          aria-selected="true"
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab13"
+          role="tab"
+        >
+          
+        
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+          
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--card"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+          
+            <span
+              class="fd-icon-tab-bar__badge fd-icon-tab-bar__badge--animated"
+            />
+            
+          
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              23
+            </span>
+            
+        
+          </div>
+          
+      
+        </a>
+        
+    
+      </li>
+      
+    
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--critical"
+        role="presentation"
+      >
+        
+      
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab14"
+          role="tab"
+        >
+          
+        
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+          
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                
+              <i
+                class="sap-icon--cart"
+                role="presentation"
+              />
+              
+          
+            </span>
+            
+          
+            <span
+              class="fd-icon-tab-bar__badge fd-icon-tab-bar__badge--animated"
+            />
+            
+          
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              10
+            </span>
+            
+        
+          </div>
+          
+      
+        </a>
+        
+    
+      </li>
+      
+    
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--informative"
+        role="presentation"
+      >
+        
+      
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab15"
+          role="tab"
+        >
+          
+        
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+          
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+            
+              <i
+                class="sap-icon--cart"
+                role="presentation"
+              />
+              
+          
+            </span>
+            
+          
+            <span
+              class="fd-icon-tab-bar__badge fd-icon-tab-bar__badge--animated"
+            />
+            
+          
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              10
+            </span>
+            
+        
+          </div>
+          
+      
+        </a>
+        
+    
+      </li>
+      
+  
+    </ul>
+    
+
+  </div>
+  
+
+</section>
+`;
+
+exports[`Storyshots Components/Icon Tab Bar Counters and Text 1`] = `
+<div
+  class="fd-icon-tab-bar fd-icon-tab-bar--counters"
+>
+  
+    
+  <ul
+    class="fd-icon-tab-bar__header"
+    role="tablist"
+  >
+      
+        
+    <li
+      class="fd-icon-tab-bar__item"
+      role="presentation"
+    >
+      
+            
+      <a
+        class="fd-icon-tab-bar__tab"
+        href="#section1"
+        id="tab1"
+        role="tab"
+      >
+        
+                
+        <span
+          class="fd-icon-tab-bar__tag"
+        >
+          Info
+        </span>
+        
+            
+      </a>
+      
+        
+    </li>
+    
+        
+    <li
+      class="fd-icon-tab-bar__item"
+      role="presentation"
+    >
+      
+            
+      <a
+        aria-selected="true"
+        class="fd-icon-tab-bar__tab"
+        href="#section2"
+        id="tab2"
+        role="tab"
+      >
+        
+                
+        <span
+          class="fd-icon-tab-bar__counter"
+        >
+          16
+        </span>
+        
+                
+        <span
+          class="fd-icon-tab-bar__tag"
+        >
+          Attachments
+        </span>
+        
+            
+      </a>
+      
+        
+    </li>
+    
+        
+    <li
+      class="fd-icon-tab-bar__item"
+      role="presentation"
+    >
+      
+            
+      <a
+        class="fd-icon-tab-bar__tab"
+        href="#section3"
+        id="tab3"
+        role="tab"
+      >
+        
+                
+        <span
+          class="fd-icon-tab-bar__counter"
+        >
+          42
+        </span>
+        
+                
+        <span
+          class="fd-icon-tab-bar__tag"
+        >
+          Approvals
+        </span>
+        
+            
+      </a>
+      
+        
+    </li>
+    
+    
+  </ul>
+   
+    
+  <section
+    aria-labelledby="tab1"
+    class="fd-icon-tab-bar__panel"
+    id="section1"
+    role="tabpanel"
+  >
+      
+        Section 1
+    
+  </section>
+    
+    
+  <section
+    aria-labelledby="tab2"
+    class="fd-icon-tab-bar__panel"
+    hidden=""
+    id="section2"
+    role="tabpanel"
+  >
+      
+        Section 2
+    
+  </section>
+    
+    
+  <section
+    aria-labelledby="tab3"
+    class="fd-icon-tab-bar__panel"
+    hidden=""
+    id="section3"
+    role="tabpanel"
+  >
+      
+        Section 3
+    
+  </section>
+  
+
+</div>
+`;
+
+exports[`Storyshots Components/Icon Tab Bar Filter 1`] = `
+<section>
+  <div
+    class="fd-icon-tab-bar fd-icon-tab-bar--filter"
+  >
+    
+    
+    <ul
+      class="fd-icon-tab-bar__header"
+      role="tablist"
+    >
+        
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          aria-selected="true"
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab1"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container fd-icon-tab-bar__container--filter"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__filter-counter"
+            >
+              ÇN
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__filter-label"
+            >
+              ProductsN
+            </span>
+            
+                
+          </div>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab2"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--letter"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__badge"
+            />
+            
+                    
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              2
+            </span>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-icon-tab-bar__label"
+          >
+            Ok
+          </div>
+          
+                
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab3"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--activate"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              23
+            </span>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-icon-tab-bar__label"
+          >
+            Heavy
+          </div>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab4"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--jam"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              10
+            </span>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-icon-tab-bar__label"
+          >
+            Overweight
+          </div>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+    
+    </ul>
+    
+
+  </div>
+  
+
+
+  <br />
+  <br />
+  
+
+  <div
+    class="fd-icon-tab-bar fd-icon-tab-bar--filter fd-icon-tab-bar--compact"
+  >
+    
+    
+    <ul
+      class="fd-icon-tab-bar__header"
+      role="tablist"
+    >
+        
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab5"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container fd-icon-tab-bar__container--filter"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__filter-counter"
+            >
+              ÇN
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__filter-label"
+            >
+              ProductsN
+            </span>
+            
+                
+          </div>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab6"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--user-settings"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__badge"
+            />
+            
+                    
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              2
+            </span>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-icon-tab-bar__label"
+          >
+            Ok
+          </div>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          aria-selected="true"
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab7"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--write-new"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              23
+            </span>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-icon-tab-bar__label"
+          >
+            Heavy
+          </div>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab8"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--bell"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              10
+            </span>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-icon-tab-bar__label"
+          >
+            Overweight
+          </div>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+    
+    </ul>
+    
+
+  </div>
+  
+
+
+  <br />
+  <br />
+  
+
+  <div
+    class="fd-icon-tab-bar fd-icon-tab-bar--filter"
+  >
+    
+    
+    <ul
+      class="fd-icon-tab-bar__header"
+      role="tablist"
+    >
+        
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab9"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container fd-icon-tab-bar__container--filter"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__filter-counter"
+            >
+              ÇN
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__filter-label"
+            >
+              ProductsN
+            </span>
+            
+                
+          </div>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--negative"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab10"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--text-color"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              2
+            </span>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-icon-tab-bar__label"
+          >
+            Ok
+          </div>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--critical"
+        role="presentation"
+      >
+        
+            
+        <a
+          aria-selected="true"
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab11"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--touch"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              23
+            </span>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-icon-tab-bar__label"
+          >
+            Heavy
+          </div>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--positive"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab12"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--feedback"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              10
+            </span>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-icon-tab-bar__label"
+          >
+            Overweight
+          </div>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+    
+    </ul>
+    
+
+  </div>
+</section>
+`;
+
+exports[`Storyshots Components/Icon Tab Bar Icon 1`] = `
+<section>
+  <div
+    class="fd-icon-tab-bar fd-icon-tab-bar--icon"
+  >
+    
+    
+    <ul
+      class="fd-icon-tab-bar__header"
+      role="tablist"
+    >
+        
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          aria-selected="true"
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="1"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--filter"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-icon-tab-bar__details"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__label"
+            >
+              Description
+            </span>
+            
+                
+          </div>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab2"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--customer"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-icon-tab-bar__details"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              99
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__label"
+            >
+              Description
+            </span>
+            
+                
+          </div>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab3"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--chain-link"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-icon-tab-bar__details"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              56 of 123
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__label"
+            >
+              Description
+            </span>
+            
+                
+          </div>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+    
+    </ul>
+     
+
+  </div>
+  
+
+
+  <br />
+  <br />
+  
+
+  <div
+    class="fd-icon-tab-bar fd-icon-tab-bar--icon fd-icon-tab-bar--compact"
+  >
+    
+    
+    <ul
+      class="fd-icon-tab-bar__header"
+      role="tablist"
+    >
+        
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab4"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--iphone"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-icon-tab-bar__details"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              25 of 789 items
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__label"
+            >
+              Claim Overweights
+            </span>
+            
+                
+          </div>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          aria-selected="true"
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab5"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--record"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-icon-tab-bar__details"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__label"
+            >
+              Confirm
+            </span>
+            
+                
+          </div>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab6"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--world"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-icon-tab-bar__details"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              12
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__label"
+            >
+              Checks
+            </span>
+            
+                
+          </div>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+    
+    </ul>
+     
+
+  </div>
+  
+
+
+  <br />
+  <br />
+  
+
+  <div
+    class="fd-icon-tab-bar fd-icon-tab-bar--icon"
+  >
+    
+    
+    <ul
+      class="fd-icon-tab-bar__header"
+      role="tablist"
+    >
+        
+        
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--positive"
+        role="presentation"
+      >
+        
+            
+        <a
+          aria-selected="true"
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab7"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--play"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-icon-tab-bar__details"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              2
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__label"
+            >
+              Description
+            </span>
+            
+                
+          </div>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--negative"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab8"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--unfavorite"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-icon-tab-bar__details"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              2
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__label"
+            >
+              Description
+            </span>
+            
+                
+          </div>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--critical"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab9"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--shipping-status"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-icon-tab-bar__details"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              2
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__label"
+            >
+              Description
+            </span>
+            
+                
+          </div>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+    
+    </ul>
+    
+
+  </div>
+  
+
+</section>
+`;
+
+exports[`Storyshots Components/Icon Tab Bar Icon Only 1`] = `
+<div
+  class="fd-icon-tab-bar fd-icon-tab-bar--icon-only"
+>
+  
+    
+  <ul
+    class="fd-icon-tab-bar__header"
+    role="tablist"
+  >
+      
+        
+    <li
+      class="fd-icon-tab-bar__item"
+      role="presentation"
+    >
+      
+            
+      <a
+        class="fd-icon-tab-bar__tab"
+        href="#section1"
+        id="tab1"
+        role="tab"
+      >
+        
+                
+        <div
+          class="fd-icon-tab-bar__container"
+        >
+          
+                    
+          <span
+            class="fd-icon-tab-bar__icon"
+          >
+            
+                        
+            <i
+              class="sap-icon--account"
+              role="presentation"
+            />
+            
+                    
+          </span>
+          
+                    
+          <span
+            class="fd-icon-tab-bar__counter"
+          >
+            2
+          </span>
+          
+                
+        </div>
+        
+            
+      </a>
+      
+        
+    </li>
+    
+        
+    <li
+      class="fd-icon-tab-bar__item"
+      role="presentation"
+    >
+      
+            
+      <a
+        aria-selected="true"
+        class="fd-icon-tab-bar__tab"
+        href="#section2"
+        id="tab2"
+        role="tab"
+      >
+        
+                
+        <div
+          class="fd-icon-tab-bar__container"
+        >
+          
+                    
+          <span
+            class="fd-icon-tab-bar__icon"
+          >
+            
+                        
+            <i
+              class="sap-icon--product"
+              role="presentation"
+            />
+            
+                    
+          </span>
+          
+                    
+          <span
+            class="fd-icon-tab-bar__counter"
+          >
+            23
+          </span>
+          
+                
+        </div>
+        
+            
+      </a>
+      
+        
+    </li>
+    
+        
+    <li
+      class="fd-icon-tab-bar__item"
+      role="presentation"
+    >
+      
+            
+      <a
+        class="fd-icon-tab-bar__tab"
+        href="#section3"
+        id="tab3"
+        role="tab"
+      >
+        
+                
+        <div
+          class="fd-icon-tab-bar__container"
+        >
+          
+                    
+          <span
+            class="fd-icon-tab-bar__icon"
+          >
+            
+                        
+            <i
+              class="sap-icon--present"
+              role="presentation"
+            />
+            
+                    
+          </span>
+          
+                    
+          <span
+            class="fd-icon-tab-bar__counter"
+          >
+            10
+          </span>
+          
+                
+        </div>
+        
+            
+      </a>
+      
+        
+    </li>
+    
+    
+  </ul>
+   
+    
+  <section
+    aria-labelledby="tab1"
+    class="fd-icon-tab-bar__panel"
+    id="section1"
+    role="tabpanel"
+  >
+      
+        Section 1
+    
+  </section>
+    
+    
+  <section
+    aria-labelledby="tab2"
+    class="fd-icon-tab-bar__panel"
+    hidden=""
+    id="section2"
+    role="tabpanel"
+  >
+      
+        Section 2
+    
+  </section>
+    
+    
+  <section
+    aria-labelledby="tab3"
+    class="fd-icon-tab-bar__panel"
+    hidden=""
+    id="section3"
+    role="tabpanel"
+  >
+      
+        Section 3
+    
+  </section>
+  
+
+</div>
+`;
+
+exports[`Storyshots Components/Icon Tab Bar Icon Only Semantic Colors 1`] = `
+<section>
+  <div
+    class="fd-icon-tab-bar fd-icon-tab-bar--icon-only"
+  >
+    
+    
+    <ul
+      class="fd-icon-tab-bar__header"
+      role="tablist"
+    >
+        
+        
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--positive"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab1"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--history"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              2
+            </span>
+            
+                
+          </div>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--negative"
+        role="presentation"
+      >
+        
+            
+        <a
+          aria-selected="true"
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab2"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--card"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              23
+            </span>
+            
+                
+          </div>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--critical"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab3"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--cart"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              10
+            </span>
+            
+                
+          </div>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--informative"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab4"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--cart"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              10
+            </span>
+            
+                
+          </div>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+    
+    </ul>
+     
+
+  </div>
+  
+
+  <br />
+  <br />
+  
+
+  <div
+    class="fd-icon-tab-bar fd-icon-tab-bar--icon-only fd-icon-tab-bar--compact"
+  >
+    
+    
+    <ul
+      class="fd-icon-tab-bar__header"
+      role="tablist"
+    >
+        
+        
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--positive"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab5"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--attachment"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              2
+            </span>
+            
+                
+          </div>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--negative"
+        role="presentation"
+      >
+        
+            
+        <a
+          aria-selected="true"
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab6"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--activities"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              23
+            </span>
+            
+                
+          </div>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--critical"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab7"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--family-care"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              10
+            </span>
+            
+                
+          </div>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--informative"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab8"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--family-care"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              10
+            </span>
+            
+                
+          </div>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+    
+    </ul>
+    
+
+  </div>
+  
+
+</section>
+`;
+
+exports[`Storyshots Components/Icon Tab Bar Icon Only in Compact Mode 1`] = `
+<div
+  class="fd-icon-tab-bar fd-icon-tab-bar--icon-only fd-icon-tab-bar--compact"
+>
+  
+    
+  <ul
+    class="fd-icon-tab-bar__header"
+    role="tablist"
+  >
+      
+        
+    <li
+      class="fd-icon-tab-bar__item"
+      role="presentation"
+    >
+      
+            
+      <a
+        class="fd-icon-tab-bar__tab"
+        href="#section1"
+        id="tab1"
+        role="tab"
+      >
+        
+                
+        <div
+          class="fd-icon-tab-bar__container"
+        >
+          
+                    
+          <span
+            class="fd-icon-tab-bar__icon"
+          >
+            
+                        
+            <i
+              class="sap-icon--cart"
+              role="presentation"
+            />
+            
+                    
+          </span>
+          
+                    
+          <span
+            class="fd-icon-tab-bar__counter"
+          >
+            2
+          </span>
+          
+                
+        </div>
+        
+            
+      </a>
+      
+        
+    </li>
+    
+        
+    <li
+      class="fd-icon-tab-bar__item"
+      role="presentation"
+    >
+      
+            
+      <a
+        aria-selected="true"
+        class="fd-icon-tab-bar__tab"
+        href="#section2"
+        id="tab2"
+        role="tab"
+      >
+        
+                
+        <div
+          class="fd-icon-tab-bar__container"
+        >
+          
+                    
+          <span
+            class="fd-icon-tab-bar__icon"
+          >
+            
+                        
+            <i
+              class="sap-icon--pending"
+              role="presentation"
+            />
+            
+                    
+          </span>
+          
+                    
+          <span
+            class="fd-icon-tab-bar__counter"
+          >
+            23
+          </span>
+          
+                
+        </div>
+        
+            
+      </a>
+      
+        
+    </li>
+    
+        
+    <li
+      class="fd-icon-tab-bar__item"
+      role="presentation"
+    >
+      
+            
+      <a
+        class="fd-icon-tab-bar__tab"
+        href="#section3"
+        id="tab3"
+        role="tab"
+      >
+        
+                
+        <div
+          class="fd-icon-tab-bar__container"
+        >
+          
+                    
+          <span
+            class="fd-icon-tab-bar__icon"
+          >
+            
+                        
+            <i
+              class="sap-icon--picture"
+              role="presentation"
+            />
+            
+                    
+          </span>
+          
+                    
+          <span
+            class="fd-icon-tab-bar__counter"
+          >
+            10
+          </span>
+          
+                
+        </div>
+        
+            
+      </a>
+      
+        
+    </li>
+    
+    
+  </ul>
+   
+    
+  <section
+    aria-labelledby="tab1"
+    class="fd-icon-tab-bar__panel"
+    id="section1"
+    role="tabpanel"
+  >
+      
+        Section 1
+    
+  </section>
+    
+    
+  <section
+    aria-labelledby="tab2"
+    class="fd-icon-tab-bar__panel"
+    hidden=""
+    id="section2"
+    role="tabpanel"
+  >
+      
+        Section 2
+    
+  </section>
+    
+    
+  <section
+    aria-labelledby="tab3"
+    class="fd-icon-tab-bar__panel"
+    hidden=""
+    id="section3"
+    role="tabpanel"
+  >
+      
+        Section 3
+    
+  </section>
+  
+
+</div>
+`;
+
+exports[`Storyshots Components/Icon Tab Bar Overflow 1`] = `
+<section>
+  <div
+    class="fd-icon-tab-bar"
+  >
+    
+    
+    <ul
+      class="fd-icon-tab-bar__header"
+      role="tablist"
+    >
+       
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <button
+          class="fd-icon-tab-bar__overflow"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__overflow-text"
+          >
+            +2
+          </span>
+          
+                
+          <i
+            class="sap-icon--slim-arrow-down"
+            role="presentation"
+          />
+          
+            
+        </button>
+        
+        
+      </li>
+       
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab1"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 1
+          </span>
+          
+                
+          <span
+            class="fd-icon-tab-bar__badge"
+          />
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          aria-selected="true"
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab2"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 2
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab3"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 3
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <button
+          class="fd-icon-tab-bar__overflow"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__overflow-text"
+          >
+            +3
+          </span>
+          
+                
+          <i
+            class="sap-icon--slim-arrow-down"
+            role="presentation"
+          />
+          
+            
+        </button>
+        
+        
+      </li>
+       
+    
+    </ul>
+    
+
+  </div>
+  
+
+  <br />
+  <br />
+  
+
+  <div
+    class="fd-icon-tab-bar"
+  >
+    
+    
+    <ul
+      class="fd-icon-tab-bar__header"
+      role="tablist"
+    >
+       
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab4"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 1
+          </span>
+          
+                
+          <span
+            class="fd-icon-tab-bar__badge"
+          />
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          aria-selected="true"
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab5"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 2
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab6"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 3
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <button
+          class="fd-icon-tab-bar__overflow"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__overflow-text"
+          >
+            More
+          </span>
+          
+                
+          <i
+            class="sap-icon--slim-arrow-down"
+            role="presentation"
+          />
+          
+            
+        </button>
+        
+        
+      </li>
+       
+    
+    </ul>
+    
+
+  </div>
+</section>
+`;
+
+exports[`Storyshots Components/Icon Tab Bar Process 1`] = `
+<section>
+  <div
+    class="fd-icon-tab-bar fd-icon-tab-bar--icon fd-icon-tab-bar--process"
+  >
+    
+    
+    <ul
+      class="fd-icon-tab-bar__header"
+      role="tablist"
+    >
+        
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          aria-selected="true"
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab1"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--person-placeholder"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__badge"
+            />
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-icon-tab-bar__details"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              2
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__label"
+            >
+              Description
+            </span>
+            
+                
+          </div>
+          
+            
+        </a>
+        
+            
+        <span
+          class="fd-icon-tab-bar__separator"
+        >
+          
+                
+          <i
+            class="sap-icon--process"
+            role="presentation"
+          />
+          
+            
+        </span>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab2"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--paper-plane"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-icon-tab-bar__details"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              2
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__label"
+            >
+              Description
+            </span>
+            
+                
+          </div>
+          
+            
+        </a>
+        
+            
+        <span
+          class="fd-icon-tab-bar__separator"
+        >
+          
+                
+          <i
+            class="sap-icon--process"
+            role="presentation"
+          />
+          
+            
+        </span>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab3"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--loan"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-icon-tab-bar__details"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              2
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__label"
+            >
+              Description
+            </span>
+            
+                
+          </div>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+    
+    </ul>
+    
+
+  </div>
+  
+
+  <br />
+  <br />
+  
+
+  <div
+    class="fd-icon-tab-bar fd-icon-tab-bar--compact fd-icon-tab-bar--icon fd-icon-tab-bar--process"
+  >
+    
+    
+    <ul
+      class="fd-icon-tab-bar__header"
+      role="tablist"
+    >
+        
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab4"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--globe"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-icon-tab-bar__details"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              2
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__label"
+            >
+              Description
+            </span>
+            
+                
+          </div>
+          
+            
+        </a>
+        
+            
+        <span
+          class="fd-icon-tab-bar__separator"
+        >
+          
+                
+          <i
+            class="sap-icon--process"
+            role="presentation"
+          />
+          
+            
+        </span>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          aria-selected="true"
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab5"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--theater"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-icon-tab-bar__details"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              2
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__label"
+            >
+              Description
+            </span>
+            
+                
+          </div>
+          
+            
+        </a>
+        
+            
+        <span
+          class="fd-icon-tab-bar__separator"
+        >
+          
+                
+          <i
+            class="sap-icon--process"
+            role="presentation"
+          />
+          
+            
+        </span>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab6"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--soccor"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-icon-tab-bar__details"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              2
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__label"
+            >
+              Description
+            </span>
+            
+                
+          </div>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+    
+    </ul>
+    
+
+  </div>
+  
+
+
+  <br />
+  <br />
+  
+
+  <div
+    class="fd-icon-tab-bar fd-icon-tab-bar--icon fd-icon-tab-bar--process"
+  >
+    
+    
+    <ul
+      class="fd-icon-tab-bar__header"
+      role="tablist"
+    >
+        
+        
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--positive"
+        role="presentation"
+      >
+        
+            
+        <a
+          aria-selected="true"
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab7"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--nutrition-activity"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-icon-tab-bar__details"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              2
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__label"
+            >
+              Description
+            </span>
+            
+                
+          </div>
+          
+            
+        </a>
+        
+            
+        <span
+          class="fd-icon-tab-bar__separator"
+        >
+          
+                
+          <i
+            class="sap-icon--process"
+            role="presentation"
+          />
+          
+            
+        </span>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--negative"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab8"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--vehicle-repair"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-icon-tab-bar__details"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              2
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__label"
+            >
+              Description
+            </span>
+            
+                
+          </div>
+          
+            
+        </a>
+        
+            
+        <span
+          class="fd-icon-tab-bar__separator"
+        >
+          
+                
+          <i
+            class="sap-icon--process"
+            role="presentation"
+          />
+          
+            
+        </span>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--critical"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab9"
+          role="tab"
+        >
+          
+                
+          <div
+            class="fd-icon-tab-bar__container"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__icon"
+            >
+              
+                        
+              <i
+                class="sap-icon--palette"
+                role="presentation"
+              />
+              
+                    
+            </span>
+            
+                
+          </div>
+          
+                
+          <div
+            class="fd-icon-tab-bar__details"
+          >
+            
+                    
+            <span
+              class="fd-icon-tab-bar__counter"
+            >
+              2
+            </span>
+            
+                    
+            <span
+              class="fd-icon-tab-bar__label"
+            >
+              Description
+            </span>
+            
+                
+          </div>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+    
+    </ul>
+    
+
+  </div>
+  
+
+
+  <br />
+  <br />
+  
+
+  <div
+    class="fd-icon-tab-bar fd-icon-tab-bar--process"
+  >
+    
+    
+    <ul
+      class="fd-icon-tab-bar__header"
+      role="tablist"
+    >
+        
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab10"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 1
+          </span>
+          
+                
+          <span
+            class="fd-icon-tab-bar__badge"
+          />
+          
+            
+        </a>
+        
+            
+        <span
+          class="fd-icon-tab-bar__separator"
+        >
+          
+                
+          <i
+            class="sap-icon--process"
+            role="presentation"
+          />
+          
+            
+        </span>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          aria-selected="true"
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab11"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 2
+          </span>
+          
+            
+        </a>
+        
+            
+        <span
+          class="fd-icon-tab-bar__separator"
+        >
+          
+                
+          <i
+            class="sap-icon--process"
+            role="presentation"
+          />
+          
+            
+        </span>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab12"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 3
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+    
+    </ul>
+    
+
+  </div>
+  
+
+</section>
+`;
+
+exports[`Storyshots Components/Icon Tab Bar Responsive Paddings 1`] = `
+<div
+  class="fd-icon-tab-bar fd-icon-tab-bar--responsive-paddings"
+>
+  
+    
+  <ul
+    class="fd-icon-tab-bar__header"
+    role="tablist"
+  >
+      
+        
+    <li
+      class="fd-icon-tab-bar__item"
+      role="presentation"
+    >
+      
+            
+      <a
+        class="fd-icon-tab-bar__tab"
+        href="#section11"
+        id="tab1"
+        role="tab"
+      >
+        
+                
+        <span
+          class="fd-icon-tab-bar__tag"
+        >
+          Section 1
+        </span>
+        
+                
+        <span
+          class="fd-icon-tab-bar__badge"
+        />
+        
+            
+      </a>
+      
+        
+    </li>
+    
+        
+    <li
+      class="fd-icon-tab-bar__item"
+      role="presentation"
+    >
+      
+            
+      <a
+        aria-selected="true"
+        class="fd-icon-tab-bar__tab"
+        href="#section12"
+        id="tab2"
+        role="tab"
+      >
+        
+                
+        <span
+          class="fd-icon-tab-bar__tag"
+        >
+          Section 2
+        </span>
+        
+            
+      </a>
+      
+        
+    </li>
+    
+        
+    <li
+      class="fd-icon-tab-bar__item"
+      role="presentation"
+    >
+      
+            
+      <a
+        class="fd-icon-tab-bar__tab"
+        href="#section13"
+        id="tab3"
+        role="tab"
+      >
+        
+                
+        <span
+          class="fd-icon-tab-bar__tag"
+        >
+          Section 3
+        </span>
+        
+            
+      </a>
+      
+        
+    </li>
+    
+    
+  </ul>
+  
+
+</div>
+`;
+
+exports[`Storyshots Components/Icon Tab Bar Sizes and Horizontal Paddings 1`] = `
+<section>
+  <h4>
+    SM (1rem) paddings
+  </h4>
+  
+
+  <div
+    class="fd-icon-tab-bar fd-icon-tab-bar--sm"
+  >
+    
+    
+    <ul
+      class="fd-icon-tab-bar__header"
+      role="tablist"
+    >
+        
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab1"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 1
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          aria-selected="true"
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab2"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 2
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab3"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 3
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+    
+    </ul>
+    
+
+  </div>
+  
+
+  <br />
+  <br />
+  
+
+  <h4>
+    MD (2rem) paddings
+  </h4>
+  
+
+  <div
+    class="fd-icon-tab-bar fd-icon-tab-bar--md"
+  >
+    
+    
+    <ul
+      class="fd-icon-tab-bar__header"
+      role="tablist"
+    >
+        
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab4"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 1
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          aria-selected="true"
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab5"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 2
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab6"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 3
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+    
+    </ul>
+    
+
+  </div>
+  
+
+  <br />
+  <br />
+  
+
+  <h4>
+    LG (2rem) paddings
+  </h4>
+  
+
+  <div
+    class="fd-icon-tab-bar fd-icon-tab-bar--lg"
+  >
+    
+    
+    <ul
+      class="fd-icon-tab-bar__header"
+      role="tablist"
+    >
+        
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab7"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 1
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          aria-selected="true"
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab8"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 2
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab9"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 3
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+    
+    </ul>
+    
+
+  </div>
+  
+
+  <br />
+  <br />
+  
+
+  <h4>
+    XL (3rem) paddings
+  </h4>
+  
+
+  <div
+    class="fd-icon-tab-bar fd-icon-tab-bar--xl"
+  >
+    
+    
+    <ul
+      class="fd-icon-tab-bar__header"
+      role="tablist"
+    >
+        
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab13"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 1
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          aria-selected="true"
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab14"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 2
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab15"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 3
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+    
+    </ul>
+    
+
+  </div>
+  
+
+  <br />
+  <br />
+  
+
+  <h4>
+    XXL (3rem) paddings
+  </h4>
+  
+
+  <div
+    class="fd-icon-tab-bar fd-icon-tab-bar--xxl"
+  >
+    
+    
+    <ul
+      class="fd-icon-tab-bar__header"
+      role="tablist"
+    >
+        
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab16"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 1
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          aria-selected="true"
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab17"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 2
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab18"
+          role="tab"
+        >
+          
+                
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 3
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+    
+    </ul>
+    
+
+  </div>
+  
+
+</section>
+`;
+
+exports[`Storyshots Components/Icon Tab Bar Text Only (Inline mode) 1`] = `
+<div
+  class="fd-icon-tab-bar"
+>
+  
+    
+  <ul
+    class="fd-icon-tab-bar__header"
+    role="tablist"
+  >
+      
+        
+    <li
+      class="fd-icon-tab-bar__item"
+      role="presentation"
+    >
+      
+            
+      <a
+        class="fd-icon-tab-bar__tab"
+        href="#section1"
+        id="tab1"
+        role="tab"
+      >
+        
+                
+        <span
+          class="fd-icon-tab-bar__tag"
+        >
+          Info
+        </span>
+        
+            
+      </a>
+      
+        
+    </li>
+    
+        
+    <li
+      class="fd-icon-tab-bar__item"
+      role="presentation"
+    >
+      
+            
+      <a
+        aria-selected="true"
+        class="fd-icon-tab-bar__tab"
+        href="#section2"
+        id="tab2"
+        role="tab"
+      >
+        
+                
+        <span
+          class="fd-icon-tab-bar__tag"
+        >
+          Attachments (16)
+        </span>
+        
+            
+      </a>
+      
+        
+    </li>
+    
+        
+    <li
+      class="fd-icon-tab-bar__item"
+      role="presentation"
+    >
+      
+            
+      <a
+        class="fd-icon-tab-bar__tab"
+        href="#section3"
+        id="tab3"
+        role="tab"
+      >
+        
+                
+        <span
+          class="fd-icon-tab-bar__tag"
+        >
+          Approvals (42)
+        </span>
+        
+            
+      </a>
+      
+        
+    </li>
+    
+    
+  </ul>
+   
+    
+  <section
+    aria-labelledby="tab1"
+    class="fd-icon-tab-bar__panel"
+    id="section1"
+    role="tabpanel"
+  >
+      
+        Section 1
+    
+  </section>
+    
+    
+  <section
+    aria-labelledby="tab2"
+    class="fd-icon-tab-bar__panel"
+    hidden=""
+    id="section2"
+    role="tabpanel"
+  >
+      
+        Section 2
+    
+  </section>
+    
+    
+  <section
+    aria-labelledby="tab3"
+    class="fd-icon-tab-bar__panel"
+    hidden=""
+    id="section3"
+    role="tabpanel"
+  >
+      
+        Section 3
+    
+  </section>
+  
+
+</div>
+`;
+
+exports[`Storyshots Components/Icon Tab Bar Text Only (Inline mode) Semantic Colors 1`] = `
+<div
+  class="fd-icon-tab-bar"
+>
+  
+    
+  <ul
+    class="fd-icon-tab-bar__header"
+    role="tablist"
+  >
+    
+        
+    <li
+      class="fd-icon-tab-bar__item fd-icon-tab-bar__item--positive"
+      role="presentation"
+    >
+      
+            
+      <a
+        aria-selected="true"
+        class="fd-icon-tab-bar__tab"
+        href="#section1"
+        id="tab1"
+        role="tab"
+      >
+        
+            
+        <span
+          class="fd-icon-tab-bar__tag"
+        >
+          Section 1
+        </span>
+        
+            
+      </a>
+      
+        
+    </li>
+    
+        
+    <li
+      class="fd-icon-tab-bar__item fd-icon-tab-bar__item--negative"
+      role="presentation"
+    >
+      
+            
+      <a
+        aria-selected="true"
+        class="fd-icon-tab-bar__tab"
+        href="#section2"
+        id="tab2"
+        role="tab"
+      >
+        
+            
+        <span
+          class="fd-icon-tab-bar__tag"
+        >
+          Section 2
+        </span>
+        
+            
+      </a>
+      
+        
+    </li>
+    
+        
+    <li
+      class="fd-icon-tab-bar__item fd-icon-tab-bar__item--critical"
+      role="presentation"
+    >
+      
+            
+      <a
+        aria-selected="true"
+        class="fd-icon-tab-bar__tab"
+        href="#section3"
+        id="tab3"
+        role="tab"
+      >
+        
+            
+        <span
+          class="fd-icon-tab-bar__tag"
+        >
+          Section 3
+        </span>
+        
+            
+      </a>
+      
+        
+    </li>
+    
+        
+    <li
+      class="fd-icon-tab-bar__item fd-icon-tab-bar__item--informative"
+      role="presentation"
+    >
+      
+            
+      <a
+        aria-selected="true"
+        class="fd-icon-tab-bar__tab"
+        href="#section4"
+        id="tab4"
+        role="tab"
+      >
+        
+            
+        <span
+          class="fd-icon-tab-bar__tag"
+        >
+          Section 4
+        </span>
+        
+            
+      </a>
+      
+        
+    </li>
+    
+    
+  </ul>
+  
+    
+  <section
+    aria-labelledby="tab1"
+    class="fd-icon-tab-bar__panel"
+    id="section1"
+    role="tabpanel"
+  >
+    Section 1
+  </section>
+  
+    
+  <section
+    aria-labelledby="tab2"
+    class="fd-icon-tab-bar__panel"
+    hidden=""
+    id="section2"
+    role="tabpanel"
+  >
+    Section 2
+  </section>
+  
+    
+  <section
+    aria-labelledby="tab3"
+    class="fd-icon-tab-bar__panel"
+    hidden=""
+    id="section3"
+    role="tabpanel"
+  >
+    Section 3
+  </section>
+  
+    
+  <section
+    aria-labelledby="tab4"
+    class="fd-icon-tab-bar__panel"
+    hidden=""
+    id="section4"
+    role="tabpanel"
+  >
+    Section 4
+  </section>
+  
+
+</div>
+`;
+
+exports[`Storyshots Components/Icon Tab Bar Universal Icon Tab Bar Multi Click Area 1`] = `
+<div
+  style="min-height: 400px;"
+>
+  
+    
+  <div
+    class="fd-icon-tab-bar fd-icon-tab-bar--md"
+  >
+    
+        
+    <ul
+      class="fd-icon-tab-bar__header"
+      role="tablist"
+    >
+        
+            
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+                
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab1"
+          role="tab"
+        >
+          
+                    
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 1
+          </span>
+          
+                    
+          <span
+            class="fd-icon-tab-bar__badge"
+          />
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--multi-click"
+        role="presentation"
+      >
+        
+                
+        <a
+          aria-selected="true"
+          class="fd-icon-tab-bar__tab"
+          id="tab2"
+          role="tab"
+          tabindex="0"
+        >
+          
+                    
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 2
+          </span>
+          
+                    
+          <span
+            class="fd-icon-tab-bar__badge"
+          />
+          
+                
+        </a>
+        
+
+                
+        <div
+          class="fd-popover fd-icon-tab-bar__popover"
+        >
+          
+                    
+          <div
+            class="fd-popover__control"
+          >
+            
+                        
+            <div
+              class="fd-icon-tab-bar__button-container"
+            >
+              
+                            
+              <button
+                aria-controls="popoverA3"
+                aria-expanded="false"
+                aria-haspopup="true"
+                aria-label="open menu button"
+                class="fd-button fd-button--transparent fd-button--compact  fd-icon-tab-bar__button"
+                onclick="onPopoverClick('popoverA3');"
+              >
+                
+                                
+                <i
+                  class="sap-icon--slim-arrow-down"
+                />
+                
+                            
+              </button>
+              
+                            
+              <span
+                class="fd-icon-tab-bar__badge"
+              />
+              
+                        
+            </div>
+            
+                    
+          </div>
+          
+                    
+          <div
+            aria-hidden="false"
+            class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right"
+            id="popoverA3"
+          >
+            
+                        
+            <ul
+              class="fd-list fd-list--navigation fd-list--no-border fd-icon-tab-bar__list"
+              role="list"
+            >
+              
+                            
+              <li
+                class="fd-icon-tab-bar__icon-separator"
+                tabindex="-1"
+              >
+                
+                                
+                <span
+                  class="sap-icon--process"
+                />
+                
+                            
+              </li>
+              
+                            
+              <li
+                aria-level="1"
+                class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
+                role="listitem"
+                tabindex="-1"
+              >
+                
+                                
+                <a
+                  class="fd-list__link"
+                  tabindex="0"
+                >
+                  
+                                    
+                  <span
+                    class="fd-list__title"
+                  >
+                    Subsection 1
+                  </span>
+                  
+                                    
+                  <span
+                    class="fd-icon-tab-bar__badge"
+                  />
+                  
+                                
+                </a>
+                
+                            
+              </li>
+              
+                            
+              <li
+                class="fd-icon-tab-bar__icon-separator"
+                tabindex="-1"
+              >
+                
+                                
+                <span
+                  class="sap-icon--process"
+                />
+                
+                            
+              </li>
+              
+                            
+              <li
+                aria-level="2"
+                class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
+                role="listitem"
+                tabindex="-1"
+              >
+                
+                                
+                <a
+                  class="fd-list__link"
+                  tabindex="0"
+                >
+                  
+                                    
+                  <span
+                    class="fd-list__title"
+                  >
+                    Subsection 1.1
+                  </span>
+                  
+                                
+                </a>
+                
+                            
+              </li>
+              
+                            
+              <li
+                class="fd-icon-tab-bar__icon-separator"
+                tabindex="-1"
+              >
+                
+                                
+                <span
+                  class="sap-icon--process"
+                />
+                
+                            
+              </li>
+              
+                            
+              <li
+                aria-level="3"
+                class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
+                role="listitem"
+                tabindex="-1"
+              >
+                
+                                
+                <a
+                  class="fd-list__link"
+                  tabindex="0"
+                >
+                  
+                                    
+                  <span
+                    class="fd-list__title"
+                  >
+                    Subsection 1.1.1
+                  </span>
+                  
+                                
+                </a>
+                
+                            
+              </li>
+              
+                            
+              <li
+                class="fd-icon-tab-bar__icon-separator"
+                tabindex="-1"
+              >
+                
+                                
+                <span
+                  class="sap-icon--process"
+                />
+                
+                            
+              </li>
+              
+                            
+              <li
+                aria-level="4"
+                class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
+                role="listitem"
+                tabindex="-1"
+              >
+                
+                                
+                <a
+                  class="fd-list__link"
+                  tabindex="0"
+                >
+                  
+                                    
+                  <span
+                    class="fd-list__title"
+                  >
+                    Subsection 1.1.1.1
+                  </span>
+                  
+                                
+                </a>
+                
+                            
+              </li>
+              
+                            
+              <li
+                class="fd-icon-tab-bar__icon-separator"
+                tabindex="-1"
+              >
+                
+                                
+                <span
+                  class="sap-icon--process"
+                />
+                
+                            
+              </li>
+              
+                            
+              <li
+                aria-level="5"
+                class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
+                role="listitem"
+                tabindex="-1"
+              >
+                
+                                
+                <a
+                  class="fd-list__link"
+                  tabindex="0"
+                >
+                  
+                                    
+                  <span
+                    class="fd-list__title"
+                  >
+                    Subsection 1.1.1.1.1
+                  </span>
+                  
+                                
+                </a>
+                
+                            
+              </li>
+              
+                            
+              <li
+                class="fd-icon-tab-bar__icon-separator"
+                tabindex="-1"
+              >
+                
+                                
+                <span
+                  class="sap-icon--process"
+                />
+                
+                            
+              </li>
+              
+                            
+              <li
+                aria-level="1"
+                class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
+                role="listitem"
+                tabindex="-1"
+              >
+                
+                                
+                <a
+                  class="fd-list__link"
+                  tabindex="0"
+                >
+                  
+                                    
+                  <span
+                    class="fd-list__title"
+                  >
+                    Subsection 2
+                  </span>
+                  
+                                
+                </a>
+                
+                            
+              </li>
+              
+                        
+            </ul>
+            
+                    
+          </div>
+          
+                
+        </div>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+                
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab3"
+          role="tab"
+        >
+          
+                    
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 3
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+        
+    </ul>
+    
+    
+  </div>
+  
+
+</div>
+`;
+
+exports[`Storyshots Components/Icon Tab Bar Universal Icon Tab Bar Single Click Area 1`] = `
+<div
+  style="min-height: 800px;"
+>
+  
+    
+  <div
+    class="fd-icon-tab-bar fd-icon-tab-bar--xl"
+  >
+    
+        
+    <ul
+      class="fd-icon-tab-bar__header"
+      role="tablist"
+    >
+        
+            
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+                
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab1"
+          role="tab"
+        >
+          
+                    
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 1
+          </span>
+          
+                    
+          <span
+            class="fd-icon-tab-bar__badge"
+          />
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--single-click"
+        role="presentation"
+      >
+        
+                
+        <div
+          class="fd-popover"
+        >
+          
+                    
+          <div
+            class="fd-popover__control"
+          >
+            
+                        
+            <a
+              aria-controls="popoverA1"
+              aria-expanded="true"
+              aria-haspopup="true"
+              aria-selected="true"
+              class="fd-icon-tab-bar__tab"
+              id="tab2"
+              onclick="onPopoverClick('popoverA1');"
+              role="tab"
+              tabindex="0"
+            >
+              
+                            
+              <div
+                class="fd-icon-tab-bar__tab-container"
+              >
+                
+                                
+                <span
+                  class="fd-icon-tab-bar__tag"
+                >
+                  Section 2
+                </span>
+                
+                                
+                <span
+                  class="fd-icon-tab-bar__arrow"
+                >
+                  
+                                    
+                  <i
+                    class="sap-icon--slim-arrow-down"
+                    role="presentation"
+                  />
+                  
+                                
+                </span>
+                
+                                
+                <span
+                  class="fd-icon-tab-bar__badge"
+                />
+                
+                            
+              </div>
+              
+                        
+            </a>
+            
+                    
+          </div>
+          
+                    
+          <div
+            aria-hidden="false"
+            class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right"
+            id="popoverA1"
+          >
+            
+                        
+            <ul
+              class="fd-list fd-list--navigation fd-list--no-border fd-icon-tab-bar__list"
+              role="list"
+            >
+              
+                            
+              <li
+                aria-level="1"
+                class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
+                role="listitem"
+                tabindex="-1"
+              >
+                
+                                
+                <a
+                  class="fd-list__link"
+                  tabindex="0"
+                >
+                  
+                                    
+                  <span
+                    class="fd-list__title"
+                  >
+                    Subsection 1
+                  </span>
+                  
+                                    
+                  <span
+                    class="fd-icon-tab-bar__badge"
+                  />
+                  
+                                
+                </a>
+                
+                            
+              </li>
+              
+                            
+              <li
+                aria-level="2"
+                class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
+                role="listitem"
+                tabindex="-1"
+              >
+                
+                                
+                <a
+                  class="fd-list__link"
+                  tabindex="0"
+                >
+                  
+                                    
+                  <span
+                    class="fd-list__title"
+                  >
+                    Subsection 1.1
+                  </span>
+                  
+                                
+                </a>
+                
+                            
+              </li>
+              
+                            
+              <li
+                aria-level="3"
+                class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
+                role="listitem"
+                tabindex="-1"
+              >
+                
+                                
+                <a
+                  class="fd-list__link"
+                  tabindex="0"
+                >
+                  
+                                    
+                  <span
+                    class="fd-list__title"
+                  >
+                    Subsection 1.1.1
+                  </span>
+                  
+                                    
+                  <span
+                    class="fd-icon-tab-bar__badge"
+                  />
+                  
+                                
+                </a>
+                
+                            
+              </li>
+              
+                            
+              <li
+                aria-level="4"
+                class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
+                role="listitem"
+                tabindex="-1"
+              >
+                
+                                
+                <a
+                  class="fd-list__link"
+                  tabindex="0"
+                >
+                  
+                                    
+                  <span
+                    class="fd-list__title"
+                  >
+                    Subsection 1.1.1.1
+                  </span>
+                  
+                                
+                </a>
+                
+                            
+              </li>
+              
+                            
+              <li
+                aria-level="5"
+                class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
+                role="listitem"
+                tabindex="-1"
+              >
+                
+                                
+                <a
+                  class="fd-list__link"
+                  tabindex="0"
+                >
+                  
+                                    
+                  <span
+                    class="fd-list__title"
+                  >
+                    Subsection 1.1.1.1.1
+                  </span>
+                  
+                                
+                </a>
+                
+                            
+              </li>
+              
+                            
+              <li
+                aria-level="1"
+                class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
+                role="listitem"
+                tabindex="-1"
+              >
+                
+                                
+                <a
+                  class="fd-list__link"
+                  tabindex="0"
+                >
+                  
+                                    
+                  <span
+                    class="fd-list__title"
+                  >
+                    Subsection 2
+                  </span>
+                  
+                                
+                </a>
+                
+                            
+              </li>
+              
+                        
+            </ul>
+            
+                    
+          </div>
+          
+                
+        </div>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+                
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab3"
+          role="tab"
+        >
+          
+                    
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 3
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+        
+    </ul>
+    
+    
+  </div>
+  
+
+    
+  <div
+    style="height: 20rem;"
+  />
+  
+
+    
+  <div
+    class="fd-icon-tab-bar fd-icon-tab-bar--xl"
+  >
+    
+        
+    <ul
+      class="fd-icon-tab-bar__header"
+      role="tablist"
+    >
+        
+            
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+                
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab4"
+          role="tab"
+        >
+          
+                    
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 1
+          </span>
+          
+                    
+          <span
+            class="fd-icon-tab-bar__badge"
+          />
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--single-click"
+        role="presentation"
+      >
+        
+                
+        <div
+          class="fd-popover"
+        >
+          
+                    
+          <div
+            class="fd-popover__control"
+          >
+            
+                        
+            <a
+              aria-controls="popoverA2"
+              aria-expanded="true"
+              aria-haspopup="true"
+              aria-selected="true"
+              class="fd-icon-tab-bar__tab"
+              id="tab5"
+              onclick="onPopoverClick('popoverA2');"
+              role="tab"
+              tabindex="0"
+            >
+              
+                            
+              <div
+                class="fd-icon-tab-bar__tab-container"
+              >
+                
+                                
+                <span
+                  class="fd-icon-tab-bar__tag"
+                >
+                  Section 2
+                </span>
+                
+                                
+                <span
+                  class="fd-icon-tab-bar__arrow"
+                >
+                  
+                                    
+                  <i
+                    class="sap-icon--slim-arrow-down"
+                    role="presentation"
+                  />
+                  
+                                
+                </span>
+                
+                            
+              </div>
+              
+                        
+            </a>
+            
+                    
+          </div>
+          
+                    
+          <div
+            aria-hidden="false"
+            class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right"
+            id="popoverA2"
+          >
+            
+                        
+            <ul
+              class="fd-list fd-list--navigation fd-list--no-border fd-icon-tab-bar__list"
+              role="list"
+            >
+              
+                            
+              <li
+                class="fd-icon-tab-bar__line-separator"
+                tabindex="-1"
+              />
+              
+                            
+              <li
+                aria-level="1"
+                class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
+                role="listitem"
+                tabindex="-1"
+              >
+                
+                                
+                <a
+                  class="fd-list__link"
+                  tabindex="0"
+                >
+                  
+                                    
+                  <span
+                    class="fd-list__title"
+                  >
+                    Subsection 1
+                  </span>
+                  
+                                    
+                  <span
+                    class="fd-icon-tab-bar__badge"
+                  />
+                  
+                                
+                </a>
+                
+                            
+              </li>
+              
+                            
+              <li
+                class="fd-icon-tab-bar__line-separator"
+                tabindex="-1"
+              />
+              
+                            
+              <li
+                aria-level="2"
+                class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
+                role="listitem"
+                tabindex="-1"
+              >
+                
+                                
+                <a
+                  class="fd-list__link"
+                  tabindex="0"
+                >
+                  
+                                    
+                  <span
+                    class="fd-list__title"
+                  >
+                    Subsection 1.1
+                  </span>
+                  
+                                
+                </a>
+                
+                            
+              </li>
+              
+                            
+              <li
+                class="fd-icon-tab-bar__line-separator"
+                tabindex="-1"
+              />
+              
+                            
+              <li
+                aria-level="3"
+                class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
+                role="listitem"
+                tabindex="-1"
+              >
+                
+                                
+                <a
+                  class="fd-list__link"
+                  tabindex="0"
+                >
+                  
+                                    
+                  <span
+                    class="fd-list__title"
+                  >
+                    Subsection 1.1.1
+                  </span>
+                  
+                                    
+                  <span
+                    class="fd-icon-tab-bar__badge"
+                  />
+                  
+                                
+                </a>
+                
+                            
+              </li>
+              
+                            
+              <li
+                class="fd-icon-tab-bar__line-separator"
+                tabindex="-1"
+              />
+              
+                            
+              <li
+                aria-level="4"
+                class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
+                role="listitem"
+                tabindex="-1"
+              >
+                
+                                
+                <a
+                  class="fd-list__link"
+                  tabindex="0"
+                >
+                  
+                                    
+                  <span
+                    class="fd-list__title"
+                  >
+                    Subsection 1.1.1.1
+                  </span>
+                  
+                                
+                </a>
+                
+                            
+              </li>
+              
+                            
+              <li
+                class="fd-icon-tab-bar__line-separator"
+                tabindex="-1"
+              />
+              
+                            
+              <li
+                aria-level="5"
+                class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
+                role="listitem"
+                tabindex="-1"
+              >
+                
+                                
+                <a
+                  class="fd-list__link"
+                  tabindex="0"
+                >
+                  
+                                    
+                  <span
+                    class="fd-list__title"
+                  >
+                    Subsection 1.1.1.1.1
+                  </span>
+                  
+                                
+                </a>
+                
+                            
+              </li>
+              
+                            
+              <li
+                class="fd-icon-tab-bar__line-separator"
+                tabindex="-1"
+              />
+              
+                            
+              <li
+                aria-level="1"
+                class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
+                role="listitem"
+                tabindex="-1"
+              >
+                
+                                
+                <a
+                  class="fd-list__link"
+                  tabindex="0"
+                >
+                  
+                                    
+                  <span
+                    class="fd-list__title"
+                  >
+                    Subsection 2
+                  </span>
+                  
+                                
+                </a>
+                
+                            
+              </li>
+              
+                        
+            </ul>
+            
+                    
+          </div>
+          
+                
+        </div>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+                
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab6"
+          role="tab"
+        >
+          
+                    
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 3
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+        
+    </ul>
+    
+    
+  </div>
+  
+
+</div>
+`;

--- a/stories/icon-tab-bar/icon-tab-bar.stories.js
+++ b/stories/icon-tab-bar/icon-tab-bar.stories.js
@@ -1,0 +1,1431 @@
+export default {
+    title: 'Components/Icon Tab Bar',
+    parameters: {
+        description: `
+The Icon Tab Bar can be used for navigation within an object, or as a filter. Each tab of the component links to a different content area or view.
+
+##Usage
+**Use the icon tab bar if:**
+
+- Your business objects need to show multiple facets at the same time.
+- You want to allow the user to browse through these facets.
+- You need a prominent or very visual filter on top of a list.
+- You have clear-cut process steps that need to be visualized.
+
+**Do not use the icon tab bar if:**
+
+- You plan to use only a single tab.
+
+##Semantic colors
+Only use semantic colors if it is important for users to know that they need to take action (for example, to indicate errors or critical situations requiring action). Otherwise, use the neutral default colors. To add semantic color to a tab use a modifier class from the table below on <code>fd-icon-tab-bar\\_\\_item</code> level.
+
+| **Color** | **Modifier class** |
+| :--------- | :---------- |
+| positive &nbsp;&nbsp; | <code>fd-icon-tab-bar\\_\\_item--positive</code> |
+| negative &nbsp;&nbsp; | <code>fd-icon-tab-bar\\_\\_item--negative</code> |
+| critical &nbsp;&nbsp; | <code>fd-icon-tab-bar\\_\\_item--critical</code> |
+| informative &nbsp;&nbsp; | <code>fd-icon-tab-bar\\_\\_item--informative</code> |
+
+##Horizontal paddings
+You can add horizontal paddings by applying a modifier class to the container. For responsive horizontal paddings (based on the screen size) add the <code>fd-icon-tab-bar--responsive-paddings</code> modifier class. In this case the left and right spacing will change as the screen size changes.
+
+| **Size** | **Modifier class** |
+| :--------- | :---------- |
+| sm (1rem) &nbsp;&nbsp; | <code>fd-icon-tab-bar--sm</code> |
+| md (2rem) &nbsp;&nbsp; | <code>fd-icon-tab-bar--md</code> |
+| lg (2rem) &nbsp;&nbsp; | <code>fd-icon-tab-bar--lg</code> |
+| xl (3rem) &nbsp;&nbsp; | <code>fd-icon-tab-bar--xl</code> |
+| xxl (3rem) &nbsp;&nbsp; | <code>fd-icon-tab-bar--xxl</code> |
+
+##Background
+By default, the background for the Icon Tab Bar header and content is set to "solid". This will apply <code>--sapObjectHeader_Background</code> background color and <code>--sapContent_HeaderShadow</code> box-shadow to the header and <code>--sapBackgroundColor</code> to the container (panel). It can be changed to "translucent" or "transparent" using modifier classes. In translucent mode the header gets <code>--sapObjectHeader_Background</code> background color and the panel <code>--sapGroup_ContentBackground</code> background color. 
+
+| **Background** | **Modifier class** |
+| :--------- | :---------- |
+| solid &nbsp;&nbsp; | default |
+| translucent &nbsp;&nbsp; | <code>fd-icon-tab-bar--translucent</code> |
+| transparent &nbsp;&nbsp; | <code>fd-icon-tab-bar--transparent</code> |
+
+<br><br><br>
+      `,
+        tags: ['f3', 'theme', 'development'],
+        components: ['icon', 'icon-tab-bar', 'popover', 'menu', 'button', 'list']
+    }
+};
+
+
+export const textOnly = () => `<div class="fd-icon-tab-bar">
+    <ul role="tablist" class="fd-icon-tab-bar__header">  
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#section1" id="tab1">
+                <span class="fd-icon-tab-bar__tag">Info</span>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#section2" aria-selected="true" id="tab2">
+                <span class="fd-icon-tab-bar__tag">Attachments (16)</span>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#section3" id="tab3">
+                <span class="fd-icon-tab-bar__tag">Approvals (42)</span>
+            </a>
+        </li>
+    </ul> 
+    <section role="tabpanel" class="fd-icon-tab-bar__panel" id="section1" aria-labelledby="tab1">  
+        Section 1
+    </section>  
+    <section role="tabpanel" class="fd-icon-tab-bar__panel" id="section2" aria-labelledby="tab2" hidden>  
+        Section 2
+    </section>  
+    <section role="tabpanel" class="fd-icon-tab-bar__panel" id="section3" aria-labelledby="tab3" hidden>  
+        Section 3
+    </section>
+</div>
+`;
+textOnly.storyName = 'Text Only (Inline mode)';
+textOnly.parameters = {
+    docs: {
+        storyDescription: 'The text-only variant is one of the most common types. It allows longer labels, and can also display counters next to the text to indicate the number of items on the tab page. The labels of the tabs do not get truncated. The full text is always shown. As a result, you need to ensure that your labels do not become too long. They should still be easy to read on smaller screens. The control has the same look and feel in Cozy and Compact mode.'
+    }
+};
+
+export const textOnlySemantic = () => `<div class="fd-icon-tab-bar">
+    <ul role="tablist" class="fd-icon-tab-bar__header">
+        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--positive">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#section1" aria-selected="true" id="tab1">
+            <span class="fd-icon-tab-bar__tag">Section 1</span>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--negative">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#section2" aria-selected="true" id="tab2">
+            <span class="fd-icon-tab-bar__tag">Section 2</span>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--critical">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#section3" aria-selected="true" id="tab3">
+            <span class="fd-icon-tab-bar__tag">Section 3</span>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--informative">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#section4" aria-selected="true" id="tab4">
+            <span class="fd-icon-tab-bar__tag">Section 4</span>
+            </a>
+        </li>
+    </ul>
+    <section role="tabpanel" class="fd-icon-tab-bar__panel" id="section1" aria-labelledby="tab1">Section 1</section>
+    <section role="tabpanel" class="fd-icon-tab-bar__panel" id="section2" aria-labelledby="tab2" hidden>Section 2</section>
+    <section role="tabpanel" class="fd-icon-tab-bar__panel" id="section3" aria-labelledby="tab3" hidden>Section 3</section>
+    <section role="tabpanel" class="fd-icon-tab-bar__panel" id="section4" aria-labelledby="tab4" hidden>Section 4</section>
+</div>
+`;
+textOnlySemantic.storyName = 'Text Only (Inline mode) Semantic Colors';
+
+
+export const counter = () => `<div class="fd-icon-tab-bar fd-icon-tab-bar--counters">
+    <ul role="tablist" class="fd-icon-tab-bar__header">  
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#section1" id="tab1">
+                <span class="fd-icon-tab-bar__tag">Info</span>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#section2" aria-selected="true" id="tab2">
+                <span class="fd-icon-tab-bar__counter">16</span>
+                <span class="fd-icon-tab-bar__tag">Attachments</span>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#section3" id="tab3">
+                <span class="fd-icon-tab-bar__counter">42</span>
+                <span class="fd-icon-tab-bar__tag">Approvals</span>
+            </a>
+        </li>
+    </ul> 
+    <section role="tabpanel" class="fd-icon-tab-bar__panel" id="section1" aria-labelledby="tab1">  
+        Section 1
+    </section>  
+    <section role="tabpanel" class="fd-icon-tab-bar__panel" id="section2" aria-labelledby="tab2" hidden>  
+        Section 2
+    </section>  
+    <section role="tabpanel" class="fd-icon-tab-bar__panel" id="section3" aria-labelledby="tab3" hidden>  
+        Section 3
+    </section>
+</div>
+`;
+counter.storyName = 'Counters and Text';
+counter.parameters = {
+    docs: {
+        storyDescription: 'Counters can be shown on top of labels. In this case you need to apply the <code>fd-icon-tab-bar--counters</code> modifier class. <br> The control has the same look and feel in Cozy and Compact mode.'
+    }
+};
+
+export const iconOnly = () => `<div class="fd-icon-tab-bar fd-icon-tab-bar--icon-only">
+    <ul role="tablist" class="fd-icon-tab-bar__header">  
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#section1" id="tab1">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--account" role="presentation"></i>
+                    </span>
+                    <span class="fd-icon-tab-bar__counter">2</span>
+                </div>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#section2" aria-selected="true" id="tab2">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--product" role="presentation"></i>
+                    </span>
+                    <span class="fd-icon-tab-bar__counter">23</span>
+                </div>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#section3" id="tab3">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--present" role="presentation"></i>
+                    </span>
+                    <span class="fd-icon-tab-bar__counter">10</span>
+                </div>
+            </a>
+        </li>
+    </ul> 
+    <section role="tabpanel" class="fd-icon-tab-bar__panel" id="section1" aria-labelledby="tab1">  
+        Section 1
+    </section>  
+    <section role="tabpanel" class="fd-icon-tab-bar__panel" id="section2" aria-labelledby="tab2" hidden>  
+        Section 2
+    </section>  
+    <section role="tabpanel" class="fd-icon-tab-bar__panel" id="section3" aria-labelledby="tab3" hidden>  
+        Section 3
+    </section>
+</div>
+`;
+iconOnly.storyName = 'Icon Only';
+iconOnly.parameters = {
+    docs: {
+        storyDescription: 'The Icon tabs are rounded tabs that can be populated with any icon. The labels in this case are omitted and counters are optional. You need to apply the <code>fd-icon-tab-bar--icon-only</code> modifier class for this type of tabs.'
+    }
+};
+
+export const iconOnlyCompact = () => `<div class="fd-icon-tab-bar fd-icon-tab-bar--icon-only fd-icon-tab-bar--compact">
+    <ul role="tablist" class="fd-icon-tab-bar__header">  
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#section1" id="tab1">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--cart" role="presentation"></i>
+                    </span>
+                    <span class="fd-icon-tab-bar__counter">2</span>
+                </div>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#section2" aria-selected="true" id="tab2">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--pending" role="presentation"></i>
+                    </span>
+                    <span class="fd-icon-tab-bar__counter">23</span>
+                </div>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#section3" id="tab3">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--picture" role="presentation"></i>
+                    </span>
+                    <span class="fd-icon-tab-bar__counter">10</span>
+                </div>
+            </a>
+        </li>
+    </ul> 
+    <section role="tabpanel" class="fd-icon-tab-bar__panel" id="section1" aria-labelledby="tab1">  
+        Section 1
+    </section>  
+    <section role="tabpanel" class="fd-icon-tab-bar__panel" id="section2" aria-labelledby="tab2" hidden>  
+        Section 2
+    </section>  
+    <section role="tabpanel" class="fd-icon-tab-bar__panel" id="section3" aria-labelledby="tab3" hidden>  
+        Section 3
+    </section>
+</div>
+`;
+iconOnlyCompact.storyName = 'Icon Only in Compact Mode';
+iconOnlyCompact.parameters = {
+    docs: {
+        storyDescription: 'In compact mode you need to apply an additional modifier class <code>fd-icon-tab-bar--compact</code>.'
+    }
+};
+
+export const iconOnlySemantic = () => `<div class="fd-icon-tab-bar fd-icon-tab-bar--icon-only">
+    <ul role="tablist" class="fd-icon-tab-bar__header">  
+        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--positive">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab1">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--history" role="presentation"></i>
+                    </span>
+                    <span class="fd-icon-tab-bar__counter">2</span>
+                </div>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--negative">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" aria-selected="true" id="tab2">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--card" role="presentation"></i>
+                    </span>
+                    <span class="fd-icon-tab-bar__counter">23</span>
+                </div>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--critical">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab3">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--cart" role="presentation"></i>
+                    </span>
+                    <span class="fd-icon-tab-bar__counter">10</span>
+                </div>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--informative">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab4">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--cart" role="presentation"></i>
+                    </span>
+                    <span class="fd-icon-tab-bar__counter">10</span>
+                </div>
+            </a>
+        </li>
+    </ul> 
+</div>
+<br><br>
+<div class="fd-icon-tab-bar fd-icon-tab-bar--icon-only fd-icon-tab-bar--compact">
+    <ul role="tablist" class="fd-icon-tab-bar__header">  
+        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--positive">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab5">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--attachment" role="presentation"></i>
+                    </span>
+                    <span class="fd-icon-tab-bar__counter">2</span>
+                </div>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--negative">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" aria-selected="true" id="tab6">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--activities" role="presentation"></i>
+                    </span>
+                    <span class="fd-icon-tab-bar__counter">23</span>
+                </div>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--critical">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab7">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--family-care" role="presentation"></i>
+                    </span>
+                    <span class="fd-icon-tab-bar__counter">10</span>
+                </div>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--informative">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab8">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--family-care" role="presentation"></i>
+                    </span>
+                    <span class="fd-icon-tab-bar__counter">10</span>
+                </div>
+            </a>
+        </li>
+    </ul>
+</div>
+`;
+iconOnlySemantic.storyName = 'Icon Only Semantic Colors';
+
+export const icon = () => `<div class="fd-icon-tab-bar fd-icon-tab-bar--icon">
+    <ul role="tablist" class="fd-icon-tab-bar__header">  
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" aria-selected="true" id="1">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--filter" role="presentation"></i>
+                    </span>
+                </div>
+                <div class="fd-icon-tab-bar__details">
+                    <span class="fd-icon-tab-bar__label">Description</span>
+                </div>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab2">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--customer" role="presentation"></i>
+                    </span>
+                </div>
+                <div class="fd-icon-tab-bar__details">
+                    <span class="fd-icon-tab-bar__counter">99</span>
+                    <span class="fd-icon-tab-bar__label">Description</span>
+                </div>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab3">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--chain-link" role="presentation"></i>
+                    </span>
+                </div>
+                <div class="fd-icon-tab-bar__details">
+                    <span class="fd-icon-tab-bar__counter">56 of 123</span>
+                    <span class="fd-icon-tab-bar__label">Description</span>
+                </div>
+            </a>
+        </li>
+    </ul> 
+</div>
+
+<br><br>
+<div class="fd-icon-tab-bar fd-icon-tab-bar--icon fd-icon-tab-bar--compact">
+    <ul role="tablist" class="fd-icon-tab-bar__header">  
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab4">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--iphone" role="presentation"></i>
+                    </span>
+                </div>
+                <div class="fd-icon-tab-bar__details">
+                    <span class="fd-icon-tab-bar__counter">25 of 789 items</span>
+                    <span class="fd-icon-tab-bar__label">Claim Overweights</span>
+                </div>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" aria-selected="true" id="tab5">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--record" role="presentation"></i>
+                    </span>
+                </div>
+                <div class="fd-icon-tab-bar__details">
+                    <span class="fd-icon-tab-bar__label">Confirm</span>
+                </div>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab6">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--world" role="presentation"></i>
+                    </span>
+                </div>
+                <div class="fd-icon-tab-bar__details">
+                    <span class="fd-icon-tab-bar__counter">12</span>
+                    <span class="fd-icon-tab-bar__label">Checks</span>
+                </div>
+            </a>
+        </li>
+    </ul> 
+</div>
+
+<br><br>
+<div class="fd-icon-tab-bar fd-icon-tab-bar--icon">
+    <ul role="tablist" class="fd-icon-tab-bar__header">  
+        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--positive">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" aria-selected="true" id="tab7">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--play" role="presentation"></i>
+                    </span>
+                </div>
+                <div class="fd-icon-tab-bar__details">
+                    <span class="fd-icon-tab-bar__counter">2</span>
+                    <span class="fd-icon-tab-bar__label">Description</span>
+                </div>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--negative">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab8">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--unfavorite" role="presentation"></i>
+                    </span>
+                </div>
+                <div class="fd-icon-tab-bar__details">
+                    <span class="fd-icon-tab-bar__counter">2</span>
+                    <span class="fd-icon-tab-bar__label">Description</span>
+                </div>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--critical">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab9">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--shipping-status" role="presentation"></i>
+                    </span>
+                </div>
+                <div class="fd-icon-tab-bar__details">
+                    <span class="fd-icon-tab-bar__counter">2</span>
+                    <span class="fd-icon-tab-bar__label">Description</span>
+                </div>
+            </a>
+        </li>
+    </ul>
+</div>
+`;
+icon.storyName = 'Icon';
+icon.parameters = {
+    docs: {
+        storyDescription: 'To display Icon Tabs with labels and counters you need to apply the <code>fd-icon-tab-bar--icon</code> modifier class. The counters are optional and can be ommited. The label is always positioned at the bottom. If you decide to use labels, use them for all tabs. The badge is rendered at the top right hand corner of the icon container. Consider using shorter labels or text tabs (without icons), since text tabs cannot get truncated.'
+    }
+};
+
+export const process = () => `<div class="fd-icon-tab-bar fd-icon-tab-bar--icon fd-icon-tab-bar--process">
+    <ul role="tablist" class="fd-icon-tab-bar__header">  
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" aria-selected="true" id="tab1">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--person-placeholder" role="presentation"></i>
+                    </span>
+                    <span class="fd-icon-tab-bar__badge"></span>
+                </div>
+                <div class="fd-icon-tab-bar__details">
+                    <span class="fd-icon-tab-bar__counter">2</span>
+                    <span class="fd-icon-tab-bar__label">Description</span>
+                </div>
+            </a>
+            <span class="fd-icon-tab-bar__separator">
+                <i class="sap-icon--process" role="presentation"></i>
+            </span>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab2">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--paper-plane" role="presentation"></i>
+                    </span>
+                </div>
+                <div class="fd-icon-tab-bar__details">
+                    <span class="fd-icon-tab-bar__counter">2</span>
+                    <span class="fd-icon-tab-bar__label">Description</span>
+                </div>
+            </a>
+            <span class="fd-icon-tab-bar__separator">
+                <i class="sap-icon--process" role="presentation"></i>
+            </span>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab3">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--loan" role="presentation"></i>
+                    </span>
+                </div>
+                <div class="fd-icon-tab-bar__details">
+                    <span class="fd-icon-tab-bar__counter">2</span>
+                    <span class="fd-icon-tab-bar__label">Description</span>
+                </div>
+            </a>
+        </li>
+    </ul>
+</div>
+<br><br>
+<div class="fd-icon-tab-bar fd-icon-tab-bar--compact fd-icon-tab-bar--icon fd-icon-tab-bar--process">
+    <ul role="tablist" class="fd-icon-tab-bar__header">  
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab4">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--globe" role="presentation"></i>
+                    </span>
+                </div>
+                <div class="fd-icon-tab-bar__details">
+                    <span class="fd-icon-tab-bar__counter">2</span>
+                    <span class="fd-icon-tab-bar__label">Description</span>
+                </div>
+            </a>
+            <span class="fd-icon-tab-bar__separator">
+                <i class="sap-icon--process" role="presentation"></i>
+            </span>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" aria-selected="true" id="tab5">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--theater" role="presentation"></i>
+                    </span>
+                </div>
+                <div class="fd-icon-tab-bar__details">
+                    <span class="fd-icon-tab-bar__counter">2</span>
+                    <span class="fd-icon-tab-bar__label">Description</span>
+                </div>
+            </a>
+            <span class="fd-icon-tab-bar__separator">
+                <i class="sap-icon--process" role="presentation"></i>
+            </span>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab6">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--soccor" role="presentation"></i>
+                    </span>
+                </div>
+                <div class="fd-icon-tab-bar__details">
+                    <span class="fd-icon-tab-bar__counter">2</span>
+                    <span class="fd-icon-tab-bar__label">Description</span>
+                </div>
+            </a>
+        </li>
+    </ul>
+</div>
+
+<br><br>
+<div class="fd-icon-tab-bar fd-icon-tab-bar--icon fd-icon-tab-bar--process">
+    <ul role="tablist" class="fd-icon-tab-bar__header">  
+        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--positive">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" aria-selected="true" id="tab7">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--nutrition-activity" role="presentation"></i>
+                    </span>
+                </div>
+                <div class="fd-icon-tab-bar__details">
+                    <span class="fd-icon-tab-bar__counter">2</span>
+                    <span class="fd-icon-tab-bar__label">Description</span>
+                </div>
+            </a>
+            <span class="fd-icon-tab-bar__separator">
+                <i class="sap-icon--process" role="presentation"></i>
+            </span>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--negative">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab8">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--vehicle-repair" role="presentation"></i>
+                    </span>
+                </div>
+                <div class="fd-icon-tab-bar__details">
+                    <span class="fd-icon-tab-bar__counter">2</span>
+                    <span class="fd-icon-tab-bar__label">Description</span>
+                </div>
+            </a>
+            <span class="fd-icon-tab-bar__separator">
+                <i class="sap-icon--process" role="presentation"></i>
+            </span>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--critical">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab9">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--palette" role="presentation"></i>
+                    </span>
+                </div>
+                <div class="fd-icon-tab-bar__details">
+                    <span class="fd-icon-tab-bar__counter">2</span>
+                    <span class="fd-icon-tab-bar__label">Description</span>
+                </div>
+            </a>
+        </li>
+    </ul>
+</div>
+
+<br><br>
+<div class="fd-icon-tab-bar fd-icon-tab-bar--process">
+    <ul role="tablist" class="fd-icon-tab-bar__header">  
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab10">
+                <span class="fd-icon-tab-bar__tag">Section 1</span>
+                <span class="fd-icon-tab-bar__badge"></span>
+            </a>
+            <span class="fd-icon-tab-bar__separator">
+                <i class="sap-icon--process" role="presentation"></i>
+            </span>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" aria-selected="true" id="tab11">
+                <span class="fd-icon-tab-bar__tag">Section 2</span>
+            </a>
+            <span class="fd-icon-tab-bar__separator">
+                <i class="sap-icon--process" role="presentation"></i>
+            </span>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab12">
+                <span class="fd-icon-tab-bar__tag">Section 3</span>
+            </a>
+        </li>
+    </ul>
+</div>
+`;
+process.storyName = 'Process';
+process.parameters = {
+    docs: {
+        storyDescription: 'You can also use the tab bar to depict a process. In this case, each tab stands for one step. You need to add the <code>fd-icon-tab-bar--process</code> modifier class and a sibling html element with <code>fd-icon-tab-bar\\_\\_separator</code> class to the tab.'
+    }
+};
+
+export const filter = () => `<div class="fd-icon-tab-bar fd-icon-tab-bar--filter">
+    <ul role="tablist" class="fd-icon-tab-bar__header">  
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab"  aria-selected="true" href="#" id="tab1">
+                <div class="fd-icon-tab-bar__container fd-icon-tab-bar__container--filter">
+                    <span class="fd-icon-tab-bar__filter-counter">ÇN</span>
+                    <span class="fd-icon-tab-bar__filter-label">ProductsN</span>
+                </div>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab2">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--letter" role="presentation"></i>
+                    </span>
+                    <span class="fd-icon-tab-bar__badge"></span>
+                    <span class="fd-icon-tab-bar__counter">2</span>
+                </div>
+                <div class="fd-icon-tab-bar__label">Ok</div>
+                
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab3">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--activate" role="presentation"></i>
+                    </span>
+                    <span class="fd-icon-tab-bar__counter">23</span>
+                </div>
+                <div class="fd-icon-tab-bar__label">Heavy</div>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab4">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--jam" role="presentation"></i>
+                    </span>
+                    <span class="fd-icon-tab-bar__counter">10</span>
+                </div>
+                <div class="fd-icon-tab-bar__label">Overweight</div>
+            </a>
+        </li>
+    </ul>
+</div>
+
+<br><br>
+<div class="fd-icon-tab-bar fd-icon-tab-bar--filter fd-icon-tab-bar--compact">
+    <ul role="tablist" class="fd-icon-tab-bar__header">  
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab5">
+                <div class="fd-icon-tab-bar__container fd-icon-tab-bar__container--filter">
+                    <span class="fd-icon-tab-bar__filter-counter">ÇN</span>
+                    <span class="fd-icon-tab-bar__filter-label">ProductsN</span>
+                </div>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab6">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--user-settings" role="presentation"></i>
+                    </span>
+                    <span class="fd-icon-tab-bar__badge"></span>
+                    <span class="fd-icon-tab-bar__counter">2</span>
+                </div>
+                <div class="fd-icon-tab-bar__label">Ok</div>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" aria-selected="true" id="tab7">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--write-new" role="presentation"></i>
+                    </span>
+                    <span class="fd-icon-tab-bar__counter">23</span>
+                </div>
+                <div class="fd-icon-tab-bar__label">Heavy</div>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab8">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--bell" role="presentation"></i>
+                    </span>
+                    <span class="fd-icon-tab-bar__counter">10</span>
+                </div>
+                <div class="fd-icon-tab-bar__label">Overweight</div>
+            </a>
+        </li>
+    </ul>
+</div>
+
+<br><br>
+<div class="fd-icon-tab-bar fd-icon-tab-bar--filter">
+    <ul role="tablist" class="fd-icon-tab-bar__header">  
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab9">
+                <div class="fd-icon-tab-bar__container fd-icon-tab-bar__container--filter">
+                    <span class="fd-icon-tab-bar__filter-counter">ÇN</span>
+                    <span class="fd-icon-tab-bar__filter-label">ProductsN</span>
+                </div>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--negative">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab10">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--text-color" role="presentation"></i>
+                    </span>
+                    <span class="fd-icon-tab-bar__counter">2</span>
+                </div>
+                <div class="fd-icon-tab-bar__label">Ok</div>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--critical">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" aria-selected="true" id="tab11">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--touch" role="presentation"></i>
+                    </span>
+                    <span class="fd-icon-tab-bar__counter">23</span>
+                </div>
+                <div class="fd-icon-tab-bar__label">Heavy</div>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--positive">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab12">
+                <div class="fd-icon-tab-bar__container">
+                    <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--feedback" role="presentation"></i>
+                    </span>
+                    <span class="fd-icon-tab-bar__counter">10</span>
+                </div>
+                <div class="fd-icon-tab-bar__label">Overweight</div>
+            </a>
+        </li>
+    </ul>
+</div>`;
+filter.storyName = 'Filter';
+filter.parameters = {
+    docs: {
+        storyDescription: `The tab bar as a filter has two parts: <br>
+        - An “all” tab on the left - shows the total number of items, and describes the type of item (for example, 189 Products). <br>
+        -  Tabs for specific filters - the tab text indicates the filter attribute. It is recommended to show a counter on every tab.
+        <br>
+        You need to add the <code>fd-icon-tab-bar--filter</code> modifier class for this type of tabs.`
+    }
+};
+
+
+export const overflow = () => `<div class="fd-icon-tab-bar">
+    <ul role="tablist" class="fd-icon-tab-bar__header"> 
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <button class="fd-icon-tab-bar__overflow">
+                <span class="fd-icon-tab-bar__overflow-text">+2</span>
+                <i class="sap-icon--slim-arrow-down" role="presentation"></i>
+            </button>
+        </li> 
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab1">
+                <span class="fd-icon-tab-bar__tag">Section 1</span>
+                <span class="fd-icon-tab-bar__badge"></span>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" aria-selected="true" id="tab2">
+                <span class="fd-icon-tab-bar__tag">Section 2</span>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab3">
+                <span class="fd-icon-tab-bar__tag">Section 3</span>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <button class="fd-icon-tab-bar__overflow">
+                <span class="fd-icon-tab-bar__overflow-text">+3</span>
+                <i class="sap-icon--slim-arrow-down" role="presentation"></i>
+            </button>
+        </li> 
+    </ul>
+</div>
+<br><br>
+<div class="fd-icon-tab-bar">
+    <ul role="tablist" class="fd-icon-tab-bar__header"> 
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab4">
+                <span class="fd-icon-tab-bar__tag">Section 1</span>
+                <span class="fd-icon-tab-bar__badge"></span>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" aria-selected="true" id="tab5">
+                <span class="fd-icon-tab-bar__tag">Section 2</span>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab6">
+                <span class="fd-icon-tab-bar__tag">Section 3</span>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <button class="fd-icon-tab-bar__overflow">
+                <span class="fd-icon-tab-bar__overflow-text">More</span>
+                <i class="sap-icon--slim-arrow-down" role="presentation"></i>
+            </button>
+        </li> 
+    </ul>
+</div>`;
+overflow.storyName = 'Overflow';
+overflow.parameters = {
+    docs: {
+        storyDescription: `Tabs can have an overflow to either sides of the control. Depending on if the order is fixed (process steps) or can be rearranged (tabs).
+        For processes with a fixed order, an overflow to both sides is used. For tabs that can be rearranged, only one overflow will be displayed on the right side.`
+    }
+};
+
+export const singleClick = () => `<div style="min-height: 800px;">
+    <div class="fd-icon-tab-bar fd-icon-tab-bar--xl">
+        <ul role="tablist" class="fd-icon-tab-bar__header">  
+            <li role="presentation" class="fd-icon-tab-bar__item">
+                <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab1">
+                    <span class="fd-icon-tab-bar__tag">Section 1</span>
+                    <span class="fd-icon-tab-bar__badge"></span>
+                </a>
+            </li>
+            <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--single-click">
+                <div class="fd-popover">
+                    <div class="fd-popover__control">
+                        <a role="tab" class="fd-icon-tab-bar__tab" tabindex="0" aria-selected="true" id="tab2" aria-controls="popoverA1" aria-expanded="true" aria-haspopup="true" onclick="onPopoverClick('popoverA1');">
+                            <div class="fd-icon-tab-bar__tab-container">
+                                <span class="fd-icon-tab-bar__tag">Section 2</span>
+                                <span class="fd-icon-tab-bar__arrow">
+                                    <i class="sap-icon--slim-arrow-down" role="presentation"></i>
+                                </span>
+                                <span class="fd-icon-tab-bar__badge"></span>
+                            </div>
+                        </a>
+                    </div>
+                    <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right" aria-hidden="false" id="popoverA1">
+                        <ul class="fd-list fd-list--navigation fd-list--no-border fd-icon-tab-bar__list" role="list">
+                            <li tabindex="-1" role="listitem" aria-level="1" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                                <a tabindex="0" class="fd-list__link">
+                                    <span class="fd-list__title">Subsection 1</span>
+                                    <span class="fd-icon-tab-bar__badge"></span>
+                                </a>
+                            </li>
+                            <li tabindex="-1" role="listitem" aria-level="2" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                                <a tabindex="0" class="fd-list__link">
+                                    <span class="fd-list__title">Subsection 1.1</span>
+                                </a>
+                            </li>
+                            <li tabindex="-1" role="listitem" aria-level="3" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                                <a tabindex="0" class="fd-list__link">
+                                    <span class="fd-list__title">Subsection 1.1.1</span>
+                                    <span class="fd-icon-tab-bar__badge"></span>
+                                </a>
+                            </li>
+                            <li tabindex="-1" role="listitem" aria-level="4" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                                <a tabindex="0" class="fd-list__link">
+                                    <span class="fd-list__title">Subsection 1.1.1.1</span>
+                                </a>
+                            </li>
+                            <li tabindex="-1" role="listitem" aria-level="5" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                                <a tabindex="0" class="fd-list__link">
+                                    <span class="fd-list__title">Subsection 1.1.1.1.1</span>
+                                </a>
+                            </li>
+                            <li tabindex="-1" role="listitem" aria-level="1" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                                <a tabindex="0" class="fd-list__link">
+                                    <span class="fd-list__title">Subsection 2</span>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </li>
+            <li role="presentation" class="fd-icon-tab-bar__item">
+                <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab3">
+                    <span class="fd-icon-tab-bar__tag">Section 3</span>
+                </a>
+            </li>
+        </ul>
+    </div>
+
+    <div style="height: 20rem;"></div>
+
+    <div class="fd-icon-tab-bar fd-icon-tab-bar--xl">
+        <ul role="tablist" class="fd-icon-tab-bar__header">  
+            <li role="presentation" class="fd-icon-tab-bar__item">
+                <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab4">
+                    <span class="fd-icon-tab-bar__tag">Section 1</span>
+                    <span class="fd-icon-tab-bar__badge"></span>
+                </a>
+            </li>
+            <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--single-click">
+                <div class="fd-popover">
+                    <div class="fd-popover__control">
+                        <a role="tab" class="fd-icon-tab-bar__tab" aria-selected="true" id="tab5" tabindex="0" aria-controls="popoverA2" aria-expanded="true" aria-haspopup="true" onclick="onPopoverClick('popoverA2');">
+                            <div class="fd-icon-tab-bar__tab-container">
+                                <span class="fd-icon-tab-bar__tag">Section 2</span>
+                                <span class="fd-icon-tab-bar__arrow">
+                                    <i class="sap-icon--slim-arrow-down" role="presentation"></i>
+                                </span>
+                            </div>
+                        </a>
+                    </div>
+                    <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right" aria-hidden="false" id="popoverA2">
+                        <ul class="fd-list fd-list--navigation fd-list--no-border fd-icon-tab-bar__list" role="list">
+                            <li tabindex="-1" class="fd-icon-tab-bar__line-separator"></li>
+                            <li tabindex="-1" role="listitem" aria-level="1" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                                <a tabindex="0" class="fd-list__link">
+                                    <span class="fd-list__title">Subsection 1</span>
+                                    <span class="fd-icon-tab-bar__badge"></span>
+                                </a>
+                            </li>
+                            <li tabindex="-1" class="fd-icon-tab-bar__line-separator"></li>
+                            <li tabindex="-1" role="listitem" aria-level="2" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                                <a tabindex="0" class="fd-list__link">
+                                    <span class="fd-list__title">Subsection 1.1</span>
+                                </a>
+                            </li>
+                            <li tabindex="-1" class="fd-icon-tab-bar__line-separator"></li>
+                            <li tabindex="-1" role="listitem" aria-level="3" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                                <a tabindex="0" class="fd-list__link">
+                                    <span class="fd-list__title">Subsection 1.1.1</span>
+                                    <span class="fd-icon-tab-bar__badge"></span>
+                                </a>
+                            </li>
+                            <li tabindex="-1" class="fd-icon-tab-bar__line-separator"></li>
+                            <li tabindex="-1" role="listitem" aria-level="4" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                                <a tabindex="0" class="fd-list__link">
+                                    <span class="fd-list__title">Subsection 1.1.1.1</span>
+                                </a>
+                            </li>
+                            <li tabindex="-1" class="fd-icon-tab-bar__line-separator"></li>
+                            <li tabindex="-1" role="listitem" aria-level="5" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                                <a tabindex="0" class="fd-list__link">
+                                    <span class="fd-list__title">Subsection 1.1.1.1.1</span>
+                                </a>
+                            </li>
+                            <li tabindex="-1" class="fd-icon-tab-bar__line-separator"></li>
+                            <li tabindex="-1" role="listitem" aria-level="1" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                                <a tabindex="0" class="fd-list__link">
+                                    <span class="fd-list__title">Subsection 2</span>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </li>
+            <li role="presentation" class="fd-icon-tab-bar__item">
+                <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab6">
+                    <span class="fd-icon-tab-bar__tag">Section 3</span>
+                </a>
+            </li>
+        </ul>
+    </div>
+</div>
+`;
+singleClick.storyName = 'Universal Icon Tab Bar Single Click Area';
+singleClick.parameters = {
+    docs: {
+        storyDescription: `When there is only one click area per tab (also including tabs with sub-items), regular tabs get selected immediately after the click is released. Tabs with sub-items trigger the expansion of a menu (Popover) showing its sub-items. The parent tab title remains displayed when its child is select.
+        <br>
+        You need to apply the <code>fd-icon-tab-bar\\_\\_item--single-click</code> modifier class to <code>fd-icon-tab-bar\\_\\_item</code> element. The List component inside the Popover has an additional modifier class <code>fd-icon-tab-bar\\_\\_list</code> to achieve the nesting (indentation) of the elements. The list menu can be borderless, with line separators (<code>fd-icon-tab-bar\\_\\_line-separator</code>) or icon separators (<code>fd-icon-tab-bar\\_\\_icon-separator</code>) `
+    }
+};
+
+
+export const multiClick = () => `<div style="min-height: 400px;">
+    <div class="fd-icon-tab-bar fd-icon-tab-bar--md">
+        <ul role="tablist" class="fd-icon-tab-bar__header">  
+            <li role="presentation" class="fd-icon-tab-bar__item">
+                <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab1">
+                    <span class="fd-icon-tab-bar__tag">Section 1</span>
+                    <span class="fd-icon-tab-bar__badge"></span>
+                </a>
+            </li>
+            <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--multi-click">
+                <a role="tab" class="fd-icon-tab-bar__tab" aria-selected="true" id="tab2" tabindex="0">
+                    <span class="fd-icon-tab-bar__tag">Section 2</span>
+                    <span class="fd-icon-tab-bar__badge"></span>
+                </a>
+
+                <div class="fd-popover fd-icon-tab-bar__popover">
+                    <div class="fd-popover__control">
+                        <div class="fd-icon-tab-bar__button-container">
+                            <button class="fd-button fd-button--transparent fd-button--compact  fd-icon-tab-bar__button" aria-controls="popoverA3" aria-expanded="false" aria-haspopup="true" onclick="onPopoverClick('popoverA3');" aria-label="open menu button">
+                                <i class="sap-icon--slim-arrow-down"></i>
+                            </button>
+                            <span class="fd-icon-tab-bar__badge"></span>
+                        </div>
+                    </div>
+                    <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right" aria-hidden="false" id="popoverA3">
+                        <ul class="fd-list fd-list--navigation fd-list--no-border fd-icon-tab-bar__list" role="list">
+                            <li tabindex="-1" class="fd-icon-tab-bar__icon-separator">
+                                <span class="sap-icon--process"></span>
+                            </li>
+                            <li tabindex="-1" role="listitem" aria-level="1" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                                <a tabindex="0" class="fd-list__link">
+                                    <span class="fd-list__title">Subsection 1</span>
+                                    <span class="fd-icon-tab-bar__badge"></span>
+                                </a>
+                            </li>
+                            <li tabindex="-1" class="fd-icon-tab-bar__icon-separator">
+                                <span class="sap-icon--process"></span>
+                            </li>
+                            <li tabindex="-1" role="listitem" aria-level="2" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                                <a tabindex="0" class="fd-list__link">
+                                    <span class="fd-list__title">Subsection 1.1</span>
+                                </a>
+                            </li>
+                            <li tabindex="-1" class="fd-icon-tab-bar__icon-separator">
+                                <span class="sap-icon--process"></span>
+                            </li>
+                            <li tabindex="-1" role="listitem" aria-level="3" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                                <a tabindex="0" class="fd-list__link">
+                                    <span class="fd-list__title">Subsection 1.1.1</span>
+                                </a>
+                            </li>
+                            <li tabindex="-1" class="fd-icon-tab-bar__icon-separator">
+                                <span class="sap-icon--process"></span>
+                            </li>
+                            <li tabindex="-1" role="listitem" aria-level="4" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                                <a tabindex="0" class="fd-list__link">
+                                    <span class="fd-list__title">Subsection 1.1.1.1</span>
+                                </a>
+                            </li>
+                            <li tabindex="-1" class="fd-icon-tab-bar__icon-separator">
+                                <span class="sap-icon--process"></span>
+                            </li>
+                            <li tabindex="-1" role="listitem" aria-level="5" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                                <a tabindex="0" class="fd-list__link">
+                                    <span class="fd-list__title">Subsection 1.1.1.1.1</span>
+                                </a>
+                            </li>
+                            <li tabindex="-1" class="fd-icon-tab-bar__icon-separator">
+                                <span class="sap-icon--process"></span>
+                            </li>
+                            <li tabindex="-1" role="listitem" aria-level="1" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                                <a tabindex="0" class="fd-list__link">
+                                    <span class="fd-list__title">Subsection 2</span>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </li>
+            <li role="presentation" class="fd-icon-tab-bar__item">
+                <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab3">
+                    <span class="fd-icon-tab-bar__tag">Section 3</span>
+                </a>
+            </li>
+        </ul>
+    </div>
+</div>
+`;
+multiClick.storyName = 'Universal Icon Tab Bar Multi Click Area';
+multiClick.parameters = {
+    docs: {
+        storyDescription: 'In case of two click areas for tabs with sub-tabs, the behaviour for regular tabs (without sub-items) remains unchanged, like described above the tabs get selected immediately. Tabs with two click areas behave differently: when the main part of the tab is clicked, it is highlighted and then selected immediately. Clicking the second area opens a menu (Popover) containing the sub-items. Once a sub-item is clicked, the main tab is highlighted as selected. '
+    }
+};
+
+export const badge = () => `<div class="fd-icon-tab-bar">
+    <ul role="tablist" class="fd-icon-tab-bar__header">  
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#section11" id="tab1">
+                <span class="fd-icon-tab-bar__tag">Section 1</span>
+                <span class="fd-icon-tab-bar__badge"></span>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#section12" aria-selected="true" id="tab2">
+                <span class="fd-icon-tab-bar__tag">Section 2</span>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#section13" id="tab3">
+                <span class="fd-icon-tab-bar__tag">Section 3</span>
+            </a>
+        </li>
+    </ul>
+</div>
+
+<br><br>
+<div class="fd-icon-tab-bar">
+    <ul role="tablist" class="fd-icon-tab-bar__header">  
+        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--positive">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#section21" aria-selected="true" id="tab4">
+                <span class="fd-icon-tab-bar__tag">Section 1</span>
+                <span class="fd-icon-tab-bar__badge"></span>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--negative">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#section22" aria-selected="true" id="tab5">
+                <span class="fd-icon-tab-bar__tag">Section 2</span>
+                <span class="fd-icon-tab-bar__badge"></span>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--critical">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#section23" aria-selected="true" id="tab6">
+                <span class="fd-icon-tab-bar__tag">Section 3</span>
+                <span class="fd-icon-tab-bar__badge"></span> 
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--informative">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#section24" aria-selected="true" id="tab7">
+                <span class="fd-icon-tab-bar__tag">Section 4</span>
+                <span class="fd-icon-tab-bar__badge"></span>
+            </a>
+        </li>
+    </ul>
+</div>
+
+<br><br>
+<div class="fd-icon-tab-bar fd-icon-tab-bar--counters">
+    <ul role="tablist" class="fd-icon-tab-bar__header">  
+        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--positive">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#section41" id="tab8">
+                <span class="fd-icon-tab-bar__tag">Section 1</span>
+                <span class="fd-icon-tab-bar__badge"></span>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--negative">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#section42" aria-selected="true" id="tab9">
+                <span class="fd-icon-tab-bar__counter">23</span>
+                <span class="fd-icon-tab-bar__tag">Section 2</span>
+                <span class="fd-icon-tab-bar__badge"></span>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--critical">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#section43" id="tab10">
+                <span class="fd-icon-tab-bar__counter">10</span>
+                <span class="fd-icon-tab-bar__tag">Section 3</span>
+                <span class="fd-icon-tab-bar__badge"></span>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--informative">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#section44" id="tab11">
+                <span class="fd-icon-tab-bar__counter">10</span>
+                <span class="fd-icon-tab-bar__tag">Section 4</span>
+                <span class="fd-icon-tab-bar__badge"></span>
+            </a>
+        </li>
+    </ul> 
+</div>
+<br><br>
+<div class="fd-icon-tab-bar fd-icon-tab-bar--icon-only">
+  <ul role="tablist" class="fd-icon-tab-bar__header">
+    <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--positive">
+      <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab12">
+        <div class="fd-icon-tab-bar__container">
+          <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--history" role="presentation"></i>
+                    </span>
+          <span class="fd-icon-tab-bar__badge fd-icon-tab-bar__badge--animated"></span>
+          <span class="fd-icon-tab-bar__counter">2</span>
+        </div>
+      </a>
+    </li>
+    <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--negative">
+      <a role="tab" class="fd-icon-tab-bar__tab" href="#" aria-selected="true" id="tab13">
+        <div class="fd-icon-tab-bar__container">
+          <span class="fd-icon-tab-bar__icon">
+                        <i class="sap-icon--card" role="presentation"></i>
+                    </span>
+          <span class="fd-icon-tab-bar__badge fd-icon-tab-bar__badge--animated"></span>
+          <span class="fd-icon-tab-bar__counter">23</span>
+        </div>
+      </a>
+    </li>
+    <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--critical">
+      <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab14">
+        <div class="fd-icon-tab-bar__container">
+          <span class="fd-icon-tab-bar__icon">
+                <i class="sap-icon--cart" role="presentation"></i>
+          </span>
+          <span class="fd-icon-tab-bar__badge fd-icon-tab-bar__badge--animated"></span>
+          <span class="fd-icon-tab-bar__counter">10</span>
+        </div>
+      </a>
+    </li>
+    <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--informative">
+      <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab15">
+        <div class="fd-icon-tab-bar__container">
+          <span class="fd-icon-tab-bar__icon">
+            <i class="sap-icon--cart" role="presentation"></i>
+          </span>
+          <span class="fd-icon-tab-bar__badge fd-icon-tab-bar__badge--animated"></span>
+          <span class="fd-icon-tab-bar__counter">10</span>
+        </div>
+      </a>
+    </li>
+  </ul>
+</div>
+`;
+badge.storyName = 'Badges';
+badge.parameters = {
+    docs: {
+        storyDescription: `The Tab attention badge is applied as a visual eye-catcher to indicate a change within a Tab. <br>
+        The badge is a span element with <code>fd-icon-tab-bar\\_\\_badge</code> class. It can be animated by adding an additional <code> fd-icon-tab-bar\\_\\_badge--animated</code> modifier class. In this case the badge appears for a few milliseconds and then disappears.`
+    }
+};
+
+export const respPaddings = () => `<div class="fd-icon-tab-bar fd-icon-tab-bar--responsive-paddings">
+    <ul role="tablist" class="fd-icon-tab-bar__header">  
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#section11" id="tab1">
+                <span class="fd-icon-tab-bar__tag">Section 1</span>
+                <span class="fd-icon-tab-bar__badge"></span>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#section12" aria-selected="true" id="tab2">
+                <span class="fd-icon-tab-bar__tag">Section 2</span>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#section13" id="tab3">
+                <span class="fd-icon-tab-bar__tag">Section 3</span>
+            </a>
+        </li>
+    </ul>
+</div>
+`;
+respPaddings.storyName = 'Responsive Paddings';
+respPaddings.parameters = {
+    docs: {
+        storyDescription: 'For an Icon Tab Bar with responsive paddings that adjust based on the screen size add the <code>fd-icon-tab-bar--responsive-paddings</code> modifier class.'
+    }
+};
+
+export const paddings = () => `<h4>SM (1rem) paddings</h4>
+<div class="fd-icon-tab-bar fd-icon-tab-bar--sm">
+    <ul role="tablist" class="fd-icon-tab-bar__header">  
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab1">
+                <span class="fd-icon-tab-bar__tag">Section 1</span>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" aria-selected="true" id="tab2">
+                <span class="fd-icon-tab-bar__tag">Section 2</span>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab3">
+                <span class="fd-icon-tab-bar__tag">Section 3</span>
+            </a>
+        </li>
+    </ul>
+</div>
+<br><br>
+<h4>MD (2rem) paddings</h4>
+<div class="fd-icon-tab-bar fd-icon-tab-bar--md">
+    <ul role="tablist" class="fd-icon-tab-bar__header">  
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab4">
+                <span class="fd-icon-tab-bar__tag">Section 1</span>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" aria-selected="true" id="tab5">
+                <span class="fd-icon-tab-bar__tag">Section 2</span>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab6">
+                <span class="fd-icon-tab-bar__tag">Section 3</span>
+            </a>
+        </li>
+    </ul>
+</div>
+<br><br>
+<h4>LG (2rem) paddings</h4>
+<div class="fd-icon-tab-bar fd-icon-tab-bar--lg">
+    <ul role="tablist" class="fd-icon-tab-bar__header">  
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab7">
+                <span class="fd-icon-tab-bar__tag">Section 1</span>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" aria-selected="true" id="tab8">
+                <span class="fd-icon-tab-bar__tag">Section 2</span>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab9">
+                <span class="fd-icon-tab-bar__tag">Section 3</span>
+            </a>
+        </li>
+    </ul>
+</div>
+<br><br>
+<h4>XL (3rem) paddings</h4>
+<div class="fd-icon-tab-bar fd-icon-tab-bar--xl">
+    <ul role="tablist" class="fd-icon-tab-bar__header">  
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab13">
+                <span class="fd-icon-tab-bar__tag">Section 1</span>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" aria-selected="true" id="tab14">
+                <span class="fd-icon-tab-bar__tag">Section 2</span>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab15">
+                <span class="fd-icon-tab-bar__tag">Section 3</span>
+            </a>
+        </li>
+    </ul>
+</div>
+<br><br>
+<h4>XXL (3rem) paddings</h4>
+<div class="fd-icon-tab-bar fd-icon-tab-bar--xxl">
+    <ul role="tablist" class="fd-icon-tab-bar__header">  
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab16">
+                <span class="fd-icon-tab-bar__tag">Section 1</span>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" aria-selected="true" id="tab17">
+                <span class="fd-icon-tab-bar__tag">Section 2</span>
+            </a>
+        </li>
+        <li role="presentation" class="fd-icon-tab-bar__item">
+            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab18">
+                <span class="fd-icon-tab-bar__tag">Section 3</span>
+            </a>
+        </li>
+    </ul>
+</div>
+`;
+paddings.storyName = 'Sizes and Horizontal Paddings';
+paddings.parameters = {
+    docs: {
+        storyDescription: 'You can set horizontal paddings by adding a modifier class and specifying the size of the paddings. Please refer to the "Paddings" section at the top of the page for the available sizes.'
+    }
+};


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#2073

## Description
Introduce new Icon Tab Bar which is similar to the existing Tabs component with the following extra features
- Single Click Area
- Two Click Areas
- Semantic tab bar (with icons and colors and theming)
- Shell Navigation color delta
- Dropdown menu with/without separators
- IconTabBar with badges
- Badge inside dropdown mene

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules - NOTE: THE TABS DO NOT TRUNCATE PER FIORI 3 SPECS
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec - NOTE: the focus for overflow button to be confirmed later by the designers. As of today it's still WIP in the design
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [na] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [NA] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
