### PR TITLE
fix: introduce modifier class to fix nested-list-popover

### DIFF
--- a/src/_nested-list.scss
+++ b/src/_nested-list.scss
@@ -110,10 +110,6 @@ $button: #{$fd-namespace}-button;
     align-items: center;
     border-top: var(--sapList_BorderWidth) solid var(--sapList_BorderColor);
 
-    &:first-child {
-      border-top: none;
-    }
-
     @include fd-hover() {
       background: var(--sapList_Hover_Background);
 

--- a/src/_nested-list.scss
+++ b/src/_nested-list.scss
@@ -69,6 +69,10 @@ $button: #{$fd-namespace}-button;
     display: none;
   }
 
+  &__popover {
+    border-bottom: none;
+  }
+
   &__item {
     @include fd-reset();
 
@@ -79,6 +83,13 @@ $button: #{$fd-namespace}-button;
       .#{$block}__link,
       .#{$block}__content {
         border-top: none;
+      }
+    }
+
+    &--popover {
+      &:last-child {
+        border-bottom-left-radius: 0.25rem;
+        border-bottom-right-radius: 0.25rem;
       }
     }
   }
@@ -93,6 +104,10 @@ $button: #{$fd-namespace}-button;
     width: 100%;
     align-items: center;
     border-top: var(--sapList_BorderWidth) solid var(--sapList_BorderColor);
+
+    &:first-child {
+      border-top: none;
+    }
 
     @include fd-hover() {
       background: var(--sapList_Hover_Background);
@@ -242,6 +257,11 @@ $button: #{$fd-namespace}-button;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+
+    &--popover {
+      border-top-left-radius: 0.25rem;
+      border-top-right-radius: 0.25rem;
+    }
   }
 
   &--no-border {

--- a/src/_nested-list.scss
+++ b/src/_nested-list.scss
@@ -32,6 +32,8 @@ $button: #{$fd-namespace}-button;
     }
   }
 
+  $border-radius: 0.25rem;
+
   @include fd-reset();
 
   list-style: none;
@@ -88,13 +90,25 @@ $button: #{$fd-namespace}-button;
 
     &--popover {
       &:first-child {
-        border-top-left-radius: 0.25rem;
-        border-top-right-radius: 0.25rem;
+        border-top-left-radius: $border-radius;
+        border-top-right-radius: $border-radius;
+
+        .#{$block}__link,
+        .#{$block}__content {
+          border-top-left-radius: $border-radius;
+          border-top-right-radius: $border-radius;
+        }
       }
 
       &:last-child {
-        border-bottom-left-radius: 0.25rem;
-        border-bottom-right-radius: 0.25rem;
+        border-bottom-left-radius: $border-radius;
+        border-bottom-right-radius: $border-radius;
+
+        .#{$block}__link,
+        .#{$block}__content {
+          border-bottom-left-radius: $border-radius;
+          border-bottom-right-radius: $border-radius;
+        }
       }
     }
   }
@@ -260,8 +274,9 @@ $button: #{$fd-namespace}-button;
     text-overflow: ellipsis;
 
     &--popover {
-      border-top-left-radius: 0.25rem;
-      border-top-right-radius: 0.25rem;
+      border-top-left-radius: $border-radius;
+      border-top-right-radius: $border-radius;
+      border-bottom: none;
     }
   }
 

--- a/src/_nested-list.scss
+++ b/src/_nested-list.scss
@@ -69,7 +69,7 @@ $button: #{$fd-namespace}-button;
     display: none;
   }
 
-  &__popover {
+  &--popover {
     border-bottom: none;
   }
 

--- a/src/_nested-list.scss
+++ b/src/_nested-list.scss
@@ -87,6 +87,11 @@ $button: #{$fd-namespace}-button;
     }
 
     &--popover {
+      &:first-child {
+        border-top-left-radius: 0.25rem;
+        border-top-right-radius: 0.25rem;
+      }
+
       &:last-child {
         border-bottom-left-radius: 0.25rem;
         border-bottom-right-radius: 0.25rem;

--- a/src/_nested-list.scss
+++ b/src/_nested-list.scss
@@ -5,6 +5,8 @@ $block: #{$fd-namespace}-nested-list;
 $button: #{$fd-namespace}-button;
 
 .#{$block} {
+  $fd-nested-list-border-radius: 0.25rem;
+
   @mixin fd-nested-level-padding($paddingLeft, $paddingRight) {
     .#{$block}__link,
     .#{$block}__content {
@@ -32,7 +34,15 @@ $button: #{$fd-namespace}-button;
     }
   }
 
-  $border-radius: 0.25rem;
+  @mixin fd-nested-list-popover-border-top-radius {
+    border-top-left-radius: $fd-nested-list-border-radius;
+    border-top-right-radius: $fd-nested-list-border-radius;
+  }
+
+  @mixin fd-nested-list-popover-border-bottom-radius {
+    border-bottom-left-radius: $fd-nested-list-border-radius;
+    border-bottom-right-radius: $fd-nested-list-border-radius;
+  }
 
   @include fd-reset();
 
@@ -73,6 +83,32 @@ $button: #{$fd-namespace}-button;
 
   &--popover {
     border-bottom: none;
+
+    .#{$block}__group-header {
+      @include fd-nested-list-popover-border-top-radius();
+
+      border-bottom: none;
+    }
+
+    .#{$block}__item {
+      &:first-child {
+        @include fd-nested-list-popover-border-top-radius();
+
+        .#{$block}__link,
+        .#{$block}__content {
+          @include fd-nested-list-popover-border-top-radius();
+        }
+      }
+
+      &:last-child {
+        @include fd-nested-list-popover-border-bottom-radius();
+
+        .#{$block}__link,
+        .#{$block}__content {
+          @include fd-nested-list-popover-border-bottom-radius();
+        }
+      }
+    }
   }
 
   &__item {
@@ -85,30 +121,6 @@ $button: #{$fd-namespace}-button;
       .#{$block}__link,
       .#{$block}__content {
         border-top: none;
-      }
-    }
-
-    &--popover {
-      &:first-child {
-        border-top-left-radius: $border-radius;
-        border-top-right-radius: $border-radius;
-
-        .#{$block}__link,
-        .#{$block}__content {
-          border-top-left-radius: $border-radius;
-          border-top-right-radius: $border-radius;
-        }
-      }
-
-      &:last-child {
-        border-bottom-left-radius: $border-radius;
-        border-bottom-right-radius: $border-radius;
-
-        .#{$block}__link,
-        .#{$block}__content {
-          border-bottom-left-radius: $border-radius;
-          border-bottom-right-radius: $border-radius;
-        }
       }
     }
   }
