### PR TITLE
fix: form grid styles

### DIFF
--- a/src/styles/form-layout-grid.scss
+++ b/src/styles/form-layout-grid.scss
@@ -12,6 +12,8 @@ $cols: 12;
 $gutter: 0.25rem;
 $groupGutter: 1rem;
 
+$verticalMargin: 0.625rem;
+
 @mixin fd-form-col-paddings($colSelector) {
   .#{$gridContainer}.#{$blockContainer} .#{$gridRow} {
     @for $col from 1 through $cols - 1 {
@@ -44,7 +46,7 @@ $groupGutter: 1rem;
     .#{$colSelector},
     .#{$colSelector}--12 {
       .#{$fd-namespace}-form-label {
-        margin-top: 0.625rem;
+        margin-top: $verticalMargin;
       }
     }
   }
@@ -55,7 +57,7 @@ $groupGutter: 1rem;
 
   .#{$gridRow} {
     align-items: center;
-    margin-bottom: 0.625rem;
+    margin-bottom: $verticalMargin;
 
     &--top {
       align-items: start;
@@ -103,7 +105,7 @@ $groupGutter: 1rem;
     padding: $groupGutter;
 
     .#{$gridRow} {
-      margin: 0 -#{$gutter};
+      margin: 0 -#{$gutter} $verticalMargin -#{$gutter};
       min-width: calc(100% + #{$gutter} * 2);
 
       .#{$gridCol} {


### PR DESCRIPTION
## Related Issue

Part of https://github.tools.sap/dxp/core/issues/402

## Description

Vertical margins normalized to avoid dialog size change.

## Screenshots

### Before:

![image](https://user-images.githubusercontent.com/20265336/140784789-6b90a02f-f68f-4574-998b-761d00d73b32.png)

### After:

![image](https://user-images.githubusercontent.com/20265336/140784745-15abc3e3-93f3-4383-bd22-d01f16529f41.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [X] All values are in `rem`
- [X] Text elements follow the truncation rules
- [X] hover state of the element follow design spec
- [X] focus state of the element follow design spec
- [X] active state of the element follow design spec
- [X] selected state of the element follow design spec
- [X] selected hover state of the element follow design spec
- [X] pressed state of the element follow design spec
- [X] Responsiveness rules - the component has modifier classes for all breakpoints
- [X] Includes Compact/Cosy/Tablet design
- [X] RTL support
2. The code follows fundamental-styles code standards and style
- [X] only one top level `fd-*` class is used in the file
- [X] BEM naming convention is used
- [X] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [X] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [X] `fd-reset()` mixin is applied to all elements
- [X] Variables are used, if some value is used more than twice.
- [X] Checked if current components can be reused, instead of having new code.
3. Testing
- [X] tested Storybook examples with "CSS Resources" `normalize` option 
- [X] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [X] Verified all styles in IE11
- [X] Updated tests
- [X] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [X] Storybook documentation has been created/updated
- [X] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
