### PR TITLE
fix: rtl support for the grid list highlighter for status

### DIFF
--- a/src/list-grid.scss
+++ b/src/list-grid.scss
@@ -327,7 +327,6 @@ $block: #{$fd-namespace}-grid-list;
 
       position: absolute;
       top: 0;
-      left: 0;
       bottom: 0;
       width: 0.375rem;
       display: block;

--- a/src/list-grid.scss
+++ b/src/list-grid.scss
@@ -327,10 +327,15 @@ $block: #{$fd-namespace}-grid-list;
 
       position: absolute;
       top: 0;
+      left: 0;
       bottom: 0;
       width: 0.375rem;
       display: block;
       border-radius: $fd-grid-list-border-radius 0 0 $fd-grid-list-border-radius;
+
+      @include fd-rtl() {
+        right: 0;
+      }
 
       &--#{$set-name} {
         background-color: map_get($colors, 'backgroundColor');


### PR DESCRIPTION
## Related Issue
Closes : https://github.com/SAP/fundamental-styles/issues/2523

## Description

rtl support for the grid list highlighter for status.

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
<img width="1219" alt="Screenshot 2021-06-29 at 12 16 19 PM" src="https://user-images.githubusercontent.com/53534379/123750253-01374d80-d8d4-11eb-9df4-02787e6f6197.png">


### After:
<img width="1219" alt="Screenshot 2021-06-29 at 1 04 19 PM" src="https://user-images.githubusercontent.com/53534379/123756499-9ccbbc80-d8da-11eb-97a9-7125abd6dce5.png">



#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [N/A]  All values are in `rem`
- [N/A]  Text elements follow the truncation rules
- [N/A] hover state of the element follow design spec
- [N/A] focus state of the element follow design spec
- [N/A] active state of the element follow design spec
- [N/A] selected state of the element follow design spec
- [N/A] selected hover state of the element follow design spec
- [N/A] pressed state of the element follow design spec
- [N/A] Responsiveness rules - the component has modifier classes for all breakpoints
- [N/A] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [N/A] only one top level `fd-*` class is used in the file
- [N/A] BEM naming convention is used
- [N/A] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [N/A] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [N/A] `fd-reset()` mixin is applied to all elements
- [N/A] Variables are used, if some value is used more than twice.
- [N/A] Checked if current components can be reused, instead of having new code.
3. Testing
- [N/A] tested Storybook examples with "CSS Resources" `normalize` option 
- [N/A] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [N/A] Verified all styles in IE11
- [N/A] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [N/A] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.

