### PR TITLE
fix: popover outline focus-visible

### DIFF
--- a/src/popover.scss
+++ b/src/popover.scss
@@ -34,6 +34,10 @@ $block: #{$fd-namespace}-popover;
     position: relative;
     margin-left: 0;
 
+    &:focus-visible {
+      outline: var(--sapContent_FocusWidth) dotted var(--sapContent_FocusColor);
+    }
+
     &.#{$fd-namespace}-input:last-child {
       margin-bottom: 0;
     }


### PR DESCRIPTION
Adds the popover outline when the control is tabbed to

before:
<img width="156" alt="Screen Shot 2021-07-09 at 1 00 53 PM" src="https://user-images.githubusercontent.com/2471874/125112835-b37dca80-e0b5-11eb-8bf0-dd6fb86330d4.png">

after:
<img width="138" alt="Screen Shot 2021-07-09 at 1 01 29 PM" src="https://user-images.githubusercontent.com/2471874/125112884-c98b8b00-e0b5-11eb-8fe4-df96f13ee1dd.png">
