### PR TITLE
fix: put nested list popover header outside list items

### DIFF
--- a/src/_nested-list.scss
+++ b/src/_nested-list.scss
@@ -86,8 +86,6 @@ $button: #{$fd-namespace}-button;
 
     .#{$block}__group-header {
       @include fd-nested-list-popover-border-top-radius();
-
-      border-bottom: none;
     }
 
     .#{$block}__item {

--- a/src/_nested-list.scss
+++ b/src/_nested-list.scss
@@ -84,41 +84,11 @@ $button: #{$fd-namespace}-button;
   &--popover {
     border-bottom: none;
 
-    .#{$block}__popover-header {
-      @include fd-nested-list-popover-border-top-radius();
-
-      height: 2.75rem;
-      background: var(--sapList_GroupHeaderBackground);
-      border-bottom: var(--sapList_BorderWidth) solid var(--sapList_GroupHeaderBorderColor);
-      color: var(--sapList_GroupHeaderTextColor);
-      display: flex;
-      align-items: flex-end;
-      font-size: var(--sapFontSize);
-      font-weight: bold;
-      line-height: 2rem;
-      padding-right: 1rem;
-      padding-left: 1rem;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-
     .#{$block}__group-header {
-      @include fd-nested-list-popover-border-top-radius();
-
       border-bottom: none;
     }
 
     .#{$block}__item {
-      &:first-child {
-        @include fd-nested-list-popover-border-top-radius();
-
-        .#{$block}__link,
-        .#{$block}__content {
-          @include fd-nested-list-popover-border-top-radius();
-        }
-      }
-
       &:last-child {
         @include fd-nested-list-popover-border-bottom-radius();
 

--- a/src/_nested-list.scss
+++ b/src/_nested-list.scss
@@ -84,8 +84,29 @@ $button: #{$fd-namespace}-button;
   &--popover {
     border-bottom: none;
 
+    .#{$block}__popover-header {
+      @include fd-nested-list-popover-border-top-radius();
+
+      height: 2.75rem;
+      background: var(--sapList_GroupHeaderBackground);
+      border-bottom: var(--sapList_BorderWidth) solid var(--sapList_GroupHeaderBorderColor);
+      color: var(--sapList_GroupHeaderTextColor);
+      display: flex;
+      align-items: flex-end;
+      font-size: var(--sapFontSize);
+      font-weight: bold;
+      line-height: 2rem;
+      padding-right: 1rem;
+      padding-left: 1rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
     .#{$block}__group-header {
       @include fd-nested-list-popover-border-top-radius();
+
+      border-bottom: none;
     }
 
     .#{$block}__item {

--- a/src/_nested-list.scss
+++ b/src/_nested-list.scss
@@ -93,6 +93,8 @@ $button: #{$fd-namespace}-button;
       height: 2.75rem;
       padding-right: 1rem;
       padding-left: 1rem;
+      font-size: var(--sapFontLargeSize);
+      color: var(--sapList_TextColor);
       display: flex;
       align-items: center;
     }
@@ -360,11 +362,13 @@ $button: #{$fd-namespace}-button;
   }
 
   &--compact {
+    .#{$block}__popover-header,
     .#{$block}__link,
     .#{$block}__content {
       height: 2rem;
     }
 
+    .#{$block}__popover-header,
     .#{$block}__title {
       font-size: var(--sapFontSize);
     }

--- a/src/_nested-list.scss
+++ b/src/_nested-list.scss
@@ -84,6 +84,19 @@ $button: #{$fd-namespace}-button;
   &--popover {
     border-bottom: none;
 
+    .#{$block}__popover-header {
+      @include fd-reset();
+      @include fd-nested-list-popover-border-top-radius();
+
+      background: var(--sapList_Background);
+      border-bottom: var(--sapList_BorderWidth) solid var(--sapList_BorderColor);
+      height: 2.75rem;
+      padding-right: 1rem;
+      padding-left: 1rem;
+      display: flex;
+      align-items: center;
+    }
+
     .#{$block}__group-header {
       border-bottom: none;
     }

--- a/stories/side-navigation/__snapshots__/side-navigation.stories.storyshot
+++ b/stories/side-navigation/__snapshots__/side-navigation.stories.storyshot
@@ -2204,7 +2204,7 @@ exports[`Storyshots Components/Side Navigation Nested List Popover 1`] = `
       <div
         class="fd-nested-list fd-nested-list--popover fd-nested-list--compact"
       >
-            
+        
                 
         <div
           class="fd-nested-list__group-header"

--- a/stories/side-navigation/__snapshots__/side-navigation.stories.storyshot
+++ b/stories/side-navigation/__snapshots__/side-navigation.stories.storyshot
@@ -2202,30 +2202,20 @@ exports[`Storyshots Components/Side Navigation Nested List Popover 1`] = `
       
             
       <div
-        class="fd-popover__body-header"
+        class="fd-nested-list fd-nested-list--text-only fd-nested-list--popover"
       >
         
                 
         <div
