### PR TITLE
feat: rating indicator non-interactive mode

### DIFF
--- a/src/rating-indicator.scss
+++ b/src/rating-indicator.scss
@@ -70,7 +70,14 @@ $block: #{$fd-namespace}-rating-indicator;
     }
   }
 
+  @mixin fd-rating-indicator-labels-after-checked() {
+    .#{$block}__input:checked ~ .#{$block}__input + .#{$block}__label {
+      @content;
+    }
+  }
+
   @include fd-reset();
+  @include fd-flex-center();
 
   position: relative;
 
@@ -93,23 +100,13 @@ $block: #{$fd-namespace}-rating-indicator;
           outline-style: var(--sapContent_FocusStyle);
         }
       }
-    ;
-
-      ~ input + .#{$block}__label {
-        @include fd-icon-glyph('unfavorite') {
-          color: var(--sapContent_UnratedColor);
-        }
-
-        &:hover::before {
-          opacity: 1;
-        }
-      }
     }
   }
 
   &__label {
     @include fd-reset();
     @include action-cursor();
+    @include fd-flex-vertical-center();
 
     @include fd-icon-glyph('favorite') {
       font-family: "SAP-icons";
@@ -117,9 +114,8 @@ $block: #{$fd-namespace}-rating-indicator;
       font-size: $fd-rating-indicator-default-font-size;
     }
 
-    display: flex;
-    align-items: center;
     float: left;
+    opacity: 1;
     height: $fd-rating-indicator-default-font-size;
     margin-right: $fd-rating-indicator-default-spacing-between-icons;
 
@@ -130,6 +126,12 @@ $block: #{$fd-namespace}-rating-indicator;
     &:hover::before {
       opacity: var(--fdRating_Indicator_Selected_Hover_Opacity);
       transition: opacity $fd-animation-speed ease-in;
+    }
+  }
+
+  @include fd-rating-indicator-labels-after-checked() {
+    @include fd-icon-glyph('unfavorite') {
+      color: var(--sapContent_UnratedColor);
     }
   }
 
@@ -176,37 +178,38 @@ $block: #{$fd-namespace}-rating-indicator;
       @include fd-icon-glyph('favorite') {
         color: var(--fdRating_Indicator_Disabled_Selected_Color);
       }
+    }
 
-      &:checked ~ input + .#{$block}__label {
-        @include fd-icon-glyph('favorite') {
-          color: var(--fdRating_Indicator_Disabled_Unselected_Color);
-        }
+    @include fd-rating-indicator-labels-after-checked() {
+      @include fd-icon-glyph('favorite') {
+        color: var(--fdRating_Indicator_Disabled_Unselected_Color);
       }
     }
   }
 
-  @include fd-flex-center();
-
-  &.is-display-mode {
-    pointer-events: none;
-
+  &.#{$block}--display-mode {
     .#{$block}__label {
+      margin-right: 0.125rem;
+
       @include fd-icon-glyph('favorite') {
+        font-size: 1rem;
         color: var(--fdRating_Indicator_Display_Only_Selected_Color);
       }
 
-      &::before {
-        font-size: 1rem;
+      @include fd-rtl() {
+        margin-right: 0;
+        margin-left: 0.125rem;
       }
-
-      margin-right: 0.125rem;
     }
+  }
 
-    .#{$block}__input {
-      &:checked ~ input + .#{$block}__label {
-        @include fd-icon-glyph('favorite') {
-          color: var(--sapContent_UnratedColor);
-        }
+  &.#{$block}--non-interactive,
+  &.#{$block}--display-mode {
+    pointer-events: none;
+
+    @include fd-rating-indicator-labels-after-checked() {
+      @include fd-icon-glyph('favorite') {
+        color: var(--sapContent_UnratedColor);
       }
     }
   }
@@ -230,21 +233,21 @@ $block: #{$fd-namespace}-rating-indicator;
       background-repeat: no-repeat;
     }
 
-    .#{$block}__input {
-      &:checked ~ input + .#{$block}__label {
-        background-image: var(--sapRating-indicator-icon-unrated);
-      }
+    @include fd-rating-indicator-labels-after-checked() {
+      background-image: var(--sapRating-indicator-icon-unrated);
     }
   }
 
