### PR TITLE
feat: introduce navigation for IconTabBar

### DIFF
--- a/src/icon-tab-bar.scss
+++ b/src/icon-tab-bar.scss
@@ -974,6 +974,131 @@ $fd-icon-tab-bar-semantic-values: (
     }
   }
 
+  &--navigation {
+    .#{$block}__header {
+      box-shadow: var(--sapShell_Shadow);
+      background: var(--sapShell_Navigation_Background);
+    }
+
+    .#{$block}__item {
+      color: var(--sapShell_Navigation_TextColor);
+    }
+
+    .#{$block}__tab {
+      .#{$block}__tag {
+        color: var(--sapShell_Navigation_TextColor);
+      }
+
+      .#{$block}__arrow {
+        [class*='sap-icon'] {
+          color: var(--sapShell_Navigation_TextColor);
+        }
+      }
+
+      @include fd-selected() {
+        .#{$block}__tag {
+          color: var(--sapShell_Navigation_Selected_TextColor);
+        }
+
+        .#{$block}__arrow {
+          [class*='sap-icon'] {
+            color: var(--sapShell_Navigation_Selected_TextColor);
+          }
+        }
+
+        &::after {
+          background: var(--sapShell_Navigation_SelectedColor);
+        }
+      }
+
+      @include fd-hover() {
+        .#{$block}__tag {
+          color: var(--sapShell_Navigation_Selected_TextColor);
+        }
+        .#{$block}__arrow {
+          [class*='sap-icon'] {
+            color: var(--sapShell_Navigation_Selected_TextColor);
+          }
+        }
+      }
+
+      @include fd-focus() {
+        .#{$block}__tag,
+        .#{$block}__icon,
+        .#{$block}__container,
+        .#{$block}__tab-container {
+          outline-color: var(--sapShell_Navigation_TextColor);
+        }
+      }
+    }
+
+    .#{$block}__button {
+      color: var(--sapShell_Navigation_SelectedColor);
+
+      @include fd-hover() {
+        color: var(--sapShell_Navigation_SelectedColor);
+        background: var(--sapShell_Navigation_Hover_Background);
+        border-color: var(--sapShell_Navigation_Hover_Background);
+      }
+
+      @include fd-active() {
+        color: var(--sapShell_Navigation_Active_TextColor);
+        background: var(--sapShell_Navigation_Active_Background);
+        border-color: var(--sapShell_Navigation_Active_Background);
+      }
+
+      @include fd-focus() {
+        outline-color: var(--sapShell_Navigation_TextColor);
+      }
+    }
+
+    &__item--single-click {
+      .#{$block}__tab {
+        @include fd-focus() {
+          .#{$block}__tab-container {
+            outline-color: var(--sapShell_Navigation_TextColor);
+          }
+        }
+      }
+    }
+
+    .#{$block}__overflow {
+      background: var(--sapShell_Navigation_Background);
+      border-color: var(--sapShell_Navigation_SelectedColor);
+
+      &-text,
+      [class*='sap-icon'] {
+        color: var(--sapShell_Navigation_SelectedColor);
+      }
+
+      @include fd-hover() {
+        border-color: var(--sapShell_Navigation_SelectedColor);
+        background: var(--sapShell_Navigation_Hover_Background);
+
+        .#{$block}__overflow-text,
+        [class*='sap-icon'] {
+          color: var(--sapShell_Navigation_SelectedColor);
+        }
+      }
+
+      @include fd-active() {
+        border-color: var(--sapShell_Navigation_SelectedColor);
+        background: var(--sapShell_Navigation_Active_Background);
+
+        .#{$block}__overflow-text,
+        [class*='sap-icon'] {
+          color: var(--sapShell_Navigation_Active_TextColor);
+        }
+      }
+
+      @include fd-focus() {
+        &::after {
+          border-color: var(--sapShell_Navigation_TextColor);
+        }
+      }
+    }
+  }
+
   @each $set-name, $set-padding in $fd-icon-tab-bar-responsive-paddings {
     &--#{$set-name} {
       .#{$block}__header {

--- a/stories/icon-tab-bar/__snapshots__/icon-tab-bar.stories.storyshot
+++ b/stories/icon-tab-bar/__snapshots__/icon-tab-bar.stories.storyshot
@@ -3009,6 +3009,668 @@ exports[`Storyshots Components/Icon Tab Bar Icon Only in Compact Mode 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/Icon Tab Bar Navigation Icon Tab Bar 1`] = `
+<div
+  style="min-height: 600px;"
+>
+  
+
+  <h4>
+    With Overflow
+  </h4>
+  
+    
+  <div
+    class="fd-icon-tab-bar fd-icon-tab-bar--sm fd-icon-tab-bar--navigation"
+    style="max-width: 400px;"
+  >
+    
+        
+    <ul
+      class="fd-icon-tab-bar__header"
+      role="tablist"
+    >
+       
+            
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+                
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab1"
+          role="tab"
+        >
+          
+                    
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 1
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+                
+        <a
+          aria-selected="true"
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab2"
+          role="tab"
+        >
+          
+                    
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 2
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+                
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab3"
+          role="tab"
+        >
+          
+                    
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 3
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+                
+        <button
+          class="fd-icon-tab-bar__overflow"
+        >
+          
+                    
+          <span
+            class="fd-icon-tab-bar__overflow-text"
+          >
+            More
+          </span>
+          
+                    
+          <i
+            class="sap-icon--slim-arrow-down"
+            role="presentation"
+          />
+          
+                
+        </button>
+        
+            
+      </li>
+       
+        
+    </ul>
+    
+    
+  </div>
+  
+    
+  <div
+    style="height: 50px;"
+  />
+  
+    
+  <h4>
+    With Multi Click Area
+  </h4>
+  
+    
+  <div
+    class="fd-icon-tab-bar fd-icon-tab-bar--navigation fd-icon-tab-bar--md"
+  >
+    
+        
+    <ul
+      class="fd-icon-tab-bar__header"
+      role="tablist"
+    >
+        
+            
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+                
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab4"
+          role="tab"
+        >
+          
+                    
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 1
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--multi-click"
+        role="presentation"
+      >
+        
+                
+        <a
+          aria-selected="true"
+          class="fd-icon-tab-bar__tab"
+          id="tab5"
+          role="tab"
+          tabindex="0"
+        >
+          
+                    
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 2
+          </span>
+          
+                
+        </a>
+        
+
+                
+        <div
+          class="fd-popover fd-icon-tab-bar__popover"
+        >
+          
+                    
+          <div
+            class="fd-popover__control"
+          >
+            
+                        
+            <div
+              class="fd-icon-tab-bar__button-container"
+            >
+              
+                            
+              <button
+                aria-controls="popoverAO4"
+                aria-expanded="false"
+                aria-haspopup="true"
+                aria-label="open menu button"
+                class="fd-button fd-button--transparent fd-button--compact  fd-icon-tab-bar__button"
+                onclick="onPopoverClick('popoverAO4');"
+              >
+                
+                                
+                <i
+                  class="sap-icon--slim-arrow-down"
+                />
+                
+                            
+              </button>
+              
+                        
+            </div>
+            
+                    
+          </div>
+          
+                    
+          <div
+            aria-hidden="false"
+            class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right"
+            id="popoverAO4"
+          >
+            
+                        
+            <ul
+              class="fd-list fd-list--navigation fd-list--no-border fd-icon-tab-bar__list"
+              role="list"
+            >
+              
+                            
+              <li
+                aria-level="1"
+                class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
+                role="listitem"
+                tabindex="-1"
+              >
+                
+                                
+                <a
+                  class="fd-list__link"
+                  tabindex="0"
+                >
+                  
+                                    
+                  <span
+                    class="fd-list__title"
+                  >
+                    Subsection 1
+                  </span>
+                  
+                                
+                </a>
+                
+                            
+              </li>
+              
+                            
+              <li
+                aria-level="1"
+                class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
+                role="listitem"
+                tabindex="-1"
+              >
+                
+                                
+                <a
+                  class="fd-list__link"
+                  tabindex="0"
+                >
+                  
+                                    
+                  <span
+                    class="fd-list__title"
+                  >
+                    Subsection 2
+                  </span>
+                  
+                                
+                </a>
+                
+                            
+              </li>
+              
+                        
+            </ul>
+            
+                    
+          </div>
+          
+                
+        </div>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+                
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab6"
+          role="tab"
+        >
+          
+                    
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 3
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+        
+    </ul>
+    
+    
+  </div>
+  
+    
+  <div
+    style="height: 120px;"
+  />
+  
+    
+  <h4>
+    With Single Click Area
+  </h4>
+  
+    
+  <div
+    class="fd-icon-tab-bar fd-icon-tab-bar--navigation fd-icon-tab-bar--xl"
+  >
+    
+    
+    <ul
+      class="fd-icon-tab-bar__header"
+      role="tablist"
+    >
+      
+      
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+        
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab7"
+          role="tab"
+        >
+          
+          
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 1
+          </span>
+          
+        
+        </a>
+        
+      
+      </li>
+      
+      
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--single-click"
+        role="presentation"
+      >
+        
+        
+        <div
+          class="fd-popover"
+        >
+          
+          
+          <div
+            class="fd-popover__control"
+          >
+            
+            
+            <a
+              aria-controls="popoverAO5"
+              aria-expanded="true"
+              aria-haspopup="true"
+              aria-selected="true"
+              class="fd-icon-tab-bar__tab"
+              id="tab8"
+              onclick="onPopoverClick('popoverAO5');"
+              role="tab"
+              tabindex="0"
+            >
+              
+              
+              <div
+                class="fd-icon-tab-bar__tab-container"
+              >
+                
+                
+                <span
+                  class="fd-icon-tab-bar__tag"
+                >
+                  Section 2
+                </span>
+                
+                
+                <span
+                  class="fd-icon-tab-bar__arrow"
+                >
+                  
+                    
+                  <i
+                    class="sap-icon--slim-arrow-down"
+                    role="presentation"
+                  />
+                  
+                
+                </span>
+                
+              
+              </div>
+              
+            
+            </a>
+            
+          
+          </div>
+          
+          
+          <div
+            aria-hidden="false"
+            class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right"
+            id="popoverAO5"
+          >
+            
+            
+            <ul
+              class="fd-list fd-list--navigation fd-list--no-border fd-icon-tab-bar__list"
+              role="list"
+            >
+              
+              
+              <li
+                aria-level="1"
+                class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
+                role="listitem"
+                tabindex="-1"
+              >
+                
+                
+                <a
+                  class="fd-list__link"
+                  tabindex="0"
+                >
+                  
+                  
+                  <span
+                    class="fd-list__title"
+                  >
+                    Subsection 1
+                  </span>
+                  
+                
+                </a>
+                
+              
+              </li>
+              
+              
+              <li
+                aria-level="1"
+                class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
+                role="listitem"
+                tabindex="-1"
+              >
+                
+                
+                <a
+                  class="fd-list__link"
+                  tabindex="0"
+                >
+                  
+                  
+                  <span
+                    class="fd-list__title"
+                  >
+                    Subsection 2
+                  </span>
+                  
+                
+                </a>
+                
+              
+              </li>
+              
+            
+            </ul>
+            
+          
+          </div>
+          
+        
+        </div>
+        
+      
+      </li>
+      
+      
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+        
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab9"
+          role="tab"
+        >
+          
+          
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 3
+          </span>
+          
+        
+        </a>
+        
+      
+      </li>
+      
+      
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--single-click"
+        role="presentation"
+      >
+        
+        
+        <div
+          class="fd-popover"
+        >
+          
+          
+          <div
+            class="fd-popover__control"
+          >
+            
+            
+            <a
+              aria-controls="popoverAO6"
+              aria-expanded="true"
+              aria-haspopup="true"
+              class="fd-icon-tab-bar__tab"
+              id="tab10"
+              onclick="onPopoverClick('popoverAO6');"
+              role="tab"
+              tabindex="0"
+            >
+              
+              
+              <div
+                class="fd-icon-tab-bar__tab-container"
+              >
+                
+                
+                <span
+                  class="fd-icon-tab-bar__tag"
+                >
+                  Section 4
+                </span>
+                
+                
+                <span
+                  class="fd-icon-tab-bar__arrow"
+                >
+                  
+                    
+                  <i
+                    class="sap-icon--slim-arrow-down"
+                    role="presentation"
+                  />
+                  
+                
+                </span>
+                
+              
+              </div>
+              
+            
+            </a>
+            
+          
+          </div>
+          
+        
+        </div>
+        
+      
+      </li>
+      
+    
+    </ul>
+    
+  
+  </div>
+  
+
+</div>
+`;
+
 exports[`Storyshots Components/Icon Tab Bar Overflow 1`] = `
 <section>
   <div

--- a/stories/icon-tab-bar/__snapshots__/icon-tab-bar.stories.storyshot
+++ b/stories/icon-tab-bar/__snapshots__/icon-tab-bar.stories.storyshot
@@ -3610,12 +3610,10 @@ exports[`Storyshots Components/Icon Tab Bar Navigation Icon Tab Bar 1`] = `
             
             
             <a
-              aria-controls="popoverAO6"
               aria-expanded="true"
               aria-haspopup="true"
               class="fd-icon-tab-bar__tab"
               id="tab10"
-              onclick="onPopoverClick('popoverAO6');"
               role="tab"
               tabindex="0"
             >

--- a/stories/icon-tab-bar/icon-tab-bar.stories.js
+++ b/stories/icon-tab-bar/icon-tab-bar.stories.js
@@ -1429,3 +1429,144 @@ paddings.parameters = {
         storyDescription: 'You can set horizontal paddings by adding a modifier class and specifying the size of the paddings. Please refer to the "Paddings" section at the top of the page for the available sizes.'
     }
 };
