### PR TITLE
fix: layout grid bug fixes, improvements, refactoring

### DIFF
--- a/src/layout-grid.scss
+++ b/src/layout-grid.scss
@@ -1,13 +1,15 @@
 @import "./mixins";
 
-/*!
-.fd-col
-*/
-
-$block: #{$fd-namespace}-col;
 $blockContainer: #{$fd-namespace}-container;
 $blockRow: #{$fd-namespace}-row;
-$size: (600:"md", 1024: "lg", 1440: "xl");
+$blockCol: #{$fd-namespace}-col;
+
+$vertical-gutter: 1rem;
+$vertical-gutter-small: 0.5rem;
+$horizontal-gutter: 0.5rem;
+$horizontal-gutter-small: 0.25rem;
+
+$size: (600 :"md", 1024: "lg", 1440: "xl");
 $md: 600;
 $lg: 1024;
 $xl: 1440;
@@ -20,10 +22,10 @@ $cols: 12;
 }
 
 @mixin responsive-column($sizePrefix: null) {
-  $classPrefix: #{$block};
+  $classPrefix: #{$blockCol};
 
   @if ($sizePrefix) {
-    $classPrefix: $block + '-' + $sizePrefix;
+    $classPrefix: $blockCol + '-' + $sizePrefix;
   }
 
   @for $n from 0 through $cols {
@@ -52,31 +54,35 @@ $cols: 12;
   }
 }
 
-.#{$blockContainer} {
+.#{$blockContainer},
+.#{$blockRow},
+.#{$blockCol} {
   @include fd-reset();
+}
 
+.#{$blockContainer} {
   display: flex;
   flex-wrap: wrap;
   flex: 0 0 100%;
   position: relative;
-  margin: 0 -0.25rem 0 -0.25rem;
+  padding: 0 $horizontal-gutter-small;
 
-  &--no-gap {
-    margin: 0;
+  &.#{$blockContainer}--no-horizontal-gap,
+  &.#{$blockContainer}--no-gap {
+    .#{$blockRow} {
+      @include fd-reset-margins-x();
 
-    .#{$block} {
-      padding: 0;
+      .#{$blockCol} {
+        @include fd-reset-paddings-x();
+      }
     }
   }
 
-  .#{$blockRow} {
-    margin-left: 0;
-    margin-right: 0;
-    margin-top: -0.5rem;
-  }
-
-  .#{$blockRow} + .#{$blockRow} {
-    margin-top: 0;
+  &.#{$blockContainer}--no-vertical-gap,
+  &.#{$blockContainer}--no-gap {
+    .#{$blockRow} .#{$blockCol} {
+      padding-top: 0;
+    }
   }
 
   @include fd-rtl() {
@@ -85,44 +91,34 @@ $cols: 12;
 }
 
 .#{$blockRow} {
-  @include fd-reset();
-
   display: flex;
   flex-wrap: wrap;
   flex: 0 0 100%;
   position: relative;
-  margin: 0 -0.25rem;
-  min-width: 100%;
+  margin-left: -$horizontal-gutter-small;
+  margin-right: -$horizontal-gutter-small;
+  min-width: calc(100% + #{$horizontal-gutter-small} * 2);
 
-  &--inner-flex {
-    display: flex;
+  &:first-child {
+    margin-top: -$vertical-gutter-small;
   }
 
-  .#{$block} {
-    .#{$blockRow} + .#{$blockRow} {
-      margin-top: -0.5rem;
-    }
+  .#{$blockCol} {
+    padding-top: $vertical-gutter-small;
   }
 }
 
-.#{$block} {
-  @include fd-reset();
-
+.#{$blockCol} {
   @at-root {
     @include responsive-column();
   }
 
-  padding: 0.5rem 0.25rem 0 0.25rem;
+  padding: 0 $horizontal-gutter-small;
   min-width: 100%;
   max-width: 100%;
 
   &--full {
     @include full();
-  }
-
-  .#{$blockRow} {
-    margin: 0 -0.25rem;
-    margin-top: -0.5rem;
   }
 
   &--wrap {
@@ -132,82 +128,42 @@ $cols: 12;
 
 @media (min-width: 600px) {
   .#{$blockContainer} {
-    margin: 0 -0.5rem 0 -0.5rem;
-
-    .#{$blockRow} {
-      margin-left: 0;
-      margin-right: 0;
-      margin-top: -1rem;
-    }
-
-    .#{$blockRow} + .#{$blockRow} {
-      margin-top: 0;
-    }
-
-    &--no-horizontal-gap {
-      .fd-col {
-        padding-left: 0;
-        padding-right: 0;
-      }
-    }
-
-    &--no-vertical-gap {
-      margin: 0;
-
-      .fd-col {
-        padding-top: 0;
-      }
-    }
+    padding: 0 $horizontal-gutter;
   }
 
   .#{$blockRow} {
-    margin-bottom: 0;
+    min-width: calc(100% + #{$horizontal-gutter} * 2);
+    margin-left: -$horizontal-gutter;
+    margin-right: -$horizontal-gutter;
 
-    .#{$block} {
-      .#{$blockRow} + .#{$blockRow} {
-        margin-top: 1rem;
-      }
+    &:first-child {
+      margin-top: -$vertical-gutter;
+    }
+
+    .#{$blockCol} {
+      padding: $vertical-gutter $horizontal-gutter 0 $horizontal-gutter;
     }
   }
 
-  .#{$block} {
+  .#{$blockCol} {
     @at-root {
       @include responsive-column(map-get($size, $md));
-    }
-
-    padding: 1rem 0.5rem 0 0.5rem;
-
-    &--full {
-      @include full();
-    }
-
-    .#{$blockRow} {
-      margin-left: -0.5rem;
-      margin-right: -0.5rem;
     }
   }
 }
 
 @media (min-width: 1024px) {
-  .#{$block} {
+  .#{$blockCol} {
     @at-root {
       @include responsive-column(map-get($size, $lg));
-    }
-
-    &--full {
-      @include full();
     }
   }
 }
 
 @media (min-width: 1440px) {
-  .#{$block} {
+  .#{$blockCol} {
     @at-root {
       @include responsive-column(map-get($size, $xl));
-    }
-
-    &--full {
-      @include full();
     }
   }
 }

--- a/stories/layout-grid/__snapshots__/layout-grid.stories.storyshot
+++ b/stories/layout-grid/__snapshots__/layout-grid.stories.storyshot
@@ -5,63 +5,65 @@ exports[`Storyshots Layouts/Layout Grid Auto Adjusting 1`] = `
   class="fd-container"
 >
   
-  
+    
   <div
     class="fd-row"
   >
     
-    
+        
     <div
       class="fd-col fd-col--full"
     >
       
-        
+            
       <div
         class="docs-layout-grid-bg docs-layout-grid-bg--color-1"
       >
         
-            Auto adjusting col before 7 col
-        
+                Auto adjusting col before 7 col
+            
       </div>
       
-    
+        
     </div>
     
-    
+        
+        
     <div
       class="fd-col fd-col--7"
     >
       
-        
+            
       <div
         class="docs-layout-grid-bg docs-layout-grid-bg--color-2"
       >
         
-            7 col
-        
+                7 col
+            
       </div>
       
-    
+        
     </div>
     
-    
+        
+        
     <div
       class="fd-col fd-col--full"
     >
       
-        
+            
       <div
         class="docs-layout-grid-bg docs-layout-grid-bg--color-1"
       >
         
-            Auto adjusting col after 7 col
-        
+                Auto adjusting col after 7 col
+            
       </div>
       
-    
+        
     </div>
     
-  
+    
   </div>
   
 
@@ -69,612 +71,488 @@ exports[`Storyshots Layouts/Layout Grid Auto Adjusting 1`] = `
 `;
 
 exports[`Storyshots Layouts/Layout Grid Different Size Columns 1`] = `
-<section>
+<div
+  class="fd-container"
+>
+  
+  
   <div
-    class="fd-container"
+    class="fd-row"
   >
     
-  
+      
     <div
-      class="fd-row"
+      class="fd-col"
     >
       
-      
-      <div
-        class="fd-col"
-      >
-        
           
-        <div
-          class="docs-layout-grid-bg docs-layout-grid-bg--color-1"
-        >
-          12 columns element
-        </div>
-        
-      
+      <div
+        class="docs-layout-grid-bg docs-layout-grid-bg--color-1"
+      >
+        12 columns element
       </div>
       
