### PR TITLE
fix: refactor toolbar styles as part of ngx style clean up task

### DIFF
--- a/src/toolbar.scss
+++ b/src/toolbar.scss
@@ -202,7 +202,7 @@ $title-toolbar-height: 2.75rem;
       @include fd-ellipsis();
     }
   }
-  
+
   &--cozy {
     height: $toolbar-height-cozy;
     min-height: $toolbar-height-cozy;

--- a/src/toolbar.scss
+++ b/src/toolbar.scss
@@ -162,7 +162,7 @@ $title-toolbar-height: 2.75rem;
     max-height: 50vh;
     overflow: auto;
 
-     & .#{$block}__overflow-button {
+    & .#{$block}__overflow-button {
       justify-content: flex-start;
       text-align: left;
       width: auto;

--- a/src/toolbar.scss
+++ b/src/toolbar.scss
@@ -195,7 +195,7 @@ $title-toolbar-height: 2.75rem;
       @include fd-reset();
       @include fd-ellipsis();
 
-      &--spacerMargin {
+      &--text {
         margin-top: 0.4375rem;
       }
     }

--- a/src/toolbar.scss
+++ b/src/toolbar.scss
@@ -23,8 +23,6 @@ $title-toolbar-height: 2.75rem;
   padding: $padding-y $padding-x;
 }
 
-
-
 @mixin toolbarAuto() {
   background-color: inherit;
 }
@@ -162,50 +160,49 @@ $title-toolbar-height: 2.75rem;
   }
 
   &__overflow {
+    @include fd-reset();
+    @include fd-flex(column);
+    @include padding(0.375rem, 0.1875rem);
+
+    max-width: 20rem;
+    max-height: 50vh;
+    overflow: auto;
+
+    & .#{$block}__button {
+      justify-content: flex-start;
+      text-align: left;
+      width: auto;
+      margin: 0.1875rem 0;
+
+      @include fd-rtl() {
+        text-align: right;
+      }
+
+      &--menu {
+        @include fd-flex-center() {
+          justify-content: space-between;
+        }
+
+        max-width: 100%;
+      }
+    }
+
+    & .#{$block}__separator {
       @include fd-reset();
-      @include fd-flex(column);
-      @include padding(0.375rem, 0.1875rem);
 
-      max-width: 20rem;
-      max-height: 50vh;
-      overflow: auto;
+      height: 0.0625rem;
+      margin: 0.1875rem;
+      width: auto;
+      background-color: var(--sapToolbar_SeparatorColor);
+    }
 
-      & .#{$block}__button {
-        justify-content: flex-start;
-        text-align: left;
-        width: auto;
-        margin: 0.1875rem 0;
+    .#{$block}__overflow--label {
+      @include fd-reset();
+      @include fd-ellipsis();
 
-        @include fd-rtl() {
-          text-align: right;
-        }
-
-        &--menu {
-          @include fd-flex-center() {
-            justify-content: space-between;
-          }
-          
-          max-width: 100%;
-        }
-      }
-
-      & .#{$block}__separator {
-        @include fd-reset();
-
-        height: 0.0625rem;
-        margin: 0.1875rem;
-        width: auto;
-        background-color: var(--sapToolbar_SeparatorColor);
-      }
-
-      .#{$block}__overflow--label {
-        @include fd-reset();
-        @include fd-ellipsis();
-
-        margin-top: 0.4375rem;
-      }
+      margin-top: 0.4375rem;
+    }
   }
-  
 
   .#{$block}__overflow-button {
     margin-left: auto;

--- a/src/toolbar.scss
+++ b/src/toolbar.scss
@@ -165,7 +165,7 @@ $title-toolbar-height: 2.75rem;
     max-height: 50vh;
     overflow: auto;
 
-    & .#{$block}__button {
+    & .#{$block}__overflow-button {
       justify-content: flex-start;
       text-align: left;
       width: auto;
@@ -198,15 +198,6 @@ $title-toolbar-height: 2.75rem;
       @include fd-ellipsis();
 
       margin-top: 0.4375rem;
-    }
-  }
-
-  .#{$block}__overflow-popover {
-    margin-left: auto;
-
-    @include fd-rtl() {
-      margin-left: 0;
-      margin-right: auto;
     }
   }
 

--- a/src/toolbar.scss
+++ b/src/toolbar.scss
@@ -181,7 +181,7 @@ $title-toolbar-height: 2.75rem;
       }
     }
 
-    > .#{$block}__separator {
+    .#{$block}__separator {
       @include fd-reset();
 
       height: 0.0625rem;
@@ -190,16 +190,14 @@ $title-toolbar-height: 2.75rem;
       background-color: var(--sapToolbar_SeparatorColor);
     }
 
-    .#{$block}__overflow-form-label {
-      &.#{$fd-namespace}-form-label {
-        margin-top: 0.4375rem;
-      }
-    }
-
     .#{$block}__overflow-form-label,
     .#{$block}__overflow-label {
       @include fd-reset();
       @include fd-ellipsis();
+
+      &--spacerMargin {
+        margin-top: 0.4375rem;
+      }
     }
   }
 

--- a/src/toolbar.scss
+++ b/src/toolbar.scss
@@ -202,7 +202,7 @@ $title-toolbar-height: 2.75rem;
       @include fd-ellipsis();
     }
   }
-
+  
   &--cozy {
     height: $toolbar-height-cozy;
     min-height: $toolbar-height-cozy;

--- a/src/toolbar.scss
+++ b/src/toolbar.scss
@@ -3,6 +3,7 @@
 
 $block: #{$fd-namespace}-toolbar;
 $toolbar-height-compact: 2rem;
+$info-toolbar-height: 2rem;
 $toolbar-height-cozy: 2.75rem;
 
 $toolbar-separator-height-compact: 1.5rem;
@@ -161,7 +162,7 @@ $title-toolbar-height: 2.75rem;
     max-height: 50vh;
     overflow: auto;
 
-    & .#{$block}__overflow-button {
+     & .#{$block}__overflow-button {
       justify-content: flex-start;
       text-align: left;
       width: auto;
@@ -180,7 +181,7 @@ $title-toolbar-height: 2.75rem;
       }
     }
 
-    & .#{$block}__separator {
+    > .#{$block}__separator {
       @include fd-reset();
 
       height: 0.0625rem;
@@ -189,16 +190,26 @@ $title-toolbar-height: 2.75rem;
       background-color: var(--sapToolbar_SeparatorColor);
     }
 
+    .#{$block}__overflow-form-label {
+      &.#{$fd-namespace}-form-label {
+        margin-top: 0.4375rem;
+      }
+    }
+
+    .#{$block}__overflow-form-label,
     .#{$block}__overflow-label {
       @include fd-reset();
       @include fd-ellipsis();
-
-      margin-top: 0.4375rem;
     }
   }
 
   &--cozy {
     height: $toolbar-height-cozy;
+    min-height: $toolbar-height-cozy;
+
+    &.#{$block}--info {
+      height: $info-toolbar-height;
+    }
 
     .#{$block}__overflow {
       @include fd-reset();

--- a/src/toolbar.scss
+++ b/src/toolbar.scss
@@ -19,10 +19,6 @@ $title-toolbar-height: 2.75rem;
   }
 }
 
-@mixin padding($padding-x, $padding-y) {
-  padding: $padding-y $padding-x;
-}
-
 @mixin toolbarAuto() {
   background-color: inherit;
 }

--- a/src/toolbar.scss
+++ b/src/toolbar.scss
@@ -196,7 +196,7 @@ $title-toolbar-height: 2.75rem;
       background-color: var(--sapToolbar_SeparatorColor);
     }
 
-    .#{$block}__overflow--label {
+    .#{$block}__overflow__label {
       @include fd-reset();
       @include fd-ellipsis();
 

--- a/src/toolbar.scss
+++ b/src/toolbar.scss
@@ -158,8 +158,8 @@ $title-toolbar-height: 2.75rem;
   &__overflow {
     @include fd-reset();
     @include fd-flex(column);
-    @include fd-set-paddings-x-equal(0.5rem);
-    @include fd-set-paddings-y-equal(0.25rem);
+    @include fd-set-paddings-x-equal(0.375rem);
+    @include fd-set-paddings-y-equal(0.1875rem);
 
     max-width: 20rem;
     max-height: 50vh;
@@ -203,5 +203,11 @@ $title-toolbar-height: 2.75rem;
 
   &--cozy {
     height: $toolbar-height-cozy;
+
+    .#{$block}__overflow {
+      @include fd-reset();
+      @include fd-set-paddings-x-equal(0.5rem);
+      @include fd-set-paddings-y-equal(0.25rem);
+    }
   }
 }

