### PR TITLE
fix: select min-width

### DIFF
--- a/src/styles/select.scss
+++ b/src/styles/select.scss
@@ -131,7 +131,7 @@ $outline-offset: 0.1875rem;
 
     font-size: var(--sapFontSize);
     padding-left: $fd-select-padding-x;
-    min-width: 5.625rem;
+    min-width: 2.125rem;
 
     @include fd-rtl() {
       padding-left: 0;


### PR DESCRIPTION
## Related Issue

## Description

Select text label `min-width` fix due to the Fiori 3 specifications.


<img width="784" alt="Screenshot 2021-11-15 at 20 10 08" src="https://user-images.githubusercontent.com/20265336/141832922-b3af22d7-28a3-43a4-aa53-f94c242e34e3.png">

## Screenshots

### Before:

![image](https://user-images.githubusercontent.com/20265336/141832554-ea07a898-f23a-4c4a-94cd-562033e1f727.png)

### After:

![image](https://user-images.githubusercontent.com/20265336/141832605-bd96e070-c2b6-46b4-96a2-51231ff4979c.png)
