### PR TITLE
docs(fn): update the documentation examples for FN Buttons

### DIFF
--- a/stories/fn-button/__snapshots__/fn-button.stories.storyshot
+++ b/stories/fn-button/__snapshots__/fn-button.stories.storyshot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots Experimental/Button Accept (Semantic) Button 1`] = `
+exports[`Storyshots Experimental/Button Icon Buttons 1`] = `
 <section>
   
 
@@ -8,11 +8,11 @@ exports[`Storyshots Experimental/Button Accept (Semantic) Button 1`] = `
     
     .docs-fn-container {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-        column-gap: 0.5rem;
-        row-gap: 0.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+        column-gap: 0.1rem;
+        row-gap: 0.1rem;
         background: white;
-        padding: 1.5rem;
+        padding: 1rem;
         justify-items: center;
         align-items: center;
     }
@@ -40,227 +40,9 @@ exports[`Storyshots Experimental/Button Accept (Semantic) Button 1`] = `
     
     <div>
       <b>
-        Rest
+        Icon-Left
       </b>
     </div>
-    
-    
-    <div>
-      <b>
-        Hover
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Active
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Focus
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Disabled
-      </b>
-    </div>
-    
-
-  </div>
-  
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        No-Icon
-      </b>
-    </div>
-    
-    
-    <button
-      class="fn-button fn-button--accept"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--accept is-hover"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--accept is-active"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--accept is-focus"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--accept"
-      disabled=""
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Only
-      </b>
-    </div>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--accept fn-button--icon-only"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--accept fn-button--icon-only is-hover"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--accept fn-button--icon-only is-active"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--accept fn-button--icon-only is-focus"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--accept fn-button--icon-only disabled"
-      disabled=""
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-
-
-  <div
-    class="docs-fn-container"
-  >
     
     
     <div>
@@ -270,20 +52,63 @@ exports[`Storyshots Experimental/Button Accept (Semantic) Button 1`] = `
     </div>
     
     
+    <div>
+      <b>
+        Icon-Only
+      </b>
+    </div>
+       
+
+  </div>
+  
+
+
+  <div
+    class="docs-fn-container"
+  >
+    
+    
+    <div>
+      <b>
+        :normal
+      </b>
+    </div>
+    
+    
     <button
-      class="fn-button fn-button--accept fn-button--icon-right"
+      class="fn-button fn-button--icon-left"
+    >
+      
+        
+      <span
+        class="sap-icon sap-icon--paper-plane"
+      />
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
+    
+    <button
+      class="fn-button fn-button--emphasized fn-button--icon-right"
     >
       
         
       <span
         class="fn-button__text"
       >
-        Send
+        Button
       </span>
       
         
       <span
-        class="sap-icon sap-icon--paper-plane"
+        class="sap-icon sap-icon--share-2"
       />
       
     
@@ -291,80 +116,13 @@ exports[`Storyshots Experimental/Button Accept (Semantic) Button 1`] = `
     
     
     <button
-      class="fn-button fn-button--accept fn-button--icon-right is-hover"
+      aria-label="More"
+      class="fn-button fn-button--transparent fn-button--icon-only"
     >
       
         
       <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--accept fn-button--icon-right is-active"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--accept fn-button--icon-right is-focus"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--accept fn-button--icon-right"
-      disabled=""
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
+        class="sap-icon sap-icon--overflow"
       />
       
     
@@ -382,25 +140,25 @@ exports[`Storyshots Experimental/Button Accept (Semantic) Button 1`] = `
     
     <div>
       <b>
-        Icon-Left
+        :hover
       </b>
     </div>
     
     
     <button
-      class="fn-button fn-button--accept fn-button--icon-left"
+      class="fn-button fn-button--icon-left is-hover"
     >
       
         
       <span
-        class="sap-icon sap-icon--share-2"
+        class="sap-icon sap-icon--paper-plane"
       />
       
         
       <span
         class="fn-button__text"
       >
-        Share
+        Button
       </span>
       
     
@@ -408,19 +166,69 @@ exports[`Storyshots Experimental/Button Accept (Semantic) Button 1`] = `
     
     
     <button
-      class="fn-button fn-button--accept fn-button--icon-left is-hover"
+      class="fn-button fn-button--emphasized fn-button--icon-right is-hover"
     >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
       
         
       <span
         class="sap-icon sap-icon--share-2"
       />
       
+    
+    </button>
+    
+    
+    <button
+      aria-label="More"
+      class="fn-button fn-button--transparent fn-button--icon-only is-hover"
+    >
+      
+        
+      <span
+        class="sap-icon sap-icon--overflow"
+      />
+      
+    
+    </button>
+    
+
+  </div>
+  
+
+
+  <div
+    class="docs-fn-container"
+  >
+    
+    
+    <div>
+      <b>
+        :active
+      </b>
+    </div>
+    
+    
+    <button
+      class="fn-button fn-button--icon-left is-active"
+    >
+      
+        
+      <span
+        class="sap-icon sap-icon--paper-plane"
+      />
+      
         
       <span
         class="fn-button__text"
       >
-        Share
+        Button
       </span>
       
     
@@ -428,19 +236,69 @@ exports[`Storyshots Experimental/Button Accept (Semantic) Button 1`] = `
     
     
     <button
-      class="fn-button fn-button--accept fn-button--icon-left is-active"
+      class="fn-button fn-button--emphasized fn-button--icon-right is-active"
     >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
       
         
       <span
         class="sap-icon sap-icon--share-2"
       />
       
+    
+    </button>
+    
+    
+    <button
+      aria-label="More"
+      class="fn-button fn-button--transparent fn-button--icon-only is-active"
+    >
+      
+        
+      <span
+        class="sap-icon sap-icon--overflow"
+      />
+      
+    
+    </button>
+    
+
+  </div>
+  
+
+
+  <div
+    class="docs-fn-container"
+  >
+    
+    
+    <div>
+      <b>
+        :focus
+      </b>
+    </div>
+    
+    
+    <button
+      class="fn-button fn-button--icon-left is-focus"
+    >
+      
+        
+      <span
+        class="sap-icon sap-icon--paper-plane"
+      />
+      
         
       <span
         class="fn-button__text"
       >
-        Share
+        Button
       </span>
       
     
@@ -448,41 +306,107 @@ exports[`Storyshots Experimental/Button Accept (Semantic) Button 1`] = `
     
     
     <button
-      class="fn-button fn-button--accept fn-button--icon-left is-focus"
+      class="fn-button fn-button--emphasized fn-button--icon-right is-focus"
     >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
       
         
       <span
         class="sap-icon sap-icon--share-2"
       />
       
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
     
     </button>
     
     
     <button
-      class="fn-button fn-button--accept fn-button--icon-left"
+      aria-label="More"
+      class="fn-button fn-button--transparent fn-button--icon-only is-focus"
+    >
+      
+        
+      <span
+        class="sap-icon sap-icon--overflow"
+      />
+      
+    
+    </button>
+    
+
+  </div>
+  
+
+
+  <div
+    class="docs-fn-container"
+  >
+    
+    
+    <div>
+      <b>
+        :disabled
+      </b>
+    </div>
+    
+    
+    <button
+      class="fn-button fn-button--icon-left"
       disabled=""
     >
       
         
       <span
-        class="sap-icon sap-icon--share-2"
+        class="sap-icon sap-icon--paper-plane"
       />
       
         
       <span
         class="fn-button__text"
       >
-        Share
+        Send
       </span>
+      
+    
+    </button>
+    
+    
+    <button
+      class="fn-button fn-button--emphasized fn-button--icon-right"
+      disabled=""
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Send
+      </span>
+      
+        
+      <span
+        class="sap-icon sap-icon--share-2"
+      />
+      
+    
+    </button>
+    
+    
+    <button
+      aria-label="More"
+      class="fn-button fn-button--transparent fn-button--icon-only"
+      disabled=""
+    >
+      
+        
+      <span
+        class="sap-icon sap-icon--overflow"
+      />
       
     
     </button>
@@ -494,7 +418,7 @@ exports[`Storyshots Experimental/Button Accept (Semantic) Button 1`] = `
 </section>
 `;
 
-exports[`Storyshots Experimental/Button Attention (Semantic) Button 1`] = `
+exports[`Storyshots Experimental/Button Primary Buttons 1`] = `
 <section>
   
 
@@ -502,11 +426,11 @@ exports[`Storyshots Experimental/Button Attention (Semantic) Button 1`] = `
     
     .docs-fn-container {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-        column-gap: 0.5rem;
-        row-gap: 0.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+        column-gap: 0.1rem;
+        row-gap: 0.1rem;
         background: white;
-        padding: 1.5rem;
+        padding: 1rem;
         justify-items: center;
         align-items: center;
     }
@@ -534,38 +458,17 @@ exports[`Storyshots Experimental/Button Attention (Semantic) Button 1`] = `
     
     <div>
       <b>
-        Rest
+        Emphasized 
       </b>
     </div>
     
     
     <div>
       <b>
-        Hover
+        Default
       </b>
     </div>
-    
-    
-    <div>
-      <b>
-        Active
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Focus
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Disabled
-      </b>
-    </div>
-    
+       
 
   </div>
   
@@ -578,13 +481,13 @@ exports[`Storyshots Experimental/Button Attention (Semantic) Button 1`] = `
     
     <div>
       <b>
-        No-Icon
+        :normal
       </b>
     </div>
     
     
     <button
-      class="fn-button fn-button--attention"
+      class="fn-button fn-button--emphasized"
     >
       
         