--- a/src/toolbar.scss
+++ b/src/toolbar.scss
@@ -92,10 +92,6 @@ $title-toolbar-height: 2.75rem;
   display: flex;
   align-items: center;
 
-  > * {
-    flex-shrink: 0;
-  }
-
   @include toolbarSpacing();
   @include toolbarStandard();
 

--- a/src/toolbar.scss
+++ b/src/toolbar.scss
@@ -193,7 +193,7 @@ $title-toolbar-height: 2.75rem;
       background-color: var(--sapToolbar_SeparatorColor);
     }
 
-    .#{$block}__overflow__label {
+    .#{$block}__overflow-label {
       @include fd-reset();
       @include fd-ellipsis();
 
@@ -201,7 +201,7 @@ $title-toolbar-height: 2.75rem;
     }
   }
 
-  .#{$block}__overflow-button {
+  .#{$block}__overflow-popover {
     margin-left: auto;
 
     @include fd-rtl() {

--- a/src/toolbar.scss
+++ b/src/toolbar.scss
@@ -19,6 +19,12 @@ $title-toolbar-height: 2.75rem;
   }
 }
 
+@mixin padding($padding-x, $padding-y) {
+  padding: $padding-y $padding-x;
+}
+
+
+
 @mixin toolbarAuto() {
   background-color: inherit;
 }
@@ -155,18 +161,17 @@ $title-toolbar-height: 2.75rem;
     background-color: var(--sapToolbar_SeparatorColor);
   }
 
-  &__body {
-    &--overflow {
+  &__overflow {
       @include fd-reset();
       @include fd-flex(column);
+      @include padding(0.375rem, 0.1875rem);
 
       max-width: 20rem;
-      padding: 0.1875rem 0.375rem;
       max-height: 50vh;
       overflow: auto;
 
       & .#{$block}__button {
-        display: block;
+        justify-content: flex-start;
         text-align: left;
         width: auto;
         margin: 0.1875rem 0;
@@ -193,16 +198,16 @@ $title-toolbar-height: 2.75rem;
         background-color: var(--sapToolbar_SeparatorColor);
       }
 
-      .#{$block}__body--overflow-label {
+      .#{$block}__overflow--label {
         @include fd-reset();
         @include fd-ellipsis();
 
         margin-top: 0.4375rem;
       }
-    }
   }
+  
 
-  .#{$block}__body {
+  .#{$block}__overflow-button {
     margin-left: auto;
 
     @include fd-rtl() {

--- a/src/toolbar.scss
+++ b/src/toolbar.scss
@@ -3,7 +3,6 @@
 
 $block: #{$fd-namespace}-toolbar;
 $toolbar-height-compact: 2rem;
-$info-toolbar-height: 2rem;
 $toolbar-height-cozy: 2.75rem;
 
 $toolbar-separator-height-compact: 1.5rem;
@@ -21,7 +20,7 @@ $title-toolbar-height: 2.75rem;
 }
 
 @mixin toolbarAuto() {
-  background-color: var(--fdToolbar_Auto_Background);
+  background-color: inherit;
 }
 
 @mixin toolbarSolid() {
@@ -33,8 +32,7 @@ $title-toolbar-height: 2.75rem;
 }
 
 @mixin toolbarInfo() {
-  height: $info-toolbar-height;
-  $active-color: var(--sapInfobar_TextColor);
+  $active-color: var(--sapInfobar__TextColor);
 
   background-color: var(--sapInfobar_NonInteractive_Background);
   color: var(--sapList_TextColor);
@@ -90,10 +88,13 @@ $title-toolbar-height: 2.75rem;
   @include fd-reset();
 
   height: $toolbar-height-compact;
-  min-height: $toolbar-height-compact;
   padding: $toolbar-padding;
   display: flex;
   align-items: center;
+
+  > * {
+    flex-shrink: 0;
+  }
 
   @include toolbarSpacing();
   @include toolbarStandard();
@@ -116,6 +117,18 @@ $title-toolbar-height: 2.75rem;
 
   &--transparent {
     @include toolbarTransparent();
+  }
+
+  &--fade-in {
+    visibility: visible;
+    opacity: 1;
+    transition: visibility 0s linear 0s, opacity 1s;
+  }
+
+  &--fade-out {
+    visibility: hidden;
+    opacity: 0;
+    transition: visibility 0s linear 1s, opacity 1ms;
   }
 
   &--info {
@@ -142,68 +155,63 @@ $title-toolbar-height: 2.75rem;
     background-color: var(--sapToolbar_SeparatorColor);
   }
 
-  &__overflow {
-    &.#{$fd-namespace}-popover {
-      .#{$block}__overflow__body {
-        @include fd-reset();
+  &__body {
+    &--overflow {
+      @include fd-reset();
+      @include fd-flex(column);
 
-        display: flex;
-        flex-direction: column;
-        max-width: 20rem;
-        padding: 0.1875rem 0.375rem;
+      max-width: 20rem;
+      padding: 0.1875rem 0.375rem;
+      max-height: 50vh;
+      overflow: auto;
 
-        > * {
-          display: block;
-          text-align: left;
-          width: auto;
-          margin: 0.1875rem 0;
+      & .#{$block}__button {
+        display: block;
+        text-align: left;
+        width: auto;
+        margin: 0.1875rem 0;
 
-          @include fd-rtl() {
-            text-align: right;
+        @include fd-rtl() {
+          text-align: right;
+        }
+
+        &--menu {
+          @include fd-flex-center() {
+            justify-content: space-between;
           }
-        }
-
-        > .#{$block}__separator {
-          height: 0.0625rem;
-          margin: 0.1875rem;
-          width: auto;
-          background-color: var(--sapToolbar_SeparatorColor);
-        }
-
-        .#{$block}__overflow__form-label {
-          &.#{$fd-namespace}-form-label {
-            margin-top: 0.4375rem;
-          }
-        }
-
-        .#{$block}__overflow__form-label,
-        .#{$block}__overflow__label {
-          overflow: hidden;
-          white-space: nowrap;
-          text-overflow: ellipsis;
+          
+          max-width: 100%;
         }
       }
+
+      & .#{$block}__separator {
+        @include fd-reset();
+
+        height: 0.0625rem;
+        margin: 0.1875rem;
+        width: auto;
+        background-color: var(--sapToolbar_SeparatorColor);
+      }
+
+      .#{$block}__body--overflow-label {
+        @include fd-reset();
+        @include fd-ellipsis();
+
+        margin-top: 0.4375rem;
+      }
+    }
+  }
+
+  .#{$block}__body {
+    margin-left: auto;
+
+    @include fd-rtl() {
+      margin-left: 0;
+      margin-right: auto;
     }
   }
 
   &--cozy {
     height: $toolbar-height-cozy;
-    min-height: $toolbar-height-cozy;
-
-    &.#{$block}--info {
-      height: $info-toolbar-height;
-    }
-
-    .#{$block}__separator {
-      height: $toolbar-separator-height-cozy;
-    }
-
-    .#{$block}__overflow {
-      &.#{$fd-namespace}-popover {
-        .#{$block}__overflow__body {
-          padding: 0.25rem 0.5rem;
-        }
-      }
-    }
   }
 }