-  
+      
     </div>
     
-
+  
+  </div>
+  
+  
+  
+  <div
+    class="fd-row"
+  >
+    
+      
+    <div
+      class="fd-col fd-col--11"
+    >
+      
+          
+      <div
+        class="docs-layout-grid-bg docs-layout-grid-bg--color-2"
+      >
+        11 columns element
+      </div>
+      
+      
+    </div>
+    
+      
+    <div
+      class="fd-col fd-col--1"
+    >
+      
+          
+      <div
+        class="docs-layout-grid-bg docs-layout-grid-bg--color-3"
+      >
+        1 column element
+      </div>
+      
+      
+    </div>
+    
+  
+  </div>
+  
+  
+  
+  <div
+    class="fd-row"
+  >
+    
+      
+    <div
+      class="fd-col fd-col--10"
+    >
+      
+          
+      <div
+        class="docs-layout-grid-bg docs-layout-grid-bg--color-4"
+      >
+        10 columns element
+      </div>
+      
+      
+    </div>
+    
+      
+    <div
+      class="fd-col fd-col--2"
+    >
+      
+          
+      <div
+        class="docs-layout-grid-bg docs-layout-grid-bg--color-5"
+      >
+        2 columns element
+      </div>
+      
+      
+    </div>
+    
+  
+  </div>
+  
+  
+  
+  <div
+    class="fd-row"
+  >
+    
+      
+    <div
+      class="fd-col fd-col--9"
+    >
+      
+          
+      <div
+        class="docs-layout-grid-bg docs-layout-grid-bg--color-6"
+      >
+        9 columns element
+      </div>
+      
+      
+    </div>
+    
+      
+    <div
+      class="fd-col fd-col--3"
+    >
+      
+          
+      <div
+        class="docs-layout-grid-bg docs-layout-grid-bg--color-7"
+      >
+        3 columns element
+      </div>
+      
+      
+    </div>
+    
+  
+  </div>
+  
+  
+  
+  <div
+    class="fd-row"
+  >
+    
+      
+    <div
+      class="fd-col fd-col--8"
+    >
+      
+          
+      <div
+        class="docs-layout-grid-bg docs-layout-grid-bg--color-8"
+      >
+        8 columns element
+      </div>
+      
+      
+    </div>
+    
+      
+    <div
+      class="fd-col fd-col--4"
+    >
+      
+          
+      <div
+        class="docs-layout-grid-bg docs-layout-grid-bg--color-9"
+      >
+        4 columns element
+      </div>
+      
+      
+    </div>
+    
+  
+  </div>
+  
+  
+  
+  <div
+    class="fd-row"
+  >
+    
+      
+    <div
+      class="fd-col fd-col--7"
+    >
+      
+          
+      <div
+        class="docs-layout-grid-bg docs-layout-grid-bg--color-10"
+      >
+        7 columns element
+      </div>
+      
+      
+    </div>
+    
+      
+    <div
+      class="fd-col fd-col--5"
+    >
+      
+          
+      <div
+        class="docs-layout-grid-bg docs-layout-grid-bg--color-11"
+      >
+        5 columns element
+      </div>
+      
+      
+    </div>
+    
+  
+  </div>
+  
+  
+  
+  <div
+    class="fd-row"
+  >
+    
+      
+    <div
+      class="fd-col fd-col--6"
+    >
+      
+          
+      <div
+        class="docs-layout-grid-bg docs-layout-grid-bg--color-12"
+      >
+        6 columns element
+      </div>
+      
+      
+    </div>
+    
+      
+    <div
+      class="fd-col fd-col--6"
+    >
+      
+          
+      <div
+        class="docs-layout-grid-bg docs-layout-grid-bg--color-1"
+      >
+        6 columns element
+      </div>
+      
+      
+    </div>
+    
+  
+  </div>
+  
+  
+  
+  <div
+    class="fd-row"
+  >
+    
+      
+    <div
+      class="fd-col fd-col--5"
+    >
+      
+          
+      <div
+        class="docs-layout-grid-bg docs-layout-grid-bg--color-2"
+      >
+        5 columns element
+      </div>
+      
+      
+    </div>
+    
+      
+    <div
+      class="fd-col fd-col--7"
+    >
+      
+          
+      <div
+        class="docs-layout-grid-bg docs-layout-grid-bg--color-3"
+      >
+        7 columns element
+      </div>
+      
+      
+    </div>
+    
+  
+  </div>
+  
+  
+  
+  <div
+    class="fd-row"
+  >
+    
+      
+    <div
+      class="fd-col fd-col--4"
+    >
+      
+          
+      <div
+        class="docs-layout-grid-bg docs-layout-grid-bg--color-4"
+      >
+        4 columns element
+      </div>
+      
+      
+    </div>
+    
+      
+    <div
+      class="fd-col fd-col--8"
+    >
+      
+          
+      <div
+        class="docs-layout-grid-bg docs-layout-grid-bg--color-5"
+      >
+        8 columns element
+      </div>
+      
+      
+    </div>
+    
+  
+  </div>
+  
+  
+  
+  <div
+    class="fd-row"
+  >
+    
+      
+    <div
+      class="fd-col fd-col--3"
+    >
+      
+          
+      <div
+        class="docs-layout-grid-bg docs-layout-grid-bg--color-6"
+      >
+        3 columns element
+      </div>
+      
+      
+    </div>
+    
+      
+    <div
+      class="fd-col fd-col--9"
+    >
+      
+          
+      <div
+        class="docs-layout-grid-bg docs-layout-grid-bg--color-7"
+      >
+        9 columns element
+      </div>
+      
+      
+    </div>
+    
+  
+  </div>
+  
+  
+  
+  <div
+    class="fd-row"
+  >
+    
+      
+    <div
+      class="fd-col fd-col--2"
+    >
+      
+          
+      <div
+        class="docs-layout-grid-bg docs-layout-grid-bg--color-8"
+      >
+        2 columns element
+      </div>
+      
+      
+    </div>
+    
+      
+    <div
+      class="fd-col fd-col--10"
+    >
+      
+          
+      <div
+        class="docs-layout-grid-bg docs-layout-grid-bg--color-9"
+      >
+        10 columns element
+      </div>
+      
+      
+    </div>
+    
+  
+  </div>
+  
+  
+  
+  <div
+    class="fd-row"
+  >
+    
+      
+    <div
+      class="fd-col fd-col--1"
+    >
+      
+          
+      <div
+        class="docs-layout-grid-bg docs-layout-grid-bg--color-10"
+      >
+        1 column element
+      </div>
+      
+      
+    </div>
+    
+      
+    <div
+      class="fd-col fd-col--11"
+    >
+      
+          
+      <div
+        class="docs-layout-grid-bg docs-layout-grid-bg--color-11"
+      >
+        11 columns element
+      </div>
+      
+      
+    </div>
+    
+  
+  </div>
+  
+  
+  
+  <div
+    class="fd-row"
+  >
+    
+      
+    <div
+      class="fd-col"
+    >
+      
+          
+      <div
+        class="docs-layout-grid-bg docs-layout-grid-bg--color-12"
+      >
+        12 columns element
+      </div>
+      
+      
+    </div>
+    
+  
   </div>
   
 
