### PR TITLE
fix(styles): refactor checkbox to use a square not an icon for tristate

### DIFF
--- a/src/styles/checkbox.scss
+++ b/src/styles/checkbox.scss
@@ -5,6 +5,10 @@
 .fd-checkbox
 */
 $block: #{$fd-namespace}-checkbox;
+$fd-checkbox-tristate-size: 0.75rem;
+$fd-checkbox-tristate-offset: 0.3125rem;
+$fd-checkbox-tristate-compact-size: 0.5rem;
+$fd-checkbox-tristate-compact-offset: 0.25rem;
 
 %fd-checkbox-input-hidden {
   position: absolute;
@@ -31,9 +35,17 @@ $block: #{$fd-namespace}-checkbox;
         color: $text-color;
       }
 
+      &::after {
+        background-color: $text-color;
+      }
+
       @include fd-hover() {
         @include fd-disabled() {
           border-color: $border-color;
+        }
+
+        &::before {
+          background-color: var(--sapField_Hover_Background);
         }
       }
     }
@@ -96,20 +108,27 @@ $block: #{$fd-namespace}-checkbox;
       outline: none;
     }
 
-    @include fd-empty() {
-      padding: $fd-checkbox-margin;
-      margin: 0;
-
-      &::before,
-      &::after {
-        margin-right: 0;
-        margin-left: 0;
+    &--required,
+    &[aria-required='true'] {
+      .#{$block}__text {
+        @include fd-form-radio-checkbox-required-label();
       }
     }
   }
 
+  &__label-container {
+    @include fd-reset();
+    @include fd-flex-vertical-center();
+
+    width: 100%;
+    height: 1rem;
+    pointer-events: none;
+  }
+
   &__text {
+    @include fd-reset();
     @include fd-ellipsis();
+    @include fd-set-margins-x($fd-checkbox-margin, 0);
 
     margin-left: $fd-checkbox-margin;
     margin-right: 0;
@@ -124,18 +143,34 @@ $block: #{$fd-namespace}-checkbox;
     content: "\e05b";
   }
 
-  &:indeterminate + .#{$block}__label::before {
-    @include applyIndeterminatePadding();
-
-    content: "\e17b";
-    font-size: 0.75rem;
+  &:indeterminate + .#{$block}__label::after {
+    content: "";
+    width: $fd-checkbox-tristate-size;
+    height: $fd-checkbox-tristate-size;
+    background-color: var(--fdCheckbox_Selected_Color);
+    position: absolute;
+    margin-left: $fd-checkbox-tristate-offset;
   }
 
-  &:indeterminate + .#{$block}__label--compact::before {
-    @include applyIndeterminatePadding();
+  &:indeterminate + .#{$block}__label--compact::after {
+    content: "";
+    width: $fd-checkbox-tristate-compact-size;
+    height: $fd-checkbox-tristate-compact-size;
+    background-color: var(--fdCheckbox_Selected_Color);
+    position: absolute;
+    margin-left: $fd-checkbox-tristate-compact-offset;
+  }
 
-    content: "\e17b";
-    font-size: 0.6rem;
+  @include fd-rtl() {
+    &:indeterminate + .#{$block}__label::after {
+      margin-left: 0;
+      margin-right: $fd-checkbox-tristate-offset;
+    }
+
+    &:indeterminate + .#{$block}__label--compact::after {
+      margin-left: 0;
+      margin-right: $fd-checkbox-tristate-compact-offset;
+    }
   }
 
   // states
@@ -189,7 +224,7 @@ $block: #{$fd-namespace}-checkbox;
       padding: $fd-checkbox-margin-compact;
 
       &::before {
-        font-size: 0.625rem;
+        font-size: var(--sapFontSmallSize);
         height: $fd-checkbox-dimensions-compact;
         width: $fd-checkbox-dimensions-compact;
         min-width: $fd-checkbox-dimensions-compact;

--- a/src/styles/mixins/_forms.scss
+++ b/src/styles/mixins/_forms.scss
@@ -163,6 +163,43 @@
   outline-offset: $fd-radio-focus-offset - $margin;
 }
 
