### PR TITLE
fix: adding focus to the bar element

### DIFF
--- a/src/bar.scss
+++ b/src/bar.scss
@@ -72,6 +72,11 @@ $block: #{$fd-namespace}-bar;
     max-width: 100%;
     max-height: 100%;
 
+    @include fd-focus() {
+      outline: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
+      outline-offset: var(--sapContent_FocusWidth);
+    }
+
     @include fd-rtl() {
       margin-right: 0;
       margin-left: $fd-bar-element-spacing;


### PR DESCRIPTION
fix: adding focus to the bar element

## Related Issue
Closes SAP/fundamental-styles#https://github.com/SAP/fundamental-styles/issues/2593

## Description

adding focus to the bar element

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:

<img width="345" alt="Screenshot 2021-07-20 at 6 45 21 PM" src="https://user-images.githubusercontent.com/53534379/126333088-08aec593-927f-4f07-94eb-3e831687d6b6.png">

### After:

<img width="345" alt="Screenshot 2021-07-20 at 7 07 14 PM" src="https://user-images.githubusercontent.com/53534379/126333723-5dee39fc-89f9-4151-b6f2-c65a1feda1cb.png">


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [NA] Verified all styles in IE11
- [NA] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [NA] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
