### PR TITLE
fix: fix action button in Rtl mode for grid list component. Move grid list styles from Ngx.

### DIFF
--- a/src/list-grid.scss
+++ b/src/list-grid.scss
@@ -175,17 +175,17 @@ $block: #{$fd-namespace}-grid-list;
           }
         }
 
-        .fd-grid-list__item-input,
+        .#{$item}-input,
         &--actions,
         &--extra-content {
-          display: flex;
-          align-items: center;
+          @include fd-flex-vertical-center();
+
           height: 100%;
         }
       }
     }
 
-    .drop-area__line--vertical {
+    .fd-drop-area__line--vertical {
       height: 100%;
 
       &.before {
@@ -320,7 +320,7 @@ $block: #{$fd-namespace}-grid-list;
 
   &__filter,
   &__filter-button {
-    color: var(--sapHighlightTextColor);
+    color: var(--sapHighlightTextColor) !important;
   }
 
   &__filter-button {

--- a/src/list-grid.scss
+++ b/src/list-grid.scss
@@ -305,7 +305,7 @@ $blockToolbar: #{$fd-namespace}-toolbar;
 
     @include fd-active() {
       @include fd-hover() {
-        color: var(--sapHighlightTextColor);
+        color: var(--sapHighlightTextColor) !important;
       }
     }
   }

--- a/src/list-grid.scss
+++ b/src/list-grid.scss
@@ -259,23 +259,24 @@ $block: #{$fd-namespace}-grid-list;
     }
   }
 
-  &__filter {
-    @include fd-fiori-focus();
+  .#{$block}__filter {
+    &[class*="active"] {
+      @include fd-fiori-focus();
+
+      color: var(--sapHighlightTextColor);
+    }
   }
 
-  &__filter,
-  &__filter-button {
-    color: var(--sapHighlightTextColor) !important;
-  }
+  .#{$block}__filter-button {
+    color: var(--sapHighlightTextColor);
 
-  &__filter-button {
     @include fd-hover() {
-      color: var(--sapButton_TextColor) !important;
+      color: var(--sapButton_TextColor);
     }
 
     @include fd-active() {
       @include fd-hover() {
-        color: var(--sapHighlightTextColor) !important;
+        color: var(--sapHighlightTextColor);
       }
     }
   }

--- a/src/list-grid.scss
+++ b/src/list-grid.scss
@@ -5,7 +5,6 @@
 .fd-grid-list
 */
 $block: #{$fd-namespace}-grid-list;
-$blockToolbar: #{$fd-namespace}-toolbar;
 
 .#{$block} {
   $item: #{$block}__item;
@@ -142,34 +141,6 @@ $blockToolbar: #{$fd-namespace}-toolbar;
       @include fd-flex-vertical-center();
 
       padding: 0 1rem;
-
-      .#{$blockToolbar} {
-        &--actions {
-          margin-left: auto;
-
-          > * {
-            margin-left: 0.5rem;
-
-            @include fd-rtl() {
-              margin-left: 0;
-              margin-right: 0.5rem;
-            }
-          }
-
-          @include fd-rtl() {
-            margin-left: 0;
-            margin-right: auto;
-          }
-        }
-
-        .#{$item}-input,
-        &--actions,
-        &--extra-content {
-          @include fd-flex-vertical-center();
-
-          height: 100%;
-        }
-      }
     }
   }
 
@@ -370,7 +341,6 @@ $blockToolbar: #{$fd-namespace}-toolbar;
       width: 0.375rem;
       display: block;
       border-radius: $fd-grid-list-border-radius 0 0 $fd-grid-list-border-radius;
-      z-index: 1;
 
       @include fd-rtl() {
         right: 0;

--- a/src/list-grid.scss
+++ b/src/list-grid.scss
@@ -25,7 +25,6 @@ $block: #{$fd-namespace}-grid-list;
     'critical': ('backgroundColor': var(--sapWarningBorderColor)),
     'neutral': ('backgroundColor': var(--sapNeutralBorderColor))
   );