@@ -272,12 +284,6 @@ $button: #{$fd-namespace}-button;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-
-    &--popover {
-      border-top-left-radius: $border-radius;
-      border-top-right-radius: $border-radius;
-      border-bottom: none;
-    }
   }
 
   &--no-border {

--- a/stories/side-navigation/__snapshots__/side-navigation.stories.storyshot
+++ b/stories/side-navigation/__snapshots__/side-navigation.stories.storyshot
@@ -2144,169 +2144,329 @@ exports[`Storyshots Components/Side Navigation Icons 1`] = `
 `;
 
 exports[`Storyshots Components/Side Navigation Nested List Popover 1`] = `
-<div
-  class="fd-popover fd-popover--right"
-  style="margin-bottom: 200px"
->
-  
-    
+<section>
   <div
-    class="fd-popover__control"
+    class="fd-popover fd-popover--right"
+    style="margin-bottom: 200px; margin-right: 200px;"
   >
     
-        
-    <ul
-      class="fd-nested-list fd-nested-list--compact"
+    
+    <div
+      class="fd-popover__control"
     >
       
-            
-      <li
-        class="fd-nested-list__item"
+        
+      <ul
+        class="fd-nested-list fd-nested-list--compact"
       >
         
-                
-        <a
-          class="fd-nested-list__link"
-          href="#/"
+            
+        <li
+          class="fd-nested-list__item"
         >
           
-                    
-          <i
-            class="fd-nested-list__icon sap-icon--home"
-            role="presentation"
-          />
-          
                 
-        </a>
-        
+          <a
+            class="fd-nested-list__link"
+            href="#/"
+          >
             
-      </li>
+                    
+            <i
+              class="fd-nested-list__icon sap-icon--home"
+              role="presentation"
+            />
+            
+                
+          </a>
+          
+            
+        </li>
+        
+        
+      </ul>
       
-        
-    </ul>
+    
+    </div>
     
     
-  </div>
-  
-    
-  <div
-    aria-hidden="false"
-    class="fd-popover__popper"
-    id="popoverA11"
-  >
-    
-        
-    <ul
-      class="fd-nested-list fd-nested-list__popover fd-nested-list--compact"
+    <div
+      aria-hidden="false"
+      class="fd-popover__popper"
+      id="popoverA11"
     >
       
-            
-      <li
-        class="fd-nested-list__group-header fd-nested-list__group-header--popover"
+        
+      <ul
+        class="fd-nested-list fd-nested-list__popover fd-nested-list--compact"
       >
         
+            
+        <li
+          class="fd-nested-list__group-header fd-nested-list__group-header--popover"
+        >
+          
                 Group Header 1
             
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item fd-nested-list__item--popover"
-      >
+        </li>
         
-                
-        <a
-          class="fd-nested-list__link"
-          href="#/"
+            
+        <li
+          class="fd-nested-list__item fd-nested-list__item--popover"
         >
           
-                    
-          <i
-            class="fd-nested-list__icon sap-icon--home"
-            role="presentation"
-          />
-          
-                    
-          <span
-            class="fd-nested-list__title"
+                
+          <a
+            class="fd-nested-list__link"
+            href="#/"
           >
-            Level 1 Item
-          </span>
+            
+                    
+            <i
+              class="fd-nested-list__icon sap-icon--home"
+              role="presentation"
+            />
+            
+                    
+            <span
+              class="fd-nested-list__title"
+            >
+              Level 1 Item
+            </span>
+            
+                
+          </a>
           
-                
-        </a>
+            
+        </li>
         
             
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item fd-nested-list__item--popover"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link is-selected"
-          href="#/"
+        <li
+          class="fd-nested-list__item fd-nested-list__item--popover"
         >
           
-                    
-          <i
-            class="fd-nested-list__icon sap-icon--calendar"
-            role="presentation"
-          />
-          
-                    
-          <span
-            class="fd-nested-list__title"
+                
+          <a
+            class="fd-nested-list__link is-selected"
+            href="#/"
           >
-            Level 1 Item
-          </span>
+            
+                    
+            <i
+              class="fd-nested-list__icon sap-icon--calendar"
+              role="presentation"
+            />
+            
+                    
+            <span
+              class="fd-nested-list__title"
+            >
+              Level 1 Item
+            </span>
+            
+                
+          </a>
           
-                
-        </a>
+            
+        </li>
         
             
-      </li>
-      
-            
-      <li
-        class="fd-nested-list__item fd-nested-list__item--popover"
-      >
-        
-                
-        <a
-          class="fd-nested-list__link"
-          href="#/"
+        <li
+          class="fd-nested-list__item fd-nested-list__item--popover"
         >
           
-                    
-          <i
-            class="fd-nested-list__icon sap-icon--activities"
-            role="presentation"
-          />
-          
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Level 1 Item
-          </span>
-          
                 
-        </a>
-        
+          <a
+            class="fd-nested-list__link"
+            href="#/"
+          >
             
-      </li>
-      
+                    
+            <i
+              class="fd-nested-list__icon sap-icon--activities"
+              role="presentation"
+            />
+            
+                    
+            <span
+              class="fd-nested-list__title"
+            >
+              Level 1 Item
+            </span>
+            
+                
+          </a>
+          
+            
+        </li>
         
-    </ul>
+        
+      </ul>
+      
     
+    </div>
     
+
   </div>
   
 
-</div>
+  <div
+    class="fd-popover fd-popover--right"
+    style="margin-bottom: 200px"
+  >
+    
+    
+    <div
+      class="fd-popover__control"
+    >
+      
+        
+      <ul
+        class="fd-nested-list fd-nested-list--compact"
+      >
+        
+            
+        <li
+          class="fd-nested-list__item"
+        >
+          
+                
+          <a
+            class="fd-nested-list__link"
+            href="#/"
+          >
+            
+                    
+            <i
+              class="fd-nested-list__icon sap-icon--home"
+              role="presentation"
+            />
+            
+                
+          </a>
+          
+            
+        </li>
+        
+        
+      </ul>
+      
+    
+    </div>
+    
+    
+    <div
+      aria-hidden="false"
+      class="fd-popover__popper"
+      id="popoverA12"
+    >
+      
+        
+      <ul
+        class="fd-nested-list fd-nested-list__popover fd-nested-list--compact"
+      >
+        
+            
+        <li
+          class="fd-nested-list__item fd-nested-list__item--popover"
+        >
+          
+                
+          <a
+            class="fd-nested-list__link"
+            href="#/"
+          >
+            
+                    
+            <i
+              class="fd-nested-list__icon sap-icon--home"
+              role="presentation"
+            />
+            
+                    
+            <span
+              class="fd-nested-list__title"
+            >
+              Level 1 Item
+            </span>
+            
+                
+          </a>
+          
+            
+        </li>
+        
+            
+        <li
+          class="fd-nested-list__item fd-nested-list__item--popover"
+        >
+          
+                
+          <a
+            class="fd-nested-list__link is-selected"
+            href="#/"
+          >
+            
+                    
+            <i
+              class="fd-nested-list__icon sap-icon--calendar"
+              role="presentation"
+            />
+            
+                    
+            <span
+              class="fd-nested-list__title"
+            >
+              Level 1 Item
+            </span>
+            
+                
+          </a>
+          
+            
+        </li>
+        
+            
+        <li
+          class="fd-nested-list__item fd-nested-list__item--popover"
+        >
+          
+                
+          <a
+            class="fd-nested-list__link"
+            href="#/"
+          >
+            
+                    
+            <i
+              class="fd-nested-list__icon sap-icon--activities"
+              role="presentation"
+            />
+            
+                    
+            <span
+              class="fd-nested-list__title"
+            >
+              Level 1 Item
+            </span>
+            
+                
+          </a>
+          
+            
+        </li>
+        
+        
+      </ul>
+      
+    
+    </div>
+    
+
+  </div>
+  
+
+</section>
 `;
 
 exports[`Storyshots Components/Side Navigation Nested List With Group Headers 1`] = `

--- a/stories/side-navigation/__snapshots__/side-navigation.stories.storyshot
+++ b/stories/side-navigation/__snapshots__/side-navigation.stories.storyshot
@@ -2144,329 +2144,333 @@ exports[`Storyshots Components/Side Navigation Icons 1`] = `
 `;
 
 exports[`Storyshots Components/Side Navigation Nested List Popover 1`] = `
-<section>
+<div
+  class="fddocs-container"
+  style="margin-bottom: 200px;"
+>
+  
+    
   <div
     class="fd-popover fd-popover--right"
-    style="margin-bottom: 200px; margin-right: 200px; margin-left: 200px;"
   >
     
-    
+        
     <div
       class="fd-popover__control"
     >
       
-        
+            
       <ul
         class="fd-nested-list fd-nested-list--compact"
       >
         
-            
+                
         <li
           class="fd-nested-list__item"
         >
           
-                
+                    
           <a
             class="fd-nested-list__link"
             href="#/"
           >
             
-                    
+                        
             <i
               class="fd-nested-list__icon sap-icon--home"
               role="presentation"
             />
             
-                
+                    
           </a>
           
-            
+                
         </li>
         
-        
+            
       </ul>
       
-    
+        
     </div>
     
-    
+        
     <div
       aria-hidden="false"
       class="fd-popover__popper"
       id="popoverA11"
     >
       
-        
+            
       <ul
         class="fd-nested-list fd-nested-list--popover fd-nested-list--compact"
       >
         
-            
+                
         <li
-          class="fd-nested-list__group-header fd-nested-list__group-header--popover"
+          class="fd-nested-list__group-header"
         >
           
-                Group Header 1
-            
+                    Group Header 1
+                
         </li>
         
-            
+                
         <li
-          class="fd-nested-list__item fd-nested-list__item--popover"
+          class="fd-nested-list__item"
         >
           
-                
+                    
           <a
             class="fd-nested-list__link"
             href="#/"
           >
             
-                    
+                        
             <i
               class="fd-nested-list__icon sap-icon--home"
               role="presentation"
             />
             
-                    
+                        
             <span
               class="fd-nested-list__title"
             >
               Level 1 Item
             </span>
             
-                
+                    
           </a>
           
-            
+                
         </li>
         
-            
+                
         <li
-          class="fd-nested-list__item fd-nested-list__item--popover"
+          class="fd-nested-list__item"
         >
           
-                
+                    
           <a
             class="fd-nested-list__link is-selected"
             href="#/"
           >
             
-                    
+                        
             <i
               class="fd-nested-list__icon sap-icon--calendar"
               role="presentation"
             />
             
-                    
+                        
             <span
               class="fd-nested-list__title"
             >
               Level 1 Item
             </span>
             
-                
+                    
           </a>
           
-            
+                
         </li>
         
-            
+                
         <li
-          class="fd-nested-list__item fd-nested-list__item--popover"
+          class="fd-nested-list__item"
         >
           
-                
+                    
           <a
             class="fd-nested-list__link"
             href="#/"
           >
             
-                    
+                        
             <i
               class="fd-nested-list__icon sap-icon--activities"
               role="presentation"
             />
             
-                    
+                        
             <span
               class="fd-nested-list__title"
             >
               Level 1 Item
             </span>
             
-                
+                    
           </a>
           
-            
+                
         </li>
         
-        
+            
       </ul>
       
-    
+        
     </div>
     
-
+    
   </div>
   
-
+    
   <div
     class="fd-popover fd-popover--right"
     style="margin-bottom: 200px"
   >
     
-    
+        
     <div
       class="fd-popover__control"
     >
       
-        
+            
       <ul
         class="fd-nested-list fd-nested-list--compact"
       >
         
-            
+                
         <li
           class="fd-nested-list__item"
         >
           
-                
+                    
           <a
             class="fd-nested-list__link"
             href="#/"
           >
             
-                    
+                        
             <i
               class="fd-nested-list__icon sap-icon--home"
               role="presentation"
             />
             
-                
+                    
           </a>
           
-            
+                
         </li>
         
-        
+            
       </ul>
       
-    
+        
     </div>
     
-    
+        
     <div
       aria-hidden="false"
       class="fd-popover__popper"
       id="popoverA12"
     >
       
-        
+            
       <ul
         class="fd-nested-list fd-nested-list--popover fd-nested-list--compact"
       >
         
-            
+                
         <li
           class="fd-nested-list__item fd-nested-list__item--popover"
         >
           
-                
+                    
           <a
             class="fd-nested-list__link"
             href="#/"
           >
             
-                    
+                        
             <i
               class="fd-nested-list__icon sap-icon--home"
               role="presentation"
             />
             
-                    
+                        
             <span
               class="fd-nested-list__title"
             >
               Level 1 Item
             </span>
             
-                
+                    
           </a>
           
-            
+                
         </li>
         
-            
+                
         <li
           class="fd-nested-list__item fd-nested-list__item--popover"
         >
           
-                
+                    
           <a
             class="fd-nested-list__link is-selected"
             href="#/"
           >
             
-                    
+                        
             <i
               class="fd-nested-list__icon sap-icon--calendar"
               role="presentation"
             />
             
-                    
+                        
             <span
               class="fd-nested-list__title"
             >
               Level 1 Item
             </span>
             
-                
+                    
           </a>
           
-            
+                
         </li>
         
-            
+                
         <li
           class="fd-nested-list__item fd-nested-list__item--popover"
         >
           
-                
+                    
           <a
             class="fd-nested-list__link"
             href="#/"
           >
             
-                    
+                        
             <i
               class="fd-nested-list__icon sap-icon--activities"
               role="presentation"
             />
             
-                    
+                        
             <span
               class="fd-nested-list__title"
             >
               Level 1 Item
             </span>
             
-                
+                    
           </a>
           
-            
+                
         </li>
         
-        
+            
       </ul>
       
-    
+        
     </div>
     
-
+    
   </div>
   
 
-</section>
+</div>
 `;
 
 exports[`Storyshots Components/Side Navigation Nested List With Group Headers 1`] = `

--- a/stories/side-navigation/__snapshots__/side-navigation.stories.storyshot
+++ b/stories/side-navigation/__snapshots__/side-navigation.stories.storyshot
@@ -2147,7 +2147,7 @@ exports[`Storyshots Components/Side Navigation Nested List Popover 1`] = `
 <section>
   <div
     class="fd-popover fd-popover--right"
-    style="margin-bottom: 200px; margin-right: 200px;"
+    style="margin-bottom: 200px; margin-right: 200px; margin-left: 200px;"
   >
     
     

--- a/stories/side-navigation/__snapshots__/side-navigation.stories.storyshot
+++ b/stories/side-navigation/__snapshots__/side-navigation.stories.storyshot
@@ -2143,6 +2143,172 @@ exports[`Storyshots Components/Side Navigation Icons 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/Side Navigation Nested List Popover 1`] = `
+<div
+  class="fd-popover fd-popover--right"
+  style="margin-bottom: 200px"
+>
+  
+    
+  <div
+    class="fd-popover__control"
+  >
+    
+        
+    <ul
+      class="fd-nested-list fd-nested-list--compact"
+    >
+      
+            
+      <li
+        class="fd-nested-list__item"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#/"
+        >
+          
+                    
+          <i
+            class="fd-nested-list__icon sap-icon--home"
+            role="presentation"
+          />
+          
+                
+        </a>
+        
+            
+      </li>
+      
+        
+    </ul>
+    
+    
+  </div>
+  
+    
+  <div
+    aria-hidden="false"
+    class="fd-popover__popper"
+    id="popoverA11"
+  >
+    
+        
+    <ul
+      class="fd-nested-list fd-nested-list__popover fd-nested-list--compact"
+    >
+      
+            
+      <li
+        class="fd-nested-list__group-header fd-nested-list__group-header--popover"
+      >
+        
+                Group Header 1
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item fd-nested-list__item--popover"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#/"
+        >
+          
+                    
+          <i
+            class="fd-nested-list__icon sap-icon--home"
+            role="presentation"
+          />
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item fd-nested-list__item--popover"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link is-selected"
+          href="#/"
+        >
+          
+                    
+          <i
+            class="fd-nested-list__icon sap-icon--calendar"
+            role="presentation"
+          />
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-nested-list__item fd-nested-list__item--popover"
+      >
+        
+                
+        <a
+          class="fd-nested-list__link"
+          href="#/"
+        >
+          
+                    
+          <i
+            class="fd-nested-list__icon sap-icon--activities"
+            role="presentation"
+          />
+          
+                    
+          <span
+            class="fd-nested-list__title"
+          >
+            Level 1 Item
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+        
+    </ul>
+    
+    
+  </div>
+  
+
+</div>
+`;
+
 exports[`Storyshots Components/Side Navigation Nested List With Group Headers 1`] = `
 <ul
   class="fd-nested-list"

--- a/stories/side-navigation/__snapshots__/side-navigation.stories.storyshot
+++ b/stories/side-navigation/__snapshots__/side-navigation.stories.storyshot
@@ -2198,7 +2198,7 @@ exports[`Storyshots Components/Side Navigation Nested List Popover 1`] = `
       
         
       <ul
-        class="fd-nested-list fd-nested-list__popover fd-nested-list--compact"
+        class="fd-nested-list fd-nested-list--popover fd-nested-list--compact"
       >
         
             
@@ -2363,7 +2363,7 @@ exports[`Storyshots Components/Side Navigation Nested List Popover 1`] = `
       
         
       <ul
-        class="fd-nested-list fd-nested-list__popover fd-nested-list--compact"
+        class="fd-nested-list fd-nested-list--popover fd-nested-list--compact"
       >
         
             

--- a/stories/side-navigation/side-navigation.stories.js
+++ b/stories/side-navigation/side-navigation.stories.js
@@ -1259,7 +1259,7 @@ export const nestedListPopover = () => `<div class="fd-popover fd-popover--right
     <div class="fd-popover__control">
         <ul class="fd-nested-list fd-nested-list--compact">
             <li class="fd-nested-list__item">
-                <a class="fd-nested-list__link"href="#/">
+                <a class="fd-nested-list__link" href="#/">
                     <i role="presentation" class="fd-nested-list__icon sap-icon--home"></i>
                 </a>
             </li>
@@ -1271,19 +1271,19 @@ export const nestedListPopover = () => `<div class="fd-popover fd-popover--right
                 Group Header 1
             </li>
             <li class="fd-nested-list__item fd-nested-list__item--popover">
-                <a class="fd-nested-list__link"href="#/">
+                <a class="fd-nested-list__link" href="#/">
                     <i role="presentation" class="fd-nested-list__icon sap-icon--home"></i>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
             <li class="fd-nested-list__item fd-nested-list__item--popover">
-                <a class="fd-nested-list__link is-selected"href="#/">
+                <a class="fd-nested-list__link is-selected" href="#/">
                     <i role="presentation" class="fd-nested-list__icon sap-icon--calendar"></i>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
             <li class="fd-nested-list__item fd-nested-list__item--popover">
-                <a class="fd-nested-list__link"href="#/">
+                <a class="fd-nested-list__link" href="#/">
                     <i role="presentation" class="fd-nested-list__icon sap-icon--activities"></i>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
@@ -1295,7 +1295,7 @@ export const nestedListPopover = () => `<div class="fd-popover fd-popover--right
     <div class="fd-popover__control">
         <ul class="fd-nested-list fd-nested-list--compact">
             <li class="fd-nested-list__item">
-                <a class="fd-nested-list__link"href="#/">
+                <a class="fd-nested-list__link" href="#/">
                     <i role="presentation" class="fd-nested-list__icon sap-icon--home"></i>
                 </a>
             </li>
@@ -1304,19 +1304,19 @@ export const nestedListPopover = () => `<div class="fd-popover fd-popover--right
     <div class="fd-popover__popper" aria-hidden="false" id="popoverA12">
         <ul class="fd-nested-list fd-nested-list--popover fd-nested-list--compact">
             <li class="fd-nested-list__item fd-nested-list__item--popover">
-                <a class="fd-nested-list__link"href="#/">
+                <a class="fd-nested-list__link" href="#/">
                     <i role="presentation" class="fd-nested-list__icon sap-icon--home"></i>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
             <li class="fd-nested-list__item fd-nested-list__item--popover">
-                <a class="fd-nested-list__link is-selected"href="#/">
+                <a class="fd-nested-list__link is-selected" href="#/">
                     <i role="presentation" class="fd-nested-list__icon sap-icon--calendar"></i>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>
             </li>
             <li class="fd-nested-list__item fd-nested-list__item--popover">
-                <a class="fd-nested-list__link"href="#/">
+                <a class="fd-nested-list__link" href="#/">
                     <i role="presentation" class="fd-nested-list__icon sap-icon--activities"></i>
                     <span class="fd-nested-list__title">Level 1 Item</span>
                 </a>

--- a/stories/side-navigation/side-navigation.stories.js
+++ b/stories/side-navigation/side-navigation.stories.js
@@ -1255,73 +1255,75 @@ nestedListWithoutLinks.parameters = {
     }
 };
 