@@ -596,983 +499,41 @@ exports[`Storyshots Experimental/Button Attention (Semantic) Button 1`] = `
       
     
     </button>
-    
-    
-    <button
-      class="fn-button fn-button--attention is-hover"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--attention is-active"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--attention is-focus"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--attention"
-      disabled=""
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Only
-      </b>
-    </div>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--attention fn-button--icon-only"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--attention fn-button--icon-only is-hover"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--attention fn-button--icon-only is-active"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--attention fn-button--icon-only is-focus"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--attention fn-button--icon-only disabled"
-      disabled=""
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Right
-      </b>
-    </div>
-    
-    
-    <button
-      class="fn-button fn-button--attention fn-button--icon-right"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--attention fn-button--icon-right is-hover"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--attention fn-button--icon-right is-active"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--attention fn-button--icon-right is-focus"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--attention fn-button--icon-right"
-      disabled=""
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Left
-      </b>
-    </div>
-    
-    
-    <button
-      class="fn-button fn-button--attention fn-button--icon-left"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--attention fn-button--icon-left is-hover"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--attention fn-button--icon-left is-active"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--attention fn-button--icon-left is-focus"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--attention fn-button--icon-left"
-      disabled=""
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-</section>
-`;
-
-exports[`Storyshots Experimental/Button Critical (Semantic) Button 1`] = `
-<section>
-  
-
-  <style>
-    
-    .docs-fn-container {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-        column-gap: 0.5rem;
-        row-gap: 0.5rem;
-        background: white;
-        padding: 1.5rem;
-        justify-items: center;
-        align-items: center;
-    }
-
-    .docs-fn-header-container {
-        display: flex;
-        align-items: center;
-    }
-
-    .docs-fn-header-container code {
-        margin: 0 1rem;
-    }
-
-  </style>
-  
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div />
-    
-    
-    <div>
-      <b>
-        Rest
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Hover
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Active
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Focus
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Disabled
-      </b>
-    </div>
-    
-
-  </div>
-  
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        No-Icon
-      </b>
-    </div>
-    
-    
-    <button
-      class="fn-button fn-button--critical"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--critical is-hover"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--critical is-active"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--critical is-focus"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--critical"
-      disabled=""
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Only
-      </b>
-    </div>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--critical fn-button--icon-only"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--critical fn-button--icon-only is-hover"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--critical fn-button--icon-only is-active"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--critical fn-button--icon-only is-focus"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--critical fn-button--icon-only disabled"
-      disabled=""
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Right
-      </b>
-    </div>
-    
-    
-    <button
-      class="fn-button fn-button--critical fn-button--icon-right"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--critical fn-button--icon-right is-hover"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--critical fn-button--icon-right is-active"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--critical fn-button--icon-right is-focus"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--critical fn-button--icon-right"
-      disabled=""
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Left
-      </b>
-    </div>
-    
-    
-    <button
-      class="fn-button fn-button--critical fn-button--icon-left"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--critical fn-button--icon-left is-hover"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--critical fn-button--icon-left is-active"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--critical fn-button--icon-left is-focus"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--critical fn-button--icon-left"
-      disabled=""
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-</section>
-`;
-
-exports[`Storyshots Experimental/Button Default (Primary) Button 1`] = `
-<section>
-  
-
-  <style>
-    
-    .docs-fn-container {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-        column-gap: 0.5rem;
-        row-gap: 0.5rem;
-        background: white;
-        padding: 1.5rem;
-        justify-items: center;
-        align-items: center;
-    }
-
-    .docs-fn-header-container {
-        display: flex;
-        align-items: center;
-    }
-
-    .docs-fn-header-container code {
-        margin: 0 1rem;
-    }
-
-  </style>
-  
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div />
-    
-    
-    <div>
-      <b>
-        Rest
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Hover
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Active
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Focus
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Disabled
-      </b>
-    </div>
-    
-
-  </div>
-  
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        No-Icon
-      </b>
-    </div>
     
     
     <button
       class="fn-button"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
+
+  </div>
+  
+
+
+  <div
+    class="docs-fn-container"
+  >
+    
+    
+    <div>
+      <b>
+        :hover
+      </b>
+    </div>
+    
+    
+    <button
+      class="fn-button fn-button--emphasized is-hover"
     >
       
         
@@ -1600,6 +561,37 @@ exports[`Storyshots Experimental/Button Default (Primary) Button 1`] = `
     
     </button>
     
+
+  </div>
+  
+
+
+  <div
+    class="docs-fn-container"
+  >
+    
+    
+    <div>
+      <b>
+        :active
+      </b>
+    </div>
+    
+    
+    <button
+      class="fn-button fn-button--emphasized is-active"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
     
     <button
       class="fn-button is-active"
@@ -1615,9 +607,72 @@ exports[`Storyshots Experimental/Button Default (Primary) Button 1`] = `
     
     </button>
     
+
+  </div>
+  
+
+
+  <div
+    class="docs-fn-container"
+  >
+    
+    
+    <div>
+      <b>
+        :focus
+      </b>
+    </div>
+    
+    
+    <button
+      class="fn-button fn-button--emphasized is-focus"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
     
     <button
       class="fn-button is-focus"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
+
+  </div>
+  
+
+
+  <div
+    class="docs-fn-container"
+  >
+    
+    
+    <div>
+      <b>
+        :disabled
+      </b>
+    </div>
+    
+    
+    <button
+      class="fn-button fn-button--emphasized"
+      disabled=""
     >
       
         
@@ -1650,333 +705,10 @@ exports[`Storyshots Experimental/Button Default (Primary) Button 1`] = `
   </div>
   
 
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Only
-      </b>
-    </div>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--icon-only"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--icon-only is-hover"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--icon-only is-active"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--icon-only is-focus"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--icon-only"
-      disabled=""
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Right
-      </b>
-    </div>
-    
-    
-    <button
-      class="fn-button fn-button--icon-right"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--icon-right is-hover"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--icon-right is-active"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--icon-right is-focus"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--icon-right"
-      disabled=""
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Left
-      </b>
-    </div>
-    
-    
-    <button
-      class="fn-button fn-button--icon-left"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--icon-left is-hover"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--icon-left is-active"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--icon-left is-focus"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--icon-left"
-      disabled=""
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-
-  </div>
-  
-
 </section>
 `;
 
-exports[`Storyshots Experimental/Button Emphasized (Primary) Button 1`] = `
+exports[`Storyshots Experimental/Button Secondary Buttons 1`] = `
 <section>
   
 
@@ -1984,11 +716,11 @@ exports[`Storyshots Experimental/Button Emphasized (Primary) Button 1`] = `
     
     .docs-fn-container {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-        column-gap: 0.5rem;
-        row-gap: 0.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+        column-gap: 0.1rem;
+        row-gap: 0.1rem;
         background: white;
-        padding: 1.5rem;
+        padding: 1rem;
         justify-items: center;
         align-items: center;
     }
@@ -2016,38 +748,24 @@ exports[`Storyshots Experimental/Button Emphasized (Primary) Button 1`] = `
     
     <div>
       <b>
-        Rest
+        Ghost
       </b>
     </div>
     
     
     <div>
       <b>
-        Hover
+        Transparent
       </b>
     </div>
-    
+     
     
     <div>
       <b>
-        Active
+        Neutral
       </b>
     </div>
-    
-    
-    <div>
-      <b>
-        Focus
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Disabled
-      </b>
-    </div>
-    
+      
 
   </div>
   
@@ -2060,501 +778,7 @@ exports[`Storyshots Experimental/Button Emphasized (Primary) Button 1`] = `
     
     <div>
       <b>
-        No-Icon
-      </b>
-    </div>
-    
-    
-    <button
-      class="fn-button fn-button--emphasized"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--emphasized is-hover"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--emphasized is-active"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--emphasized is-focus"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--emphasized"
-      disabled=""
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Only
-      </b>
-    </div>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--emphasized fn-button--icon-only"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--emphasized fn-button--icon-only is-hover"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--emphasized fn-button--icon-only is-active"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--emphasized fn-button--icon-only is-focus"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--emphasized fn-button--icon-only disabled"
-      disabled=""
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Right
-      </b>
-    </div>
-    
-    
-    <button
-      class="fn-button fn-button--emphasized fn-button--icon-right"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--emphasized fn-button--icon-right is-hover"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--emphasized fn-button--icon-right is-active"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--emphasized fn-button--icon-right is-focus"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--emphasized fn-button--icon-right"
-      disabled=""
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Left
-      </b>
-    </div>
-    
-    
-    <button
-      class="fn-button fn-button--emphasized fn-button--icon-left"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--emphasized fn-button--icon-left is-hover"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--emphasized fn-button--icon-left is-active"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--emphasized fn-button--icon-left is-focus"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--emphasized fn-button--icon-left"
-      disabled=""
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-</section>
-`;
-
-exports[`Storyshots Experimental/Button Ghost (Secondary) Button 1`] = `
-<section>
-  
-
-  <style>
-    
-    .docs-fn-container {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-        column-gap: 0.5rem;
-        row-gap: 0.5rem;
-        background: white;
-        padding: 1.5rem;
-        justify-items: center;
-        align-items: center;
-    }
-
-    .docs-fn-header-container {
-        display: flex;
-        align-items: center;
-    }
-
-    .docs-fn-header-container code {
-        margin: 0 1rem;
-    }
-
-  </style>
-  
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div />
-    
-    
-    <div>
-      <b>
-        Rest
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Hover
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Active
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Focus
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Disabled
-      </b>
-    </div>
-    
-
-  </div>
-  
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        No-Icon
+        :normal
       </b>
     </div>
     
@@ -2572,6 +796,52 @@ exports[`Storyshots Experimental/Button Ghost (Secondary) Button 1`] = `
       
     
     </button>
+    
+    
+    <button
+      class="fn-button fn-button--transparent"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
+    
+    <button
+      class="fn-button fn-button--neutral"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
+
+  </div>
+  
+
+
+  <div
+    class="docs-fn-container"
+  >
+    
+    
+    <div>
+      <b>
+        :hover
+      </b>
+    </div>
     
     
     <button
@@ -2590,965 +860,7 @@ exports[`Storyshots Experimental/Button Ghost (Secondary) Button 1`] = `
     
     
     <button
-      class="fn-button fn-button--ghost is-active"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--ghost is-focus"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--ghost"
-      disabled=""
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Only
-      </b>
-    </div>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--ghost fn-button--icon-only"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--ghost fn-button--icon-only is-hover"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--ghost fn-button--icon-only is-active"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--ghost fn-button--icon-only is-focus"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--ghost fn-button--icon-only disabled"
-      disabled=""
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Right
-      </b>
-    </div>
-    
-    
-    <button
-      class="fn-button fn-button--ghost fn-button--icon-right"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--ghost fn-button--icon-right is-hover"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--ghost fn-button--icon-right is-active"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--ghost fn-button--icon-right is-focus"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--ghost fn-button--icon-right"
-      disabled=""
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Left
-      </b>
-    </div>
-    
-    
-    <button
-      class="fn-button fn-button--ghost fn-button--icon-left"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--ghost fn-button--icon-left is-hover"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--ghost fn-button--icon-left is-active"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--ghost fn-button--icon-left is-focus"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--ghost fn-button--icon-left"
-      disabled=""
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-</section>
-`;
-
-exports[`Storyshots Experimental/Button Negative (Semantic) Button 1`] = `
-<section>
-  
-
-  <style>
-    
-    .docs-fn-container {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-        column-gap: 0.5rem;
-        row-gap: 0.5rem;
-        background: white;
-        padding: 1.5rem;
-        justify-items: center;
-        align-items: center;
-    }
-
-    .docs-fn-header-container {
-        display: flex;
-        align-items: center;
-    }
-
-    .docs-fn-header-container code {
-        margin: 0 1rem;
-    }
-
-  </style>
-  
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div />
-    
-    
-    <div>
-      <b>
-        Rest
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Hover
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Active
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Focus
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Disabled
-      </b>
-    </div>
-    
-
-  </div>
-  
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        No-Icon
-      </b>
-    </div>
-    
-    
-    <button
-      class="fn-button fn-button--negative"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--negative is-hover"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--negative is-active"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--negative is-focus"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--negative"
-      disabled=""
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Only
-      </b>
-    </div>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--negative fn-button--icon-only"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--negative fn-button--icon-only is-hover"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--negative fn-button--icon-only is-active"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--negative fn-button--icon-only is-focus"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--negative fn-button--icon-only disabled"
-      disabled=""
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Right
-      </b>
-    </div>
-    
-    
-    <button
-      class="fn-button fn-button--negative fn-button--icon-right"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--negative fn-button--icon-right is-hover"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--negative fn-button--icon-right is-active"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--negative fn-button--icon-right is-focus"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--negative fn-button--icon-right"
-      disabled=""
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Left
-      </b>
-    </div>
-    
-    
-    <button
-      class="fn-button fn-button--negative fn-button--icon-left"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--negative fn-button--icon-left is-hover"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--negative fn-button--icon-left is-active"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--negative fn-button--icon-left is-focus"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--negative fn-button--icon-left"
-      disabled=""
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-</section>
-`;
-
-exports[`Storyshots Experimental/Button Neutral (Secondary) Button 1`] = `
-<section>
-  
-
-  <style>
-    
-    .docs-fn-container {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-        column-gap: 0.5rem;
-        row-gap: 0.5rem;
-        background: white;
-        padding: 1.5rem;
-        justify-items: center;
-        align-items: center;
-    }
-
-    .docs-fn-header-container {
-        display: flex;
-        align-items: center;
-    }
-
-    .docs-fn-header-container code {
-        margin: 0 1rem;
-    }
-
-  </style>
-  
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div />
-    
-    
-    <div>
-      <b>
-        Rest
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Hover
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Active
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Focus
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Disabled
-      </b>
-    </div>
-    
-
-  </div>
-  
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        No-Icon
-      </b>
-    </div>
-    
-    
-    <button
-      class="fn-button fn-button--neutral"
+      class="fn-button fn-button--transparent is-hover"
     >
       
         