--- a/src/toolbar.scss
+++ b/src/toolbar.scss
@@ -158,8 +158,8 @@ $title-toolbar-height: 2.75rem;
   &__overflow {
     @include fd-reset();
     @include fd-flex(column);
-    @include fd-set-paddings-x-equal(0.375rem);
-    @include fd-set-paddings-y-equal(0.1875rem);
+    @include fd-set-paddings-x-equal(0.5rem);
+    @include fd-set-paddings-y-equal(0.25rem);
 
     max-width: 20rem;
     max-height: 50vh;

--- a/src/toolbar.scss
+++ b/src/toolbar.scss
@@ -162,7 +162,8 @@ $title-toolbar-height: 2.75rem;
   &__overflow {
     @include fd-reset();
     @include fd-flex(column);
-    @include padding(0.375rem, 0.1875rem);
+    @include fd-set-paddings-x-equal(0.375rem);
+    @include fd-set-paddings-y-equal(0.1875rem);
 
     max-width: 20rem;
     max-height: 50vh;

--- a/stories/dynamic-page/__snapshots__/dynamic-page.stories.storyshot
+++ b/stories/dynamic-page/__snapshots__/dynamic-page.stories.storyshot
@@ -256,14 +256,14 @@ exports[`Storyshots Layouts/Dynamic Page Collapsed Header (mobile) 1`] = `
                       
                                                 
                       <button
-                        class="fd-button fd-button--transparent"
+                        class="fd-button fd-button--transparent fd-toolbar__overflow-button "
                       >
                         Accept
                       </button>
                       
                                                 
                       <button
-                        class="fd-button fd-button--transparent"
+                        class="fd-button fd-button--transparent fd-toolbar__overflow-button "
                       >
                         Reject
                       </button>
@@ -1908,14 +1908,14 @@ exports[`Storyshots Layouts/Dynamic Page Mobile 1`] = `
                       
                                                 
                       <button
-                        class="fd-button fd-button--transparent"
+                        class="fd-button fd-button--transparent fd-toolbar__overflow-button"
                       >
                         Accept
                       </button>
                       
                                                 
                       <button
-                        class="fd-button fd-button--transparent"
+                        class="fd-button fd-button--transparent fd-toolbar__overflow-button"
                       >
                         Reject
                       </button>
@@ -3363,14 +3363,14 @@ exports[`Storyshots Layouts/Dynamic Page With header facets (mobile) 1`] = `
                       
                                                 
                       <button
-                        class="fd-button fd-button--transparent"
+                        class="fd-button fd-button--transparent fd-toolbar__overflow-button"
                       >
                         Accept
                       </button>
                       
                                                 
                       <button
-                        class="fd-button fd-button--transparent"
+                        class="fd-button fd-button--transparent fd-toolbar__overflow-button"
                       >
                         Reject
                       </button>
@@ -3619,14 +3619,14 @@ exports[`Storyshots Layouts/Dynamic Page With header facets (mobile) 1`] = `
                       
                                                 
                       <button
-                        class="fd-button fd-button--transparent"
+                        class="fd-button fd-button--transparent fd-toolbar__overflow-button"
                       >
                         Accept
                       </button>
                       
                                                 
                       <button
-                        class="fd-button fd-button--transparent"
+                        class="fd-button fd-button--transparent fd-toolbar__overflow-button"
                       >
                         Reject
                       </button>

--- a/stories/dynamic-page/__snapshots__/dynamic-page.stories.storyshot
+++ b/stories/dynamic-page/__snapshots__/dynamic-page.stories.storyshot
@@ -142,7 +142,7 @@ exports[`Storyshots Layouts/Dynamic Page Collapsed Header (mobile) 1`] = `
                 
                                     
                 <div
-                  class="fd-popover fd-toolbar__overflow"
+                  class="fd-popover"
                 >
                   
                                         
@@ -184,7 +184,7 @@ exports[`Storyshots Layouts/Dynamic Page Collapsed Header (mobile) 1`] = `
                     
                                             
                     <div
-                      class="fd-toolbar__overflow__body"
+                      class="fd-toolbar__overflow"
                     >
                       
                                                 Overflowing title content
@@ -209,7 +209,7 @@ exports[`Storyshots Layouts/Dynamic Page Collapsed Header (mobile) 1`] = `
                 
                                     
                 <div
-                  class="fd-popover fd-toolbar__overflow"
+                  class="fd-popover"
                 >
                   
                                         
@@ -251,7 +251,7 @@ exports[`Storyshots Layouts/Dynamic Page Collapsed Header (mobile) 1`] = `
                     
                                             
                     <div
-                      class="fd-toolbar__overflow__body"
+                      class="fd-toolbar__overflow"
                     >
                       
                                                 
@@ -1794,7 +1794,7 @@ exports[`Storyshots Layouts/Dynamic Page Mobile 1`] = `
                 
                                     
                 <div
-                  class="fd-popover fd-toolbar__overflow"
+                  class="fd-popover"
                 >
                   
                                         
@@ -1836,7 +1836,7 @@ exports[`Storyshots Layouts/Dynamic Page Mobile 1`] = `
                     
                                             
                     <div
-                      class="fd-toolbar__overflow__body"
+                      class="fd-toolbar__overflow"
                     >
                       
                                                 Overflowing title content
@@ -1861,7 +1861,7 @@ exports[`Storyshots Layouts/Dynamic Page Mobile 1`] = `
                 
                                     
                 <div
-                  class="fd-popover fd-toolbar__overflow"
+                  class="fd-popover"
                 >
                   
                                         
@@ -1903,7 +1903,7 @@ exports[`Storyshots Layouts/Dynamic Page Mobile 1`] = `
                     
                                             
                     <div
-                      class="fd-toolbar__overflow__body"
+                      class="fd-toolbar__overflow"
                     >
                       
                                                 
@@ -3316,7 +3316,7 @@ exports[`Storyshots Layouts/Dynamic Page With header facets (mobile) 1`] = `
                 
                                     
                 <div
-                  class="fd-popover fd-toolbar__overflow"
+                  class="fd-popover"
                 >
                   
                                         
@@ -3358,7 +3358,7 @@ exports[`Storyshots Layouts/Dynamic Page With header facets (mobile) 1`] = `
                     
                                             
                     <div
-                      class="fd-toolbar__overflow__body"
+                      class="fd-toolbar__overflow"
                     >
                       
                                                 
@@ -3572,7 +3572,7 @@ exports[`Storyshots Layouts/Dynamic Page With header facets (mobile) 1`] = `
                 
                                     
                 <div
-                  class="fd-popover fd-toolbar__overflow"
+                  class="fd-popover"
                 >
                   
                                         
@@ -3614,7 +3614,7 @@ exports[`Storyshots Layouts/Dynamic Page With header facets (mobile) 1`] = `
                     
                                             
                     <div
-                      class="fd-toolbar__overflow__body"
+                      class="fd-toolbar__overflow"
                     >
                       
                                                 

--- a/stories/dynamic-page/dynamic-page.stories.js
+++ b/stories/dynamic-page/dynamic-page.stories.js
@@ -415,8 +415,8 @@ export const mobile = () =>
                                             aria-hidden="false"
                                             id="wgxzK85914">
                                             <div class="fd-toolbar__overflow">
-                                                <button class="fd-button fd-button--transparent">Accept</button>
-                                                <button class="fd-button fd-button--transparent">Reject</button>
+                                                <button class="fd-button fd-button--transparent fd-toolbar__overflow-button">Accept</button>
+                                                <button class="fd-button fd-button--transparent fd-toolbar__overflow-button">Reject</button>
                                             </div>
                                         </div>
                                     </div>
@@ -573,8 +573,8 @@ export const mobileCollapsed = () =>
                                             aria-hidden="false"
                                             id="wgxzK85912">
                                             <div class="fd-toolbar__overflow">
-                                                <button class="fd-button fd-button--transparent">Accept</button>
-                                                <button class="fd-button fd-button--transparent">Reject</button>
+                                                <button class="fd-button fd-button--transparent fd-toolbar__overflow-button ">Accept</button>
+                                                <button class="fd-button fd-button--transparent fd-toolbar__overflow-button ">Reject</button>
                                             </div>
                                         </div>
                                     </div>
@@ -1339,8 +1339,8 @@ export const withFacetsMobile = () =>
                                             aria-hidden="false"
                                             id="wgxzK85901">
                                             <div class="fd-toolbar__overflow">
-                                                <button class="fd-button fd-button--transparent">Accept</button>
-                                                <button class="fd-button fd-button--transparent">Reject</button>
+                                                <button class="fd-button fd-button--transparent fd-toolbar__overflow-button">Accept</button>
+                                                <button class="fd-button fd-button--transparent fd-toolbar__overflow-button">Reject</button>
                                             </div>
                                         </div>
                                     </div>
@@ -1398,8 +1398,8 @@ export const withFacetsMobile = () =>
                                             aria-hidden="false"
                                             id="wgxzK85911">
                                             <div class="fd-toolbar__overflow">
-                                                <button class="fd-button fd-button--transparent">Accept</button>
-                                                <button class="fd-button fd-button--transparent">Reject</button>
+                                                <button class="fd-button fd-button--transparent fd-toolbar__overflow-button">Accept</button>
+                                                <button class="fd-button fd-button--transparent fd-toolbar__overflow-button">Reject</button>
                                             </div>
                                         </div>
                                     </div>

--- a/stories/dynamic-page/dynamic-page.stories.js
+++ b/stories/dynamic-page/dynamic-page.stories.js
@@ -369,7 +369,7 @@ export const mobile = () =>
                             <div class="fd-dynamic-page__title-container">
                                 <h1 class="fd-title fd-dynamic-page__title" title="Balenciaga Triple S Trainers"> Balenciaga Triple S Trainers </h1>
                                 <div role="toolbar" aria-label="Header Content" class="fd-dynamic-page__toolbar fd-dynamic-page__toolbar--content fd-toolbar fd-toolbar--cozy fd-toolbar--clear fd-toolbar--transparent">
-                                    <div class="fd-popover fd-toolbar__overflow">
+                                    <div class="fd-popover">
                                         <div class="fd-popover__control">
                                             <button
                                                 id="asfmiasudashd"
@@ -388,14 +388,14 @@ export const mobile = () =>
                                         <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow"
                                             aria-hidden="false"
                                             id="wgxzK85915">
-                                            <div class="fd-toolbar__overflow__body">
+                                            <div class="fd-toolbar__overflow">
                                                 Overflowing title content
                                             </div>
                                         </div>
                                     </div>
                                 </div>
                                 <div role="toolbar" aria-label="Product actions" class="fd-dynamic-page__toolbar fd-toolbar fd-toolbar--cozy fd-toolbar--clear fd-toolbar--transparent">
-                                    <div class="fd-popover fd-toolbar__overflow">
+                                    <div class="fd-popover">
                                         <div class="fd-popover__control">
                                             <button
                                                 id="maisodusakdnsma"
@@ -414,7 +414,7 @@ export const mobile = () =>
                                         <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow"
                                             aria-hidden="false"
                                             id="wgxzK85914">
-                                            <div class="fd-toolbar__overflow__body">
+                                            <div class="fd-toolbar__overflow">
                                                 <button class="fd-button fd-button--transparent">Accept</button>
                                                 <button class="fd-button fd-button--transparent">Reject</button>
                                             </div>
@@ -527,7 +527,7 @@ export const mobileCollapsed = () =>
                             <div class="fd-dynamic-page__title-container">
                                 <h1 class="fd-title fd-dynamic-page__title" title="Balenciaga Triple S Trainers"> Balenciaga Triple S Trainers </h1>
                                 <div role="toolbar" aria-label="Header Content" class="fd-dynamic-page__toolbar fd-dynamic-page__toolbar--content fd-toolbar fd-toolbar--cozy fd-toolbar--clear fd-toolbar--transparent">
-                                    <div class="fd-popover fd-toolbar__overflow">
+                                    <div class="fd-popover">
                                         <div class="fd-popover__control">
                                             <button
                                                 id="ko9as8dajskdj"
@@ -546,14 +546,14 @@ export const mobileCollapsed = () =>
                                         <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow"
                                             aria-hidden="false"
                                             id="wgxzK85913">
-                                            <div class="fd-toolbar__overflow__body">
+                                            <div class="fd-toolbar__overflow">
                                                 Overflowing title content
                                             </div>
                                         </div>
                                     </div>
                                 </div>
                                 <div role="toolbar" aria-label="Product actions" class="fd-dynamic-page__toolbar fd-toolbar fd-toolbar--cozy fd-toolbar--clear fd-toolbar--transparent">
-                                    <div class="fd-popover fd-toolbar__overflow">
+                                    <div class="fd-popover">
                                         <div class="fd-popover__control">
                                             <button
                                                 id="k9r0a8ioasjd"
@@ -572,7 +572,7 @@ export const mobileCollapsed = () =>
                                         <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow"
                                             aria-hidden="false"
                                             id="wgxzK85912">
-                                            <div class="fd-toolbar__overflow__body">
+                                            <div class="fd-toolbar__overflow">
                                                 <button class="fd-button fd-button--transparent">Accept</button>
                                                 <button class="fd-button fd-button--transparent">Reject</button>
                                             </div>
@@ -1319,7 +1319,7 @@ export const withFacetsMobile = () =>
                             <div class="fd-dynamic-page__title-container">
                                 <h1 class="fd-title fd-dynamic-page__title" title="Balenciaga Triple S Trainers"> Balenciaga Triple S Trainers </h1>
                                 <div role="toolbar" aria-label="Product actions" class="fd-dynamic-page__toolbar fd-toolbar fd-toolbar--cozy fd-toolbar--clear fd-toolbar--transparent">
-                                    <div class="fd-popover fd-toolbar__overflow">
+                                    <div class="fd-popover">
                                         <div class="fd-popover__control">
                                             <button
                                                 id="maisodusakdnsmb"
@@ -1338,7 +1338,7 @@ export const withFacetsMobile = () =>
                                         <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow"
                                             aria-hidden="false"
                                             id="wgxzK85901">
-                                            <div class="fd-toolbar__overflow__body">
+                                            <div class="fd-toolbar__overflow">
                                                 <button class="fd-button fd-button--transparent">Accept</button>
                                                 <button class="fd-button fd-button--transparent">Reject</button>
                                             </div>
@@ -1378,7 +1378,7 @@ export const withFacetsMobile = () =>
                                     <div class="fd-dynamic-page__subtitle"> Collapsed header in mobile </div>
                                 </div>
                                 <div role="toolbar" aria-label="Product actions" class="fd-dynamic-page__toolbar fd-toolbar fd-toolbar--cozy fd-toolbar--clear fd-toolbar--transparent">
-                                    <div class="fd-popover fd-toolbar__overflow">
+                                    <div class="fd-popover">
                                         <div class="fd-popover__control">
                                             <button
                                                 id="maisodusakdnsmag"
@@ -1397,7 +1397,7 @@ export const withFacetsMobile = () =>
                                         <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow"
                                             aria-hidden="false"
                                             id="wgxzK85911">
-                                            <div class="fd-toolbar__overflow__body">
+                                            <div class="fd-toolbar__overflow">
                                                 <button class="fd-button fd-button--transparent">Accept</button>
                                                 <button class="fd-button fd-button--transparent">Reject</button>
                                             </div>

--- a/stories/facets/__snapshots__/facets.stories.storyshot
+++ b/stories/facets/__snapshots__/facets.stories.storyshot
@@ -1723,7 +1723,7 @@ exports[`Storyshots Dev/Facets Facets in Object Page Mobile 1`] = `
                 
                                     
                 <div
-                  class="fd-popover fd-toolbar__overflow"
+                  class="fd-popover"
                 >
                   
                                         
@@ -1765,7 +1765,7 @@ exports[`Storyshots Dev/Facets Facets in Object Page Mobile 1`] = `
                     
                                             
                     <div
-                      class="fd-toolbar__overflow__body"
+                      class="fd-toolbar__overflow"
                     >
                       
                                                 
@@ -1979,7 +1979,7 @@ exports[`Storyshots Dev/Facets Facets in Object Page Mobile 1`] = `
                 
                                     
                 <div
-                  class="fd-popover fd-toolbar__overflow"
+                  class="fd-popover"
                 >
                   
                                         
@@ -2021,7 +2021,7 @@ exports[`Storyshots Dev/Facets Facets in Object Page Mobile 1`] = `
                     
                                             
                     <div
-                      class="fd-toolbar__overflow__body"
+                      class="fd-toolbar__overflow"
                     >
                       
                                                 

--- a/stories/facets/facets.stories.js
+++ b/stories/facets/facets.stories.js
@@ -564,7 +564,7 @@ export const objectPageMobile = () =>
                             <div class="fd-dynamic-page__title-container">
                                 <h1 class="fd-title fd-dynamic-page__title" title="Balenciaga Triple S Trainers"> Balenciaga Triple S Trainers </h1>
                                 <div role="toolbar" aria-label="Product actions" class="fd-dynamic-page__toolbar fd-toolbar fd-toolbar--cozy fd-toolbar--clear fd-toolbar--transparent">
-                                    <div class="fd-popover fd-toolbar__overflow">
+                                    <div class="fd-popover">
                                         <div class="fd-popover__control">
                                             <button
                                                 id="maisodusakdnsmb"
@@ -583,7 +583,7 @@ export const objectPageMobile = () =>
                                         <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow"
                                             aria-hidden="false"
                                             id="wgxzK85901">
-                                            <div class="fd-toolbar__overflow__body">
+                                            <div class="fd-toolbar__overflow">
                                                 <button class="fd-button fd-button--transparent">Accept</button>
                                                 <button class="fd-button fd-button--transparent">Reject</button>
                                             </div>
@@ -623,7 +623,7 @@ export const objectPageMobile = () =>
                                     <div class="fd-dynamic-page__subtitle"> Collapsed header in mobile </div>
                                 </div>
                                 <div role="toolbar" aria-label="Product actions" class="fd-dynamic-page__toolbar fd-toolbar fd-toolbar--cozy fd-toolbar--clear fd-toolbar--transparent">
-                                    <div class="fd-popover fd-toolbar__overflow">
+                                    <div class="fd-popover">
                                         <div class="fd-popover__control">
                                             <button
                                                 id="maisodusakdnsmag"
@@ -642,7 +642,7 @@ export const objectPageMobile = () =>
                                         <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow"
                                             aria-hidden="false"
                                             id="wgxzK85911">
-                                            <div class="fd-toolbar__overflow__body">
+                                            <div class="fd-toolbar__overflow">
                                                 <button class="fd-button fd-button--transparent">Accept</button>
                                                 <button class="fd-button fd-button--transparent">Reject</button>
                                             </div>

--- a/stories/toolbar/__snapshots__/toolbar.stories.storyshot
+++ b/stories/toolbar/__snapshots__/toolbar.stories.storyshot
@@ -328,7 +328,7 @@ exports[`Storyshots Components/Toolbar Overflow 1`] = `
       
         
       <div
-        class="fd-popover fd-toolbar__overflow-popover"
+        class="fd-popover"
       >
         
             
@@ -372,7 +372,7 @@ exports[`Storyshots Components/Toolbar Overflow 1`] = `
             
                     
             <button
-              class="fd-button fd-button--transparent fd-toolbar__button"
+              class="fd-button fd-button--transparent fd-toolbar__overflow-button"
             >
               Edit
             </button>
@@ -384,7 +384,7 @@ exports[`Storyshots Components/Toolbar Overflow 1`] = `
             
                     
             <button
-              class="fd-button fd-button--transparent fd-toolbar__button"
+              class="fd-button fd-button--transparent fd-toolbar__overflow-button"
             >
               Delete
             </button>
@@ -396,14 +396,14 @@ exports[`Storyshots Components/Toolbar Overflow 1`] = `
             
                     
             <button
-              class="fd-button fd-button--transparent fd-toolbar__button"
+              class="fd-button fd-button--transparent fd-toolbar__overflow-button"
             >
               Assign
             </button>
             
                     
             <button
-              class="fd-button fd-button--transparent fd-toolbar__button"
+              class="fd-button fd-button--transparent fd-toolbar__overflow-button"
             >
               Exit
             </button>
@@ -478,7 +478,7 @@ exports[`Storyshots Components/Toolbar Overflow 1`] = `
       
         
       <div
-        class="fd-popover fd-toolbar__overflow-popover"
+        class="fd-popover"
       >
         
             
@@ -529,7 +529,7 @@ exports[`Storyshots Components/Toolbar Overflow 1`] = `
             
                     
             <button
-              class="fd-button fd-button--compact fd-button--transparent fd-toolbar__button"
+              class="fd-button fd-button--compact fd-button--transparent fd-toolbar__overflow-button"
             >
               Edit
             </button>
@@ -548,7 +548,7 @@ exports[`Storyshots Components/Toolbar Overflow 1`] = `
             
                     
             <button
-              class="fd-button fd-button--compact fd-button--transparent fd-toolbar__button"
+              class="fd-button fd-button--compact fd-button--transparent fd-toolbar__overflow-button"
             >
               Delete
             </button>
@@ -560,21 +560,21 @@ exports[`Storyshots Components/Toolbar Overflow 1`] = `
             
                     
             <button
-              class="fd-button fd-button--compact fd-button--transparent fd-toolbar__button"
+              class="fd-button fd-button--compact fd-button--transparent fd-toolbar__overflow-button"
             >
               Assign
             </button>
             
                     
             <button
-              class="fd-button fd-button--compact fd-button--transparent fd-toolbar__button"
+              class="fd-button fd-button--compact fd-button--transparent fd-toolbar__overflow-button"
             >
               Exit
             </button>
             
                     
             <button
-              class="fd-button fd-button--compact fd-button--transparent fd-button--menu fd-toolbar__button fd-toolbar__button--menu"
+              class="fd-button fd-button--compact fd-button--transparent fd-button--menu fd-toolbar__overflow-button fd-toolbar__overflow-button--menu"
             >
               
                         

--- a/stories/toolbar/__snapshots__/toolbar.stories.storyshot
+++ b/stories/toolbar/__snapshots__/toolbar.stories.storyshot
@@ -541,7 +541,7 @@ exports[`Storyshots Components/Toolbar Overflow 1`] = `
             
                     
             <label
-              class="fd-form-label fd-toolbar__overflow-form-label fd-toolbar__overflow-form-label--spacerMargin"
+              class="fd-form-label fd-toolbar__overflow-form-label fd-toolbar__overflow-form-label--text"
             >
               Form label
             </label>

--- a/stories/toolbar/__snapshots__/toolbar.stories.storyshot
+++ b/stories/toolbar/__snapshots__/toolbar.stories.storyshot
@@ -367,12 +367,12 @@ exports[`Storyshots Components/Toolbar Overflow 1`] = `
           
                 
           <div
-            class="fd-toolbar__overflow__body"
+            class="fd-toolbar__body--overflow"
           >
             
                     
             <button
-              class="fd-button fd-button--transparent"
+              class="fd-button fd-button--transparent fd-toolbar__button"
             >
               Edit
             </button>
@@ -384,7 +384,7 @@ exports[`Storyshots Components/Toolbar Overflow 1`] = `
             
                     
             <button
-              class="fd-button fd-button--transparent"
+              class="fd-button fd-button--transparent fd-toolbar__button"
             >
               Delete
             </button>
@@ -396,14 +396,14 @@ exports[`Storyshots Components/Toolbar Overflow 1`] = `
             
                     
             <button
-              class="fd-button fd-button--transparent"
+              class="fd-button fd-button--transparent fd-toolbar__button"
             >
               Assign
             </button>
             
                     
             <button
-              class="fd-button fd-button--transparent"
+              class="fd-button fd-button--transparent fd-toolbar__button"
             >
               Exit
             </button>
@@ -517,19 +517,19 @@ exports[`Storyshots Components/Toolbar Overflow 1`] = `
           
                 
           <div
-            class="fd-toolbar__overflow__body"
+            class="fd-toolbar__body--overflow"
           >
             
                     
             <label
-              class="fd-label fd-toolbar__overflow__label"
+              class="fd-label fd-toolbar__body--overflow-label"
             >
               Label
             </label>
             
                     
             <button
-              class="fd-button fd-button--compact fd-button--transparent"
+              class="fd-button fd-button--compact fd-button--transparent fd-toolbar__button"
             >
               Edit
             </button>
@@ -541,14 +541,14 @@ exports[`Storyshots Components/Toolbar Overflow 1`] = `
             
                     
             <label
-              class="fd-form-label fd-toolbar__overflow__form-label"
+              class="fd-form-label fd-toolbar__body--overflow-label"
             >
               Form label
             </label>
             
                     
             <button
-              class="fd-button fd-button--compact fd-button--transparent"
+              class="fd-button fd-button--compact fd-button--transparent fd-toolbar__button"
             >
               Delete
             </button>
@@ -560,14 +560,14 @@ exports[`Storyshots Components/Toolbar Overflow 1`] = `
             
                     
             <button
-              class="fd-button fd-button--compact fd-button--transparent"
+              class="fd-button fd-button--compact fd-button--transparent fd-toolbar__button"
             >
               Assign
             </button>
             
                     
             <button
-              class="fd-button fd-button--compact fd-button--transparent"
+              class="fd-button fd-button--compact fd-button--transparent fd-toolbar__button"
             >
               Exit
             </button>

--- a/stories/toolbar/__snapshots__/toolbar.stories.storyshot
+++ b/stories/toolbar/__snapshots__/toolbar.stories.storyshot
@@ -522,7 +522,7 @@ exports[`Storyshots Components/Toolbar Overflow 1`] = `
             
                     
             <label
-              class="fd-label fd-toolbar__overflow--label"
+              class="fd-label fd-toolbar__overflow__label"
             >
               Label
             </label>
@@ -541,7 +541,7 @@ exports[`Storyshots Components/Toolbar Overflow 1`] = `
             
                     
             <label
-              class="fd-form-label fd-toolbar__overflow--label"
+              class="fd-form-label fd-toolbar__overflow__label"
             >
               Form label
             </label>

--- a/stories/toolbar/__snapshots__/toolbar.stories.storyshot
+++ b/stories/toolbar/__snapshots__/toolbar.stories.storyshot
@@ -302,7 +302,7 @@ exports[`Storyshots Components/Toolbar Overflow 1`] = `
       
         
       <span
-        class="fd-toolbar__spacer "
+        class="fd-toolbar__spacer"
       >
          
       </span>
@@ -328,7 +328,7 @@ exports[`Storyshots Components/Toolbar Overflow 1`] = `
       
         
       <div
-        class="fd-popover fd-toolbar__overflow"
+        class="fd-popover fd-toolbar__overflow-button"
       >
         
             
@@ -367,7 +367,7 @@ exports[`Storyshots Components/Toolbar Overflow 1`] = `
           
                 
           <div
-            class="fd-toolbar__body--overflow"
+            class="fd-toolbar__overflow"
           >
             
                     
@@ -478,7 +478,7 @@ exports[`Storyshots Components/Toolbar Overflow 1`] = `
       
         
       <div
-        class="fd-popover fd-toolbar__overflow"
+        class="fd-popover fd-toolbar__overflow-button"
       >
         
             
@@ -517,12 +517,12 @@ exports[`Storyshots Components/Toolbar Overflow 1`] = `
           
                 
           <div
-            class="fd-toolbar__body--overflow"
+            class="fd-toolbar__overflow"
           >
             
                     
             <label
-              class="fd-label fd-toolbar__body--overflow-label"
+              class="fd-label fd-toolbar__overflow--label"
             >
               Label
             </label>
@@ -541,7 +541,7 @@ exports[`Storyshots Components/Toolbar Overflow 1`] = `
             
                     
             <label
-              class="fd-form-label fd-toolbar__body--overflow-label"
+              class="fd-form-label fd-toolbar__overflow--label"
             >
               Form label
             </label>
@@ -570,6 +570,26 @@ exports[`Storyshots Components/Toolbar Overflow 1`] = `
               class="fd-button fd-button--compact fd-button--transparent fd-toolbar__button"
             >
               Exit
+            </button>
+            
+                    
+            <button
+              class="fd-button fd-button--compact fd-button--transparent fd-button--menu fd-toolbar__button fd-toolbar__button--menu"
+            >
+              
+                        
+              <span
+                class="fd-button__text"
+              >
+                Menu Button
+              </span>
+              
+                        
+              <i
+                class="sap-icon--slim-arrow-down"
+              />
+              
+                    
             </button>
             
                 

--- a/stories/toolbar/__snapshots__/toolbar.stories.storyshot
+++ b/stories/toolbar/__snapshots__/toolbar.stories.storyshot
@@ -541,7 +541,7 @@ exports[`Storyshots Components/Toolbar Overflow 1`] = `
             
                     
             <label
-              class="fd-form-label fd-toolbar__overflow-form-label"
+              class="fd-form-label fd-toolbar__overflow-form-label fd-toolbar__overflow-form-label--spacerMargin"
             >
               Form label
             </label>

--- a/stories/toolbar/__snapshots__/toolbar.stories.storyshot
+++ b/stories/toolbar/__snapshots__/toolbar.stories.storyshot
@@ -328,7 +328,7 @@ exports[`Storyshots Components/Toolbar Overflow 1`] = `
       
         
       <div
-        class="fd-popover fd-toolbar__overflow-button"
+        class="fd-popover fd-toolbar__overflow-popover"
       >
         
             
@@ -478,7 +478,7 @@ exports[`Storyshots Components/Toolbar Overflow 1`] = `
       
         
       <div
-        class="fd-popover fd-toolbar__overflow-button"
+        class="fd-popover fd-toolbar__overflow-popover"
       >
         
             
@@ -522,7 +522,7 @@ exports[`Storyshots Components/Toolbar Overflow 1`] = `
             
                     
             <label
-              class="fd-label fd-toolbar__overflow__label"
+              class="fd-label fd-toolbar__overflow-label"
             >
               Label
             </label>
@@ -541,7 +541,7 @@ exports[`Storyshots Components/Toolbar Overflow 1`] = `
             
                     
             <label
-              class="fd-form-label fd-toolbar__overflow__label"
+              class="fd-form-label fd-toolbar__overflow-label"
             >
               Form label
             </label>

--- a/stories/toolbar/__snapshots__/toolbar.stories.storyshot
+++ b/stories/toolbar/__snapshots__/toolbar.stories.storyshot
@@ -541,7 +541,7 @@ exports[`Storyshots Components/Toolbar Overflow 1`] = `
             
                     
             <label
-              class="fd-form-label fd-toolbar__overflow-label"
+              class="fd-form-label fd-toolbar__overflow-form-label"
             >
               Form label
             </label>

--- a/stories/toolbar/toolbar.stories.js
+++ b/stories/toolbar/toolbar.stories.js
@@ -119,7 +119,7 @@ export const overflow = () => `<div style="height:250px">
                     <label class="fd-label fd-toolbar__overflow-label">Label</label>
                     <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__overflow-button">Edit</button>
                     <span class="fd-toolbar__separator"></span>
-                    <label class="fd-form-label fd-toolbar__overflow-form-label">Form label</label>
+                    <label class="fd-form-label fd-toolbar__overflow-form-label fd-toolbar__overflow-form-label--spacerMargin">Form label</label>
                     <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__overflow-button">Delete</button>
                     <span class="fd-toolbar__separator"></span>
                     <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__overflow-button">Assign</button>

--- a/stories/toolbar/toolbar.stories.js
+++ b/stories/toolbar/toolbar.stories.js
@@ -119,7 +119,7 @@ export const overflow = () => `<div style="height:250px">
                     <label class="fd-label fd-toolbar__overflow-label">Label</label>
                     <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__overflow-button">Edit</button>
                     <span class="fd-toolbar__separator"></span>
-                    <label class="fd-form-label fd-toolbar__overflow-label">Form label</label>
+                    <label class="fd-form-label fd-toolbar__overflow-form-label">Form label</label>
                     <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__overflow-button">Delete</button>
                     <span class="fd-toolbar__separator"></span>
                     <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__overflow-button">Assign</button>

--- a/stories/toolbar/toolbar.stories.js
+++ b/stories/toolbar/toolbar.stories.js
@@ -78,7 +78,7 @@ export const overflow = () => `<div style="height:250px">
             <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow"
                 aria-hidden="false"
                 id="wgxzK85912">
-                <div class="fd-toolbar__overflow--body">
+                <div class="fd-toolbar__body--overflow">
                     <button class="fd-button fd-button--transparent fd-toolbar__button">Edit</button>
                     <span class="fd-toolbar__separator"></span>
                     <button class="fd-button fd-button--transparent fd-toolbar__button">Delete</button>
@@ -115,11 +115,11 @@ export const overflow = () => `<div style="height:250px">
             <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow"
                 aria-hidden="false"
                 id="mw0daw8d7h">
-                <div class="fd-toolbar__overflow--body">
-                    <label class="fd-label fd-toolbar__overflow--label">Label</label>
+                <div class="fd-toolbar__body--overflow">
+                    <label class="fd-label fd-toolbar__body--overflow-label">Label</label>
                     <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__button">Edit</button>
                     <span class="fd-toolbar__separator"></span>
-                    <label class="fd-form-label fd-toolbar__overflow--form-label">Form label</label>
+                    <label class="fd-form-label fd-toolbar__body--overflow-label">Form label</label>
                     <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__button">Delete</button>
                     <span class="fd-toolbar__separator"></span>
                     <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__button">Assign</button>

--- a/stories/toolbar/toolbar.stories.js
+++ b/stories/toolbar/toolbar.stories.js
@@ -63,7 +63,7 @@ export const overflow = () => `<div style="height:250px">
         <button class="fd-button fd-button--transparent">Save</button>
         <button class="fd-button fd-button--transparent">Copy</button>
         <span class="fd-toolbar__separator"></span>
-        <div class="fd-popover fd-toolbar__overflow-button">
+        <div class="fd-popover fd-toolbar__overflow-popover">
             <div class="fd-popover__control">
                 <button class="fd-button fd-button--transparent"
                 aria-controls="wgxzK85912"
@@ -99,7 +99,7 @@ export const overflow = () => `<div style="height:250px">
         <button class="fd-button fd-button--compact fd-button--transparent">Save</button>
         <button class="fd-button fd-button--compact fd-button--transparent">Copy</button>
         <span class="fd-toolbar__separator"></span>
-        <div class="fd-popover fd-toolbar__overflow-button">
+        <div class="fd-popover fd-toolbar__overflow-popover">
             <div class="fd-popover__control">
                 <button
                 class="fd-button fd-button--compact fd-button--transparent"
@@ -116,10 +116,10 @@ export const overflow = () => `<div style="height:250px">
                 aria-hidden="false"
                 id="mw0daw8d7h">
                 <div class="fd-toolbar__overflow">
-                    <label class="fd-label fd-toolbar__overflow__label">Label</label>
+                    <label class="fd-label fd-toolbar__overflow-label">Label</label>
                     <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__button">Edit</button>
                     <span class="fd-toolbar__separator"></span>
-                    <label class="fd-form-label fd-toolbar__overflow__label">Form label</label>
+                    <label class="fd-form-label fd-toolbar__overflow-label">Form label</label>
                     <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__button">Delete</button>
                     <span class="fd-toolbar__separator"></span>
                     <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__button">Assign</button>
@@ -141,7 +141,7 @@ overflow.parameters = {
         storyDescription: `The overflow toolbar can display additional elements when space is limited. This can be achieved with a **Button** and/or **Popover** component. 
 
 To display an overflow in a button, pass the \`sap-icon--overflow\` in the \`fd-button\` class. Additionally, you can add a popover by passing \`fd-popover\` in the \`fd-toolbar__overflow\` element.
- Add any element inside overflow body with \`fd-toolbar__button\` , \`fd-toolbar__button--menu\` \`fd-toolbar__overflow__label \` modifier ,        `
+ Add any element inside overflow body with \`fd-toolbar__button\` , \`fd-toolbar__button--menu\` \`fd-toolbar__overflow-label \` modifier ,        `
     }
 };
 