+
+export const navigation = () => `<div style="min-height: 600px;">
+<h4>With Overflow</h4>
+    <div class="fd-icon-tab-bar fd-icon-tab-bar--sm fd-icon-tab-bar--navigation" style="max-width: 400px;">
+        <ul role="tablist" class="fd-icon-tab-bar__header"> 
+            <li role="presentation" class="fd-icon-tab-bar__item">
+                <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab1">
+                    <span class="fd-icon-tab-bar__tag">Section 1</span>
+                </a>
+            </li>
+            <li role="presentation" class="fd-icon-tab-bar__item">
+                <a role="tab" class="fd-icon-tab-bar__tab" href="#" aria-selected="true" id="tab2">
+                    <span class="fd-icon-tab-bar__tag">Section 2</span>
+                </a>
+            </li>
+            <li role="presentation" class="fd-icon-tab-bar__item">
+                <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab3">
+                    <span class="fd-icon-tab-bar__tag">Section 3</span>
+                </a>
+            </li>
+            <li role="presentation" class="fd-icon-tab-bar__item">
+                <button class="fd-icon-tab-bar__overflow">
+                    <span class="fd-icon-tab-bar__overflow-text">More</span>
+                    <i class="sap-icon--slim-arrow-down" role="presentation"></i>
+                </button>
+            </li> 
+        </ul>
+    </div>
+    <div style="height: 50px;"></div>
+    <h4>With Multi Click Area</h4>
+    <div class="fd-icon-tab-bar fd-icon-tab-bar--navigation fd-icon-tab-bar--md">
+        <ul role="tablist" class="fd-icon-tab-bar__header">  
+            <li role="presentation" class="fd-icon-tab-bar__item">
+                <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab4">
+                    <span class="fd-icon-tab-bar__tag">Section 1</span>
+                </a>
+            </li>
+            <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--multi-click">
+                <a role="tab" class="fd-icon-tab-bar__tab" aria-selected="true" id="tab5" tabindex="0">
+                    <span class="fd-icon-tab-bar__tag">Section 2</span>
+                </a>
+
+                <div class="fd-popover fd-icon-tab-bar__popover">
+                    <div class="fd-popover__control">
+                        <div class="fd-icon-tab-bar__button-container">
+                            <button class="fd-button fd-button--transparent fd-button--compact  fd-icon-tab-bar__button" aria-controls="popoverAO4" aria-expanded="false" aria-haspopup="true" onclick="onPopoverClick('popoverAO4');" aria-label="open menu button">
+                                <i class="sap-icon--slim-arrow-down"></i>
+                            </button>
+                        </div>
+                    </div>
+                    <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right" aria-hidden="false" id="popoverAO4">
+                        <ul class="fd-list fd-list--navigation fd-list--no-border fd-icon-tab-bar__list" role="list">
+                            <li tabindex="-1" role="listitem" aria-level="1" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                                <a tabindex="0" class="fd-list__link">
+                                    <span class="fd-list__title">Subsection 1</span>
+                                </a>
+                            </li>
+                            <li tabindex="-1" role="listitem" aria-level="1" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                                <a tabindex="0" class="fd-list__link">
+                                    <span class="fd-list__title">Subsection 2</span>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </li>
+            <li role="presentation" class="fd-icon-tab-bar__item">
+                <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab6">
+                    <span class="fd-icon-tab-bar__tag">Section 3</span>
+                </a>
+            </li>
+        </ul>
+    </div>
+    <div style="height: 120px;"></div>
+    <h4>With Single Click Area</h4>
+    <div class="fd-icon-tab-bar fd-icon-tab-bar--navigation fd-icon-tab-bar--xl">
+    <ul role="tablist" class="fd-icon-tab-bar__header">
+      <li role="presentation" class="fd-icon-tab-bar__item">
+        <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab7">
+          <span class="fd-icon-tab-bar__tag">Section 1</span>
+        </a>
+      </li>
+      <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--single-click">
+        <div class="fd-popover">
+          <div class="fd-popover__control">
+            <a role="tab" class="fd-icon-tab-bar__tab" aria-selected="true" id="tab8" tabindex="0" aria-controls="popoverAO5" aria-expanded="true" aria-haspopup="true" onclick="onPopoverClick('popoverAO5');">
+              <div class="fd-icon-tab-bar__tab-container">
+                <span class="fd-icon-tab-bar__tag">Section 2</span>
+                <span class="fd-icon-tab-bar__arrow">
+                    <i class="sap-icon--slim-arrow-down" role="presentation"></i>
+                </span>
+              </div>
+            </a>
+          </div>
+          <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right" aria-hidden="false" id="popoverAO5">
+            <ul class="fd-list fd-list--navigation fd-list--no-border fd-icon-tab-bar__list" role="list">
+              <li tabindex="-1" role="listitem" aria-level="1" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                <a tabindex="0" class="fd-list__link">
+                  <span class="fd-list__title">Subsection 1</span>
+                </a>
+              </li>
+              <li tabindex="-1" role="listitem" aria-level="1" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                <a tabindex="0" class="fd-list__link">
+                  <span class="fd-list__title">Subsection 2</span>
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </li>
+      <li role="presentation" class="fd-icon-tab-bar__item">
+        <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab9">
+          <span class="fd-icon-tab-bar__tag">Section 3</span>
+        </a>
+      </li>
+      <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--single-click">
+        <div class="fd-popover">
+          <div class="fd-popover__control">
+            <a role="tab" class="fd-icon-tab-bar__tab" id="tab10" tabindex="0" aria-expanded="true" aria-haspopup="true">
+              <div class="fd-icon-tab-bar__tab-container">
+                <span class="fd-icon-tab-bar__tag">Section 4</span>
+                <span class="fd-icon-tab-bar__arrow">
+                    <i class="sap-icon--slim-arrow-down" role="presentation"></i>
+                </span>
+              </div>
+            </a>
+          </div>
+        </div>
+      </li>
+    </ul>
+  </div>
+</div>
+`;
+navigation.storyName = 'Navigation Icon Tab Bar';
+navigation.parameters = {
+    docs: {
+        storyDescription: `The Navigation Tab Bar is the main/default navigation displayed on the SAP Fiori launchpad home page. It offers the user an easy access to multiple pages per space. The background color of the Shell Navigation is connected the Home/Shell Header to properly differentiate the global shell navigation versus any application specific navigation. The Navigation Bar snaps to top and remains visible while scrolling. It is not visible in App view. <br>
+        The implementation is based on UniversalIconTabBar with some different color parameters that are specific to Shell Bar and Tool Header. <br>
+        If there are more Tabs than the screen can accommodate, the remaining Tabs move into an Overflow.`
+    }
+};


### PR DESCRIPTION
## Related Issue
Part of SAP/fundamental-styles#2210

## Description
Shell Navigation Tabs are a type of Icon Tab Bar with some color modifications so it can be used with Tool Header and Shell Bar. Once this PR and https://github.com/SAP/fundamental-styles/pull/2550 are merged I will create documentation for the entire Horizontal Navigation topic. There won't be more css needed, just putting 2 components together (Tool Header+Shell Navigation Tabs) in a documentation page.

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [na] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