-  <br />
-  
-
-  <div
-    class="fd-container"
-  >
-    
-  
-    <div
-      class="fd-row"
-    >
-      
-      
-      <div
-        class="fd-col fd-col--11"
-      >
-        
-          
-        <div
-          class="docs-layout-grid-bg docs-layout-grid-bg--color-2"
-        >
-          11 columns element
-        </div>
-        
-      
-      </div>
-      
-      
-      <div
-        class="fd-col fd-col--1"
-      >
-        
-          
-        <div
-          class="docs-layout-grid-bg docs-layout-grid-bg--color-3"
-        >
-          1 column element
-        </div>
-        
-      
-      </div>
-      
-  
-    </div>
-    
-
-  </div>
-  
-
-  <br />
-  
-
-  <div
-    class="fd-container"
-  >
-    
-  
-    <div
-      class="fd-row"
-    >
-      
-      
-      <div
-        class="fd-col fd-col--10"
-      >
-        
-          
-        <div
-          class="docs-layout-grid-bg docs-layout-grid-bg--color-4"
-        >
-          10 columns element
-        </div>
-        
-      
-      </div>
-      
-      
-      <div
-        class="fd-col fd-col--2"
-      >
-        
-          
-        <div
-          class="docs-layout-grid-bg docs-layout-grid-bg--color-5"
-        >
-          2 columns element
-        </div>
-        
-      
-      </div>
-      
-  
-    </div>
-    
-
-  </div>
-  
-
-  <br />
-  
-
-  <div
-    class="fd-container"
-  >
-    
-  
-    <div
-      class="fd-row"
-    >
-      
-      
-      <div
-        class="fd-col fd-col--9"
-      >
-        
-          
-        <div
-          class="docs-layout-grid-bg docs-layout-grid-bg--color-6"
-        >
-          9 columns element
-        </div>
-        
-      
-      </div>
-      
-      
-      <div
-        class="fd-col fd-col--3"
-      >
-        
-          
-        <div
-          class="docs-layout-grid-bg docs-layout-grid-bg--color-7"
-        >
-          3 columns element
-        </div>
-        
-      
-      </div>
-      
-  
-    </div>
-    
-
-  </div>
-  
-
-  <br />
-  
-
-  <div
-    class="fd-container"
-  >
-    
-  
-    <div
-      class="fd-row"
-    >
-      
-      
-      <div
-        class="fd-col fd-col--8"
-      >
-        
-          
-        <div
-          class="docs-layout-grid-bg docs-layout-grid-bg--color-8"
-        >
-          8 columns element
-        </div>
-        
-      
-      </div>
-      
-      
-      <div
-        class="fd-col fd-col--4"
-      >
-        
-          
-        <div
-          class="docs-layout-grid-bg docs-layout-grid-bg--color-9"
-        >
-          4 columns element
-        </div>
-        
-      
-      </div>
-      
-  
-    </div>
-    
-
-  </div>
-  
-
-  <br />
-  
-
-  <div
-    class="fd-container"
-  >
-    
-  
-    <div
-      class="fd-row"
-    >
-      
-      
-      <div
-        class="fd-col fd-col--7"
-      >
-        
-          
-        <div
-          class="docs-layout-grid-bg docs-layout-grid-bg--color-10"
-        >
-          7 columns element
-        </div>
-        
-      
-      </div>
-      
-      
-      <div
-        class="fd-col fd-col--5"
-      >
-        
-          
-        <div
-          class="docs-layout-grid-bg docs-layout-grid-bg--color-11"
-        >
-          5 columns element
-        </div>
-        
-      
-      </div>
-      
-  
-    </div>
-    
-
-  </div>
-  
-
-  <br />
-  
-
-  <div
-    class="fd-container"
-  >
-    
-  
-    <div
-      class="fd-row"
-    >
-      
-      
-      <div
-        class="fd-col fd-col--6"
-      >
-        
-          
-        <div
-          class="docs-layout-grid-bg docs-layout-grid-bg--color-12"
-        >
-          6 columns element
-        </div>
-        
-      
-      </div>
-      
-      
-      <div
-        class="fd-col fd-col--6"
-      >
-        
-          
-        <div
-          class="docs-layout-grid-bg docs-layout-grid-bg--color-1"
-        >
-          6 columns element
-        </div>
-        
-      
-      </div>
-      
-  
-    </div>
-    
-
-  </div>
-  
-
-  <br />
-  
-
-  <div
-    class="fd-container"
-  >
-    
-  
-    <div
-      class="fd-row"
-    >
-      
-      
-      <div
-        class="fd-col fd-col--5"
-      >
-        
-          
-        <div
-          class="docs-layout-grid-bg docs-layout-grid-bg--color-2"
-        >
-          5 columns element
-        </div>
-        
-      
-      </div>
-      
-      
-      <div
-        class="fd-col fd-col--7"
-      >
-        
-          
-        <div
-          class="docs-layout-grid-bg docs-layout-grid-bg--color-3"
-        >
-          7 columns element
-        </div>
-        
-      
-      </div>
-      
-  
-    </div>
-    
-
-  </div>
-  
-
-  <br />
-  
-
-  <div
-    class="fd-container"
-  >
-    
-  
-    <div
-      class="fd-row"
-    >
-      
-      
-      <div
-        class="fd-col fd-col--4"
-      >
-        
-          
-        <div
-          class="docs-layout-grid-bg docs-layout-grid-bg--color-4"
-        >
-          4 columns element
-        </div>
-        
-      
-      </div>
-      
-      
-      <div
-        class="fd-col fd-col--8"
-      >
-        
-          
-        <div
-          class="docs-layout-grid-bg docs-layout-grid-bg--color-5"
-        >
-          8 columns element
-        </div>
-        
-      
-      </div>
-      
-  
-    </div>
-    
-
-  </div>
-  
-
-  <br />
-  
-
-  <div
-    class="fd-container"
-  >
-    
-  
-    <div
-      class="fd-row"
-    >
-      
-      
-      <div
-        class="fd-col fd-col--3"
-      >
-        
-          
-        <div
-          class="docs-layout-grid-bg docs-layout-grid-bg--color-6"
-        >
-          3 columns element
-        </div>
-        
-      
-      </div>
-      
-      
-      <div
-        class="fd-col fd-col--9"
-      >
-        
-          
-        <div
-          class="docs-layout-grid-bg docs-layout-grid-bg--color-7"
-        >
-          9 columns element
-        </div>
-        
-      
-      </div>
-      
-  
-    </div>
-    
-
-  </div>
-  
-
-  <br />
-  
-
-  <div
-    class="fd-container"
-  >
-    
-  
-    <div
-      class="fd-row"
-    >
-      
-      
-      <div
-        class="fd-col fd-col--2"
-      >
-        
-          
-        <div
-          class="docs-layout-grid-bg docs-layout-grid-bg--color-8"
-        >
-          2 columns element
-        </div>
-        
-      
-      </div>
-      
-      
-      <div
-        class="fd-col fd-col--10"
-      >
-        
-          
-        <div
-          class="docs-layout-grid-bg docs-layout-grid-bg--color-9"
-        >
-          10 columns element
-        </div>
-        
-      
-      </div>
-      
-  
-    </div>
-    
-
-  </div>
-  
-
-  <br />
-  
-
-  <div
-    class="fd-container"
-  >
-    
-  
-    <div
-      class="fd-row"
-    >
-      
-      
-      <div
-        class="fd-col fd-col--1"
-      >
-        
-          
-        <div
-          class="docs-layout-grid-bg docs-layout-grid-bg--color-10"
-        >
-          1 column element
-        </div>
-        
-      
-      </div>
-      
-      
-      <div
-        class="fd-col fd-col--11"
-      >
-        
-          
-        <div
-          class="docs-layout-grid-bg docs-layout-grid-bg--color-11"
-        >
-          11 columns element
-        </div>
-        
-      
-      </div>
-      
-  
-    </div>
-    
-
-  </div>
-  
-
-  <br />
-  
-
-  <div
-    class="fd-container"
-  >
-    
-  
-    <div
-      class="fd-row"
-    >
-      
-      
-      <div
-        class="fd-col"
-      >
-        
-          
-        <div
-          class="docs-layout-grid-bg docs-layout-grid-bg--color-12"
-        >
-          12 columns element
-        </div>
-        
-      
-      </div>
-      
-  
-    </div>
-    
-
-  </div>
-  
-
-</section>
+</div>
 `;
 
 exports[`Storyshots Layouts/Layout Grid Nesting 1`] = `
@@ -697,12 +575,13 @@ exports[`Storyshots Layouts/Layout Grid Nesting 1`] = `
         class="docs-layout-grid-bg docs-layout-grid-bg--color-1"
       >
         
-            6 col (1/2 = 50%)
+            2 col (~17%)
         
       </div>
       
     
     </div>
+    
     
     
     <div
@@ -725,13 +604,14 @@ exports[`Storyshots Layouts/Layout Grid Nesting 1`] = `
             class="docs-layout-grid-bg docs-layout-grid-bg--color-2"
           >
              
-                    2 col inner row 1 (1/12 ~8%)
+                    2 col inner row 1 (~14%)
                 
           </div>
            
             
         </div>
         
+            
             
         <div
           class="fd-col fd-col--10"
