### PR TITLE
fix(styles): add focus state for activable row and cell [ci visual]

### DIFF
--- a/src/styles/table.scss
+++ b/src/styles/table.scss
@@ -39,6 +39,12 @@ $block: #{$fd-namespace}-table;
     }
   }
 
+  @mixin fd-table-row-active-focus() {
+    @include fd-fiori-focus() {
+      outline-color: var(--sapContent_ContrastFocusColor);
+    }
+  }
+
   @mixin fd-table-nested-cell-padding($levels: 20, $content-density-cozy: false, $include-expand: false) {
     $level-padding: 0.5rem;
     $second-level-padding: 1.5rem;
@@ -87,9 +93,7 @@ $block: #{$fd-namespace}-table;
       @include fd-table-active();
 
       &--focusable {
-        @include fd-fiori-focus() {
-          outline-color: var(--sapContent_ContrastFocusColor);
-        }
+        @include fd-table-row-active-focus();
       }
     }
   }
@@ -353,9 +357,7 @@ $block: #{$fd-namespace}-table;
             background-color: var(--sapList_Active_Background);
 
             &#{$block}__row--focusable {
-              @include fd-fiori-focus() {
-                outline-color: var(--sapContent_ContrastFocusColor);
-              }
+              @include fd-table-row-active-focus();
             }
           }
         }
@@ -391,9 +393,7 @@ $block: #{$fd-namespace}-table;
           color: var(--sapList_Active_TextColor) !important;
         }
 
-        @include fd-fiori-focus() {
-          outline-color: var(--sapContent_ContrastFocusColor);
-        }
+        @include fd-table-row-active-focus();
       }
 
       @include fd-trigger-element();


### PR DESCRIPTION
## Related Issue
Closes #2840 

## Description
Added focus state for activable row/cell

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/6586561/138442830-0714bab0-8fc5-4eb7-bc15-90a8eb37324f.png)

### After:
![image](https://user-images.githubusercontent.com/6586561/138442850-af0f58fa-6b96-48a6-9c4b-c38db5488977.png)


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [n/a] Storybook documentation has been created/updated
- [n/a] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
