### PR TITLE
fix(styles): empty icon tab bar

### DIFF
--- a/src/styles/icon-tab-bar.scss
+++ b/src/styles/icon-tab-bar.scss
@@ -266,6 +266,7 @@ $fd-icon-tab-bar-semantic-values: (
     list-style: none;
     box-shadow: var(--sapContent_HeaderShadow);
     background: var(--sapObjectHeader_Background);
+    min-height: 2.75rem;
     position: relative;
     overflow-x: hidden;
 


### PR DESCRIPTION
## Related Issue

Closes SAP/fundamental-styles#

## Description

Covering case when all items are hidden.

## Screenshots

### Before:

<img width="224" alt="Screenshot 2021-11-03 at 15 11 16" src="https://user-images.githubusercontent.com/20265336/140069873-abf5b843-af0d-4f2c-9188-10ae94392354.png">

### After:

<img width="225" alt="Screenshot 2021-11-03 at 15 11 02" src="https://user-images.githubusercontent.com/20265336/140069896-6746c557-a05c-4fd5-bb1a-5d00cfe512d3.png">

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [X] All values are in `rem`
- [X] Text elements follow the truncation rules
- [X] hover state of the element follow design spec
- [X] focus state of the element follow design spec
- [X] active state of the element follow design spec
- [X] selected state of the element follow design spec
- [X] selected hover state of the element follow design spec
- [X] pressed state of the element follow design spec
- [X] Responsiveness rules - the component has modifier classes for all breakpoints
- [X] Includes Compact/Cosy/Tablet design
- [X] RTL support
2. The code follows fundamental-styles code standards and style
- [X] only one top level `fd-*` class is used in the file
- [X] BEM naming convention is used
- [X] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [X] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [X] `fd-reset()` mixin is applied to all elements
- [X] Variables are used, if some value is used more than twice.
- [X] Checked if current components can be reused, instead of having new code.
3. Testing
- [X] tested Storybook examples with "CSS Resources" `normalize` option 
- [X] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [X] Verified all styles in IE11
- [X] Updated tests
- [X] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [X] Storybook documentation has been created/updated
- [X] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.