--- a/stories/toolbar/toolbar.stories.js
+++ b/stories/toolbar/toolbar.stories.js
@@ -63,7 +63,7 @@ export const overflow = () => `<div style="height:250px">
         <button class="fd-button fd-button--transparent">Save</button>
         <button class="fd-button fd-button--transparent">Copy</button>
         <span class="fd-toolbar__separator"></span>
-        <div class="fd-popover fd-toolbar__overflow-popover">
+        <div class="fd-popover">
             <div class="fd-popover__control">
                 <button class="fd-button fd-button--transparent"
                 aria-controls="wgxzK85912"
@@ -79,12 +79,12 @@ export const overflow = () => `<div style="height:250px">
                 aria-hidden="false"
                 id="wgxzK85912">
                 <div class="fd-toolbar__overflow">
-                    <button class="fd-button fd-button--transparent fd-toolbar__button">Edit</button>
+                    <button class="fd-button fd-button--transparent fd-toolbar__overflow-button">Edit</button>
                     <span class="fd-toolbar__separator"></span>
-                    <button class="fd-button fd-button--transparent fd-toolbar__button">Delete</button>
+                    <button class="fd-button fd-button--transparent fd-toolbar__overflow-button">Delete</button>
                     <span class="fd-toolbar__separator"></span>
