### PR TITLE
fix: dialog resize handle alignment [ci visual] (#2773)

### DIFF
--- a/src/dialog.scss
+++ b/src/dialog.scss
@@ -159,15 +159,15 @@ $button: #{$fd-namespace}-button;
     @include fd-reset();
 
     position: absolute;
-    right: 0;
-    bottom: -4px;
+    right: 1px;
+    bottom: -5px;
     font-size: 1rem;
     cursor: se-resize;
     overflow: hidden;
 
     @include fd-rtl() {
       right: unset;
-      left: 0;
+      left: 1px;
       cursor: sw-resize;
       transform: scaleX(-1);
     }


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-ngx/issues/6332

## Description
Fixed alignment of the resize handle 

## Screenshots

### Before:

<img width="1098" alt="before" src="https://user-images.githubusercontent.com/33101123/136178900-c781da70-9bec-4ef8-880c-759784f5e587.png">


### After:
<img width="1084" alt="after" src="https://user-images.githubusercontent.com/33101123/136178889-c4171fed-c5c0-4716-a663-0108e012dbcc.png">
#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [n/a] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
