### PR TITLE
fix: dynamic page sm paddings

### DIFF
--- a/src/styles/dynamic-page.scss
+++ b/src/styles/dynamic-page.scss
@@ -391,7 +391,7 @@ $block: #{$fd-namespace}-dynamic-page;
   }
 
   &--sm {
-    @include fd-responsive-page($fd-dynamic-page-header-padding-top-bottom, 0.5rem);
+    @include fd-responsive-page($fd-dynamic-page-header-padding-top-bottom, 1rem);
 
     .#{$block}__breadcrumb {
       padding: 0;


### PR DESCRIPTION
## Related Issue

Part of https://github.tools.sap/dxp/backlog/issues/185

## Description

Horizontal padding fix for the dynamic page component at sm size. 

https://wiki.wdf.sap.corp/wiki/display/visualcore/Responsive+Spacing+System?preview=/2108063887/2108070925/Screen%20Shot%202019-06-17%20at%2017.39.16.png

## Screenshots

### Before:

8px/0.5rem
![image](https://user-images.githubusercontent.com/20265336/141104411-cf9427d8-9bd0-4a32-a845-e7d0f63b2ecc.png)

### After:

16px/1rem
![image](https://user-images.githubusercontent.com/20265336/141104333-920f22e7-75d9-49b3-bb75-75ed7e0b03a2.png)