### PR TITLE
fix: add focus style on clickable object marker

### DIFF
--- a/src/object-marker.scss
+++ b/src/object-marker.scss
@@ -24,6 +24,8 @@ $block: #{$fd-namespace}-object-marker;
 
   // CLICKABLE OBJECT STATUS
   &--link {
+    @include fd-fiori-focus(0.0625rem);
+
     cursor: pointer;
     text-decoration: none;
     color: $fd-object-marker-color;

--- a/src/object-marker.scss
+++ b/src/object-marker.scss
@@ -75,6 +75,7 @@ $block: #{$fd-namespace}-object-marker;
     }
   }
 
+  // OBJECT MARKER TEXT
   &__text {
     @include fd-reset();
     @include fd-ellipsis();

--- a/stories/object-marker/__snapshots__/object-marker.stories.storyshot
+++ b/stories/object-marker/__snapshots__/object-marker.stories.storyshot
@@ -6,6 +6,7 @@ exports[`Storyshots Components/Object Marker Clickable Object Marker 1`] = `
 
   <a
     class="fd-object-marker fd-object-marker--link"
+    href="#"
   >
     
     
@@ -27,6 +28,7 @@ exports[`Storyshots Components/Object Marker Clickable Object Marker 1`] = `
 
   <a
     class="fd-object-marker fd-object-marker--link"
+    href="#"
   >
     
     

--- a/stories/object-marker/object-marker.stories.js
+++ b/stories/object-marker/object-marker.stories.js
@@ -84,11 +84,11 @@ iconAndText.parameters = {
  */
 
 export const clickableObjectMarker = () => `
-<a class="fd-object-marker fd-object-marker--link">
+<a href="#" class="fd-object-marker fd-object-marker--link">
     <i class="fd-object-marker__icon sap-icon--private" role="presentation"></i>
     <span class="fd-object-marker__text">Locked</span>
 </a>
-<a class="fd-object-marker fd-object-marker--link">
+<a href="#" class="fd-object-marker fd-object-marker--link">
     <i class="fd-object-marker__icon sap-icon--user-edit" role="presentation"></i>
     <span class="fd-object-marker__text">Unsaved Changes</span>
 </a>


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles https://github.com/SAP/fundamental-styles/issues/2729

## Description
This PR change contains adding focus to clickable object marker.

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
<img width="240" alt="Screenshot 2021-09-16 at 8 56 23 PM" src="https://user-images.githubusercontent.com/53512176/134032939-a74d12be-044c-45e3-9de8-52daf5caf5b7.png">

### After:

<img width="360" alt="Screenshot 2021-09-20 at 9 24 10 PM" src="https://user-images.githubusercontent.com/53512176/134033734-4487bcc7-75b4-4789-b474-275640b76f2c.png">


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [NA] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
