### PR TITLE
fix(core): fixed wrong styles for toolbar active state [ci visual]

### DIFF
--- a/src/toolbar.scss
+++ b/src/toolbar.scss
@@ -33,7 +33,7 @@ $title-toolbar-height: 2.75rem;
 }
 
 @mixin toolbarInfo() {
-  $active-color: var(--sapInfobar__TextColor);
+  $active-color: var(--sapInfobar_TextColor);
 
   background-color: var(--sapInfobar_NonInteractive_Background);
   color: var(--sapList_TextColor);


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#2622

## Description
Fixed active state for info toolbar

## Screenshots

### Before
![2021-08-06_15-43](https://user-images.githubusercontent.com/14183958/128512195-86bc1952-10ac-4e61-9bd0-40d13035f111.png)


### After
![2021-08-06_15-43_1](https://user-images.githubusercontent.com/14183958/128512215-f5a094e3-761e-407b-9713-e490c26eb38d.png)


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