@@ -3576,6 +888,52 @@ exports[`Storyshots Experimental/Button Neutral (Secondary) Button 1`] = `
     
     </button>
     
+
+  </div>
+  
+
+
+  <div
+    class="docs-fn-container"
+  >
+    
+    
+    <div>
+      <b>
+        :active
+      </b>
+    </div>
+    
+    
+    <button
+      class="fn-button fn-button--ghost is-active"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
+    
+    <button
+      class="fn-button fn-button--transparent is-active"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
     
     <button
       class="fn-button fn-button--neutral is-active"
@@ -3591,9 +949,103 @@ exports[`Storyshots Experimental/Button Neutral (Secondary) Button 1`] = `
     
     </button>
     
+
+  </div>
+  
+
+
+  <div
+    class="docs-fn-container"
+  >
+    
+    
+    <div>
+      <b>
+        :focus
+      </b>
+    </div>
+    
+    
+    <button
+      class="fn-button fn-button--ghost is-focus"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
+    
+    <button
+      class="fn-button fn-button--transparent is-focus"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
     
     <button
       class="fn-button fn-button--neutral is-focus"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
+
+  </div>
+  
+
+
+  <div
+    class="docs-fn-container"
+  >
+    
+    
+    <div>
+      <b>
+        :disabled
+      </b>
+    </div>
+    
+    
+    <button
+      class="fn-button fn-button--ghost"
+      disabled=""
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
+    
+    <button
+      class="fn-button fn-button--transparent"
+      disabled=""
     >
       
         
@@ -3626,823 +1078,6 @@ exports[`Storyshots Experimental/Button Neutral (Secondary) Button 1`] = `
   </div>
   
 
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Only
-      </b>
-    </div>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--neutral fn-button--icon-only"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--neutral fn-button--icon-only is-hover"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--neutral fn-button--icon-only is-active"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--neutral fn-button--icon-only is-focus"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--neutral fn-button--icon-only disabled"
-      disabled=""
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Right
-      </b>
-    </div>
-    
-    
-    <button
-      class="fn-button fn-button--neutral fn-button--icon-right"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--neutral fn-button--icon-right is-hover"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--neutral fn-button--icon-right is-active"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--neutral fn-button--icon-right is-focus"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--neutral fn-button--icon-right"
-      disabled=""
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Left
-      </b>
-    </div>
-    
-    
-    <button
-      class="fn-button fn-button--neutral fn-button--icon-left"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--neutral fn-button--icon-left is-hover"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--neutral fn-button--icon-left is-active"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--neutral fn-button--icon-left is-focus"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--neutral fn-button--icon-left"
-      disabled=""
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-</section>
-`;
-
-exports[`Storyshots Experimental/Button Reject (Semantic) Button 1`] = `
-<section>
-  
-
-  <style>
-    
-    .docs-fn-container {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-        column-gap: 0.5rem;
-        row-gap: 0.5rem;
-        background: white;
-        padding: 1.5rem;
-        justify-items: center;
-        align-items: center;
-    }
-
-    .docs-fn-header-container {
-        display: flex;
-        align-items: center;
-    }
-
-    .docs-fn-header-container code {
-        margin: 0 1rem;
-    }
-
-  </style>
-  
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div />
-    
-    
-    <div>
-      <b>
-        Rest
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Hover
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Active
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Focus
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Disabled
-      </b>
-    </div>
-    
-
-  </div>
-  
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        No-Icon
-      </b>
-    </div>
-    
-    
-    <button
-      class="fn-button fn-button--reject"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--reject is-hover"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--reject is-active"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--reject is-focus"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--reject"
-      disabled=""
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Only
-      </b>
-    </div>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--reject fn-button--icon-only"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--reject fn-button--icon-only is-hover"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--reject fn-button--icon-only is-active"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--reject fn-button--icon-only is-focus"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--reject fn-button--icon-only disabled"
-      disabled=""
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Right
-      </b>
-    </div>
-    
-    
-    <button
-      class="fn-button fn-button--reject fn-button--icon-right"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--reject fn-button--icon-right is-hover"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--reject fn-button--icon-right is-active"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--reject fn-button--icon-right is-focus"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--reject fn-button--icon-right"
-      disabled=""
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Left
-      </b>
-    </div>
-    
-    
-    <button
-      class="fn-button fn-button--reject fn-button--icon-left"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--reject fn-button--icon-left is-hover"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--reject fn-button--icon-left is-active"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--reject fn-button--icon-left is-focus"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--reject fn-button--icon-left"
-      disabled=""
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-
-  </div>
-  
-
 </section>
 `;
 
@@ -4454,11 +1089,11 @@ exports[`Storyshots Experimental/Button Segmented Button 1`] = `
     
     .docs-fn-container {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-        column-gap: 0.5rem;
-        row-gap: 0.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+        column-gap: 0.1rem;
+        row-gap: 0.1rem;
         background: white;
-        padding: 1.5rem;
+        padding: 1rem;
         justify-items: center;
         align-items: center;
     }
@@ -4998,7 +1633,7 @@ exports[`Storyshots Experimental/Button Segmented Button 1`] = `
 </section>
 `;
 
-exports[`Storyshots Experimental/Button Success (Semantic) Button 1`] = `
+exports[`Storyshots Experimental/Button Semantic Buttons 1`] = `
 <section>
   
 
@@ -5006,11 +1641,11 @@ exports[`Storyshots Experimental/Button Success (Semantic) Button 1`] = `
     
     .docs-fn-container {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-        column-gap: 0.5rem;
-        row-gap: 0.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+        column-gap: 0.1rem;
+        row-gap: 0.1rem;
         background: white;
-        padding: 1.5rem;
+        padding: 1rem;
         justify-items: center;
         align-items: center;
     }
@@ -5038,35 +1673,42 @@ exports[`Storyshots Experimental/Button Success (Semantic) Button 1`] = `
     
     <div>
       <b>
-        Rest
+        Accept
       </b>
     </div>
     
     
     <div>
       <b>
-        Hover
+        Success
       </b>
     </div>
     
     
     <div>
       <b>
-        Active
+        Attention
       </b>
     </div>
     
     
     <div>
       <b>
-        Focus
+        Critical
       </b>
     </div>
     
     
     <div>
       <b>
-        Disabled
+        Reject
+      </b>
+    </div>
+    
+    
+    <div>
+      <b>
+        Negative
       </b>
     </div>
     
@@ -5082,13 +1724,119 @@ exports[`Storyshots Experimental/Button Success (Semantic) Button 1`] = `
     
     <div>
       <b>
-        No-Icon
+        :normal
       </b>
     </div>
     
     
     <button
+      class="fn-button fn-button--accept"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
+    
+    <button
       class="fn-button fn-button--success"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
+    
+    <button
+      class="fn-button fn-button--attention"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
+    
+    <button
+      class="fn-button fn-button--critical"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
+    
+    <button
+      class="fn-button fn-button--reject"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
+    
+    <button
+      class="fn-button fn-button--negative"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
+
+  </div>
+  
+
+
+  <div
+    class="docs-fn-container"
+  >
+    
+    
+    <div>
+      <b>
+        :hover
+      </b>
+    </div>
+    
+    
+    <button
+      class="fn-button fn-button--accept is-hover"
     >
       
         
@@ -5118,7 +1866,189 @@ exports[`Storyshots Experimental/Button Success (Semantic) Button 1`] = `
     
     
     <button
+      class="fn-button fn-button--attention is-hover"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
+    
+    <button
+      class="fn-button fn-button--critical is-hover"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
+    
+    <button
+      class="fn-button fn-button--reject is-hover"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
+    
+    <button
+      class="fn-button fn-button--negative is-hover"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
+
+  </div>
+  
+
+
+  <div
+    class="docs-fn-container"
+  >
+    
+    
+    <div>
+      <b>
+        :active
+      </b>
+    </div>
+    
+    
+    <button
+      class="fn-button fn-button--accept is-active"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
+    
+    <button
       class="fn-button fn-button--success is-active"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
+    
+    <button
+      class="fn-button fn-button--attention is-active"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
+    
+    <button
+      class="fn-button fn-button--critical is-active"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
+    
+    <button
+      class="fn-button fn-button--reject is-active"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
+    
+    <button
+      class="fn-button fn-button--negative is-active"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
+
+  </div>
+  
+
+
+  <div
+    class="docs-fn-container"
+  >
+    
+    
+    <div>
+      <b>
+        :focus
+      </b>
+    </div>
+    
+    
+    <button
+      class="fn-button fn-button--accept is-focus"
     >
       
         
@@ -5148,6 +2078,98 @@ exports[`Storyshots Experimental/Button Success (Semantic) Button 1`] = `
     
     
     <button
+      class="fn-button fn-button--attention is-focus"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
+    
+    <button
+      class="fn-button fn-button--critical is-focus"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
+    
+    <button
+      class="fn-button fn-button--reject is-focus"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
+    
+    <button
+      class="fn-button fn-button--negative is-focus"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
+
+  </div>
+  
+
+
+  <div
+    class="docs-fn-container"
+  >
+    
+    
+    <div>
+      <b>
+        :disabled
+      </b>
+    </div>
+    
+    
+    <button
+      class="fn-button fn-button--accept"
+      disabled=""
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
+    
+    <button
       class="fn-button fn-button--success"
       disabled=""
     >
@@ -5162,194 +2184,9 @@ exports[`Storyshots Experimental/Button Success (Semantic) Button 1`] = `
     
     </button>
     
-
-  </div>
-  
-
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Only
-      </b>
-    </div>
-    
     
     <button
-      aria-label="Share"
-      class="fn-button fn-button--success fn-button--icon-only"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--success fn-button--icon-only is-hover"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--success fn-button--icon-only is-active"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--success fn-button--icon-only is-focus"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--success fn-button--icon-only disabled"
-      disabled=""
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Right
-      </b>
-    </div>
-    
-    
-    <button
-      class="fn-button fn-button--success fn-button--icon-right"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--success fn-button--icon-right is-hover"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--success fn-button--icon-right is-active"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--success fn-button--icon-right is-focus"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--success fn-button--icon-right"
+      class="fn-button fn-button--attention"
       disabled=""
     >
       
@@ -5357,48 +2194,7 @@ exports[`Storyshots Experimental/Button Success (Semantic) Button 1`] = `
       <span
         class="fn-button__text"
       >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Left