-          class="fd-bar fd-bar--header"
+          class="fd-nested-list__popover-header"
         >
           
                     
-          <div
-            class="fd-bar__left"
+          <span
+            class="fd-nested-list__title"
           >
-            
-                        
-            <div
-              class="fd-bar__element"
-            >
-              
-                            Popover Header
-                        
-            </div>
-            
-                    
-          </div>
+            Popover Header
+          </span>
           
                 
         </div>
@@ -2233,6 +2223,7 @@ exports[`Storyshots Components/Side Navigation Nested List Popover 1`] = `
             
       </div>
       
+
             
       <ul
         class="fd-nested-list fd-nested-list--popover fd-nested-list--compact"
@@ -2391,30 +2382,20 @@ exports[`Storyshots Components/Side Navigation Nested List Popover 1`] = `
       
             
       <div
-        class="fd-popover__body-header"
+        class="fd-nested-list fd-nested-list--text-only fd-nested-list--popover"
       >
         
                 
         <div
-          class="fd-bar fd-bar--header"
+          class="fd-nested-list__popover-header"
         >
           
                     
-          <div
-            class="fd-bar__left"
+          <span
+            class="fd-nested-list__title"
           >
-            
-                        
-            <div
-              class="fd-bar__element"
-            >
-              
-                            Popover Header
-                        
-            </div>
-            
-                    
-          </div>
+            Popover Header
+          </span>
           
                 
         </div>

--- a/stories/side-navigation/__snapshots__/side-navigation.stories.storyshot
+++ b/stories/side-navigation/__snapshots__/side-navigation.stories.storyshot
@@ -2202,14 +2202,32 @@ exports[`Storyshots Components/Side Navigation Nested List Popover 1`] = `
       
             
       <div
-        class="fd-nested-list fd-nested-list--popover fd-nested-list--compact"
+        class="fd-popover__body-header"
       >
         
                 
         <div
-          class="fd-nested-list__popover-header"
+          class="fd-bar fd-bar--header"
         >
-          Popover Header
+          
+                    
+          <div
+            class="fd-bar__left"
+          >
+            
+                        
+            <div
+              class="fd-bar__element"
+            >
+              
+                            Popover Header
+                        
+            </div>
+            
+                    
+          </div>
+          
+                
         </div>
         
             
@@ -2373,14 +2391,32 @@ exports[`Storyshots Components/Side Navigation Nested List Popover 1`] = `
       
             
       <div
-        class="fd-nested-list fd-nested-list--popover fd-nested-list--compact"
+        class="fd-popover__body-header"
       >
         
                 
         <div
-          class="fd-nested-list__popover-header"
+          class="fd-bar fd-bar--header"
         >
-          Popover Header
+          
+                    
+          <div
+            class="fd-bar__left"
+          >
+            
+                        
+            <div
+              class="fd-bar__element"
+            >
+              
+                            Popover Header
+                        
+            </div>
+            
+                    
+          </div>
+          
+                
         </div>
         
             
