### PR TITLE
fix(styles): add correct outline color in Grid List

### DIFF
--- a/src/styles/list-grid.scss
+++ b/src/styles/list-grid.scss
@@ -119,6 +119,10 @@ $block: #{$fd-namespace}-grid-list;
         * {
           color: $fd-grid-list-active-text-color !important;
         }
+
+        @include fd-fiori-focus() {
+          outline-color: var(--sapContent_ContrastFocusColor);
+        }
       }
 
       @include fd-navigated() {


### PR DESCRIPTION
## Related Issue
Closes #2852 

## Description
Added correct outline color when focusing on active element

## Screenshots

### Before:
![image](https://user-images.githubusercontent.com/6586561/140061792-52347383-afca-4bdf-b4bc-70dce378ab97.png)

### After:
![image](https://user-images.githubusercontent.com/6586561/140061813-f6cce8f3-2c9d-4722-9a52-6dfdb6856ed4.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- n/a Storybook documentation has been created/updated
- n/a Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