-  $fd-grid-list-drop-area-vertical: 0.55rem;
 
   @include fd-reset();
   @include fd-flex(column);

--- a/src/list-grid.scss
+++ b/src/list-grid.scss
@@ -25,9 +25,26 @@ $block: #{$fd-namespace}-grid-list;
     'critical': ('backgroundColor': var(--sapWarningBorderColor)),
     'neutral': ('backgroundColor': var(--sapNeutralBorderColor))
   );
+  $fd-grid-list-drop-area-vertical: 0.55rem;
+
+  @mixin grabbing-cursor {
+    cursor: -webkit-grabbing;
+    cursor: -moz-grabbing;
+    cursor: -o-grabbing;
+    cursor: -ms-grabbing;
+    cursor: grabbing;
+  }
 
   @include fd-reset();
   @include fd-flex(column);
+
+  display: block;
+
+  .fd-dnd-item.fd-dnd-on-drag {
+    @include grabbing-cursor();
+
+    background-color: transparent;
+  }
 
   &__item {
     @include fd-reset();
@@ -138,6 +155,46 @@ $block: #{$fd-namespace}-grid-list;
       @include fd-flex-vertical-center();
 
       padding: 0 1rem;
+
+      .fd-toolbar {
+        &--actions {
+          margin-left: auto;
+
+          > * {
+            margin-left: 0.5rem;
+
+            @include fd-rtl() {
+              margin-left: 0;
+              margin-right: 0.5rem;
+            }
+          }
+
+          @include fd-rtl() {
+            margin-left: 0;
+            margin-right: auto;
+          }
+        }
+
+        .fd-grid-list__item-input,
+        &--actions,
+        &--extra-content {
+          display: flex;
+          align-items: center;
+          height: 100%;
+        }
+      }
+    }
+
+    .drop-area__line--vertical {
+      height: 100%;
+
+      &.before {
+        left: -$fd-grid-list-drop-area-vertical;
+      }
+
+      &.after {
+        right: -$fd-grid-list-drop-area-vertical;
+      }
     }
   }
 
@@ -263,12 +320,18 @@ $block: #{$fd-namespace}-grid-list;
 
   &__filter,
   &__filter-button {
-    color: #fff !important;
+    color: var(--sapHighlightTextColor);
   }
 
   &__filter-button {
     @include fd-hover() {
       color: var(--sapButton_TextColor) !important;
+    }
+
+    @include fd-active() {
+      @include fd-hover() {
+        color: var(--sapHighlightTextColor);
+      }
     }
   }
 
@@ -332,6 +395,7 @@ $block: #{$fd-namespace}-grid-list;
       width: 0.375rem;
       display: block;
       border-radius: $fd-grid-list-border-radius 0 0 $fd-grid-list-border-radius;
+      z-index: 1;
 
       @include fd-rtl() {
         right: 0;
@@ -340,6 +404,12 @@ $block: #{$fd-namespace}-grid-list;
       &--#{$set-name} {
         background-color: map_get($colors, 'backgroundColor');
       }
+    }
+  }
+
+  &__btn-navigation {
+    @include fd-rtl() {
+      transform: rotate(180deg);
     }
   }
 }

--- a/src/list-grid.scss
+++ b/src/list-grid.scss
@@ -5,6 +5,7 @@
 .fd-grid-list
 */
 $block: #{$fd-namespace}-grid-list;
+$blockToolbar: #{$fd-namespace}-toolbar;
 
 .#{$block} {
   $item: #{$block}__item;
@@ -27,24 +28,10 @@ $block: #{$fd-namespace}-grid-list;
   );
   $fd-grid-list-drop-area-vertical: 0.55rem;
 
-  @mixin grabbing-cursor {
-    cursor: -webkit-grabbing;
-    cursor: -moz-grabbing;
-    cursor: -o-grabbing;
-    cursor: -ms-grabbing;
-    cursor: grabbing;
-  }
-
   @include fd-reset();
   @include fd-flex(column);
 
   display: block;