-      </b>
-    </div>
-    
-    
-    <button
-      class="fn-button fn-button--success fn-button--icon-left"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
+        Button
       </span>
       
     
@@ -5406,80 +2202,47 @@ exports[`Storyshots Experimental/Button Success (Semantic) Button 1`] = `
     
     
     <button
-      class="fn-button fn-button--success fn-button--icon-left is-hover"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--success fn-button--icon-left is-active"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--success fn-button--icon-left is-focus"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--success fn-button--icon-left"
+      class="fn-button fn-button--critical"
       disabled=""
     >
       
         
       <span
-        class="sap-icon sap-icon--share-2"
-      />
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
+    
+    <button
+      class="fn-button fn-button--reject"
+      disabled=""
+    >
       
         
       <span
         class="fn-button__text"
       >
-        Share
+        Button
+      </span>
+      
+    
+    </button>
+    
+    
+    <button
+      class="fn-button fn-button--negative"
+      disabled=""
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
       </span>
       
     
@@ -5492,7 +2255,7 @@ exports[`Storyshots Experimental/Button Success (Semantic) Button 1`] = `
 </section>
 `;
 
-exports[`Storyshots Experimental/Button Toggled Button 1`] = `
+exports[`Storyshots Experimental/Button Toggle Buttons 1`] = `
 <section>
   
 
@@ -5500,11 +2263,11 @@ exports[`Storyshots Experimental/Button Toggled Button 1`] = `
     
     .docs-fn-container {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-        column-gap: 0.5rem;
-        row-gap: 0.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+        column-gap: 0.1rem;
+        row-gap: 0.1rem;
         background: white;
-        padding: 1.5rem;
+        padding: 1rem;
         justify-items: center;
         align-items: center;
     }
@@ -5532,37 +2295,62 @@ exports[`Storyshots Experimental/Button Toggled Button 1`] = `
     
     <div>
       <b>
-        Rest
+        Selected 
       </b>
     </div>
     
     
     <div>
       <b>
-        Hover
+        Default
       </b>
     </div>
+       
+
+  </div>
+  
+
+
+  <div
+    class="docs-fn-container"
+  >
     
     
     <div>
       <b>
-        Active
+        :normal
       </b>
     </div>
     
     
-    <div>
-      <b>
-        Focus
-      </b>
-    </div>
+    <button
+      class="fn-button fn-button--selected"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
     
     
-    <div>
-      <b>
-        Disabled
-      </b>
-    </div>
+    <button
+      class="fn-button fn-button--ghost"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
     
 
   </div>
@@ -5576,13 +2364,13 @@ exports[`Storyshots Experimental/Button Toggled Button 1`] = `
     
     <div>
       <b>
-        No-Icon
+        :hover
       </b>
     </div>
     
     
     <button
-      class="fn-button fn-button--ghost fn-button--toggled"
+      class="fn-button fn-button--selected is-hover"
     >
       
         
@@ -5597,7 +2385,38 @@ exports[`Storyshots Experimental/Button Toggled Button 1`] = `
     
     
     <button
-      class="fn-button fn-button--ghost fn-button--toggled is-hover"
+      class="fn-button fn-button--ghost is-hover"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
+
+  </div>
+  
+
+
+  <div
+    class="docs-fn-container"
+  >
+    
+    
+    <div>
+      <b>
+        :active
+      </b>
+    </div>
+    
+    
+    <button
+      class="fn-button fn-button--selected is-active"
     >
       
         
@@ -5612,7 +2431,38 @@ exports[`Storyshots Experimental/Button Toggled Button 1`] = `
     
     
     <button
-      class="fn-button fn-button--ghost fn-button--toggled is-active"
+      class="fn-button fn-button--ghost is-active"
+    >
+      
+        
+      <span
+        class="fn-button__text"
+      >
+        Button
+      </span>
+      
+    
+    </button>
+    
+
+  </div>
+  
+
+
+  <div
+    class="docs-fn-container"
+  >
+    
+    
+    <div>
+      <b>
+        :focus
+      </b>
+    </div>
+    
+    
+    <button
+      class="fn-button fn-button--selected is-focus"
     >
       
         
@@ -5627,7 +2477,7 @@ exports[`Storyshots Experimental/Button Toggled Button 1`] = `
     
     
     <button
-      class="fn-button fn-button--ghost fn-button--toggled is-focus"
+      class="fn-button fn-button--ghost is-focus"
     >
       
         
@@ -5640,9 +2490,25 @@ exports[`Storyshots Experimental/Button Toggled Button 1`] = `
     
     </button>
     
+
+  </div>
+  
+
+
+  <div
+    class="docs-fn-container"
+  >
+    
+    
+    <div>
+      <b>
+        :disabled
+      </b>
+    </div>
+    
     
     <button
-      class="fn-button fn-button--ghost fn-button--toggled"
+      class="fn-button fn-button--selected"
       disabled=""
     >
       
@@ -5656,487 +2522,9 @@ exports[`Storyshots Experimental/Button Toggled Button 1`] = `
     
     </button>
     
-
-  </div>
-  
-
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Only
-      </b>
-    </div>
-    
     
     <button
-      aria-label="Share"
-      class="fn-button fn-button--ghost fn-button--toggled fn-button--icon-only"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--ghost fn-button--toggled fn-button--icon-only is-hover"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--ghost fn-button--toggled fn-button--icon-only is-active"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--ghost fn-button--toggled fn-button--icon-only is-focus"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--ghost fn-button--toggled fn-button--icon-only disabled"
-      disabled=""
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Right
-      </b>
-    </div>
-    
-    
-    <button
-      class="fn-button fn-button--ghost fn-button--toggled fn-button--icon-right"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--ghost fn-button--toggled fn-button--icon-right is-hover"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--ghost fn-button--toggled fn-button--icon-right is-active"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--ghost fn-button--toggled fn-button--icon-right is-focus"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--ghost fn-button--toggled fn-button--icon-right"
-      disabled=""
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Left
-      </b>
-    </div>
-    
-    
-    <button
-      class="fn-button fn-button--ghost fn-button--toggled fn-button--icon-left"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--ghost fn-button--toggled fn-button--icon-left is-hover"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--ghost fn-button--toggled fn-button--icon-left is-active"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--ghost fn-button--toggled fn-button--icon-left is-focus"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--ghost fn-button--toggled fn-button--icon-left"
-      disabled=""
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-</section>
-`;
-
-exports[`Storyshots Experimental/Button Transparent (Layout) Button 1`] = `
-<section>
-  
-
-  <style>
-    
-    .docs-fn-container {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-        column-gap: 0.5rem;
-        row-gap: 0.5rem;
-        background: white;
-        padding: 1.5rem;
-        justify-items: center;
-        align-items: center;
-    }
-
-    .docs-fn-header-container {
-        display: flex;
-        align-items: center;
-    }
-
-    .docs-fn-header-container code {
-        margin: 0 1rem;
-    }
-
-  </style>
-  
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div />
-    
-    
-    <div>
-      <b>
-        Rest
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Hover
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Active
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Focus
-      </b>
-    </div>
-    
-    
-    <div>
-      <b>
-        Disabled
-      </b>
-    </div>
-    
-
-  </div>
-  
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        No-Icon
-      </b>
-    </div>
-    
-    
-    <button
-      class="fn-button fn-button--transparent"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--transparent is-hover"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--transparent is-active"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--transparent is-focus"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Button
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--transparent"
+      class="fn-button fn-button--ghost"
       disabled=""
     >
       
@@ -6145,329 +2533,6 @@ exports[`Storyshots Experimental/Button Transparent (Layout) Button 1`] = `
         class="fn-button__text"
       >
         Button
-      </span>
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Only
-      </b>
-    </div>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--transparent fn-button--icon-only"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--transparent fn-button--icon-only is-hover"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--transparent fn-button--icon-only is-active"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--transparent fn-button--icon-only is-focus"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      aria-label="Share"
-      class="fn-button fn-button--transparent fn-button--icon-only disabled"
-      disabled=""
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Right
-      </b>
-    </div>
-    
-    
-    <button
-      class="fn-button fn-button--transparent fn-button--icon-right"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--transparent fn-button--icon-right is-hover"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--transparent fn-button--icon-right is-active"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--transparent fn-button--icon-right is-focus"
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--transparent fn-button--icon-right"
-      disabled=""
-    >
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Send
-      </span>
-      
-        
-      <span
-        class="sap-icon sap-icon--paper-plane"
-      />
-      
-    
-    </button>
-    
-
-  </div>
-  
-
-
-  <div
-    class="docs-fn-container"
-  >
-    
-    
-    <div>
-      <b>
-        Icon-Left
-      </b>
-    </div>
-    
-    
-    <button
-      class="fn-button fn-button--transparent fn-button--icon-left"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--transparent fn-button--icon-left is-hover"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--transparent fn-button--icon-left is-active"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--transparent fn-button--icon-left is-focus"
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
-      </span>
-      
-    
-    </button>
-    
-    
-    <button
-      class="fn-button fn-button--transparent fn-button--icon-left"
-      disabled=""
-    >
-      
-        
-      <span
-        class="sap-icon sap-icon--share-2"
-      />
-      
-        
-      <span
-        class="fn-button__text"
-      >
-        Share
       </span>
       
     

