### PR TITLE
fix: form grid layout

### DIFF
--- a/src/form-layout-grid.scss
+++ b/src/form-layout-grid.scss
@@ -19,7 +19,7 @@ $cols: 11;
 
 @media (min-width: 0) {
   .#{$blockContainer}.#{$block}-container {
-    margin: 0 -0.25rem;
+    padding: 0 0.25rem;
 
     & > .fd-row {
       & > :first-child & :not(.fd-col--wrap) {
@@ -36,8 +36,7 @@ $cols: 11;
 
     .#{$blockRow} {
       align-items: center;
-      margin-top: 0;
-      margin-bottom: 0.625rem;
+      margin: 0 -0.25rem 0.625rem -0.25rem;
 
       &--top {
         align-items: start;
@@ -98,15 +97,12 @@ $cols: 11;
             @include placement('right');
           }
         }
-
-        .#{$blockRow} {
-          margin: 0 -0.25rem;
-        }
       }
 
       .#{$blockCol}__form-group {
         padding: 1rem;
       }
+
       .#{$blockRow}__form-item {
         flex-direction: row;
       }
@@ -161,7 +157,6 @@ $cols: 11;
 }
 
 @media (min-width: 1024px) {
-
   .#{$blockContainer}.#{$block}-container {
     .#{$blockRow} {
       .#{$blockCol} {


### PR DESCRIPTION
## Related Issue

Closes #2612.

## Description

Negative margin fixes for the grid.

Negative margins were set for the container what is the wrong approach which causes bugs.

The container should have padding then the row should have negative margins and columns should have padding.
Negative margins are applied to neutralize columns padding.

## Screenshots

<img width="659" alt="Screenshot 2021-08-18 at 17 50 53" src="https://user-images.githubusercontent.com/20265336/129910416-b55a404e-6f7d-4788-83ab-a74157e186f2.png">

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [X] All values are in `rem`
- [n/a] Text elements follow the truncation rules
- [n/a] hover state of the element follow design spec
- [n/a] focus state of the element follow design spec
- [X] active state of the element follow design spec
- [n/a] selected state of the element follow design spec
- [n/a] selected hover state of the element follow design spec
- [n/a] pressed state of the element follow design spec
- [X] Responsiveness rules - the component has modifier classes for all breakpoints
- [X] Includes Compact/Cosy/Tablet design
- [X] RTL support
2. The code follows fundamental-styles code standards and style
- [n/a] only one top level `fd-*` class is used in the file
- [n/a] BEM naming convention is used
- [n/a] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [n/a] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [n/a] `fd-reset()` mixin is applied to all elements
- [n/a] Variables are used, if some value is used more than twice.
- [X] Checked if current components can be reused, instead of having new code.
3. Testing
- [X] tested Storybook examples with "CSS Resources" `normalize` option 
- [X] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [X] Verified all styles in IE11
- [n/a] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [n/a] Storybook documentation has been created/updated
- [n/a] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.