-export const nestedListPopover = () => `<div class="fd-popover fd-popover--right" style="margin-bottom: 200px; margin-right: 200px; margin-left: 200px;">
-    <div class="fd-popover__control">
-        <ul class="fd-nested-list fd-nested-list--compact">
-            <li class="fd-nested-list__item">
-                <a class="fd-nested-list__link" href="#/">
-                    <i role="presentation" class="fd-nested-list__icon sap-icon--home"></i>
-                </a>
-            </li>
-        </ul>
+export const nestedListPopover = () => `<div class="fddocs-container" style="margin-bottom: 200px;">
+    <div class="fd-popover fd-popover--right">
+        <div class="fd-popover__control">
+            <ul class="fd-nested-list fd-nested-list--compact">
+                <li class="fd-nested-list__item">
+                    <a class="fd-nested-list__link" href="#/">
+                        <i role="presentation" class="fd-nested-list__icon sap-icon--home"></i>
+                    </a>
+                </li>
+            </ul>
+        </div>
+        <div class="fd-popover__popper" aria-hidden="false" id="popoverA11">
+            <ul class="fd-nested-list fd-nested-list--popover fd-nested-list--compact">
+                <li class="fd-nested-list__group-header">
+                    Group Header 1
+                </li>
+                <li class="fd-nested-list__item">
+                    <a class="fd-nested-list__link" href="#/">
+                        <i role="presentation" class="fd-nested-list__icon sap-icon--home"></i>
+                        <span class="fd-nested-list__title">Level 1 Item</span>
+                    </a>
+                </li>
+                <li class="fd-nested-list__item">
+                    <a class="fd-nested-list__link is-selected" href="#/">
+                        <i role="presentation" class="fd-nested-list__icon sap-icon--calendar"></i>
+                        <span class="fd-nested-list__title">Level 1 Item</span>
+                    </a>
+                </li>
+                <li class="fd-nested-list__item">
+                    <a class="fd-nested-list__link" href="#/">
+                        <i role="presentation" class="fd-nested-list__icon sap-icon--activities"></i>
+                        <span class="fd-nested-list__title">Level 1 Item</span>
+                    </a>
+                </li>
+            </ul>
+        </div>
     </div>