-  // BLOCK MODIFIERS ************
-  // sizes
+  // ************ BLOCK MODIFIERS ************
+  // Sizes
 
   @each $set-name, $size-set in $fd-rating-indicator-sizes {
     $fd-rating-indicator-sizes-font-size: map_get($size-set, "fontSize");
     $fd-rating-indicator-sizes-spacing-between-icons: map_get($size-set, "spacingBetweenIcons");
+
     &--#{$set-name} {
       @include fd-reset-spacing();
+
       $controlMargin: map_get($size-set, "controlMargin");
 
       @if $controlMargin {

--- a/stories/rating-indicator/__snapshots__/rating-indicator.stories.storyshot
+++ b/stories/rating-indicator/__snapshots__/rating-indicator.stories.storyshot
@@ -1,14 +1,126 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Components/Rating Indicator Custom icons 1`] = `
+<div
+  class="example-container"
+>
+  
+    
+  <div
+    class="fd-rating-indicator fd-rating-indicator--icon"
+    style="--sapRating-indicator-icon-rated: url('./assets/icons/rated.png'); --sapRating-indicator-icon-unrated: url('./assets/icons/unrated.png')"
+  >
+    
+        
+    <div
+      aria-label="Star Rating (out of 5)"
+      class="fd-rating-indicator__container"
+    >
+      
+            
+      <input
+        aria-label="1 star"
+        class="fd-rating-indicator__input"
+        id="rating-icon-1"
+        name="rating-icon"
+        type="radio"
+        value="1"
+      />
+      
+            
+      <label
+        class="fd-rating-indicator__label"
+        for="rating-icon-1"
+      />
+      
+            
+            
+      <input
+        aria-label="2 star"
+        checked=""
+        class="fd-rating-indicator__input"
+        id="rating-icon-2"
+        name="rating-icon"
+        type="radio"
+        value="2\\""
+      />
+      
+            
+      <label
+        class="fd-rating-indicator__label"
+        for="rating-icon-2"
+      />
+      
+            
+            
+      <input
+        aria-label="3 star"
+        class="fd-rating-indicator__input"
+        id="rating-icon-3"
+        name="rating-icon"
+        type="radio"
+        value="3"
+      />
+      
+            
+      <label
+        class="fd-rating-indicator__label"
+        for="rating-icon-3"
+      />
+      
+            
+            
+      <input
+        aria-label="4 star"
+        class="fd-rating-indicator__input"
+        id="rating-icon-4"
+        name="rating-icon"
+        type="radio"
+        value="4"
+      />
+      
+            
+      <label
+        class="fd-rating-indicator__label"
+        for="rating-icon-4"
+      />
+      
+            
+            
+      <input
+        aria-label="5 star"
+        class="fd-rating-indicator__input"
+        id="rating-icon-5"
+        name="rating-icon"
+        type="radio"
+        value="5"
+      />
+      
+            
+      <label
+        class="fd-rating-indicator__label"
+        for="rating-icon-5"
+      />
+      
+        
+    </div>
+    
+        
+    <span
+      class="fd-rating-indicator__dynamic-text"
+    >
+      (2 of 5)
+    </span>
+    
+    
+  </div>
+  
 
-
+</div>
 `;
 
 exports[`Storyshots Components/Rating Indicator Different values 1`] = `
 <section>
-  
-    
   <div
     class="example-container"
   >
@@ -417,24 +529,580 @@ exports[`Storyshots Components/Rating Indicator Different values 1`] = `
 `;
 
 exports[`Storyshots Components/Rating Indicator Disabled 1`] = `
+<div
+  class="example-container"
+>
+  
+    
+  <div
+    aria-disabled="true"
+    class="fd-rating-indicator"
+  >
+    
+        
+    <div
+      aria-label="Star Rating (out of 5)"
+      class="fd-rating-indicator__container"
+    >
+      
+            
+      <input
+        aria-label="1 star"
+        class="fd-rating-indicator__input"
+        disabled=""
+        id="rating-disabled-1"
+        name="rating-disabled"
+        type="radio"
+        value="1"
+      />
+        
+            
+      <label
+        class="fd-rating-indicator__label"
+        for="rating-disabled-1"
+      />
+      
+            
+            
+      <input
+        aria-label="2 star"
+        checked=""
+        class="fd-rating-indicator__input"
+        disabled=""
+        id="rating-disabled-2"
+        name="rating-disabled"
+        type="radio"
+        value="2"
+      />
+      
+            
+      <label
+        class="fd-rating-indicator__label"
+        for="rating-disabled-2"
+      />
+      
+            
+            
+      <input
+        aria-label="3 star"
+        class="fd-rating-indicator__input"
+        disabled=""
+        id="rating-disabled-3"
+        name="rating-disabled"
+        type="radio"
+        value="3"
+      />
+      
+            
+      <label
+        class="fd-rating-indicator__label"
+        for="rating-disabled-3"
+      />
+      
+            
+            
+      <input
+        aria-label="4 star"
+        class="fd-rating-indicator__input"
+        disabled=""
+        id="rating-disabled-4"
+        name="rating-disabled"
+        type="radio"
+        value="4"
+      />
+      
+            
+      <label
+        class="fd-rating-indicator__label"
+        for="rating-disabled-4"
+      />
+      
+            
+            
+      <input
+        aria-label="5 star"
+        class="fd-rating-indicator__input"
+        disabled=""
+        id="rating-disabled-5"
+        name="rating-disabled"
+        type="radio"
+        value="5"
+      />
+      
+            
+      <label
+        class="fd-rating-indicator__label"
+        for="rating-disabled-5"
+      />
+      
+        
+    </div>
+    
+        
+    <span
+      class="fd-rating-indicator__dynamic-text"
+    >
+      (2 of 5)
+    </span>
+    
+    
+  </div>
+  
 
-
+</div>
 `;
 
 exports[`Storyshots Components/Rating Indicator Display mode 1`] = `
+<div
+  class="example-container"
+>
+  
+        
+  <div
+    class="fd-rating-indicator fd-rating-indicator--display-mode"
+  >
     
+            
+    <div
+      aria-label="Star Rating (out of 5)"
+      class="fd-rating-indicator__container"
+    >
+      
+                
+      <input
+        aria-label="1 star"
+        class="fd-rating-indicator__input"
+        disabled=""
+        id="rating-display-mode-1"
+        name="rating-display-mode"
+        type="radio"
+        value="1"
+      />
+        
+                
+      <label
+        class="fd-rating-indicator__label"
+        for="rating-display-mode-1"
+      />
+      
+                
+                
+      <input
+        aria-label="2 star"
+        checked=""
+        class="fd-rating-indicator__input"
+        disabled=""
+        id="rating-display-mode-2"
+        name="rating-display-mode"
+        type="radio"
+        value="2"
+      />
+      
+                
+      <label
+        class="fd-rating-indicator__label"
+        for="rating-display-mode-2"
+      />
+      
+                
+                
+      <input
+        aria-label="3 star"
+        class="fd-rating-indicator__input"
+        disabled=""
+        id="rating-display-mode-3"
+        name="rating-display-mode"
+        type="radio"
+        value="3"
+      />
+      
+                
+      <label
+        class="fd-rating-indicator__label"
+        for="rating-display-mode-3"
+      />
+      
+                
+                
+      <input
+        aria-label="4 star"
+        class="fd-rating-indicator__input"
+        disabled=""
+        id="rating-display-mode-4"
+        name="rating-display-mode"
+        type="radio"
+        value="4"
+      />
+      
+                
+      <label
+        class="fd-rating-indicator__label"
+        for="rating-display-mode-4"
+      />
+      
+                
+                
+      <input
+        aria-label="5 star"
+        class="fd-rating-indicator__input"
+        disabled=""
+        id="rating-display-mode-5"
+        name="rating-display-mode"
+        type="radio"
+        value="5"
+      />
+      
+                
+      <label
+        class="fd-rating-indicator__label"
+        for="rating-display-mode-5"
+      />
+      
+            
+    </div>
     
+            
+    <span
+      class="fd-rating-indicator__dynamic-text"
+    >
+      (2 of 5)
+    </span>
+    
+        
+  </div>
+  
+    
+</div>
 `;
 
 exports[`Storyshots Components/Rating Indicator Half values 1`] = `
+<div
+  class="example-container"
+>
+  
+    
+  <div
+    class="fd-rating-indicator fd-rating-indicator--half-star"
+  >
+    
+        
+    <div
+      aria-label="Star Rating (out of 5)"
+      class="fd-rating-indicator__container"
+    >
+      
+            
+      <input
+        aria-label="half star"
+        class="fd-rating-indicator__input"
+        id="rating-half-sizes-05"
+        name="rating-half-sizes"
+        type="radio"
+        value="0.5"
+      />
+        
+            
+      <label
+        class="fd-rating-indicator__label"
+        for="rating-half-sizes-05"
+      />
+      
 
+            
+      <input
+        aria-label="1 star"
+        class="fd-rating-indicator__input"
+        id="rating-half-sizes-1"
+        name="rating-half-sizes"
+        type="radio"
+        value="1"
+      />
+      
+            
+      <label
+        class="fd-rating-indicator__label"
+        for="rating-half-sizes-1"
+      />
+      
+            
+            
+      <input
+        aria-label="1 and half star"
+        class="fd-rating-indicator__input"
+        id="rating-half-sizes-15"
+        name="rating-half-sizes"
+        type="radio"
+        value="1.5"
+      />
+      
+            
+      <label
+        class="fd-rating-indicator__label"
+        for="rating-half-sizes-15"
+      />
+      
+            
+            
+      <input
+        aria-label="2 star"
+        class="fd-rating-indicator__input"
+        id="rating-half-sizes-2"
+        name="rating-half-sizes"
+        type="radio"
+        value="2\\""
+      />
+      
+            
+      <label
+        class="fd-rating-indicator__label"
+        for="rating-half-sizes-2"
+      />
+      
+            
+            
+      <input
+        aria-label="2 and half star"
+        checked=""
+        class="fd-rating-indicator__input"
+        id="rating-half-sizes-25"
+        name="rating-half-sizes"
+        type="radio"
+        value="2.5"
+      />
+      
+            
+      <label
+        class="fd-rating-indicator__label"
+        for="rating-half-sizes-25"
+      />
+      
+            
+            
+      <input
+        aria-label="3 star"
+        class="fd-rating-indicator__input"
+        id="rating-half-sizes-3"
+        name="rating-half-sizes"
+        type="radio"
+        value="3"
+      />
+      
+            
+      <label
+        class="fd-rating-indicator__label"
+        for="rating-half-sizes-3"
+      />
+      
+            
+            
+      <input
+        aria-label="3 and half star"
+        class="fd-rating-indicator__input"
+        id="rating-half-sizes-35"
+        name="rating-half-sizes"
+        type="radio"
+        value="3.5"
+      />
+      
+            
+      <label
+        class="fd-rating-indicator__label"
+        for="rating-half-sizes-35"
+      />
+      
+            
+            
+      <input
+        aria-label="4 star"
+        class="fd-rating-indicator__input"
+        id="rating-half-sizes-4"
+        name="rating-half-sizes"
+        type="radio"
+        value="4"
+      />
+      
+            
+      <label
+        class="fd-rating-indicator__label"
+        for="rating-half-sizes-4"
+      />
+      
+            
+            
+      <input
+        aria-label="4 and half star"
+        class="fd-rating-indicator__input"
+        id="rating-half-sizes-45"
+        name="rating-half-sizes"
+        type="radio"
+        value="4.5"
+      />
+      
+            
+      <label
+        class="fd-rating-indicator__label"
+        for="rating-half-sizes-45"
+      />
+      
+            
+            
+      <input
+        aria-label="5 star"
+        class="fd-rating-indicator__input"
+        id="rating-half-sizes-5"
+        name="rating-half-sizes"
+        type="radio"
+        value="5"
+      />
+      
+            
+      <label
+        class="fd-rating-indicator__label"
+        for="rating-half-sizes-5"
+      />
+      
+        
+    </div>
+    
+        
+    <span
+      class="fd-rating-indicator__dynamic-text"
+    >
+      (2.5 of 5)
+    </span>
+    
+    
+  </div>
+  
 
+</div>
+`;
+
+exports[`Storyshots Components/Rating Indicator Non-interactive 1`] = `
+<div
+  class="example-container"
+>
+  
+        
+  <div
+    class="fd-rating-indicator fd-rating-indicator--non-interactive"
+  >
+    
+            
+    <div
+      aria-label="Star Rating (out of 5)"
+      class="fd-rating-indicator__container"
+    >
+      
+                
+      <input
+        aria-label="1 star"
+        class="fd-rating-indicator__input"
+        disabled=""
+        id="rating-non-interactive-mode-1"
+        name="rating-non-interactive-mode"
+        type="radio"
+        value="1"
+      />
+        
+                
+      <label
+        class="fd-rating-indicator__label"
+        for="rating-non-interactive-mode-1"
+      />
+      
+                
+                
+      <input
+        aria-label="2 star"
+        checked=""
+        class="fd-rating-indicator__input"
+        disabled=""
+        id="rating-non-interactive-mode-2"
+        name="rating-non-interactive-mode"
+        type="radio"
+        value="2"
+      />
+      
+                
+      <label
+        class="fd-rating-indicator__label"
+        for="rating-non-interactive-mode-2"
+      />
+      
+                
+                
+      <input
+        aria-label="3 star"
+        class="fd-rating-indicator__input"
+        disabled=""
+        id="rating-non-interactive-mode-3"
+        name="rating-non-interactive-mode"
+        type="radio"
+        value="3"
+      />
+      
+                
+      <label
+        class="fd-rating-indicator__label"
+        for="rating-non-interactive-mode-3"
+      />
+      
+                
+                
+      <input
+        aria-label="4 star"
+        class="fd-rating-indicator__input"
+        disabled=""
+        id="rating-non-interactive-mode-4"
+        name="rating-non-interactive-mode"
+        type="radio"
+        value="4"
+      />
+      
+                
+      <label
+        class="fd-rating-indicator__label"
+        for="rating-non-interactive-mode-4"
+      />
+      
+                
+                
+      <input
+        aria-label="5 star"
+        class="fd-rating-indicator__input"
+        disabled=""
+        id="rating-non-interactive-mode-5"
+        name="rating-non-interactive-mode"
+        type="radio"
+        value="5"
+      />
+      
+                
+      <label
+        class="fd-rating-indicator__label"
+        for="rating-non-interactive-mode-5"
+      />
+      
+            
+    </div>
+    
+            
+    <span
+      class="fd-rating-indicator__dynamic-text"
+    >
+      (2 of 5)
+    </span>
+    
+        
+  </div>
+  
+    
+</div>
 `;
 
 exports[`Storyshots Components/Rating Indicator Sizes 1`] = `
 <section>
-  
-    
   <div
     class="example-container"
   >

--- a/stories/rating-indicator/rating-indicator.stories.js
+++ b/stories/rating-indicator/rating-indicator.stories.js
@@ -14,8 +14,7 @@ Use the rating indicator in forms, tables, or in a dialog box.
     }
 };
 
-export const Sizes = () => `
-    <div class="example-container">
+export const Sizes = () => `<div class="example-container">
         <span style="min-width: 150px;">Default (Medium):</span>
         <div class="fd-rating-indicator fd-rating-indicator--hide-dynamic-text">
             <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
@@ -195,8 +194,7 @@ Sizes.parameters = {
     }
 };
 
-export const HalfValues = () => `
-<div class="example-container">
+export const HalfValues = () => `<div class="example-container">
     <div class="fd-rating-indicator fd-rating-indicator--half-star">
         <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
             <input aria-label="half star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-05" name="rating-half-sizes" value="0.5">  
@@ -244,8 +242,7 @@ modifier class together with the \`fd-rating-indicator\` class.
     }
 };
 
-export const CustomIcons = () => `
-<div class="example-container">
+export const CustomIcons = () => `<div class="example-container">
     <div class="fd-rating-indicator fd-rating-indicator--icon"
     style="--sapRating-indicator-icon-rated: url('./assets/icons/rated.png'); --sapRating-indicator-icon-unrated: url('./assets/icons/unrated.png')">
         <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
@@ -280,8 +277,7 @@ Additionally, needs to set css variables \`--sapRating-indicator-icon-rated: url
     }
 };
 
-export const Disabled = () => `
-<div class="example-container">
+export const Disabled = () => `<div class="example-container">
     <div class="fd-rating-indicator" aria-disabled="true">
         <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
             <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-disabled-1" name="rating-disabled" value="1" disabled>  
@@ -317,9 +313,8 @@ Additionally, one of the selectors listed below needs to be added to the \`fd-ra
     }
 };
 
-export const DisplayMode = () => `    
-    <div class="example-container">
-        <div class="fd-rating-indicator is-display-mode">
+export const DisplayMode = () => `<div class="example-container">
+        <div class="fd-rating-indicator fd-rating-indicator--display-mode">
             <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
                 <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-display-mode-1" name="rating-display-mode" value="1" disabled>  
                 <label class="fd-rating-indicator__label" for="rating-display-mode-1"></label>
@@ -345,15 +340,46 @@ DisplayMode.storyName = 'Display mode';
 DisplayMode.parameters = {
     docs: {
         storyDescription: `
-Data can be presented as label-value field pairs without editable fields in display-only forms, 
-see <a href="form-grid.html">Form Grid</a> for more details. If you want to include a rating indicator in a display-only form, 
-add the \`.is-display-mode\` to the \`fd-rating-indicator\` element.
+Data can be presented as label-value field pairs without editable fields in display-only forms, see <a href="../?path=/docs/components-forms-form-grid--s-size">Form Grid</a> for more details.
+If you want to include a rating indicator in a display-only form, add the \`.fd-rating-indicator--display-mode\` to the \`fd-rating-indicator\` element.
 `
     }
 };
 