-
-  .fd-dnd-item.fd-dnd-on-drag {
-    @include grabbing-cursor();
-
-    background-color: transparent;
-  }
 
   &__item {
     @include fd-reset();
@@ -156,7 +143,7 @@ $block: #{$fd-namespace}-grid-list;
 
       padding: 0 1rem;
 
-      .fd-toolbar {
+      .#{$blockToolbar} {
         &--actions {
           margin-left: auto;
 
@@ -182,18 +169,6 @@ $block: #{$fd-namespace}-grid-list;
 
           height: 100%;
         }
-      }
-    }
-
-    .fd-drop-area__line--vertical {
-      height: 100%;
-
-      &.before {
-        left: -$fd-grid-list-drop-area-vertical;
-      }
-
-      &.after {
-        right: -$fd-grid-list-drop-area-vertical;
       }
     }
   }

--- a/stories/list-grid/__snapshots__/list-grid.stories.storyshot
+++ b/stories/list-grid/__snapshots__/list-grid.stories.storyshot
@@ -4829,7 +4829,7 @@ exports[`Storyshots Components/Grid List None mode 1`] = `
                         
               <button
                 aria-label="Navigation"
-                class="fd-button fd-button--compact fd-grid-list__btn-navigation fd-button--transparent fd-grid-list__btn-navigation"
+                class="fd-button fd-button--compact fd-button--transparent fd-grid-list__btn-navigation"
               >
                 
                             

--- a/stories/list-grid/__snapshots__/list-grid.stories.storyshot
+++ b/stories/list-grid/__snapshots__/list-grid.stories.storyshot
@@ -135,7 +135,7 @@ exports[`Storyshots Components/Grid List "More" Button 1`] = `
                         
               <button
                 aria-label="Navigation"
-                class="fd-button fd-button--compact fd-button--transparent"
+                class="fd-button fd-button--compact fd-button--transparent fd-grid-list__btn-navigation"
               >
                 
                             
@@ -731,7 +731,7 @@ exports[`Storyshots Components/Grid List Delete mode 1`] = `
                         
               <button
                 aria-label="Navigation"
-                class="fd-button fd-button--compact fd-button--transparent"
+                class="fd-button fd-button--compact fd-button--transparent fd-grid-list__btn-navigation"
               >
                 
                             
@@ -1389,7 +1389,7 @@ exports[`Storyshots Components/Grid List Filter Infobar 1`] = `
                         
               <button
                 aria-label="Navigation"
-                class="fd-button fd-button--compact fd-button--transparent"
+                class="fd-button fd-button--compact fd-button--transparent fd-grid-list__btn-navigation"
               >
                 
                             
@@ -1929,7 +1929,7 @@ exports[`Storyshots Components/Grid List Footer 1`] = `
                         
               <button
                 aria-label="Navigation"
-                class="fd-button fd-button--compact fd-button--transparent"
+                class="fd-button fd-button--compact fd-button--transparent fd-grid-list__btn-navigation"
               >
                 
                             
@@ -2516,7 +2516,7 @@ exports[`Storyshots Components/Grid List Group 1`] = `
                         
               <button
                 aria-label="Navigation"
-                class="fd-button fd-button--compact fd-button--transparent"
+                class="fd-button fd-button--compact fd-button--transparent fd-grid-list__btn-navigation"
               >
                 
                             
@@ -3085,7 +3085,7 @@ exports[`Storyshots Components/Grid List Highlight 1`] = `
                         
               <button
                 aria-label="Navigation"
-                class="fd-button fd-button--compact fd-button--transparent"
+                class="fd-button fd-button--compact fd-button--transparent fd-grid-list__btn-navigation"
               >
                 
                             
@@ -3677,7 +3677,7 @@ exports[`Storyshots Components/Grid List Multi select mode 1`] = `
                         
               <button
                 aria-label="Navigation"
