### PR TITLE
fix: table semantic column styles

### DIFF
--- a/src/table.scss
+++ b/src/table.scss
@@ -246,6 +246,24 @@ $block: #{$fd-namespace}-table;
       @include fd-table-reset-spacing();
     }
 
+    &--fixed {
+      left: 0;
+      position: absolute;
+      background-color: inherit;
+      border-bottom: $fd-table-border;
+      border-left: $fd-table-border;
+      border-right: none;
+
+      @include fd-flex-vertical-center();
+
+      @include fd-rtl() {
+        border-right: $fd-table-border;
+        border-left: none;
+        left: auto;
+        right: 0;
+      }
+    }
+
     &--status-indicator {
       width: 0.375rem;
       padding: 0;
@@ -267,25 +285,11 @@ $block: #{$fd-namespace}-table;
       }
     }
 
-    &--fixed {
-      left: 0;
-      position: absolute;
-      background-color: inherit;
-      border-bottom: $fd-table-border;
-      border-left: $fd-table-border;
-      border-right: none;
-
-      @include fd-flex-vertical-center();
-
-      @include fd-hover() {
-        background-color: var(--sapList_Hover_Background);
-      }
+    &--navigated {
+      box-shadow: inset -0.1875rem 0 var(--sapSelectedColor);
 
       @include fd-rtl() {
-        border-right: $fd-table-border;
-        border-left: none;
-        left: auto;
-        right: 0;
+        box-shadow: inset 0.1875rem 0 var(--sapSelectedColor);
       }
     }
 
@@ -305,14 +309,6 @@ $block: #{$fd-namespace}-table;
         &.#{$block}__cell--status-indicator {
           padding: 0;
         }
-      }
-    }
-
-    &--navigated {
-      box-shadow: inset -0.1875rem 0 var(--sapSelectedColor);
-
-      @include fd-rtl() {
-        box-shadow: inset 0.1875rem 0 var(--sapSelectedColor);
       }
     }
   }
@@ -365,7 +361,7 @@ $block: #{$fd-namespace}-table;
   &__row {
     &--hoverable {
       @include fd-selected() {
-        .#{$block}__cell {
+        .#{$block}__cell:not(.#{$block}__cell--status-indicator) {
           @include fd-hover() {
             background-color: var(--sapList_Hover_SelectionBackground);
           }
@@ -373,7 +369,7 @@ $block: #{$fd-namespace}-table;
       }
 
       &,
-      .#{$block}__cell {
+      .#{$block}__cell:not(.#{$block}__cell--status-indicator) {
         @include fd-hover() {
           background-color: var(--sapList_Hover_Background);
           color: var(--fdTable_Hover_Down_Color);
@@ -397,14 +393,6 @@ $block: #{$fd-namespace}-table;
 
     &--focusable {
       @include fd-fiori-focus();
-    }
-
-    @include fd-selected() {
-      .#{$block}__cell--fixed {
-        @include fd-hover() {
-          background-color: var(--sapList_Hover_SelectionBackground);
-        }
-      }
     }
   }
 


### PR DESCRIPTION
## Related Issues

Relates to https://github.com/SAP/fundamental-ngx/issues/6360

## Description

Styles fixed, refactored before implementing Semantic Highlighting in Fundamental-NGX for Platform Table.

## Screenshots

### Before:

![image](https://user-images.githubusercontent.com/20265336/134198840-ae23664a-a9dd-4722-bd0f-08dde8859290.png)

<img width="957" alt="Screenshot 2021-09-21 at 18 19 20" src="https://user-images.githubusercontent.com/20265336/134199391-1fe85cd6-dddb-440f-b317-976822e608b5.png">

### After:

![Uploading image.png…]()

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [X] All values are in `rem`
- [X] Text elements follow the truncation rules
- [X] hover state of the element follow design spec
- [X] focus state of the element follow design spec
- [X] active state of the element follow design spec
- [X] selected state of the element follow design spec
- [X] selected hover state of the element follow design spec
- [X] pressed state of the element follow design spec
- [X] Responsiveness rules - the component has modifier classes for all breakpoints
- [X] Includes Compact/Cosy/Tablet design
- [X] RTL support
2. The code follows fundamental-styles code standards and style
- [X] only one top level `fd-*` class is used in the file
- [X] BEM naming convention is used
- [X] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [X] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [X] `fd-reset()` mixin is applied to all elements
- [X] Variables are used, if some value is used more than twice.
- [X] Checked if current components can be reused, instead of having new code.
3. Testing
- [X] tested Storybook examples with "CSS Resources" `normalize` option 
- [X] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [X] Verified all styles in IE11
- [X] Updated tests
- [X] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [X] Storybook documentation has been created/updated
- [X] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
