### PR TITLE
fix: added additional panding for slider [ci visual]

### DIFF
--- a/src/slider.scss
+++ b/src/slider.scss
@@ -6,6 +6,10 @@ $handle-desktop-dimensions: 1.25rem;
 $handle-hit-area-desktop-dimensions: 2rem;
 $handle-mobile-dimensions: 1.625rem;
 $handle-hit-area-mobile-dimensions: 2.75rem;
+$handle-outline-offset: 0.0625rem;
+$handle-outline-width: 0.0625rem;
+$slider-x-paddings: $handle-desktop-dimensions / 2;
+$slider-x-paddings--lg: $handle-mobile-dimensions / 2;
 
 .#{$block} {
   @include fd-reset();
@@ -16,11 +20,11 @@ $handle-hit-area-mobile-dimensions: 2.75rem;
 
   min-width: 4rem;
   max-width: 100%;
-  padding: 1rem 0.625rem;
+  padding: 1rem calc(#{$slider-x-paddings} + #{$handle-outline-offset} + #{$handle-outline-width});
   position: relative;
 
   &--lg {
-    @include fd-set-paddings-x-equal(0.8125rem);
+    @include fd-set-paddings-x-equal(calc(#{$slider-x-paddings--lg} + #{$handle-outline-offset} + #{$handle-outline-width}));
   }
 
   &__inner {
@@ -126,8 +130,8 @@ $handle-hit-area-mobile-dimensions: 2.75rem;
     }
 
     &:focus {
-      outline: 1px dotted var(--sapButton_Hover_BorderColor);
-      outline-offset: 0.0625rem;
+      outline: $handle-outline-width dotted var(--sapButton_Hover_BorderColor);
+      outline-offset: $handle-outline-offset;
     }
 
     @include fd-hover() {


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#2503

## Description
Added additional padding to prevent hiding  of outline of handle inside block with overflow: hidden.

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

![image](https://user-images.githubusercontent.com/14183958/124875411-89eb7300-dfd1-11eb-8f20-5b0b9ab44194.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