--- a/stories/fn-button/fn-button.stories.js
+++ b/stories/fn-button/fn-button.stories.js
@@ -10,14 +10,14 @@ export default {
 | emphasized (primary)&nbsp;&nbsp;&nbsp;&nbsp;     | \`fn-button--emphasized\` |
 | ghost (secondary)&nbsp;&nbsp;&nbsp;&nbsp;        | \`fn-button--ghost\`      |
 | neutral (secondary) &nbsp;&nbsp;&nbsp;&nbsp;     | \`fn-button--neutral\`    |
-| transparent (layout)&nbsp;&nbsp;&nbsp;&nbsp;     | \`fn-button--transparent\`|
+| transparent (secondary)&nbsp;&nbsp;&nbsp;&nbsp;     | \`fn-button--transparent\`|
 | accept (semantic)&nbsp;&nbsp;&nbsp;&nbsp;        | \`fn-button--accept\`     |
 | success (semantic)&nbsp;&nbsp;&nbsp;&nbsp;       | \`fn-button--success\`    |
 | attention (semantic)&nbsp;&nbsp;&nbsp;&nbsp;     | \`fn-button--attention\`  |
 | critical (semantic)&nbsp;&nbsp;&nbsp;&nbsp;      | \`fn-button--critical\`   |
 | reject (semantic)&nbsp;&nbsp;&nbsp;&nbsp;        | \`fn-button--reject\`     |
 | negative (semantic)&nbsp;&nbsp;&nbsp;&nbsp;      | \`fn-button--negative\`   |
-| toggled (semantic)&nbsp;&nbsp;&nbsp;&nbsp;       | \`fn-button--toggled\`    |
+| selected (semantic)&nbsp;&nbsp;&nbsp;&nbsp;       | \`fn-button--selected\`    |
 
 <br><br>
 
@@ -40,11 +40,11 @@ const localStyles = `
 <style>
     .docs-fn-container {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-        column-gap: 0.5rem;
-        row-gap: 0.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+        column-gap: 0.1rem;
+        row-gap: 0.1rem;
         background: white;
-        padding: 1.5rem;
+        padding: 1rem;
         justify-items: center;
         align-items: center;
     }
@@ -60,1300 +60,468 @@ const localStyles = `
 </style>
 `;
 
-export const defaultPrimary = () => `${localStyles}
+export const primary = () => `${localStyles}
 <div class="docs-fn-container">
     <div></div>
-    <div><b>Rest</b></div>
-    <div><b>Hover</b></div>
-    <div><b>Active</b></div>
-    <div><b>Focus</b></div>
-    <div><b>Disabled</b></div>
+    <div><b>Emphasized </b></div>
+    <div><b>Default</b></div>   
 </div>
 
 <div class="docs-fn-container">
-    <div><b>No-Icon</b></div>
+    <div><b>:normal</b></div>
+    <button class="fn-button fn-button--emphasized">
+        <span class="fn-button__text">Button</span>
+    </button>
     <button class="fn-button">
+        <span class="fn-button__text">Button</span>
+    </button>
+</div>
+
+<div class="docs-fn-container">
+    <div><b>:hover</b></div>
+    <button class="fn-button fn-button--emphasized is-hover">
         <span class="fn-button__text">Button</span>
     </button>
     <button class="fn-button is-hover">
         <span class="fn-button__text">Button</span>
     </button>
+</div>
+
+<div class="docs-fn-container">
+    <div><b>:active</b></div>
+    <button class="fn-button fn-button--emphasized is-active">
+        <span class="fn-button__text">Button</span>
+    </button>
     <button class="fn-button is-active">
         <span class="fn-button__text">Button</span>
     </button>
+</div>
+
+<div class="docs-fn-container">
+    <div><b>:focus</b></div>
+    <button class="fn-button fn-button--emphasized is-focus">
+        <span class="fn-button__text">Button</span>
+    </button>
     <button class="fn-button is-focus">
+        <span class="fn-button__text">Button</span>
+    </button>
+</div>
+
+<div class="docs-fn-container">
+    <div><b>:disabled</b></div>
+    <button class="fn-button fn-button--emphasized" disabled>
         <span class="fn-button__text">Button</span>
     </button>
     <button class="fn-button" disabled>
         <span class="fn-button__text">Button</span>
     </button>
 </div>
-
-
-<div class="docs-fn-container">
-    <div><b>Icon-Only</b></div>
-    <button class="fn-button fn-button--icon-only" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--icon-only is-hover" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--icon-only is-active" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--icon-only is-focus" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--icon-only" aria-label="Share" disabled>
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-</div>
-
-
-<div class="docs-fn-container">
-    <div><b>Icon-Right</b></div>
-    <button class="fn-button fn-button--icon-right">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--icon-right is-hover">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--icon-right is-active">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--icon-right is-focus">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--icon-right" disabled>
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-</div>
-
-<div class="docs-fn-container">
-    <div><b>Icon-Left</b></div>
-    <button class="fn-button fn-button--icon-left">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--icon-left is-hover">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--icon-left is-active">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--icon-left is-focus">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--icon-left" disabled>
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-</div>
 `;
 
-defaultPrimary.storyName = 'Default (Primary) Button';
+primary.storyName = 'Primary Buttons';
 
-defaultPrimary.parameters = {
+primary.parameters = {
     docs: {
         iframeHeight: 500,
-        storyDescription: 'For the default button no modifier class is needed. For an icon-only button add the `.fn-button--icon-only` modifier class. To add an icon you can use `.fn-button--icon-right` or `.fn-button--icon-left` based on where you want the icon to be rendered.'
+        storyDescription: 'Primary buttons are two types: default and emphasized. For the default one no modifier class is needed, just add the `.fn-button` class to your html element. For emphasized button add `.fn-button--emphasized` modifier class to the `.fn-button` base class.'
     }
 };
 
-
-export const emphasized = () => `${localStyles}
+export const secondary = () => `${localStyles}
 <div class="docs-fn-container">
     <div></div>
-    <div><b>Rest</b></div>
-    <div><b>Hover</b></div>
-    <div><b>Active</b></div>
-    <div><b>Focus</b></div>
-    <div><b>Disabled</b></div>
+    <div><b>Ghost</b></div>
+    <div><b>Transparent</b></div> 
+    <div><b>Neutral</b></div>  
 </div>
 
 <div class="docs-fn-container">
-    <div><b>No-Icon</b></div>
-    <button class="fn-button fn-button--emphasized">
-        <span class="fn-button__text">Button</span>
-    </button>
-    <button class="fn-button fn-button--emphasized is-hover">
-        <span class="fn-button__text">Button</span>
-    </button>
-    <button class="fn-button fn-button--emphasized is-active">
-        <span class="fn-button__text">Button</span>
-    </button>
-    <button class="fn-button fn-button--emphasized is-focus">
-        <span class="fn-button__text">Button</span>
-    </button>
-    <button class="fn-button fn-button--emphasized" disabled>
-        <span class="fn-button__text">Button</span>
-    </button>
-</div>
-
-
-<div class="docs-fn-container">
-    <div><b>Icon-Only</b></div>
-    <button class="fn-button fn-button--emphasized fn-button--icon-only" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--emphasized fn-button--icon-only is-hover" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--emphasized fn-button--icon-only is-active" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--emphasized fn-button--icon-only is-focus" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--emphasized fn-button--icon-only disabled" aria-label="Share" disabled>
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-</div>
-
-
-<div class="docs-fn-container">
-    <div><b>Icon-Right</b></div>
-    <button class="fn-button fn-button--emphasized fn-button--icon-right">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--emphasized fn-button--icon-right is-hover">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--emphasized fn-button--icon-right is-active">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--emphasized fn-button--icon-right is-focus">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--emphasized fn-button--icon-right" disabled>
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-</div>
-
-<div class="docs-fn-container">
-    <div><b>Icon-Left</b></div>
-    <button class="fn-button fn-button--emphasized fn-button--icon-left">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--emphasized fn-button--icon-left is-hover">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--emphasized fn-button--icon-left is-active">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--emphasized fn-button--icon-left is-focus">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--emphasized fn-button--icon-left" disabled>
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-</div>
-`;
-
-emphasized.storyName = 'Emphasized (Primary) Button';
-
-emphasized.parameters = {
-    docs: {
-        iframeHeight: 500,
-        storyDescription: 'Add the `.fn-button--emphasized` modifier class to `.fn-button` for emphasized button.'
-    }
-};
-
-export const ghost = () => `${localStyles}
-<div class="docs-fn-container">
-    <div></div>
-    <div><b>Rest</b></div>
-    <div><b>Hover</b></div>
-    <div><b>Active</b></div>
-    <div><b>Focus</b></div>
-    <div><b>Disabled</b></div>
-</div>
-
-<div class="docs-fn-container">
-    <div><b>No-Icon</b></div>
+    <div><b>:normal</b></div>
     <button class="fn-button fn-button--ghost">
         <span class="fn-button__text">Button</span>
     </button>
+    <button class="fn-button fn-button--transparent">
+        <span class="fn-button__text">Button</span>
+    </button>
+    <button class="fn-button fn-button--neutral">
+        <span class="fn-button__text">Button</span>
+    </button>
+</div>
+
+<div class="docs-fn-container">
+    <div><b>:hover</b></div>
     <button class="fn-button fn-button--ghost is-hover">
         <span class="fn-button__text">Button</span>
     </button>
-    <button class="fn-button fn-button--ghost is-active">
-        <span class="fn-button__text">Button</span>
-    </button>
-    <button class="fn-button fn-button--ghost is-focus">
-        <span class="fn-button__text">Button</span>
-    </button>
-    <button class="fn-button fn-button--ghost" disabled>
-        <span class="fn-button__text">Button</span>
-    </button>
-</div>
-
-
-<div class="docs-fn-container">
-    <div><b>Icon-Only</b></div>
-    <button class="fn-button fn-button--ghost fn-button--icon-only" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--ghost fn-button--icon-only is-hover" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--ghost fn-button--icon-only is-active" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--ghost fn-button--icon-only is-focus" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--ghost fn-button--icon-only disabled" aria-label="Share" disabled>
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-</div>
-
-
-<div class="docs-fn-container">
-    <div><b>Icon-Right</b></div>
-    <button class="fn-button fn-button--ghost fn-button--icon-right">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--ghost fn-button--icon-right is-hover">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--ghost fn-button--icon-right is-active">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--ghost fn-button--icon-right is-focus">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--ghost fn-button--icon-right" disabled>
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-</div>
-
-<div class="docs-fn-container">
-    <div><b>Icon-Left</b></div>
-    <button class="fn-button fn-button--ghost fn-button--icon-left">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--ghost fn-button--icon-left is-hover">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--ghost fn-button--icon-left is-active">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--ghost fn-button--icon-left is-focus">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--ghost fn-button--icon-left" disabled>
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-</div>
-`;
-
-ghost.storyName = 'Ghost (Secondary) Button';
-
-ghost.parameters = {
-    docs: {
-        iframeHeight: 500,
-        storyDescription: 'Add the `.fn-button--ghost` modifier class to `.fn-button` for ghost button.'
-    }
-};
-
-export const neutral = () => `${localStyles}
-<div class="docs-fn-container">
-    <div></div>
-    <div><b>Rest</b></div>
-    <div><b>Hover</b></div>
-    <div><b>Active</b></div>
-    <div><b>Focus</b></div>
-    <div><b>Disabled</b></div>
-</div>
-
-<div class="docs-fn-container">
-    <div><b>No-Icon</b></div>
-    <button class="fn-button fn-button--neutral">
+    <button class="fn-button fn-button--transparent is-hover">
         <span class="fn-button__text">Button</span>
     </button>
     <button class="fn-button fn-button--neutral is-hover">
         <span class="fn-button__text">Button</span>
     </button>
+</div>
+
+<div class="docs-fn-container">
+    <div><b>:active</b></div>
+    <button class="fn-button fn-button--ghost is-active">
+        <span class="fn-button__text">Button</span>
+    </button>
+    <button class="fn-button fn-button--transparent is-active">
+        <span class="fn-button__text">Button</span>
+    </button>
     <button class="fn-button fn-button--neutral is-active">
         <span class="fn-button__text">Button</span>
     </button>
+</div>
+
+<div class="docs-fn-container">
+    <div><b>:focus</b></div>
+    <button class="fn-button fn-button--ghost is-focus">
+        <span class="fn-button__text">Button</span>
+    </button>
+    <button class="fn-button fn-button--transparent is-focus">
+        <span class="fn-button__text">Button</span>
+    </button>
     <button class="fn-button fn-button--neutral is-focus">
+        <span class="fn-button__text">Button</span>
+    </button>
+</div>
+
+<div class="docs-fn-container">
+    <div><b>:disabled</b></div>
+    <button class="fn-button fn-button--ghost" disabled>
+        <span class="fn-button__text">Button</span>
+    </button>
+    <button class="fn-button fn-button--transparent" disabled>
         <span class="fn-button__text">Button</span>
     </button>
     <button class="fn-button fn-button--neutral" disabled>
         <span class="fn-button__text">Button</span>
     </button>
 </div>
-
-
-<div class="docs-fn-container">
-    <div><b>Icon-Only</b></div>
-    <button class="fn-button fn-button--neutral fn-button--icon-only" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--neutral fn-button--icon-only is-hover" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--neutral fn-button--icon-only is-active" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--neutral fn-button--icon-only is-focus" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--neutral fn-button--icon-only disabled" aria-label="Share" disabled>
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-</div>
-
-
-<div class="docs-fn-container">
-    <div><b>Icon-Right</b></div>
-    <button class="fn-button fn-button--neutral fn-button--icon-right">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--neutral fn-button--icon-right is-hover">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--neutral fn-button--icon-right is-active">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--neutral fn-button--icon-right is-focus">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--neutral fn-button--icon-right" disabled>
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-</div>
-
-<div class="docs-fn-container">
-    <div><b>Icon-Left</b></div>
-    <button class="fn-button fn-button--neutral fn-button--icon-left">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--neutral fn-button--icon-left is-hover">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--neutral fn-button--icon-left is-active">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--neutral fn-button--icon-left is-focus">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--neutral fn-button--icon-left" disabled>
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-</div>
 `;
 
-neutral.storyName = 'Neutral (Secondary) Button';
+secondary.storyName = 'Secondary Buttons';
 
-neutral.parameters = {
+secondary.parameters = {
     docs: {
         iframeHeight: 500,
-        storyDescription: 'Add the `.fn-button--neutral` modifier class to `.fn-button` for neutral button.'
+        storyDescription: `Secondary buttons are three types: ghost, transparent and neutral.
+
+| Style&nbsp;&nbsp;&nbsp;&nbsp;        | Modifier class           |
+| ------------------------------------ | ------------------------ |
+| ghost&nbsp;&nbsp;&nbsp;&nbsp;        | \`fn-button--ghost\`      |
+| transparent&nbsp;&nbsp;&nbsp;&nbsp;  | \`fn-button--transparent\`|
+| neutral&nbsp;&nbsp;&nbsp;&nbsp;      | \`fn-button--neutral\`    |
+`
     }
 };
 
-export const transparent = () => `${localStyles}
+export const semantic = () => `${localStyles}
 <div class="docs-fn-container">
     <div></div>
-    <div><b>Rest</b></div>
-    <div><b>Hover</b></div>
-    <div><b>Active</b></div>
-    <div><b>Focus</b></div>
-    <div><b>Disabled</b></div>
+    <div><b>Accept</b></div>
+    <div><b>Success</b></div>
+    <div><b>Attention</b></div>
+    <div><b>Critical</b></div>
+    <div><b>Reject</b></div>
+    <div><b>Negative</b></div>
 </div>
 
 <div class="docs-fn-container">
-    <div><b>No-Icon</b></div>
-    <button class="fn-button fn-button--transparent">
-        <span class="fn-button__text">Button</span>
-    </button>
-    <button class="fn-button fn-button--transparent is-hover">
-        <span class="fn-button__text">Button</span>
-    </button>
-    <button class="fn-button fn-button--transparent is-active">
-        <span class="fn-button__text">Button</span>
-    </button>
-    <button class="fn-button fn-button--transparent is-focus">
-        <span class="fn-button__text">Button</span>
-    </button>
-    <button class="fn-button fn-button--transparent" disabled>
-        <span class="fn-button__text">Button</span>
-    </button>
-</div>
-
-
-<div class="docs-fn-container">
-    <div><b>Icon-Only</b></div>
-    <button class="fn-button fn-button--transparent fn-button--icon-only" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--transparent fn-button--icon-only is-hover" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--transparent fn-button--icon-only is-active" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--transparent fn-button--icon-only is-focus" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--transparent fn-button--icon-only disabled" aria-label="Share" disabled>
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-</div>
-
-
-<div class="docs-fn-container">
-    <div><b>Icon-Right</b></div>
-    <button class="fn-button fn-button--transparent fn-button--icon-right">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--transparent fn-button--icon-right is-hover">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--transparent fn-button--icon-right is-active">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--transparent fn-button--icon-right is-focus">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--transparent fn-button--icon-right" disabled>
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-</div>
-
-<div class="docs-fn-container">
-    <div><b>Icon-Left</b></div>
-    <button class="fn-button fn-button--transparent fn-button--icon-left">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--transparent fn-button--icon-left is-hover">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--transparent fn-button--icon-left is-active">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--transparent fn-button--icon-left is-focus">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--transparent fn-button--icon-left" disabled>
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-</div>
-`;
-
-transparent.storyName = 'Transparent (Layout) Button';
-
-transparent.parameters = {
-    docs: {
-        iframeHeight: 500,
-        storyDescription: 'Add the `.fn-button--transparent` modifier class to `.fn-button` for transparent button.'
-    }
-};
-
-export const accept = () => `${localStyles}
-<div class="docs-fn-container">
-    <div></div>
-    <div><b>Rest</b></div>
-    <div><b>Hover</b></div>
-    <div><b>Active</b></div>
-    <div><b>Focus</b></div>
-    <div><b>Disabled</b></div>
-</div>
-
-<div class="docs-fn-container">
-    <div><b>No-Icon</b></div>
+    <div><b>:normal</b></div>
     <button class="fn-button fn-button--accept">
         <span class="fn-button__text">Button</span>
     </button>
-    <button class="fn-button fn-button--accept is-hover">
-        <span class="fn-button__text">Button</span>
-    </button>
-    <button class="fn-button fn-button--accept is-active">
-        <span class="fn-button__text">Button</span>
-    </button>
-    <button class="fn-button fn-button--accept is-focus">
-        <span class="fn-button__text">Button</span>
-    </button>
-    <button class="fn-button fn-button--accept" disabled>
-        <span class="fn-button__text">Button</span>
-    </button>
-</div>
-
-
-<div class="docs-fn-container">
-    <div><b>Icon-Only</b></div>
-    <button class="fn-button fn-button--accept fn-button--icon-only" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--accept fn-button--icon-only is-hover" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--accept fn-button--icon-only is-active" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--accept fn-button--icon-only is-focus" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--accept fn-button--icon-only disabled" aria-label="Share" disabled>
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-</div>
-
-
-<div class="docs-fn-container">
-    <div><b>Icon-Right</b></div>
-    <button class="fn-button fn-button--accept fn-button--icon-right">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--accept fn-button--icon-right is-hover">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--accept fn-button--icon-right is-active">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--accept fn-button--icon-right is-focus">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--accept fn-button--icon-right" disabled>
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-</div>
-
-<div class="docs-fn-container">
-    <div><b>Icon-Left</b></div>
-    <button class="fn-button fn-button--accept fn-button--icon-left">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--accept fn-button--icon-left is-hover">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--accept fn-button--icon-left is-active">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--accept fn-button--icon-left is-focus">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--accept fn-button--icon-left" disabled>
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-</div>
-`;
-
-accept.storyName = 'Accept (Semantic) Button';
-
-accept.parameters = {
-    docs: {
-        iframeHeight: 500,
-        storyDescription: 'Add the `.fn-button--accept` modifier class to `.fn-button` for Accept button.'
-    }
-};
-
-export const success = () => `${localStyles}
-<div class="docs-fn-container">
-    <div></div>
-    <div><b>Rest</b></div>
-    <div><b>Hover</b></div>
-    <div><b>Active</b></div>
-    <div><b>Focus</b></div>
-    <div><b>Disabled</b></div>
-</div>
-
-<div class="docs-fn-container">
-    <div><b>No-Icon</b></div>
     <button class="fn-button fn-button--success">
+        <span class="fn-button__text">Button</span>
+    </button>
+    <button class="fn-button fn-button--attention">
+        <span class="fn-button__text">Button</span>
+    </button>
+    <button class="fn-button fn-button--critical">
+        <span class="fn-button__text">Button</span>
+    </button>
+    <button class="fn-button fn-button--reject">
+        <span class="fn-button__text">Button</span>
+    </button>
+    <button class="fn-button fn-button--negative">
+        <span class="fn-button__text">Button</span>
+    </button>
+</div>
+
+<div class="docs-fn-container">
+    <div><b>:hover</b></div>
+    <button class="fn-button fn-button--accept is-hover">
         <span class="fn-button__text">Button</span>
     </button>
     <button class="fn-button fn-button--success is-hover">
         <span class="fn-button__text">Button</span>
     </button>
-    <button class="fn-button fn-button--success is-active">
-        <span class="fn-button__text">Button</span>
-    </button>
-    <button class="fn-button fn-button--success is-focus">
-        <span class="fn-button__text">Button</span>
-    </button>
-    <button class="fn-button fn-button--success" disabled>
-        <span class="fn-button__text">Button</span>
-    </button>
-</div>
-
-
-<div class="docs-fn-container">
-    <div><b>Icon-Only</b></div>
-    <button class="fn-button fn-button--success fn-button--icon-only" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--success fn-button--icon-only is-hover" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--success fn-button--icon-only is-active" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--success fn-button--icon-only is-focus" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--success fn-button--icon-only disabled" aria-label="Share" disabled>
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-</div>
-
-
-<div class="docs-fn-container">
-    <div><b>Icon-Right</b></div>
-    <button class="fn-button fn-button--success fn-button--icon-right">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--success fn-button--icon-right is-hover">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--success fn-button--icon-right is-active">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--success fn-button--icon-right is-focus">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--success fn-button--icon-right" disabled>
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-</div>
-
-<div class="docs-fn-container">
-    <div><b>Icon-Left</b></div>
-    <button class="fn-button fn-button--success fn-button--icon-left">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--success fn-button--icon-left is-hover">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--success fn-button--icon-left is-active">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--success fn-button--icon-left is-focus">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--success fn-button--icon-left" disabled>
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-</div>
-`;
-
-success.storyName = 'Success (Semantic) Button';
-
-success.parameters = {
-    docs: {
-        iframeHeight: 500,
-        storyDescription: 'Add the `.fn-button--success` modifier class to `.fn-button` for success button.'
-    }
-};
-
-export const attention = () => `${localStyles}
-<div class="docs-fn-container">
-    <div></div>
-    <div><b>Rest</b></div>
-    <div><b>Hover</b></div>
-    <div><b>Active</b></div>
-    <div><b>Focus</b></div>
-    <div><b>Disabled</b></div>
-</div>
-
-<div class="docs-fn-container">
-    <div><b>No-Icon</b></div>
-    <button class="fn-button fn-button--attention">
-        <span class="fn-button__text">Button</span>
-    </button>
     <button class="fn-button fn-button--attention is-hover">
-        <span class="fn-button__text">Button</span>
-    </button>
-    <button class="fn-button fn-button--attention is-active">
-        <span class="fn-button__text">Button</span>
-    </button>
-    <button class="fn-button fn-button--attention is-focus">
-        <span class="fn-button__text">Button</span>
-    </button>
-    <button class="fn-button fn-button--attention" disabled>
-        <span class="fn-button__text">Button</span>
-    </button>
-</div>
-
-
-<div class="docs-fn-container">
-    <div><b>Icon-Only</b></div>
-    <button class="fn-button fn-button--attention fn-button--icon-only" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--attention fn-button--icon-only is-hover" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--attention fn-button--icon-only is-active" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--attention fn-button--icon-only is-focus" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--attention fn-button--icon-only disabled" aria-label="Share" disabled>
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-</div>
-
-
-<div class="docs-fn-container">
-    <div><b>Icon-Right</b></div>
-    <button class="fn-button fn-button--attention fn-button--icon-right">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--attention fn-button--icon-right is-hover">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--attention fn-button--icon-right is-active">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--attention fn-button--icon-right is-focus">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--attention fn-button--icon-right" disabled>
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-</div>
-
-<div class="docs-fn-container">
-    <div><b>Icon-Left</b></div>
-    <button class="fn-button fn-button--attention fn-button--icon-left">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--attention fn-button--icon-left is-hover">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--attention fn-button--icon-left is-active">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--attention fn-button--icon-left is-focus">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--attention fn-button--icon-left" disabled>
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-</div>
-`;
-
-attention.storyName = 'Attention (Semantic) Button';
-
-attention.parameters = {
-    docs: {
-        iframeHeight: 500,
-        storyDescription: 'Add the `.fn-button--attention` modifier class to `.fn-button` for attention button.'
-    }
-};
-
-export const critical = () => `${localStyles}
-<div class="docs-fn-container">
-    <div></div>
-    <div><b>Rest</b></div>
-    <div><b>Hover</b></div>
-    <div><b>Active</b></div>
-    <div><b>Focus</b></div>
-    <div><b>Disabled</b></div>
-</div>
-
-<div class="docs-fn-container">
-    <div><b>No-Icon</b></div>
-    <button class="fn-button fn-button--critical">
         <span class="fn-button__text">Button</span>
     </button>
     <button class="fn-button fn-button--critical is-hover">
         <span class="fn-button__text">Button</span>
     </button>
-    <button class="fn-button fn-button--critical is-active">
-        <span class="fn-button__text">Button</span>
-    </button>
-    <button class="fn-button fn-button--critical is-focus">
-        <span class="fn-button__text">Button</span>
-    </button>
-    <button class="fn-button fn-button--critical" disabled>
-        <span class="fn-button__text">Button</span>
-    </button>
-</div>
-
-
-<div class="docs-fn-container">
-    <div><b>Icon-Only</b></div>
-    <button class="fn-button fn-button--critical fn-button--icon-only" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--critical fn-button--icon-only is-hover" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--critical fn-button--icon-only is-active" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--critical fn-button--icon-only is-focus" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--critical fn-button--icon-only disabled" aria-label="Share" disabled>
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-</div>
-
-
-<div class="docs-fn-container">
-    <div><b>Icon-Right</b></div>
-    <button class="fn-button fn-button--critical fn-button--icon-right">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--critical fn-button--icon-right is-hover">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--critical fn-button--icon-right is-active">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--critical fn-button--icon-right is-focus">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--critical fn-button--icon-right" disabled>
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-</div>
-
-<div class="docs-fn-container">
-    <div><b>Icon-Left</b></div>
-    <button class="fn-button fn-button--critical fn-button--icon-left">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--critical fn-button--icon-left is-hover">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--critical fn-button--icon-left is-active">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--critical fn-button--icon-left is-focus">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--critical fn-button--icon-left" disabled>
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-</div>
-`;
-
-critical.storyName = 'Critical (Semantic) Button';
-
-critical.parameters = {
-    docs: {
-        iframeHeight: 500,
-        storyDescription: 'Add the `.fn-button--critical` modifier class to `.fn-button` for critical button.'
-    }
-};
-
-export const reject = () => `${localStyles}
-<div class="docs-fn-container">
-    <div></div>
-    <div><b>Rest</b></div>
-    <div><b>Hover</b></div>
-    <div><b>Active</b></div>
-    <div><b>Focus</b></div>
-    <div><b>Disabled</b></div>
-</div>
-
-<div class="docs-fn-container">
-    <div><b>No-Icon</b></div>
-    <button class="fn-button fn-button--reject">
-        <span class="fn-button__text">Button</span>
-    </button>
     <button class="fn-button fn-button--reject is-hover">
-        <span class="fn-button__text">Button</span>
-    </button>
-    <button class="fn-button fn-button--reject is-active">
-        <span class="fn-button__text">Button</span>
-    </button>
-    <button class="fn-button fn-button--reject is-focus">
-        <span class="fn-button__text">Button</span>
-    </button>
-    <button class="fn-button fn-button--reject" disabled>
-        <span class="fn-button__text">Button</span>
-    </button>
-</div>
-
-
-<div class="docs-fn-container">
-    <div><b>Icon-Only</b></div>
-    <button class="fn-button fn-button--reject fn-button--icon-only" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--reject fn-button--icon-only is-hover" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--reject fn-button--icon-only is-active" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--reject fn-button--icon-only is-focus" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--reject fn-button--icon-only disabled" aria-label="Share" disabled>
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-</div>
-
-
-<div class="docs-fn-container">
-    <div><b>Icon-Right</b></div>
-    <button class="fn-button fn-button--reject fn-button--icon-right">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--reject fn-button--icon-right is-hover">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--reject fn-button--icon-right is-active">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--reject fn-button--icon-right is-focus">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--reject fn-button--icon-right" disabled>
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-</div>
-
-<div class="docs-fn-container">
-    <div><b>Icon-Left</b></div>
-    <button class="fn-button fn-button--reject fn-button--icon-left">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--reject fn-button--icon-left is-hover">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--reject fn-button--icon-left is-active">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--reject fn-button--icon-left is-focus">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--reject fn-button--icon-left" disabled>
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-</div>
-`;
-
-reject.storyName = 'Reject (Semantic) Button';
-
-reject.parameters = {
-    docs: {
-        iframeHeight: 500,
-        storyDescription: 'Add the `.fn-button--reject` modifier class to `.fn-button` for reject button.'
-    }
-};
-
-export const negative = () => `${localStyles}
-<div class="docs-fn-container">
-    <div></div>
-    <div><b>Rest</b></div>
-    <div><b>Hover</b></div>
-    <div><b>Active</b></div>
-    <div><b>Focus</b></div>
-    <div><b>Disabled</b></div>
-</div>
-
-<div class="docs-fn-container">
-    <div><b>No-Icon</b></div>
-    <button class="fn-button fn-button--negative">
         <span class="fn-button__text">Button</span>
     </button>
     <button class="fn-button fn-button--negative is-hover">
         <span class="fn-button__text">Button</span>
     </button>
+</div>
+
+<div class="docs-fn-container">
+    <div><b>:active</b></div>
+    <button class="fn-button fn-button--accept is-active">
+        <span class="fn-button__text">Button</span>
+    </button>
+    <button class="fn-button fn-button--success is-active">
+        <span class="fn-button__text">Button</span>
+    </button>
+    <button class="fn-button fn-button--attention is-active">
+        <span class="fn-button__text">Button</span>
+    </button>
+    <button class="fn-button fn-button--critical is-active">
+        <span class="fn-button__text">Button</span>
+    </button>
+    <button class="fn-button fn-button--reject is-active">
+        <span class="fn-button__text">Button</span>
+    </button>
     <button class="fn-button fn-button--negative is-active">
         <span class="fn-button__text">Button</span>
     </button>
+</div>
+
+<div class="docs-fn-container">
+    <div><b>:focus</b></div>
+    <button class="fn-button fn-button--accept is-focus">
+        <span class="fn-button__text">Button</span>
+    </button>
+    <button class="fn-button fn-button--success is-focus">
+        <span class="fn-button__text">Button</span>
+    </button>
+    <button class="fn-button fn-button--attention is-focus">
+        <span class="fn-button__text">Button</span>
+    </button>
+    <button class="fn-button fn-button--critical is-focus">
+        <span class="fn-button__text">Button</span>
+    </button>
+    <button class="fn-button fn-button--reject is-focus">
+        <span class="fn-button__text">Button</span>
+    </button>
     <button class="fn-button fn-button--negative is-focus">
+        <span class="fn-button__text">Button</span>
+    </button>
+</div>
+
+<div class="docs-fn-container">
+    <div><b>:disabled</b></div>
+    <button class="fn-button fn-button--accept" disabled>
+        <span class="fn-button__text">Button</span>
+    </button>
+    <button class="fn-button fn-button--success" disabled>
+        <span class="fn-button__text">Button</span>
+    </button>
+    <button class="fn-button fn-button--attention" disabled>
+        <span class="fn-button__text">Button</span>
+    </button>
+    <button class="fn-button fn-button--critical" disabled>
+        <span class="fn-button__text">Button</span>
+    </button>
+    <button class="fn-button fn-button--reject" disabled>
         <span class="fn-button__text">Button</span>
     </button>
     <button class="fn-button fn-button--negative" disabled>
         <span class="fn-button__text">Button</span>
     </button>
 </div>
-
-
-<div class="docs-fn-container">
-    <div><b>Icon-Only</b></div>
-    <button class="fn-button fn-button--negative fn-button--icon-only" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--negative fn-button--icon-only is-hover" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--negative fn-button--icon-only is-active" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--negative fn-button--icon-only is-focus" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--negative fn-button--icon-only disabled" aria-label="Share" disabled>
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-</div>
-
-
-<div class="docs-fn-container">
-    <div><b>Icon-Right</b></div>
-    <button class="fn-button fn-button--negative fn-button--icon-right">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--negative fn-button--icon-right is-hover">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--negative fn-button--icon-right is-active">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--negative fn-button--icon-right is-focus">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--negative fn-button--icon-right" disabled>
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-</div>
-
-<div class="docs-fn-container">
-    <div><b>Icon-Left</b></div>
-    <button class="fn-button fn-button--negative fn-button--icon-left">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--negative fn-button--icon-left is-hover">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--negative fn-button--icon-left is-active">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--negative fn-button--icon-left is-focus">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-    <button class="fn-button fn-button--negative fn-button--icon-left" disabled>
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
-    </button>
-</div>
 `;
 
-negative.storyName = 'Negative (Semantic) Button';
+semantic.storyName = 'Semantic Buttons';
 
-negative.parameters = {
+semantic.parameters = {
     docs: {
         iframeHeight: 500,
-        storyDescription: 'Add the `.fn-button--negative` modifier class to `.fn-button` for negative button.'
+        storyDescription: `For semantic button add the appropriate modifier class to the \`.fn-button\` base class.
+
+| Style&nbsp;&nbsp;&nbsp;&nbsp;     | Modifier class           |
+| --------------------------------- | ------------------------ |
+| accept&nbsp;&nbsp;&nbsp;&nbsp;        | \`fn-button--accept\`     |
+| success&nbsp;&nbsp;&nbsp;&nbsp;       | \`fn-button--success\`    |
+| attention&nbsp;&nbsp;&nbsp;&nbsp;     | \`fn-button--attention\`  |
+| critical&nbsp;&nbsp;&nbsp;&nbsp;      | \`fn-button--critical\`   |
+| reject&nbsp;&nbsp;&nbsp;&nbsp;        | \`fn-button--reject\`     |
+| negative&nbsp;&nbsp;&nbsp;&nbsp;      | \`fn-button--negative\`   |
+        `
     }
 };
 
