### PR TITLE
fix: fix selection in menu styles

### DIFF
--- a/src/styles/menu.scss
+++ b/src/styles/menu.scss
@@ -92,7 +92,7 @@ $block: #{$fd-namespace}-menu;
     }
   }
 
-  &__list > li {
+  &__list > .#{$block}__item {
     position: relative;
     width: 100%;
   }

--- a/src/styles/menu.scss
+++ b/src/styles/menu.scss
@@ -93,8 +93,8 @@ $block: #{$fd-namespace}-menu;
   }
 
   &__list > .#{$block}__item {
-    position: relative;
     width: 100%;
+    position: relative;
   }
 
   &__separator {


### PR DESCRIPTION
## Description
Corrected selection for menu component
It needs for fundamental-ngx in the case when we use fdp-menu-item component instead of li tag

## Screenshots
### Before:
<img width="1352" alt="Screenshot 2021-11-12 at 18 02 24" src="https://user-images.githubusercontent.com/8318592/141497337-66a9a826-f802-400a-9f87-0a06425f7a3e.png">

### After:
<img width="726" alt="Screenshot 2021-11-12 at 18 04 41" src="https://user-images.githubusercontent.com/8318592/141497373-59bdd25d-8f5c-446b-9da3-b7d38ba9db31.png">


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [n/a] All values are in `rem`
- [n/a] Text elements follow the truncation rules
- [n/a] hover state of the element follow design spec
- [n/a] focus state of the element follow design spec
- [n/a] active state of the element follow design spec
- [n/a] selected state of the element follow design spec
- [n/a] selected hover state of the element follow design spec
- [n/a] pressed state of the element follow design spec
- [n/a] Responsiveness rules - the component has modifier classes for all breakpoints
- [n/a] Includes Compact/Cosy/Tablet design
- [n/a] RTL support
2. The code follows fundamental-styles code standards and style
- [n/a] only one top level `fd-*` class is used in the file
- [n/a] BEM naming convention is used
- [n/a] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [n/a] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [n/a] `fd-reset()` mixin is applied to all elements
- [n/a] Variables are used, if some value is used more than twice.
- [n/a] Checked if current components can be reused, instead of having new code.
3. Testing
- [n/a] tested Storybook examples with "CSS Resources" `normalize` option 
- [n/a] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [n/a] Verified all styles in IE11
- [n/a] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [n/a] Storybook documentation has been created/updated
- [n/a] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