-                    <button class="fd-button fd-button--transparent fd-toolbar__button">Assign</button>
-                    <button class="fd-button fd-button--transparent fd-toolbar__button">Exit</button>
+                    <button class="fd-button fd-button--transparent fd-toolbar__overflow-button">Assign</button>
+                    <button class="fd-button fd-button--transparent fd-toolbar__overflow-button">Exit</button>
                 </div>
             </div>
         </div>
@@ -99,7 +99,7 @@ export const overflow = () => `<div style="height:250px">
         <button class="fd-button fd-button--compact fd-button--transparent">Save</button>
         <button class="fd-button fd-button--compact fd-button--transparent">Copy</button>
         <span class="fd-toolbar__separator"></span>
-        <div class="fd-popover fd-toolbar__overflow-popover">
+        <div class="fd-popover">
             <div class="fd-popover__control">
                 <button
                 class="fd-button fd-button--compact fd-button--transparent"
@@ -117,14 +117,14 @@ export const overflow = () => `<div style="height:250px">
                 id="mw0daw8d7h">
                 <div class="fd-toolbar__overflow">
                     <label class="fd-label fd-toolbar__overflow-label">Label</label>
-                    <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__button">Edit</button>
+                    <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__overflow-button">Edit</button>
                     <span class="fd-toolbar__separator"></span>
                     <label class="fd-form-label fd-toolbar__overflow-label">Form label</label>
