### PR TITLE
fix: provide padding if title is first element in bar

### DIFF
--- a/src/bar.scss
+++ b/src/bar.scss
@@ -28,6 +28,16 @@ $block: #{$fd-namespace}-bar;
     right: $margin-x;
   }
 
+  @mixin padding-left-right($left, $right) {
+    padding-left: $left;
+    padding-right: $right;
+
+    @include fd-rtl() {
+      padding-left: $right;
+      padding-right: $left;
+    }
+  }
+
   @include fd-reset();
   @include bar-design();
 
@@ -83,6 +93,12 @@ $block: #{$fd-namespace}-bar;
 
     & > *:first-child {
       flex-grow: 1;
+    }
+  }
+
+  &__left > &__element:first-child {
+    span:nth-child(1) {
+      @include padding-left-right(1rem, 0);
     }
   }
 

--- a/src/bar.scss
+++ b/src/bar.scss
@@ -28,16 +28,6 @@ $block: #{$fd-namespace}-bar;
     right: $margin-x;
   }
 
-  @mixin padding-left-right($left, $right) {
-    padding-left: $left;
-    padding-right: $right;
-
-    @include fd-rtl() {
-      padding-left: $right;
-      padding-right: $left;
-    }
-  }
-
   @include fd-reset();
   @include bar-design();
 
@@ -86,6 +76,10 @@ $block: #{$fd-namespace}-bar;
       margin-right: 0;
       margin-left: $fd-bar-element-spacing;
     }
+
+    &--title {
+      @include fd-set-paddings-x(0.5rem,0);
+    }
   }
 
   &__element--full-width {
@@ -93,12 +87,6 @@ $block: #{$fd-namespace}-bar;
 
     & > *:first-child {
       flex-grow: 1;
-    }
-  }
-
-  &__left > &__element:first-child {
-    span:nth-child(1) {
-      @include padding-left-right(1rem, 0);
     }
   }
 

--- a/stories/bar/__snapshots__/bar.stories.storyshot
+++ b/stories/bar/__snapshots__/bar.stories.storyshot
@@ -226,6 +226,7 @@ exports[`Storyshots Components/Bar Default 1`] = `
             
         <span
           aria-label="text"
+          class="fd-bar__element fd-bar__element--title"
         >
           TEXT
         </span>

--- a/stories/bar/__snapshots__/bar.stories.storyshot
+++ b/stories/bar/__snapshots__/bar.stories.storyshot
@@ -224,28 +224,6 @@ exports[`Storyshots Components/Bar Default 1`] = `
       >
         
             
-        <button
-          aria-label="button"
-          class="fd-button fd-button--transparent fd-button--compact"
-        >
-          
-                
-          <i
-            class="sap-icon--navigation-left-arrow"
-          />
-          
-            
-        </button>
-        
-        
-      </div>
-      
-        
-      <div
-        class="fd-bar__element"
-      >
-        
-            
         <span
           aria-label="text"
         >

--- a/stories/bar/bar.stories.js
+++ b/stories/bar/bar.stories.js
@@ -44,11 +44,6 @@ export const Default = () => `
 <div class="fd-bar">
     <div class="fd-bar__left">
         <div class="fd-bar__element">
-            <button aria-label="button" class="fd-button fd-button--transparent fd-button--compact">
-                <i class="sap-icon--navigation-left-arrow"></i>
-            </button>
-        </div>
-        <div class="fd-bar__element">
             <span aria-label="text">TEXT</span>
         </div>
     </div>

--- a/stories/bar/bar.stories.js
+++ b/stories/bar/bar.stories.js
@@ -44,7 +44,7 @@ export const Default = () => `
 <div class="fd-bar">
     <div class="fd-bar__left">
         <div class="fd-bar__element">
-            <span aria-label="text">TEXT</span>
+            <span class="fd-bar__element fd-bar__element--title" aria-label="text">TEXT</span>
         </div>
     </div>
     <div class="fd-bar__middle">
@@ -122,7 +122,7 @@ export const Default = () => `
 Default.parameters = {
     docs: {
         iframeHeight: 200,
-        storyDescription: 'The default bar contains a back button, page title, segmented button and product switch button. It can be displayed by using the <code class="docs-code">fd-bar</code> class, and is responsive to desktop screen sizes. The default bar is in compact mode. Fiori 3 doesn\'t forbid including cozy elements inside (e.g. cozy buttons)'
+        storyDescription: 'The default bar contains a back button, page title, segmented button and product switch button. It can be displayed by using the <code class="docs-code">fd-bar</code> class, and is responsive to desktop screen sizes. The default bar is in compact mode. Fiori 3 doesn\'t forbid including cozy elements inside (e.g. cozy buttons). Add <code class="docs-code">--title</code> modifier class to bar element, if title is first element in bar.'
     }
 };
 


### PR DESCRIPTION
## Related Issue
Closes #2479 

## Description
BREAKING CHANGE:

Added modifier class `fd-bar__element--title` class to bar component when title is placed as first element to add 0.5rem padding to it as per visual core.

Before:
```
  <span aria-label="text">TEXT</span>
```
After:
```
  <span class="fd-bar__element fd-bar__element--title" aria-label="text">TEXT</span>
```

## Screenshots

### Before:
<img width="1263" alt="2021-06-24_20-39-13" src="https://user-images.githubusercontent.com/53487468/123287579-726dae00-d52c-11eb-99d9-04d86bee3b91.png">

### After:

<img width="1173" alt="2021-06-24_20-41-09" src="https://user-images.githubusercontent.com/53487468/123287690-8addc880-d52c-11eb-9be2-a412dcd6ac7c.png">

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
