### PR TITLE
fix: center tristate icon horizontally

### DIFF
--- a/src/checkbox.scss
+++ b/src/checkbox.scss
@@ -11,6 +11,17 @@ $block: #{$fd-namespace}-checkbox;
   opacity: 0.0001;
 }
 
+@mixin applyIndeterminatePadding() {
+  $offset: 0.0625rem;
+
+  padding-left: $offset;
+
+  @include fd-rtl() {
+    padding-left: 0;
+    padding-right: $offset;
+  }
+}
+
 .#{$block} {
   @mixin fd-checkbox-state($background-color, $text-color, $border-color, $border-size, $border-type) {
     + .#{$block}__label {
@@ -114,11 +125,15 @@ $block: #{$fd-namespace}-checkbox;
   }
 
   &:indeterminate + .#{$block}__label::before {
+    @include applyIndeterminatePadding();
+
     content: "\e17b";
     font-size: 0.75rem;
   }
 
   &:indeterminate + .#{$block}__label--compact::before {
+    @include applyIndeterminatePadding();
+
     content: "\e17b";
     font-size: 0.6rem;
   }


### PR DESCRIPTION
## Related Issue
Part of SAP/fundamental-styles#2460

## Description
Center horizontally the "square" icon used for tristate chackbox

## Screenshots
### Before:
<img width="516" alt="Screen Shot 2021-07-19 at 5 00 34 PM" src="https://user-images.githubusercontent.com/39598672/126227391-2d45d676-c204-4268-8713-d393b41cffc7.png">
<img width="381" alt="Screen Shot 2021-07-19 at 5 00 52 PM" src="https://user-images.githubusercontent.com/39598672/126227409-a5d0b30e-cab0-4279-bb3f-0d91e43383bb.png">


### After:

<img width="357" alt="Screen Shot 2021-07-19 at 5 01 41 PM" src="https://user-images.githubusercontent.com/39598672/126227458-7ac02bba-d02f-4908-9a69-b86889fd85f2.png">
<img width="483" alt="Screen Shot 2021-07-19 at 5 01 35 PM" src="https://user-images.githubusercontent.com/39598672/126227459-09622eec-3273-4bc0-8a80-5594dbc462dd.png">


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [na] Text elements follow the truncation rules
- [na] hover state of the element follow design spec
- [na] focus state of the element follow design spec
- [na] active state of the element follow design spec
- [na] selected state of the element follow design spec
- [na] selected hover state of the element follow design spec
- [na] pressed state of the element follow design spec
- [na] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [na] only one top level `fd-*` class is used in the file
- [na] BEM naming convention is used
- [na] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [na] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [na] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [na] tested Storybook examples with "CSS Resources" `normalize` option 
- [na] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [na] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [na] Storybook documentation has been created/updated
- [na] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