@@ -752,13 +632,14 @@ exports[`Storyshots Layouts/Layout Grid Nesting 1`] = `
                 class="docs-layout-grid-bg docs-layout-grid-bg--color-3"
               >
                 
-                            6 coll inner row 2 (5/24 ~21%)
+                            6 coll inner row 2 (~34%)
                         
               </div>
               
                     
             </div>
-                  
+                 
+                     
                     
             <div
               class="fd-col fd-col--6"
@@ -779,13 +660,14 @@ exports[`Storyshots Layouts/Layout Grid Nesting 1`] = `
                     class="docs-layout-grid-bg docs-layout-grid-bg--color-4"
                   >
                     
-                                4 coll inner row 3 (5/72 ~7%)
+                                    4 coll inner row 3 (~10%)
                                 
                   </div>
                   
                             
                 </div>
                 
+                            
                             
                 <div
                   class="fd-col fd-col--8"
@@ -796,7 +678,7 @@ exports[`Storyshots Layouts/Layout Grid Nesting 1`] = `
                     class="docs-layout-grid-bg docs-layout-grid-bg--color-5"
                   >
                     
-                                8 coll inner row 3 (10/72 ~14%)
+                                    8 coll inner row 3 (~23%)
                                 
                   </div>
                   
@@ -838,109 +720,130 @@ exports[`Storyshots Layouts/Layout Grid No Gap 1`] = `
     class="fd-row"
   >
     
-    
+        
     <div
       class="fd-col fd-col--8"
     >
       
-        
+            
       <div
         class="docs-layout-grid-bg docs-layout-grid-bg--color-1"
       >
         
-            8 col no gap
-        
+                8 col no gap
+            
       </div>
       
-    
+        
     </div>
     
-    
+        
+        
     <div
       class="fd-col fd-col--4"
     >
       
-        
+            
       <div
         class="docs-layout-grid-bg docs-layout-grid-bg--color-2"
       >
         
-            4 col no gap
-        
+                4 col no gap
+            
       </div>
       
-    
+        
     </div>
     
     
+  </div>
+  
+    
+    
+  <div
+    class="fd-row"
+  >
+    
+        
     <div
       class="fd-col fd-col--6"
     >
       
-        
+            
       <div
         class="docs-layout-grid-bg docs-layout-grid-bg--color-3"
       >
         
-            6 col no gap
-        
+                6 col no gap
+            
       </div>
       
-    
+        
     </div>
     
-    
+        
+        
     <div
       class="fd-col fd-col--6"
     >
       
-        
+            
       <div
         class="docs-layout-grid-bg docs-layout-grid-bg--color-4"
       >
         
-            6 col no gap
-        
+                6 col no gap
+            
       </div>
       
-    
+        
     </div>
     
     
+  </div>
+  
+    
+    
+  <div
+    class="fd-row"
+  >
+    
+        
     <div
       class="fd-col fd-col--4"
     >
       
-        
+            
       <div
         class="docs-layout-grid-bg docs-layout-grid-bg--color-5"
       >
         
-            4 col no gap
-        
+                4 col no gap
+            
       </div>
       
-    
+        
     </div>
     
-    
+        
+        
     <div
       class="fd-col fd-col--8"
     >
       
-        
+            
       <div
         class="docs-layout-grid-bg docs-layout-grid-bg--color-6"
       >
         
-            8 col no gap
-        
+                8 col no gap
+            
       </div>
       
-    
+        
     </div>
     
-  
+    
   </div>
   
 
@@ -952,114 +855,135 @@ exports[`Storyshots Layouts/Layout Grid No Horizontal Gap 1`] = `
   class="fd-container fd-container--no-horizontal-gap"
 >
   
-  
+    
   <div
     class="fd-row"
   >
     
-    
+        
     <div
       class="fd-col fd-col--8"
     >
       
-        
+            
       <div
         class="docs-layout-grid-bg docs-layout-grid-bg--color-1"
       >
         
-            8 col no gap
-        
+                8 col no gap
+            
       </div>
       
-    
+        
     </div>
     
-    
+        
+        
     <div
       class="fd-col fd-col--4"
     >
       
-        
+            
       <div
         class="docs-layout-grid-bg docs-layout-grid-bg--color-2"
       >
         
-            4 col no gap
-        
+                4 col no gap
+            
       </div>
       
-    
+        
     </div>
     
     
+  </div>
+  
+    
+    
+  <div
+    class="fd-row"
+  >
+    
+        
     <div
       class="fd-col fd-col--6"
     >
       
-        
+            
       <div
         class="docs-layout-grid-bg docs-layout-grid-bg--color-3"
       >
         
-            6 col no gap
-        
+                6 col no gap
+            
       </div>
       
-    
+        
     </div>
     
-    
+        
+        
     <div
       class="fd-col fd-col--6"
     >
       
-        
+            
       <div
         class="docs-layout-grid-bg docs-layout-grid-bg--color-4"
       >
         
-            6 col no gap
-        
+                6 col no gap
+            
       </div>
       
-    
+        
     </div>
     
     
+  </div>
+  
+    
+    
+  <div
+    class="fd-row"
+  >
+    
+        
     <div
       class="fd-col fd-col--4"
     >
       
-        
+            
       <div
         class="docs-layout-grid-bg docs-layout-grid-bg--color-5"
       >
         
-            4 col no gap
-        
+                4 col no gap
+            
       </div>
       
-    
+        
     </div>
     
-    
+        
+        
     <div
       class="fd-col fd-col--8"
     >
       
-        
+            
       <div
         class="docs-layout-grid-bg docs-layout-grid-bg--color-6"
       >
         
-            8 col no gap
-        
+                8 col no gap
+            
       </div>
       
-    
+        
     </div>
     
-  
+    
   </div>
   
 
@@ -1071,114 +995,135 @@ exports[`Storyshots Layouts/Layout Grid No Vertical Gap 1`] = `
   class="fd-container fd-container--no-vertical-gap"
 >
   
-  
+    
   <div
     class="fd-row"
   >
     
-    
+        
     <div
       class="fd-col fd-col--8"
     >
       
-        
+            
       <div
         class="docs-layout-grid-bg docs-layout-grid-bg--color-1"
       >
         
-            8 col no gap
-        
+                8 col no gap
+            
       </div>
       
-    
+        
     </div>
     
-    
+        
+        
     <div
       class="fd-col fd-col--4"
     >
       
-        
+            
       <div
         class="docs-layout-grid-bg docs-layout-grid-bg--color-2"
       >
         
-            4 col no gap
-        
+                4 col no gap
+            
       </div>
       
-    
+        
     </div>
     
     
+  </div>
+  
+    
+    
+  <div
+    class="fd-row"
+  >
+    
+        
     <div
       class="fd-col fd-col--6"
     >
       
-        
+            
       <div
         class="docs-layout-grid-bg docs-layout-grid-bg--color-3"
       >
         
-            6 col no gap
-        
+                6 col no gap
+            
       </div>
       
-    
+        
     </div>
     
-    
+        
+        
     <div
       class="fd-col fd-col--6"
     >
       
-        
+            
       <div
         class="docs-layout-grid-bg docs-layout-grid-bg--color-4"
       >
         
-            6 col no gap
-        
+                6 col no gap
+            
       </div>
       
-    
+        
     </div>
     
     
+  </div>
+  
+    
+    
+  <div
+    class="fd-row"
+  >
+    
+        
     <div
       class="fd-col fd-col--4"
     >
       
-        
+            
       <div
         class="docs-layout-grid-bg docs-layout-grid-bg--color-5"
       >
         
-            4 col no gap
-        
+                4 col no gap
+            
       </div>
       
-    
+        
     </div>
     
-    
+        
+        
     <div
       class="fd-col fd-col--8"
     >
       
-        
+            
       <div
         class="docs-layout-grid-bg docs-layout-grid-bg--color-6"
       >
         
-            8 col no gap
-        
+                8 col no gap
+            
       </div>
       
-    
+        
     </div>
     
-  
+    
   </div>
   
 