@@ -2397,324 +2433,6 @@ exports[`Storyshots Components/Side Navigation Nested List Popover 1`] = `
         >
           Group Header
         </li>
-        
-                
-        <li
-          class="fd-nested-list__item fd-nested-list__item--popover"
-        >
-          
-                    
-          <a
-            class="fd-nested-list__link"
-            href="#/"
-          >
-            
-                        
-            <i
-              class="fd-nested-list__icon sap-icon--home"
-              role="presentation"
-            />
-            
-                        
-            <span
-              class="fd-nested-list__title"
-            >
-              Level 1 Item
-            </span>
-            
-                    
-          </a>
-          
-                
-        </li>
-        
-                
-        <li
-          class="fd-nested-list__item fd-nested-list__item--popover"
-        >
-          
-                    
-          <a
-            class="fd-nested-list__link is-selected"
-            href="#/"
-          >
-            
-                        
-            <i
-              class="fd-nested-list__icon sap-icon--calendar"
-              role="presentation"
-            />
-            
-                        
-            <span
-              class="fd-nested-list__title"
-            >
-              Level 1 Item
-            </span>
-            
-                    
-          </a>
-          
-                
-        </li>
-        
-                
-        <li
-          class="fd-nested-list__item fd-nested-list__item--popover"
-        >
-          
-                    
-          <a
-            class="fd-nested-list__link"
-            href="#/"
-          >
-            
-                        
-            <i
-              class="fd-nested-list__icon sap-icon--activities"
-              role="presentation"
-            />
-            
-                        
-            <span
-              class="fd-nested-list__title"
-            >
-              Level 1 Item
-            </span>
-            
-                    
-          </a>
-          
-                
-        </li>
-        
-            
-      </ul>
-      
-        
-    </div>
-    
-    
-  </div>
-  
-
-    
-  <div
-    class="fd-popover fd-popover--right"
-  >
-    
-        
-    <div
-      class="fd-popover__control"
-    >
-      
-            
-      <ul
-        class="fd-nested-list fd-nested-list--compact"
-      >
-        
-                
-        <li
-          class="fd-nested-list__item"
-        >
-          
-                    
-          <a
-            class="fd-nested-list__link"
-            href="#/"
-          >
-            
-                        
-            <i
-              class="fd-nested-list__icon sap-icon--home"
-              role="presentation"
-            />
-            
-                    
-          </a>
-          
-                
-        </li>
-        
-            
-      </ul>
-      
-        
-    </div>
-    
-        
-    <div
-      aria-hidden="false"
-      class="fd-popover__popper"
-      id="popoverA12"
-    >
-      
-            
-      <ul
-        class="fd-nested-list fd-nested-list--popover fd-nested-list--compact"
-      >
-        
-                
-        <li
-          class="fd-nested-list__group-header"
-        >
-          Group Header
-        </li>
-        
-                
-        <li
-          class="fd-nested-list__item fd-nested-list__item--popover"
-        >
-          
-                    
-          <a
-            class="fd-nested-list__link"
-            href="#/"
-          >
-            
-                        
-            <i
-              class="fd-nested-list__icon sap-icon--home"
-              role="presentation"
-            />
-            
-                        
-            <span
-              class="fd-nested-list__title"
-            >
-              Level 1 Item
-            </span>
-            
-                    
-          </a>
-          
-                
-        </li>
-        
-                
-        <li
-          class="fd-nested-list__item fd-nested-list__item--popover"
-        >
-          
-                    
-          <a
-            class="fd-nested-list__link is-selected"
-            href="#/"
-          >
-            
-                        
-            <i
-              class="fd-nested-list__icon sap-icon--calendar"
-              role="presentation"
-            />
-            
-                        
-            <span
-              class="fd-nested-list__title"
-            >
-              Level 1 Item
-            </span>
-            
-                    
-          </a>
-          
-                
-        </li>
-        
-                
-        <li
-          class="fd-nested-list__item fd-nested-list__item--popover"
-        >
-          
-                    
-          <a
-            class="fd-nested-list__link"
-            href="#/"
-          >
-            
-                        
-            <i
-              class="fd-nested-list__icon sap-icon--activities"
-              role="presentation"
-            />
-            
-                        
-            <span
-              class="fd-nested-list__title"
-            >
-              Level 1 Item
-            </span>
-            
-                    
-          </a>
-          
-                
-        </li>
-        
-            
-      </ul>
-      
-        
-    </div>
-    
-    
-  </div>
-  
-    
-  <div
-    class="fd-popover fd-popover--right"
-  >
-    
-        
-    <div
-      class="fd-popover__control"
-    >
-      
-            
-      <ul
-        class="fd-nested-list fd-nested-list--compact"
-      >
-        
-                
-        <li
-          class="fd-nested-list__item"
-        >
-          
-                    
-          <a
-            class="fd-nested-list__link"
-            href="#/"
-          >
-            
-                        
-            <i
-              class="fd-nested-list__icon sap-icon--home"
-              role="presentation"
-            />
-            
-                    
-          </a>
-          
-                
-        </li>
-        
-            
-      </ul>
-      
-        
-    </div>
-    
-        
-    <div
-      aria-hidden="false"
-      class="fd-popover__popper"
-      id="popoverA12"
-    >
-      
-            
-      <ul
-        class="fd-nested-list fd-nested-list--popover fd-nested-list--compact"
-      >
         
                 
         <li

--- a/stories/side-navigation/__snapshots__/side-navigation.stories.storyshot
+++ b/stories/side-navigation/__snapshots__/side-navigation.stories.storyshot
@@ -2202,7 +2202,7 @@ exports[`Storyshots Components/Side Navigation Nested List Popover 1`] = `
       
             
       <div
-        class="fd-nested-list fd-nested-list--text-only fd-nested-list--popover"
+        class="fd-nested-list fd-nested-list--popover fd-nested-list--compact"
       >
         
                 
@@ -2210,13 +2210,7 @@ exports[`Storyshots Components/Side Navigation Nested List Popover 1`] = `
           class="fd-nested-list__popover-header"
         >
           
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Popover Header
-          </span>
-          
+                    Popover Header
                 
         </div>
         
@@ -2341,7 +2335,7 @@ exports[`Storyshots Components/Side Navigation Nested List Popover 1`] = `
       
             
       <ul
-        class="fd-nested-list fd-nested-list--compact"
+        class="fd-nested-list"
       >
         
                 
@@ -2382,7 +2376,7 @@ exports[`Storyshots Components/Side Navigation Nested List Popover 1`] = `
       
             
       <div
-        class="fd-nested-list fd-nested-list--text-only fd-nested-list--popover"
+        class="fd-nested-list fd-nested-list--popover"
       >
         
                 
@@ -2390,13 +2384,7 @@ exports[`Storyshots Components/Side Navigation Nested List Popover 1`] = `
           class="fd-nested-list__popover-header"
         >
           
