### PR TITLE
fix(fn): move border style and width to variables [ci visual]

### DIFF
--- a/src/fn/_fn-variables.scss
+++ b/src/fn/_fn-variables.scss
@@ -30,6 +30,10 @@ $fn-border-radius-medium: 0.75rem; // 12px
 $fn-border-radius-large: 1rem; // 16px
 $fn-border-radius-xl: 1.5rem; // 24px
 
+// Border width and style
+$fn-border-width: 0.125rem;
+$fn-border-style: solid;
+
 // Colors
 $fn-color-grey-1: #f5f6f7;
 $fn-color-grey-2: #d5dadd;

--- a/src/fn/fn-input.scss
+++ b/src/fn/fn-input.scss
@@ -188,8 +188,8 @@ $block: #{$fn-namespace}-text-field;
       width: 100%;
       height: 0;
       position: absolute;
-      border-bottom-width: 2px;
-      border-bottom-style: solid;
+      border-bottom-width: $fn-border-width;
+      border-bottom-style: $fn-border-style;
       border-bottom-color: $fn-color-grey-4;
     }
   }

--- a/src/fn/fn-select.scss
+++ b/src/fn/fn-select.scss
@@ -62,8 +62,8 @@ $block: #{$fn-namespace}-select;
       content: '';
       height: 100%;
       position: absolute;
-      border-left-width: 2px;
-      border-left-style: solid;
+      border-left-width: $fn-border-width;
+      border-left-style: $fn-border-style;
     }
 
     @include fn-rtl() {

--- a/src/fn/fn-tabs.scss
+++ b/src/fn/fn-tabs.scss
@@ -54,8 +54,8 @@ $tag-border-width: 0.125rem;
       width: 100%;
       height: 0;
       position: absolute;
-      border-bottom-width: 2px;
-      border-bottom-style: solid;
+      border-bottom-width: $fn-border-width;
+      border-bottom-style: $fn-border-style;
     }
 
     @include fn-hover() {

--- a/src/fn/fn-tag.scss
+++ b/src/fn/fn-tag.scss
@@ -1,7 +1,6 @@
 @import "./fn-settings";
 
 $block: #{$fn-namespace}-tag;
-$tag-border-width: 0.125rem;
 
 $tag-colors-rest: (
   "grey": (
@@ -107,8 +106,8 @@ $tag-colors-rest: (
     content: '';
     height: 100%;
     position: absolute;
-    border-left-width: $tag-border-width;
-    border-left-style: solid;
+    border-left-width: $fn-border-width;
+    border-left-style: $fn-border-style;
   }
 
   @include fn-rtl() {


### PR DESCRIPTION
## Description
Select, Input, Tabs and Tags components use the same value for border-width (0.125rem) and border-style (solid) so I created variables in `_fn-variables.scss` file for easier maintenance.