@@ -1190,129 +1135,169 @@ exports[`Storyshots Layouts/Layout Grid Offset 1`] = `
   class="fd-container"
 >
   
-  
+    
   <div
     class="fd-row"
   >
     
-    
+        
     <div
       class="fd-col"
     >
       
-        
+            
       <div
         class="docs-layout-grid-bg docs-layout-grid-bg--color-1"
       >
         
-            12 columns
-        
+                12 columns
+            
       </div>
       
-    
+        
     </div>
     
     
+  </div>
+  
+    
+    
+  <div
+    class="fd-row"
+  >
+    
+        
     <div
       class="fd-col fd-col--6"
     >
       
-        
+            
       <div
         class="docs-layout-grid-bg docs-layout-grid-bg--color-3"
       >
         
-            6 columns
-        
+                6 columns
+            
       </div>
       
-    
+        
     </div>
     
     
+  </div>
+  
+    
+    
+  <div
+    class="fd-row"
+  >
+    
+        
     <div
       class="fd-col fd-col--8 fd-col--offset-4 fd-col-md--6 fd-col-md--offset-2 fd-col-lg--4 fd-col-lg--offset-4 fd-col-lx--3 fd-col-lx--offset-6"
     >
       
-        
+            
       <div
         class="docs-layout-grid-bg docs-layout-grid-bg--color-5"
       >
          
-            Different column-width and offset in different inflection points 
-        
+                Different column-width and offset in different inflection points 
+            
       </div>
       
-    
+        
     </div>
     
     
+  </div>
+  
+    
+    
+  <div
+    class="fd-row"
+  >
+    
+        
     <div
       class="fd-col fd-col--6 fd-col--offset-6"
     >
       
-        
+            
       <div
         class="docs-layout-grid-bg docs-layout-grid-bg--color-7"
       >
          
-            6 columns with 6-column offset 
-        
+                6 columns with 6-column offset 
+            
       </div>
       
-    
+        
     </div>
     
     
+  </div>
+  
+    
+    
+  <div
+    class="fd-row"
+  >
+    
+        
     <div
       class="fd-col fd-col--3 fd-col--offset-after-1 fd-col-md--offset-after-2 fd-col-lg--offset-after-2 fd-col-xl--offset-after-1"
     >
       
-      
+            
       <div
         class="docs-layout-grid-bg docs-layout-grid-bg--color-8"
       >
          
-          2 column-width and offset after in different inflection points 
-      
+                2 column-width and offset after in different inflection points 
+            
       </div>
       
-    
+        
     </div>
     
-    
+        
+        
     <div
       class="fd-col fd-col--4 fd-col--offset-after-1"
     >
       
-        
+            
       <div
         class="docs-layout-grid-bg docs-layout-grid-bg--color-9"
       >
          
-            4 columns with 2-column offset after
-        
+                4 columns with 2-column offset after
+            
       </div>
       
-    
+        
     </div>
     
-    
+        
+        
     <div
       class="fd-col fd-col--2"
     >
       
-        
+            
       <div
         class="docs-layout-grid-bg docs-layout-grid-bg--color-12"
       >
-        2 column element
+        
+                2 column element
+            
       </div>
       
-    
+        
     </div>
     
-  
+    
   </div>
   
 
@@ -1331,7 +1316,7 @@ exports[`Storyshots Layouts/Layout Grid Responsiveness 1`] = `
     
     
     <div
-      class="fd-col fd-col--12 fd-col-md--6 fd-col-lg--4 fd-col-xl--4 "
+      class="fd-col fd-col--12 fd-col-md--6 fd-col-lg--4 fd-col-xl--4"
     >
       
         
@@ -1345,8 +1330,9 @@ exports[`Storyshots Layouts/Layout Grid Responsiveness 1`] = `
     </div>
     
     
+    
     <div
-      class="fd-col fd-col--12 fd-col-md--6 fd-col-lg--4 fd-col-xl--4 "
+      class="fd-col fd-col--12 fd-col-md--6 fd-col-lg--4 fd-col-xl--4"
     >
       
         
@@ -1360,8 +1346,9 @@ exports[`Storyshots Layouts/Layout Grid Responsiveness 1`] = `
     </div>
     
     
+    
     <div
-      class="fd-col fd-col--12 fd-col-md--6 fd-col-lg--4 fd-col-xl--4 "
+      class="fd-col fd-col--12 fd-col-md--6 fd-col-lg--4 fd-col-xl--4"
     >
       
         