+@mixin fd-form-radio-checkbox-focus($offset) {
+  outline: none;
+
+  &::before {
+    content: '';
+    position: absolute;
+    display: block;
+    border: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
+    border-radius: var(--fdCheckbox_Outline_Border_Radius);
+    top: $offset;
+    right: $offset;
+    bottom: $offset;
+    left: $offset;
+    z-index: 3;
+  }
+}
+
+@mixin fd-form-radio-checkbox-required-label {
+  @include fd-set-padding-right(0.5rem);
+
+  &::after {
+    content: '*';
+    font-size: var(--sapFontSize);
+    font-weight: bold;
+    color: var(--sapField_RequiredColor);
+    position: absolute;
+    padding-left: 0.125rem;
+  }
+
+  @include fd-rtl() {
+    &::after {
+      padding-left: 0;
+      padding-right: 0.125rem;
+    }
+  }
+}
+
 @mixin fd-form-label() {
   $fd-label-spacing: 0.5rem;
 

--- a/stories/checkbox/__snapshots__/checkbox.stories.storyshot
+++ b/stories/checkbox/__snapshots__/checkbox.stories.storyshot
@@ -50,11 +50,19 @@ exports[`Storyshots Components/Forms/Checkbox Desktop 1`] = `
         >
           
                 
-          <span
-            class="fd-checkbox__text"
+          <div
+            class="fd-checkbox__label-container"
           >
-            Apple
-          </span>
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              Apple
+            </span>
+            
+                
+          </div>
           
             
         </label>
@@ -82,11 +90,19 @@ exports[`Storyshots Components/Forms/Checkbox Desktop 1`] = `
         >
           
                 
-          <span
-            class="fd-checkbox__text"
+          <div
+            class="fd-checkbox__label-container"
           >
-            Banana
-          </span>
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              Banana
+            </span>
+            
+                
+          </div>
           
             
         </label>
@@ -114,11 +130,19 @@ exports[`Storyshots Components/Forms/Checkbox Desktop 1`] = `
         >
           
                 
-          <span
-            class="fd-checkbox__text"
+          <div
+            class="fd-checkbox__label-container"
           >
-            Kiwi
-          </span>
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              Kiwi
+            </span>
+            
+                
+          </div>
           
             
         </label>
@@ -147,11 +171,19 @@ exports[`Storyshots Components/Forms/Checkbox Desktop 1`] = `
         >
           
                 
-          <span
-            class="fd-checkbox__text"
+          <div
+            class="fd-checkbox__label-container"
           >
-            Lemon
-          </span>
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              Lemon
+            </span>
+            
+                
+          </div>
           
             
         </label>
@@ -178,11 +210,19 @@ exports[`Storyshots Components/Forms/Checkbox Desktop 1`] = `
         >
           
                 
-          <span
-            class="fd-checkbox__text"
+          <div
+            class="fd-checkbox__label-container"
           >
-            All Fruits (TriState)
-          </span>
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              All Fruits (TriState)
+            </span>
+            
+                
+          </div>
           
             
         </label>
@@ -210,11 +250,19 @@ exports[`Storyshots Components/Forms/Checkbox Desktop 1`] = `
         >
           
                 
-          <span
-            class="fd-checkbox__text"
+          <div
+            class="fd-checkbox__label-container"
           >
-            All Fruits (TriState)
-          </span>
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              All Fruits (TriState)
+            </span>
+            
+                
+          </div>
           
             
         </label>
@@ -268,11 +316,19 @@ exports[`Storyshots Components/Forms/Checkbox Inline 1`] = `
       >
         
                 
-        <span
-          class="fd-checkbox__text"
+        <div
+          class="fd-checkbox__label-container"
         >
-          Potatoes
-        </span>
+          
+                    
+          <span
+            class="fd-checkbox__text"
+          >
+            Potatoes
+          </span>
+          
+                
+        </div>
         
             
       </label>
@@ -300,11 +356,19 @@ exports[`Storyshots Components/Forms/Checkbox Inline 1`] = `
       >
         
                 
-        <span
-          class="fd-checkbox__text"
+        <div
+          class="fd-checkbox__label-container"
         >
-          Tomatoes
-        </span>
+          
+                    
+          <span
+            class="fd-checkbox__text"
+          >
+            Tomatoes
+          </span>
+          
+                
+        </div>
         
             
       </label>
@@ -333,11 +397,19 @@ exports[`Storyshots Components/Forms/Checkbox Inline 1`] = `
       >
         
                 
-        <span
-          class="fd-checkbox__text"
+        <div
+          class="fd-checkbox__label-container"
         >
-          Carrots
-        </span>
+          
+                    
+          <span
+            class="fd-checkbox__text"
+          >
+            Carrots
+          </span>
+          
+                
+        </div>
         
             
       </label>
@@ -402,11 +474,19 @@ exports[`Storyshots Components/Forms/Checkbox Mobile 1`] = `
         >
           
                 
-          <span
-            class="fd-checkbox__text"
+          <div
+            class="fd-checkbox__label-container"
           >
-            Apple
-          </span>
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              Apple
+            </span>
+            
+                
+          </div>
           
             
         </label>
@@ -434,11 +514,19 @@ exports[`Storyshots Components/Forms/Checkbox Mobile 1`] = `
         >
           
                 
-          <span
-            class="fd-checkbox__text"
+          <div
+            class="fd-checkbox__label-container"
           >
-            Banana
-          </span>
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              Banana
+            </span>
+            
+                
+          </div>
           
             
         </label>
@@ -466,11 +554,19 @@ exports[`Storyshots Components/Forms/Checkbox Mobile 1`] = `
         >
           
                 
-          <span
-            class="fd-checkbox__text"
+          <div
+            class="fd-checkbox__label-container"
           >
-            Kiwi
-          </span>
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              Kiwi
+            </span>
+            
+                
+          </div>
           
             
         </label>
@@ -499,11 +595,19 @@ exports[`Storyshots Components/Forms/Checkbox Mobile 1`] = `
         >
           
                 
-          <span
-            class="fd-checkbox__text"
+          <div
+            class="fd-checkbox__label-container"
           >
-            Lemon
-          </span>
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              Lemon
+            </span>
+            
+                
+          </div>
           
             
         </label>
@@ -530,11 +634,19 @@ exports[`Storyshots Components/Forms/Checkbox Mobile 1`] = `
         >
           
                 
-          <span
-            class="fd-checkbox__text"
+          <div
+            class="fd-checkbox__label-container"
           >
-            All Fruits (TriState)
-          </span>
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              All Fruits (TriState)
+            </span>
+            
+                
+          </div>
           
             
         </label>
@@ -562,11 +674,19 @@ exports[`Storyshots Components/Forms/Checkbox Mobile 1`] = `
         >
           
                 
-          <span
-            class="fd-checkbox__text"
+          <div
+            class="fd-checkbox__label-container"
           >
-            All Fruits (TriState)
-          </span>
+            
+                    
+            <span
+              class="fd-checkbox__text"
+            >
+              All Fruits (TriState)
+            </span>
+            
+                
+          </div>
           
             
         </label>
@@ -644,11 +764,19 @@ exports[`Storyshots Components/Forms/Checkbox States 1`] = `
           >
             
                     
-            <span
-              class="fd-checkbox__text"
+            <div
+              class="fd-checkbox__label-container"
             >
-              Text Option
-            </span>
+              
+                        
+              <span
+                class="fd-checkbox__text"
+              >
+                Text Option
+              </span>
+              
+                    
+            </div>
             
                 
           </label>
@@ -676,11 +804,19 @@ exports[`Storyshots Components/Forms/Checkbox States 1`] = `
           >
             
                     
-            <span
-              class="fd-checkbox__text"
+            <div
+              class="fd-checkbox__label-container"
             >
-              Selected State
-            </span>
+              
+                        
+              <span
+                class="fd-checkbox__text"
+              >
+                Selected State
+              </span>
+              
+                    
+            </div>
             
                 
           </label>
@@ -707,11 +843,19 @@ exports[`Storyshots Components/Forms/Checkbox States 1`] = `
           >
             
                     
-            <span
-              class="fd-checkbox__text"
+            <div
+              class="fd-checkbox__label-container"
             >
-              TriState Text
-            </span>
+              
+                        
+              <span
+                class="fd-checkbox__text"
+              >
+                TriState Text
+              </span>
+              
+                    
+            </div>
             
                 
           </label>
@@ -762,11 +906,19 @@ exports[`Storyshots Components/Forms/Checkbox States 1`] = `
           >
             
                     
-            <span
-              class="fd-checkbox__text"
+            <div
+              class="fd-checkbox__label-container"
             >
-              Text Option
-            </span>
+              
+                        
+              <span
+                class="fd-checkbox__text"
+              >
+                Text Option
+              </span>
+              
+                    
+            </div>
             
                 
           </label>
@@ -794,11 +946,19 @@ exports[`Storyshots Components/Forms/Checkbox States 1`] = `
           >
             
                     
-            <span
-              class="fd-checkbox__text"
+            <div
+              class="fd-checkbox__label-container"
             >
-              Selected State
-            </span>
+              
+                        
+              <span
+                class="fd-checkbox__text"
+              >
+                Selected State
+              </span>
+              
+                    
+            </div>
             
                 
           </label>
@@ -825,11 +985,19 @@ exports[`Storyshots Components/Forms/Checkbox States 1`] = `
           >
             
                     
-            <span
-              class="fd-checkbox__text"
+            <div
+              class="fd-checkbox__label-container"
             >
-              TriState Text
-            </span>
+              
+                        
+              <span
+                class="fd-checkbox__text"
+              >
+                TriState Text
+              </span>
+              
+                    
+            </div>
             
                 
           </label>
@@ -880,11 +1048,19 @@ exports[`Storyshots Components/Forms/Checkbox States 1`] = `
           >
             
                     
-            <span
-              class="fd-checkbox__text"
+            <div
+              class="fd-checkbox__label-container"
             >
-              Text Option
-            </span>
+              
+                        
+              <span
+                class="fd-checkbox__text"
+              >
+                Text Option
+              </span>
+              
+                    
+            </div>
             
                 
           </label>
@@ -912,11 +1088,19 @@ exports[`Storyshots Components/Forms/Checkbox States 1`] = `
           >
             
                     
-            <span
-              class="fd-checkbox__text"
+            <div
+              class="fd-checkbox__label-container"
             >
-              Selected State
-            </span>
+              
+                        
+              <span
+                class="fd-checkbox__text"
+              >
+                Selected State
+              </span>
+              
+                    
+            </div>
             
                 
           </label>
@@ -943,11 +1127,19 @@ exports[`Storyshots Components/Forms/Checkbox States 1`] = `
           >
             
                     
-            <span
-              class="fd-checkbox__text"
+            <div
+              class="fd-checkbox__label-container"
             >
-              TriState Text
-            </span>
+              
+                        
+              <span
+                class="fd-checkbox__text"
+              >
+                TriState Text
+              </span>
+              
+                    
+            </div>
             
                 
           </label>
@@ -998,11 +1190,19 @@ exports[`Storyshots Components/Forms/Checkbox States 1`] = `
           >
             
                     
-            <span
-              class="fd-checkbox__text"
+            <div
+              class="fd-checkbox__label-container"
             >
-              Text Option
-            </span>
+              
+                        
+              <span
+                class="fd-checkbox__text"
+              >
+                Text Option
+              </span>
+              
+                    
+            </div>
             
                 
           </label>
@@ -1030,11 +1230,19 @@ exports[`Storyshots Components/Forms/Checkbox States 1`] = `
           >
             
                     
-            <span
-              class="fd-checkbox__text"
+            <div
+              class="fd-checkbox__label-container"
             >
-              Selected State
-            </span>
+              
+                        
+              <span
+                class="fd-checkbox__text"
+              >
+                Selected State
+              </span>
+              
+                    
+            </div>
             
                 
           </label>
@@ -1061,11 +1269,19 @@ exports[`Storyshots Components/Forms/Checkbox States 1`] = `
           >
             
                     
-            <span
-              class="fd-checkbox__text"
+            <div
+              class="fd-checkbox__label-container"
             >
-              TriState Text
-            </span>
+              
+                        
+              <span
+                class="fd-checkbox__text"
+              >
+                TriState Text
+              </span>
+              
+                    
+            </div>
             
                 
           </label>
@@ -1117,11 +1333,19 @@ exports[`Storyshots Components/Forms/Checkbox States 1`] = `
           >
             
                     
-            <span
-              class="fd-checkbox__text"
+            <div
+              class="fd-checkbox__label-container"
             >
-              Text Option
-            </span>
+              
+                        
+              <span
+                class="fd-checkbox__text"
+              >
+                Text Option
+              </span>
+              
+                    
+            </div>
             
                 
           </label>
@@ -1150,11 +1374,19 @@ exports[`Storyshots Components/Forms/Checkbox States 1`] = `
           >
             
                     
-            <span
-              class="fd-checkbox__text"
+            <div
+              class="fd-checkbox__label-container"
             >
-              Selected State
-            </span>
+              
+                        
+              <span
+                class="fd-checkbox__text"
+              >
+                Selected State
+              </span>
+              
+                    
+            </div>
             
                 
           </label>
@@ -1182,11 +1414,164 @@ exports[`Storyshots Components/Forms/Checkbox States 1`] = `
           >
             
                     
-            <span
-              class="fd-checkbox__text"
+            <div
+              class="fd-checkbox__label-container"
             >
-              TriState Text
-            </span>
+              
+                        
+              <span
+                class="fd-checkbox__text"
+              >
+                TriState Text
+              </span>
+              
+                    
+            </div>
+            
+                
+          </label>
+          
+            
+        </div>
+        
+        
+      </div>
+      
+    
+    </fieldset>
+    
+
+    
+    <fieldset
+      class="fd-fieldset"
+    >
+      
+        
+      <legend
+        class="fd-fieldset__legend"
+      >
+        Readonly checkboxes
+      </legend>
+      
+        
+      <div
+        class="fd-form-group"
+      >
+        
+            
+        <div
+          class="fd-form-item"
+        >
+          
+                
+          <input
+            class="fd-checkbox"
+            id="Ai4ez611967"
+            readonly=""
+            type="checkbox"
+          />
+          
+                
+          <label
+            class="fd-checkbox__label"
+            for="Ai4ez611967"
+          >
+            
+                    
+            <div
+              class="fd-checkbox__label-container"
+            >
+              
+                        
+              <span
+                class="fd-checkbox__text"
+              >
+                Text Option
+              </span>
+              
+                    
+            </div>
+            
+                
+          </label>
+          
+            
+        </div>
+        
+            
+        <div
+          class="fd-form-item"
+        >
+          
+                
+          <input
+            checked=""
+            class="fd-checkbox"
+            id="Ai4ez61296cc"
+            readonly=""
+            type="checkbox"
+          />
+          
+                
+          <label
+            class="fd-checkbox__label"
+            for="Ai4ez61296cc"
+          >
+            
+                    
+            <div
+              class="fd-checkbox__label-container"
+            >
+              
+                        
+              <span
+                class="fd-checkbox__text"
+              >
+                Selected State
+              </span>
+              
+                    
+            </div>
+            
+                
+          </label>
+          
+            
+        </div>
+        
+            
+        <div
+          class="fd-form-item"
+        >
+          
+                
+          <input
+            class="fd-checkbox"
+            id="Ai4ez613i6cc"
+            readonly=""
+            type="checkbox"
+          />
+          
+                
+          <label
+            class="fd-checkbox__label"
+            for="Ai4ez613i6cc"
+          >
+            
+                    
+            <div
+              class="fd-checkbox__label-container"
+            >
+              
+                        
+              <span
+                class="fd-checkbox__text"
+              >
+                TriState Text
+              </span>
+              
+                    
+            </div>
             
                 
           </label>

--- a/stories/checkbox/checkbox.stories.js
+++ b/stories/checkbox/checkbox.stories.js
@@ -45,37 +45,49 @@ ${localStyles}
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox fd-checkbox--compact" id="Ai4ez611c">
             <label class="fd-checkbox__label fd-checkbox__label--compact" for="Ai4ez611c">
-                <span class="fd-checkbox__text">Apple</span>
+                <div class="fd-checkbox__label-container">
+                    <span class="fd-checkbox__text">Apple</span>
+                </div>
             </label>
         </div>
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox fd-checkbox--compact" id="Ai4ez612c" checked>
             <label class="fd-checkbox__label fd-checkbox__label--compact" for="Ai4ez612c">
-                <span class="fd-checkbox__text">Banana</span>
+                <div class="fd-checkbox__label-container">
+                    <span class="fd-checkbox__text">Banana</span>
+                </div>
             </label>
         </div>
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox fd-checkbox--compact" id="Ai4ez622c" disabled>
             <label class="fd-checkbox__label fd-checkbox__label--compact" for="Ai4ez622c">
-                <span class="fd-checkbox__text">Kiwi</span>
+                <div class="fd-checkbox__label-container">
+                    <span class="fd-checkbox__text">Kiwi</span>
+                </div>
             </label>
         </div>
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox fd-checkbox--compact" id="Ai4ez632c"  checked disabled>
             <label class="fd-checkbox__label fd-checkbox__label--compact" for="Ai4ez632c">
-                <span class="fd-checkbox__text">Lemon</span>
+                <div class="fd-checkbox__label-container">
+                    <span class="fd-checkbox__text">Lemon</span>
+                </div>
             </label>
         </div>
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox fd-checkbox--compact" id="Ai4ez613c">
             <label class="fd-checkbox__label fd-checkbox__label--compact" for="Ai4ez613c">
-                <span class="fd-checkbox__text">All Fruits (TriState)</span>
+                <div class="fd-checkbox__label-container">
+                    <span class="fd-checkbox__text">All Fruits (TriState)</span>
+                </div>
             </label>
         </div>
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox fd-checkbox--compact" id="Ai4ez643c" disabled>
             <label class="fd-checkbox__label fd-checkbox__label--compact" for="Ai4ez643c">
-                <span class="fd-checkbox__text">All Fruits (TriState)</span>
+                <div class="fd-checkbox__label-container">
+                    <span class="fd-checkbox__text">All Fruits (TriState)</span>
+                </div>
             </label>
         </div>
     </div>
@@ -98,8 +110,10 @@ export const required = () => `
     <div class="fd-form-group">
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox fd-checkbox--compact" id="Ai4ez61rc">
-            <label class="fd-form-label--required fd-checkbox__label fd-checkbox__label--compact" for="Ai4ez61rc">
-                <span class="fd-checkbox__text">Required Checkbox</span>
+            <label class="fd-checkbox__label fd-checkbox__label--compact fd-checkbox__label--required" for="Ai4ez61rc">
+                <div class="fd-checkbox__label-container">
+                    <span class="fd-checkbox__text">Required Checkbox</span>
+                </div>
             </label>
         </div>
     </div>
@@ -109,7 +123,7 @@ required.storyName = 'Required';
 required.parameters = {
     docs: {
         iframeHeight: 330,
-        storyDescription: `To show that a checkbox input is required, use the \`fd-from-label--required\` class.
+        storyDescription: `To show that a checkbox input is required, use the \`fd-checkbox__label--required\` class.
         `
     }
 };
