### PR TITLE
fix: table - remove cell outline [ci visual]

### DIFF
--- a/src/styles/table.scss
+++ b/src/styles/table.scss
@@ -207,6 +207,7 @@ $block: #{$fd-namespace}-table;
     padding: 0 $fd-table-cell-padding;
     color: inherit;
     border-right: $fd-table-border;
+    outline: none;
 
     &--valid {
       color: var(--sapSuccessColor);


### PR DESCRIPTION
## Related Issue
related to SAP/fundamental-ngx#7013

## Description
Currently a focus appears on cell click. Removing it
{{ _Enter short description of the change_ }}

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
<img src="https://user-images.githubusercontent.com/33101123/139828421-a2296264-7b5e-4697-a0f1-fc428968b82a.png" height="300px">


### After:
<img src="https://user-images.githubusercontent.com/33101123/139828502-b2072cc3-398d-478e-b873-4e7147c29a60.png" height="300px">

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [n/a] Verified all styles in IE11
- [n/a] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