@@ -1375,8 +1362,9 @@ exports[`Storyshots Layouts/Layout Grid Responsiveness 1`] = `
     </div>
     
     
+    
     <div
-      class="fd-col fd-col--12 fd-col-md--6 fd-col-lg--4 fd-col-xl--4 "
+      class="fd-col fd-col--12 fd-col-md--6 fd-col-lg--4 fd-col-xl--4"
     >
       
         

--- a/stories/layout-grid/layout-grid.stories.js
+++ b/stories/layout-grid/layout-grid.stories.js
@@ -1,14 +1,16 @@
 export default {
     title: 'Layouts/Layout Grid',
     parameters: {
-        description: `The layout grid is made to seperate data into both columns and rows. If there is not enough space on the current line of the same row, the item will go to the next line without the margin at the top.
-To use the grid, the user must use all of the \`fd-container\`, \`fd-row\`, and \`fd-col\` tags.
+        description: `The layout grid is made to separate data into both columns and rows. If there is not enough space on the current line of the same row, the item will go to the next line.
+To use the grid, the user must use all of the \`fd-container\`, \`fd-row\`, and \`fd-col\` classes.
 
-- Use the \`fd-container\` class to wrap the whole grid and help apply the proper row margin.
-- Use the \`fd-container--no-gap\` modifier to remove the gutter spacing between all columns.
-- Use the \`fd-row\` to seperate rows and have an automatic gutter in between columns when they column wraps to the next line.
-- Use the \`fd-col\` to create a column of a certain width. The default value will create a column the full width, being 12 columns of the parent at size small and above unless specified another size.
-- Use the \`fd-col--x\` modifier will make the column spread x-rows/12 (e.g. \`fd-col--4\` which will take 4 columns out of 12).
+- Use the \`fd-container\` class to wrap the whole grid.
+- Use the \`fd-container--no-vertical-gap\` modifier to remove the gutter spacing between rows.
+- Use the \`fd-container--no-horizontal-gap\` modifier to remove the gutter spacing between columns.
+- Use the \`fd-container--no-gap\` modifier to remove the gutter spacing between columns and rows.
+- Use the \`fd-row\` to separate rows.
+- Use the \`fd-col\` to separate a column of certain width. The default value will create a column the full width, being 12 columns of the parent at size small and above unless specified another size.
+- Use the \`fd-col--x\` modifier class to make the column spread x-rows/12 (e.g. \`fd-col--4\` which will take 4 columns out of 12).
 
 <h2>Breakpoints</h2>
 
@@ -24,139 +26,115 @@ To use the grid, the user must use all of the \`fd-container\`, \`fd-row\`, and 
     }
 };
 
-export const differentSizeColumns = () => `<div class="fd-container">
-  <div class="fd-row">
-      <div class="fd-col">
-          <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1">12 columns element</div>
+export const differentSizeColumns = () => `<div class='fd-container'>
+  <div class='fd-row'>
+      <div class='fd-col'>
+          <div class='docs-layout-grid-bg docs-layout-grid-bg--color-1'>12 columns element</div>
       </div>
   </div>
-</div>
-<br />
-<div class="fd-container">
-  <div class="fd-row">
-      <div class="fd-col fd-col--11">
-          <div class="docs-layout-grid-bg docs-layout-grid-bg--color-2">11 columns element</div>
+  
+  <div class='fd-row'>
+      <div class='fd-col fd-col--11'>
+          <div class='docs-layout-grid-bg docs-layout-grid-bg--color-2'>11 columns element</div>
       </div>
-      <div class="fd-col fd-col--1">
-          <div class="docs-layout-grid-bg docs-layout-grid-bg--color-3">1 column element</div>
+      <div class='fd-col fd-col--1'>
+          <div class='docs-layout-grid-bg docs-layout-grid-bg--color-3'>1 column element</div>
       </div>
   </div>
-</div>
-<br />
-<div class="fd-container">
-  <div class="fd-row">
-      <div class="fd-col fd-col--10">
-          <div class="docs-layout-grid-bg docs-layout-grid-bg--color-4">10 columns element</div>
+  
+  <div class='fd-row'>
+      <div class='fd-col fd-col--10'>
+          <div class='docs-layout-grid-bg docs-layout-grid-bg--color-4'>10 columns element</div>
       </div>
-      <div class="fd-col fd-col--2">
-          <div class="docs-layout-grid-bg docs-layout-grid-bg--color-5">2 columns element</div>
+      <div class='fd-col fd-col--2'>
+          <div class='docs-layout-grid-bg docs-layout-grid-bg--color-5'>2 columns element</div>
       </div>
   </div>
-</div>
-<br />
-<div class="fd-container">
-  <div class="fd-row">
-      <div class="fd-col fd-col--9">
-          <div class="docs-layout-grid-bg docs-layout-grid-bg--color-6">9 columns element</div>
+  
+  <div class='fd-row'>
+      <div class='fd-col fd-col--9'>
+          <div class='docs-layout-grid-bg docs-layout-grid-bg--color-6'>9 columns element</div>
       </div>
-      <div class="fd-col fd-col--3">
-          <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7">3 columns element</div>
+      <div class='fd-col fd-col--3'>
+          <div class='docs-layout-grid-bg docs-layout-grid-bg--color-7'>3 columns element</div>
       </div>
   </div>
-</div>
-<br />
-<div class="fd-container">
-  <div class="fd-row">
-      <div class="fd-col fd-col--8">
-          <div class="docs-layout-grid-bg docs-layout-grid-bg--color-8">8 columns element</div>
+  
+  <div class='fd-row'>
+      <div class='fd-col fd-col--8'>
+          <div class='docs-layout-grid-bg docs-layout-grid-bg--color-8'>8 columns element</div>
       </div>
-      <div class="fd-col fd-col--4">
-          <div class="docs-layout-grid-bg docs-layout-grid-bg--color-9">4 columns element</div>
+      <div class='fd-col fd-col--4'>
+          <div class='docs-layout-grid-bg docs-layout-grid-bg--color-9'>4 columns element</div>
       </div>
   </div>
-</div>
-<br />
-<div class="fd-container">
-  <div class="fd-row">
-      <div class="fd-col fd-col--7">
-          <div class="docs-layout-grid-bg docs-layout-grid-bg--color-10">7 columns element</div>
+  
+  <div class='fd-row'>
+      <div class='fd-col fd-col--7'>
+          <div class='docs-layout-grid-bg docs-layout-grid-bg--color-10'>7 columns element</div>
       </div>
-      <div class="fd-col fd-col--5">
-          <div class="docs-layout-grid-bg docs-layout-grid-bg--color-11">5 columns element</div>
+      <div class='fd-col fd-col--5'>
+          <div class='docs-layout-grid-bg docs-layout-grid-bg--color-11'>5 columns element</div>
       </div>
   </div>
-</div>
-<br />
-<div class="fd-container">
-  <div class="fd-row">
-      <div class="fd-col fd-col--6">
-          <div class="docs-layout-grid-bg docs-layout-grid-bg--color-12">6 columns element</div>
+  
+  <div class='fd-row'>
+      <div class='fd-col fd-col--6'>
+          <div class='docs-layout-grid-bg docs-layout-grid-bg--color-12'>6 columns element</div>
       </div>
-      <div class="fd-col fd-col--6">
-          <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1">6 columns element</div>
+      <div class='fd-col fd-col--6'>
+          <div class='docs-layout-grid-bg docs-layout-grid-bg--color-1'>6 columns element</div>
       </div>
   </div>
-</div>
-<br />
-<div class="fd-container">
-  <div class="fd-row">
-      <div class="fd-col fd-col--5">
-          <div class="docs-layout-grid-bg docs-layout-grid-bg--color-2">5 columns element</div>
+  
+  <div class='fd-row'>
+      <div class='fd-col fd-col--5'>
+          <div class='docs-layout-grid-bg docs-layout-grid-bg--color-2'>5 columns element</div>
       </div>
-      <div class="fd-col fd-col--7">
-          <div class="docs-layout-grid-bg docs-layout-grid-bg--color-3">7 columns element</div>
+      <div class='fd-col fd-col--7'>
+          <div class='docs-layout-grid-bg docs-layout-grid-bg--color-3'>7 columns element</div>
       </div>
   </div>
-</div>
-<br />
-<div class="fd-container">
-  <div class="fd-row">
-      <div class="fd-col fd-col--4">
-          <div class="docs-layout-grid-bg docs-layout-grid-bg--color-4">4 columns element</div>
+  
+  <div class='fd-row'>
+      <div class='fd-col fd-col--4'>
+          <div class='docs-layout-grid-bg docs-layout-grid-bg--color-4'>4 columns element</div>
       </div>
-      <div class="fd-col fd-col--8">
-          <div class="docs-layout-grid-bg docs-layout-grid-bg--color-5">8 columns element</div>
+      <div class='fd-col fd-col--8'>
+          <div class='docs-layout-grid-bg docs-layout-grid-bg--color-5'>8 columns element</div>
       </div>
   </div>
-</div>
-<br />
-<div class="fd-container">
-  <div class="fd-row">
-      <div class="fd-col fd-col--3">
-          <div class="docs-layout-grid-bg docs-layout-grid-bg--color-6">3 columns element</div>
+  
+  <div class='fd-row'>
+      <div class='fd-col fd-col--3'>
+          <div class='docs-layout-grid-bg docs-layout-grid-bg--color-6'>3 columns element</div>
       </div>
-      <div class="fd-col fd-col--9">
-          <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7">9 columns element</div>
+      <div class='fd-col fd-col--9'>
+          <div class='docs-layout-grid-bg docs-layout-grid-bg--color-7'>9 columns element</div>
       </div>
   </div>
-</div>
-<br />
-<div class="fd-container">
-  <div class="fd-row">
-      <div class="fd-col fd-col--2">
-          <div class="docs-layout-grid-bg docs-layout-grid-bg--color-8">2 columns element</div>
+  
+  <div class='fd-row'>
+      <div class='fd-col fd-col--2'>
+          <div class='docs-layout-grid-bg docs-layout-grid-bg--color-8'>2 columns element</div>
       </div>
-      <div class="fd-col fd-col--10">
-          <div class="docs-layout-grid-bg docs-layout-grid-bg--color-9">10 columns element</div>
+      <div class='fd-col fd-col--10'>
+          <div class='docs-layout-grid-bg docs-layout-grid-bg--color-9'>10 columns element</div>
       </div>
   </div>
-</div>
-<br />
-<div class="fd-container">
-  <div class="fd-row">
-      <div class="fd-col fd-col--1">
-          <div class="docs-layout-grid-bg docs-layout-grid-bg--color-10">1 column element</div>
+  
+  <div class='fd-row'>
+      <div class='fd-col fd-col--1'>
+          <div class='docs-layout-grid-bg docs-layout-grid-bg--color-10'>1 column element</div>
       </div>
-      <div class="fd-col fd-col--11">
-          <div class="docs-layout-grid-bg docs-layout-grid-bg--color-11">11 columns element</div>
+      <div class='fd-col fd-col--11'>
+          <div class='docs-layout-grid-bg docs-layout-grid-bg--color-11'>11 columns element</div>
       </div>
   </div>
-</div>
-<br />
-<div class="fd-container">
-  <div class="fd-row">
-      <div class="fd-col">
-          <div class="docs-layout-grid-bg docs-layout-grid-bg--color-12">12 columns element</div>
+  
+  <div class='fd-row'>
+      <div class='fd-col'>
+          <div class='docs-layout-grid-bg docs-layout-grid-bg--color-12'>12 columns element</div>
       </div>
   </div>
 </div>
@@ -169,19 +147,22 @@ differentSizeColumns.parameters = {
     }
 };
 
-export const responsiveness = () => `<div class="fd-container">
-  <div class="fd-row">
-    <div class="fd-col fd-col--12 fd-col-md--6 fd-col-lg--4 fd-col-xl--4 ">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1">(1 cell)</div>
+export const responsiveness = () => `<div class='fd-container'>
+  <div class='fd-row'>
+    <div class='fd-col fd-col--12 fd-col-md--6 fd-col-lg--4 fd-col-xl--4'>
+        <div class='docs-layout-grid-bg docs-layout-grid-bg--color-1'>(1 cell)</div>
     </div>
-    <div class="fd-col fd-col--12 fd-col-md--6 fd-col-lg--4 fd-col-xl--4 ">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-2">(2 cell)</div>
+    
+    <div class='fd-col fd-col--12 fd-col-md--6 fd-col-lg--4 fd-col-xl--4'>
+        <div class='docs-layout-grid-bg docs-layout-grid-bg--color-2'>(2 cell)</div>
     </div>
-    <div class="fd-col fd-col--12 fd-col-md--6 fd-col-lg--4 fd-col-xl--4 ">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-3">(3 cell)</div>
+    
+    <div class='fd-col fd-col--12 fd-col-md--6 fd-col-lg--4 fd-col-xl--4'>
+        <div class='docs-layout-grid-bg docs-layout-grid-bg--color-3'>(3 cell)</div>
     </div>
-    <div class="fd-col fd-col--12 fd-col-md--6 fd-col-lg--4 fd-col-xl--4 ">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-4">(4 cell)</div>
+    
+    <div class='fd-col fd-col--12 fd-col-md--6 fd-col-lg--4 fd-col-xl--4'>
+        <div class='docs-layout-grid-bg docs-layout-grid-bg--color-4'>(4 cell)</div>
     </div>
   </div>
 </div>
@@ -194,37 +175,41 @@ responsiveness.parameters = {
     }
 };
 
-export const nesting = () => `<div class="fd-container">
-  <div class="fd-row">
-    <div class="fd-col fd-col--2">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1">
-            6 col (1/2 = 50%)
+export const nesting = () => `<div class='fd-container'>
+  <div class='fd-row'>
+    <div class='fd-col fd-col--2'>
+        <div class='docs-layout-grid-bg docs-layout-grid-bg--color-1'>
+            2 col (~17%)
         </div>
     </div>
-    <div class="fd-col fd-col--10">
-        <div class="fd-row"">
-            <div class="fd-col fd-col--2">
-                <div class="docs-layout-grid-bg docs-layout-grid-bg--color-2"> 
-                    2 col inner row 1 (1/12 ~8%)
+    
+    <div class='fd-col fd-col--10'>
+        <div class='fd-row'">
+            <div class='fd-col fd-col--2'>
+                <div class='docs-layout-grid-bg docs-layout-grid-bg--color-2'> 
+                    2 col inner row 1 (~14%)
                 </div> 
             </div>
-            <div class="fd-col fd-col--10">
-                <div class="fd-row">
-                    <div class="fd-col fd-col--6">
-                        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-3">
-                            6 coll inner row 2 (5/24 ~21%)
+            
+            <div class='fd-col fd-col--10'>
+                <div class='fd-row'>
+                    <div class='fd-col fd-col--6'>
+                        <div class='docs-layout-grid-bg docs-layout-grid-bg--color-3'>
+                            6 coll inner row 2 (~34%)
                         </div>
-                    </div>      
-                    <div class="fd-col fd-col--6">
-                        <div class="fd-row">
-                            <div class="fd-col fd-col--4">
-                                <div class="docs-layout-grid-bg docs-layout-grid-bg--color-4">
-                                4 coll inner row 3 (5/72 ~7%)
+                    </div>     
+                     
+                    <div class='fd-col fd-col--6'>
+                        <div class='fd-row'>
+                            <div class='fd-col fd-col--4'>
+                                <div class='docs-layout-grid-bg docs-layout-grid-bg--color-4'>
+                                    4 coll inner row 3 (~10%)
                                 </div>
                             </div>
-                            <div class="fd-col fd-col--8">
-                                <div class="docs-layout-grid-bg docs-layout-grid-bg--color-5">
-                                8 coll inner row 3 (10/72 ~14%)
+                            
+                            <div class='fd-col fd-col--8'>
+                                <div class='docs-layout-grid-bg docs-layout-grid-bg--color-5'>
+                                    8 coll inner row 3 (~23%)
                                 </div>
                             </div>
                         </div>
@@ -244,42 +229,58 @@ nesting.parameters = {
     }
 };
 
-export const offset = () => `<div class="fd-container">
-  <div class="fd-row">
-    <div class="fd-col">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1">
-            12 columns
+export const offset = () => `<div class='fd-container'>
+    <div class='fd-row'>
+        <div class='fd-col'>
+            <div class='docs-layout-grid-bg docs-layout-grid-bg--color-1'>
+                12 columns
+            </div>
         </div>
     </div>
-    <div class="fd-col fd-col--6">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-3">
-            6 columns
+    
+    <div class='fd-row'>
+        <div class='fd-col fd-col--6'>
+            <div class='docs-layout-grid-bg docs-layout-grid-bg--color-3'>
+                6 columns
+            </div>
         </div>
     </div>
-    <div class="fd-col fd-col--8 fd-col--offset-4 fd-col-md--6 fd-col-md--offset-2 fd-col-lg--4 fd-col-lg--offset-4 fd-col-lx--3 fd-col-lx--offset-6">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-5"> 
-            Different column-width and offset in different inflection points 
+    
+    <div class='fd-row'>
+        <div class='fd-col fd-col--8 fd-col--offset-4 fd-col-md--6 fd-col-md--offset-2 fd-col-lg--4 fd-col-lg--offset-4 fd-col-lx--3 fd-col-lx--offset-6'>
+            <div class='docs-layout-grid-bg docs-layout-grid-bg--color-5'> 
+                Different column-width and offset in different inflection points 
+            </div>
         </div>
     </div>
-    <div class="fd-col fd-col--6 fd-col--offset-6">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-7"> 
-            6 columns with 6-column offset 
+    
+    <div class='fd-row'>
+        <div class='fd-col fd-col--6 fd-col--offset-6'>
+            <div class='docs-layout-grid-bg docs-layout-grid-bg--color-7'> 
+                6 columns with 6-column offset 
+            </div>
         </div>
     </div>
-    <div class="fd-col fd-col--3 fd-col--offset-after-1 fd-col-md--offset-after-2 fd-col-lg--offset-after-2 fd-col-xl--offset-after-1">
-      <div class="docs-layout-grid-bg docs-layout-grid-bg--color-8"> 
-          2 column-width and offset after in different inflection points 
-      </div>
-    </div>
-    <div class="fd-col fd-col--4 fd-col--offset-after-1">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-9"> 
-            4 columns with 2-column offset after
+    
+    <div class='fd-row'>
+        <div class='fd-col fd-col--3 fd-col--offset-after-1 fd-col-md--offset-after-2 fd-col-lg--offset-after-2 fd-col-xl--offset-after-1'>
+            <div class='docs-layout-grid-bg docs-layout-grid-bg--color-8'> 
+                2 column-width and offset after in different inflection points 
+            </div>
+        </div>
+        
+        <div class='fd-col fd-col--4 fd-col--offset-after-1'>
+            <div class='docs-layout-grid-bg docs-layout-grid-bg--color-9'> 
+                4 columns with 2-column offset after
+            </div>
+        </div>
+        
+        <div class='fd-col fd-col--2'>
+            <div class='docs-layout-grid-bg docs-layout-grid-bg--color-12'>
+                2 column element
+            </div>
         </div>
     </div>
-    <div class="fd-col fd-col--2">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-12">2 column element</div>
-    </div>
-  </div>
 </div>
 `;
 
