### PR TITLE
fix(styles): add padding for inline code [ci visual]

### DIFF
--- a/src/styles/code.scss
+++ b/src/styles/code.scss
@@ -29,6 +29,6 @@ $block: #{$fd-namespace}-code;
 
   &--inline {
     display: inline;
-    padding: 0;
+    padding: 0.1rem 0.3rem;
   }
 }


### PR DESCRIPTION
add padding for inline code
<img width="1379" alt="Screen Shot 2021-11-08 at 10 20 20" src="https://user-images.githubusercontent.com/4380815/140768668-dce52709-7054-4763-94eb-cbeb155d8ecc.png">
