### PR TITLE
fix: adding placeholder color and adding rtl to the button

### DIFF
--- a/src/feed-input.scss
+++ b/src/feed-input.scss
@@ -57,12 +57,6 @@ $block: #{$fd-namespace}-feed-input;
     padding: 0.3125rem 0.5rem;
   }
 
-  .fd-button {
-    @include fd-rtl() {
-      transform: rotate(180deg);
-    }
-  }
-
   // It's needed to have stronger selector to override fd-button styles
   .#{$block}__submit-button {
     margin-top: auto;
@@ -70,17 +64,10 @@ $block: #{$fd-namespace}-feed-input;
     margin-left: $fd-feed-input-btn-margin-start;
     margin-right: $fd-feed-input-btn-margin-end;
 
-    &[class*=sap-icon]::before {
-      display: inline-block;
-    }
-
     @include fd-rtl() {
       margin-left: $fd-feed-input-btn-margin-end;
       margin-right: $fd-feed-input-btn-margin-start;
-
-      &[class*=sap-icon]::before {
-        transform: rotate(180deg);
-      }
+      transform: rotate(180deg);
     }
   }
 

--- a/src/feed-input.scss
+++ b/src/feed-input.scss
@@ -27,6 +27,8 @@ $block: #{$fd-namespace}-feed-input;
 
   @include fd-disabled() {
     cursor: not-allowed;
+    pointer-events: initial;
+    opacity: initial;
   }
 
   .#{$block}__thumb {
@@ -49,6 +51,35 @@ $block: #{$fd-namespace}-feed-input;
 
     &::placeholder {
       font-style: var(--fdFeed_Input_Placeholder_Font_Style);
+      color: #32363a;
+      color: var(--sapTextColor, #32363a);
+
+      &::-webkit-input-placeholder {
+        color: #32363a;
+        color: var(--sapTextColor, #32363a);
+      }
+
+      &::-moz-placeholder {
+        color: #32363a;
+        color: var(--sapTextColor, #32363a);
+      }
+
+      &:-ms-input-placeholder {
+        color: #32363a;
+        color: var(--sapTextColor, #32363a);
+      }
+
+      &:-moz-placeholder {
+        color: #32363a;
+        color: var(--sapTextColor, #32363a);
+      }
+    }
+  }
+
+  .fd-button {
+    [dir="rtl"] &,
+    &[dir="rtl"] {
+      transform: rotate(180deg);
     }
   }
 

--- a/src/feed-input.scss
+++ b/src/feed-input.scss
@@ -29,6 +29,13 @@ $block: #{$fd-namespace}-feed-input;
     cursor: not-allowed;
     pointer-events: initial;
     opacity: initial;
+
+    textarea {
+      &::placeholder {
+        font-style: var(--fdFeed_Input_Placeholder_Font_Style);
+        color: var(--sapTextColor, #32363a);
+      }
+    }
   }
 
   .#{$block}__thumb {
@@ -48,37 +55,10 @@ $block: #{$fd-namespace}-feed-input;
     max-height: $fd-feed-input-max-height;
     margin: 0;
     padding: 0.3125rem 0.5rem;
-
-    &::placeholder {
-      font-style: var(--fdFeed_Input_Placeholder_Font_Style);
-      color: #32363a;
-      color: var(--sapTextColor, #32363a);
-
-      &::-webkit-input-placeholder {
-        color: #32363a;
-        color: var(--sapTextColor, #32363a);
-      }
-
-      &::-moz-placeholder {
-        color: #32363a;
-        color: var(--sapTextColor, #32363a);
-      }
-
-      &:-ms-input-placeholder {
-        color: #32363a;
-        color: var(--sapTextColor, #32363a);
-      }
-
-      &:-moz-placeholder {
-        color: #32363a;
-        color: var(--sapTextColor, #32363a);
-      }
-    }
   }
 
   .fd-button {
-    [dir="rtl"] &,
-    &[dir="rtl"] {
+    @include fd-rtl() {
       transform: rotate(180deg);
     }
   }


### PR DESCRIPTION

## Related Issue
part of: https://github.com/SAP/fundamental-ngx/issues/5025

## Description
adding placeholder color for text area and adding rtl to the button
 
## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
<img width="1223" alt="Screenshot 2021-07-13 at 6 10 11 PM" src="https://user-images.githubusercontent.com/53534379/125453204-910cb6d7-4da7-4758-9504-343599f06536.png">

### After:
<img width="1223" alt="Screenshot 2021-07-13 at 6 10 34 PM" src="https://user-images.githubusercontent.com/53534379/125453225-3ff7f898-ebe6-4f40-a9a4-914d6fd682a1.png">


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [NA] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.