### PR TITLE
fix(styles): add corrections for horizon deltas for Avatar

### DIFF
--- a/src/styles/theming/sap_horizon.scss
+++ b/src/styles/theming/sap_horizon.scss
@@ -10,20 +10,20 @@
   /* Avatar */
   --fdAvatar_BackgroundColor: var(--sapAccentBackgroundColor6);
   --fdAvatar_Color: var(--sapAccentColor6);
-  --fdAvatar_Tile_Color: var(--sapAccentColor10);
+  --fdAvatar_Tile_Color: var(--sapTile_IconColor);
   --fdAvatar_Tile_BackgroundColor: var(--sapAccentBackgroundColor10);
   --fdAvatar-Transparent_BackgroundColor: transparent;
   --fdAvatar_Border: none;
-  --fdAvatar_Accent_Color_Text_1: var(--sapAccentColor1);
+  --fdAvatar_Accent_Color_Text_1: #c26e00;
   --fdAvatar_Accent_Color_Text_2: var(--sapAccentColor2);
-  --fdAvatar_Accent_Color_Text_3: var(--sapAccentColor3);
+  --fdAvatar_Accent_Color_Text_3: #9d00a9;
   --fdAvatar_Accent_Color_Text_4: var(--sapAccentColor4);
-  --fdAvatar_Accent_Color_Text_5: var(--sapAccentColor5);
+  --fdAvatar_Accent_Color_Text_5: #552cff;
   --fdAvatar_Accent_Color_Text_6: var(--sapAccentColor6);
   --fdAvatar_Accent_Color_Text_7: var(--sapAccentColor7);
   --fdAvatar_Accent_Color_Text_8: var(--sapAccentColor8);
-  --fdAvatar_Accent_Color_Text_9: var(--sapAccentColor9);
-  --fdAvatar_Accent_Color_Text_10: var(--sapAccentColor10);
+  --fdAvatar_Accent_Color_Text_9: #077a85;
+  --fdAvatar_Accent_Color_Text_10: #556b82;
   --fdAvatar_Accent_Color_Background_1: var(--sapAccentBackgroundColor1);
   --fdAvatar_Accent_Color_Background_2: var(--sapAccentBackgroundColor2);
   --fdAvatar_Accent_Color_Background_3: var(--sapAccentBackgroundColor3);


### PR DESCRIPTION
Add some hardcoded values as discussed during the meeting this morning.
The hardcoded values are results of darken function which is not supported in SCSS. They will be added later as css variables in sap-theming.