### PR TITLE
fix: introduce Flat Navigation, refactor Horizontal Navigation

### DIFF
--- a/src/fundamental-styles.scss
+++ b/src/fundamental-styles.scss
@@ -34,6 +34,7 @@
 @import "./form-label";
 @import "./form-message";
 @import "./helpers";
+@import "./horizontal-navigation";
 @import "./icon-tab-bar.scss";
 @import "./info-label";
 @import "./input";

--- a/src/horizontal-navigation.scss
+++ b/src/horizontal-navigation.scss
@@ -1,0 +1,9 @@
+@import './mixins';
+
+$block: fd-horizontal-navigation;
+
+.#{$block} {
+  @include fd-reset();
+
+  box-shadow: var(--sapContent_HeaderShadow);
+}

--- a/src/icon-tab-bar.scss
+++ b/src/icon-tab-bar.scss
@@ -13,7 +13,7 @@ $fd-icon-tab-bar-multi-click-button-size: 1.5rem !default;
 $fd-icon-tab-bar-tablist-border: var(--sapContent_HeaderShadow);
 $fd-icon-tab-bar-filter-container-top-offset: 1.625rem !default;
 $fd-icon-tab-bar-overflow-button-border-radius: 0.75rem !default;
-$fd-icon-tab-bar-overflow-button-focus-offset: 0.0625rem !default;
+$fd-icon-tab-bar-overflow-button-focus-offset: 0.125rem !default;
 $fd-icon-tab-bar-filter-container-top-offset-compact: 1.375rem !default;
 
 $fd-icon-tab-bar-responsive-paddings: (
@@ -335,6 +335,8 @@ $fd-icon-tab-bar-semantic-values: (
         position: relative;
 
         &-body {
+          @include fd-set-margin-right(-0.25rem);
+
           margin-top: 0.375rem;
         }
       }
@@ -451,7 +453,6 @@ $fd-icon-tab-bar-semantic-values: (
     @include fd-flex-center();
     @include fd-set-margin-left(0.375rem);
 
-    width: $fd-icon-tab-bar-single-click-arrow-size;
     height: $fd-icon-tab-bar-single-click-arrow-size;
   }
 
@@ -648,6 +649,8 @@ $fd-icon-tab-bar-semantic-values: (
     position: absolute;
 
     &-body {
+      @include fd-set-margin-right(-0.25rem);
+
       margin-top: -0.25rem;
       z-index: 10;
     }
@@ -809,6 +812,10 @@ $fd-icon-tab-bar-semantic-values: (
       .#{$block}__badge {
         position: static;
         margin-bottom: 0.625rem;
+
+        [class*='sap-icon'] {
+          @include fd-set-margin-right(0);
+        }
       }
 
       [class*='sap-icon'] {
@@ -1159,6 +1166,12 @@ $fd-icon-tab-bar-semantic-values: (
           @include fd-tabs-focus(var(--sapShell_Navigation_TextColor), true);
         }
       }
+
+      .#{$block}__arrow {
+        [class*='sap-icon'] {
+          margin: 0;
+        }
+      }
     }
 
     .#{$block}__button {
@@ -1175,6 +1188,10 @@ $fd-icon-tab-bar-semantic-values: (
         color: var(--sapShell_Navigation_Active_TextColor);
         background: var(--sapShell_Navigation_Active_Background);
         border-color: var(--sapShell_Navigation_Active_Background);
+      }
+
+      @include fd-selected() {
+        border-color: var(--sapShell_Navigation_Background);
       }
 
       @include fd-focus() {
@@ -1215,6 +1232,62 @@ $fd-icon-tab-bar-semantic-values: (
         &::after {
           border-color: var(--sapShell_Navigation_TextColor);
         }
+      }
+    }
+  }
+
+  &--navigation-flat {
+    .#{$block}__header {
+      background: var(--sapShellColor);
+    }
+
+    .#{$block}__item {
+      &--with-separator {
+        @include fd-set-margin-right(2rem);
+
+        position: relative;
+
+        &::after {
+          content: '';
+          position: absolute;
+          width: 0.063rem;
+          height: 1.5rem;
+          background: var(--sapShell_InteractiveBorderColor);
+          right: -1rem;
+        }
+
+        @include fd-rtl() {
+          &::after {
+            right: auto;
+            left: -1rem;
+          }
+        }
+      }
+    }
+  }
+
+  &--navigation-horizontal {
+    .#{$block}__header {
+      box-shadow: none;
+    }
+
+    .#{$block}__tab {
+      padding-top: 0.75rem;
+      padding-bottom: 1rem;
+
+      @include fd-selected() {
+        &::after {
+          border-radius: 0.125rem;
+          margin-bottom: 0.188rem;
+        }
+      }
+    }
+
+    .#{$block}__button-container {
+      align-items: normal;
+
+      .#{$block}__button {
+        margin-top: 0.5rem;
       }
     }
   }

