### PR TITLE
fix: refactor bar documentation as suggested

### DIFF
--- a/stories/bar/__snapshots__/bar.stories.storyshot
+++ b/stories/bar/__snapshots__/bar.stories.storyshot
@@ -220,16 +220,16 @@ exports[`Storyshots Components/Bar Default 1`] = `
       
         
       <div
-        class="fd-bar__element"
+        class="fd-bar__element fd-bar__element--title"
       >
         
             
-        <span
+        <h4
           aria-label="text"
-          class="fd-bar__element--title"
+          class="fd-title"
         >
           TEXT
-        </span>
+        </h4>
         
         
       </div>

--- a/stories/bar/__snapshots__/bar.stories.storyshot
+++ b/stories/bar/__snapshots__/bar.stories.storyshot
@@ -226,7 +226,7 @@ exports[`Storyshots Components/Bar Default 1`] = `
             
         <span
           aria-label="text"
-          class="fd-bar__element fd-bar__element--title"
+          class="fd-bar__element--title"
         >
           TEXT
         </span>

--- a/stories/bar/__snapshots__/bar.stories.storyshot
+++ b/stories/bar/__snapshots__/bar.stories.storyshot
@@ -224,12 +224,12 @@ exports[`Storyshots Components/Bar Default 1`] = `
       >
         
             
-        <h4
+        <h6
           aria-label="text"
-          class="fd-title"
+          class="fd-title fd-title--h6"
         >
           TEXT
-        </h4>
+        </h6>
         
         
       </div>

--- a/stories/bar/bar.stories.js
+++ b/stories/bar/bar.stories.js
@@ -44,7 +44,7 @@ export const Default = () => `
 <div class="fd-bar">
     <div class="fd-bar__left">
         <div class="fd-bar__element fd-bar__element--title">
-            <h4 class="fd-title" aria-label="text">TEXT</h4>
+            <h6 class="fd-title fd-title--h6" aria-label="text">TEXT</h6>
         </div>
     </div>
     <div class="fd-bar__middle">

--- a/stories/bar/bar.stories.js
+++ b/stories/bar/bar.stories.js
@@ -35,7 +35,7 @@ export default {
 - Buttons are sorted by usage i.e. from frequently-used to seldomly-used.
         `,
         tags: ['f3', 'a11y', 'theme'],
-        components: ['button', 'icon', 'input', 'segmented-button', 'avatar', 'bar']
+        components: ['button', 'icon', 'input', 'segmented-button', 'avatar', 'bar', 'title']
     }
 };
 
@@ -43,8 +43,8 @@ export const Default = () => `
 <p><b>Compact bar with compact elements</b></p>
 <div class="fd-bar">
     <div class="fd-bar__left">
-        <div class="fd-bar__element">
-            <span class="fd-bar__element--title" aria-label="text">TEXT</span>
+        <div class="fd-bar__element fd-bar__element--title">
+            <h4 class="fd-title" aria-label="text">TEXT</h4>
         </div>
     </div>
     <div class="fd-bar__middle">

--- a/stories/bar/bar.stories.js
+++ b/stories/bar/bar.stories.js
@@ -44,7 +44,7 @@ export const Default = () => `
 <div class="fd-bar">
     <div class="fd-bar__left">
         <div class="fd-bar__element">
-            <span class="fd-bar__element fd-bar__element--title" aria-label="text">TEXT</span>
+            <span class="fd-bar__element--title" aria-label="text">TEXT</span>
         </div>
     </div>
     <div class="fd-bar__middle">


### PR DESCRIPTION
## Related Issue
Closes #2528 

## Description

Updated documention examples with title component as first element in bar.

Before:
```
<div class="fd-bar__element">  
 <span class="fd-bar__element--title" aria-label="text">TEXT</span>
</div>
```
After:
```
<div class="fd-bar__element fd-bar__element--title">
<h6 class="fd-title fd-title--h6" aria-label="text">TEXT</h6>
</div>
```

## Screenshots
### Before:
<img width="1263" alt="2021-06-24_20-39-13" src="https://user-images.githubusercontent.com/53487468/123287579-726dae00-d52c-11eb-99d9-04d86bee3b91.png">

### After:

<img width="1173" alt="2021-06-24_20-41-09" src="https://user-images.githubusercontent.com/53487468/123287690-8addc880-d52c-11eb-9be2-a412dcd6ac7c.png">


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [n/a] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
