### PR TITLE
fix: added wrapper for slider [ci visual]

### DIFF
--- a/src/slider.scss
+++ b/src/slider.scss
@@ -19,7 +19,7 @@ $handle-hit-area-mobile-dimensions: 2.75rem;
   padding: 1rem 0.625rem;
   position: relative;
 
-  &--lg-x-paddings {
+  &--lg {
     @include fd-set-paddings-x-equal(0.8125rem);
   }
 

--- a/src/slider.scss
+++ b/src/slider.scss
@@ -16,8 +16,12 @@ $handle-hit-area-mobile-dimensions: 2.75rem;
 
   min-width: 4rem;
   max-width: 100%;
-  padding: 1rem 0;
+  padding: 1rem 0.625rem;
   position: relative;
+
+  &--lg-x-paddings {
+    @include fd-set-paddings-x-equal(0.8125rem);
+  }
 
   &__inner {
     @include fd-reset();
@@ -144,6 +148,12 @@ $handle-hit-area-mobile-dimensions: 2.75rem;
         width: $handle-hit-area-mobile-dimensions;
         height: $handle-hit-area-mobile-dimensions;
       }
+    }
+  }
+
+  @include fd-rtl() {
+    .#{$block}__handle::before {
+      transform: translate(25%, -25%);
     }
   }
 }

--- a/stories/slider/slider.stories.js
+++ b/stories/slider/slider.stories.js
@@ -171,7 +171,7 @@ The slider can display labels that indicate the values of each tick. Labels can 
 
 export const mobileMode = () => `
 <div class="slider-container">
-    <div class="fd-slider fd-slider--lg-x-paddings">
+    <div class="fd-slider fd-slider--lg">
         <div class="fd-slider__inner">
             <div class="fd-slider__track">
                 <div class="fd-slider__track-range" style="width: 50%;"></div>
@@ -186,6 +186,7 @@ mobileMode.parameters = {
     docs: {
         storyDescription: `
 By default, the slider is not responsive. However, to make the slider more mobile-friendly, you may enlarge the slider handle and its hit area by adding \`fd-slider__handle--lg\` class to \`fd-slider__handle\` element.
+To add horizontal paddings of \`0.8125rem\` use the \`fd-slider--lg\` modifier class
         `
     }
 };

--- a/stories/slider/slider.stories.js
+++ b/stories/slider/slider.stories.js
@@ -171,7 +171,7 @@ The slider can display labels that indicate the values of each tick. Labels can 
 
 export const mobileMode = () => `
 <div class="slider-container">
-    <div class="fd-slider">
+    <div class="fd-slider fd-slider--lg-x-paddings">
         <div class="fd-slider__inner">
             <div class="fd-slider__track">
                 <div class="fd-slider__track-range" style="width: 50%;"></div>


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#2503

## Description
Added wrapper for slider to prevent getting out of the strip edges of slider track. (look related issue)
Also fixed position of "before element" of handle for rtl.

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![2021-06-29_09-50](https://user-images.githubusercontent.com/14183958/123750700-91b76300-d8bf-11eb-80eb-1d58aa8833d7.png)

### After:
![2021-06-29_09-51](https://user-images.githubusercontent.com/14183958/123750710-967c1700-d8bf-11eb-8af5-7d0e4455df7b.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
