### PR TITLE
fix: correct style in input-group 

### DIFF
--- a/src/input-group.scss
+++ b/src/input-group.scss
@@ -23,6 +23,7 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
     }
   }
 
+  $fd-input-padding: 0.625rem;
   $fd-input-width-basis: 10rem;
   $fd-input-group-add-on-border: 0.0625rem;
   $fd-input-group-button-active-text-color: var(--sapButton_Active_TextColor);
@@ -98,21 +99,11 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
     }
 
     &:nth-child(1) {
-      padding-left: 0.625rem;
-
-      @include fd-rtl() {
-        padding-left: 0.25rem;
-        padding-right: 0.625rem;
-      }
+      @include fd-set-padding-left($fd-input-padding);
     }
 
     &:nth-last-child(1) {
-      padding-right: 0.625rem;
-
-      @include fd-rtl() {
-        padding-left: 0.625rem;
-        padding-right: 0.25rem;
-      }
+      @include fd-set-padding-right($fd-input-padding);
     }
   }
 

--- a/src/input-group.scss
+++ b/src/input-group.scss
@@ -99,7 +99,6 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
 
     &:nth-child(1) {
       padding-left: 0.625rem;
-      padding-right: 0.25rem;
 
       @include fd-rtl() {
         padding-left: 0.25rem;
@@ -108,7 +107,6 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
     }
 
     &:nth-last-child(1) {
-      padding-left: 0.25rem;
       padding-right: 0.625rem;
 
       @include fd-rtl() {


### PR DESCRIPTION
## Related Issue
targets [#5938](https://github.com/SAP/fundamental-ngx/issues/5938)

## Description
Deleted not needed styles for input-group in order to avoid values changing position(padding) inside the field

## Screenshots
![image](https://user-images.githubusercontent.com/53093915/128746930-e187da19-e9ca-402d-b6d0-cf28ad6d3569.png)
![image](https://user-images.githubusercontent.com/53093915/128747070-a944bae9-0bf6-4ccb-a415-1d6a2f0f9d45.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [n/a] tested Storybook examples with "CSS Resources" `normalize` option 
- [n/a] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [n/a] Verified all styles in IE11
- [n/a] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [n/a] Storybook documentation has been created/updated
- [n/a] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
