### PR TITLE
fix: static dialog nobackdrop position fix [ci-visual]

### DIFF
--- a/src/styles/dialog.scss
+++ b/src/styles/dialog.scss
@@ -175,4 +175,10 @@ $button: #{$fd-namespace}-button;
       color: $fd-dialog-resize-handle-color;
     }
   }
+
+  &--no-backdrop:not(.#{$block}--targeted) {
+    @include fd-position-center($position: fixed);
+
+    z-index: 1000;
+  }
 }

--- a/src/styles/flexible-column-layout.scss
+++ b/src/styles/flexible-column-layout.scss
@@ -58,7 +58,7 @@ $block: #{$fd-namespace}-flexible-column-layout;
     padding: 0;
     z-index: 2;
 
-    @include fd-absolute-center();
+    @include fd-position-center();
   }
 
   &__column {

--- a/src/styles/mixins/_mixins.scss
+++ b/src/styles/mixins/_mixins.scss
@@ -365,8 +365,8 @@
   transform: translateX(-50%);
 }
 
-@mixin fd-absolute-center {
-  position: absolute;
+@mixin fd-position-center($position: absolute) {
+  position: $position;
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);

--- a/stories/dialog/dialog.stories.js
+++ b/stories/dialog/dialog.stories.js
@@ -34,6 +34,11 @@ The dialog component is a container that appears in response to an action made b
       - \`fd-dialog__decisive-button\` Dialog footer's _Begin/End_ button
     - \`fd-dialog__resize-handle\` Handle for resizing modal
 
+**Additional classes (applied to main \`.fd-dialog\` element):**
+
+- \`fd-dialog--no-backdrop\` needed, if dialog is used without overlay. Centers the dialog vertically and horizontally
+- \`fd-dialog--targeted\` to be used, if dialog is attached to the specific element, not body
+
 Note: Dialog's header, subheader and footer are elements from the **Bar** component. This means that dialog headers and footers can be customized using bar component features. To style the elements according to dialog’s needs, CSS classes are used to slightly override bar’s original behaviour.
 `,
         tags: ['f3', 'a11y', 'theme'],


### PR DESCRIPTION
## Related Issue
Is being done as part of the fix for https://github.com/SAP/fundamental-ngx/issues/5286

## Description
Added styles for dialog without backdrop

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:


### After:

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [n/a] Verified all styles in IE11
- [n/a] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
