### PR TITLE
fix(core): remove object status outline [ci visual]

### DIFF
--- a/src/object-status.scss
+++ b/src/object-status.scss
@@ -224,6 +224,10 @@ $inverted-color-accents: (
   align-items: center;
   line-height: 1;
 
+  @include fd-focus() {
+    outline: none;
+  }
+
   &__text {
     @include fd-reset();
     @include fd-object-status-text-inherit();


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-ngx/#6544

## Description
When focused, object status had undesired outline. It should be removed. The problem was reproducible in fundamental-ngx repo


## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:


![before](https://user-images.githubusercontent.com/33101123/134885417-876201de-0a1a-42e3-aae5-6eb578fcafc1.gif)

### After:
![after](https://user-images.githubusercontent.com/33101123/134885411-ab0dbff3-dc35-4ae5-9e10-991985d0191f.gif)
#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [n/a] Verified all styles in IE11
- [n/a] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [n/a] Storybook documentation has been created/updated
- [n/a] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