-    <div class="fd-popover__popper" aria-hidden="false" id="popoverA11">
-        <ul class="fd-nested-list fd-nested-list--popover fd-nested-list--compact">
-            <li class="fd-nested-list__group-header fd-nested-list__group-header--popover">
-                Group Header 1
-            </li>
-            <li class="fd-nested-list__item fd-nested-list__item--popover">
-                <a class="fd-nested-list__link" href="#/">
-                    <i role="presentation" class="fd-nested-list__icon sap-icon--home"></i>
-                    <span class="fd-nested-list__title">Level 1 Item</span>
-                </a>
-            </li>
-            <li class="fd-nested-list__item fd-nested-list__item--popover">
-                <a class="fd-nested-list__link is-selected" href="#/">
-                    <i role="presentation" class="fd-nested-list__icon sap-icon--calendar"></i>
-                    <span class="fd-nested-list__title">Level 1 Item</span>
-                </a>
-            </li>
-            <li class="fd-nested-list__item fd-nested-list__item--popover">
-                <a class="fd-nested-list__link" href="#/">
-                    <i role="presentation" class="fd-nested-list__icon sap-icon--activities"></i>
-                    <span class="fd-nested-list__title">Level 1 Item</span>
-                </a>
-            </li>
-        </ul>
-    </div>
-</div>
-<div class="fd-popover fd-popover--right" style="margin-bottom: 200px">
-    <div class="fd-popover__control">
-        <ul class="fd-nested-list fd-nested-list--compact">
-            <li class="fd-nested-list__item">
-                <a class="fd-nested-list__link" href="#/">
-                    <i role="presentation" class="fd-nested-list__icon sap-icon--home"></i>
-                </a>
-            </li>
-        </ul>
-    </div>
-    <div class="fd-popover__popper" aria-hidden="false" id="popoverA12">
-        <ul class="fd-nested-list fd-nested-list--popover fd-nested-list--compact">
-            <li class="fd-nested-list__item fd-nested-list__item--popover">
-                <a class="fd-nested-list__link" href="#/">
-                    <i role="presentation" class="fd-nested-list__icon sap-icon--home"></i>
-                    <span class="fd-nested-list__title">Level 1 Item</span>
-                </a>
-            </li>
-            <li class="fd-nested-list__item fd-nested-list__item--popover">
-                <a class="fd-nested-list__link is-selected" href="#/">
-                    <i role="presentation" class="fd-nested-list__icon sap-icon--calendar"></i>
-                    <span class="fd-nested-list__title">Level 1 Item</span>
-                </a>
-            </li>
-            <li class="fd-nested-list__item fd-nested-list__item--popover">
-                <a class="fd-nested-list__link" href="#/">
-                    <i role="presentation" class="fd-nested-list__icon sap-icon--activities"></i>
-                    <span class="fd-nested-list__title">Level 1 Item</span>
-                </a>
-            </li>
-        </ul>
+    <div class="fd-popover fd-popover--right" style="margin-bottom: 200px">
+        <div class="fd-popover__control">
+            <ul class="fd-nested-list fd-nested-list--compact">
+                <li class="fd-nested-list__item">
+                    <a class="fd-nested-list__link" href="#/">
+                        <i role="presentation" class="fd-nested-list__icon sap-icon--home"></i>
+                    </a>
+                </li>
+            </ul>
+        </div>
+        <div class="fd-popover__popper" aria-hidden="false" id="popoverA12">
+            <ul class="fd-nested-list fd-nested-list--popover fd-nested-list--compact">
+                <li class="fd-nested-list__item fd-nested-list__item--popover">
+                    <a class="fd-nested-list__link" href="#/">
+                        <i role="presentation" class="fd-nested-list__icon sap-icon--home"></i>
+                        <span class="fd-nested-list__title">Level 1 Item</span>
+                    </a>
+                </li>
+                <li class="fd-nested-list__item fd-nested-list__item--popover">
+                    <a class="fd-nested-list__link is-selected" href="#/">
+                        <i role="presentation" class="fd-nested-list__icon sap-icon--calendar"></i>
+                        <span class="fd-nested-list__title">Level 1 Item</span>
+                    </a>
+                </li>
+                <li class="fd-nested-list__item fd-nested-list__item--popover">
+                    <a class="fd-nested-list__link" href="#/">
+                        <i role="presentation" class="fd-nested-list__icon sap-icon--activities"></i>
+                        <span class="fd-nested-list__title">Level 1 Item</span>
+                    </a>
+                </li>
+            </ul>
+        </div>
     </div>
 </div>
 `;
@@ -1332,7 +1334,7 @@ nestedListPopover.parameters = {
     docs: {
         iframeHeight: 900,
         storyDescription: `