-export const toggled = () => `${localStyles}
+export const icon = () => `${localStyles}
 <div class="docs-fn-container">
     <div></div>
-    <div><b>Rest</b></div>
-    <div><b>Hover</b></div>
-    <div><b>Active</b></div>
-    <div><b>Focus</b></div>
-    <div><b>Disabled</b></div>
-</div>
-
-<div class="docs-fn-container">
-    <div><b>No-Icon</b></div>
-    <button class="fn-button fn-button--ghost fn-button--toggled">
-        <span class="fn-button__text">Button</span>
-    </button>
-    <button class="fn-button fn-button--ghost fn-button--toggled is-hover">
-        <span class="fn-button__text">Button</span>
-    </button>
-    <button class="fn-button fn-button--ghost fn-button--toggled is-active">
-        <span class="fn-button__text">Button</span>
-    </button>
-    <button class="fn-button fn-button--ghost fn-button--toggled is-focus">
-        <span class="fn-button__text">Button</span>
-    </button>
-    <button class="fn-button fn-button--ghost fn-button--toggled" disabled>
-        <span class="fn-button__text">Button</span>
-    </button>
-</div>
-
-
-<div class="docs-fn-container">
-    <div><b>Icon-Only</b></div>
-    <button class="fn-button fn-button--ghost fn-button--toggled fn-button--icon-only" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--ghost fn-button--toggled fn-button--icon-only is-hover" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--ghost fn-button--toggled fn-button--icon-only is-active" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--ghost fn-button--toggled fn-button--icon-only is-focus" aria-label="Share">
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-    <button class="fn-button fn-button--ghost fn-button--toggled fn-button--icon-only disabled" aria-label="Share" disabled>
-        <span class="sap-icon sap-icon--share-2"></span>
-    </button>
-</div>
-
-
-<div class="docs-fn-container">
-    <div><b>Icon-Right</b></div>
-    <button class="fn-button fn-button--ghost fn-button--toggled fn-button--icon-right">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--ghost fn-button--toggled fn-button--icon-right is-hover">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--ghost fn-button--toggled fn-button--icon-right is-active">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--ghost fn-button--toggled fn-button--icon-right is-focus">
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-    <button class="fn-button fn-button--ghost fn-button--toggled fn-button--icon-right" disabled>
-        <span class="fn-button__text">Send</span>
-        <span class="sap-icon sap-icon--paper-plane"></span>
-    </button>
-</div>
-
-<div class="docs-fn-container">
     <div><b>Icon-Left</b></div>