-                    
-          <span
-            class="fd-nested-list__title"
-          >
-            Popover Header
-          </span>
-          
+                    Popover Header
                 
         </div>
         
@@ -2405,7 +2393,7 @@ exports[`Storyshots Components/Side Navigation Nested List Popover 1`] = `
       
             
       <ul
-        class="fd-nested-list fd-nested-list--popover fd-nested-list--compact"
+        class="fd-nested-list fd-nested-list--popover"
       >
         
                 

--- a/stories/side-navigation/__snapshots__/side-navigation.stories.storyshot
+++ b/stories/side-navigation/__snapshots__/side-navigation.stories.storyshot
@@ -2201,18 +2201,24 @@ exports[`Storyshots Components/Side Navigation Nested List Popover 1`] = `
     >
       
             
+      <div
+        class="fd-nested-list fd-nested-list--popover fd-nested-list--compact"
+      >
+            
+                
+        <div
+          class="fd-nested-list__group-header"
+        >
+          Group Header 1
+        </div>
+        
+            
+      </div>
+      
+            
       <ul
         class="fd-nested-list fd-nested-list--popover fd-nested-list--compact"
       >
-        
-                
-        <li
-          class="fd-nested-list__group-header"
-        >
-          
-                    Group Header 1
-                
-        </li>
         
                 
         <li

--- a/stories/side-navigation/__snapshots__/side-navigation.stories.storyshot
+++ b/stories/side-navigation/__snapshots__/side-navigation.stories.storyshot
@@ -2207,9 +2207,9 @@ exports[`Storyshots Components/Side Navigation Nested List Popover 1`] = `
         
                 
         <div
-          class="fd-nested-list__group-header"
+          class="fd-nested-list__popover-header"
         >
-          Group Header 1
+          Popover Header
         </div>
         
             
@@ -2319,10 +2319,350 @@ exports[`Storyshots Components/Side Navigation Nested List Popover 1`] = `
     
   </div>
   
+
     
   <div
     class="fd-popover fd-popover--right"