@@ -122,37 +136,49 @@ ${localStyles}
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez611">
             <label class="fd-checkbox__label" for="Ai4ez611">
-                <span class="fd-checkbox__text">Apple</span>
+                <div class="fd-checkbox__label-container">
+                    <span class="fd-checkbox__text">Apple</span>
+                </div>
             </label>
         </div>
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez612" checked>
             <label class="fd-checkbox__label" for="Ai4ez612">
-                <span class="fd-checkbox__text">Banana</span>
+                <div class="fd-checkbox__label-container">
+                    <span class="fd-checkbox__text">Banana</span>
+                </div>
             </label>
         </div>
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez622" disabled>
             <label class="fd-checkbox__label" for="Ai4ez622">
-                <span class="fd-checkbox__text">Kiwi</span>
+                <div class="fd-checkbox__label-container">
+                    <span class="fd-checkbox__text">Kiwi</span>
+                </div>
             </label>
         </div>
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez632"  checked disabled>
             <label class="fd-checkbox__label" for="Ai4ez632">
-                <span class="fd-checkbox__text">Lemon</span>
+                <div class="fd-checkbox__label-container">
+                    <span class="fd-checkbox__text">Lemon</span>
+                </div>
             </label>
         </div>
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez613">
             <label class="fd-checkbox__label" for="Ai4ez613">
