### PR TITLE
fix: box-sizing of wizard step in progress bar [ci visual]

### DIFF
--- a/src/wizard.scss
+++ b/src/wizard.scss
@@ -81,6 +81,7 @@ $fd-wizard-stacked-upcoming-step-offset: 2.375rem !default;
     position: relative;
     display: table-cell;
     vertical-align: top;
+    box-sizing: content-box;
 
     // --- STEP MODIFIERS ---
     &--completed {


### PR DESCRIPTION
fixes #2546 

Reset was bringing `box-sizing: border-box` to wizard steps in the progress bar where `content-box` should have been used, to accommodate for padding.

Before:
<img width="357" alt="Screen Shot 2021-07-07 at 3 49 27 PM" src="https://user-images.githubusercontent.com/2471874/124819991-f0718200-df3a-11eb-9040-3384da1ccf04.png">

After:
<img width="394" alt="Screen Shot 2021-07-07 at 3 46 34 PM" src="https://user-images.githubusercontent.com/2471874/124819867-cc15a580-df3a-11eb-90e4-bc05e7929a4e.png">
