### PR TITLE
docs: add fixed container size for Calendar in portrait mode

### DIFF
--- a/stories/calendar/__snapshots__/calendar.stories.storyshot
+++ b/stories/calendar/__snapshots__/calendar.stories.storyshot
@@ -2913,6 +2913,7 @@ exports[`Storyshots Components/Calendar Portrait (mobile) 1`] = `
     
   <section
     class="fd-dialog__content fd-dialog__content--s fd-dialog__content--mobile"
+    style="width: 375px; height: 600px;"
   >
     
         

--- a/stories/calendar/calendar.stories.js
+++ b/stories/calendar/calendar.stories.js
@@ -1001,7 +1001,7 @@ Note: For landscape mode, no dialog header element should be used. However, a di
 };
 
 export const PortraitMobile = () => `<div class="fd-dialog-docs-static fd-calendar-mobile-docs-static--portrait fd-dialog fd-dialog--active">
-    <section class="fd-dialog__content fd-dialog__content--s fd-dialog__content--mobile">
+    <section class="fd-dialog__content fd-dialog__content--s fd-dialog__content--mobile" style="width: 375px; height: 600px;">
         <header class="fd-dialog__header fd-bar fd-bar--header fd-bar--cozy">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">


### PR DESCRIPTION
## Related Issue
Part of SAP/fundamental-styles#2460

## Description
hardcode the size of the Calendar container so it shows the component in Portrait mode all the time in the documentation. 