-    style="margin-bottom: 200px"
+  >
+    
+        
+    <div
+      class="fd-popover__control"
+    >
+      
+            
+      <ul
+        class="fd-nested-list fd-nested-list--compact"
+      >
+        
+                
+        <li
+          class="fd-nested-list__item"
+        >
+          
+                    
+          <a
+            class="fd-nested-list__link"
+            href="#/"
+          >
+            
+                        
+            <i
+              class="fd-nested-list__icon sap-icon--home"
+              role="presentation"
+            />
+            
+                    
+          </a>
+          
+                
+        </li>
+        
+            
+      </ul>
+      
+        
+    </div>
+    
+        
+    <div
+      aria-hidden="false"
+      class="fd-popover__popper"
+      id="popoverA12"
+    >
+      
+            
+      <div
+        class="fd-nested-list fd-nested-list--popover fd-nested-list--compact"
+      >
+        
+                
+        <div
+          class="fd-nested-list__popover-header"
+        >
+          Popover Header
+        </div>
+        
+            
+      </div>
+      
+            
+      <ul
+        class="fd-nested-list fd-nested-list--popover fd-nested-list--compact"
+      >
+        
+                
+        <li
+          class="fd-nested-list__group-header"
+        >
+          Group Header
+        </li>
+        
+                
+        <li
+          class="fd-nested-list__item fd-nested-list__item--popover"
+        >
+          
+                    
+          <a
+            class="fd-nested-list__link"
+            href="#/"
+          >
+            
+                        
+            <i
+              class="fd-nested-list__icon sap-icon--home"
+              role="presentation"
+            />
+            
+                        
+            <span
+              class="fd-nested-list__title"
+            >
+              Level 1 Item
+            </span>
+            
+                    
+          </a>
+          
+                
+        </li>
+        
+                
+        <li
+          class="fd-nested-list__item fd-nested-list__item--popover"
+        >
+          
+                    
+          <a
+            class="fd-nested-list__link is-selected"
+            href="#/"
+          >
+            
+                        
+            <i
+              class="fd-nested-list__icon sap-icon--calendar"
+              role="presentation"
+            />
+            
+                        
+            <span
+              class="fd-nested-list__title"
+            >
+              Level 1 Item
+            </span>
+            
+                    
+          </a>
+          
+                
+        </li>
+        
+                
+        <li
+          class="fd-nested-list__item fd-nested-list__item--popover"
+        >
+          
+                    
+          <a
+            class="fd-nested-list__link"
+            href="#/"
+          >
+            
+                        
+            <i
+              class="fd-nested-list__icon sap-icon--activities"
+              role="presentation"
+            />
+            
+                        
+            <span
+              class="fd-nested-list__title"
+            >
+              Level 1 Item
+            </span>
+            
+                    
+          </a>
+          
+                
+        </li>
+        
+            
+      </ul>
+      
+        
+    </div>
+    
+    
+  </div>
+  
+
+    
+  <div
+    class="fd-popover fd-popover--right"
+  >
+    
+        
+    <div
+      class="fd-popover__control"
+    >
+      
+            
+      <ul
+        class="fd-nested-list fd-nested-list--compact"
+      >
+        
+                
+        <li
+          class="fd-nested-list__item"
+        >
+          
+                    
+          <a
+            class="fd-nested-list__link"
+            href="#/"
+          >
+            
+                        
+            <i
+              class="fd-nested-list__icon sap-icon--home"
+              role="presentation"
+            />
+            
+                    
+          </a>
+          
+                
+        </li>
+        
+            
+      </ul>
+      
+        
+    </div>
+    
+        
+    <div
+      aria-hidden="false"
+      class="fd-popover__popper"
+      id="popoverA12"
+    >
+      
+            
+      <ul
+        class="fd-nested-list fd-nested-list--popover fd-nested-list--compact"
+      >
+        
+                
+        <li
+          class="fd-nested-list__group-header"
+        >
+          Group Header
+        </li>
+        
+                
+        <li
+          class="fd-nested-list__item fd-nested-list__item--popover"
+        >
+          
+                    
+          <a
+            class="fd-nested-list__link"
+            href="#/"
+          >
+            
+                        
+            <i
+              class="fd-nested-list__icon sap-icon--home"
+              role="presentation"
+            />
+            
+                        
+            <span
+              class="fd-nested-list__title"
+            >
+              Level 1 Item
+            </span>
+            
+                    
+          </a>
+          
+                
+        </li>
+        
+                
+        <li
+          class="fd-nested-list__item fd-nested-list__item--popover"
+        >
+          
+                    
+          <a
+            class="fd-nested-list__link is-selected"
+            href="#/"
+          >
+            
+                        
+            <i
+              class="fd-nested-list__icon sap-icon--calendar"
+              role="presentation"
+            />
+            
+                        
+            <span
+              class="fd-nested-list__title"
+            >
+              Level 1 Item
+            </span>
+            
+                    
+          </a>
+          
+                
+        </li>
+        
+                
+        <li
+          class="fd-nested-list__item fd-nested-list__item--popover"
+        >
+          
+                    
+          <a
+            class="fd-nested-list__link"
+            href="#/"
+          >
+            
+                        
+            <i
+              class="fd-nested-list__icon sap-icon--activities"
+              role="presentation"
+            />
+            
+                        
+            <span
+              class="fd-nested-list__title"
+            >
+              Level 1 Item
+            </span>
+            
+                    
+          </a>
+          
+                
+        </li>
+        
+            
+      </ul>
+      
+        
+    </div>
+    
+    
+  </div>
+  
+    
+  <div
+    class="fd-popover fd-popover--right"
   >
     
         

--- a/stories/side-navigation/side-navigation.stories.js
+++ b/stories/side-navigation/side-navigation.stories.js
@@ -29,7 +29,7 @@ Side navigation can be viewed in three different states:
         `,
 
         tags: ['f3', 'a11y', 'theme'],
-        components: ['side-nav', 'button', 'icon', 'nested-list', 'popover', 'bar']
+        components: ['side-nav', 'button', 'icon', 'nested-list', 'popover']
     }
 };
 
@@ -1267,15 +1267,12 @@ export const nestedListPopover = () => `<div class="fddocs-container" style="mar
             </ul>
         </div>
         <div class="fd-popover__popper" aria-hidden="false" id="popoverA11">
-            <div class="fd-popover__body-header">
-                <div class="fd-bar fd-bar--header">
-                    <div class="fd-bar__left">
-                        <div class="fd-bar__element">
-                            Popover Header
-                        </div>
-                    </div>
+            <div class="fd-nested-list fd-nested-list--text-only fd-nested-list--popover">
+                <div class="fd-nested-list__popover-header">
+                    <span class="fd-nested-list__title">Popover Header</span>
                 </div>
             </div>
+
             <ul class="fd-nested-list fd-nested-list--popover fd-nested-list--compact">
                 <li class="fd-nested-list__item">
                     <a class="fd-nested-list__link" href="#/">
@@ -1310,13 +1307,9 @@ export const nestedListPopover = () => `<div class="fddocs-container" style="mar
             </ul>
         </div>
         <div class="fd-popover__popper" aria-hidden="false" id="popoverA12">
-            <div class="fd-popover__body-header">
-                <div class="fd-bar fd-bar--header">
-                    <div class="fd-bar__left">
-                        <div class="fd-bar__element">
-                            Popover Header
-                        </div>
-                    </div>
+            <div class="fd-nested-list fd-nested-list--text-only fd-nested-list--popover">
+                <div class="fd-nested-list__popover-header">
+                    <span class="fd-nested-list__title">Popover Header</span>
                 </div>
             </div>
             <ul class="fd-nested-list fd-nested-list--popover fd-nested-list--compact">

--- a/stories/side-navigation/side-navigation.stories.js
+++ b/stories/side-navigation/side-navigation.stories.js
@@ -1267,7 +1267,7 @@ export const nestedListPopover = () => `<div class="fddocs-container" style="mar
             </ul>
         </div>
         <div class="fd-popover__popper" aria-hidden="false" id="popoverA11">