--- a/stories/horizontal-navigation/__snapshots__/horizontal-navigation.stories.storyshot
+++ b/stories/horizontal-navigation/__snapshots__/horizontal-navigation.stories.storyshot
@@ -5,215 +5,1147 @@ exports[`Storyshots Patterns/Horizontal Navigation Horizontal Navigation Text An
   style="height: 200px;"
 >
   
-
+    
   <div
-    class="fd-tool-header"
+    class="fd-horizontal-navigation"
   >
     
-    
+        
     <div
-      class="fd-tool-header__group"
+      class="fd-tool-header"
     >
       
-        
+            
       <div
-        class="fd-tool-header__element"
+        class="fd-tool-header__group"
       >
         
-            
-        <img
-          alt="SAP"
-          class="fd-tool-header__logo"
-          src="//unpkg.com/fundamental-styles/dist/images/sap-logo.png"
-          srcset="//unpkg.com/fundamental-styles/dist/images/sap-logo@2x.png 1x, //unpkg.com/fundamental-styles/dist/images/sap-logo@3x.png 2x, //unpkg.com/fundamental-styles/dist/images/sap-logo@4x.png 3x"
-        />
-        
-        
-      </div>
-      
-        
-      <div
-        class="fd-tool-header__element"
-      >
-        
-            
-        <h4
-          class="fd-title fd-title--h5 fd-tool-header__title"
+                
+        <div
+          class="fd-tool-header__element"
         >
-          Product Name
-        </h4>
+          
+                    
+          <img
+            alt="SAP"
+            class="fd-tool-header__logo"
+            src="//unpkg.com/fundamental-styles/dist/images/sap-logo.png"
+            srcset="//unpkg.com/fundamental-styles/dist/images/sap-logo@2x.png 1x, //unpkg.com/fundamental-styles/dist/images/sap-logo@3x.png 2x, //unpkg.com/fundamental-styles/dist/images/sap-logo@4x.png 3x"
+          />
+          
+                
+        </div>
         
+                
+        <div
+          class="fd-tool-header__element"
+        >
+          
+                    
+          <h4
+            class="fd-title fd-title--h5 fd-tool-header__title"
+          >
+            Product Name
+          </h4>
+          
+                
+        </div>
         
-      </div>
-      
-        
-      <div
-        class="fd-tool-header__element"
-      >
+                
+        <div
+          class="fd-tool-header__element"
+        >
+          
+                    
+          <label
+            class="fd-form-label fd-tool-header__label"
+            for="input-1"
+          >
+            Second Title
+          </label>
+          
+                
+        </div>
         
             
-        <label
-          class="fd-form-label fd-tool-header__label"
-          for="input-1"
-        >
-          Second Title
-        </label>
-        
-        
       </div>
       
+            
+      <div
+        class="fd-tool-header__group"
+      >
+        
+                
+        <div
+          class="fd-tool-header__element"
+        >
+          
+                    
+          <button
+            aria-label="search"
+            class="fd-button fd-button--compact fd-button--transparent fd-tool-header__button"
+          >
+            
+                        
+            <i
+              class="sap-icon--search"
+            />
+            
+                    
+          </button>
+          
+                
+        </div>
+        
+                
+        <div
+          class="fd-tool-header__element"
+        >
+          
+                    
+          <button
+            aria-label="task"
+            class="fd-button fd-button--compact fd-button--transparent fd-tool-header__button"
+          >
+            
+                        
+            <i
+              class="sap-icon--circle-task"
+            />
+            
+                    
+          </button>
+          
+                
+        </div>
+        
+                
+        <div
+          class="fd-tool-header__element"
+        >
+          
+                    
+          <button
+            aria-label="notification"
+            class="fd-button fd-button--compact fd-button--transparent fd-tool-header__button"
+          >
+            
+                        
+            <i
+              class="sap-icon--bell"
+            />
+            
+                    
+          </button>
+          
+                
+        </div>
+        
+                
+        <div
+          class="fd-tool-header__element"
+        >
+          
+                    
+          <span
+            aria-label="John Doe"
+            class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail"
+            role="img"
+            style="background-image: url('/assets/images/avatars/1.svg')"
+          />
+          
+                
+        </div>
+        
+                
+        <div
+          class="fd-tool-header__element"
+        >
+          
+                    
+          <button
+            aria-label="user menu control"
+            class="fd-button fd-button--compact fd-button--transparent fd-tool-header__button"
+          >
+            
+                        
+            <i
+              class="sap-icon--grid"
+            />
+            
+                    
+          </button>
+          
+                
+        </div>
+        
+            
+      </div>
+      
+        
+    </div>
     
+        
+    <div
+      class="fd-icon-tab-bar fd-icon-tab-bar--navigation fd-icon-tab-bar--navigation-horizontal fd-icon-tab-bar--sm"
+    >
+      
+            
+      <ul
+        class="fd-icon-tab-bar__header"
+        role="tablist"
+        style="overflow: visible;"
+      >
+        
+                
+        <li
+          class="fd-icon-tab-bar__item"
+          role="presentation"
+        >
+          
+                    
+          <a
+            class="fd-icon-tab-bar__tab"
+            href="#"
+            id="tab7"
+            role="tab"
+          >
+            
+                        
+            <div
+              class="fd-icon-tab-bar__tab-container"
+            >
+              
+                            
+              <i
+                class="sap-icon--home"
+              />
+              
+                            
+              <span
+                class="fd-icon-tab-bar__tag"
+              >
+                Section 1
+              </span>
+              
+                        
+            </div>
+            
+                    
+          </a>
+          
+                
+        </li>
+        
+                
+        <li
+          class="fd-icon-tab-bar__item fd-icon-tab-bar__item--single-click"
+          role="presentation"
+        >
+          
+                    
+          <div
+            class="fd-popover"
+          >
+            
+                        
+            <div
+              class="fd-popover__control"
+            >
+              
+                            
+              <a
+                aria-controls="popoverA3"
+                aria-expanded="true"
+                aria-haspopup="true"
+                aria-selected="true"
+                class="fd-icon-tab-bar__tab"
+                id="tab8"
+                onclick="onPopoverClick('popoverA3');"
+                role="tab"
+                tabindex="0"
+              >
+                
+                            
+                <div
+                  class="fd-icon-tab-bar__tab-container"
+                >
+                  
+                                
+                  <i
+                    class="sap-icon--internet-browser"
+                    role="presentation"
+                  />
+                  
+                                
+                  <span
+                    class="fd-icon-tab-bar__tag"
+                  >
+                    Section 2
+                  </span>
+                  
+                                
+                  <span
+                    class="fd-icon-tab-bar__arrow"
+                  >
+                    
+                                    
+                    <i
+                      class="sap-icon--slim-arrow-down"
+                      role="presentation"
+                    />
+                    
+                                
+                  </span>
+                  
+                            
+                </div>
+                
+                            
+              </a>
+              
+                        
+            </div>
+            
+                        
+            <div
+              aria-hidden="false"
+              class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right fd-icon-tab-bar__popover-body"
+              id="popoverA3"
+            >
+              
+                            
+              <ul
+                class="fd-list fd-list--navigation fd-list--no-border fd-icon-tab-bar__list"
+                role="list"
+              >
+                
+                                
+                <li
+                  aria-level="1"
+                  class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
+                  role="listitem"
+                  tabindex="-1"
+                >
+                  
+                                    
+                  <a
+                    class="fd-list__link"
+                    tabindex="0"
+                  >
+                    
+                                        
+                    <span
+                      class="fd-list__title"
+                    >
+                      Subsection 1
+                    </span>
+                    
+                                    
+                  </a>
+                  
+                                
+                </li>
+                
+                                
+                <li
+                  aria-level="2"
+                  class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
+                  role="listitem"
+                  tabindex="-1"
+                >
+                  
+                                    
+                  <a
+                    class="fd-list__link"
+                    tabindex="0"
+                  >
+                    
+                                    
+                    <span
+                      class="fd-list__title"
+                    >
+                      Subsection 1.1
+                    </span>
+                    
+                                    
+                  </a>
+                  
+                                
+                </li>
+                
+                            
+              </ul>
+              
+                        
+            </div>
+            
+                    
+          </div>
+          
+                
+        </li>
+        
+                
+        <li
+          class="fd-icon-tab-bar__item"
+          role="presentation"
+        >
+          
+                    
+          <a
+            class="fd-icon-tab-bar__tab"
+            href="#"
+            id="tab9"
+            role="tab"
+          >
+            
+                        
+            <div
+              class="fd-icon-tab-bar__tab-container"
+            >
+              
+                            
+              <i
+                class="sap-icon--home-share"
+              />
+              
+                            
+              <span
+                class="fd-icon-tab-bar__tag"
+              >
+                Section 3
+              </span>
+              
+                        
+            </div>
+            
+                    
+          </a>
+          
+                
+        </li>
+        
+            
+      </ul>
+      
+        
     </div>
     
     
-    <div
-      class="fd-tool-header__group"
-    >
-      
-        
-      <div
-        class="fd-tool-header__element"
-      >
-        
-            
-        <button
-          aria-label="search"
-          class="fd-button fd-button--compact fd-button--transparent fd-tool-header__button"
-        >
-          
-                
-          <i
-            class="sap-icon--search"
-          />
-          
-            
-        </button>
-        
-        
-      </div>
-      
-        
-      <div
-        class="fd-tool-header__element"
-      >
-        
-            
-        <button
-          aria-label="task"
-          class="fd-button fd-button--compact fd-button--transparent fd-tool-header__button"
-        >
-          
-                
-          <i
-            class="sap-icon--circle-task"
-          />
-          
-            
-        </button>
-        
-        
-      </div>
-      
-        
-      <div
-        class="fd-tool-header__element"
-      >
-        
-            
-        <button
-          aria-label="notification"
-          class="fd-button fd-button--compact fd-button--transparent fd-tool-header__button"
-        >
-          
-                
-          <i
-            class="sap-icon--bell"
-          />
-          
-            
-        </button>
-        
-        
-      </div>
-      
-        
-      <div
-        class="fd-tool-header__element"
-      >
-        
-            
-        <span
-          aria-label="John Doe"
-          class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail"
-          role="img"
-          style="background-image: url('/assets/images/avatars/1.svg')"
-        />
-        
-        
-      </div>
-      
-        
-      <div
-        class="fd-tool-header__element"
-      >
-        
-            
-        <button
-          aria-label="user menu control"
-          class="fd-button fd-button--compact fd-button--transparent fd-tool-header__button"
-        >
-          
-                
-          <i
-            class="sap-icon--grid"
-          />
-          
-            
-        </button>
-        
-        
-      </div>
-      
-    
-    </div>
-    
-
   </div>
   
 
+</div>
+`;
+
+exports[`Storyshots Patterns/Horizontal Navigation Horizontal Navigation Text And Icon Phone View 1`] = `
+<div
+  style="height: 200px;"
+>
+  
+    
   <div
-    class="fd-icon-tab-bar fd-icon-tab-bar--navigation fd-icon-tab-bar--sm"
+    class="fd-horizontal-navigation"
+    style="max-width: 500px;"
   >
     
-    
-    <ul
-      class="fd-icon-tab-bar__header"
-      role="tablist"
+        
+    <div
+      class="fd-tool-header fd-tool-header--sm"
+      style="max-width: 500px;"
     >
       
-        
-      <li
-        class="fd-icon-tab-bar__item"
-        role="presentation"
+            
+      <div
+        class="fd-tool-header__group"
       >
         
-            
-        <a
-          class="fd-icon-tab-bar__tab"
-          href="#"
-          id="tab7"
-          role="tab"
+                
+        <div
+          class="fd-tool-header__element"
         >
           
+                    
+          <img
+            alt="SAP"
+            class="fd-tool-header__logo"
+            src="//unpkg.com/fundamental-styles/dist/images/sap-logo.png"
+            srcset="//unpkg.com/fundamental-styles/dist/images/sap-logo@2x.png 1x, //unpkg.com/fundamental-styles/dist/images/sap-logo@3x.png 2x, //unpkg.com/fundamental-styles/dist/images/sap-logo@4x.png 3x"
+          />
+          
                 
-          <div
-            class="fd-icon-tab-bar__tab-container"
+        </div>
+        
+                
+        <div
+          class="fd-tool-header__element"
+        >
+          
+                    
+          <h4
+            class="fd-title fd-title--h5 fd-tool-header__title"
+          >
+            Product Name
+          </h4>
+          
+                
+        </div>
+        
+            
+      </div>
+      
+            
+      <div
+        class="fd-tool-header__group"
+      >
+        
+                
+        <div
+          class="fd-tool-header__element"
+        >
+          
+                    
+          <button
+            aria-label="more items"
+            class="fd-button fd-button--transparent fd-tool-header__button"
           >
             
-                    
+                        
             <i
-              class="sap-icon--home"
+              class="sap-icon--overflow"
             />
+            
+                    
+          </button>
+          
+                
+        </div>
+        
+                
+        <div
+          class="fd-tool-header__element"
+        >
+          
+                    
+          <span
+            aria-label="John Doe"
+            class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail"
+            role="img"
+            style="background-image: url('/assets/images/avatars/1.svg')"
+          />
+          
+                
+        </div>
+        
+            
+      </div>
+      
+        
+    </div>
+    
+        
+    <div
+      class="fd-icon-tab-bar fd-icon-tab-bar--navigation fd-icon-tab-bar--navigation-horizontal fd-icon-tab-bar--sm"
+      style="max-width: 500px;"
+    >
+      
+            
+      <ul
+        class="fd-icon-tab-bar__header"
+        role="tablist"
+        style="overflow: visible;"
+      >
+        
+                
+        <li
+          class="fd-icon-tab-bar__item"
+          role="presentation"
+        >
+          
+                    
+          <a
+            class="fd-icon-tab-bar__tab"
+            href="#"
+            id="tab10"
+            role="tab"
+          >
+            
+                        
+            <div
+              class="fd-icon-tab-bar__tab-container"
+            >
+              
+                            
+              <i
+                class="sap-icon--home"
+              />
+              
+                            
+              <span
+                class="fd-icon-tab-bar__tag"
+              >
+                Section 1
+              </span>
+              
+                        
+            </div>
+            
+                    
+          </a>
+          
+                
+        </li>
+        
+                
+        <li
+          class="fd-icon-tab-bar__item fd-icon-tab-bar__item--multi-click"
+          role="presentation"
+        >
+          
+                    
+          <a
+            aria-selected="true"
+            class="fd-icon-tab-bar__tab"
+            id="tab11"
+            role="tab"
+            tabindex="0"
+          >
+            
+                        
+            <div
+              class="fd-icon-tab-bar__tab-container"
+            >
+              
+                            
+              <i
+                class="sap-icon--family-care"
+              />
+              
+                            
+              <span
+                class="fd-icon-tab-bar__tag"
+              >
+                Section 2
+              </span>
+              
+                        
+            </div>
+            
+                    
+          </a>
+          
+                    
+          <div
+            class="fd-popover fd-icon-tab-bar__popover"
+          >
+            
+                        
+            <div
+              class="fd-popover__control"
+            >
+              
+                            
+              <div
+                class="fd-icon-tab-bar__button-container"
+              >
+                
+                                
+                <button
+                  aria-controls="popoverA4"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="open menu button"
+                  class="fd-button fd-button--transparent fd-button--compact  fd-icon-tab-bar__button"
+                  onclick="onPopoverClick('popoverA4');"
+                >
+                  
+                                    
+                  <i
+                    class="sap-icon--slim-arrow-down"
+                  />
+                  
+                                
+                </button>
+                
+                            
+              </div>
+              
+                        
+            </div>
+            
+                        
+            <div
+              aria-hidden="false"
+              class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right fd-icon-tab-bar__popover-body"
+              id="popoverA4"
+            >
+              
+                            
+              <ul
+                class="fd-list fd-list--navigation fd-list--no-border fd-icon-tab-bar__list"
+                role="list"
+              >
+                
+                                
+                <li
+                  aria-level="1"
+                  class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
+                  role="listitem"
+                  tabindex="-1"
+                >
+                  
+                                    
+                  <a
+                    class="fd-list__link"
+                    tabindex="0"
+                  >
+                    
+                                    
+                    <span
+                      class="fd-list__title"
+                    >
+                      Subsection 1
+                    </span>
+                    
+                                    
+                  </a>
+                  
+                                
+                </li>
+                
+                                
+                <li
+                  aria-level="1"
+                  class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
+                  role="listitem"
+                  tabindex="-1"
+                >
+                  
+                                    
+                  <a
+                    class="fd-list__link"
+                    tabindex="0"
+                  >
+                    
+                                    
+                    <span
+                      class="fd-list__title"
+                    >
+                      Subsection 2
+                    </span>
+                    
+                                    
+                  </a>
+                  
+                                
+                </li>
+                
+                            
+              </ul>
+              
+                        
+            </div>
+            
+                    
+          </div>
+          
+                
+        </li>
+        
+                
+        <li
+          class="fd-icon-tab-bar__item"
+          role="presentation"
+        >
+          
+                    
+          <a
+            class="fd-icon-tab-bar__tab"
+            href="#"
+            id="tab12"
+            role="tab"
+          >
+            
+                        
+            <div
+              class="fd-icon-tab-bar__tab-container"
+            >
+              
+                            
+              <i
+                class="sap-icon--monitor-payments"
+              />
+              
+                            
+              <span
+                class="fd-icon-tab-bar__tag"
+              >
+                Section 3
+              </span>
+              
+                        
+            </div>
+            
+                    
+          </a>
+          
+                
+        </li>
+        
+                
+        <li
+          class="fd-icon-tab-bar__item fd-icon-tab-bar__item--overflow"
+          fd-icon-tab-bar__popover"=""
+          fd-popover=""
+          role="presentation"
+          style="left: 26rem;>
+                <div class="
+        >
+          
+                    
+          <div
+            class="fd-popover__control"
+          >
+            
+                        
+            <button
+              aria-controls="popoverA5"
+              aria-expanded="false"
+              aria-haspopup="true"
+              aria-label="open menu button"
+              class="fd-icon-tab-bar__overflow"
+              onclick="onPopoverClick('popoverA5');"
+            >
+              
+                        
+              <span
+                class="fd-icon-tab-bar__overflow-text"
+              >
+                More
+              </span>
+              
+                            
+              <i
+                class="sap-icon--slim-arrow-down"
+                role="presentation"
+              />
+              
+                        
+            </button>
+            
+                    
+          </div>
+          
+                    
+          <div
+            aria-hidden="false"
+            class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right fd-icon-tab-bar__popover-body"
+            id="popoverA5"
+          >
+            
+                        
+            <ul
+              class="fd-list fd-list--navigation fd-list--no-border fd-icon-tab-bar__list"
+              role="list"
+            >
+              
+                            
+              <li
+                aria-level="1"
+                class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
+                role="listitem"
+                tabindex="-1"
+              >
+                
+                                
+                <a
+                  class="fd-list__link"
+                  tabindex="0"
+                >
+                  
+                                    
+                  <i
+                    class="sap-icon--batch-payments"
+                    role="presentation"
+                  />
+                  
+                                    
+                  <span
+                    class="fd-list__title"
+                  >
+                    Section 4
+                  </span>
+                  
+                                
+                </a>
+                
+                            
+              </li>
+              
+                            
+              <li
+                aria-level="1"
+                class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
+                role="listitem"
+                tabindex="-1"
+              >
+                
+                                
+                <a
+                  class="fd-list__link"
+                  tabindex="0"
+                >
+                  
+                                    
+                  <i
+                    class="sap-icon--credit-card"
+                    role="presentation"
+                  />
+                  
+                                    
+                  <span
+                    class="fd-list__title"
+                  >
+                    Section 5
+                  </span>
+                  
+                                
+                </a>
+                
+                            
+              </li>
+              
+                        
+            </ul>
+            
+                    
+          </div>
+          
+                
+        </li>
+      </ul>
+    </div>
+    
+            
+            
+        
+  </div>
+  
+    
+</div>
+`;
+
+exports[`Storyshots Patterns/Horizontal Navigation Horizontal Navigation Text Only 1`] = `
+<div
+  style="height: 200px;"
+>
+  
+    
+  <div
+    class="fd-horizontal-navigation"
+  >
+    
+        
+    <div
+      class="fd-tool-header"
+    >
+      
+            
+      <div
+        class="fd-tool-header__group"
+      >
+        
+                
+        <div
+          class="fd-tool-header__element"
+        >
+          
+                    
+          <img
+            alt="SAP"
+            class="fd-tool-header__logo"
+            src="//unpkg.com/fundamental-styles/dist/images/sap-logo.png"
+            srcset="//unpkg.com/fundamental-styles/dist/images/sap-logo@2x.png 1x, //unpkg.com/fundamental-styles/dist/images/sap-logo@3x.png 2x, //unpkg.com/fundamental-styles/dist/images/sap-logo@4x.png 3x"
+          />
+          
+                
+        </div>
+        
+                
+        <div
+          class="fd-tool-header__element"
+        >
+          
+                    
+          <h4
+            class="fd-title fd-title--h5 fd-tool-header__title"
+          >
+            Product Name
+          </h4>
+          
+                
+        </div>
+        
+                
+        <div
+          class="fd-tool-header__element"
+        >
+          
+                    
+          <label
+            class="fd-form-label fd-tool-header__label"
+            for="input-1"
+          >
+            Second Title
+          </label>
+          
+                
+        </div>
+        
+            
+      </div>
+      
+            
+      <div
+        class="fd-tool-header__group"
+      >
+        
+                
+        <div
+          class="fd-tool-header__element"
+        >
+          
+                    
+          <button
+            aria-label="search"
+            class="fd-button fd-button--compact fd-button--transparent fd-tool-header__button"
+          >
+            
+                        
+            <i
+              class="sap-icon--search"
+            />
+            
+                    
+          </button>
+          
+                
+        </div>
+        
+                
+        <div
+          class="fd-tool-header__element"
+        >
+          
+                    
+          <button
+            aria-label="task"
+            class="fd-button fd-button--compact fd-button--transparent fd-tool-header__button"
+          >
+            
+                        
+            <i
+              class="sap-icon--circle-task"
+            />
+            
+                    
+          </button>
+          
+                
+        </div>
+        
+                
+        <div
+          class="fd-tool-header__element"
+        >
+          
+                    
+          <button
+            aria-label="notification"
+            class="fd-button fd-button--compact fd-button--transparent fd-tool-header__button"
+          >
+            
+                        
+            <i
+              class="sap-icon--bell"
+            />
+            
+                    
+          </button>
+          
+                
+        </div>
+        
+                
+        <div
+          class="fd-tool-header__element"
+        >
+          
+                    
+          <span
+            aria-label="John Doe"
+            class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail"
+            role="img"
+            style="background-image: url('/assets/images/avatars/1.svg')"
+          />
+          
+                
+        </div>
+        
+                
+        <div
+          class="fd-tool-header__element"
+        >
+          
+                    
+          <button
+            aria-label="user menu control"
+            class="fd-button fd-button--compact fd-button--transparent fd-tool-header__button"
+          >
+            
+                        
+            <i
+              class="sap-icon--grid"
+            />
+            
+                    
+          </button>
+          
+                
+        </div>
+        
+            
+      </div>
+      
+        
+    </div>
+    
+        
+    <div
+      class="fd-icon-tab-bar fd-icon-tab-bar--navigation fd-icon-tab-bar--navigation-horizontal fd-icon-tab-bar--sm"
+    >
+      
+            
+      <ul
+        class="fd-icon-tab-bar__header"
+        role="tablist"
+        style="overflow: visible;"
+      >
+        
+                
+        <li
+          class="fd-icon-tab-bar__item"
+          role="presentation"
+        >
+          
+                    
+          <a
+            class="fd-icon-tab-bar__tab"
+            href="#"
+            id="tab1"
+            role="tab"
+          >
             
                     
             <span
@@ -222,99 +1154,461 @@ exports[`Storyshots Patterns/Horizontal Navigation Horizontal Navigation Text An
               Section 1
             </span>
             
-                
-          </div>
+                    
+          </a>
           
-            
-        </a>
+                
+        </li>
         
-        
-      </li>
-      
-        
-      <li
-        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--single-click"
-        role="presentation"
-      >
-        
-            
-        <div
-          class="fd-popover"
+                
+        <li
+          class="fd-icon-tab-bar__item fd-icon-tab-bar__item--multi-click"
+          role="presentation"
         >
           
-                
-          <div
-            class="fd-popover__control"
+                    
+          <a
+            aria-selected="true"
+            class="fd-icon-tab-bar__tab"
+            id="tab2"
+            role="tab"
+            tabindex="0"
           >
             
                     
-            <a
-              aria-controls="popoverA3"
-              aria-expanded="true"
-              aria-haspopup="true"
-              aria-selected="true"
-              class="fd-icon-tab-bar__tab"
-              id="tab8"
-              onclick="onPopoverClick('popoverA3');"
-              role="tab"
-              tabindex="0"
+            <span
+              class="fd-icon-tab-bar__tag"
+            >
+              Section 2
+            </span>
+            
+                    
+          </a>
+          
+
+                    
+          <div
+            class="fd-popover fd-icon-tab-bar__popover"
+          >
+            
+                    
+            <div
+              class="fd-popover__control"
             >
               
-                    
+                        
               <div
-                class="fd-icon-tab-bar__tab-container"
+                class="fd-icon-tab-bar__button-container"
               >
                 
                         
-                <i
-                  class="sap-icon--internet-browser"
-                  role="presentation"
-                />
-                
-                        
-                <span
-                  class="fd-icon-tab-bar__tag"
-                >
-                  Section 2
-                </span>
-                
-                        
-                <span
-                  class="fd-icon-tab-bar__arrow"
+                <button
+                  aria-controls="popoverA1"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="open menu button"
+                  class="fd-button fd-button--transparent fd-button--compact  fd-icon-tab-bar__button"
+                  onclick="onPopoverClick('popoverA1');"
                 >
                   
                             
                   <i
                     class="sap-icon--slim-arrow-down"
-                    role="presentation"
                   />
                   
                         
-                </span>
+                </button>
                 
-                    
+                        
               </div>
               
                     
-            </a>
+            </div>
             
+                    
+            <div
+              aria-hidden="false"
+              class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right fd-icon-tab-bar__popover-body"
+              id="popoverA1"
+            >
+              
+                        
+              <ul
+                class="fd-list fd-list--navigation fd-list--no-border fd-icon-tab-bar__list"
+                role="list"
+              >
                 
+                        
+                <li
+                  aria-level="1"
+                  class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
+                  role="listitem"
+                  tabindex="-1"
+                >
+                  
+                            
+                  <a
+                    class="fd-list__link"
+                    tabindex="0"
+                  >
+                    
+                            
+                    <span
+                      class="fd-list__title"
+                    >
+                      Subsection 1
+                    </span>
+                    
+                            
+                  </a>
+                  
+                        
+                </li>
+                
+                        
+                <li
+                  aria-level="1"
+                  class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
+                  role="listitem"
+                  tabindex="-1"
+                >
+                  
+                            
+                  <a
+                    class="fd-list__link"
+                    tabindex="0"
+                  >
+                    
+                            
+                    <span
+                      class="fd-list__title"
+                    >
+                      Subsection 2
+                    </span>
+                    
+                            
+                  </a>
+                  
+                        
+                </li>
+                
+                        
+              </ul>
+              
+                    
+            </div>
+            
+                    
           </div>
           
                 
-          <div
-            aria-hidden="false"
-            class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right fd-icon-tab-bar__popover-body"
-            id="popoverA3"
+        </li>
+        
+                
+        <li
+          class="fd-icon-tab-bar__item"
+          role="presentation"
+        >
+          
+                    
+          <a
+            class="fd-icon-tab-bar__tab"
+            href="#"
+            id="tab3"
+            role="tab"
           >
             
                     
+            <span
+              class="fd-icon-tab-bar__tag"
+            >
+              Section 3
+            </span>
+            
+                    
+          </a>
+          
+                
+        </li>
+        
+            
+      </ul>
+      
+        
+    </div>
+    
+    
+  </div>
+  
+
+</div>
+`;
+
+exports[`Storyshots Patterns/Horizontal Navigation Horizontal Navigation Text Only Phone View 1`] = `
+<div
+  style="height: 200px;"
+>
+  
+    
+  <div
+    class="fd-horizontal-navigation"
+    style="max-width: 500px;"
+  >
+    
+        
+    <div
+      class="fd-tool-header fd-tool-header--sm"
+      style="max-width: 500px;"
+    >
+      
+            
+      <div
+        class="fd-tool-header__group"
+      >
+        
+                
+        <div
+          class="fd-tool-header__element"
+        >
+          
+                
+          <img
+            alt="SAP"
+            class="fd-tool-header__logo"
+            src="//unpkg.com/fundamental-styles/dist/images/sap-logo.png"
+            srcset="//unpkg.com/fundamental-styles/dist/images/sap-logo@2x.png 1x, //unpkg.com/fundamental-styles/dist/images/sap-logo@3x.png 2x, //unpkg.com/fundamental-styles/dist/images/sap-logo@4x.png 3x"
+          />
+          
+                
+        </div>
+        
+                
+        <div
+          class="fd-tool-header__element"
+        >
+          
+                
+          <button
+            aria-label="mega menu"
+            class="fd-button fd-button--transparent fd-button--menu fd-tool-header__button"
+          >
+            
+                    
+            <i
+              class="sap-icon--megamenu"
+            />
+            
+                
+          </button>
+          
+                
+        </div>
+        
+            
+      </div>
+      
+            
+      <div
+        class="fd-tool-header__group"
+      >
+        
+                
+        <div
+          class="fd-tool-header__element"
+        >
+          
+                
+          <button
+            aria-label="more items"
+            class="fd-button fd-button--transparent fd-tool-header__button"
+          >
+            
+                    
+            <i
+              class="sap-icon--overflow"
+            />
+            
+                
+          </button>
+          
+                
+        </div>
+        
+                
+        <div
+          class="fd-tool-header__element"
+        >
+          
+                
+          <span
+            aria-label="John Doe"
+            class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail"
+            role="img"
+            style="background-image: url('/assets/images/avatars/1.svg')"
+          />
+          
+                
+        </div>
+        
+            
+      </div>
+      
+        
+    </div>
+    
+        
+    <div
+      class="fd-icon-tab-bar fd-icon-tab-bar--navigation fd-icon-tab-bar--navigation-horizontal fd-icon-tab-bar--sm"
+      style="max-width: 500px;"
+    >
+      
+            
+      <ul
+        class="fd-icon-tab-bar__header"
+        role="tablist"
+        style="overflow: visible;"
+      >
+        
+                
+        <li
+          class="fd-icon-tab-bar__item"
+          role="presentation"
+        >
+          
+                    
+          <a
+            class="fd-icon-tab-bar__tab"
+            href="#"
+            id="tab4"
+            role="tab"
+          >
+            
+                        
+            <span
+              class="fd-icon-tab-bar__tag"
+            >
+              Section 1
+            </span>
+            
+                    
+          </a>
+          
+                
+        </li>
+        
+                
+        <li
+          class="fd-icon-tab-bar__item"
+          role="presentation"
+        >
+          
+                    
+          <a
+            aria-selected="true"
+            class="fd-icon-tab-bar__tab"
+            href="#"
+            id="tab5"
+            role="tab"
+          >
+            
+                        
+            <span
+              class="fd-icon-tab-bar__tag"
+            >
+              Section 2
+            </span>
+            
+                    
+          </a>
+          
+                
+        </li>
+        
+                
+        <li
+          class="fd-icon-tab-bar__item"
+          role="presentation"
+        >
+          
+                    
+          <a
+            class="fd-icon-tab-bar__tab"
+            href="#"
+            id="tab6"
+            role="tab"
+          >
+            
+                        
+            <span
+              class="fd-icon-tab-bar__tag"
+            >
+              Section 3
+            </span>
+            
+                    
+          </a>
+          
+                
+        </li>
+        
+                
+        <li
+          class="fd-icon-tab-bar__item fd-icon-tab-bar__item--overflow"
+          fd-icon-tab-bar__popover"=""
+          fd-popover=""
+          role="presentation"
+          style="left: 26rem;>
+                    <div class="
+        >
+          
+                        
+          <div
+            class="fd-popover__control"
+          >
+            
+                            
+            <button
+              aria-controls="popoverA2"
+              aria-expanded="false"
+              aria-haspopup="true"
+              aria-label="open menu button"
+              class="fd-icon-tab-bar__overflow"
+              onclick="onPopoverClick('popoverA2');"
+            >
+              
+                                
+              <span
+                class="fd-icon-tab-bar__overflow-text"
+              >
+                More
+              </span>
+              
+                                
+              <i
+                class="sap-icon--slim-arrow-down"
+                role="presentation"
+              />
+              
+                            
+            </button>
+            
+                        
+          </div>
+          
+                        
+          <div
+            aria-hidden="false"
+            class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right fd-icon-tab-bar__popover-body"
+            id="popoverA2"
+          >
+            
+                        
             <ul
               class="fd-list fd-list--navigation fd-list--no-border fd-icon-tab-bar__list"
               role="list"
             >
               
-                        
+                            
               <li
                 aria-level="1"
                 class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
@@ -332,1291 +1626,16 @@ exports[`Storyshots Patterns/Horizontal Navigation Horizontal Navigation Text An
                   <span
                     class="fd-list__title"
                   >
-                    Subsection 1
-                  </span>
-                  
-                            
-                </a>
-                
-                        
-              </li>
-              
-                        
-              <li
-                aria-level="2"
-                class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
-                role="listitem"
-                tabindex="-1"
-              >
-                
-                            
-                <a
-                  class="fd-list__link"
-                  tabindex="0"
-                >
-                  
-                            
-                  <span
-                    class="fd-list__title"
-                  >
-                    Subsection 1.1
-                  </span>
-                  
-                            
-                </a>
-                
-                        
-              </li>
-              
-                    
-            </ul>
-            
-                
-          </div>
-          
-            
-        </div>
-        
-        
-      </li>
-      
-        
-      <li
-        class="fd-icon-tab-bar__item"
-        role="presentation"
-      >
-        
-            
-        <a
-          class="fd-icon-tab-bar__tab"
-          href="#"
-          id="tab9"
-          role="tab"
-        >
-          
-                
-          <div
-            class="fd-icon-tab-bar__tab-container"
-          >
-            
-                    
-            <i
-              class="sap-icon--home-share"
-            />
-            
-                    
-            <span
-              class="fd-icon-tab-bar__tag"
-            >
-              Section 3
-            </span>
-            
-                
-          </div>
-          
-            
-        </a>
-        
-        
-      </li>
-      
-    
-    </ul>
-    
-
-  </div>
-  
-
-</div>
-`;
-
-exports[`Storyshots Patterns/Horizontal Navigation Horizontal Navigation Text And Icon Phone View 1`] = `
-<div
-  style="height: 200px;"
->
-  
-
-
-  <div
-    style="height: 200px;"
-  >
-    
-  
-    <div
-      class="fd-tool-header fd-tool-header--sm"
-      style="max-width: 500px;"
-    >
-      
-    
-      <div
-        class="fd-tool-header__group"
-      >
-        
-      
-        <div
-          class="fd-tool-header__element"
-        >
-          
-        
-          <img
-            alt="SAP"
-            class="fd-tool-header__logo"
-            src="//unpkg.com/fundamental-styles/dist/images/sap-logo.png"
-            srcset="//unpkg.com/fundamental-styles/dist/images/sap-logo@2x.png 1x, //unpkg.com/fundamental-styles/dist/images/sap-logo@3x.png 2x, //unpkg.com/fundamental-styles/dist/images/sap-logo@4x.png 3x"
-          />
-          
-      
-        </div>
-        
-      
-        <div
-          class="fd-tool-header__element"
-        >
-          
-        
-          <h4
-            class="fd-title fd-title--h5 fd-tool-header__title"
-          >
-            Product Name
-          </h4>
-          
-      
-        </div>
-        
-    
-      </div>
-      
-    
-      <div
-        class="fd-tool-header__group"
-      >
-        
-      
-        <div
-          class="fd-tool-header__element"
-        >
-          
-        
-          <button
-            aria-label="more items"
-            class="fd-button fd-button--transparent fd-tool-header__button"
-          >
-            
-          
-            <i
-              class="sap-icon--overflow"
-            />
-            
-        
-          </button>
-          
-      
-        </div>
-        
-      
-        <div
-          class="fd-tool-header__element"
-        >
-          
-        
-          <span
-            aria-label="John Doe"
-            class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail"
-            role="img"
-            style="background-image: url('/assets/images/avatars/1.svg')"
-          />
-          
-      
-        </div>
-        
-    
-      </div>
-      
-
-    </div>
-    
-
-    <div
-      class="fd-icon-tab-bar fd-icon-tab-bar--navigation fd-icon-tab-bar--sm"
-      style="max-width: 500px;"
-    >
-      
-    
-      <ul
-        class="fd-icon-tab-bar__header"
-        role="tablist"
-      >
-        
-        
-        <li
-          class="fd-icon-tab-bar__item"
-          role="presentation"
-        >
-          
-            
-          <a
-            class="fd-icon-tab-bar__tab"
-            href="#"
-            id="tab10"
-            role="tab"
-          >
-            
-                
-            <div
-              class="fd-icon-tab-bar__tab-container"
-            >
-              
-                    
-              <i
-                class="sap-icon--home"
-              />
-              
-                    
-              <span
-                class="fd-icon-tab-bar__tag"
-              >
-                Section 1
-              </span>
-              
-                
-            </div>
-            
-            
-          </a>
-          
-        
-        </li>
-        
-        
-        <li
-          class="fd-icon-tab-bar__item fd-icon-tab-bar__item--multi-click"
-          role="presentation"
-        >
-          
-            
-          <a
-            aria-selected="true"
-            class="fd-icon-tab-bar__tab"
-            id="tab11"
-            role="tab"
-            tabindex="0"
-          >
-            
-                
-            <div
-              class="fd-icon-tab-bar__tab-container"
-            >
-              
-                    
-              <i
-                class="sap-icon--family-care"
-              />
-              
-                    
-              <span
-                class="fd-icon-tab-bar__tag"
-              >
-                Section 2
-              </span>
-              
-                
-            </div>
-            
-            
-          </a>
-          
-            
-          <div
-            class="fd-popover fd-icon-tab-bar__popover"
-          >
-            
-                
-            <div
-              class="fd-popover__control"
-            >
-              
-                    
-              <div
-                class="fd-icon-tab-bar__button-container"
-              >
-                
-                    
-                <button
-                  aria-controls="popoverA4"
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  aria-label="open menu button"
-                  class="fd-button fd-button--transparent fd-button--compact  fd-icon-tab-bar__button"
-                  onclick="onPopoverClick('popoverA4');"
-                >
-                  
-                        
-                  <i
-                    class="sap-icon--slim-arrow-down"
-                  />
-                  
-                    
-                </button>
-                
-                    
-              </div>
-              
-                
-            </div>
-            
-                
-            <div
-              aria-hidden="false"
-              class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right fd-icon-tab-bar__popover-body"
-              id="popoverA4"
-            >
-              
-                    
-              <ul
-                class="fd-list fd-list--navigation fd-list--no-border fd-icon-tab-bar__list"
-                role="list"
-              >
-                
-                    
-                <li
-                  aria-level="1"
-                  class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
-                  role="listitem"
-                  tabindex="-1"
-                >
-                  
-                        
-                  <a
-                    class="fd-list__link"
-                    tabindex="0"
-                  >
-                    
-                        
-                    <span
-                      class="fd-list__title"
-                    >
-                      Subsection 1
-                    </span>
-                    
-                        
-                  </a>
-                  
-                    
-                </li>
-                
-                    
-                <li
-                  aria-level="1"
-                  class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
-                  role="listitem"
-                  tabindex="-1"
-                >
-                  
-                        
-                  <a
-                    class="fd-list__link"
-                    tabindex="0"
-                  >
-                    
-                        
-                    <span
-                      class="fd-list__title"
-                    >
-                      Subsection 2
-                    </span>
-                    
-                        
-                  </a>
-                  
-                    
-                </li>
-                
-                    
-              </ul>
-              
-                
-            </div>
-            
-            
-          </div>
-          
-        
-        </li>
-        
-        
-        <li
-          class="fd-icon-tab-bar__item"
-          role="presentation"
-        >
-          
-            
-          <a
-            class="fd-icon-tab-bar__tab"
-            href="#"
-            id="tab12"
-            role="tab"
-          >
-            
-                
-            <div
-              class="fd-icon-tab-bar__tab-container"
-            >
-              
-                    
-              <i
-                class="sap-icon--monitor-payments"
-              />
-              
-                    
-              <span
-                class="fd-icon-tab-bar__tag"
-              >
-                Section 3
-              </span>
-              
-                
-            </div>
-            
-            
-          </a>
-          
-        
-        </li>
-        
-        
-        <li
-          class="fd-icon-tab-bar__item fd-icon-tab-bar__item--overflow"
-          role="presentation"
-        >
-          
-        
-          <div
-            class="fd-popover fd-icon-tab-bar__popover"
-          >
-            
-          
-            <div
-              class="fd-popover__control"
-            >
-              
-            
-              <button
-                aria-controls="popoverA5"
-                aria-expanded="false"
-                aria-haspopup="true"
-                aria-label="open menu button"
-                class="fd-icon-tab-bar__overflow"
-                onclick="onPopoverClick('popoverA5');"
-              >
-                
-              
-                <span
-                  class="fd-icon-tab-bar__overflow-text"
-                >
-                  More
-                </span>
-                
-              
-                <i
-                  class="sap-icon--slim-arrow-down"
-                  role="presentation"
-                />
-                
-            
-              </button>
-              
-          
-            </div>
-            
-          
-            <div
-              aria-hidden="false"
-              class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right fd-icon-tab-bar__popover-body"
-              id="popoverA5"
-            >
-              
-            
-              <ul
-                class="fd-list fd-list--navigation fd-list--no-border fd-icon-tab-bar__list"
-                role="list"
-              >
-                
-              
-                <li
-                  aria-level="1"
-                  class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
-                  role="listitem"
-                  tabindex="-1"
-                >
-                  
-                
-                  <a
-                    class="fd-list__link"
-                    tabindex="0"
-                  >
-                    
-                  
-                    <i
-                      class="sap-icon--batch-payments"
-                      role="presentation"
-                    />
-                    
-                  
-                    <span
-                      class="fd-list__title"
-                    >
-                      Section 4
-                    </span>
-                    
-                
-                  </a>
-                  
-              
-                </li>
-                
-              
-                <li
-                  aria-level="1"
-                  class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
-                  role="listitem"
-                  tabindex="-1"
-                >
-                  
-                
-                  <a
-                    class="fd-list__link"
-                    tabindex="0"
-                  >
-                    
-                  
-                    <i
-                      class="sap-icon--credit-card"
-                      role="presentation"
-                    />
-                    
-                  
-                    <span
-                      class="fd-list__title"
-                    >
-                      Section 5
-                    </span>
-                    
-                
-                  </a>
-                  
-              
-                </li>
-                
-            
-              </ul>
-              
-          
-            </div>
-            
-        
-          </div>
-          
-      
-        </li>
-        
-    
-      </ul>
-      
-
-    </div>
-    
-
-  </div>
-  
-
-</div>
-`;
-
-exports[`Storyshots Patterns/Horizontal Navigation Horizontal Navigation Text Only 1`] = `
-<div
-  style="height: 200px;"
->
-  
-
-  <div
-    class="fd-tool-header"
-  >
-    
-    
-    <div
-      class="fd-tool-header__group"
-    >
-      
-        
-      <div
-        class="fd-tool-header__element"
-      >
-        
-            
-        <img
-          alt="SAP"
-          class="fd-tool-header__logo"
-          src="//unpkg.com/fundamental-styles/dist/images/sap-logo.png"
-          srcset="//unpkg.com/fundamental-styles/dist/images/sap-logo@2x.png 1x, //unpkg.com/fundamental-styles/dist/images/sap-logo@3x.png 2x, //unpkg.com/fundamental-styles/dist/images/sap-logo@4x.png 3x"
-        />
-        
-        
-      </div>
-      
-        
-      <div
-        class="fd-tool-header__element"
-      >
-        
-            
-        <h4
-          class="fd-title fd-title--h5 fd-tool-header__title"
-        >
-          Product Name
-        </h4>
-        
-        
-      </div>
-      
-        
-      <div
-        class="fd-tool-header__element"
-      >
-        
-            
-        <label
-          class="fd-form-label fd-tool-header__label"
-          for="input-1"
-        >
-          Second Title
-        </label>
-        
-        
-      </div>
-      
-    
-    </div>
-    
-    
-    <div
-      class="fd-tool-header__group"
-    >
-      
-        
-      <div
-        class="fd-tool-header__element"
-      >
-        
-            
-        <button
-          aria-label="search"
-          class="fd-button fd-button--compact fd-button--transparent fd-tool-header__button"
-        >
-          
-                
-          <i
-            class="sap-icon--search"
-          />
-          
-            
-        </button>
-        
-        
-      </div>
-      
-        
-      <div
-        class="fd-tool-header__element"
-      >
-        
-            
-        <button
-          aria-label="task"
-          class="fd-button fd-button--compact fd-button--transparent fd-tool-header__button"
-        >
-          
-                
-          <i
-            class="sap-icon--circle-task"
-          />
-          
-            
-        </button>
-        
-        
-      </div>
-      
-        
-      <div
-        class="fd-tool-header__element"
-      >
-        
-            
-        <button
-          aria-label="notification"
-          class="fd-button fd-button--compact fd-button--transparent fd-tool-header__button"
-        >
-          
-                
-          <i
-            class="sap-icon--bell"
-          />
-          
-            
-        </button>
-        
-        
-      </div>
-      
-        
-      <div
-        class="fd-tool-header__element"
-      >
-        
-            
-        <span
-          aria-label="John Doe"
-          class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail"
-          role="img"
-          style="background-image: url('/assets/images/avatars/1.svg')"
-        />
-        
-        
-      </div>
-      
-        
-      <div
-        class="fd-tool-header__element"
-      >
-        
-            
-        <button
-          aria-label="user menu control"
-          class="fd-button fd-button--compact fd-button--transparent fd-tool-header__button"
-        >
-          
-                
-          <i
-            class="sap-icon--grid"
-          />
-          
-            
-        </button>
-        
-        
-      </div>
-      
-    
-    </div>
-    
-
-  </div>
-  
-
-  <div
-    class="fd-icon-tab-bar fd-icon-tab-bar--navigation fd-icon-tab-bar--sm"
-  >
-    
-    
-    <ul
-      class="fd-icon-tab-bar__header"
-      role="tablist"
-    >
-      
-        
-      <li
-        class="fd-icon-tab-bar__item"
-        role="presentation"
-      >
-        
-            
-        <a
-          class="fd-icon-tab-bar__tab"
-          href="#"
-          id="tab1"
-          role="tab"
-        >
-          
-            
-          <span
-            class="fd-icon-tab-bar__tag"
-          >
-            Section 1
-          </span>
-          
-            
-        </a>
-        
-        
-      </li>
-      
-        
-      <li
-        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--multi-click"
-        role="presentation"
-      >
-        
-            
-        <a
-          aria-selected="true"
-          class="fd-icon-tab-bar__tab"
-          id="tab2"
-          role="tab"
-          tabindex="0"
-        >
-          
-            
-          <span
-            class="fd-icon-tab-bar__tag"
-          >
-            Section 2
-          </span>
-          
-            
-        </a>
-        
-
-            
-        <div
-          class="fd-popover fd-icon-tab-bar__popover"
-        >
-          
-            
-          <div
-            class="fd-popover__control"
-          >
-            
-                
-            <div
-              class="fd-icon-tab-bar__button-container"
-            >
-              
-                
-              <button
-                aria-controls="popoverA1"
-                aria-expanded="false"
-                aria-haspopup="true"
-                aria-label="open menu button"
-                class="fd-button fd-button--transparent fd-button--compact  fd-icon-tab-bar__button"
-                onclick="onPopoverClick('popoverA1');"
-              >
-                
-                    
-                <i
-                  class="sap-icon--slim-arrow-down"
-                />
-                
-                
-              </button>
-              
-                
-            </div>
-            
-            
-          </div>
-          
-            
-          <div
-            aria-hidden="false"
-            class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right fd-icon-tab-bar__popover-body"
-            id="popoverA1"
-          >
-            
-                
-            <ul
-              class="fd-list fd-list--navigation fd-list--no-border fd-icon-tab-bar__list"
-              role="list"
-            >
-              
-                
-              <li
-                aria-level="1"
-                class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
-                role="listitem"
-                tabindex="-1"
-              >
-                
-                    
-                <a
-                  class="fd-list__link"
-                  tabindex="0"
-                >
-                  
-                    
-                  <span
-                    class="fd-list__title"
-                  >
-                    Subsection 1
-                  </span>
-                  
-                    
-                </a>
-                
-                
-              </li>
-              
-                
-              <li
-                aria-level="1"
-                class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
-                role="listitem"
-                tabindex="-1"
-              >
-                
-                    
-                <a
-                  class="fd-list__link"
-                  tabindex="0"
-                >
-                  
-                    
-                  <span
-                    class="fd-list__title"
-                  >
-                    Subsection 2
-                  </span>
-                  
-                    
-                </a>
-                
-                
-              </li>
-              
-                
-            </ul>
-            
-            
-          </div>
-          
-            
-        </div>
-        
-        
-      </li>
-      
-        
-      <li
-        class="fd-icon-tab-bar__item"
-        role="presentation"
-      >
-        
-            
-        <a
-          class="fd-icon-tab-bar__tab"
-          href="#"
-          id="tab3"
-          role="tab"
-        >
-          
-            
-          <span
-            class="fd-icon-tab-bar__tag"
-          >
-            Section 3
-          </span>
-          
-            
-        </a>
-        
-        
-      </li>
-      
-    
-    </ul>
-    
-
-  </div>
-  
-
-</div>
-`;
-
-exports[`Storyshots Patterns/Horizontal Navigation Horizontal Navigation Text Only Phone View 1`] = `
-<div
-  style="height: 200px;"
->
-  
-
-  <div
-    class="fd-tool-header fd-tool-header--sm"
-    style="max-width: 500px;"
-  >
-    
-  
-    <div
-      class="fd-tool-header__group"
-    >
-      
-    
-      <div
-        class="fd-tool-header__element"
-      >
-        
-      
-        <img
-          alt="SAP"
-          class="fd-tool-header__logo"
-          src="//unpkg.com/fundamental-styles/dist/images/sap-logo.png"
-          srcset="//unpkg.com/fundamental-styles/dist/images/sap-logo@2x.png 1x, //unpkg.com/fundamental-styles/dist/images/sap-logo@3x.png 2x, //unpkg.com/fundamental-styles/dist/images/sap-logo@4x.png 3x"
-        />
-        
-    
-      </div>
-      
-    
-      <div
-        class="fd-tool-header__element"
-      >
-        
-      
-        <button
-          aria-label="mega menu"
-          class="fd-button fd-button--transparent fd-button--menu fd-tool-header__button"
-        >
-          
-        
-          <i
-            class="sap-icon--megamenu"
-          />
-          
-      
-        </button>
-        
-    
-      </div>
-      
-  
-    </div>
-    
-  
-    <div
-      class="fd-tool-header__group"
-    >
-      
-    
-      <div
-        class="fd-tool-header__element"
-      >
-        
-      
-        <button
-          aria-label="more items"
-          class="fd-button fd-button--transparent fd-tool-header__button"
-        >
-          
-        
-          <i
-            class="sap-icon--overflow"
-          />
-          
-      
-        </button>
-        
-    
-      </div>
-      
-    
-      <div
-        class="fd-tool-header__element"
-      >
-        
-      
-        <span
-          aria-label="John Doe"
-          class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail"
-          role="img"
-          style="background-image: url('/assets/images/avatars/1.svg')"
-        />
-        
-    
-      </div>
-      
-  
-    </div>
-    
-
-  </div>
-  
-
-  <div
-    class="fd-icon-tab-bar fd-icon-tab-bar--sm fd-icon-tab-bar--navigation"
-    style="max-width: 500px;"
-  >
-    
-    
-    <ul
-      class="fd-icon-tab-bar__header"
-      role="tablist"
-    >
-      
-        
-      <li
-        class="fd-icon-tab-bar__item"
-        role="presentation"
-      >
-        
-            
-        <a
-          class="fd-icon-tab-bar__tab"
-          href="#"
-          id="tab4"
-          role="tab"
-        >
-          
-                
-          <span
-            class="fd-icon-tab-bar__tag"
-          >
-            Section 1
-          </span>
-          
-            
-        </a>
-        
-        
-      </li>
-      
-        
-      <li
-        class="fd-icon-tab-bar__item"
-        role="presentation"
-      >
-        
-            
-        <a
-          aria-selected="true"
-          class="fd-icon-tab-bar__tab"
-          href="#"
-          id="tab5"
-          role="tab"
-        >
-          
-                
-          <span
-            class="fd-icon-tab-bar__tag"
-          >
-            Section 2
-          </span>
-          
-            
-        </a>
-        
-        
-      </li>
-      
-        
-      <li
-        class="fd-icon-tab-bar__item"
-        role="presentation"
-      >
-        
-            
-        <a
-          class="fd-icon-tab-bar__tab"
-          href="#"
-          id="tab6"
-          role="tab"
-        >
-          
-                
-          <span
-            class="fd-icon-tab-bar__tag"
-          >
-            Section 3
-          </span>
-          
-            
-        </a>
-        
-        
-      </li>
-      
-        
-      <li
-        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--overflow"
-        role="presentation"
-      >
-        
-            
-        <div
-          class="fd-popover fd-icon-tab-bar__popover"
-        >
-          
-                
-          <div
-            class="fd-popover__control"
-          >
-            
-                    
-            <button
-              aria-controls="popoverA2"
-              aria-expanded="false"
-              aria-haspopup="true"
-              aria-label="open menu button"
-              class="fd-icon-tab-bar__overflow"
-              onclick="onPopoverClick('popoverA2');"
-            >
-              
-                        
-              <span
-                class="fd-icon-tab-bar__overflow-text"
-              >
-                More
-              </span>
-              
-                        
-              <i
-                class="sap-icon--slim-arrow-down"
-                role="presentation"
-              />
-              
-                    
-            </button>
-            
-                
-          </div>
-          
-                
-          <div
-            aria-hidden="false"
-            class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right fd-icon-tab-bar__popover-body"
-            id="popoverA2"
-          >
-            
-                
-            <ul
-              class="fd-list fd-list--navigation fd-list--no-border fd-icon-tab-bar__list"
-              role="list"
-            >
-              
-                    
-              <li
-                aria-level="1"
-                class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
-                role="listitem"
-                tabindex="-1"
-              >
-                
-                    
-                <a
-                  class="fd-list__link"
-                  tabindex="0"
-                >
-                  
-                        
-                  <span
-                    class="fd-list__title"
-                  >
                     Section 4
                   </span>
                   
-                    
+                            
                 </a>
                 
-                    
+                            
               </li>
               
-                    
+                            
               <li
                 aria-level="1"
                 class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
@@ -1624,43 +1643,41 @@ exports[`Storyshots Patterns/Horizontal Navigation Horizontal Navigation Text On
                 tabindex="-1"
               >
                 
-                    
+                            
                 <a
                   class="fd-list__link"
                   tabindex="0"
                 >
                   
-                        
+                                
                   <span
                     class="fd-list__title"
                   >
                     Section 5
                   </span>
                   
-                    
+                            
                 </a>
                 
-                    
+                            
               </li>
               
-                
+                        
             </ul>
             
-                
+                        
           </div>
           
+                    
+        </li>
+      </ul>
+    </div>
+    
+                
             
-        </div>
         
-        
-      </li>
-      
-    
-    </ul>
-    
-
   </div>
   
-
+    
 </div>
 `;

--- a/stories/horizontal-navigation/horizontal-navigation.stories.js
+++ b/stories/horizontal-navigation/horizontal-navigation.stories.js
@@ -7,9 +7,11 @@ Preferably the Horizontal Navigation is suitable for a maximum of seven to nine 
 
 It displays the navigation items respectively in horizontal mode. The Tabs are displayed underneath the Tool Header, enabling the navigation into another page and context within the same Application while the Tool Header and the Tabs remain static.   
 
-The Horizontal Navigation Tabs are built with the IconTabBar component.
+The Horizontal Navigation Tabs are built with the IconTabBar component with two additional modifier classes \`.fd-icon-tab-bar--navigation\` nad \`.fd-icon-tab-bar--navigation-horizontal\`.
 
 The Horizontal Navigation is always integrated with the Tool Header. It should not be displayed standalone. 
+
+Both components, Tool Header and IconTabBar, are wrapped in an element with \`.fd-horizontal-navigation \` class.
 
 Differently than the Side Navigation, the Horizontal Navigation does not embed a separate Utility Section (bottom aligned in the Side Navigation). Those items, mainly legal information and useful links, are recommended to be placed in the User Menu within the Tool Header.
 
@@ -17,256 +19,262 @@ Another aspect differentiating the Horizontal Navigation layout is that it has o
 
         `,
         tags: ['btp', 'non-f3', 'theme', 'development'],
-        components: ['tool-header', 'button', 'icon', 'list', 'popover', 'icon-tab-bar', 'avatar', 'form-label', 'input-group', 'text', 'title' ]
+        components: ['tool-header', 'button', 'icon', 'list', 'popover', 'icon-tab-bar', 'avatar', 'form-label', 'input-group', 'text', 'title', 'horizontal-navigation' ]
     }
 };
 
 export const textOnly = () => `<div style="height: 200px;">
-<div class="fd-tool-header">
-    <div class="fd-tool-header__group">
-        <div class="fd-tool-header__element">
-            <img class="fd-tool-header__logo" src="//unpkg.com/fundamental-styles/dist/images/sap-logo.png" srcset="//unpkg.com/fundamental-styles/dist/images/sap-logo@2x.png 1x, //unpkg.com/fundamental-styles/dist/images/sap-logo@3x.png 2x, //unpkg.com/fundamental-styles/dist/images/sap-logo@4x.png 3x" alt="SAP">
-        </div>
-        <div class="fd-tool-header__element">
-            <h4 class="fd-title fd-title--h5 fd-tool-header__title">Product Name</h4>
-        </div>
-        <div class="fd-tool-header__element">
-            <label class="fd-form-label fd-tool-header__label" for="input-1">Second Title</label>
-        </div>
-    </div>
-    <div class="fd-tool-header__group">
-        <div class="fd-tool-header__element">
-            <button class="fd-button fd-button--compact fd-button--transparent fd-tool-header__button" aria-label="search">
-                <i class="sap-icon--search"></i>
-            </button>
-        </div>
-        <div class="fd-tool-header__element">
-            <button class="fd-button fd-button--compact fd-button--transparent fd-tool-header__button" aria-label="task">
-                <i class="sap-icon--circle-task"></i>
-            </button>
-        </div>
-        <div class="fd-tool-header__element">
-            <button class="fd-button fd-button--compact fd-button--transparent fd-tool-header__button" aria-label="notification">
-                <i class="sap-icon--bell"></i>
-            </button>
-        </div>
-        <div class="fd-tool-header__element">
-            <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/1.svg')" role="img" aria-label="John Doe"></span>
-        </div>
-        <div class="fd-tool-header__element">
-            <button class="fd-button fd-button--compact fd-button--transparent fd-tool-header__button" aria-label="user menu control">
-                <i class="sap-icon--grid"></i>
-            </button>
-        </div>
-    </div>
-</div>
-<div class="fd-icon-tab-bar fd-icon-tab-bar--navigation fd-icon-tab-bar--sm">
-    <ul role="tablist" class="fd-icon-tab-bar__header">
-        <li role="presentation" class="fd-icon-tab-bar__item">
-            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab1">
-            <span class="fd-icon-tab-bar__tag">Section 1</span>
-            </a>
-        </li>
-        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--multi-click">
-            <a role="tab" class="fd-icon-tab-bar__tab" aria-selected="true" id="tab2" tabindex="0">
-            <span class="fd-icon-tab-bar__tag">Section 2</span>
-            </a>
-
-            <div class="fd-popover fd-icon-tab-bar__popover">
-            <div class="fd-popover__control">
-                <div class="fd-icon-tab-bar__button-container">
-                <button class="fd-button fd-button--transparent fd-button--compact  fd-icon-tab-bar__button" aria-controls="popoverA1" aria-expanded="false" aria-haspopup="true" onclick="onPopoverClick('popoverA1');" aria-label="open menu button">
-                    <i class="sap-icon--slim-arrow-down"></i>
-                </button>
+    <div class="fd-horizontal-navigation">
+        <div class="fd-tool-header">
+            <div class="fd-tool-header__group">
+                <div class="fd-tool-header__element">
+                    <img class="fd-tool-header__logo" src="//unpkg.com/fundamental-styles/dist/images/sap-logo.png" srcset="//unpkg.com/fundamental-styles/dist/images/sap-logo@2x.png 1x, //unpkg.com/fundamental-styles/dist/images/sap-logo@3x.png 2x, //unpkg.com/fundamental-styles/dist/images/sap-logo@4x.png 3x" alt="SAP">
+                </div>
+                <div class="fd-tool-header__element">
+                    <h4 class="fd-title fd-title--h5 fd-tool-header__title">Product Name</h4>
+                </div>
+                <div class="fd-tool-header__element">
+                    <label class="fd-form-label fd-tool-header__label" for="input-1">Second Title</label>
                 </div>
             </div>
-            <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right fd-icon-tab-bar__popover-body" aria-hidden="false" id="popoverA1">
-                <ul class="fd-list fd-list--navigation fd-list--no-border fd-icon-tab-bar__list" role="list">
-                <li tabindex="-1" role="listitem" aria-level="1" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
-                    <a tabindex="0" class="fd-list__link">
-                    <span class="fd-list__title">Subsection 1</span>
+            <div class="fd-tool-header__group">
+                <div class="fd-tool-header__element">
+                    <button class="fd-button fd-button--compact fd-button--transparent fd-tool-header__button" aria-label="search">
+                        <i class="sap-icon--search"></i>
+                    </button>
+                </div>
+                <div class="fd-tool-header__element">
+                    <button class="fd-button fd-button--compact fd-button--transparent fd-tool-header__button" aria-label="task">
+                        <i class="sap-icon--circle-task"></i>
+                    </button>
+                </div>
+                <div class="fd-tool-header__element">
+                    <button class="fd-button fd-button--compact fd-button--transparent fd-tool-header__button" aria-label="notification">
+                        <i class="sap-icon--bell"></i>
+                    </button>
+                </div>
+                <div class="fd-tool-header__element">
+                    <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/1.svg')" role="img" aria-label="John Doe"></span>
+                </div>
+                <div class="fd-tool-header__element">
+                    <button class="fd-button fd-button--compact fd-button--transparent fd-tool-header__button" aria-label="user menu control">
+                        <i class="sap-icon--grid"></i>
+                    </button>
+                </div>
+            </div>
+        </div>
+        <div class="fd-icon-tab-bar fd-icon-tab-bar--navigation fd-icon-tab-bar--navigation-horizontal fd-icon-tab-bar--sm">
+            <ul role="tablist" class="fd-icon-tab-bar__header" style="overflow: visible;">
+                <li role="presentation" class="fd-icon-tab-bar__item">
+                    <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab1">
+                    <span class="fd-icon-tab-bar__tag">Section 1</span>
                     </a>
                 </li>
-                <li tabindex="-1" role="listitem" aria-level="1" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
-                    <a tabindex="0" class="fd-list__link">
-                    <span class="fd-list__title">Subsection 2</span>
+                <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--multi-click">
+                    <a role="tab" class="fd-icon-tab-bar__tab" aria-selected="true" id="tab2" tabindex="0">
+                    <span class="fd-icon-tab-bar__tag">Section 2</span>
+                    </a>
+
+                    <div class="fd-popover fd-icon-tab-bar__popover">
+                    <div class="fd-popover__control">
+                        <div class="fd-icon-tab-bar__button-container">
+                        <button class="fd-button fd-button--transparent fd-button--compact  fd-icon-tab-bar__button" aria-controls="popoverA1" aria-expanded="false" aria-haspopup="true" onclick="onPopoverClick('popoverA1');" aria-label="open menu button">
+                            <i class="sap-icon--slim-arrow-down"></i>
+                        </button>
+                        </div>
+                    </div>
+                    <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right fd-icon-tab-bar__popover-body" aria-hidden="false" id="popoverA1">
+                        <ul class="fd-list fd-list--navigation fd-list--no-border fd-icon-tab-bar__list" role="list">
+                        <li tabindex="-1" role="listitem" aria-level="1" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                            <a tabindex="0" class="fd-list__link">
+                            <span class="fd-list__title">Subsection 1</span>
+                            </a>
+                        </li>
+                        <li tabindex="-1" role="listitem" aria-level="1" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                            <a tabindex="0" class="fd-list__link">
+                            <span class="fd-list__title">Subsection 2</span>
+                            </a>
+                        </li>
+                        </ul>
+                    </div>
+                    </div>
+                </li>
+                <li role="presentation" class="fd-icon-tab-bar__item">
+                    <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab3">
+                    <span class="fd-icon-tab-bar__tag">Section 3</span>
                     </a>
                 </li>
-                </ul>
-            </div>
-            </div>
-        </li>
-        <li role="presentation" class="fd-icon-tab-bar__item">
-            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab3">
-            <span class="fd-icon-tab-bar__tag">Section 3</span>
-            </a>
-        </li>
-    </ul>
-</div>
+            </ul>
+        </div>
+    </div>
 </div>
 `;
 
 textOnly.storyName = 'Horizontal Navigation Text Only';
 
 export const textOnlyPhone = () => `<div style="height: 200px;">
-<div class="fd-tool-header fd-tool-header--sm" style="max-width: 500px;">
-  <div class="fd-tool-header__group">
-    <div class="fd-tool-header__element">
-      <img class="fd-tool-header__logo" src="//unpkg.com/fundamental-styles/dist/images/sap-logo.png" srcset="//unpkg.com/fundamental-styles/dist/images/sap-logo@2x.png 1x, //unpkg.com/fundamental-styles/dist/images/sap-logo@3x.png 2x, //unpkg.com/fundamental-styles/dist/images/sap-logo@4x.png 3x" alt="SAP">
-    </div>
-    <div class="fd-tool-header__element">
-      <button class="fd-button fd-button--transparent fd-button--menu fd-tool-header__button" aria-label="mega menu">
-        <i class="sap-icon--megamenu"></i>
-      </button>
-    </div>
-  </div>
-  <div class="fd-tool-header__group">
-    <div class="fd-tool-header__element">
-      <button class="fd-button fd-button--transparent fd-tool-header__button" aria-label="more items">
-        <i class="sap-icon--overflow"></i>
-      </button>
-    </div>
-    <div class="fd-tool-header__element">
-      <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/1.svg')" role="img" aria-label="John Doe"></span>
-    </div>
-  </div>
-</div>
-<div class="fd-icon-tab-bar fd-icon-tab-bar--sm fd-icon-tab-bar--navigation" style="max-width: 500px;">
-    <ul role="tablist" class="fd-icon-tab-bar__header">
-        <li role="presentation" class="fd-icon-tab-bar__item">
-            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab4">
-                <span class="fd-icon-tab-bar__tag">Section 1</span>
-            </a>
-        </li>
-        <li role="presentation" class="fd-icon-tab-bar__item">
-            <a role="tab" class="fd-icon-tab-bar__tab" href="#" aria-selected="true" id="tab5">
-                <span class="fd-icon-tab-bar__tag">Section 2</span>
-            </a>
-        </li>
-        <li role="presentation" class="fd-icon-tab-bar__item">
-            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab6">
-                <span class="fd-icon-tab-bar__tag">Section 3</span>
-            </a>
-        </li>
-        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--overflow">
-            <div class="fd-popover fd-icon-tab-bar__popover">
-                <div class="fd-popover__control">
-                    <button class="fd-icon-tab-bar__overflow" aria-controls="popoverA2" aria-expanded="false" aria-haspopup="true" onclick="onPopoverClick('popoverA2');" aria-label="open menu button">
-                        <span class="fd-icon-tab-bar__overflow-text">More</span>
-                        <i class="sap-icon--slim-arrow-down" role="presentation"></i>
-                    </button>
+    <div class="fd-horizontal-navigation" style="max-width: 500px;">
+        <div class="fd-tool-header fd-tool-header--sm" style="max-width: 500px;">
+            <div class="fd-tool-header__group">
+                <div class="fd-tool-header__element">
+                <img class="fd-tool-header__logo" src="//unpkg.com/fundamental-styles/dist/images/sap-logo.png" srcset="//unpkg.com/fundamental-styles/dist/images/sap-logo@2x.png 1x, //unpkg.com/fundamental-styles/dist/images/sap-logo@3x.png 2x, //unpkg.com/fundamental-styles/dist/images/sap-logo@4x.png 3x" alt="SAP">
                 </div>
-                <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right fd-icon-tab-bar__popover-body" aria-hidden="false" id="popoverA2">
-                <ul class="fd-list fd-list--navigation fd-list--no-border fd-icon-tab-bar__list" role="list">
-                    <li tabindex="-1" role="listitem" aria-level="1" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
-                    <a tabindex="0" class="fd-list__link">
-                        <span class="fd-list__title">Section 4</span>
-                    </a>
-                    </li>
-                    <li tabindex="-1" role="listitem" aria-level="1" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
-                    <a tabindex="0" class="fd-list__link">
-                        <span class="fd-list__title">Section 5</span>
-                    </a>
-                    </li>
-                </ul>
+                <div class="fd-tool-header__element">
+                <button class="fd-button fd-button--transparent fd-button--menu fd-tool-header__button" aria-label="mega menu">
+                    <i class="sap-icon--megamenu"></i>
+                </button>
                 </div>
             </div>
-        </li>
-    </ul>
-</div>
+            <div class="fd-tool-header__group">
+                <div class="fd-tool-header__element">
+                <button class="fd-button fd-button--transparent fd-tool-header__button" aria-label="more items">
+                    <i class="sap-icon--overflow"></i>
+                </button>
+                </div>
+                <div class="fd-tool-header__element">
+                <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/1.svg')" role="img" aria-label="John Doe"></span>
+                </div>
+            </div>
+        </div>
+        <div class="fd-icon-tab-bar fd-icon-tab-bar--navigation fd-icon-tab-bar--navigation-horizontal fd-icon-tab-bar--sm" style="max-width: 500px;">
+            <ul role="tablist" class="fd-icon-tab-bar__header" style="overflow: visible;">
+                <li role="presentation" class="fd-icon-tab-bar__item">
+                    <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab4">
+                        <span class="fd-icon-tab-bar__tag">Section 1</span>
+                    </a>
+                </li>
+                <li role="presentation" class="fd-icon-tab-bar__item">
+                    <a role="tab" class="fd-icon-tab-bar__tab" href="#" aria-selected="true" id="tab5">
+                        <span class="fd-icon-tab-bar__tag">Section 2</span>
+                    </a>
+                </li>
+                <li role="presentation" class="fd-icon-tab-bar__item">
+                    <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab6">
+                        <span class="fd-icon-tab-bar__tag">Section 3</span>
+                    </a>
+                </li>
+                <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--overflow" style="left: 26rem;>
+                    <div class="fd-popover fd-icon-tab-bar__popover">
+                        <div class="fd-popover__control">
+                            <button class="fd-icon-tab-bar__overflow" aria-controls="popoverA2" aria-expanded="false" aria-haspopup="true" onclick="onPopoverClick('popoverA2');" aria-label="open menu button">
+                                <span class="fd-icon-tab-bar__overflow-text">More</span>
+                                <i class="sap-icon--slim-arrow-down" role="presentation"></i>
+                            </button>
+                        </div>
+                        <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right fd-icon-tab-bar__popover-body" aria-hidden="false" id="popoverA2">
+                        <ul class="fd-list fd-list--navigation fd-list--no-border fd-icon-tab-bar__list" role="list">
+                            <li tabindex="-1" role="listitem" aria-level="1" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                            <a tabindex="0" class="fd-list__link">
+                                <span class="fd-list__title">Section 4</span>
+                            </a>
+                            </li>
+                            <li tabindex="-1" role="listitem" aria-level="1" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                            <a tabindex="0" class="fd-list__link">
+                                <span class="fd-list__title">Section 5</span>
+                            </a>
+                            </li>
+                        </ul>
+                        </div>
+                    </div>
+                </li>
+            </ul>
+        </div>
+    </div>
 </div>
 `;
 
 textOnlyPhone.storyName = 'Horizontal Navigation Text Only Phone View';
 
 export const textAndIcon = () => `<div style="height: 200px;">
-<div class="fd-tool-header">
-    <div class="fd-tool-header__group">
-        <div class="fd-tool-header__element">
-            <img class="fd-tool-header__logo" src="//unpkg.com/fundamental-styles/dist/images/sap-logo.png" srcset="//unpkg.com/fundamental-styles/dist/images/sap-logo@2x.png 1x, //unpkg.com/fundamental-styles/dist/images/sap-logo@3x.png 2x, //unpkg.com/fundamental-styles/dist/images/sap-logo@4x.png 3x" alt="SAP">
-        </div>
-        <div class="fd-tool-header__element">
-            <h4 class="fd-title fd-title--h5 fd-tool-header__title">Product Name</h4>
-        </div>
-        <div class="fd-tool-header__element">
-            <label class="fd-form-label fd-tool-header__label" for="input-1">Second Title</label>
-        </div>
-    </div>
-    <div class="fd-tool-header__group">
-        <div class="fd-tool-header__element">
-            <button class="fd-button fd-button--compact fd-button--transparent fd-tool-header__button" aria-label="search">
-                <i class="sap-icon--search"></i>
-            </button>
-        </div>
-        <div class="fd-tool-header__element">
-            <button class="fd-button fd-button--compact fd-button--transparent fd-tool-header__button" aria-label="task">
-                <i class="sap-icon--circle-task"></i>
-            </button>
-        </div>
-        <div class="fd-tool-header__element">
-            <button class="fd-button fd-button--compact fd-button--transparent fd-tool-header__button" aria-label="notification">
-                <i class="sap-icon--bell"></i>
-            </button>
-        </div>
-        <div class="fd-tool-header__element">
-            <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/1.svg')" role="img" aria-label="John Doe"></span>
-        </div>
-        <div class="fd-tool-header__element">
-            <button class="fd-button fd-button--compact fd-button--transparent fd-tool-header__button" aria-label="user menu control">
-                <i class="sap-icon--grid"></i>
-            </button>
-        </div>
-    </div>
-</div>
-<div class="fd-icon-tab-bar fd-icon-tab-bar--navigation fd-icon-tab-bar--sm">
-    <ul role="tablist" class="fd-icon-tab-bar__header">
-        <li role="presentation" class="fd-icon-tab-bar__item">
-            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab7">
-                <div class="fd-icon-tab-bar__tab-container">
-                    <i class="sap-icon--home"></i>
-                    <span class="fd-icon-tab-bar__tag">Section 1</span>
+    <div class="fd-horizontal-navigation">
+        <div class="fd-tool-header">
+            <div class="fd-tool-header__group">
+                <div class="fd-tool-header__element">
+                    <img class="fd-tool-header__logo" src="//unpkg.com/fundamental-styles/dist/images/sap-logo.png" srcset="//unpkg.com/fundamental-styles/dist/images/sap-logo@2x.png 1x, //unpkg.com/fundamental-styles/dist/images/sap-logo@3x.png 2x, //unpkg.com/fundamental-styles/dist/images/sap-logo@4x.png 3x" alt="SAP">
                 </div>
-            </a>
-        </li>
-        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--single-click">
-            <div class="fd-popover">
-                <div class="fd-popover__control">
-                    <a role="tab" class="fd-icon-tab-bar__tab" tabindex="0" aria-selected="true" id="tab8" aria-controls="popoverA3" aria-expanded="true" aria-haspopup="true" onclick="onPopoverClick('popoverA3');">
-                    <div class="fd-icon-tab-bar__tab-container">
-                        <i class="sap-icon--internet-browser" role="presentation"></i>
-                        <span class="fd-icon-tab-bar__tag">Section 2</span>
-                        <span class="fd-icon-tab-bar__arrow">
-                            <i class="sap-icon--slim-arrow-down" role="presentation"></i>
-                        </span>
-                    </div>
-                    </a>
+                <div class="fd-tool-header__element">
+                    <h4 class="fd-title fd-title--h5 fd-tool-header__title">Product Name</h4>
                 </div>
-                <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right fd-icon-tab-bar__popover-body" aria-hidden="false" id="popoverA3">
-                    <ul class="fd-list fd-list--navigation fd-list--no-border fd-icon-tab-bar__list" role="list">
-                        <li tabindex="-1" role="listitem" aria-level="1" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
-                            <a tabindex="0" class="fd-list__link">
-                                <span class="fd-list__title">Subsection 1</span>
-                            </a>
-                        </li>
-                        <li tabindex="-1" role="listitem" aria-level="2" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
-                            <a tabindex="0" class="fd-list__link">
-                            <span class="fd-list__title">Subsection 1.1</span>
-                            </a>
-                        </li>
-                    </ul>
+                <div class="fd-tool-header__element">
+                    <label class="fd-form-label fd-tool-header__label" for="input-1">Second Title</label>
                 </div>
             </div>
-        </li>
-        <li role="presentation" class="fd-icon-tab-bar__item">
-            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab9">
-                <div class="fd-icon-tab-bar__tab-container">
-                    <i class="sap-icon--home-share"></i>
-                    <span class="fd-icon-tab-bar__tag">Section 3</span>
+            <div class="fd-tool-header__group">
+                <div class="fd-tool-header__element">
+                    <button class="fd-button fd-button--compact fd-button--transparent fd-tool-header__button" aria-label="search">
+                        <i class="sap-icon--search"></i>
+                    </button>
                 </div>
-            </a>
-        </li>
-    </ul>
-</div>
+                <div class="fd-tool-header__element">
+                    <button class="fd-button fd-button--compact fd-button--transparent fd-tool-header__button" aria-label="task">
+                        <i class="sap-icon--circle-task"></i>
+                    </button>
+                </div>
+                <div class="fd-tool-header__element">
+                    <button class="fd-button fd-button--compact fd-button--transparent fd-tool-header__button" aria-label="notification">
+                        <i class="sap-icon--bell"></i>
+                    </button>
+                </div>
+                <div class="fd-tool-header__element">
+                    <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/1.svg')" role="img" aria-label="John Doe"></span>
+                </div>
+                <div class="fd-tool-header__element">
+                    <button class="fd-button fd-button--compact fd-button--transparent fd-tool-header__button" aria-label="user menu control">
+                        <i class="sap-icon--grid"></i>
+                    </button>
+                </div>
+            </div>
+        </div>
+        <div class="fd-icon-tab-bar fd-icon-tab-bar--navigation fd-icon-tab-bar--navigation-horizontal fd-icon-tab-bar--sm">
+            <ul role="tablist" class="fd-icon-tab-bar__header" style="overflow: visible;">
+                <li role="presentation" class="fd-icon-tab-bar__item">
+                    <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab7">
+                        <div class="fd-icon-tab-bar__tab-container">
+                            <i class="sap-icon--home"></i>
+                            <span class="fd-icon-tab-bar__tag">Section 1</span>
+                        </div>
+                    </a>
+                </li>
+                <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--single-click">
+                    <div class="fd-popover">
+                        <div class="fd-popover__control">
+                            <a role="tab" class="fd-icon-tab-bar__tab" tabindex="0" aria-selected="true" id="tab8" aria-controls="popoverA3" aria-expanded="true" aria-haspopup="true" onclick="onPopoverClick('popoverA3');">
+                            <div class="fd-icon-tab-bar__tab-container">
+                                <i class="sap-icon--internet-browser" role="presentation"></i>
+                                <span class="fd-icon-tab-bar__tag">Section 2</span>
+                                <span class="fd-icon-tab-bar__arrow">
+                                    <i class="sap-icon--slim-arrow-down" role="presentation"></i>
+                                </span>
+                            </div>
+                            </a>
+                        </div>
+                        <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right fd-icon-tab-bar__popover-body" aria-hidden="false" id="popoverA3">
+                            <ul class="fd-list fd-list--navigation fd-list--no-border fd-icon-tab-bar__list" role="list">
+                                <li tabindex="-1" role="listitem" aria-level="1" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                                    <a tabindex="0" class="fd-list__link">
+                                        <span class="fd-list__title">Subsection 1</span>
+                                    </a>
+                                </li>
+                                <li tabindex="-1" role="listitem" aria-level="2" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                                    <a tabindex="0" class="fd-list__link">
+                                    <span class="fd-list__title">Subsection 1.1</span>
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </li>
+                <li role="presentation" class="fd-icon-tab-bar__item">
+                    <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab9">
+                        <div class="fd-icon-tab-bar__tab-container">
+                            <i class="sap-icon--home-share"></i>
+                            <span class="fd-icon-tab-bar__tag">Section 3</span>
+                        </div>
+                    </a>
+                </li>
+            </ul>
+        </div>
+    </div>
 </div>
 `;
 
