### PR TITLE
fix: update margin value for popover no-arrow

### DIFF
--- a/src/popover.scss
+++ b/src/popover.scss
@@ -252,7 +252,7 @@ $block: #{$fd-namespace}-popover;
     opacity: 1;
 
     &--no-arrow {
-      margin: 0 !important;
+      margin: 0 0.05rem !important;
 
       .#{$block}__arrow {
         display: none;


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#2690

## Description
margin value, for popover no-arrow, need to be updated, to fit combobox, multi-select, etc. dropdown popover

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/3863691/131334954-e8e9c3d3-c2bf-479e-82a3-41d2f6c22320.png)


### After:
![image](https://user-images.githubusercontent.com/3863691/131334921-c8e4a235-af8c-4a52-aefd-2ef81985191b.png)


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [N/A] Text elements follow the truncation rules
- [N/A] hover state of the element follow design spec
- [N/A ] focus state of the element follow design spec
- [ N/A] active state of the element follow design spec
- [ N/A] selected state of the element follow design spec
- [ N/A] selected hover state of the element follow design spec
- [ N/A] pressed state of the element follow design spec
- [ N/A] Responsiveness rules - the component has modifier classes for all breakpoints
- [ N/A] Includes Compact/Cosy/Tablet design
- [ N/A] RTL support
2. The code follows fundamental-styles code standards and style
- [ N/A] only one top level `fd-*` class is used in the file
- [ N/A] BEM naming convention is used
- [ N/A] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [ N/A] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [ N/A] `fd-reset()` mixin is applied to all elements
- [ N/A] Variables are used, if some value is used more than twice.
- [ N/A] Checked if current components can be reused, instead of having new code.
3. Testing
- [ N/A] tested Storybook examples with "CSS Resources" `normalize` option 
- [ N/A] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [ N/A] Verified all styles in IE11
- [ N/A] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [ N/A] Storybook documentation has been created/updated
- [ N/A] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