-            <div class="fd-nested-list fd-nested-list--popover fd-nested-list--compact">    
+            <div class="fd-nested-list fd-nested-list--popover fd-nested-list--compact">
                 <div class="fd-nested-list__group-header">Group Header 1</div>
             </div>
             <ul class="fd-nested-list fd-nested-list--popover fd-nested-list--compact">

--- a/stories/side-navigation/side-navigation.stories.js
+++ b/stories/side-navigation/side-navigation.stories.js
@@ -1267,9 +1267,9 @@ export const nestedListPopover = () => `<div class="fddocs-container" style="mar
             </ul>
         </div>
         <div class="fd-popover__popper" aria-hidden="false" id="popoverA11">
-            <div class="fd-nested-list fd-nested-list--text-only fd-nested-list--popover">
+            <div class="fd-nested-list fd-nested-list--popover fd-nested-list--compact">
                 <div class="fd-nested-list__popover-header">
-                    <span class="fd-nested-list__title">Popover Header</span>
+                    Popover Header
                 </div>
             </div>
 
@@ -1298,7 +1298,7 @@ export const nestedListPopover = () => `<div class="fddocs-container" style="mar
 
     <div class="fd-popover fd-popover--right">
         <div class="fd-popover__control">
-            <ul class="fd-nested-list fd-nested-list--compact">
+            <ul class="fd-nested-list">
                 <li class="fd-nested-list__item">
                     <a class="fd-nested-list__link" href="#/">
                         <i role="presentation" class="fd-nested-list__icon sap-icon--home"></i>
@@ -1307,12 +1307,12 @@ export const nestedListPopover = () => `<div class="fddocs-container" style="mar
             </ul>
         </div>
         <div class="fd-popover__popper" aria-hidden="false" id="popoverA12">
-            <div class="fd-nested-list fd-nested-list--text-only fd-nested-list--popover">
+            <div class="fd-nested-list fd-nested-list--popover">
                 <div class="fd-nested-list__popover-header">
-                    <span class="fd-nested-list__title">Popover Header</span>
+                    Popover Header
                 </div>
             </div>
-            <ul class="fd-nested-list fd-nested-list--popover fd-nested-list--compact">
+            <ul class="fd-nested-list fd-nested-list--popover">
                 <li class="fd-nested-list__group-header">Group Header</li>
                 <li class="fd-nested-list__item fd-nested-list__item--popover">
                     <a class="fd-nested-list__link" href="#/">

--- a/stories/side-navigation/side-navigation.stories.js
+++ b/stories/side-navigation/side-navigation.stories.js
@@ -29,7 +29,7 @@ Side navigation can be viewed in three different states:
         `,
 
         tags: ['f3', 'a11y', 'theme'],
-        components: ['side-nav', 'button', 'icon', 'nested-list', 'popover']
+        components: ['side-nav', 'button', 'icon', 'nested-list', 'popover', 'bar']
     }
 };
 
@@ -1267,8 +1267,14 @@ export const nestedListPopover = () => `<div class="fddocs-container" style="mar
             </ul>
         </div>
         <div class="fd-popover__popper" aria-hidden="false" id="popoverA11">
-            <div class="fd-nested-list fd-nested-list--popover fd-nested-list--compact">
-                <div class="fd-nested-list__popover-header">Popover Header</div>
+            <div class="fd-popover__body-header">
+                <div class="fd-bar fd-bar--header">
+                    <div class="fd-bar__left">
+                        <div class="fd-bar__element">
+                            Popover Header
+                        </div>
+                    </div>
+                </div>
             </div>
             <ul class="fd-nested-list fd-nested-list--popover fd-nested-list--compact">
                 <li class="fd-nested-list__item">
@@ -1304,79 +1310,17 @@ export const nestedListPopover = () => `<div class="fddocs-container" style="mar
             </ul>
         </div>
         <div class="fd-popover__popper" aria-hidden="false" id="popoverA12">
-            <div class="fd-nested-list fd-nested-list--popover fd-nested-list--compact">
-                <div class="fd-nested-list__popover-header">Popover Header</div>
+            <div class="fd-popover__body-header">
+                <div class="fd-bar fd-bar--header">
+                    <div class="fd-bar__left">
+                        <div class="fd-bar__element">
+                            Popover Header
+                        </div>
+                    </div>
+                </div>
             </div>
             <ul class="fd-nested-list fd-nested-list--popover fd-nested-list--compact">
                 <li class="fd-nested-list__group-header">Group Header</li>