-    <button class="fn-button fn-button--ghost fn-button--toggled fn-button--icon-left">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
+    <div><b>Icon-Right</b></div>
+    <div><b>Icon-Only</b></div>   
+</div>
+
+<div class="docs-fn-container">
+    <div><b>:normal</b></div>
+    <button class="fn-button fn-button--icon-left">
+        <span class="sap-icon sap-icon--paper-plane"></span>
+        <span class="fn-button__text">Button</span>
     </button>
-    <button class="fn-button fn-button--ghost fn-button--toggled fn-button--icon-left is-hover">
+    <button class="fn-button fn-button--emphasized fn-button--icon-right">
+        <span class="fn-button__text">Button</span>
         <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
     </button>
-    <button class="fn-button fn-button--ghost fn-button--toggled fn-button--icon-left is-active">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
+    <button class="fn-button fn-button--transparent fn-button--icon-only" aria-label="More">
+        <span class="sap-icon sap-icon--overflow"></span>
     </button>
-    <button class="fn-button fn-button--ghost fn-button--toggled fn-button--icon-left is-focus">
-        <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
+</div>
+
+<div class="docs-fn-container">
+    <div><b>:hover</b></div>
+    <button class="fn-button fn-button--icon-left is-hover">
+        <span class="sap-icon sap-icon--paper-plane"></span>
+        <span class="fn-button__text">Button</span>
     </button>
