### PR TITLE
fix: added paddings for fd-icon-tab-bar__list-item-counter

### DIFF
--- a/src/icon-tab-bar.scss
+++ b/src/icon-tab-bar.scss
@@ -832,6 +832,10 @@ $fd-icon-tab-bar-semantic-values: (
       width: 1.25rem;
     }
 
+    .#{$block}__list-item-counter {
+      @include fd-set-padding-left(0.25rem);
+    }
+
     .#{$block}__list-link {
       @include fd-selected() {
         border-bottom: none;


### PR DESCRIPTION
## Description
Added missed styles for icon tab bar component.

**Before:** 
![2021-08-25_16-09_1](https://user-images.githubusercontent.com/14183958/130796458-f67e039b-23cd-4d74-965f-8ef97074f1ab.png)
**After:**
![2021-08-25_16-09](https://user-images.githubusercontent.com/14183958/130796504-ed70b5eb-ec07-4702-bb4b-39bcae963f6e.png)
