### PR TITLE
fix: add active state background color for object list as per spec

### DIFF
--- a/.storybook/static/preview-head.js
+++ b/.storybook/static/preview-head.js
@@ -16,6 +16,8 @@
             }
             return block;
         }
+        
+        document.getElementById('anchor').focus();
 
         //get all tablists
         var tablists = document.querySelectorAll('[role="tablist"]');

--- a/src/_listDefinitions.scss
+++ b/src/_listDefinitions.scss
@@ -111,6 +111,10 @@ $semantic-color: (
 
   .#{$block}__link {
     background: inherit;
+
+    @include fd-active() {
+      background: var(--sapList_Active_Background);
+    }
   }
 
   @include fd-hover() {

--- a/src/object-list.scss
+++ b/src/object-list.scss
@@ -21,7 +21,6 @@ $block: #{$fd-namespace}-object-list;
 
     .#{$fd-namespace}-list__link {
       @include fd-active() {
-        background: var(--sapList_Active_Background);
 
         .#{$block}__intro,
         .#{$block}__object-attribute,

--- a/stories/object-list/__snapshots__/object-list.stories.storyshot
+++ b/stories/object-list/__snapshots__/object-list.stories.storyshot
@@ -1791,20 +1791,18 @@ exports[`Storyshots Components/Object List Selection With Navigation 1`] = `
       <li
         aria-selected="true"
         class="fd-list__item fd-object-list__item fd-list__item--link is-selected"
-        id="check"
         role="option"
-        style="outline:#fff;"
         tabindex="0"
       >
         
-
+  
         <a
-          class="fd-list__link"
-          style="background:#0854a0;outline-offset:-0.1875rem;outline:0.0625rem dotted #fff;"
+          class="fd-list__link is-active"
+          id="anchor"
           tabindex="0"
         >
            
-
+  
           <div
             class="fd-object-list__container"
           >
@@ -1812,7 +1810,6 @@ exports[`Storyshots Components/Object List Selection With Navigation 1`] = `
       
             <div
               class="fd-object-list__intro"
-              style="color:#fff;text-shadow: none;"
             >
               
        Optional inline text
@@ -1827,7 +1824,7 @@ exports[`Storyshots Components/Object List Selection With Navigation 1`] = `
         
               <span
                 class="fd-avatar fd-avatar--s"
-                style="background-image: url('/assets/images/products/fitbit.png');color:#fff;text-shadow: none;"
+                style="background-image: url('/assets/images/products/fitbit.png')"
               >
                 
         
@@ -1846,7 +1843,6 @@ exports[`Storyshots Components/Object List Selection With Navigation 1`] = `
           
                   <p
                     class="fd-object-identifier__title"
-                    style="color:#fff;text-shadow: none;"
                   >
                     
            Fitbit Versa Smart Watch, Black Fitbit Versa Smart Watch
@@ -1872,7 +1868,6 @@ exports[`Storyshots Components/Object List Selection With Navigation 1`] = `
             
                   <span
                     class="fd-object-number__text"
-                    style="color:#fff;"
                   >
                     457.00
                   </span>
@@ -1880,7 +1875,6 @@ exports[`Storyshots Components/Object List Selection With Navigation 1`] = `
             
                   <span
                     class="fd-object-number__unit"
-                    style="color:#fff;"
                   >
                     Euro
                   </span>
@@ -1912,7 +1906,6 @@ exports[`Storyshots Components/Object List Selection With Navigation 1`] = `
             
                   <div
                     class="fd-object-list__object-attribute"
-                    style="color:#fff;text-shadow: none;"
                   >
                     
               
@@ -1937,7 +1930,6 @@ exports[`Storyshots Components/Object List Selection With Navigation 1`] = `
                     <i
                       aria-label="icon for flag"
                       class="fd-object-marker__icon sap-icon--flag"
-                      style="color:#fff;"
                     />
                     
             
@@ -1952,7 +1944,6 @@ exports[`Storyshots Components/Object List Selection With Navigation 1`] = `
                     <i
                       aria-label="icon for favourite"
                       class="fd-object-marker__icon sap-icon--favorite"
-                      style="color:#fff;"
                     />
                     
             
@@ -1977,7 +1968,6 @@ exports[`Storyshots Components/Object List Selection With Navigation 1`] = `
             
                   <div
                     class="fd-object-list__object-attribute"
-                    style="color:#fff;text-shadow: none;"
                   >
                     
               Second Attribute
@@ -2000,7 +1990,6 @@ exports[`Storyshots Components/Object List Selection With Navigation 1`] = `
               
                     <span
                       class="fd-object-status__text"
-                      style="color:#fff;"
                     >
                       Avaliable
                     </span>
@@ -2027,7 +2016,6 @@ exports[`Storyshots Components/Object List Selection With Navigation 1`] = `
             
                   <div
                     class="fd-object-list__object-attribute"
-                    style="color:#fff;text-shadow: none;"
                   >
                     
               Third Attribute

--- a/stories/object-list/__snapshots__/object-list.stories.storyshot
+++ b/stories/object-list/__snapshots__/object-list.stories.storyshot
@@ -1787,6 +1787,271 @@ exports[`Storyshots Components/Object List Selection With Navigation 1`] = `
       role="listbox"
     >
       
+
+      <li
+        aria-selected="true"
+        class="fd-list__item fd-object-list__item fd-list__item--link is-selected"
+        id="check"
+        role="option"
+        style="outline:#fff;"
+        tabindex="0"
+      >
+        
+
+        <a
+          class="fd-list__link"
+          style="background:#0854a0;outline-offset:-0.1875rem;outline:0.0625rem dotted #fff;"
+          tabindex="0"
+        >
+           
+
+          <div
+            class="fd-object-list__container"
+          >
+            
+      
+            <div
+              class="fd-object-list__intro"
+              style="color:#fff;text-shadow: none;"
+            >
+              
+       Optional inline text
+      
+            </div>
+            
+      
+            <div
+              class="fd-object-list__header"
+            >
+              
+        
+              <span
+                class="fd-avatar fd-avatar--s"
+                style="background-image: url('/assets/images/products/fitbit.png');color:#fff;text-shadow: none;"
+              >
+                
+        
+              </span>
+              
+        
+              <div
+                class="fd-object-list__header-left"
+              >
+                
+         
+                <div
+                  class="fd-object-identifier fd-object-list__object-identifier"
+                >
+                  
+          
+                  <p
+                    class="fd-object-identifier__title"
+                    style="color:#fff;text-shadow: none;"
+                  >
+                    
+           Fitbit Versa Smart Watch, Black Fitbit Versa Smart Watch
+          
+                  </p>
+                  
+         
+                </div>
+                
+        
+              </div>
+              
+        
+              <div
+                class="fd-object-list__header-right"
+              >
+                
+          
+                <span
+                  class="fd-object-number fd-object-list__object-number"
+                >
+                  
+            
+                  <span
+                    class="fd-object-number__text"
+                    style="color:#fff;"
+                  >
+                    457.00
+                  </span>
+                  
+            
+                  <span
+                    class="fd-object-number__unit"
+                    style="color:#fff;"
+                  >
+                    Euro
+                  </span>
+                  
+          
+                </span>
+                
+        
+              </div>
+              
+      
+            </div>
+            
+      
+            <div
+              class="fd-object-list__content"
+            >
+              
+        
+              <div
+                class="fd-object-list__row"
+              >
+                
+          
+                <div
+                  class="fd-object-list__row-left"
+                >
+                  
+            
+                  <div
+                    class="fd-object-list__object-attribute"
+                    style="color:#fff;text-shadow: none;"
+                  >
+                    
+              
+              First Attribute
+            
+                  </div>
+                  
+          
+                </div>
+                
+          
+                <div
+                  class="fd-object-list__row-right"
+                >
+                  
+            
+                  <div
+                    class="fd-object-marker"
+                  >
+                    
+              
+                    <i
+                      aria-label="icon for flag"
+                      class="fd-object-marker__icon sap-icon--flag"
+                      style="color:#fff;"
+                    />
+                    
+            
+                  </div>
+                  
+            
+                  <div
+                    class="fd-object-marker"
+                  >
+                    
+              
+                    <i
+                      aria-label="icon for favourite"
+                      class="fd-object-marker__icon sap-icon--favorite"
+                      style="color:#fff;"
+                    />
+                    
+            
+                  </div>
+                  
+          
+                </div>
+                
+        
+              </div>
+              
+        
+              <div
+                class="fd-object-list__row"
+              >
+                
+          
+                <div
+                  class="fd-object-list__row-left"
+                >
+                  
+            
+                  <div
+                    class="fd-object-list__object-attribute"
+                    style="color:#fff;text-shadow: none;"
+                  >
+                    
+              Second Attribute
+            
+                  </div>
+                  
+          
+                </div>
+                
+          
+                <div
+                  class="fd-object-list__row-right"
+                >
+                  
+            
+                  <span
+                    class="fd-object-status fd-object-status--critical"
+                  >
+                    
+              
+                    <span
+                      class="fd-object-status__text"
+                      style="color:#fff;"
+                    >
+                      Avaliable
+                    </span>
+                    
+            
+                  </span>
+                  
+          
+                </div>
+                
+        
+              </div>
+              
+        
+              <div
+                class="fd-object-list__row"
+              >
+                
+          
+                <div
+                  class="fd-object-list__row-left"
+                >
+                  
+            
+                  <div
+                    class="fd-object-list__object-attribute"
+                    style="color:#fff;text-shadow: none;"
+                  >
+                    
+              Third Attribute
+            
+                  </div>
+                  
+        
+                </div>
+                
+      
+              </div>
+              
+    
+            </div>
+            
+    
+          </div>
+          
+    
+        </a>
+        
+  
+      </li>
+      
   
       <li
         aria-selected="true"

--- a/stories/object-list/object-list.stories.js
+++ b/stories/object-list/object-list.stories.js
@@ -599,34 +599,34 @@ export const selectionWithNavigation = () => `
 <h4 id="objectListItemRowSelectionAndNavigation">Object List Item With Row Selection And Navigation</h4>
 <div role="navigation" style="max-width: 450px">
 <ul class="fd-list fd-object-list fd-list--navigation-object fd-list--navigation fd-list--selection" role="listbox" aria-labelledby="objectListItemRowSelectionAndNavigation">
-<li role="option" id="check" style="outline:#fff;" aria-selected="true" tabindex="0" class="fd-list__item fd-object-list__item fd-list__item--link is-selected">
-<a tabindex="0" class="fd-list__link" style="background:#0854a0;outline-offset:-0.1875rem;outline:0.0625rem dotted #fff;"> 
-<div class="fd-object-list__container">
-      <div class="fd-object-list__intro" style="color:#fff;text-shadow: none;">
+<li role="option" aria-selected="true" tabindex="0" class="fd-list__item fd-object-list__item fd-list__item--link is-selected">
+  <a tabindex="0" id="anchor" class="fd-list__link is-active"> 
+  <div class="fd-object-list__container">
+      <div class="fd-object-list__intro">
        Optional inline text</span>
       </div>
       <div class="fd-object-list__header">
         <span class="fd-avatar fd-avatar--s"
-         style="background-image: url('/assets/images/products/fitbit.png');color:#fff;text-shadow: none;">
+         style="background-image: url('/assets/images/products/fitbit.png')">
         </span>
         <div class="fd-object-list__header-left">
          <div class="fd-object-identifier fd-object-list__object-identifier">
-          <p class="fd-object-identifier__title" style="color:#fff;text-shadow: none;">
+          <p class="fd-object-identifier__title">
            Fitbit Versa Smart Watch, Black Fitbit Versa Smart Watch
           </p>
          </div>
         </div>
         <div class="fd-object-list__header-right">
           <span class="fd-object-number fd-object-list__object-number">
-            <span class="fd-object-number__text" style="color:#fff;">457.00</span>
-            <span class="fd-object-number__unit" style="color:#fff;">Euro</span>
+            <span class="fd-object-number__text">457.00</span>
+            <span class="fd-object-number__unit">Euro</span>
           </span>
         </div>
       </div>
       <div class="fd-object-list__content">
         <div class="fd-object-list__row">
           <div class="fd-object-list__row-left">
-            <div class="fd-object-list__object-attribute" style="color:#fff;text-shadow: none;">
+            <div class="fd-object-list__object-attribute">
               
               First Attribute
             </div>
@@ -634,28 +634,28 @@ export const selectionWithNavigation = () => `
           <div class="fd-object-list__row-right">
             <div class="fd-object-marker">
               <i class="fd-object-marker__icon sap-icon--flag"
-               aria-label="icon for flag" style="color:#fff;"></i>
+               aria-label="icon for flag"></i>
             </div>
             <div class="fd-object-marker">
-              <i class="fd-object-marker__icon sap-icon--favorite" aria-label="icon for favourite" style="color:#fff;"></i>
+              <i class="fd-object-marker__icon sap-icon--favorite" aria-label="icon for favourite"></i>
             </div>
           </div>
         </div>
         <div class="fd-object-list__row">
           <div class="fd-object-list__row-left">
-            <div class="fd-object-list__object-attribute" style="color:#fff;text-shadow: none;">
+            <div class="fd-object-list__object-attribute">
               Second Attribute
             </div>
           </div>
           <div class="fd-object-list__row-right">
             <span class="fd-object-status fd-object-status--critical">
-              <span class="fd-object-status__text" style="color:#fff;">Avaliable</span>
+              <span class="fd-object-status__text">Avaliable</span>
             </span>
           </div>
         </div>
         <div class="fd-object-list__row">
           <div class="fd-object-list__row-left">
-            <div class="fd-object-list__object-attribute" style="color:#fff;text-shadow: none;">
+            <div class="fd-object-list__object-attribute">
               Third Attribute
             </div>
         </div>

--- a/stories/object-list/object-list.stories.js
+++ b/stories/object-list/object-list.stories.js
@@ -599,6 +599,71 @@ export const selectionWithNavigation = () => `
 <h4 id="objectListItemRowSelectionAndNavigation">Object List Item With Row Selection And Navigation</h4>
 <div role="navigation" style="max-width: 450px">
 <ul class="fd-list fd-object-list fd-list--navigation-object fd-list--navigation fd-list--selection" role="listbox" aria-labelledby="objectListItemRowSelectionAndNavigation">
+<li role="option" id="check" style="outline:#fff;" aria-selected="true" tabindex="0" class="fd-list__item fd-object-list__item fd-list__item--link is-selected">
+<a tabindex="0" class="fd-list__link" style="background:#0854a0;outline-offset:-0.1875rem;outline:0.0625rem dotted #fff;"> 
+<div class="fd-object-list__container">
+      <div class="fd-object-list__intro" style="color:#fff;text-shadow: none;">
+       Optional inline text</span>
+      </div>
+      <div class="fd-object-list__header">
+        <span class="fd-avatar fd-avatar--s"
+         style="background-image: url('/assets/images/products/fitbit.png');color:#fff;text-shadow: none;">
+        </span>
+        <div class="fd-object-list__header-left">
+         <div class="fd-object-identifier fd-object-list__object-identifier">
+          <p class="fd-object-identifier__title" style="color:#fff;text-shadow: none;">
+           Fitbit Versa Smart Watch, Black Fitbit Versa Smart Watch
+          </p>
+         </div>
+        </div>
+        <div class="fd-object-list__header-right">
+          <span class="fd-object-number fd-object-list__object-number">
+            <span class="fd-object-number__text" style="color:#fff;">457.00</span>
+            <span class="fd-object-number__unit" style="color:#fff;">Euro</span>
+          </span>
+        </div>
+      </div>
+      <div class="fd-object-list__content">
+        <div class="fd-object-list__row">
+          <div class="fd-object-list__row-left">
+            <div class="fd-object-list__object-attribute" style="color:#fff;text-shadow: none;">
+              
+              First Attribute
+            </div>
+          </div>
+          <div class="fd-object-list__row-right">
+            <div class="fd-object-marker">
+              <i class="fd-object-marker__icon sap-icon--flag"
+               aria-label="icon for flag" style="color:#fff;"></i>
+            </div>
+            <div class="fd-object-marker">
+              <i class="fd-object-marker__icon sap-icon--favorite" aria-label="icon for favourite" style="color:#fff;"></i>
+            </div>
+          </div>
+        </div>
+        <div class="fd-object-list__row">
+          <div class="fd-object-list__row-left">
+            <div class="fd-object-list__object-attribute" style="color:#fff;text-shadow: none;">
+              Second Attribute
+            </div>
+          </div>
+          <div class="fd-object-list__row-right">
+            <span class="fd-object-status fd-object-status--critical">
+              <span class="fd-object-status__text" style="color:#fff;">Avaliable</span>
+            </span>
+          </div>
+        </div>
+        <div class="fd-object-list__row">
+          <div class="fd-object-list__row-left">
+            <div class="fd-object-list__object-attribute" style="color:#fff;text-shadow: none;">
+              Third Attribute
+            </div>
+        </div>
+      </div>
+    </div>
+    </div>
+    </a>
+  </li>
   <li role="option" aria-selected="true" tabindex="0" class="fd-list__item fd-object-list__item fd-list__item--link is-selected">
   <a tabindex="0" class="fd-list__link"> 
   <div class="fd-object-list__container">
@@ -935,3 +1000,4 @@ borderless.parameters = {
         storyDescription: 'Object list items can be displayed without borders. To display a borderless list, add the `fd-list--no-border` modifier class to the list element.'
     }
 };
+


### PR DESCRIPTION
## Related Issue
Closes #2520 

## Description
Active state of Object List should has value as per fiori specifications.

## Screenshots
### Before:

<img width="1042" alt="Screen Shot 2021-03-25 at 5 21 41 PM" src="https://user-images.githubusercontent.com/39598672/112545534-b23ac300-8d8e-11eb-9497-7964a8689f08.png">

### After:
<img width="1427" alt="2021-07-14_16-54-03" src="https://user-images.githubusercontent.com/53487468/125614195-44059301-b9e3-4521-9be7-a777b6b09d5a.png">




#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [n/a] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