-Nested list can be displayed inside popover. Set of extra classes like \`fd-nested-list--popover, fd-nested-list__item--popover, fd-nested-list__group-header--popover\` are needed for correct style representation.
+Nested list can be displayed inside popover.
         `
     }
 };

--- a/stories/side-navigation/side-navigation.stories.js
+++ b/stories/side-navigation/side-navigation.stories.js
@@ -29,7 +29,7 @@ Side navigation can be viewed in three different states:
         `,
 
         tags: ['f3', 'a11y', 'theme'],
-        components: ['side-nav', 'button', 'icon', 'nested-list']
+        components: ['side-nav', 'button', 'icon', 'nested-list', 'popover']
     }
 };
 
@@ -1252,5 +1252,54 @@ export const nestedListWithoutLinks = () => `<ul class="fd-nested-list fd-nested
 nestedListWithoutLinks.parameters = {
     docs: {
         disable: true
+    }
+};
+
+export const nestedListPopover = () => `<div class="fd-popover fd-popover--right" style="margin-bottom: 200px">
+    <div class="fd-popover__control">
+        <ul class="fd-nested-list fd-nested-list--compact">
+            <li class="fd-nested-list__item">
+                <a class="fd-nested-list__link"href="#/">
+                    <i role="presentation" class="fd-nested-list__icon sap-icon--home"></i>
+                </a>
+            </li>
+        </ul>
+    </div>
+    <div class="fd-popover__popper" aria-hidden="false" id="popoverA11">
+        <ul class="fd-nested-list fd-nested-list__popover fd-nested-list--compact">
+            <li class="fd-nested-list__group-header fd-nested-list__group-header--popover">
+                Group Header 1
+            </li>
+            <li class="fd-nested-list__item fd-nested-list__item--popover">
+                <a class="fd-nested-list__link"href="#/">
+                    <i role="presentation" class="fd-nested-list__icon sap-icon--home"></i>
+                    <span class="fd-nested-list__title">Level 1 Item</span>
+                </a>
+            </li>
+            <li class="fd-nested-list__item fd-nested-list__item--popover">
+                <a class="fd-nested-list__link is-selected"href="#/">
+                    <i role="presentation" class="fd-nested-list__icon sap-icon--calendar"></i>
+                    <span class="fd-nested-list__title">Level 1 Item</span>
+                </a>
+            </li>
+            <li class="fd-nested-list__item fd-nested-list__item--popover">
+                <a class="fd-nested-list__link"href="#/">
+                    <i role="presentation" class="fd-nested-list__icon sap-icon--activities"></i>
+                    <span class="fd-nested-list__title">Level 1 Item</span>
+                </a>
+            </li>
+        </ul>
+    </div>
+</div>
+`;
+
+nestedListPopover.storyName = 'Nested List PopOver';
+
+nestedListPopover.parameters = {
+    docs: {
+        iframeHeight: 900,
+        storyDescription: `
+Nested list can be displayed inside popover. Set of extra classes like \`fd-nested-list__popover, fd-nested-list__item--popover, fd-nested-list__group-header--popover\` are needed for correct style representation.
+        `
     }
 };