@@ -278,105 +286,105 @@ textAndIcon.parameters = {
 };
 
 export const textAndIconPhone = () => `<div style="height: 200px;">
-
-<div style="height: 200px;">
-  <div class="fd-tool-header fd-tool-header--sm" style="max-width: 500px;">
-    <div class="fd-tool-header__group">
-      <div class="fd-tool-header__element">
-        <img class="fd-tool-header__logo" src="//unpkg.com/fundamental-styles/dist/images/sap-logo.png" srcset="//unpkg.com/fundamental-styles/dist/images/sap-logo@2x.png 1x, //unpkg.com/fundamental-styles/dist/images/sap-logo@3x.png 2x, //unpkg.com/fundamental-styles/dist/images/sap-logo@4x.png 3x" alt="SAP">
-      </div>
-      <div class="fd-tool-header__element">
-        <h4 class="fd-title fd-title--h5 fd-tool-header__title">Product Name</h4>
-      </div>
-    </div>
-    <div class="fd-tool-header__group">
-      <div class="fd-tool-header__element">
-        <button class="fd-button fd-button--transparent fd-tool-header__button" aria-label="more items">
-          <i class="sap-icon--overflow"></i>
-        </button>
-      </div>
-      <div class="fd-tool-header__element">
-        <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/1.svg')" role="img" aria-label="John Doe"></span>
-      </div>
-    </div>
-</div>
-<div class="fd-icon-tab-bar fd-icon-tab-bar--navigation fd-icon-tab-bar--sm" style="max-width: 500px;">
-    <ul role="tablist" class="fd-icon-tab-bar__header">
-        <li role="presentation" class="fd-icon-tab-bar__item">
-            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab10">
-                <div class="fd-icon-tab-bar__tab-container">
-                    <i class="sap-icon--home"></i>
-                    <span class="fd-icon-tab-bar__tag">Section 1</span>
+    <div class="fd-horizontal-navigation" style="max-width: 500px;">
+        <div class="fd-tool-header fd-tool-header--sm" style="max-width: 500px;">
+            <div class="fd-tool-header__group">
+                <div class="fd-tool-header__element">
+                    <img class="fd-tool-header__logo" src="//unpkg.com/fundamental-styles/dist/images/sap-logo.png" srcset="//unpkg.com/fundamental-styles/dist/images/sap-logo@2x.png 1x, //unpkg.com/fundamental-styles/dist/images/sap-logo@3x.png 2x, //unpkg.com/fundamental-styles/dist/images/sap-logo@4x.png 3x" alt="SAP">
                 </div>
-            </a>
-        </li>
-        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--multi-click">
-            <a role="tab" class="fd-icon-tab-bar__tab" aria-selected="true" id="tab11" tabindex="0">
-                <div class="fd-icon-tab-bar__tab-container">
-                    <i class="sap-icon--family-care"></i>
-                    <span class="fd-icon-tab-bar__tag">Section 2</span>
-                </div>
-            </a>
-            <div class="fd-popover fd-icon-tab-bar__popover">
-                <div class="fd-popover__control">
-                    <div class="fd-icon-tab-bar__button-container">
-                    <button class="fd-button fd-button--transparent fd-button--compact  fd-icon-tab-bar__button" aria-controls="popoverA4" aria-expanded="false" aria-haspopup="true" onclick="onPopoverClick('popoverA4');" aria-label="open menu button">
-                        <i class="sap-icon--slim-arrow-down"></i>
-                    </button>
-                    </div>
-                </div>
-                <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right fd-icon-tab-bar__popover-body" aria-hidden="false" id="popoverA4">
-                    <ul class="fd-list fd-list--navigation fd-list--no-border fd-icon-tab-bar__list" role="list">
-                    <li tabindex="-1" role="listitem" aria-level="1" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
-                        <a tabindex="0" class="fd-list__link">
-                        <span class="fd-list__title">Subsection 1</span>
-                        </a>
-                    </li>
-                    <li tabindex="-1" role="listitem" aria-level="1" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
-                        <a tabindex="0" class="fd-list__link">
-                        <span class="fd-list__title">Subsection 2</span>
-                        </a>
-                    </li>
-                    </ul>
+                <div class="fd-tool-header__element">
+                    <h4 class="fd-title fd-title--h5 fd-tool-header__title">Product Name</h4>
                 </div>
             </div>
-        </li>
-        <li role="presentation" class="fd-icon-tab-bar__item">
-            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab12">
-                <div class="fd-icon-tab-bar__tab-container">
-                    <i class="sap-icon--monitor-payments"></i>
-                    <span class="fd-icon-tab-bar__tag">Section 3</span>
+            <div class="fd-tool-header__group">
+                <div class="fd-tool-header__element">
+                    <button class="fd-button fd-button--transparent fd-tool-header__button" aria-label="more items">
+                        <i class="sap-icon--overflow"></i>
+                    </button>
                 </div>
-            </a>
-        </li>
-        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--overflow">
-        <div class="fd-popover fd-icon-tab-bar__popover">
-          <div class="fd-popover__control">
-            <button class="fd-icon-tab-bar__overflow" aria-controls="popoverA5" aria-expanded="false" aria-haspopup="true" onclick="onPopoverClick('popoverA5');" aria-label="open menu button">
-              <span class="fd-icon-tab-bar__overflow-text">More</span>
-              <i class="sap-icon--slim-arrow-down" role="presentation"></i>
-            </button>
-          </div>
-          <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right fd-icon-tab-bar__popover-body" aria-hidden="false" id="popoverA5">
-            <ul class="fd-list fd-list--navigation fd-list--no-border fd-icon-tab-bar__list" role="list">
-              <li tabindex="-1" role="listitem" aria-level="1" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
-                <a tabindex="0" class="fd-list__link">
-                  <i class="sap-icon--batch-payments" role="presentation"></i>
-                  <span class="fd-list__title">Section 4</span>
-                </a>
-              </li>
-              <li tabindex="-1" role="listitem" aria-level="1" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
-                <a tabindex="0" class="fd-list__link">
-                  <i class="sap-icon--credit-card" role="presentation"></i>
-                  <span class="fd-list__title">Section 5</span>
-                </a>
-              </li>
-            </ul>
-          </div>
+                <div class="fd-tool-header__element">
+                    <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/avatars/1.svg')" role="img" aria-label="John Doe"></span>
+                </div>
+            </div>
         </div>
-      </li>
-    </ul>
-</div>
+        <div class="fd-icon-tab-bar fd-icon-tab-bar--navigation fd-icon-tab-bar--navigation-horizontal fd-icon-tab-bar--sm" style="max-width: 500px;">
+            <ul role="tablist" class="fd-icon-tab-bar__header" style="overflow: visible;">
+                <li role="presentation" class="fd-icon-tab-bar__item">
+                    <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab10">
+                        <div class="fd-icon-tab-bar__tab-container">
+                            <i class="sap-icon--home"></i>
+                            <span class="fd-icon-tab-bar__tag">Section 1</span>
+                        </div>
+                    </a>
+                </li>
+                <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--multi-click">
+                    <a role="tab" class="fd-icon-tab-bar__tab" aria-selected="true" id="tab11" tabindex="0">
+                        <div class="fd-icon-tab-bar__tab-container">
+                            <i class="sap-icon--family-care"></i>
+                            <span class="fd-icon-tab-bar__tag">Section 2</span>
+                        </div>
+                    </a>
+                    <div class="fd-popover fd-icon-tab-bar__popover">
+                        <div class="fd-popover__control">
+                            <div class="fd-icon-tab-bar__button-container">
+                                <button class="fd-button fd-button--transparent fd-button--compact  fd-icon-tab-bar__button" aria-controls="popoverA4" aria-expanded="false" aria-haspopup="true" onclick="onPopoverClick('popoverA4');" aria-label="open menu button">
+                                    <i class="sap-icon--slim-arrow-down"></i>
+                                </button>
+                            </div>
+                        </div>
+                        <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right fd-icon-tab-bar__popover-body" aria-hidden="false" id="popoverA4">
+                            <ul class="fd-list fd-list--navigation fd-list--no-border fd-icon-tab-bar__list" role="list">
+                                <li tabindex="-1" role="listitem" aria-level="1" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                                    <a tabindex="0" class="fd-list__link">
+                                    <span class="fd-list__title">Subsection 1</span>
+                                    </a>
+                                </li>
+                                <li tabindex="-1" role="listitem" aria-level="1" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                                    <a tabindex="0" class="fd-list__link">
+                                    <span class="fd-list__title">Subsection 2</span>
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </li>
+                <li role="presentation" class="fd-icon-tab-bar__item">
+                    <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab12">
+                        <div class="fd-icon-tab-bar__tab-container">
+                            <i class="sap-icon--monitor-payments"></i>
+                            <span class="fd-icon-tab-bar__tag">Section 3</span>
+                        </div>
+                    </a>
+                </li>
+                <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--overflow" style="left: 26rem;>
+                <div class="fd-popover fd-icon-tab-bar__popover">
+                    <div class="fd-popover__control">
+                        <button class="fd-icon-tab-bar__overflow" aria-controls="popoverA5" aria-expanded="false" aria-haspopup="true" onclick="onPopoverClick('popoverA5');" aria-label="open menu button">
+                        <span class="fd-icon-tab-bar__overflow-text">More</span>
+                            <i class="sap-icon--slim-arrow-down" role="presentation"></i>
+                        </button>
+                    </div>
+                    <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right fd-icon-tab-bar__popover-body" aria-hidden="false" id="popoverA5">
+                        <ul class="fd-list fd-list--navigation fd-list--no-border fd-icon-tab-bar__list" role="list">
+                            <li tabindex="-1" role="listitem" aria-level="1" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                                <a tabindex="0" class="fd-list__link">
+                                    <i class="sap-icon--batch-payments" role="presentation"></i>
+                                    <span class="fd-list__title">Section 4</span>
+                                </a>
+                            </li>
+                            <li tabindex="-1" role="listitem" aria-level="1" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                                <a tabindex="0" class="fd-list__link">
+                                    <i class="sap-icon--credit-card" role="presentation"></i>
+                                    <span class="fd-list__title">Section 5</span>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </li>
+            </ul>
+        </div>
+    </div>
 </div>
 `;
 

