### PR TITLE
fix: remove word-break from fixed-card-layout, leaking outside to other components

### DIFF
--- a/src/fixed-card-layout.scss
+++ b/src/fixed-card-layout.scss
@@ -13,10 +13,6 @@ $block: #{$fd-namespace}-fixed-card-layout;
   &__card-layout {
     @include fd-reset();
     @include fd-flex-horizontal-center();
-
-    * {
-      word-break: break-all;
-    }
   }
 
   &__card-layout-column {


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/2592

## Description
removed not-required word-break style which is causing style leak.
It is not needed any more as original issue for which this was added, has been addressed in table component.
Now column text in table does not overflow, but wraps.
so word break is not needed, it can be safely removed.


## Screenshots

### Before:


### After:

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [NA] Storybook documentation has been created/updated
- [NA] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
