### PR TITLE
fix: focus indication provided for Inverted Link.

### DIFF
--- a/src/mixins/_mixins.scss
+++ b/src/mixins/_mixins.scss
@@ -245,6 +245,10 @@
     @include fd-hover() {
       color: var(--sapLink_InvertedColor);
     }
+
+    @include fd-focus() {
+      outline-color: var(--sapContent_ContrastFocusColor);
+    }
   }
 
   &--subtle {

--- a/stories/link/__snapshots__/link.stories.storyshot
+++ b/stories/link/__snapshots__/link.stories.storyshot
@@ -55,7 +55,7 @@ exports[`Storyshots Components/Link Types 1`] = `
   
 
   <div
-    class="fd-shellbar"
+    style="background-color:var(--sapShellColor);padding:10px"
   >
     
     

--- a/stories/link/__snapshots__/link.stories.storyshot
+++ b/stories/link/__snapshots__/link.stories.storyshot
@@ -55,7 +55,7 @@ exports[`Storyshots Components/Link Types 1`] = `
   
 
   <div
-    style="background-color:#314a5e;padding:10px"
+    class="fd-shellbar"
   >
     
     

--- a/stories/link/link.stories.js
+++ b/stories/link/link.stories.js
@@ -21,7 +21,7 @@ Use a meaningful link text that indicates what will happen when the user interac
 Avoid texts such as *Click Here* or *Link*, as these do not make it clear to the user what the purpose of the link is.
 `,
         tags: ['f3', 'a11y', 'theme'],
-        components: ['icon', 'link', 'shellbar']
+        components: ['icon', 'link']
     }
 };
 
@@ -34,7 +34,7 @@ export const primary = () => `
 <br><br>
 <a class="fd-link" aria-disabled="true">Disabled link</a>
 <br><br>
-<div class="fd-shellbar">
+<div  style="background-color:var(--sapShellColor);padding:10px">
     <a href="#" class="fd-link fd-link--inverted">Inverted link</a>
 </div>
 <br><br>
@@ -70,6 +70,5 @@ You can display a link with an icon placed on either side of the link text.
 | Left Arrow | \`sap-icon--slim-arrow-left sap-icon--s\` |
 | Right Arrow | \`sap-icon--slim-arrow-right sap-icon--s\` |
 `
-
     }
 };

--- a/stories/link/link.stories.js
+++ b/stories/link/link.stories.js
@@ -21,7 +21,7 @@ Use a meaningful link text that indicates what will happen when the user interac
 Avoid texts such as *Click Here* or *Link*, as these do not make it clear to the user what the purpose of the link is.
 `,
         tags: ['f3', 'a11y', 'theme'],
-        components: ['icon', 'link']
+        components: ['icon', 'link', 'shellbar']
     }
 };
 
@@ -34,7 +34,7 @@ export const primary = () => `
 <br><br>
 <a class="fd-link" aria-disabled="true">Disabled link</a>
 <br><br>
-<div style="background-color:#314a5e;padding:10px">
+<div class="fd-shellbar">
     <a href="#" class="fd-link fd-link--inverted">Inverted link</a>
 </div>
 <br><br>


### PR DESCRIPTION
fix: focus indication provided for Inverted Link [ci visual]

## Related Issue
Closes: https://github.com/SAP/fundamental-styles/issues/2697

## Description
In high contrast white theme, focus indication provided for Inverted Link does not satisfy the minimum contrast ratio of 7:1

### Before:
<img width="783" alt="Screenshot 2021-08-27 at 7 07 57 PM" src="https://user-images.githubusercontent.com/53534379/131136227-5f19541b-f4c3-4dbe-a749-e8d9d39ca95c.png">

### After:
<img width="783" alt="Screenshot 2021-08-27 at 7 11 15 PM" src="https://user-images.githubusercontent.com/53534379/131136552-563a1c4c-6d6b-4248-ba29-1f58943a9835.png">



#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [NA] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
