### PR TITLE
fix(fn): update the spacing between text and icon in FN Button 

### DIFF
--- a/src/fn/fn-button.scss
+++ b/src/fn/fn-button.scss
@@ -40,7 +40,7 @@ $block: #{$fn-namespace}-button;
     line-height: $fn-element-line-height;
 
     & + .#{$block}__text {
-      @include fn-set-margin-left($fn-margin-medium);
+      @include fn-set-margin-left($fn-padding-xs);
     }
   }
 
@@ -52,7 +52,7 @@ $block: #{$fn-namespace}-button;
     line-height: 1.375rem;
 
     & + [class*='sap-icon'] {
-      @include fn-set-margin-left($fn-margin-medium);
+      @include fn-set-margin-left($fn-padding-xs);
     }
   }
 


### PR DESCRIPTION
## Description
Designers confirmed that the spacing between button text and icon is 4px (0.25rem) so now we are updating Fiori Next Button with the correct value.