### PR TITLE
fix: correct position for rtl icons for alert component

### DIFF
--- a/src/alert.scss
+++ b/src/alert.scss
@@ -111,12 +111,10 @@ $block: #{$fd-namespace}-alert;
       padding-right: $fd-alert-padding-status;
       padding-left: $fd-alert-padding-default;
 
-      &::before {
-        display: none;
-      }
-
+      &::before,
       &::after {
-        display: none;
+        left: auto;
+        right: 0;
       }
     }
 


### PR DESCRIPTION
## Related Issue
Relates to https://github.com/SAP/fundamental-ngx/issues/5790

## Description
Changed position of the icons for alert component do render in the correct position.

## Screenshots

### Before:
![image](https://user-images.githubusercontent.com/6586561/124562068-4533d080-de47-11eb-9e20-769831b14cbe.png)

### After:
![image](https://user-images.githubusercontent.com/6586561/124562094-4cf37500-de47-11eb-862d-70b832b27cff.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
