### PR TITLE
fix: add focus to focusable disabled button

### DIFF
--- a/config/bundlesize.json
+++ b/config/bundlesize.json
@@ -2,7 +2,7 @@
     "files": [
         {
             "path": "./dist/fundamental-styles.css",
-            "maxSize": "110 kB"
+            "maxSize": "115 kB"
         }
     ]
 }

--- a/src/button.scss
+++ b/src/button.scss
@@ -406,7 +406,13 @@ $block: #{$fd-namespace}-button;
     @include buttonContainerPressedFocus();
   }
 
-  @include fd-disabled() {
+  &[aria-disabled="true"],
+  &.is-disabled {
+    @include isDisabled();
+    @include buttonContainer();
+  }
+
+  &:disabled {
     @include buttonContainerDisabled();
   }
 }


### PR DESCRIPTION
## Related Issue
Part of SAP/fundamental-styles#2460

## Description
Focusable disabled should get a focus outline for a11y purposes. This is achieved by using `aria-disabled` and `is-disabled` class. The element is styled as disabled but it gets a focus and is read by the screenreader. If `disabled` is used, the button does not get focus. 

## Screenshots
### After:
<img width="1968" alt="Screen Shot 2021-07-20 at 2 31 32 PM" src="https://user-images.githubusercontent.com/39598672/126379340-afbe74de-dff0-4ac4-8214-089783e829bd.png">
<img width="540" alt="Screen Shot 2021-07-20 at 2 31 15 PM" src="https://user-images.githubusercontent.com/39598672/126379350-11629a54-c113-4b02-bb34-51b9f715ddb1.png">
<img width="526" alt="Screen Shot 2021-07-20 at 2 31 20 PM" src="https://user-images.githubusercontent.com/39598672/126379371-ee64a0c6-87e0-48c1-ae9b-389e00c6191d.png">