-                <li class="fd-nested-list__item fd-nested-list__item--popover">
-                    <a class="fd-nested-list__link" href="#/">
-                        <i role="presentation" class="fd-nested-list__icon sap-icon--home"></i>
-                        <span class="fd-nested-list__title">Level 1 Item</span>
-                    </a>
-                </li>
-                <li class="fd-nested-list__item fd-nested-list__item--popover">
-                    <a class="fd-nested-list__link is-selected" href="#/">
-                        <i role="presentation" class="fd-nested-list__icon sap-icon--calendar"></i>
-                        <span class="fd-nested-list__title">Level 1 Item</span>
-                    </a>
-                </li>
-                <li class="fd-nested-list__item fd-nested-list__item--popover">
-                    <a class="fd-nested-list__link" href="#/">
-                        <i role="presentation" class="fd-nested-list__icon sap-icon--activities"></i>
-                        <span class="fd-nested-list__title">Level 1 Item</span>
-                    </a>
-                </li>
-            </ul>
-        </div>
-    </div>
-
-    <div class="fd-popover fd-popover--right">
-        <div class="fd-popover__control">
-            <ul class="fd-nested-list fd-nested-list--compact">
-                <li class="fd-nested-list__item">
-                    <a class="fd-nested-list__link" href="#/">
-                        <i role="presentation" class="fd-nested-list__icon sap-icon--home"></i>
-                    </a>
-                </li>
-            </ul>
-        </div>
-        <div class="fd-popover__popper" aria-hidden="false" id="popoverA12">
-            <ul class="fd-nested-list fd-nested-list--popover fd-nested-list--compact">
-                <li class="fd-nested-list__group-header">Group Header</li>
-                <li class="fd-nested-list__item fd-nested-list__item--popover">
-                    <a class="fd-nested-list__link" href="#/">
-                        <i role="presentation" class="fd-nested-list__icon sap-icon--home"></i>
-                        <span class="fd-nested-list__title">Level 1 Item</span>
-                    </a>
-                </li>
-                <li class="fd-nested-list__item fd-nested-list__item--popover">
-                    <a class="fd-nested-list__link is-selected" href="#/">
-                        <i role="presentation" class="fd-nested-list__icon sap-icon--calendar"></i>
-                        <span class="fd-nested-list__title">Level 1 Item</span>
-                    </a>
-                </li>
-                <li class="fd-nested-list__item fd-nested-list__item--popover">
-                    <a class="fd-nested-list__link" href="#/">
-                        <i role="presentation" class="fd-nested-list__icon sap-icon--activities"></i>
-                        <span class="fd-nested-list__title">Level 1 Item</span>
-                    </a>
-                </li>
-            </ul>
-        </div>
-    </div>
-    <div class="fd-popover fd-popover--right">
-        <div class="fd-popover__control">
-            <ul class="fd-nested-list fd-nested-list--compact">
-                <li class="fd-nested-list__item">
-                    <a class="fd-nested-list__link" href="#/">
-                        <i role="presentation" class="fd-nested-list__icon sap-icon--home"></i>
-                    </a>
-                </li>
-            </ul>
-        </div>
-        <div class="fd-popover__popper" aria-hidden="false" id="popoverA12">
-            <ul class="fd-nested-list fd-nested-list--popover fd-nested-list--compact">
                 <li class="fd-nested-list__item fd-nested-list__item--popover">
                     <a class="fd-nested-list__link" href="#/">
                         <i role="presentation" class="fd-nested-list__icon sap-icon--home"></i>

--- a/stories/side-navigation/side-navigation.stories.js
+++ b/stories/side-navigation/side-navigation.stories.js
@@ -1268,7 +1268,7 @@ export const nestedListPopover = () => `<div class="fddocs-container" style="mar
         </div>
         <div class="fd-popover__popper" aria-hidden="false" id="popoverA11">
             <div class="fd-nested-list fd-nested-list--popover fd-nested-list--compact">
-                <div class="fd-nested-list__group-header">Group Header 1</div>
+                <div class="fd-nested-list__popover-header">Popover Header</div>
             </div>
             <ul class="fd-nested-list fd-nested-list--popover fd-nested-list--compact">
                 <li class="fd-nested-list__item">
@@ -1292,7 +1292,80 @@ export const nestedListPopover = () => `<div class="fddocs-container" style="mar
             </ul>
         </div>
     </div>