-                    <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__button">Delete</button>
+                    <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__overflow-button">Delete</button>
                     <span class="fd-toolbar__separator"></span>
-                    <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__button">Assign</button>
-                    <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__button">Exit</button>
-                    <button class="fd-button fd-button--compact fd-button--transparent fd-button--menu fd-toolbar__button fd-toolbar__button--menu">
+                    <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__overflow-button">Assign</button>
+                    <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__overflow-button">Exit</button>
+                    <button class="fd-button fd-button--compact fd-button--transparent fd-button--menu fd-toolbar__overflow-button fd-toolbar__overflow-button--menu">
                         <span class="fd-button__text">Menu Button</span>
                         <i class="sap-icon--slim-arrow-down"></i>
                     </button>
@@ -141,7 +141,7 @@ overflow.parameters = {
         storyDescription: `The overflow toolbar can display additional elements when space is limited. This can be achieved with a **Button** and/or **Popover** component. 
 
 To display an overflow in a button, pass the \`sap-icon--overflow\` in the \`fd-button\` class. Additionally, you can add a popover by passing \`fd-popover\` in the \`fd-toolbar__overflow\` element.
- Add any element inside overflow body with \`fd-toolbar__button\` , \`fd-toolbar__button--menu\` \`fd-toolbar__overflow-label \` modifier ,        `
+ Add any element inside overflow body with \`fd-toolbar__overflow-button\` , \`fd-toolbar__overflow-button--menu\` \`fd-toolbar__overflow-label \` modifier ,        `
     }
 };
 

