### PR TITLE
fix: add bottom border to panel content

### DIFF
--- a/src/panel.scss
+++ b/src/panel.scss
@@ -37,6 +37,7 @@ $block: #{$fd-namespace}-panel;
   &__content {
     padding: 0.625rem 1rem 1.375rem 1rem;
     overflow: auto;
+    border-bottom: solid 0.0625rem var(--sapGroup_TitleBorderColor);
 
     &[aria-hidden="true"] {
       display: none;


### PR DESCRIPTION
## Related Issue
fixes #2482 

## Description
add panel content bottom border

## Screenshots

### Before:
<img width="808" alt="Screen Shot 2021-06-26 at 6 31 26 PM" src="https://user-images.githubusercontent.com/4380815/123527357-c2737e80-d6ac-11eb-9c01-36a572479a95.png">
<img width="805" alt="Screen Shot 2021-06-26 at 6 31 20 PM" src="https://user-images.githubusercontent.com/4380815/123527359-c30c1500-d6ac-11eb-9177-b7aecb5e42b0.png">


### After:
<img width="805" alt="Screen Shot 2021-06-26 at 6 30 56 PM" src="https://user-images.githubusercontent.com/4380815/123527361-c99a8c80-d6ac-11eb-8784-1fbb6cd5bbe3.png">
<img width="795" alt="Screen Shot 2021-06-26 at 6 30 48 PM" src="https://user-images.githubusercontent.com/4380815/123527362-c99a8c80-d6ac-11eb-92b7-af7368a9b655.png">


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [X] All values are in `rem`
- [na] Text elements follow the truncation rules
- [na] hover state of the element follow design spec
- [na] focus state of the element follow design spec
- [na] active state of the element follow design spec
- [na] selected state of the element follow design spec
- [na] selected hover state of the element follow design spec
- [na] pressed state of the element follow design spec
- [na] Responsiveness rules - the component has modifier classes for all breakpoints
- [na] Includes Compact/Cosy/Tablet design
- [na] RTL support
2. The code follows fundamental-styles code standards and style
- [na] only one top level `fd-*` class is used in the file
- [na] BEM naming convention is used
- [na] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [na] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [na] `fd-reset()` mixin is applied to all elements
- [na] Variables are used, if some value is used more than twice.
- [na] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [na] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [na] Storybook documentation has been created/updated
- [na] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
