### PR TITLE
fix(fn): consistent tab highlights across zoom levels [ci visual]

### DIFF
--- a/src/fn/fn-tabs.scss
+++ b/src/fn/fn-tabs.scss
@@ -18,7 +18,7 @@ $tag-border-width: 0.125rem;
   background: $background;
 
   &::before {
-    background-color: $border;
+    border-bottom-color: $border;
   }
 }
 
@@ -52,8 +52,10 @@ $tag-border-width: 0.125rem;
       bottom: 0;
       content: '';
       width: 100%;
-      height: 0.125rem;
+      height: 0;
       position: absolute;
+      border-bottom-width: 2px;
+      border-bottom-style: solid;
     }
 
     @include fn-hover() {


### PR DESCRIPTION
## Description
On some operating systems supporting sub-pixel rendering the browser may inconsistently approximate the height/widths of boxes across zoom level. The issue becomes apparent when multiple controls are placed together (e.g., table rows, tags, input boxes) as the user zooms in/out.

Specifying the border-width property is a solution that does not involve
using future CSS specs or GPU-based calculations.

## Screenshots

This issue occurs across different zoom levels.

### Before:

![image](https://user-images.githubusercontent.com/1516659/142173681-64278853-7bf6-4e4a-9986-568b825414e0.png)

### After:

![image](https://user-images.githubusercontent.com/1516659/142173696-7230434f-7f40-4901-9fc6-f286228a2122.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [na] tested Storybook examples with "CSS Resources" `normalize` option 
- [na] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [na] Verified all styles in IE11
- [na] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [na] Storybook documentation has been created/updated
- [na] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.