--- a/stories/icon-tab-bar/__snapshots__/icon-tab-bar.stories.storyshot
+++ b/stories/icon-tab-bar/__snapshots__/icon-tab-bar.stories.storyshot
@@ -1533,6 +1533,181 @@ exports[`Storyshots Components/Icon Tab Bar Filter 1`] = `
 </section>
 `;
 
+exports[`Storyshots Components/Icon Tab Bar Flat Navigation 1`] = `
+<div
+  class="fddocs-icon-tab-container"
+  style="min-height: 100px;"
+>
+  
+    
+  <div
+    class="fd-icon-tab-bar fd-icon-tab-bar--navigation fd-icon-tab-bar--navigation-flat fd-icon-tab-bar--md"
+  >
+    
+        
+    <ul
+      class="fd-icon-tab-bar__header"
+      role="tablist"
+    >
+        
+            
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+                
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab11"
+          role="tab"
+        >
+          
+                    
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 1
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--multi-click fd-icon-tab-bar__item--with-separator"
+        role="presentation"
+      >
+        
+                
+        <a
+          aria-selected="true"
+          class="fd-icon-tab-bar__tab"
+          id="tab12"
+          role="tab"
+          tabindex="0"
+        >
+          
+                    
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 2
+          </span>
+          
+                
+        </a>
+        
+
+                
+        <div
+          class="fd-popover fd-icon-tab-bar__popover"
+        >
+          
+                    
+          <div
+            class="fd-popover__control"
+          >
+            
+                        
+            <div
+              class="fd-icon-tab-bar__button-container"
+            >
+              
+                            
+              <button
+                aria-label="open menu button"
+                class="fd-button fd-button--transparent fd-button--compact  fd-icon-tab-bar__button"
+              >
+                
+                                
+                <i
+                  class="sap-icon--slim-arrow-down"
+                />
+                
+                            
+              </button>
+              
+                        
+            </div>
+            
+                    
+          </div>
+          
+                
+        </div>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-icon-tab-bar__item fd-icon-tab-bar__item--with-separator"
+        role="presentation"
+      >
+        
+                
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab13"
+          role="tab"
+        >
+          
+                    
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 3
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-icon-tab-bar__item"
+        role="presentation"
+      >
+        
+                
+        <a
+          class="fd-icon-tab-bar__tab"
+          href="#"
+          id="tab14"
+          role="tab"
+        >
+          
+                    
+          <span
+            class="fd-icon-tab-bar__tag"
+          >
+            Section 4
+          </span>
+          
+                
+        </a>
+        
+            
+      </li>
+      
+        
+    </ul>
+    
+    
+  </div>
+  
+
+</div>
+`;
+
 exports[`Storyshots Components/Icon Tab Bar Icon 1`] = `
 <section>
   <div
@@ -3009,7 +3184,7 @@ exports[`Storyshots Components/Icon Tab Bar Icon Only in Compact Mode 1`] = `
 </div>
 `;
 
-exports[`Storyshots Components/Icon Tab Bar Navigation Icon Tab Bar 1`] = `
+exports[`Storyshots Components/Icon Tab Bar Navigation Icon Tab Bar (Shell Navigation) 1`] = `
 <div
   class="fddocs-icon-tab-container"
   style="min-height: 600px;"
@@ -3391,19 +3566,19 @@ exports[`Storyshots Components/Icon Tab Bar Navigation Icon Tab Bar 1`] = `
     class="fd-icon-tab-bar fd-icon-tab-bar--navigation fd-icon-tab-bar--xl"
   >
     
