### PR TITLE
fix: add fix for Card header focus offset

### DIFF
--- a/src/card.scss
+++ b/src/card.scss
@@ -16,6 +16,7 @@ $fd-card-sections-horizontal-spacing: 2rem !default;
 $fd-card-sections-vertical-spacing: 1.75rem !default;
 $fd-card-content-avatar-text-spacing: 0.5rem !default;
 $fd-card-default-body-background-color: var(--sapTile_Background) !default;
+$fd-card-header-outline-offset: 0.0625rem !default;
 
 @mixin line-clamp($lines: 2) {
   display: -webkit-box;
@@ -24,6 +25,24 @@ $fd-card-default-body-background-color: var(--sapTile_Background) !default;
   overflow: hidden;
   white-space: normal;
   text-overflow: ellipsis;
+}
+
+@mixin fake-card-outline() {
+  @include fd-focus() {
+    outline: none;
+
+    &::before {
+      content: '';
+      position: absolute;
+      display: block;
+      border: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
+      top: $fd-card-header-outline-offset;
+      left: $fd-card-header-outline-offset;
+      right: $fd-card-header-outline-offset;
+      bottom: $fd-card-header-outline-offset * 2;
+      z-index: 3;
+    }
+  }
 }
 
 .#{$block} {
@@ -41,6 +60,7 @@ $fd-card-default-body-background-color: var(--sapTile_Background) !default;
   &__header {
     @include fd-reset();
     @include fd-flex();
+    @include fake-card-outline();
 
     padding: 1rem;
     background: $fd-card-default-body-background-color;
@@ -48,6 +68,7 @@ $fd-card-default-body-background-color: var(--sapTile_Background) !default;
     border-radius: $fd-card-header-border-radius $fd-card-header-border-radius 0 0;
     text-decoration: none;
     cursor: pointer;
+    position: relative;
 
     @include fd-hover() {
       background: var(--sapTile_Hover_Background);
@@ -55,13 +76,6 @@ $fd-card-default-body-background-color: var(--sapTile_Background) !default;
 
     @include fd-active() {
       background: var(--sapTile_Active_Background);
-    }
-
-    @include fd-focus() {
-      outline-style: dotted;
-      outline-width: var(--sapContent_FocusWidth);
-      outline-color: var(--sapContent_FocusColor);
-      outline-offset: -0.125rem;
     }
 
     .#{$block}__avatar {
@@ -89,6 +103,13 @@ $fd-card-default-body-background-color: var(--sapTile_Background) !default;
       border-bottom: none;
       border-top: $fd-card-header-border;
       border-radius: 0 0 $fd-card-header-border-radius $fd-card-header-border-radius;
+
+      @include fd-focus() {
+        &::before {
+          top: $fd-card-header-outline-offset * 2;
+          bottom: $fd-card-header-outline-offset;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#2514

## Description
The Card header focus outline didn't have the same offset on all sides. Replaced the outline with fake focus, a similar approach used in List and Tiles.  

## Screenshots
### Before:
<img width="808" alt="Screen Shot 2021-07-19 at 3 17 31 PM" src="https://user-images.githubusercontent.com/39598672/126214835-0ea66690-13f2-47c9-928d-4cfcece9ee7f.png">
<img width="794" alt="Screen Shot 2021-07-19 at 3 17 38 PM" src="https://user-images.githubusercontent.com/39598672/126214840-731d0da8-4d8d-4e41-b0c0-86ceb3e6c353.png">


### After:
<img width="618" alt="Screen Shot 2021-07-19 at 3 04 45 PM" src="https://user-images.githubusercontent.com/39598672/126214861-fc7d1147-879d-4b5d-825f-cbf2faf05b6c.png">
<img width="647" alt="Screen Shot 2021-07-19 at 3 04 37 PM" src="https://user-images.githubusercontent.com/39598672/126214864-02bfa06d-84ce-4ad8-9279-ed8d2e0aecfc.png">


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [na] Text elements follow the truncation rules
- [na] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [na] selected state of the element follow design spec
- [na] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [na] Responsiveness rules - the component has modifier classes for all breakpoints
- [na] Includes Compact/Cosy/Tablet design
- [na] RTL support
2. The code follows fundamental-styles code standards and style
- [na] only one top level `fd-*` class is used in the file
- [na] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [na] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [na] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [na] tested Storybook examples with "CSS Resources" `normalize` option 
- [na] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [na] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [na] Storybook documentation has been created/updated
- [na] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