-                class="fd-button fd-button--compact fd-button--transparent"
+                class="fd-button fd-button--compact fd-button--transparent fd-grid-list__btn-navigation"
               >
                 
                             
@@ -4312,7 +4312,7 @@ exports[`Storyshots Components/Grid List None mode 1`] = `
                         
               <button
                 aria-label="Navigation"
-                class="fd-button fd-button--compact fd-button--transparent"
+                class="fd-button fd-button--compact fd-button--transparent fd-grid-list__btn-navigation"
               >
                 
                             
@@ -4829,7 +4829,7 @@ exports[`Storyshots Components/Grid List None mode 1`] = `
                         
               <button
                 aria-label="Navigation"
-                class="fd-button fd-button--compact fd-button--transparent"
+                class="fd-button fd-button--compact fd-grid-list__btn-navigation fd-button--transparent fd-grid-list__btn-navigation"
               >
                 
                             
@@ -5176,7 +5176,7 @@ exports[`Storyshots Components/Grid List Single select left mode 1`] = `
                         
               <button
                 aria-label="Navigation"
-                class="fd-button fd-button--compact fd-button--transparent"
+                class="fd-button fd-button--compact fd-button--transparent fd-grid-list__btn-navigation"
               >
                 
                             
@@ -5819,7 +5819,7 @@ exports[`Storyshots Components/Grid List Single select mode 1`] = `
                         
               <button
                 aria-label="Navigation"
-                class="fd-button fd-button--compact fd-button--transparent"
+                class="fd-button fd-button--compact fd-button--transparent fd-grid-list__btn-navigation"
               >
                 
                             
@@ -6448,7 +6448,7 @@ exports[`Storyshots Components/Grid List Single select right mode 1`] = `
                         
               <button
                 aria-label="Navigation"
-                class="fd-button fd-button--compact fd-button--transparent"
+                class="fd-button fd-button--compact fd-button--transparent fd-grid-list__btn-navigation"
               >
                 
                             
@@ -7096,7 +7096,7 @@ exports[`Storyshots Components/Grid List States 1`] = `
                         
               <button
                 aria-label="Navigation"
-                class="fd-button fd-button--compact fd-button--transparent"
+                class="fd-button fd-button--compact fd-button--transparent fd-grid-list__btn-navigation"
               >
                 
                             

--- a/stories/list-grid/list-grid.stories.js
+++ b/stories/list-grid/list-grid.stories.js
@@ -73,7 +73,7 @@ export const noneMode = () => `<div style="min-height: 500px;">
 
                         <span class="fd-grid-list__item-counter" aria-label="Item has 10 children">10</span>
 
-                        <button class="fd-button fd-button--compact fd-button--transparent" aria-label="Navigation">
+                        <button class="fd-button fd-button--compact fd-button--transparent fd-grid-list__btn-navigation" aria-label="Navigation">
                             <i class="sap-icon--navigation-right-arrow"></i>
                         </button>
                     </div>
@@ -201,7 +201,7 @@ export const noneMode = () => `<div style="min-height: 500px;">
 
                         <span class="fd-grid-list__item-counter" aria-label="Item has 10 children">10</span>
 
-                        <button class="fd-button fd-button--compact fd-button--transparent" aria-label="Navigation">
+                        <button class="fd-button fd-button--compact fd-grid-list__btn-navigation fd-button--transparent fd-grid-list__btn-navigation" aria-label="Navigation">
                             <i class="sap-icon--navigation-right-arrow"></i>
                         </button>
                     </div>
@@ -256,7 +256,8 @@ noneMode.storyName = 'None mode';
 
 noneMode.parameters = {
     docs: {
-        storyDescription: 'Items cannot be selected but can still use "navigation", which allows click handling on specific items.'
+        storyDescription:
+            'Items cannot be selected but can still use "navigation", which allows click handling on specific items.'
     }
 };
 