-    
+        
     <ul
       class="fd-icon-tab-bar__header"
       role="tablist"
     >
       
-      
+            
       <li
         class="fd-icon-tab-bar__item"
         role="presentation"
       >
         
-        
+                
         <a
           class="fd-icon-tab-bar__tab"
           href="#"
@@ -3411,36 +3586,36 @@ exports[`Storyshots Components/Icon Tab Bar Navigation Icon Tab Bar 1`] = `
           role="tab"
         >
           
-          
+                    
           <span
             class="fd-icon-tab-bar__tag"
           >
             Section 1
           </span>
           
-        
+                
         </a>
         
-      
+            
       </li>
       
-      
+            
       <li
         class="fd-icon-tab-bar__item fd-icon-tab-bar__item--single-click"
         role="presentation"
       >
         
-        
+                
         <div
           class="fd-popover"
         >
           
-          
+                
           <div
             class="fd-popover__control"
           >
             
-            
+                    
             <a
               aria-controls="popoverAO5"
               aria-expanded="true"
@@ -3453,55 +3628,55 @@ exports[`Storyshots Components/Icon Tab Bar Navigation Icon Tab Bar 1`] = `
               tabindex="0"
             >
               
-              
+                    
               <div
                 class="fd-icon-tab-bar__tab-container"
               >
                 
