### PR TITLE
fix(styles): add word break [ci visual]

### DIFF
--- a/src/styles/list-grid.scss
+++ b/src/styles/list-grid.scss
@@ -152,6 +152,7 @@ $block: #{$fd-namespace}-grid-list;
 
     height: 100%;
     padding: 1rem;
+    word-break: break-word;
 
     &--no-padding {
       padding: 0;


### PR DESCRIPTION
## Related Issue
Closes #2853 

## Description
Added word break for list grid item body.

## Screenshots

### Before:
![image](https://user-images.githubusercontent.com/6586561/139813942-e4cc426b-344c-42ee-8222-2cae7b9028c6.png)

### After:
![image](https://user-images.githubusercontent.com/6586561/139813971-dfc9d8e7-470b-4265-b2d1-8aa7a5c8f580.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- n/a Storybook documentation has been created/updated
- n/a Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
