### PR TITLE
docs: add a minor fix for Select component in FN

### DIFF
--- a/stories/fn-select/__snapshots__/fn-select.stories.storyshot
+++ b/stories/fn-select/__snapshots__/fn-select.stories.storyshot
@@ -10,6 +10,7 @@ exports[`Storyshots Experimental/Select Select 1`] = `
         background: white;
         padding: 1.5rem;
         border-radius: 0.25rem;
+        height: 600px;
     }
 
   </style>
@@ -120,8 +121,9 @@ exports[`Storyshots Experimental/Select Select 1`] = `
     
 
 
-    <br />
-    <br />
+    <div
+      style="margin-bottom: 15rem;"
+    />
     
 
     <div

--- a/stories/fn-select/fn-select.stories.js
+++ b/stories/fn-select/fn-select.stories.js
@@ -14,6 +14,7 @@ const localStyles = `
         background: white;
         padding: 1.5rem;
         border-radius: 0.25rem;
+        height: 600px;
     }
 </style>
 `;
@@ -38,7 +39,7 @@ export const defaultInput = () => `${localStyles}
     </ul>
 </div>
 
-<br><br>
+<div style="margin-bottom: 15rem;"></div>
 <div class="fn-select">
     <div class="fn-text-field">
         <label class="fn-text-field__label" for="field-2">Editable Selector</label>


### PR DESCRIPTION
Updated the documentation to reflect the show both examples without overlapping, caused by the latest css changes for the Menu position.