-                
+                        
                 <span
                   class="fd-icon-tab-bar__tag"
                 >
                   Section 2
                 </span>
                 
-                
+                        
                 <span
                   class="fd-icon-tab-bar__arrow"
                 >
                   
-                    
+                            
                   <i
                     class="sap-icon--slim-arrow-down"
                     role="presentation"
                   />
                   
-                
+                        
                 </span>
                 
-              
+                    
               </div>
               
-            
+                    
             </a>
             
-          
+                
           </div>
           
-          
+                
           <div
             aria-hidden="false"
             class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right fd-icon-tab-bar__popover-body"
             id="popoverAO5"
           >
             
-            
+                    
             <ul
               class="fd-list fd-list--navigation fd-list--no-border fd-icon-tab-bar__list"
               role="list"
             >
               
-              
+                    
               <li
                 aria-level="1"
                 class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
@@ -3509,26 +3684,26 @@ exports[`Storyshots Components/Icon Tab Bar Navigation Icon Tab Bar 1`] = `
                 tabindex="-1"
               >
                 
-                
+                        
                 <a
                   class="fd-list__link fd-icon-tab-bar__list-link"
                   tabindex="0"
                 >
                   
-                  
+                            
                   <span
                     class="fd-list__title"
                   >
                     Subsection 1
                   </span>
                   
-                
+                        
                 </a>
                 
-              
+                    
               </li>
               
-              
+                    
               <li
                 aria-level="1"
                 class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item"
@@ -3536,44 +3711,44 @@ exports[`Storyshots Components/Icon Tab Bar Navigation Icon Tab Bar 1`] = `
                 tabindex="-1"
               >
                 