-    <div class="fd-popover fd-popover--right" style="margin-bottom: 200px">
+
+    <div class="fd-popover fd-popover--right">
+        <div class="fd-popover__control">
+            <ul class="fd-nested-list fd-nested-list--compact">
+                <li class="fd-nested-list__item">
+                    <a class="fd-nested-list__link" href="#/">
+                        <i role="presentation" class="fd-nested-list__icon sap-icon--home"></i>
+                    </a>
+                </li>
+            </ul>
+        </div>
+        <div class="fd-popover__popper" aria-hidden="false" id="popoverA12">
+            <div class="fd-nested-list fd-nested-list--popover fd-nested-list--compact">
+                <div class="fd-nested-list__popover-header">Popover Header</div>
+            </div>
+            <ul class="fd-nested-list fd-nested-list--popover fd-nested-list--compact">
+                <li class="fd-nested-list__group-header">Group Header</li>
+                <li class="fd-nested-list__item fd-nested-list__item--popover">
+                    <a class="fd-nested-list__link" href="#/">
+                        <i role="presentation" class="fd-nested-list__icon sap-icon--home"></i>
+                        <span class="fd-nested-list__title">Level 1 Item</span>
+                    </a>
+                </li>
+                <li class="fd-nested-list__item fd-nested-list__item--popover">
+                    <a class="fd-nested-list__link is-selected" href="#/">
+                        <i role="presentation" class="fd-nested-list__icon sap-icon--calendar"></i>
+                        <span class="fd-nested-list__title">Level 1 Item</span>
+                    </a>
+                </li>
+                <li class="fd-nested-list__item fd-nested-list__item--popover">
+                    <a class="fd-nested-list__link" href="#/">
+                        <i role="presentation" class="fd-nested-list__icon sap-icon--activities"></i>
+                        <span class="fd-nested-list__title">Level 1 Item</span>
+                    </a>
+                </li>
+            </ul>
+        </div>
+    </div>
+
+    <div class="fd-popover fd-popover--right">
+        <div class="fd-popover__control">
+            <ul class="fd-nested-list fd-nested-list--compact">
+                <li class="fd-nested-list__item">
+                    <a class="fd-nested-list__link" href="#/">
+                        <i role="presentation" class="fd-nested-list__icon sap-icon--home"></i>
+                    </a>
+                </li>
+            </ul>
+        </div>
+        <div class="fd-popover__popper" aria-hidden="false" id="popoverA12">
+            <ul class="fd-nested-list fd-nested-list--popover fd-nested-list--compact">
+                <li class="fd-nested-list__group-header">Group Header</li>
+                <li class="fd-nested-list__item fd-nested-list__item--popover">
+                    <a class="fd-nested-list__link" href="#/">
+                        <i role="presentation" class="fd-nested-list__icon sap-icon--home"></i>
+                        <span class="fd-nested-list__title">Level 1 Item</span>
+                    </a>
+                </li>
+                <li class="fd-nested-list__item fd-nested-list__item--popover">
+                    <a class="fd-nested-list__link is-selected" href="#/">
+                        <i role="presentation" class="fd-nested-list__icon sap-icon--calendar"></i>
+                        <span class="fd-nested-list__title">Level 1 Item</span>
+                    </a>
+                </li>
+                <li class="fd-nested-list__item fd-nested-list__item--popover">
+                    <a class="fd-nested-list__link" href="#/">
+                        <i role="presentation" class="fd-nested-list__icon sap-icon--activities"></i>
+                        <span class="fd-nested-list__title">Level 1 Item</span>
+                    </a>
+                </li>
+            </ul>
+        </div>
+    </div>
+    <div class="fd-popover fd-popover--right">
         <div class="fd-popover__control">
             <ul class="fd-nested-list fd-nested-list--compact">
                 <li class="fd-nested-list__item">

--- a/stories/side-navigation/side-navigation.stories.js
+++ b/stories/side-navigation/side-navigation.stories.js
@@ -1267,10 +1267,10 @@ export const nestedListPopover = () => `<div class="fddocs-container" style="mar
             </ul>
         </div>
         <div class="fd-popover__popper" aria-hidden="false" id="popoverA11">
+            <div class="fd-nested-list fd-nested-list--popover fd-nested-list--compact">    
+                <div class="fd-nested-list__group-header">Group Header 1</div>
+            </div>
             <ul class="fd-nested-list fd-nested-list--popover fd-nested-list--compact">
-                <li class="fd-nested-list__group-header">
-                    Group Header 1
-                </li>
                 <li class="fd-nested-list__item">
                     <a class="fd-nested-list__link" href="#/">
                         <i role="presentation" class="fd-nested-list__icon sap-icon--home"></i>


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/2691

## Description
Currently header for nested list popover is inside the list(**edit**: this header is list header, not popover header). But Ngx implementation shows that, it need to be outside the list(**edit**: popover header will be outside).
So created class "__popover-header" which will apply on popover header, outside list.
Also fixed border issue because of this change.

## Screenshots

### Before:
<img width="1032" alt="Screenshot 2021-08-26 at 12 18 12 PM" src="https://user-images.githubusercontent.com/57661487/130914844-a747730e-1abb-415d-aa1b-98153d5c2eb1.png">


### After:
<img width="1107" alt="Screenshot 2021-08-26 at 12 18 59 PM" src="https://user-images.githubusercontent.com/57661487/130914856-6c590028-035a-4bb8-ba4c-df1f765c0fac.png">

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [NA] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