@@ -296,7 +297,7 @@ export const singleSelectMasterMode = () => `<div style="min-height: 300px;">
 
                         <span class="fd-grid-list__item-counter" aria-label="Item has 10 children">10</span>
 
-                        <button class="fd-button fd-button--compact fd-button--transparent" aria-label="Navigation">
+                        <button class="fd-button fd-button--compact fd-button--transparent fd-grid-list__btn-navigation" aria-label="Navigation">
                             <i class="sap-icon--navigation-right-arrow"></i>
                         </button>
                     </div>
@@ -462,7 +463,7 @@ export const singleSelectLeftMode = () => `<div style="min-height: 300px;">
 
                         <span class="fd-grid-list__item-counter" aria-label="Item has 10 children">10</span>
 
-                        <button class="fd-button fd-button--compact fd-button--transparent" aria-label="Navigation">
+                        <button class="fd-button fd-button--compact fd-button--transparent fd-grid-list__btn-navigation" aria-label="Navigation">
                             <i class="sap-icon--navigation-right-arrow"></i>
                         </button>
                     </div>
@@ -630,7 +631,7 @@ export const singleSelectRightMode = () => `<div style="min-height: 300px;">
 
                         <span class="fd-grid-list__item-counter" aria-label="Item has 10 children">10</span>
 
-                        <button class="fd-button fd-button--compact fd-button--transparent" aria-label="Navigation">
+                        <button class="fd-button fd-button--compact fd-button--transparent fd-grid-list__btn-navigation" aria-label="Navigation">
                             <i class="sap-icon--navigation-right-arrow"></i>
                         </button>
                     </div>
@@ -799,7 +800,7 @@ export const multiSelectMode = () => `<div style="min-height: 300px;">
 
                         <span class="fd-grid-list__item-counter" aria-label="Item has 10 children">10</span>
 
-                        <button class="fd-button fd-button--compact fd-button--transparent" aria-label="Navigation">
+                        <button class="fd-button fd-button--compact fd-button--transparent fd-grid-list__btn-navigation" aria-label="Navigation">
                             <i class="sap-icon--navigation-right-arrow"></i>
                         </button>
                     </div>
@@ -972,7 +973,7 @@ export const deleteMode = () => `<div style="min-height: 300px;">
                             <i class="sap-icon--decline"></i>
                         </button>
                         
-                        <button class="fd-button fd-button--compact fd-button--transparent" aria-label="Navigation">
+                        <button class="fd-button fd-button--compact fd-button--transparent fd-grid-list__btn-navigation" aria-label="Navigation">
                             <i class="sap-icon--navigation-right-arrow"></i>
                         </button>
                     </div>
@@ -1145,7 +1146,7 @@ export const group = () => `<div style="min-height: 600px;">
 
                         <span class="fd-grid-list__item-counter" aria-label="Item has 10 children">10</span>
 
-                        <button class="fd-button fd-button--compact fd-button--transparent" aria-label="Navigation">
+                        <button class="fd-button fd-button--compact fd-button--transparent fd-grid-list__btn-navigation" aria-label="Navigation">
                             <i class="sap-icon--navigation-right-arrow"></i>
                         </button>
                     </div>
@@ -1304,7 +1305,7 @@ export const states = () => `<div style="min-height: 600px;">
 
                         <span class="fd-grid-list__item-counter" aria-label="Item has 10 children">10</span>
 
-                        <button class="fd-button fd-button--compact fd-button--transparent" aria-label="Navigation">
+                        <button class="fd-button fd-button--compact fd-button--transparent fd-grid-list__btn-navigation" aria-label="Navigation">
                             <i class="sap-icon--navigation-right-arrow"></i>
                         </button>
                     </div>
@@ -1493,7 +1494,7 @@ export const highlight = () => `<div style="min-height: 350px;">
 
                         <span class="fd-grid-list__item-counter" aria-label="Item has 10 children">10</span>
 