-                
+                        
                 <a
                   class="fd-list__link fd-icon-tab-bar__list-link"
                   tabindex="0"
                 >
                   
-                  
+                            
                   <span
                     class="fd-list__title"
                   >
                     Subsection 2
                   </span>
                   
-                
+                        
                 </a>
                 
-              
+                    
               </li>
               
-            
+                    
             </ul>
             
-          
+                
           </div>
           
-        
+                
         </div>
         
-      
+            
       </li>
       
-      
+            
       <li
         class="fd-icon-tab-bar__item"
         role="presentation"
       >
         
-        
+                
         <a
           class="fd-icon-tab-bar__tab"
           href="#"
@@ -3581,36 +3756,36 @@ exports[`Storyshots Components/Icon Tab Bar Navigation Icon Tab Bar 1`] = `
           role="tab"
         >
           
-          
+                
           <span
             class="fd-icon-tab-bar__tag"
           >
             Section 3
           </span>
           
-        
+                
         </a>
         
-      
+            
       </li>
       
-      
+            
       <li
         class="fd-icon-tab-bar__item fd-icon-tab-bar__item--single-click"
         role="presentation"
       >
         
-        
+                
         <div
           class="fd-popover"
         >
           
-          
+                    
           <div
             class="fd-popover__control"
           >
             
-            
+                        
             <a
               aria-expanded="true"
               aria-haspopup="true"
@@ -3620,51 +3795,51 @@ exports[`Storyshots Components/Icon Tab Bar Navigation Icon Tab Bar 1`] = `
               tabindex="0"
             >
               
