### PR TITLE
fix: add compact class

### DIFF
--- a/src/form-layout-grid.scss
+++ b/src/form-layout-grid.scss
@@ -13,6 +13,10 @@ $cols: 11;
   }
 }
 
+.#{$blockContainer}.#{$block}-container.#{$blockCol}--compact {
+  padding: 0;
+}
+
 @media (min-width: 0) {
   .#{$blockContainer}.#{$block}-container {
     margin: 0 -0.25rem;
@@ -43,6 +47,10 @@ $cols: 11;
         padding: 0 0.25rem;
         overflow: hidden;
         text-overflow: ellipsis;
+
+        &--compact {
+          padding: 0 1rem 0 1rem;
+        }
 
         @include placement('left');
 

--- a/src/form-layout-grid.scss
+++ b/src/form-layout-grid.scss
@@ -49,7 +49,7 @@ $cols: 11;
         text-overflow: ellipsis;
 
         &--compact {
-          padding: 0 1rem 0 1rem;
+          padding: 0 1rem;
         }
 
         @include placement('left');


### PR DESCRIPTION
## Related Issue
Related to SAP/fundamental-ngx[#6062](https://github.com/SAP/fundamental-ngx/pull/6062)

## Description
Added fd-col-compact class into form-layout-grit to have possibility change padding using attribute [compact]="true" or "Content Density"  on home page when user selects Compact
This issue is related to [#4906](https://github.com/SAP/fundamental-ngx/issues/4906)
## Screenshots
### Before:
![image](https://user-images.githubusercontent.com/53093915/128607276-f9142aeb-26df-456d-be15-a4556c8d7374.png)

### After:
![image](https://user-images.githubusercontent.com/53093915/128607484-158b8258-7441-4d5d-b24b-7313b802d838.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [n/a] tested Storybook examples with "CSS Resources" `normalize` option 
- [n/a] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [n/a] Verified all styles in IE11
- [n/a] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [n/a] Storybook documentation has been created/updated
- [n/a] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
