### PR TITLE
fix(fn): inconsistent selected item border in Select across zoom levels

### DIFF
--- a/src/fn/fn-select.scss
+++ b/src/fn/fn-select.scss
@@ -7,8 +7,13 @@ $block: #{$fn-namespace}-select;
   background: $background;
 
   &::before {
-    background: $border;
+    border-left-color: $border;
   }
+
+  // @include fn-rtl() {
+  //   border-left-color: transparent;
+  //   border-right-color: $border;
+  // }
 }
 
 .#{$block} {
@@ -57,13 +62,20 @@ $block: #{$fn-namespace}-select;
     padding: $fn-padding-xs $fn-padding-small;
 
     &::before {
-      @include fn-set-position-left(0);
-
       top: 0;
+      left: 0;
       content: '';
       height: 100%;
-      width: 0.125rem;
       position: absolute;
+      border-left-width: 2px;
+      border-left-style: solid;
+    }
+
+    @include fn-rtl() {
+      &::before {
+        right: 0;
+        left: auto;
+      }
     }
 
     @include fn-hover() {

--- a/src/fn/fn-select.scss
+++ b/src/fn/fn-select.scss
@@ -9,11 +9,6 @@ $block: #{$fn-namespace}-select;
   &::before {
     border-left-color: $border;
   }
-
-  // @include fn-rtl() {
-  //   border-left-color: transparent;
-  //   border-right-color: $border;
-  // }
 }
 
 .#{$block} {


### PR DESCRIPTION
## Description
On some operating systems supporting sub-pixel rendering the browser may
inconsistently approximate the height/widths of boxes across zoom level. The
issue becomes apparent when multiple controls are placed together (e.g.,
table rows, tags, input boxes) as the user zooms in/out.

Specifying the border-width property is a solution that does not involve
using future CSS specs or GPU-based calculations.


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
-  All values are in `rem`
- Text elements follow the truncation rules
- hover state of the element follow design spec
- focus state of the element follow design spec
- active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
-  pressed state of the element follow design spec
- Responsiveness rules - the component has modifier classes for all breakpoints
- Includes Compact/Cosy/Tablet design
- [x] RTL support
3. Testing
- tested Storybook examples with "CSS Resources" `normalize` option 
- tested Storybook examples with "CSS Resources" `unnormalize` option 
- Verified all styles in IE11
- Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- Storybook documentation has been created/updated
- Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
