### PR TITLE
fix: add fix for correct height of Grid List actions

### DIFF
--- a/src/toolbar.scss
+++ b/src/toolbar.scss
@@ -90,6 +90,7 @@ $title-toolbar-height: 2.75rem;
   @include fd-reset();
 
   height: $toolbar-height-compact;
+  min-height: $toolbar-height-compact;
   padding: $toolbar-padding;
   display: flex;
   align-items: center;
@@ -187,6 +188,7 @@ $title-toolbar-height: 2.75rem;
 
   &--cozy {
     height: $toolbar-height-cozy;
+    min-height: $toolbar-height-cozy;
 
     &.#{$block}--info {
       height: $info-toolbar-height;


### PR DESCRIPTION
## Related Issue
part of SAP/fundamental-styles#2460

## Description
When the GridList Item requires multi-selection and/or any kind of actions they are placed inside a Toolbar at the top, before the content area. The problem was that Toolbar didn't have a min-height, just a height. This was resulting in Toolbar having the same height as its content (buttons). The fix was to add min-height same as the height in cozy and compact mode. 

## Screenshots

### Before:
<img width="486" alt="Screen Shot 2021-07-19 at 4 24 09 PM" src="https://user-images.githubusercontent.com/39598672/126223670-38ddd793-8765-4699-9785-0a5aeaf1326b.png">
<img width="489" alt="Screen Shot 2021-07-19 at 4 23 58 PM" src="https://user-images.githubusercontent.com/39598672/126223672-b0b3d3b7-45d7-4eff-b944-ae7418d3e08b.png">

### After:
<img width="484" alt="Screen Shot 2021-07-19 at 4 23 50 PM" src="https://user-images.githubusercontent.com/39598672/126223697-f24847cb-6c72-432b-a83e-b8799f4523b3.png">
<img width="484" alt="Screen Shot 2021-07-19 at 4 23 38 PM" src="https://user-images.githubusercontent.com/39598672/126223698-7bfde05f-671f-48be-ac01-577df40a9c95.png">