-                        <button class="fd-button fd-button--compact fd-button--transparent" aria-label="Navigation">
+                        <button class="fd-button fd-button--compact fd-button--transparent fd-grid-list__btn-navigation" aria-label="Navigation">
                             <i class="sap-icon--navigation-right-arrow"></i>
                         </button>
                     </div>
@@ -1663,7 +1664,7 @@ export const filterInfobar = () => `<div style="min-height: 350px;">
 
                         <span class="fd-grid-list__item-counter" aria-label="Item has 10 children">10</span>
 
-                        <button class="fd-button fd-button--compact fd-button--transparent" aria-label="Navigation">
+                        <button class="fd-button fd-button--compact fd-button--transparent fd-grid-list__btn-navigation" aria-label="Navigation">
                             <i class="sap-icon--navigation-right-arrow"></i>
                         </button>
                     </div>
@@ -1811,7 +1812,7 @@ export const more = () => `<div style="min-height: 400px;">
 
                         <span class="fd-grid-list__item-counter" aria-label="Item has 10 children">10</span>
 
-                        <button class="fd-button fd-button--compact fd-button--transparent" aria-label="Navigation">
+                        <button class="fd-button fd-button--compact fd-button--transparent fd-grid-list__btn-navigation" aria-label="Navigation">
                             <i class="sap-icon--navigation-right-arrow"></i>
                         </button>
                     </div>
@@ -1968,7 +1969,7 @@ export const footer = () => `<div style="min-height: 300px;">
 
                         <span class="fd-grid-list__item-counter" aria-label="Item has 10 children">10</span>
 
-                        <button class="fd-button fd-button--compact fd-button--transparent" aria-label="Navigation">
+                        <button class="fd-button fd-button--compact fd-button--transparent fd-grid-list__btn-navigation" aria-label="Navigation">
                             <i class="sap-icon--navigation-right-arrow"></i>
                         </button>
                     </div>

--- a/stories/list-grid/list-grid.stories.js
+++ b/stories/list-grid/list-grid.stories.js
@@ -201,7 +201,7 @@ export const noneMode = () => `<div style="min-height: 500px;">
 
                         <span class="fd-grid-list__item-counter" aria-label="Item has 10 children">10</span>
 
-                        <button class="fd-button fd-button--compact fd-grid-list__btn-navigation fd-button--transparent fd-grid-list__btn-navigation" aria-label="Navigation">
+                        <button class="fd-button fd-button--compact fd-button--transparent fd-grid-list__btn-navigation" aria-label="Navigation">
                             <i class="sap-icon--navigation-right-arrow"></i>
                         </button>
                     </div>


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-ngx/issues/5025

Breaking Change:
Added a modifier class `fd-grid-list__btn-navigation` to the navigation button to support RTL.

wiki link [here](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes#grid-list-2525)

## Description
This fixes and moves the grid list styles present in fundamental-ngx.
1. fix action button in Rtl mode
2. fix color for decline button on active hover
3. toolbar paddings


## Screenshots

### Before:
<img width="1351" alt="Screenshot 2021-07-02 at 5 30 59 PM" src="https://user-images.githubusercontent.com/57661487/124271719-6cdf1c00-db5b-11eb-8fc0-34265751aff2.png">

<img width="1234" alt="Screenshot 2021-07-02 at 5 22 02 PM" src="https://user-images.githubusercontent.com/57661487/124270893-68663380-db5a-11eb-925c-c50bfcb50e09.png">


### After:
<img width="1410" alt="Screenshot 2021-07-02 at 5 33 41 PM" src="https://user-images.githubusercontent.com/57661487/124272012-ce9f8600-db5b-11eb-9c60-ab99d642f17f.png">

<img width="1406" alt="Screenshot 2021-07-02 at 5 36 32 PM" src="https://user-images.githubusercontent.com/57661487/124272246-1d4d2000-db5c-11eb-8845-555b2882e89e.png">


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [NA] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