@@ -290,39 +291,48 @@ offset.parameters = {
     }
 };
 
-export const noHorizontalGap = () => `<div class="fd-container fd-container--no-horizontal-gap">
-  <div class="fd-row">
-    <div class="fd-col fd-col--8">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1">
-            8 col no gap
+export const noHorizontalGap = () => `<div class='fd-container fd-container--no-horizontal-gap'>
+    <div class='fd-row'>
+        <div class='fd-col fd-col--8'>
+            <div class='docs-layout-grid-bg docs-layout-grid-bg--color-1'>
+                8 col no gap
+            </div>
+        </div>
+        
+        <div class='fd-col fd-col--4'>
+            <div class='docs-layout-grid-bg docs-layout-grid-bg--color-2'>
+                4 col no gap
+            </div>
         </div>
     </div>
-    <div class="fd-col fd-col--4">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-2">
-            4 col no gap
+    
+    <div class='fd-row'>
+        <div class='fd-col fd-col--6'>
+            <div class='docs-layout-grid-bg docs-layout-grid-bg--color-3'>
+                6 col no gap
+            </div>
+        </div>
+        
+        <div class='fd-col fd-col--6'>
+            <div class='docs-layout-grid-bg docs-layout-grid-bg--color-4'>
+                6 col no gap
+            </div>
         </div>
     </div>
