### PR TITLE
fix: update border width for combobox button

### DIFF
--- a/src/theming/sap_fiori_3.scss
+++ b/src/theming/sap_fiori_3.scss
@@ -108,7 +108,7 @@
 
   /* Input Group */
   --fdInputGroup_Text_Shadow: none;
-  --fdInputGroup_ControlButton_SideBorder: solid 0.0625rem transparent;
+  --fdInputGroup_ControlButton_SideBorder: solid var(--sapButton_BorderWidth) transparent;
 
   /* Input */
   --fdInput_Text_Shadow: none;

--- a/src/theming/sap_fiori_3.scss
+++ b/src/theming/sap_fiori_3.scss
@@ -108,7 +108,7 @@
 
   /* Input Group */
   --fdInputGroup_Text_Shadow: none;
-  --fdInputGroup_ControlButton_SideBorder: none;
+  --fdInputGroup_ControlButton_SideBorder: solid 0.0625rem transparent;
 
   /* Input */
   --fdInput_Text_Shadow: none;

--- a/src/theming/sap_fiori_3_dark.scss
+++ b/src/theming/sap_fiori_3_dark.scss
@@ -108,7 +108,7 @@
 
   /* Input Group */
   --fdInputGroup_Text_Shadow: none;
-  --fdInputGroup_ControlButton_SideBorder: solid 0.0625rem transparent;
+  --fdInputGroup_ControlButton_SideBorder: solid var(--sapButton_BorderWidth) transparent;
 
   /* Input */
   --fdInput_Text_Shadow: none;

--- a/src/theming/sap_fiori_3_dark.scss
+++ b/src/theming/sap_fiori_3_dark.scss
@@ -108,7 +108,7 @@
 
   /* Input Group */
   --fdInputGroup_Text_Shadow: none;
-  --fdInputGroup_ControlButton_SideBorder: none;
+  --fdInputGroup_ControlButton_SideBorder: solid 0.0625rem transparent;
 
   /* Input */
   --fdInput_Text_Shadow: none;

--- a/src/theming/sap_fiori_3_hcb.scss
+++ b/src/theming/sap_fiori_3_hcb.scss
@@ -108,7 +108,7 @@
 
   /* Input Group */
   --fdInputGroup_Text_Shadow: 0 0 0.125rem #000;
-  --fdInputGroup_ControlButton_SideBorder: solid 0.0625rem var(--sapList_SelectionBorderColor);
+  --fdInputGroup_ControlButton_SideBorder: solid var(--sapButton_BorderWidth) var(--sapList_SelectionBorderColor);
 
   /* Input */
   --fdInput_Text_Shadow: 0 0 0.125rem #000;

--- a/src/theming/sap_fiori_3_hcw.scss
+++ b/src/theming/sap_fiori_3_hcw.scss
@@ -108,7 +108,7 @@
 
   /* Input Group */
   --fdInputGroup_Text_Shadow: none;
-  --fdInputGroup_ControlButton_SideBorder: solid 0.0625rem var(--sapList_SelectionBorderColor);
+  --fdInputGroup_ControlButton_SideBorder: solid var(--sapButton_BorderWidth) var(--sapList_SelectionBorderColor);
 
   /* Input */
   --fdInput_Text_Shadow: none;

--- a/src/theming/sap_fiori_3_light_dark.scss
+++ b/src/theming/sap_fiori_3_light_dark.scss
@@ -108,7 +108,7 @@
 
   /* Input Group */
   --fdInputGroup_Text_Shadow: none;
-  --fdInputGroup_ControlButton_SideBorder: solid 0.0625rem transparent;
+  --fdInputGroup_ControlButton_SideBorder: solid var(--sapButton_BorderWidth) transparent;
 
   /* Input */
   --fdInput_Text_Shadow: none;

--- a/src/theming/sap_fiori_3_light_dark.scss
+++ b/src/theming/sap_fiori_3_light_dark.scss
@@ -108,7 +108,7 @@
 
   /* Input Group */
   --fdInputGroup_Text_Shadow: none;
-  --fdInputGroup_ControlButton_SideBorder: none;
+  --fdInputGroup_ControlButton_SideBorder: solid 0.0625rem transparent;
 
   /* Input */
   --fdInput_Text_Shadow: none;


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#2509

## Description
Updated border width so it won't jump on hover or focus.

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
