### PR TITLE
fix: table condensed checkbox

### DIFF
--- a/src/table.scss
+++ b/src/table.scss
@@ -622,10 +622,8 @@ $block: #{$fd-namespace}-table;
         height: $fd-table-condensed-cell-height;
 
         &--checkbox {
-          position: relative;
-
           .#{$block}__checkbox-label {
-            top: -0.25rem;
+            margin-top: -0.25rem;
             position: absolute;
           }
         }


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#2746

## Description

Fixed checkbox column in the table in condensed mode.

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/20265336/134805867-ce025e97-e735-46b2-a226-01f621d71074.png)

### After:
Don't look at the padding before the name, it's fixed in the scope of [NGX #6716](https://github.com/SAP/fundamental-ngx/pull/6716)
![image](https://user-images.githubusercontent.com/20265336/134805876-1ee1e5b0-4f4c-4dba-9783-68cd583a541c.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [X] All values are in `rem`
- [X] Text elements follow the truncation rules
- [X] hover state of the element follow design spec
- [X] focus state of the element follow design spec
- [X] active state of the element follow design spec
- [X] selected state of the element follow design spec
- [X] selected hover state of the element follow design spec
- [X] pressed state of the element follow design spec
- [X] Responsiveness rules - the component has modifier classes for all breakpoints
- [X] Includes Compact/Cosy/Tablet design
- [X] RTL support
2. The code follows fundamental-styles code standards and style
- [X] only one top level `fd-*` class is used in the file
- [X] BEM naming convention is used
- [X] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [X] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [X] `fd-reset()` mixin is applied to all elements
- [X] Variables are used, if some value is used more than twice.
- [X] Checked if current components can be reused, instead of having new code.
3. Testing
- [X] tested Storybook examples with "CSS Resources" `normalize` option 
- [X] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [X] Verified all styles in IE11
- [X] Updated tests
- [X] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [X] Storybook documentation has been created/updated
- [X] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.