-export const DifferentValues = () => `
-    <div class="example-container">
+export const NonInteractive = () => `<div class="example-container">
+        <div class="fd-rating-indicator fd-rating-indicator--non-interactive">
+            <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
+                <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-non-interactive-mode-1" name="rating-non-interactive-mode" value="1" disabled>  
+                <label class="fd-rating-indicator__label" for="rating-non-interactive-mode-1"></label>
+                
+                <input aria-label="2 star" type="radio" class="fd-rating-indicator__input" id="rating-non-interactive-mode-2" name="rating-non-interactive-mode" value="2" disabled checked>
+                <label class="fd-rating-indicator__label" for="rating-non-interactive-mode-2"></label>
+                
+                <input aria-label="3 star" type="radio" class="fd-rating-indicator__input" id="rating-non-interactive-mode-3" name="rating-non-interactive-mode" value="3" disabled>
+                <label class="fd-rating-indicator__label" for="rating-non-interactive-mode-3"></label>
+                
+                <input aria-label="4 star" type="radio" class="fd-rating-indicator__input" id="rating-non-interactive-mode-4" name="rating-non-interactive-mode" value="4" disabled>
+                <label class="fd-rating-indicator__label" for="rating-non-interactive-mode-4"></label>
+                
+                <input aria-label="5 star" type="radio" class="fd-rating-indicator__input" id="rating-non-interactive-mode-5" name="rating-non-interactive-mode" value="5" disabled>
+                <label class="fd-rating-indicator__label" for="rating-non-interactive-mode-5"></label>
+            </div>
+            <span class="fd-rating-indicator__dynamic-text">(2 of 5)</span>
+        </div>
+    </div>
+`;
+
+NonInteractive.storyName = 'Non-interactive';
+NonInteractive.parameters = {
+    docs: {
+        storyDescription: `
+If you want to include a rating indicator in a display-only form, 
+add the \`.fd-rating-indicator--non-interactive\` class to the \`fd-rating-indicator\` element.
+`
+    }
+};
+
+export const DifferentValues = () => `<div class="example-container">
         <div class="fd-rating-indicator">
             <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
                 <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-max-value-5-1" name="rating-max-value-5" value="1">  


### PR DESCRIPTION
## Related Issue

Closes #2008.

## Description

Non-interactive mode for the Rating Indicator component, styles refactoring.

## Screenshots

### Before:

### After:

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [X] All values are in `rem`
- [X] Text elements follow the truncation rules
- [X] hover state of the element follow design spec
- [X] focus state of the element follow design spec
- [X] active state of the element follow design spec
- [X] selected state of the element follow design spec
- [X] selected hover state of the element follow design spec
- [X] pressed state of the element follow design spec
- [X] Responsiveness rules - the component has modifier classes for all breakpoints
- [X] Includes Compact/Cosy/Tablet design
- [X] RTL support
2. The code follows fundamental-styles code standards and style
- [X] only one top level `fd-*` class is used in the file
- [X] BEM naming convention is used
- [X] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [X] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [X] `fd-reset()` mixin is applied to all elements
- [X] Variables are used, if some value is used more than twice.
- [X] Checked if current components can be reused, instead of having new code.
3. Testing
- [X] tested Storybook examples with "CSS Resources" `normalize` option 
- [X] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [X] Verified all styles in IE11
- [X] Updated tests
- [X] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [X] Storybook documentation has been created/updated
- [X] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.