--- a/stories/side-navigation/side-navigation.stories.js
+++ b/stories/side-navigation/side-navigation.stories.js
@@ -1255,7 +1255,7 @@ nestedListWithoutLinks.parameters = {
     }
 };
 
-export const nestedListPopover = () => `<div class="fd-popover fd-popover--right" style="margin-bottom: 200px; margin-right: 200px;">
+export const nestedListPopover = () => `<div class="fd-popover fd-popover--right" style="margin-bottom: 200px; margin-right: 200px; margin-left: 200px;">
     <div class="fd-popover__control">
         <ul class="fd-nested-list fd-nested-list--compact">
             <li class="fd-nested-list__item">

--- a/stories/side-navigation/side-navigation.stories.js
+++ b/stories/side-navigation/side-navigation.stories.js
@@ -1293,7 +1293,7 @@ export const nestedListPopover = () => `<div class="fd-popover fd-popover--right
 </div>
 `;
 
-nestedListPopover.storyName = 'Nested List PopOver';
+nestedListPopover.storyName = 'Nested List Popover';
 
 nestedListPopover.parameters = {
     docs: {

--- a/stories/side-navigation/side-navigation.stories.js
+++ b/stories/side-navigation/side-navigation.stories.js
@@ -1255,7 +1255,7 @@ nestedListWithoutLinks.parameters = {
     }
 };
 
-export const nestedListPopover = () => `<div class="fd-popover fd-popover--right" style="margin-bottom: 200px">
+export const nestedListPopover = () => `<div class="fd-popover fd-popover--right" style="margin-bottom: 200px; margin-right: 200px;">
     <div class="fd-popover__control">
         <ul class="fd-nested-list fd-nested-list--compact">
             <li class="fd-nested-list__item">
@@ -1270,6 +1270,39 @@ export const nestedListPopover = () => `<div class="fd-popover fd-popover--right
             <li class="fd-nested-list__group-header fd-nested-list__group-header--popover">
                 Group Header 1
             </li>
+            <li class="fd-nested-list__item fd-nested-list__item--popover">
+                <a class="fd-nested-list__link"href="#/">
+                    <i role="presentation" class="fd-nested-list__icon sap-icon--home"></i>
+                    <span class="fd-nested-list__title">Level 1 Item</span>
+                </a>
+            </li>
+            <li class="fd-nested-list__item fd-nested-list__item--popover">
+                <a class="fd-nested-list__link is-selected"href="#/">
+                    <i role="presentation" class="fd-nested-list__icon sap-icon--calendar"></i>
+                    <span class="fd-nested-list__title">Level 1 Item</span>
+                </a>
+            </li>
+            <li class="fd-nested-list__item fd-nested-list__item--popover">
+                <a class="fd-nested-list__link"href="#/">
+                    <i role="presentation" class="fd-nested-list__icon sap-icon--activities"></i>
+                    <span class="fd-nested-list__title">Level 1 Item</span>
+                </a>
+            </li>
+        </ul>
+    </div>
+</div>
+<div class="fd-popover fd-popover--right" style="margin-bottom: 200px">
+    <div class="fd-popover__control">
+        <ul class="fd-nested-list fd-nested-list--compact">
+            <li class="fd-nested-list__item">
+                <a class="fd-nested-list__link"href="#/">
+                    <i role="presentation" class="fd-nested-list__icon sap-icon--home"></i>
+                </a>
+            </li>
+        </ul>
+    </div>
+    <div class="fd-popover__popper" aria-hidden="false" id="popoverA12">
+        <ul class="fd-nested-list fd-nested-list__popover fd-nested-list--compact">
             <li class="fd-nested-list__item fd-nested-list__item--popover">
                 <a class="fd-nested-list__link"href="#/">
                     <i role="presentation" class="fd-nested-list__icon sap-icon--home"></i>

--- a/stories/side-navigation/side-navigation.stories.js
+++ b/stories/side-navigation/side-navigation.stories.js
@@ -1266,7 +1266,7 @@ export const nestedListPopover = () => `<div class="fd-popover fd-popover--right
         </ul>
     </div>
     <div class="fd-popover__popper" aria-hidden="false" id="popoverA11">
-        <ul class="fd-nested-list fd-nested-list__popover fd-nested-list--compact">
+        <ul class="fd-nested-list fd-nested-list--popover fd-nested-list--compact">
             <li class="fd-nested-list__group-header fd-nested-list__group-header--popover">
                 Group Header 1
             </li>
@@ -1302,7 +1302,7 @@ export const nestedListPopover = () => `<div class="fd-popover fd-popover--right
         </ul>
     </div>
     <div class="fd-popover__popper" aria-hidden="false" id="popoverA12">
-        <ul class="fd-nested-list fd-nested-list__popover fd-nested-list--compact">
+        <ul class="fd-nested-list fd-nested-list--popover fd-nested-list--compact">
             <li class="fd-nested-list__item fd-nested-list__item--popover">
                 <a class="fd-nested-list__link"href="#/">
                     <i role="presentation" class="fd-nested-list__icon sap-icon--home"></i>
@@ -1332,7 +1332,7 @@ nestedListPopover.parameters = {
     docs: {
         iframeHeight: 900,
         storyDescription: `
-Nested list can be displayed inside popover. Set of extra classes like \`fd-nested-list__popover, fd-nested-list__item--popover, fd-nested-list__group-header--popover\` are needed for correct style representation.
+Nested list can be displayed inside popover. Set of extra classes like \`fd-nested-list--popover, fd-nested-list__item--popover, fd-nested-list__group-header--popover\` are needed for correct style representation.
         `
     }
 };


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/2618

Breaking Change:
Added a new modifier class .fd-nested-list--popover to display nested list inside a popover.

## Description
Nested list popover has some styles issue in fundamental-ngx.
It is because `fd-popover` component in `fundamental-ngx` is using class `fd-popover__popper` and not using class `fd-popover__body`.

To fix the issue, some modifier class needs to be created here.

## Screenshots

### Before:
![image](https://user-images.githubusercontent.com/57661487/127681488-9fda611d-68eb-4f47-8bd7-9b3cb62ce3b1.png)


### After:
<img width="823" alt="Screenshot 2021-07-30 at 9 42 55 PM" src="https://user-images.githubusercontent.com/57661487/127681586-3b5bff30-975a-415e-b122-1a977930d5c5.png">

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
