### PR TITLE
fix: form layout grid, remove unnecessary styles

### DIFF
--- a/src/form-layout-grid.scss
+++ b/src/form-layout-grid.scss
@@ -136,8 +136,6 @@ $cols: 11;
 
             @include fd-rtl() {
               @include placement('left');
-
-              text-align: left;
             }
 
             margin-bottom: 0;
@@ -215,8 +213,6 @@ $cols: 11;
 
             @include fd-rtl() {
               @include placement('left');
-
-              text-align: left;
             }
 
             margin-bottom: 0;


### PR DESCRIPTION
## Related Issue
Closes https://github.com/sap/fundamental-ngx/issues/6389

## Description
Removed `form layout grid` unnecessary styles

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [n/a] All values are in `rem`
- [n/a] Text elements follow the truncation rules
- [n/a] hover state of the element follow design spec
- [n/a] focus state of the element follow design spec
- [n/a] active state of the element follow design spec
- [n/a] selected state of the element follow design spec
- [n/a] selected hover state of the element follow design spec
- [n/a] pressed state of the element follow design spec
- [n/a] Responsiveness rules - the component has modifier classes for all breakpoints
- [n/a] Includes Compact/Cosy/Tablet design
- [X] RTL support
2. The code follows fundamental-styles code standards and style
- [n/a] only one top level `fd-*` class is used in the file
- [n/a] BEM naming convention is used
- [n/a] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [n/a] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [n/a] `fd-reset()` mixin is applied to all elements
- [n/a] Variables are used, if some value is used more than twice.
- [n/a] Checked if current components can be reused, instead of having new code.
3. Testing
- [n/a] tested Storybook examples with "CSS Resources" `normalize` option 
- [n/a] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [n/a] Verified all styles in IE11
- [n/a] Updated tests
- [X] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [n/a] Storybook documentation has been created/updated
- [n/a] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
