### PR TITLE
fix: update toolbar styling

### DIFF
--- a/src/theming/sap_fiori_3.scss
+++ b/src/theming/sap_fiori_3.scss
@@ -226,4 +226,7 @@
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Negative: var(--sapNegativeElementColor);
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Critical: var(--sapCriticalElementColor);
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapInformativeElementColor);
+
+  /* Toolbar */
+  --fdToolbar_Auto_Background: inherit;
 }

--- a/src/theming/sap_fiori_3_dark.scss
+++ b/src/theming/sap_fiori_3_dark.scss
@@ -225,4 +225,7 @@
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Negative: var(--sapNegativeElementColor);
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Critical: var(--sapCriticalElementColor);
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapInformativeElementColor);
+
+  /* Toolbar */
+  --fdToolbar_Auto_Background: inherit;
 }

--- a/src/theming/sap_fiori_3_hcb.scss
+++ b/src/theming/sap_fiori_3_hcb.scss
@@ -225,4 +225,7 @@
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Negative: var(--sapContent_IconColor);
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Critical: var(--sapContent_IconColor);
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapContent_IconColor);
+
+  /* Toolbar */
+  --fdToolbar_Auto_Background: var(--sapToolbar_Background);
 }

--- a/src/theming/sap_fiori_3_hcw.scss
+++ b/src/theming/sap_fiori_3_hcw.scss
@@ -225,4 +225,7 @@
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Negative: var(--sapContent_IconColor);
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Critical: var(--sapContent_IconColor);
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapContent_IconColor);
+
+  /* Toolbar */
+  --fdToolbar_Auto_Background: var(--sapToolbar_Background);
 }

--- a/src/theming/sap_fiori_3_light_dark.scss
+++ b/src/theming/sap_fiori_3_light_dark.scss
@@ -225,4 +225,7 @@
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Negative: var(--sapNegativeElementColor);
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Critical: var(--sapCriticalElementColor);
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapInformativeElementColor);
+
+  /* Toolbar */
+  --fdToolbar_Auto_Background: inherit;
 }

--- a/src/toolbar.scss
+++ b/src/toolbar.scss
@@ -3,6 +3,7 @@
 
 $block: #{$fd-namespace}-toolbar;
 $toolbar-height-compact: 2rem;
+$info-toolbar-height: 2rem;
 $toolbar-height-cozy: 2.75rem;
 
 $toolbar-separator-height-compact: 1.5rem;
@@ -20,7 +21,7 @@ $title-toolbar-height: 2.75rem;
 }
 
 @mixin toolbarAuto() {
-  background-color: inherit;
+  background-color: var(--fdToolbar_Auto_Background);
 }
 
 @mixin toolbarSolid() {
@@ -32,7 +33,8 @@ $title-toolbar-height: 2.75rem;
 }
 
 @mixin toolbarInfo() {
-  $active-color: var(--sapInfobar__TextColor);
+  height: $info-toolbar-height;
+  $active-color: var(--sapInfobar_TextColor);
 
   background-color: var(--sapInfobar_NonInteractive_Background);
   color: var(--sapList_TextColor);
@@ -185,6 +187,11 @@ $title-toolbar-height: 2.75rem;
 
   &--cozy {
     height: $toolbar-height-cozy;
+
+    &.#{$block}--info {
+      height: $info-toolbar-height;
+    }
+
     .#{$block}__separator {
       height: $toolbar-separator-height-cozy;
     }

--- a/stories/toolbar/__snapshots__/toolbar.stories.storyshot
+++ b/stories/toolbar/__snapshots__/toolbar.stories.storyshot
@@ -687,7 +687,7 @@ exports[`Storyshots Components/Toolbar Separators 1`] = `
   
 
   <div
-    class="fd-toolbar fd-toolbar--info fd-toolbar--cozy"
+    class="fd-toolbar fd-toolbar--cozy"
   >
     
     
@@ -788,7 +788,7 @@ exports[`Storyshots Components/Toolbar Separators 1`] = `
 
 exports[`Storyshots Components/Toolbar Types 1`] = `
 <div
-  style="background-color: #00000012; padding: 1rem"
+  style="padding: 1rem"
 >
   
     
@@ -1074,7 +1074,7 @@ exports[`Storyshots Components/Toolbar Types 1`] = `
   
     
   <div
-    class="fd-toolbar fd-toolbar--info"
+    class="fd-toolbar fd-toolbar--info fd-toolbar--cozy"
   >
     3 item selected
   </div>

--- a/stories/toolbar/toolbar.stories.js
+++ b/stories/toolbar/toolbar.stories.js
@@ -141,7 +141,7 @@ To display an overflow in a button, pass the \`sap-icon--overflow\` in the \`fd-
     }
 };
 
-export const types = () => `<div style="background-color: #00000012; padding: 1rem">
+export const types = () => `<div style="padding: 1rem">
     <h3>Solid</h3>
     <div class="fd-toolbar fd-toolbar--solid">
         <span>Products (23)</span>
@@ -196,7 +196,7 @@ export const types = () => `<div style="background-color: #00000012; padding: 1r
         </button>
     </div>
     <h3>Info</h3>
-    <div class="fd-toolbar fd-toolbar--info">3 item selected</div>
+    <div class="fd-toolbar fd-toolbar--info fd-toolbar--cozy">3 item selected</div>
     <br>
     <div class="fd-toolbar fd-toolbar--info fd-toolbar--active">3 item selected</div>
     <h3>Title</h3>
@@ -210,7 +210,7 @@ export const types = () => `<div style="background-color: #00000012; padding: 1r
 `;
 
 export const separator = () => `
-<div class="fd-toolbar fd-toolbar--info fd-toolbar--cozy">
+<div class="fd-toolbar fd-toolbar--cozy">
     <button class="fd-button fd-button--positive">Accept</button>
     <span class="fd-toolbar__separator"></span>
     <button class="fd-button fd-button--reject">Reject</button>


### PR DESCRIPTION
## Related Issue
fixes: #2082 

## Description
few fixes:
- delta theming for toolbar
- typo in 1 css variable
- update info toolbar height (cozy and compact have same height)


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Includes Compact/Cosy/Tablet design
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