-    <div class="fd-col fd-col--6">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-3">
-            6 col no gap
+    
+    <div class='fd-row'>
+        <div class='fd-col fd-col--4'>
+            <div class='docs-layout-grid-bg docs-layout-grid-bg--color-5'>
+                4 col no gap
+            </div>
+        </div>
+        
+        <div class='fd-col fd-col--8'>
+            <div class='docs-layout-grid-bg docs-layout-grid-bg--color-6'>
+                8 col no gap
+            </div>
         </div>
     </div>
-    <div class="fd-col fd-col--6">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-4">
-            6 col no gap
-        </div>
-    </div>
-    <div class="fd-col fd-col--4">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-5">
-            4 col no gap
-        </div>
-    </div>
-    <div class="fd-col fd-col--8">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-6">
-            8 col no gap
-        </div>
-    </div>
-  </div>
 </div>
 `;
 
@@ -333,39 +343,48 @@ noHorizontalGap.parameters = {
     }
 };
 
-export const noVerticalGap = () => `<div class="fd-container fd-container--no-vertical-gap">
-  <div class="fd-row">
-    <div class="fd-col fd-col--8">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1">
-            8 col no gap
+export const noVerticalGap = () => `<div class='fd-container fd-container--no-vertical-gap'>
+    <div class='fd-row'>
+        <div class='fd-col fd-col--8'>
+            <div class='docs-layout-grid-bg docs-layout-grid-bg--color-1'>
+                8 col no gap
+            </div>
+        </div>
+        
+        <div class='fd-col fd-col--4'>
+            <div class='docs-layout-grid-bg docs-layout-grid-bg--color-2'>
+                4 col no gap
+            </div>
         </div>
     </div>
-    <div class="fd-col fd-col--4">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-2">
-            4 col no gap
+    
+    <div class='fd-row'>
+        <div class='fd-col fd-col--6'>
+            <div class='docs-layout-grid-bg docs-layout-grid-bg--color-3'>
+                6 col no gap
+            </div>
+        </div>
+        
+        <div class='fd-col fd-col--6'>
+            <div class='docs-layout-grid-bg docs-layout-grid-bg--color-4'>
+                6 col no gap
+            </div>
         </div>
     </div>
-    <div class="fd-col fd-col--6">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-3">
-            6 col no gap
+    
+    <div class='fd-row'>
+        <div class='fd-col fd-col--4'>
+            <div class='docs-layout-grid-bg docs-layout-grid-bg--color-5'>
+                4 col no gap
+            </div>
+        </div>
+        
+        <div class='fd-col fd-col--8'>
+            <div class='docs-layout-grid-bg docs-layout-grid-bg--color-6'>
+                8 col no gap
+            </div>
         </div>
     </div>
-    <div class="fd-col fd-col--6">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-4">
-            6 col no gap
-        </div>
-    </div>
-    <div class="fd-col fd-col--4">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-5">
-            4 col no gap
-        </div>
-    </div>
-    <div class="fd-col fd-col--8">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-6">
-            8 col no gap
-        </div>
-    </div>
-  </div>
 </div>
 `;
 
@@ -376,39 +395,48 @@ noVerticalGap.parameters = {
     }
 };
 
-export const noGap = () => `<div class="fd-container fd-container--no-horizontal-gap fd-container--no-vertical-gap">
-  <div class="fd-row">
-    <div class="fd-col fd-col--8">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1">
-            8 col no gap
+export const noGap = () => `<div class='fd-container fd-container--no-horizontal-gap fd-container--no-vertical-gap'>
+  <div class='fd-row'>
+        <div class='fd-col fd-col--8'>
+            <div class='docs-layout-grid-bg docs-layout-grid-bg--color-1'>
+                8 col no gap
+            </div>
+        </div>
+        
+        <div class='fd-col fd-col--4'>
+            <div class='docs-layout-grid-bg docs-layout-grid-bg--color-2'>
+                4 col no gap
+            </div>
         </div>
     </div>
-    <div class="fd-col fd-col--4">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-2">
-            4 col no gap
+    
+    <div class='fd-row'>
+        <div class='fd-col fd-col--6'>
+            <div class='docs-layout-grid-bg docs-layout-grid-bg--color-3'>
+                6 col no gap
+            </div>
+        </div>
+        
+        <div class='fd-col fd-col--6'>
+            <div class='docs-layout-grid-bg docs-layout-grid-bg--color-4'>
+                6 col no gap
+            </div>
         </div>
     </div>
-    <div class="fd-col fd-col--6">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-3">
-            6 col no gap
+    
+    <div class='fd-row'>
+        <div class='fd-col fd-col--4'>
+            <div class='docs-layout-grid-bg docs-layout-grid-bg--color-5'>
+                4 col no gap
+            </div>
+        </div>
+        
+        <div class='fd-col fd-col--8'>
+            <div class='docs-layout-grid-bg docs-layout-grid-bg--color-6'>
+                8 col no gap
+            </div>
         </div>
     </div>
-    <div class="fd-col fd-col--6">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-4">
-            6 col no gap
-        </div>
-    </div>
-    <div class="fd-col fd-col--4">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-5">
-            4 col no gap
-        </div>
-    </div>
-    <div class="fd-col fd-col--8">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-6">
-            8 col no gap
-        </div>
-    </div>
-  </div>
 </div>
 `;
 
@@ -419,24 +447,26 @@ noGap.parameters = {
     }
 };
 
-export const autoAdjusting = () => `<div class="fd-container">
-  <div class="fd-row">
-    <div class="fd-col fd-col--full">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1">
-            Auto adjusting col before 7 col
+export const autoAdjusting = () => `<div class='fd-container'>
+    <div class='fd-row'>
+        <div class='fd-col fd-col--full'>
+            <div class='docs-layout-grid-bg docs-layout-grid-bg--color-1'>
+                Auto adjusting col before 7 col
+            </div>
+        </div>
+        
+        <div class='fd-col fd-col--7'>
+            <div class='docs-layout-grid-bg docs-layout-grid-bg--color-2'>
+                7 col
+            </div>
+        </div>
+        
+        <div class='fd-col fd-col--full'>
+            <div class='docs-layout-grid-bg docs-layout-grid-bg--color-1'>
+                Auto adjusting col after 7 col
+            </div>
         </div>
     </div>
-    <div class="fd-col fd-col--7">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-2">
-            7 col
-        </div>
-    </div>
-    <div class="fd-col fd-col--full">
-        <div class="docs-layout-grid-bg docs-layout-grid-bg--color-1">
-            Auto adjusting col after 7 col
-        </div>
-    </div>
-  </div>
 </div>
 `;
 


### PR DESCRIPTION
## Related Issue

Closes #2612.

## Description

Negative margins were applied to the inappropriate elements that make rows wider than container and cause appearing the scrollbars. 

Gutter between rows was set by padding for the column not by a margin for the row.

## Screenshots

### Before + After:

<img width="976" alt="Screenshot 2021-09-09 at 21 03 43" src="https://user-images.githubusercontent.com/20265336/132730763-5b9d62fd-557a-4781-8784-939f2a8ee65a.png">

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [X] All values are in `rem`
- [X] Text elements follow the truncation rules
- [X] hover state of the element follow design spec
- [X] focus state of the element follow design spec
- [X] active state of the element follow design spec
- [X] selected state of the element follow design spec
- [X] selected hover state of the element follow design spec
- [X] pressed state of the element follow design spec
- [X] Responsiveness rules - the component has modifier classes for all breakpoints
- [X] Includes Compact/Cosy/Tablet design
- [X] RTL support
2. The code follows fundamental-styles code standards and style
- [X] only one top level `fd-*` class is used in the file
- [X] BEM naming convention is used
- [X] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [X] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [X] `fd-reset()` mixin is applied to all elements
- [X] Variables are used, if some value is used more than twice.
- [X] Checked if current components can be reused, instead of having new code.
3. Testing
- [X] tested Storybook examples with "CSS Resources" `normalize` option 
- [X] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [X] Verified all styles in IE11
- [x] Updated tests
- [X] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [X] Storybook documentation has been created/updated
- [X] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.