-    <button class="fn-button fn-button--ghost fn-button--toggled fn-button--icon-left" disabled>
+    <button class="fn-button fn-button--emphasized fn-button--icon-right is-hover">
+        <span class="fn-button__text">Button</span>
         <span class="sap-icon sap-icon--share-2"></span>
-        <span class="fn-button__text">Share</span>
+    </button>
+    <button class="fn-button fn-button--transparent fn-button--icon-only is-hover" aria-label="More">
+        <span class="sap-icon sap-icon--overflow"></span>
+    </button>
+</div>
+
+<div class="docs-fn-container">
+    <div><b>:active</b></div>
+    <button class="fn-button fn-button--icon-left is-active">
+        <span class="sap-icon sap-icon--paper-plane"></span>
+        <span class="fn-button__text">Button</span>
+    </button>
+    <button class="fn-button fn-button--emphasized fn-button--icon-right is-active">
+        <span class="fn-button__text">Button</span>
+        <span class="sap-icon sap-icon--share-2"></span>
+    </button>
+    <button class="fn-button fn-button--transparent fn-button--icon-only is-active" aria-label="More">
+        <span class="sap-icon sap-icon--overflow"></span>
+    </button>
+</div>
+
+<div class="docs-fn-container">
+    <div><b>:focus</b></div>
+    <button class="fn-button fn-button--icon-left is-focus">
+        <span class="sap-icon sap-icon--paper-plane"></span>
+        <span class="fn-button__text">Button</span>
+    </button>
+    <button class="fn-button fn-button--emphasized fn-button--icon-right is-focus">
+        <span class="fn-button__text">Button</span>
+        <span class="sap-icon sap-icon--share-2"></span>
+    </button>
+    <button class="fn-button fn-button--transparent fn-button--icon-only is-focus" aria-label="More">
+        <span class="sap-icon sap-icon--overflow"></span>
+    </button>
+</div>
+
+<div class="docs-fn-container">
+    <div><b>:disabled</b></div>
+    <button class="fn-button fn-button--icon-left" disabled>
+        <span class="sap-icon sap-icon--paper-plane"></span>
+        <span class="fn-button__text">Send</span>
+    </button>
+    <button class="fn-button fn-button--emphasized fn-button--icon-right" disabled>
+        <span class="fn-button__text">Send</span>
+        <span class="sap-icon sap-icon--share-2"></span>
+    </button>
+    <button class="fn-button fn-button--transparent fn-button--icon-only" disabled aria-label="More">
+        <span class="sap-icon sap-icon--overflow"></span>
     </button>
 </div>
 `;
 
-toggled.storyName = 'Toggled Button';
+icon.storyName = 'Icon Buttons';
 
-toggled.parameters = {
+icon.parameters = {
     docs: {
         iframeHeight: 500,
-        storyDescription: 'Add the `.fn-button--toggled` modifier class to `.fn-button` for toggled button.'
+        storyDescription: `Depending on where you want the icon to be rendered add the appropriate modifier class to the \`.fn-button\` base class.
+
+| Structure&nbsp;&nbsp;&nbsp;&nbsp; | Modifier class           |
+| --------------------------------- | ------------------------ |
+| Icon-Left&nbsp;&nbsp;&nbsp;&nbsp; | \`fn-button--icon-left\` |
+| Icon-Right&nbsp;&nbsp;&nbsp;&nbsp;| \`fn-button--icon-right\`|
+| Icon-Only&nbsp;&nbsp;&nbsp;&nbsp; | \`fn-button--icon-only\` |
+`
+    }
+};
+
+export const toggle = () => `${localStyles}
+<div class="docs-fn-container">
+    <div></div>
+    <div><b>Selected </b></div>
+    <div><b>Default</b></div>   
+</div>
+
+<div class="docs-fn-container">
+    <div><b>:normal</b></div>
+    <button class="fn-button fn-button--selected">
+        <span class="fn-button__text">Button</span>
+    </button>
+    <button class="fn-button fn-button--ghost">
+        <span class="fn-button__text">Button</span>
+    </button>
+</div>
+
+<div class="docs-fn-container">
+    <div><b>:hover</b></div>
+    <button class="fn-button fn-button--selected is-hover">
+        <span class="fn-button__text">Button</span>
+    </button>
+    <button class="fn-button fn-button--ghost is-hover">
+        <span class="fn-button__text">Button</span>
+    </button>
+</div>
+
+<div class="docs-fn-container">
+    <div><b>:active</b></div>
+    <button class="fn-button fn-button--selected is-active">
+        <span class="fn-button__text">Button</span>
+    </button>
+    <button class="fn-button fn-button--ghost is-active">
+        <span class="fn-button__text">Button</span>
+    </button>
+</div>
+
+<div class="docs-fn-container">
+    <div><b>:focus</b></div>
+    <button class="fn-button fn-button--selected is-focus">
+        <span class="fn-button__text">Button</span>
+    </button>
+    <button class="fn-button fn-button--ghost is-focus">
+        <span class="fn-button__text">Button</span>
+    </button>
+</div>
+
+<div class="docs-fn-container">
+    <div><b>:disabled</b></div>
+    <button class="fn-button fn-button--selected" disabled>
+        <span class="fn-button__text">Button</span>
+    </button>
+    <button class="fn-button fn-button--ghost" disabled>
+        <span class="fn-button__text">Button</span>
+    </button>
+</div>
+`;
+
+toggle.storyName = 'Toggle Buttons';
+
+toggle.parameters = {
+    docs: {
+        iframeHeight: 500,
+        storyDescription: 'Add the `.fn-button--selected` class to the button when it is in toggled (selected) state.'
     }
 };
 

--- a/stories/fn-button/fn-button.stories.js
+++ b/stories/fn-button/fn-button.stories.js
@@ -119,7 +119,6 @@ export const primary = () => `${localStyles}
 `;
 
 primary.storyName = 'Primary Buttons';
-
 primary.parameters = {
     docs: {
         iframeHeight: 500,
@@ -202,7 +201,6 @@ export const secondary = () => `${localStyles}
 `;
 
 secondary.storyName = 'Secondary Buttons';
-
 secondary.parameters = {
     docs: {
         iframeHeight: 500,
@@ -340,7 +338,6 @@ export const semantic = () => `${localStyles}
 `;
 
 semantic.storyName = 'Semantic Buttons';
-
 semantic.parameters = {
     docs: {
         iframeHeight: 500,
@@ -443,7 +440,6 @@ export const icon = () => `${localStyles}
 `;
 
 icon.storyName = 'Icon Buttons';
-
 icon.parameters = {
     docs: {
         iframeHeight: 500,
@@ -517,7 +513,6 @@ export const toggle = () => `${localStyles}
 `;
 
 toggle.storyName = 'Toggle Buttons';
-
 toggle.parameters = {
     docs: {
         iframeHeight: 500,
@@ -638,7 +633,6 @@ export const segmented = () => `${localStyles}
 `;
 
 segmented.storyName = 'Segmented Button';
-
 segmented.parameters = {
     docs: {
         iframeHeight: 500,


### PR DESCRIPTION
## Description
Per discussion with the designers I changed the way we show the button types in the documentation

## Screenshots
### Before:
<img width="806" alt="Screen Shot 2021-11-26 at 2 17 36 PM" src="https://user-images.githubusercontent.com/39598672/143623027-65fe052e-b1f7-496b-9548-67810d4439db.png">
<img width="811" alt="Screen Shot 2021-11-26 at 2 17 44 PM" src="https://user-images.githubusercontent.com/39598672/143623028-e6f92214-c9ce-4964-9166-11dd02411f35.png">

### After:
<img width="813" alt="Screen Shot 2021-11-26 at 2 17 25 PM" src="https://user-images.githubusercontent.com/39598672/143623021-ae2d0f14-83f1-4f1d-9ba4-7c5e890abf01.png">
<img width="807" alt="Screen Shot 2021-11-26 at 2 17 18 PM" src="https://user-images.githubusercontent.com/39598672/143623023-1863bb1a-6012-4f53-9253-c4ea9a3aa915.png">

