### PR TITLE
fix: focus entire rating indicator

### DIFF
--- a/src/styles/rating-indicator.scss
+++ b/src/styles/rating-indicator.scss
@@ -81,6 +81,18 @@ $block: #{$fd-namespace}-rating-indicator;
 
   position: relative;
 
+  &__container {
+    @include fd-reset();
+
+    @include fd-fiori-focus-within(0) {
+      // do not show outline for each rating item
+      // keeping it this way in order to preserve fallback behavior for IE
+      .#{$block}__label, .#{$block}__input {
+        outline: none !important;
+      }
+    }
+  }
+
   &__input {
     @include fd-reset();
 
@@ -92,6 +104,8 @@ $block: #{$fd-namespace}-rating-indicator;
     height: $fd-rating-indicator-default-font-size;
 
     &:checked {
+      // focus for each individual star
+      // will be applied only in IE
       @include fd-fiori-focus(0) {
         + .#{$block}__label {
           outline-offset: 0;


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-ngx#6602

## Description
Currently rating indicator shows an outline for the focused/active item. This creates an awkward behavior, when there's `0` accepted as a value: in this case it's simply nothing selected. 

Instead of this should focus the entire rating indicator. This is how it's done on SAPUI5 https://sapui5.hana.ondemand.com/#/entity/sap.m.RatingIndicator/sample/sap.m.sample.RatingIndicator

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/33101123/137159547-55027222-6185-4f5d-8f64-72328a4ccf72.png)



### After:
![image](https://user-images.githubusercontent.com/33101123/137157478-328d7014-d07d-49e2-8036-43944060bfb5.png)


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