--- a/stories/toolbar/toolbar.stories.js
+++ b/stories/toolbar/toolbar.stories.js
@@ -79,12 +79,12 @@ export const overflow = () => `<div style="height:250px">
                 aria-hidden="false"
                 id="wgxzK85912">
                 <div class="fd-toolbar__overflow--body">
-                    <button class="fd-button fd-button--transparent">Edit</button>
+                    <button class="fd-button fd-button--transparent fd-toolbar__button">Edit</button>
                     <span class="fd-toolbar__separator"></span>
-                    <button class="fd-button fd-button--transparent">Delete</button>
+                    <button class="fd-button fd-button--transparent fd-toolbar__button">Delete</button>
                     <span class="fd-toolbar__separator"></span>
-                    <button class="fd-button fd-button--transparent">Assign</button>
-                    <button class="fd-button fd-button--transparent">Exit</button>
+                    <button class="fd-button fd-button--transparent fd-toolbar__button">Assign</button>
+                    <button class="fd-button fd-button--transparent fd-toolbar__button">Exit</button>
                 </div>
             </div>
         </div>
@@ -117,13 +117,13 @@ export const overflow = () => `<div style="height:250px">
                 id="mw0daw8d7h">
                 <div class="fd-toolbar__overflow--body">
                     <label class="fd-label fd-toolbar__overflow--label">Label</label>
-                    <button class="fd-button fd-button--compact fd-button--transparent">Edit</button>
+                    <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__button">Edit</button>
                     <span class="fd-toolbar__separator"></span>
-                    <label class="fd-form-label fd-toolbar__overflow__form-label">Form label</label>
-                    <button class="fd-button fd-button--compact fd-button--transparent">Delete</button>
+                    <label class="fd-form-label fd-toolbar__overflow--form-label">Form label</label>
+                    <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__button">Delete</button>
                     <span class="fd-toolbar__separator"></span>
-                    <button class="fd-button fd-button--compact fd-button--transparent">Assign</button>
-                    <button class="fd-button fd-button--compact fd-button--transparent">Exit</button>
+                    <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__button">Assign</button>
+                    <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__button">Exit</button>
                 </div>
             </div>
         </div>
@@ -136,8 +136,8 @@ overflow.parameters = {
     docs: {
         storyDescription: `The overflow toolbar can display additional elements when space is limited. This can be achieved with a **Button** and/or **Popover** component. 
 
-To display an overflow in a button, pass the \`sap-icon--overflow\` in the \`fd-button\` class. Additionally, you can add a popover by passing \`fd-popover\` in the \`fd-toolbar__overflow\` element.
-        `
+To display an overflow in a button, pass the \`sap-icon--overflow\` in the \`fd-button\` class. Additionally, you can add a popover by passing \`fd-popover\` in the \`fd-toolbar__overflow--body\` element.
+ Add any element inside overflow body with \`fd-toolbar__button\` , \`fd-toolbar__button--menu\` \`fd-toolbar__overflow--label\` modifier ,        `
     }
 };
 

--- a/stories/toolbar/toolbar.stories.js
+++ b/stories/toolbar/toolbar.stories.js
@@ -78,7 +78,7 @@ export const overflow = () => `<div style="height:250px">
             <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow"
                 aria-hidden="false"
                 id="wgxzK85912">
-                <div class="fd-toolbar__overflow__body">
+                <div class="fd-toolbar__overflow--body">
                     <button class="fd-button fd-button--transparent">Edit</button>
                     <span class="fd-toolbar__separator"></span>
                     <button class="fd-button fd-button--transparent">Delete</button>
@@ -115,8 +115,8 @@ export const overflow = () => `<div style="height:250px">
             <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow"
                 aria-hidden="false"
                 id="mw0daw8d7h">
