### PR TITLE
fix(styles): dark, hcb, hcw bundled CSS to contain the right colors 

### DIFF
--- a/src/styles/fundamental-styles.scss
+++ b/src/styles/fundamental-styles.scss
@@ -1,5 +1,4 @@
 // do not change import order
-@import "./variables";
 @import "./icon";
 @import "./layout";
 @import "./action-bar";

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1,1 +1,0 @@
-@import '@sap-theming/theming-base-content/content/Base/baseLib/sap_fiori_3/css_variables.css';


### PR DESCRIPTION
## Related Issue
Closes #2837

BREAKING CHANGE:
remove `variables.css`, `variables-sap_fiori_3*.css` files from `dist` folder 

## Description
our bundled CSS files(e.g. `fundamental-sap_fiori_3_dark.css`) for all the themes were having wrongly built with fiori 3 light colors.


#### Please check whether the PR fulfills the following requirements

3. Testing
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
