### PR TITLE
fix(fn): consistent highlights of tags across zoom levels [ci visual]

### DIFF
--- a/src/fn/fn-tag.scss
+++ b/src/fn/fn-tag.scss
@@ -107,7 +107,8 @@ $tag-colors-rest: (
     content: '';
     height: 100%;
     position: absolute;
-    width: $tag-border-width;
+    border-left-width: $tag-border-width;
+    border-left-style: solid;
   }
 
   @include fn-rtl() {
@@ -123,7 +124,7 @@ $tag-colors-rest: (
       background: map_get($color-set, "background");
 
       &::before {
-        background: map_get($color-set, "border");
+        border-left-color: map_get($color-set, "border");
       }
 
       @include fn-hover() {
@@ -171,7 +172,7 @@ $tag-colors-rest: (
         background: $fn-color-grey-1;
 
         &::before {
-          background: $fn-color-grey-2;
+          border-left-color: $fn-color-grey-2;
         }
       }
     }


### PR DESCRIPTION
## Description
On some operating systems supporting sub-pixel rendering the browser may inconsistently approximate the height/widths of boxes across zoom level. The issue becomes apparent when multiple controls are placed together (e.g., table rows, tags, input boxes) as the user zooms in/out.

Specifying the border-width property is a solution that does not involve
using future CSS specs or GPU-based calculations.

## Screenshots

This issue occurs across different zoom levels.

### Before:

![image](https://user-images.githubusercontent.com/1516659/142172333-70df58fd-0b04-48b3-bb5c-5d67e19d23fe.png)

### After:

![image](https://user-images.githubusercontent.com/1516659/142172352-79151480-4ed1-4ed0-93b6-4ca35ca47303.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [na] tested Storybook examples with "CSS Resources" `normalize` option 
- [na] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [na] Verified all styles in IE11
- [na] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [na] Storybook documentation has been created/updated
- [na] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.