-                <div class="fd-toolbar__overflow__body">
-                    <label class="fd-label fd-toolbar__overflow__label">Label</label>
+                <div class="fd-toolbar__overflow--body">
+                    <label class="fd-label fd-toolbar__overflow--label">Label</label>
                     <button class="fd-button fd-button--compact fd-button--transparent">Edit</button>
                     <span class="fd-toolbar__separator"></span>
                     <label class="fd-form-label fd-toolbar__overflow__form-label">Form label</label>

--- a/stories/toolbar/toolbar.stories.js
+++ b/stories/toolbar/toolbar.stories.js
@@ -59,11 +59,11 @@ export const overflow = () => `<div style="height:250px">
     <div class="fd-toolbar fd-toolbar--cozy">
         <span>Products (34)</span>
         <button class="fd-button fd-button--transparent">Create</button>
-        <span class="fd-toolbar__spacer "> </span>
+        <span class="fd-toolbar__spacer"> </span>
         <button class="fd-button fd-button--transparent">Save</button>
         <button class="fd-button fd-button--transparent">Copy</button>
         <span class="fd-toolbar__separator"></span>
-        <div class="fd-popover fd-toolbar__overflow">
+        <div class="fd-popover fd-toolbar__overflow-button">
             <div class="fd-popover__control">
                 <button class="fd-button fd-button--transparent"
                 aria-controls="wgxzK85912"
@@ -78,7 +78,7 @@ export const overflow = () => `<div style="height:250px">
             <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow"
                 aria-hidden="false"
                 id="wgxzK85912">
-                <div class="fd-toolbar__body--overflow">
+                <div class="fd-toolbar__overflow">
                     <button class="fd-button fd-button--transparent fd-toolbar__button">Edit</button>
                     <span class="fd-toolbar__separator"></span>
                     <button class="fd-button fd-button--transparent fd-toolbar__button">Delete</button>
@@ -99,7 +99,7 @@ export const overflow = () => `<div style="height:250px">
         <button class="fd-button fd-button--compact fd-button--transparent">Save</button>
         <button class="fd-button fd-button--compact fd-button--transparent">Copy</button>
         <span class="fd-toolbar__separator"></span>
-        <div class="fd-popover fd-toolbar__overflow">
+        <div class="fd-popover fd-toolbar__overflow-button">
             <div class="fd-popover__control">
                 <button
                 class="fd-button fd-button--compact fd-button--transparent"
@@ -115,15 +115,19 @@ export const overflow = () => `<div style="height:250px">
             <div class="fd-popover__body fd-popover__body--right fd-popover__body--no-arrow"
                 aria-hidden="false"
                 id="mw0daw8d7h">
-                <div class="fd-toolbar__body--overflow">
-                    <label class="fd-label fd-toolbar__body--overflow-label">Label</label>
+                <div class="fd-toolbar__overflow">
+                    <label class="fd-label fd-toolbar__overflow--label">Label</label>
                     <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__button">Edit</button>
                     <span class="fd-toolbar__separator"></span>
-                    <label class="fd-form-label fd-toolbar__body--overflow-label">Form label</label>
+                    <label class="fd-form-label fd-toolbar__overflow--label">Form label</label>
                     <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__button">Delete</button>
                     <span class="fd-toolbar__separator"></span>
                     <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__button">Assign</button>
                     <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__button">Exit</button>
+                    <button class="fd-button fd-button--compact fd-button--transparent fd-button--menu fd-toolbar__button fd-toolbar__button--menu">
+                        <span class="fd-button__text">Menu Button</span>
+                        <i class="sap-icon--slim-arrow-down"></i>
+                    </button>
                 </div>
             </div>
         </div>
@@ -136,8 +140,8 @@ overflow.parameters = {
     docs: {
         storyDescription: `The overflow toolbar can display additional elements when space is limited. This can be achieved with a **Button** and/or **Popover** component. 
 
-To display an overflow in a button, pass the \`sap-icon--overflow\` in the \`fd-button\` class. Additionally, you can add a popover by passing \`fd-popover\` in the \`fd-toolbar__body--overflow\` element.
- Add any element inside overflow body with \`fd-toolbar__button\` , \`fd-toolbar__button--menu\` \`fd-toolbar__body--overflow-label \` modifier ,        `
+To display an overflow in a button, pass the \`sap-icon--overflow\` in the \`fd-button\` class. Additionally, you can add a popover by passing \`fd-popover\` in the \`fd-toolbar__overflow\` element.
+ Add any element inside overflow body with \`fd-toolbar__button\` , \`fd-toolbar__button--menu\` \`fd-toolbar__overflow--label \` modifier ,        `
     }
 };
 

--- a/stories/toolbar/toolbar.stories.js
+++ b/stories/toolbar/toolbar.stories.js
@@ -116,10 +116,10 @@ export const overflow = () => `<div style="height:250px">
                 aria-hidden="false"
                 id="mw0daw8d7h">
                 <div class="fd-toolbar__overflow">
-                    <label class="fd-label fd-toolbar__overflow--label">Label</label>
+                    <label class="fd-label fd-toolbar__overflow__label">Label</label>
                     <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__button">Edit</button>
                     <span class="fd-toolbar__separator"></span>
-                    <label class="fd-form-label fd-toolbar__overflow--label">Form label</label>
+                    <label class="fd-form-label fd-toolbar__overflow__label">Form label</label>
                     <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__button">Delete</button>
                     <span class="fd-toolbar__separator"></span>
                     <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__button">Assign</button>
@@ -141,7 +141,7 @@ overflow.parameters = {
         storyDescription: `The overflow toolbar can display additional elements when space is limited. This can be achieved with a **Button** and/or **Popover** component. 
 
 To display an overflow in a button, pass the \`sap-icon--overflow\` in the \`fd-button\` class. Additionally, you can add a popover by passing \`fd-popover\` in the \`fd-toolbar__overflow\` element.
- Add any element inside overflow body with \`fd-toolbar__button\` , \`fd-toolbar__button--menu\` \`fd-toolbar__overflow--label \` modifier ,        `
+ Add any element inside overflow body with \`fd-toolbar__button\` , \`fd-toolbar__button--menu\` \`fd-toolbar__overflow__label \` modifier ,        `
     }
 };
 

--- a/stories/toolbar/toolbar.stories.js
+++ b/stories/toolbar/toolbar.stories.js
@@ -119,7 +119,7 @@ export const overflow = () => `<div style="height:250px">
                     <label class="fd-label fd-toolbar__overflow-label">Label</label>
                     <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__overflow-button">Edit</button>
                     <span class="fd-toolbar__separator"></span>
-                    <label class="fd-form-label fd-toolbar__overflow-form-label fd-toolbar__overflow-form-label--spacerMargin">Form label</label>
+                    <label class="fd-form-label fd-toolbar__overflow-form-label fd-toolbar__overflow-form-label--text">Form label</label>
                     <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__overflow-button">Delete</button>
                     <span class="fd-toolbar__separator"></span>
                     <button class="fd-button fd-button--compact fd-button--transparent fd-toolbar__overflow-button">Assign</button>

--- a/stories/toolbar/toolbar.stories.js
+++ b/stories/toolbar/toolbar.stories.js
@@ -136,8 +136,8 @@ overflow.parameters = {
     docs: {
         storyDescription: `The overflow toolbar can display additional elements when space is limited. This can be achieved with a **Button** and/or **Popover** component. 
 
-To display an overflow in a button, pass the \`sap-icon--overflow\` in the \`fd-button\` class. Additionally, you can add a popover by passing \`fd-popover\` in the \`fd-toolbar__overflow--body\` element.
- Add any element inside overflow body with \`fd-toolbar__button\` , \`fd-toolbar__button--menu\` \`fd-toolbar__overflow--label\` modifier ,        `
+To display an overflow in a button, pass the \`sap-icon--overflow\` in the \`fd-button\` class. Additionally, you can add a popover by passing \`fd-popover\` in the \`fd-toolbar__body--overflow\` element.
+ Add any element inside overflow body with \`fd-toolbar__button\` , \`fd-toolbar__button--menu\` \`fd-toolbar__body--overflow-label \` modifier ,        `
     }
 };
 


### PR DESCRIPTION
## Related Issue
Part of SAP/fundamental-ngx#5025

## Description
Refactoring toolbar styles as part of ngx style clean up task.

BREAKING CHANGE:
- Modified class name as per BEM naming convention `fd-toolbar__overflow`
- Added modifiers for overflow body elements `fd-toolbar__button`, `fd-toolbar__button--menu`
- Changed `fd-toolbar__overflow__label` class name to `fd-toolbar__overflow-label` 
- Changed `fd-toolbar__overflow__form__label` class name to `fd-toolbar__overflow-form-label` with modifier class  `fd-toolbar__overflow-form-label--text`

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [NA] Verified all styles in IE11
- [NA] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
