### PR TITLE
fix(fn): inconsistent text field borders across zoom levels [ci visual]

### DIFF
--- a/src/fn/fn-input.scss
+++ b/src/fn/fn-input.scss
@@ -17,7 +17,7 @@ $block: #{$fn-namespace}-text-field;
 
   & + .#{$block}__input-border {
     &::before {
-      background: $border;
+      border-bottom-color: $border;
     }
   }
 
@@ -25,7 +25,7 @@ $block: #{$fn-namespace}-text-field;
     background: $fn-color-grey-1;
 
     & ~ .#{$block}__input-border::before {
-      background: transparent;
+      border-bottom-color: transparent;
     }
   }
 }
@@ -114,7 +114,7 @@ $block: #{$fn-namespace}-text-field;
 
     &:not(:placeholder-shown) {
       & ~ .#{$block}__input-border::before {
-        background: $fn-color-blue-4;
+        border-bottom-color: $fn-color-blue-4;
       }
     }
 
@@ -122,7 +122,7 @@ $block: #{$fn-namespace}-text-field;
       background: $fn-color-grey-1;
 
       & ~ .#{$block}__input-border::before {
-        background: transparent;
+        border-bottom-color: transparent;
       }
     }
 
@@ -131,7 +131,7 @@ $block: #{$fn-namespace}-text-field;
 
       &:not(:placeholder-shown) {
         & ~ .#{$block}__input-border::before {
-          background: $fn-color-blue-4;
+          border-bottom-color: $fn-color-blue-4;
         }
       }
     }
@@ -150,7 +150,7 @@ $block: #{$fn-namespace}-text-field;
       @include fn-hover() {
         &:not(:placeholder-shown) {
           & ~ .#{$block}__input-border::before {
-            background: transparent;
+            border-bottom-color: transparent;
           }
         }
       }
@@ -186,9 +186,11 @@ $block: #{$fn-namespace}-text-field;
       bottom: 0;
       content: '';
       width: 100%;
-      height: 0.125rem;
+      height: 0;
       position: absolute;
-      background: $fn-color-grey-4;
+      border-bottom-width: 2px;
+      border-bottom-style: solid;
+      border-bottom-color: $fn-color-grey-4;
     }
   }
 
@@ -397,7 +399,7 @@ $block: #{$fn-namespace}-text-field;
           background: $fn-color-base-white;
 
           & ~ .#{$block}__input-border::before {
-            background: transparent;
+            border-bottom-color: transparent;
           }
 
           & ~ [class*='sap-icon'] {
@@ -410,7 +412,7 @@ $block: #{$fn-namespace}-text-field;
         background: $fn-color-green-1;
 
         & ~ .#{$block}__input-border::before {
-          background: $fn-color-green-4;
+          border-bottom-color: $fn-color-green-4;
         }
 
         & ~ [class*='sap-icon'] {


### PR DESCRIPTION
## Description
On some operating systems supporting sub-pixel rendering the browser may
inconsistently approximate the height/widths of boxes across zoom level. The
issue becomes apparent when multiple controls are placed together (e.g.,
table rows, tags, input boxes) as the user zooms in/out.

Specifying the border-width property is a solution that does not involve
using future CSS specs or GPU-based calculations.

## Screenshots

Zoom level 80% - but the same issue occurs across multiple zoom levels.

### Before:

![image](https://user-images.githubusercontent.com/1516659/142010831-3b598575-4e46-40b0-81af-118ac378af33.png)

### After:

![image](https://user-images.githubusercontent.com/1516659/142010749-9a4c83c5-3194-4340-9f32-f000fe559361.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [na] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [na] tested Storybook examples with "CSS Resources" `normalize` option 
- [na] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [na] Verified all styles in IE11
- [na] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [na] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