-              
+                        
               <div
                 class="fd-icon-tab-bar__tab-container"
               >
                 
-                
+                            
                 <span
                   class="fd-icon-tab-bar__tag"
                 >
                   Section 4
                 </span>
                 
-                
+                            
                 <span
                   class="fd-icon-tab-bar__arrow"
                 >
                   
-                    
+                                
                   <i
                     class="sap-icon--slim-arrow-down"
                     role="presentation"
                   />
                   
-                
+                            
                 </span>
                 
-              
+                        
               </div>
               
-            
+                        
             </a>
             
-          
+                    
           </div>
           
-        
+                
         </div>
         
-      
+            
       </li>
       
-    
+        
     </ul>
     
-  
+    
   </div>
   
 

--- a/stories/icon-tab-bar/icon-tab-bar.stories.js
+++ b/stories/icon-tab-bar/icon-tab-bar.stories.js
@@ -1524,68 +1524,116 @@ export const navigation = () => `<div class="fddocs-icon-tab-container" style="m
     <div style="height: 120px;"></div>
     <h4>With Single Click Area</h4>
     <div class="fd-icon-tab-bar fd-icon-tab-bar--navigation fd-icon-tab-bar--xl">
-    <ul role="tablist" class="fd-icon-tab-bar__header">
-      <li role="presentation" class="fd-icon-tab-bar__item">
-        <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab7">
-          <span class="fd-icon-tab-bar__tag">Section 1</span>
-        </a>
-      </li>
-      <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--single-click">
-        <div class="fd-popover">
-          <div class="fd-popover__control">
-            <a role="tab" class="fd-icon-tab-bar__tab" aria-selected="true" id="tab8" tabindex="0" aria-controls="popoverAO5" aria-expanded="true" aria-haspopup="true" onclick="onPopoverClick('popoverAO5');">
-              <div class="fd-icon-tab-bar__tab-container">
-                <span class="fd-icon-tab-bar__tag">Section 2</span>
-                <span class="fd-icon-tab-bar__arrow">
-                    <i class="sap-icon--slim-arrow-down" role="presentation"></i>
-                </span>
-              </div>
-            </a>
-          </div>
-          <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right fd-icon-tab-bar__popover-body" aria-hidden="false" id="popoverAO5">
-            <ul class="fd-list fd-list--navigation fd-list--no-border fd-icon-tab-bar__list" role="list">
-              <li tabindex="-1" role="listitem" aria-level="1" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
-                <a tabindex="0" class="fd-list__link fd-icon-tab-bar__list-link">
-                  <span class="fd-list__title">Subsection 1</span>
+        <ul role="tablist" class="fd-icon-tab-bar__header">
+            <li role="presentation" class="fd-icon-tab-bar__item">
+                <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab7">
+                    <span class="fd-icon-tab-bar__tag">Section 1</span>
                 </a>
-              </li>
-              <li tabindex="-1" role="listitem" aria-level="1" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
-                <a tabindex="0" class="fd-list__link fd-icon-tab-bar__list-link">
-                  <span class="fd-list__title">Subsection 2</span>
+            </li>
+            <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--single-click">
+                <div class="fd-popover">
+                <div class="fd-popover__control">
+                    <a role="tab" class="fd-icon-tab-bar__tab" aria-selected="true" id="tab8" tabindex="0" aria-controls="popoverAO5" aria-expanded="true" aria-haspopup="true" onclick="onPopoverClick('popoverAO5');">
+                    <div class="fd-icon-tab-bar__tab-container">
+                        <span class="fd-icon-tab-bar__tag">Section 2</span>
+                        <span class="fd-icon-tab-bar__arrow">
+                            <i class="sap-icon--slim-arrow-down" role="presentation"></i>
+                        </span>
+                    </div>
+                    </a>
+                </div>
+                <div class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right fd-icon-tab-bar__popover-body" aria-hidden="false" id="popoverAO5">
+                    <ul class="fd-list fd-list--navigation fd-list--no-border fd-icon-tab-bar__list" role="list">
+                    <li tabindex="-1" role="listitem" aria-level="1" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                        <a tabindex="0" class="fd-list__link fd-icon-tab-bar__list-link">
+                            <span class="fd-list__title">Subsection 1</span>
+                        </a>
+                    </li>
+                    <li tabindex="-1" role="listitem" aria-level="1" class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item">
+                        <a tabindex="0" class="fd-list__link fd-icon-tab-bar__list-link">
+                            <span class="fd-list__title">Subsection 2</span>
+                        </a>
+                    </li>
+                    </ul>
+                </div>
+                </div>
+            </li>
+            <li role="presentation" class="fd-icon-tab-bar__item">
+                <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab9">
+                <span class="fd-icon-tab-bar__tag">Section 3</span>
                 </a>
-              </li>
-            </ul>
-          </div>
-        </div>
-      </li>
-      <li role="presentation" class="fd-icon-tab-bar__item">
-        <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab9">
-          <span class="fd-icon-tab-bar__tag">Section 3</span>
-        </a>
-      </li>
-      <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--single-click">
-        <div class="fd-popover">
-          <div class="fd-popover__control">
-            <a role="tab" class="fd-icon-tab-bar__tab" id="tab10" tabindex="0" aria-expanded="true" aria-haspopup="true">
-              <div class="fd-icon-tab-bar__tab-container">
-                <span class="fd-icon-tab-bar__tag">Section 4</span>
-                <span class="fd-icon-tab-bar__arrow">
-                    <i class="sap-icon--slim-arrow-down" role="presentation"></i>
-                </span>
-              </div>
-            </a>
-          </div>
-        </div>
-      </li>
-    </ul>
-  </div>
+            </li>
+            <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--single-click">
+                <div class="fd-popover">
+                    <div class="fd-popover__control">
+                        <a role="tab" class="fd-icon-tab-bar__tab" id="tab10" tabindex="0" aria-expanded="true" aria-haspopup="true">
+                        <div class="fd-icon-tab-bar__tab-container">
+                            <span class="fd-icon-tab-bar__tag">Section 4</span>
+                            <span class="fd-icon-tab-bar__arrow">
+                                <i class="sap-icon--slim-arrow-down" role="presentation"></i>
+                            </span>
+                        </div>
+                        </a>
+                    </div>
+                </div>
+            </li>
+        </ul>
+    </div>
 </div>
 `;
-navigation.storyName = 'Navigation Icon Tab Bar';
+navigation.storyName = 'Navigation Icon Tab Bar (Shell Navigation)';
 navigation.parameters = {
     docs: {
         storyDescription: `The Navigation Tab Bar is the main/default navigation displayed on the SAP Fiori launchpad home page. It offers the user an easy access to multiple pages per space. The background color of the Shell Navigation is connected the Home/Shell Header to properly differentiate the global shell navigation versus any application specific navigation. The Navigation Bar snaps to top and remains visible while scrolling. It is not visible in App view. <br>
-        The implementation is based on UniversalIconTabBar with some different color parameters that are specific to Shell Bar and Tool Header. <br>
+        The implementation is based on UniversalIconTabBar with some different color parameters that are specific to Shell Bar. <br>
         If there are more Tabs than the screen can accommodate, the remaining Tabs move into an Overflow.`
+    }
+};
+
+export const navigationFlat = () => `<div class="fddocs-icon-tab-container" style="min-height: 100px;">
+    <div class="fd-icon-tab-bar fd-icon-tab-bar--navigation fd-icon-tab-bar--navigation-flat fd-icon-tab-bar--md">
+        <ul role="tablist" class="fd-icon-tab-bar__header">  
+            <li role="presentation" class="fd-icon-tab-bar__item">
+                <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab11">
+                    <span class="fd-icon-tab-bar__tag">Section 1</span>
+                </a>
+            </li>
+            <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--multi-click fd-icon-tab-bar__item--with-separator">
+                <a role="tab" class="fd-icon-tab-bar__tab" aria-selected="true" id="tab12" tabindex="0">
+                    <span class="fd-icon-tab-bar__tag">Section 2</span>
+                </a>
+
+                <div class="fd-popover fd-icon-tab-bar__popover">
+                    <div class="fd-popover__control">
+                        <div class="fd-icon-tab-bar__button-container">
+                            <button class="fd-button fd-button--transparent fd-button--compact  fd-icon-tab-bar__button" aria-label="open menu button">
+                                <i class="sap-icon--slim-arrow-down"></i>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </li>
+            <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--with-separator">
+                <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab13">
+                    <span class="fd-icon-tab-bar__tag">Section 3</span>
+                </a>
+            </li>
+            <li role="presentation" class="fd-icon-tab-bar__item">
+                <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab14">
+                    <span class="fd-icon-tab-bar__tag">Section 4</span>
+                </a>
+            </li>
+        </ul>
+    </div>
+</div>
+`;
+navigationFlat.storyName = 'Flat Navigation';
+navigationFlat.parameters = {
+    docs: {
+        storyDescription: `The Flat Navigation offers the user an easy access to multiple pages per space. 
+        As the ShellNavigation (Fiori 3), the Flat Navigation is the main/default navigation displayed on the SAP Fiori launchpad home page. It snaps to top and remains visible while scrolling and is not visible in App view. 
+        The Flat Navigation Concept allows putting all entities of a single space directly into the first level of the Top Level Navigation Bar for direct access.
+        Add the \`.fd-icon-tab-bar--navigation-flat\` modifier class to \`.fd-icon-tab-bar.fd-icon-tab-bar--navigation\` to achieve the flat navigation look and feel. The items that have separators need to receive the \`.fd-icon-tab-bar__item--with-separator\` modifier class to \`.fd-icon-tab-bar__item\` class. This will append a vertical separator line on the right hand side of the item with an 1rem offset.
+        `
     }
 };


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#2668

## Description
In the current PR:
- introduced Flat Navigation (Part of ShellNavigation)
- refactored Horizontal Navigation to match the correct deltas from IconTabBar
- introduced a wrapper class (.fd-horizontal-navigation) for IcontTabBar and ToolHeader that applies box-shadow around the two elements.

BREAKING CHANGE:
- introduced a wrapper element with class ".fd-horizontal-navigation" for Tool Header and Navigation IconTabBar
- introduced an additional modifier class ".fd-icon-tab-bar--navigation-horizontal" to IconTabBar when used in Horizontal Navigation

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [na] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [na] tested Storybook examples with "CSS Resources" `normalize` option 
- [na] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [na] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
