### PR TITLE
fix(styles): horizontal scroll remove in carousel [ci visual]

### DIFF
--- a/src/styles/carousel.scss
+++ b/src/styles/carousel.scss
@@ -5,8 +5,10 @@
 $block: #{$fd-namespace}-carousel;
 $button: #{$fd-namespace}-button;
 
-#{$block}:focus {
-  outline: 0.0625rem dotted;
+#{$block} {
+  @include fd-focus() {
+    outline: 0.0625rem dotted;
+  }
 }
 
 .#{$block} {
@@ -34,7 +36,7 @@ $button: #{$fd-namespace}-button;
   }
 
   width: 100%;
-  min-width: 15.5rem;
+  min-width: 11rem;
   max-width: 100%;
   height: 100%;
 
@@ -120,8 +122,8 @@ $button: #{$fd-namespace}-button;
       flex-wrap: wrap;
     }
 
-    width: 9rem;
-    padding: 0.5rem;
+    min-width: 7rem;
+    padding: 0.5rem 0;
   }
 
   &__page-indicator {
@@ -202,21 +204,6 @@ $button: #{$fd-namespace}-button;
           display: none;
         }
       }
-    }
-  }
-}
-
-@media (max-width: 21.25rem) {
-  .#{$block} {
-    min-width: 11rem;
-
-    &__page-indicators {
-      width: 8rem;
-      padding: 0;
-    }
-
-    &__page-indicator-container {
-      padding: 0;
     }
   }
 }

--- a/src/styles/carousel.scss
+++ b/src/styles/carousel.scss
@@ -5,6 +5,10 @@
 $block: #{$fd-namespace}-carousel;
 $button: #{$fd-namespace}-button;
 
+#{$block}:focus {
+  outline: 0.0625rem dotted;
+}
+
 .#{$block} {
   $fd-carousel-page-indicator-border: 0.0625rem solid var(--sapPageFooter_BorderColor) !default;
   $fd-carousel-button-size: 2.125rem !default;
@@ -198,6 +202,21 @@ $button: #{$fd-namespace}-button;
           display: none;
         }
       }
+    }
+  }
+}
+
+@media (max-width: 21.25rem) {
+  .#{$block} {
+    min-width: 11rem;
+
+    &__page-indicators {
+      width: 8rem;
+      padding: 0;
+    }
+
+    &__page-indicator-container {
+      padding: 0;
     }
   }
 }


### PR DESCRIPTION
## Related Issue
part of [#5765](https://github.com/SAP/fundamental-ngx/issues/5765) 

## Description
{{ _Enter short description of the change_ }}

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/53093915/140966101-597f48f9-d2dd-4ae4-81f9-39a5716c60f4.png)
### After:
![image](https://user-images.githubusercontent.com/53093915/140966958-c23aeb9e-964b-4695-9be7-5ff0b472565f.png)


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [n/a] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [n/a] Includes Compact/Cosy/Tablet design
- [n/a] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [n/a] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [n/a] Verified all styles in IE11
- [n/a] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [n/a] Storybook documentation has been created/updated
- [n/a] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