-                <span class="fd-checkbox__text">All Fruits (TriState)</span>
+                <div class="fd-checkbox__label-container">
+                    <span class="fd-checkbox__text">All Fruits (TriState)</span>
+                </div>
             </label>
         </div>
         <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez643" disabled>
             <label class="fd-checkbox__label" for="Ai4ez643">
-                <span class="fd-checkbox__text">All Fruits (TriState)</span>
+                <div class="fd-checkbox__label-container">
+                    <span class="fd-checkbox__text">All Fruits (TriState)</span>
+                </div>
             </label>
         </div>
     </div>
@@ -174,19 +200,25 @@ export const inline = () => `<fieldset class="fd-fieldset">
         <div class="fd-form-group__item fd-form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez617">
             <label class="fd-checkbox__label" for="Ai4ez617">
-                <span class="fd-checkbox__text">Potatoes</span>
+                <div class="fd-checkbox__label-container">
+                    <span class="fd-checkbox__text">Potatoes</span>
+                </div>
             </label>
         </div>
         <div class="fd-form-group__item fd-form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez618" checked>
             <label class="fd-checkbox__label" for="Ai4ez618">
-                <span class="fd-checkbox__text">Tomatoes</span>
+                <div class="fd-checkbox__label-container">
+                    <span class="fd-checkbox__text">Tomatoes</span>
+                </div>
             </label>
         </div>
         <div class="fd-form-group__item fd-form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez619" disabled checked>
             <label class="fd-checkbox__label" for="Ai4ez619">
-                <span class="fd-checkbox__text">Carrots</span>
+                <div class="fd-checkbox__label-container">
+                    <span class="fd-checkbox__text">Carrots</span>
+                </div>
             </label>
         </div>
     </div>
@@ -210,19 +242,25 @@ ${localStyles}
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox is-error" id="Ai4ez6119">
                 <label class="fd-checkbox__label" for="Ai4ez6119">
-                    <span class="fd-checkbox__text">Text Option</span>
+                    <div class="fd-checkbox__label-container">
+                        <span class="fd-checkbox__text">Text Option</span>
+                    </div>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox is-error" id="Ai4ez6129" checked>
                 <label class="fd-checkbox__label" for="Ai4ez6129">
-                    <span class="fd-checkbox__text">Selected State</span>
+                    <div class="fd-checkbox__label-container">
+                        <span class="fd-checkbox__text">Selected State</span>
+                    </div>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox is-error" id="Ai4ez613i1">
                 <label class="fd-checkbox__label" for="Ai4ez613i1">
-                    <span class="fd-checkbox__text">TriState Text</span>
+                    <div class="fd-checkbox__label-container">
+                        <span class="fd-checkbox__text">TriState Text</span>
+                    </div>
                 </label>
             </div>
         </div>
@@ -234,19 +272,25 @@ ${localStyles}
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox is-success" id="Ai4ez61192">
                 <label class="fd-checkbox__label" for="Ai4ez61192">
-                    <span class="fd-checkbox__text">Text Option</span>
+                    <div class="fd-checkbox__label-container">
+                        <span class="fd-checkbox__text">Text Option</span>
+                    </div>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox is-success" id="Ai4ez61292" checked>
                 <label class="fd-checkbox__label" for="Ai4ez61292">
-                    <span class="fd-checkbox__text">Selected State</span>
+                    <div class="fd-checkbox__label-container">
+                        <span class="fd-checkbox__text">Selected State</span>
+                    </div>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox is-success" id="Ai4ez613i2">
                 <label class="fd-checkbox__label" for="Ai4ez613i2">
-                    <span class="fd-checkbox__text">TriState Text</span>
+                    <div class="fd-checkbox__label-container">
+                        <span class="fd-checkbox__text">TriState Text</span>
+                    </div>
                 </label>
             </div>
         </div>
@@ -258,19 +302,25 @@ ${localStyles}
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox is-warning" id="Ai4ez61193">
                 <label class="fd-checkbox__label" for="Ai4ez61193">
-                    <span class="fd-checkbox__text">Text Option</span>
+                    <div class="fd-checkbox__label-container">
+                        <span class="fd-checkbox__text">Text Option</span>
+                    </div>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox is-warning" id="Ai4ez61293" checked>
                 <label class="fd-checkbox__label" for="Ai4ez61293">
-                    <span class="fd-checkbox__text">Selected State</span>
+                    <div class="fd-checkbox__label-container">
+                        <span class="fd-checkbox__text">Selected State</span>
+                    </div>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox is-warning" id="Ai4ez613i3">
                 <label class="fd-checkbox__label" for="Ai4ez613i3">
-                    <span class="fd-checkbox__text">TriState Text</span>
+                    <div class="fd-checkbox__label-container">
+                        <span class="fd-checkbox__text">TriState Text</span>
+                    </div>
                 </label>
             </div>
         </div>
@@ -282,19 +332,25 @@ ${localStyles}
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox is-information" id="Ai4ez61194">
                 <label class="fd-checkbox__label" for="Ai4ez61194">
-                    <span class="fd-checkbox__text">Text Option</span>
+                    <div class="fd-checkbox__label-container">
+                        <span class="fd-checkbox__text">Text Option</span>
+                    </div>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox is-information" id="Ai4ez61294" checked>
                 <label class="fd-checkbox__label" for="Ai4ez61294">
-                    <span class="fd-checkbox__text">Selected State</span>
+                    <div class="fd-checkbox__label-container">
+                        <span class="fd-checkbox__text">Selected State</span>
+                    </div>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox is-information" id="Ai4ez613i4">
                 <label class="fd-checkbox__label" for="Ai4ez613i4">
-                    <span class="fd-checkbox__text">TriState Text</span>
+                    <div class="fd-checkbox__label-container">
+                        <span class="fd-checkbox__text">TriState Text</span>
+                    </div>
                 </label>
             </div>
         </div>
@@ -306,19 +362,55 @@ ${localStyles}
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox" id="Ai4ez61196" disabled>
                 <label class="fd-checkbox__label" for="Ai4ez61196">
-                    <span class="fd-checkbox__text">Text Option</span>
+                    <div class="fd-checkbox__label-container">
+                        <span class="fd-checkbox__text">Text Option</span>
+                    </div>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox" id="Ai4ez61296" checked disabled>
                 <label class="fd-checkbox__label" for="Ai4ez61296">
-                    <span class="fd-checkbox__text">Selected State</span>
+                    <div class="fd-checkbox__label-container">
+                        <span class="fd-checkbox__text">Selected State</span>
+                    </div>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox" id="Ai4ez613i6" disabled>
                 <label class="fd-checkbox__label" for="Ai4ez613i6">
-                    <span class="fd-checkbox__text">TriState Text</span>
+                    <div class="fd-checkbox__label-container">
+                        <span class="fd-checkbox__text">TriState Text</span>
+                    </div>
+                </label>
+            </div>
+        </div>
+    </fieldset>
+
+    <fieldset class="fd-fieldset">
+        <legend class="fd-fieldset__legend">Readonly checkboxes</legend>
+        <div class="fd-form-group">
+            <div class="fd-form-item">
+                <input type="checkbox" class="fd-checkbox" id="Ai4ez611967" readonly>
+                <label class="fd-checkbox__label" for="Ai4ez611967">
+                    <div class="fd-checkbox__label-container">
+                        <span class="fd-checkbox__text">Text Option</span>
+                    </div>
+                </label>
+            </div>
+            <div class="fd-form-item">
+                <input type="checkbox" class="fd-checkbox" id="Ai4ez61296cc" checked readonly>
+                <label class="fd-checkbox__label" for="Ai4ez61296cc">
+                    <div class="fd-checkbox__label-container">
+                        <span class="fd-checkbox__text">Selected State</span>
+                    </div>
+                </label>
+            </div>
+            <div class="fd-form-item">
+                <input type="checkbox" class="fd-checkbox" id="Ai4ez613i6cc" readonly>
+                <label class="fd-checkbox__label" for="Ai4ez613i6cc">
+                    <div class="fd-checkbox__label-container">
+                        <span class="fd-checkbox__text">TriState Text</span>
+                    </div>
                 </label>
             </div>
         </div>


### PR DESCRIPTION
## Related Issue
none

## Description
Checkbox was using icon for the square that represents the tri-state. This was causing a lot of alignment issues and the new set of icons changed the look of this icon so we can no longer rely on it for the tri-state.

BREAKING CHANGE:
- **Checkbox:** introduced a new element with a class `.fd-checkbox__label-container` that is necessary for the fake focus and the new way of implementing the tri-state.

Before:
```
<label class="fd-checkbox__label">
    <span class="fd-checkbox__text">Apple</span>
</label>
```

Now:
```
<label class="fd-checkbox__label">
    <div class="fd-checkbox__label-container">
        <span class="fd-checkbox__text">Apple</span>
    </div>
</label>
```

- **Checkbox:** introduced a new modifier class for the label `.fd-checkbox__label--required` for when the Checkbox is a required element. It replaces the `.fd-from-label--required` modifier class.

Before:
```
<input type="checkbox" class="fd-checkbox">
<label class="fd-checkbox__label fd-form-label--required">
    <span class="fd-checkbox__text">Required Checkbox</span>
</label>
```

Now:
```
<input type="checkbox" class="fd-checkbox">
<label class="fd-checkbox__label fd-checkbox__label--required">
    <span class="fd-checkbox__text">Required Checkbox</span>
</label>
```



#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
