### PR TITLE
fix(fn): update Radio and Checkbox to latest FN design [ci visual]

### DIFF
--- a/src/fn/_fn-mixins.scss
+++ b/src/fn/_fn-mixins.scss
@@ -121,6 +121,12 @@
   }
 }
 
+@mixin fn-display() {
+  &.is-display {
+    @content;
+  }
+}
+
 // Flex Helpers
 @mixin fn-flex($direction: row) {
   display: flex;
@@ -232,4 +238,11 @@
     left: auto;
     right: $left;
   }
+}
+
+@mixin fn-user-select() {
+  user-select: none;
+  -ms-user-select: none;
+  -moz-user-select: none;
+  -webkit-user-select: none;
 }

--- a/src/fn/_fn-new-variables.scss
+++ b/src/fn/_fn-new-variables.scss
@@ -194,3 +194,6 @@ $fn-focus-outline-shadow-cyan: 0 0 0 0.125rem #007fa9;
 $fn-focus-outline-shadow-yellow: 0 0 0 0.125rem #a16b00;
 $fn-focus-outline-shadow-crimson: 0 0 0 0.125rem #df0597;
 $fn-focus-outline-inner-shadow: inset 0 0 0 0.125rem #ffffff;
+
+// Opacity for disabled state
+$fn-disabled-opacity: 0.4;

--- a/src/fn/fn-button.scss
+++ b/src/fn/fn-button.scss
@@ -101,8 +101,8 @@ $block: #{$fn-namespace}-button;
   @include fn-disabled() {
     @include fn-button-base($fn-color-white, $fn-color-blue-500, none);
 
-    opacity: 0.4;
     cursor: not-allowed;
+    opacity: $fn-disabled-opacity;
   }
 
   &--icon-only {

--- a/src/fn/fn-checkbox.scss
+++ b/src/fn/fn-checkbox.scss
@@ -5,34 +5,27 @@ $block: #{$fn-namespace}-checkbox;
 .#{$block} {
   @include fn-reset();
   @include fn-transition();
+  @include fn-user-select();
   @include fn-flex-vertical-center();
 
   cursor: pointer;
-  padding: 0.5rem;
+  height: 1.625rem;
   width: fit-content;
   position: relative;
   display: inline-flex;
-  user-select: none;
-  -ms-user-select: none;
-  -moz-user-select: none;
-  -webkit-user-select: none;
-  height: $fn-element-height;
-  border-radius: $fn-border-radius-small;
-
-  &--group {
-    width: 100%;
-  }
+  padding: $fn-padding-xs;
+  border-radius: $fn-border-radius-xs;
 
   @include fn-hover() {
-    box-shadow: $fn-shadow-grey-medium;
+    box-shadow: $fn-shadow-grey-level-1;
   }
 
   @include fn-pressed() {
-    box-shadow: $fn-shadow-grey-xs !important;
+    box-shadow: $fn-shadow-grey-level-0 !important;
   }
 
   @include fn-active() {
-    box-shadow: $fn-shadow-grey-xs !important;
+    box-shadow: $fn-shadow-grey-level-0 !important;
   }
 
   @include fn-not-focus-visible() {
@@ -42,23 +35,43 @@ $block: #{$fn-namespace}-checkbox;
 
   @include fn-focus-visible() {
     outline: none;
-    box-shadow: $fn-shadow-blue-medium, $fn-focus-outline-shadow-blue;
+    box-shadow: $fn-focus-outline-shadow-blue;
+  }
+
+  @include fn-is-focus() {
+    outline: none;
+    box-shadow: $fn-focus-outline-shadow-blue;
   }
 
   @include fn-disabled() {
-    cursor: not-allowed;
     pointer-events: none;
+    opacity: $fn-disabled-opacity;
+  }
 
+  @include fn-readonly() {
     .#{$block}__input ~ .#{$block}__checkmark {
-      border-color: $fn-color-grey-3;
+      pointer-events: none;
+      border: 0.0625rem dashed $fn-color-grey-500;
     }
 
-    .#{$block}__input ~ .#{$block}__checkmark::after {
-      color: $fn-color-grey-3;
+    .#{$block}__input:checked ~ .#{$block}__checkmark {
+      background: $fn-color-grey-50;
+      border: 0.0625rem dashed $fn-color-grey-500;
     }
 
-    .#{$block}__input ~ .#{$block}__label {
-      color: $fn-color-grey-3;
+    .#{$block}__input:checked ~ .#{$block}__checkmark::after {
+      color: $fn-color-grey-500;
+    }
+  }
+
+  @include fn-display() {
+    .#{$block}__checkmark {
+      border-color: $fn-color-grey-700;
+    }
+
+    .#{$block}__input:checked ~ .#{$block}__checkmark {
+      background: $fn-color-grey-700;
+      border-color: $fn-color-grey-700;
     }
   }
 
@@ -73,24 +86,27 @@ $block: #{$fn-namespace}-checkbox;
     position: absolute;
 
     &:checked ~ .#{$block}__checkmark {
-      border-color: $fn-color-blue-4;
+      background: $fn-color-blue-500;
+      border-color: $fn-color-blue-500;
     }
 
     &:checked ~ .#{$block}__checkmark::after {
       opacity: 1;
     }
 
-    @include fn-disabled() {
+    @include fn-readonly() {
       & ~ .#{$block}__checkmark {
-        border-color: $fn-color-grey-3;
+        pointer-events: none;
+        border: 0.0625rem dashed $fn-color-grey-500;
       }
 
-      & ~ .#{$block}__checkmark::after {
-        color: $fn-color-grey-3;
+      &:checked ~ .#{$block}__checkmark {
+        background: $fn-color-grey-50;
+        border: 0.0625rem dashed $fn-color-grey-500;
       }
 
-      & ~ .#{$block}__label {
-        color: $fn-color-grey-3;
+      &:checked ~ .#{$block}__checkmark::after {
+        color: $fn-color-grey-500;
       }
     }
   }
@@ -103,21 +119,23 @@ $block: #{$fn-namespace}-checkbox;
     width: 1.125rem;
     height: 1.125rem;
     border-radius: 0.25rem;
-    background-color: $fn-color-base-white;
-    border: 0.125rem solid $fn-color-grey-5;
+    background-color: $fn-color-grey-50;
+    border: 0.125rem solid $fn-color-grey-500;
 
     &::after {
       opacity: 0;
       display: block;
       content: "\e05b";
       font-size: 0.75rem;
-      color: $fn-color-blue-4;
+      color: $fn-color-white;
       font-family: "SAP-icons";
     }
   }
 
   &__label {
     @include fn-reset();
-    @include fn-set-margin-left($fn-margin-medium);
+    @include fn-set-margin-left($fn-margin-xs);
+
+    color: $fn-color-grey-700;
   }
 }

--- a/src/fn/fn-fieldset.scss
+++ b/src/fn/fn-fieldset.scss
@@ -1,0 +1,26 @@
+@import "./fn-settings";
+
+$block: #{$fn-namespace}-fieldset;
+
+.#{$block} {
+  @include fn-reset();
+  @include fn-flex(column);
+
+  label:not(:last-child) {
+    margin-bottom: 0.375rem;
+  }
+
+  &--horizontal {
+    @include fn-flex(row);
+
+    label:not(:last-child) {
+      @include fn-set-margin-right($fn-margin-medium);
+    }
+  }
+
+  &--full-width {
+    label {
+      width: 100%;
+    }
+  }
+}

--- a/src/fn/fn-radio.scss
+++ b/src/fn/fn-radio.scss
@@ -5,34 +5,27 @@ $block: #{$fn-namespace}-radio;
 .#{$block} {
   @include fn-reset();
   @include fn-transition();
+  @include fn-user-select();
   @include fn-flex-vertical-center();
 
   cursor: pointer;
-  padding: 0.5rem;
+  height: 1.625rem;
   width: fit-content;
   position: relative;
   display: inline-flex;
-  user-select: none;
-  -ms-user-select: none;
-  -moz-user-select: none;
-  -webkit-user-select: none;
-  height: $fn-element-height;
-  border-radius: $fn-border-radius-large;
-
-  &--group {
-    width: 100%;
-  }
+  padding: 0.1875rem;
+  border-radius: $fn-border-radius-xs;
 
   @include fn-hover() {
-    box-shadow: $fn-shadow-grey-medium;
+    box-shadow: $fn-shadow-grey-level-1;
   }
 
   @include fn-pressed() {
-    box-shadow: $fn-shadow-grey-xs !important;
+    box-shadow: $fn-shadow-grey-level-0 !important;
   }
 
   @include fn-active() {
-    box-shadow: $fn-shadow-grey-xs !important;
+    box-shadow: $fn-shadow-grey-level-0 !important;
   }
 
   @include fn-not-focus-visible() {
@@ -42,23 +35,43 @@ $block: #{$fn-namespace}-radio;
 
   @include fn-focus-visible() {
     outline: none;
-    box-shadow: $fn-shadow-blue-medium, $fn-focus-outline-shadow-blue;
+    box-shadow: $fn-focus-outline-shadow-blue;
+  }
+
+  @include fn-is-focus() {
+    outline: none;
+    box-shadow: $fn-focus-outline-shadow-blue;
   }
 
   @include fn-disabled() {
-    cursor: not-allowed;
     pointer-events: none;
+    opacity: $fn-disabled-opacity;
+  }
 
+  @include fn-readonly() {
     .#{$block}__input ~ .#{$block}__checkmark {
-      border-color: $fn-color-grey-3;
+      pointer-events: none;
+      border: 0.0625rem dashed $fn-color-grey-500;
     }
 
-    .#{$block}__input ~ .#{$block}__checkmark::after {
-      color: $fn-color-grey-3;
+    .#{$block}__input:checked ~ .#{$block}__checkmark {
+      background: $fn-color-grey-50;
+      border: 0.0625rem dashed $fn-color-grey-500;
     }
 
-    .#{$block}__input ~ .#{$block}__label {
-      color: $fn-color-grey-3;
+    .#{$block}__input:checked ~ .#{$block}__checkmark::after {
+      background: $fn-color-grey-500;
+    }
+  }
+
+  @include fn-display() {
+    .#{$block}__checkmark {
+      border-color: $fn-color-grey-700;
+    }
+
+    .#{$block}__input:checked ~ .#{$block}__checkmark {
+      background: $fn-color-grey-700;
+      border-color: $fn-color-grey-700;
     }
   }
 
@@ -73,24 +86,27 @@ $block: #{$fn-namespace}-radio;
     position: absolute;
 
     &:checked ~ .#{$block}__checkmark {
-      border-color: $fn-color-blue-4;
+      background: $fn-color-blue-500;
+      border-color: $fn-color-blue-500;
     }
 
     &:checked ~ .#{$block}__checkmark::after {
       opacity: 1;
     }
 
-    @include fn-disabled() {
+    @include fn-readonly() {
       & ~ .#{$block}__checkmark {
-        border-color: $fn-color-grey-3;
+        pointer-events: none;
+        border: 0.0625rem dashed $fn-color-grey-500;
       }
 
-      & ~ .#{$block}__checkmark::after {
-        color: $fn-color-grey-3;
+      &:checked ~ .#{$block}__checkmark {
+        background: $fn-color-grey-50;
+        border: 0.0625rem dashed $fn-color-grey-500;
       }
 
-      & ~ .#{$block}__label {
-        color: $fn-color-grey-3;
+      &:checked ~ .#{$block}__checkmark::after {
+        background: $fn-color-grey-500;
       }
     }
   }
@@ -100,11 +116,11 @@ $block: #{$fn-namespace}-radio;
     @include fn-flex-center();
     @include fn-transition();
 
-    width: 1.125rem;
-    height: 1.125rem;
+    width: 1.25rem;
+    height: 1.25rem;
     border-radius: 50%;
-    background-color: $fn-color-base-white;
-    border: 0.125rem solid $fn-color-grey-5;
+    background-color: $fn-color-grey-50;
+    border: 0.125rem solid $fn-color-grey-500;
 
     &::after {
       opacity: 0;
@@ -114,13 +130,14 @@ $block: #{$fn-namespace}-radio;
       display: block;
       border-radius: 50%;
       font-size: 0.435rem;
-      background: $fn-color-blue-4;
-      font-family: "SAP-icons";
+      background: $fn-color-white;
     }
   }
 
   &__label {
     @include fn-reset();
-    @include fn-set-margin-left($fn-margin-medium);
+    @include fn-set-margin-left($fn-margin-xs);
+
+    color: $fn-color-grey-700;
   }
 }

--- a/src/fn/fundamental-next.scss
+++ b/src/fn/fundamental-next.scss
@@ -1,6 +1,7 @@
 // FIORI NEXT
 @import "./fn-button";
 @import "./fn-checkbox";
+@import "./fn-fieldset";
 @import "./fn-input";
 @import "./fn-radio";
 @import "./fn-search";

--- a/stories/fn-toggles/__snapshots__/fn-toggles.stories.storyshot
+++ b/stories/fn-toggles/__snapshots__/fn-toggles.stories.storyshot
@@ -7,15 +7,30 @@ exports[`Storyshots Experimental/Toggles Checkbox 1`] = `
   <style>
     
     .docs-fn-container {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+        column-gap: 0.1rem;
+        row-gap: 0.1rem;
         background: white;
-        padding: 1.5rem;
-        border-radius: 0.25rem;
-        display: flex;
-        flex-direction: column;
+        padding: 1rem;
+        justify-items: center;
+        align-items: center;
     }
 
-    .docs-fn-container label {
-        margin-bottom: 1rem;
+    .docs-fn-header-container {
+        display: flex;
+        align-items: center;
+    }
+
+    .docs-fn-header-container code {
+        margin: 0 1rem;
+    }
+
+    .docs-fn-container-group {
+        background: white;
+        padding: 1rem;
+        justify-items: center;
+        align-items: center;
     }
 
   </style>
@@ -27,6 +42,13 @@ exports[`Storyshots Experimental/Toggles Checkbox 1`] = `
   >
     
     
+    <div>
+      <b>
+        :normal
+      </b>
+    </div>
+    
+    
     <label
       class="fn-checkbox"
       tabindex="0"
@@ -34,6 +56,60 @@ exports[`Storyshots Experimental/Toggles Checkbox 1`] = `
       
         
       <input
+        aria-label="checkbox"
+        class="fn-checkbox__input"
+        tabindex="-1"
+        type="checkbox"
+      />
+      
+        
+      <span
+        class="fn-checkbox__checkmark"
+      />
+      
+        
+      <span
+        class="fn-checkbox__label"
+      >
+        Checkbox
+      </span>
+      
+    
+    </label>
+    
+
+    
+    <label
+      class="fn-checkbox"
+      tabindex="0"
+    >
+      
+        
+      <input
+        aria-label="checkbox"
+        class="fn-checkbox__input"
+        tabindex="-1"
+        type="checkbox"
+      />
+      
+        
+      <span
+        class="fn-checkbox__checkmark"
+      />
+      
+    
+    </label>
+    
+
+    
+    <label
+      class="fn-checkbox"
+      tabindex="0"
+    >
+      
+        
+      <input
+        aria-label="checkbox"
         checked="checked"
         class="fn-checkbox__input"
         tabindex="-1"
@@ -49,7 +125,7 @@ exports[`Storyshots Experimental/Toggles Checkbox 1`] = `
       <span
         class="fn-checkbox__label"
       >
-        First
+        Checkbox
       </span>
       
     
@@ -64,6 +140,46 @@ exports[`Storyshots Experimental/Toggles Checkbox 1`] = `
       
         
       <input
+        aria-label="checkbox"
+        checked="checked"
+        class="fn-checkbox__input"
+        tabindex="-1"
+        type="checkbox"
+      />
+      
+        
+      <span
+        class="fn-checkbox__checkmark"
+      />
+      
+    
+    </label>
+    
+
+  </div>
+  
+
+
+  <div
+    class="docs-fn-container"
+  >
+    
+    
+    <div>
+      <b>
+        :hover
+      </b>
+    </div>
+    
+    
+    <label
+      class="fn-checkbox is-hover"
+      tabindex="0"
+    >
+      
+        
+      <input
+        aria-label="checkbox"
         class="fn-checkbox__input"
         tabindex="-1"
         type="checkbox"
@@ -78,7 +194,7 @@ exports[`Storyshots Experimental/Toggles Checkbox 1`] = `
       <span
         class="fn-checkbox__label"
       >
-        Second
+        Checkbox
       </span>
       
     
@@ -87,12 +203,37 @@ exports[`Storyshots Experimental/Toggles Checkbox 1`] = `
 
     
     <label
-      class="fn-checkbox"
+      class="fn-checkbox is-hover"
       tabindex="0"
     >
       
         
       <input
+        aria-label="checkbox"
+        class="fn-checkbox__input"
+        tabindex="-1"
+        type="checkbox"
+      />
+      
+        
+      <span
+        class="fn-checkbox__checkmark"
+      />
+      
+    
+    </label>
+    
+
+    
+    <label
+      class="fn-checkbox is-hover"
+      tabindex="0"
+    >
+      
+        
+      <input
+        aria-label="checkbox"
+        checked="checked"
         class="fn-checkbox__input"
         tabindex="-1"
         type="checkbox"
@@ -107,13 +248,175 @@ exports[`Storyshots Experimental/Toggles Checkbox 1`] = `
       <span
         class="fn-checkbox__label"
       >
-        Third
+        Checkbox
       </span>
       
     
     </label>
     
 
+    
+    <label
+      class="fn-checkbox is-hover"
+      tabindex="0"
+    >
+      
+        
+      <input
+        aria-label="checkbox"
+        checked="checked"
+        class="fn-checkbox__input"
+        tabindex="-1"
+        type="checkbox"
+      />
+      
+        
+      <span
+        class="fn-checkbox__checkmark"
+      />
+      
+    
+    </label>
+    
+
+  </div>
+  
+
+
+  <div
+    class="docs-fn-container"
+  >
+    
+    
+    <div>
+      <b>
+        :focus
+      </b>
+    </div>
+    
+    
+    <label
+      class="fn-checkbox is-focus"
+      tabindex="0"
+    >
+      
+        
+      <input
+        aria-label="checkbox"
+        class="fn-checkbox__input"
+        tabindex="-1"
+        type="checkbox"
+      />
+      
+        
+      <span
+        class="fn-checkbox__checkmark"
+      />
+      
+        
+      <span
+        class="fn-checkbox__label"
+      >
+        Checkbox
+      </span>
+      
+    
+    </label>
+    
+
+    
+    <label
+      class="fn-checkbox is-focus"
+      tabindex="0"
+    >
+      
+        
+      <input
+        aria-label="checkbox"
+        class="fn-checkbox__input"
+        tabindex="-1"
+        type="checkbox"
+      />
+      
+        
+      <span
+        class="fn-checkbox__checkmark"
+      />
+      
+    
+    </label>
+    
+
+    
+    <label
+      class="fn-checkbox is-focus"
+      tabindex="0"
+    >
+      
+        
+      <input
+        aria-label="checkbox"
+        checked="checked"
+        class="fn-checkbox__input"
+        tabindex="-1"
+        type="checkbox"
+      />
+      
+        
+      <span
+        class="fn-checkbox__checkmark"
+      />
+      
+        
+      <span
+        class="fn-checkbox__label"
+      >
+        Checkbox
+      </span>
+      
+    
+    </label>
+    
+
+    
+    <label
+      class="fn-checkbox is-focus"
+      tabindex="0"
+    >
+      
+        
+      <input
+        aria-label="checkbox"
+        checked="checked"
+        class="fn-checkbox__input"
+        tabindex="-1"
+        type="checkbox"
+      />
+      
+        
+      <span
+        class="fn-checkbox__checkmark"
+      />
+      
+    
+    </label>
+    
+
+  </div>
+  
+
+
+  <div
+    class="docs-fn-container"
+  >
+    
+    
+    <div>
+      <b>
+        :disabled
+      </b>
+    </div>
+    
     
     <label
       class="fn-checkbox is-disabled"
@@ -121,6 +424,7 @@ exports[`Storyshots Experimental/Toggles Checkbox 1`] = `
       
         
       <input
+        aria-label="checkbox"
         class="fn-checkbox__input"
         disabled=""
         tabindex="-1"
@@ -136,8 +440,336 @@ exports[`Storyshots Experimental/Toggles Checkbox 1`] = `
       <span
         class="fn-checkbox__label"
       >
-        Fourth
+        Checkbox
       </span>
+      
+    
+    </label>
+    
+
+    
+    <label
+      class="fn-checkbox is-disabled"
+    >
+      
+        
+      <input
+        aria-label="checkbox"
+        class="fn-checkbox__input"
+        disabled=""
+        tabindex="-1"
+        type="checkbox"
+      />
+      
+        
+      <span
+        class="fn-checkbox__checkmark"
+      />
+      
+    
+    </label>
+    
+
+    
+    <label
+      class="fn-checkbox is-disabled"
+    >
+      
+        
+      <input
+        aria-label="checkbox"
+        checked="checked"
+        class="fn-checkbox__input"
+        disabled=""
+        tabindex="-1"
+        type="checkbox"
+      />
+      
+        
+      <span
+        class="fn-checkbox__checkmark"
+      />
+      
+        
+      <span
+        class="fn-checkbox__label"
+      >
+        Checkbox
+      </span>
+      
+    
+    </label>
+    
+
+    
+    <label
+      class="fn-checkbox is-disabled"
+    >
+      
+        
+      <input
+        aria-label="checkbox"
+        checked="checked"
+        class="fn-checkbox__input"
+        disabled=""
+        tabindex="-1"
+        type="checkbox"
+      />
+      
+        
+      <span
+        class="fn-checkbox__checkmark"
+      />
+      
+    
+    </label>
+    
+
+  </div>
+  
+
+
+  <div
+    class="docs-fn-container"
+  >
+    
+    
+    <div>
+      <b>
+        :read-only
+      </b>
+    </div>
+    
+    
+    <label
+      class="fn-checkbox is-readonly"
+    >
+      
+        
+      <input
+        aria-label="checkbox"
+        class="fn-checkbox__input"
+        disabled=""
+        readonly=""
+        tabindex="-1"
+        type="checkbox"
+      />
+      
+        
+      <span
+        class="fn-checkbox__checkmark"
+      />
+      
+        
+      <span
+        class="fn-checkbox__label"
+      >
+        Checkbox
+      </span>
+      
+    
+    </label>
+    
+
+    
+    <label
+      class="fn-checkbox is-readonly"
+    >
+      
+        
+      <input
+        aria-label="checkbox"
+        class="fn-checkbox__input"
+        disabled=""
+        readonly=""
+        tabindex="-1"
+        type="checkbox"
+      />
+      
+        
+      <span
+        class="fn-checkbox__checkmark"
+      />
+      
+    
+    </label>
+    
+
+    
+    <label
+      class="fn-checkbox is-readonly"
+    >
+      
+        
+      <input
+        aria-label="checkbox"
+        checked="checked"
+        class="fn-checkbox__input"
+        disabled=""
+        readonly=""
+        tabindex="-1"
+        type="checkbox"
+      />
+      
+        
+      <span
+        class="fn-checkbox__checkmark"
+      />
+      
+        
+      <span
+        class="fn-checkbox__label"
+      >
+        Checkbox
+      </span>
+      
+    
+    </label>
+    
+
+    
+    <label
+      class="fn-checkbox is-readonly"
+    >
+      
+        
+      <input
+        aria-label="checkbox"
+        checked="checked"
+        class="fn-checkbox__input"
+        disabled=""
+        readonly=""
+        tabindex="-1"
+        type="checkbox"
+      />
+      
+        
+      <span
+        class="fn-checkbox__checkmark"
+      />
+      
+    
+    </label>
+    
+
+  </div>
+  
+
+
+  <div
+    class="docs-fn-container"
+  >
+    
+    
+    <div>
+      <b>
+        :display
+      </b>
+    </div>
+    
+    
+    <label
+      class="fn-checkbox is-display"
+      tabindex="0"
+    >
+      
+        
+      <input
+        aria-label="checkbox"
+        class="fn-checkbox__input"
+        tabindex="-1"
+        type="checkbox"
+      />
+      
+        
+      <span
+        class="fn-checkbox__checkmark"
+      />
+      
+        
+      <span
+        class="fn-checkbox__label"
+      >
+        Checkbox
+      </span>
+      
+    
+    </label>
+    
+
+    
+    <label
+      class="fn-checkbox is-display"
+      tabindex="0"
+    >
+      
+        
+      <input
+        aria-label="checkbox"
+        class="fn-checkbox__input"
+        tabindex="-1"
+        type="checkbox"
+      />
+      
+        
+      <span
+        class="fn-checkbox__checkmark"
+      />
+      
+    
+    </label>
+    
+
+    
+    <label
+      class="fn-checkbox is-display"
+      tabindex="0"
+    >
+      
+        
+      <input
+        aria-label="checkbox"
+        checked="checked"
+        class="fn-checkbox__input"
+        tabindex="-1"
+        type="checkbox"
+      />
+      
+        
+      <span
+        class="fn-checkbox__checkmark"
+      />
+      
+        
+      <span
+        class="fn-checkbox__label"
+      >
+        Checkbox
+      </span>
+      
+    
+    </label>
+    
+
+    
+    <label
+      class="fn-checkbox is-display"
+      tabindex="0"
+    >
+      
+        
+      <input
+        aria-label="checkbox"
+        checked="checked"
+        class="fn-checkbox__input"
+        tabindex="-1"
+        type="checkbox"
+      />
+      
+        
+      <span
+        class="fn-checkbox__checkmark"
+      />
       
     
     </label>
@@ -156,15 +788,30 @@ exports[`Storyshots Experimental/Toggles Checkbox Group 1`] = `
   <style>
     
     .docs-fn-container {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+        column-gap: 0.1rem;
+        row-gap: 0.1rem;
         background: white;
-        padding: 1.5rem;
-        border-radius: 0.25rem;
-        display: flex;
-        flex-direction: column;
+        padding: 1rem;
+        justify-items: center;
+        align-items: center;
     }
 
-    .docs-fn-container label {
-        margin-bottom: 1rem;
+    .docs-fn-header-container {
+        display: flex;
+        align-items: center;
+    }
+
+    .docs-fn-header-container code {
+        margin: 0 1rem;
+    }
+
+    .docs-fn-container-group {
+        background: white;
+        padding: 1rem;
+        justify-items: center;
+        align-items: center;
     }
 
   </style>
@@ -172,24 +819,26 @@ exports[`Storyshots Experimental/Toggles Checkbox Group 1`] = `
 
 
   <div
-    class="docs-fn-container"
+    class="docs-fn-container-group"
   >
     
     
-    <div
-      style="width: 10rem"
+    <fieldset
+      class="fn-fieldset"
     >
       
         
       <label
-        class="fn-checkbox fn-checkbox--group"
+        class="fn-checkbox"
         tabindex="0"
       >
         
             
         <input
+          aria-label="checkbox"
           checked="checked"
           class="fn-checkbox__input"
+          name="checkbox_group"
           tabindex="-1"
           type="checkbox"
         />
@@ -209,16 +858,17 @@ exports[`Storyshots Experimental/Toggles Checkbox Group 1`] = `
         
       </label>
       
-
         
       <label
-        class="fn-checkbox fn-checkbox--group"
+        class="fn-checkbox"
         tabindex="0"
       >
         
             
         <input
+          aria-label="checkbox"
           class="fn-checkbox__input"
+          name="checkbox_group"
           tabindex="-1"
           type="checkbox"
         />
@@ -238,16 +888,17 @@ exports[`Storyshots Experimental/Toggles Checkbox Group 1`] = `
         
       </label>
       
-
         
       <label
-        class="fn-checkbox fn-checkbox--group"
+        class="fn-checkbox"
         tabindex="0"
       >
         
             
         <input
+          aria-label="checkbox"
           class="fn-checkbox__input"
+          name="checkbox_group"
           tabindex="-1"
           type="checkbox"
         />
@@ -267,16 +918,36 @@ exports[`Storyshots Experimental/Toggles Checkbox Group 1`] = `
         
       </label>
       
+    
+    </fieldset>
+    
 
+  </div>
+  
+
+
+  <div
+    class="docs-fn-container-group"
+  >
+    
+    
+    <fieldset
+      class="fn-fieldset fn-fieldset--full-width"
+      style="width: 120px;"
+    >
+      
         
       <label
-        class="fn-checkbox fn-checkbox--group is-disabled"
+        class="fn-checkbox"
+        tabindex="0"
       >
         
             
         <input
+          aria-label="checkbox"
+          checked="checked"
           class="fn-checkbox__input"
-          disabled=""
+          name="checkbox_group_width"
           tabindex="-1"
           type="checkbox"
         />
@@ -290,14 +961,182 @@ exports[`Storyshots Experimental/Toggles Checkbox Group 1`] = `
         <span
           class="fn-checkbox__label"
         >
-          Fourth
+          First
+        </span>
+        
+        
+      </label>
+      
+        
+      <label
+        class="fn-checkbox"
+        tabindex="0"
+      >
+        
+            
+        <input
+          aria-label="checkbox"
+          class="fn-checkbox__input"
+          name="checkbox_group_width"
+          tabindex="-1"
+          type="checkbox"
+        />
+        
+            
+        <span
+          class="fn-checkbox__checkmark"
+        />
+        
+            
+        <span
+          class="fn-checkbox__label"
+        >
+          Second
+        </span>
+        
+        
+      </label>
+      
+        
+      <label
+        class="fn-checkbox"
+        tabindex="0"
+      >
+        
+            
+        <input
+          aria-label="checkbox"
+          class="fn-checkbox__input"
+          name="checkbox_group_width"
+          tabindex="-1"
+          type="checkbox"
+        />
+        
+            
+        <span
+          class="fn-checkbox__checkmark"
+        />
+        
+            
+        <span
+          class="fn-checkbox__label"
+        >
+          Third
         </span>
         
         
       </label>
       
     
-    </div>
+    </fieldset>
+    
+
+  </div>
+  
+
+
+  <div
+    class="docs-fn-container-group"
+  >
+    
+    
+    <fieldset
+      class="fn-fieldset fn-fieldset--horizontal"
+    >
+      
+        
+      <label
+        class="fn-checkbox"
+        tabindex="0"
+      >
+        
+            
+        <input
+          aria-label="checkbox"
+          checked="checked"
+          class="fn-checkbox__input"
+          name="checkbox_group_horizontal"
+          tabindex="-1"
+          type="checkbox"
+        />
+        
+            
+        <span
+          class="fn-checkbox__checkmark"
+        />
+        
+            
+        <span
+          class="fn-checkbox__label"
+        >
+          Checkbox
+        </span>
+        
+        
+      </label>
+      
+        
+      <label
+        class="fn-checkbox"
+        tabindex="0"
+      >
+        
+            
+        <input
+          aria-label="checkbox"
+          class="fn-checkbox__input"
+          name="checkbox_group_horizontal"
+          tabindex="-1"
+          type="checkbox"
+        />
+        
+            
+        <span
+          class="fn-checkbox__checkmark"
+        />
+        
+            
+        <span
+          class="fn-checkbox__label"
+        >
+          Checkbox
+        </span>
+        
+        
+      </label>
+      
+        
+      <label
+        class="fn-checkbox"
+        tabindex="0"
+      >
+        
+            
+        <input
+          aria-label="checkbox"
+          class="fn-checkbox__input"
+          name="checkbox_group_horizontal"
+          tabindex="-1"
+          type="checkbox"
+        />
+        
+            
+        <span
+          class="fn-checkbox__checkmark"
+        />
+        
+            
+        <span
+          class="fn-checkbox__label"
+        >
+          Checkbox
+        </span>
+        
+        
+      </label>
+      
+    
+    </fieldset>
     
 
   </div>
@@ -313,15 +1152,30 @@ exports[`Storyshots Experimental/Toggles Radio 1`] = `
   <style>
     
     .docs-fn-container {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+        column-gap: 0.1rem;
+        row-gap: 0.1rem;
         background: white;
-        padding: 1.5rem;
-        border-radius: 0.25rem;
-        display: flex;
-        flex-direction: column;
+        padding: 1rem;
+        justify-items: center;
+        align-items: center;
     }
 
-    .docs-fn-container label {
-        margin-bottom: 1rem;
+    .docs-fn-header-container {
+        display: flex;
+        align-items: center;
+    }
+
+    .docs-fn-header-container code {
+        margin: 0 1rem;
+    }
+
+    .docs-fn-container-group {
+        background: white;
+        padding: 1rem;
+        justify-items: center;
+        align-items: center;
     }
 
   </style>
@@ -333,6 +1187,13 @@ exports[`Storyshots Experimental/Toggles Radio 1`] = `
   >
     
     
+    <div>
+      <b>
+        :normal
+      </b>
+    </div>
+    
+    
     <label
       class="fn-radio"
       tabindex="0"
@@ -340,9 +1201,62 @@ exports[`Storyshots Experimental/Toggles Radio 1`] = `
       
         
       <input
+        aria-label="radio"
+        class="fn-radio__input"
+        tabindex="-1"
+        type="radio"
+      />
+      
+        
+      <span
+        class="fn-radio__checkmark"
+      />
+      
+        
+      <span
+        class="fn-radio__label"
+      >
+        Radio Button
+      </span>
+      
+    
+    </label>
+    
+
+    
+    <label
+      class="fn-radio"
+      tabindex="0"
+    >
+      
+        
+      <input
+        aria-label="radio"
+        class="fn-radio__input"
+        tabindex="-1"
+        type="radio"
+      />
+      
+        
+      <span
+        class="fn-radio__checkmark"
+      />
+      
+    
+    </label>
+    
+
+    
+    <label
+      class="fn-radio"
+      tabindex="0"
+    >
+      
+        
+      <input
+        aria-label="radio"
         checked="checked"
         class="fn-radio__input"
-        name="radio"
         tabindex="-1"
         type="radio"
       />
@@ -356,7 +1270,7 @@ exports[`Storyshots Experimental/Toggles Radio 1`] = `
       <span
         class="fn-radio__label"
       >
-        First
+        Radio Button
       </span>
       
     
@@ -371,8 +1285,47 @@ exports[`Storyshots Experimental/Toggles Radio 1`] = `
       
         
       <input
+        aria-label="radio"
+        checked="checked"
         class="fn-radio__input"
-        name="radio"
+        tabindex="-1"
+        type="radio"
+      />
+      
+        
+      <span
+        class="fn-radio__checkmark"
+      />
+      
+    
+    </label>
+    
+
+  </div>
+  
+
+
+  <div
+    class="docs-fn-container"
+  >
+    
+    
+    <div>
+      <b>
+        :hover
+      </b>
+    </div>
+    
+    
+    <label
+      class="fn-radio is-hover"
+      tabindex="0"
+    >
+      
+        
+      <input
+        aria-label="radio"
+        class="fn-radio__input"
         tabindex="-1"
         type="radio"
       />
@@ -386,7 +1339,7 @@ exports[`Storyshots Experimental/Toggles Radio 1`] = `
       <span
         class="fn-radio__label"
       >
-        Second
+        Radio Button
       </span>
       
     
@@ -395,14 +1348,38 @@ exports[`Storyshots Experimental/Toggles Radio 1`] = `
 
     
     <label
-      class="fn-radio"
+      class="fn-radio is-hover"
       tabindex="0"
     >
       
         
       <input
+        aria-label="radio"
         class="fn-radio__input"
-        name="radio"
+        tabindex="-1"
+        type="radio"
+      />
+      
+        
+      <span
+        class="fn-radio__checkmark"
+      />
+      
+    
+    </label>
+    
+
+    
+    <label
+      class="fn-radio is-hover"
+      tabindex="0"
+    >
+      
+        
+      <input
+        aria-label="radio"
+        checked="checked"
+        class="fn-radio__input"
         tabindex="-1"
         type="radio"
       />
@@ -416,7 +1393,199 @@ exports[`Storyshots Experimental/Toggles Radio 1`] = `
       <span
         class="fn-radio__label"
       >
-        Third
+        Radio Button
+      </span>
+      
+    
+    </label>
+    
+
+    
+    <label
+      class="fn-radio is-hover"
+      tabindex="0"
+    >
+      
+        
+      <input
+        aria-label="radio"
+        checked="checked"
+        class="fn-radio__input"
+        tabindex="-1"
+        type="radio"
+      />
+      
+        
+      <span
+        class="fn-radio__checkmark"
+      />
+      
+    
+    </label>
+    
+
+  </div>
+  
+
+
+  <div
+    class="docs-fn-container"
+  >
+    
+    
+    <div>
+      <b>
+        :focus
+      </b>
+    </div>
+    
+    
+    <label
+      class="fn-radio is-focus"
+      tabindex="0"
+    >
+      
+        
+      <input
+        aria-label="radio"
+        class="fn-radio__input"
+        tabindex="-1"
+        type="radio"
+      />
+      
+        
+      <span
+        class="fn-radio__checkmark"
+      />
+      
+        
+      <span
+        class="fn-radio__label"
+      >
+        Radio Button
+      </span>
+      
+    
+    </label>
+    
+
+    
+    <label
+      class="fn-radio is-focus"
+      tabindex="0"
+    >
+      
+        
+      <input
+        aria-label="radio"
+        class="fn-radio__input"
+        tabindex="-1"
+        type="radio"
+      />
+      
+        
+      <span
+        class="fn-radio__checkmark"
+      />
+      
+    
+    </label>
+    
+
+    
+    <label
+      class="fn-radio is-focus"
+      tabindex="0"
+    >
+      
+        
+      <input
+        aria-label="radio"
+        checked="checked"
+        class="fn-radio__input"
+        tabindex="-1"
+        type="radio"
+      />
+      
+        
+      <span
+        class="fn-radio__checkmark"
+      />
+      
+        
+      <span
+        class="fn-radio__label"
+      >
+        Radio Button
+      </span>
+      
+    
+    </label>
+    
+
+    
+    <label
+      class="fn-radio is-focus"
+      tabindex="0"
+    >
+      
+        
+      <input
+        aria-label="radio"
+        checked="checked"
+        class="fn-radio__input"
+        tabindex="-1"
+        type="radio"
+      />
+      
+        
+      <span
+        class="fn-radio__checkmark"
+      />
+      
+    
+    </label>
+    
+
+  </div>
+  
+
+
+  <div
+    class="docs-fn-container"
+  >
+    
+    
+    <div>
+      <b>
+        :disabled
+      </b>
+    </div>
+    
+    
+    <label
+      class="fn-radio is-disabled"
+    >
+      
+        
+      <input
+        aria-label="radio"
+        class="fn-radio__input"
+        disabled=""
+        tabindex="-1"
+        type="radio"
+      />
+      
+        
+      <span
+        class="fn-radio__checkmark"
+      />
+      
+        
+      <span
+        class="fn-radio__label"
+      >
+        Radio Button
       </span>
       
     
@@ -430,9 +1599,33 @@ exports[`Storyshots Experimental/Toggles Radio 1`] = `
       
         
       <input
+        aria-label="radio"
         class="fn-radio__input"
         disabled=""
-        name="radio"
+        tabindex="-1"
+        type="radio"
+      />
+      
+        
+      <span
+        class="fn-radio__checkmark"
+      />
+      
+    
+    </label>
+    
+
+    
+    <label
+      class="fn-radio is-disabled"
+    >
+      
+        
+      <input
+        aria-label="radio"
+        checked="checked"
+        class="fn-radio__input"
+        disabled=""
         tabindex="-1"
         type="radio"
       />
@@ -446,8 +1639,282 @@ exports[`Storyshots Experimental/Toggles Radio 1`] = `
       <span
         class="fn-radio__label"
       >
-        Fourth
+        Radio Button
       </span>
+      
+    
+    </label>
+    
+
+    
+    <label
+      class="fn-radio is-disabled"
+    >
+      
+        
+      <input
+        aria-label="radio"
+        checked="checked"
+        class="fn-radio__input"
+        disabled=""
+        tabindex="-1"
+        type="radio"
+      />
+      
+        
+      <span
+        class="fn-radio__checkmark"
+      />
+      
+    
+    </label>
+    
+
+  </div>
+  
+
+
+  <div
+    class="docs-fn-container"
+  >
+    
+    
+    <div>
+      <b>
+        :read-only
+      </b>
+    </div>
+    
+    
+    <label
+      class="fn-radio is-readonly"
+    >
+      
+        
+      <input
+        aria-label="radio"
+        class="fn-radio__input"
+        disabled=""
+        readonly=""
+        tabindex="-1"
+        type="radio"
+      />
+      
+        
+      <span
+        class="fn-radio__checkmark"
+      />
+      
+        
+      <span
+        class="fn-radio__label"
+      >
+        Radio Button
+      </span>
+      
+    
+    </label>
+    
+
+    
+    <label
+      class="fn-radio is-readonly"
+    >
+      
+        
+      <input
+        aria-label="radio"
+        class="fn-radio__input"
+        disabled=""
+        readonly=""
+        tabindex="-1"
+        type="radio"
+      />
+      
+        
+      <span
+        class="fn-radio__checkmark"
+      />
+      
+    
+    </label>
+    
+
+    
+    <label
+      class="fn-radio is-readonly"
+    >
+      
+        
+      <input
+        aria-label="radio"
+        checked="checked"
+        class="fn-radio__input"
+        disabled=""
+        readonly=""
+        tabindex="-1"
+        type="radio"
+      />
+      
+        
+      <span
+        class="fn-radio__checkmark"
+      />
+      
+        
+      <span
+        class="fn-radio__label"
+      >
+        Radio Button
+      </span>
+      
+    
+    </label>
+    
+
+    
+    <label
+      class="fn-radio is-readonly"
+    >
+      
+        
+      <input
+        aria-label="radio"
+        checked="checked"
+        class="fn-radio__input"
+        disabled=""
+        readonly=""
+        tabindex="-1"
+        type="radio"
+      />
+      
+        
+      <span
+        class="fn-radio__checkmark"
+      />
+      
+    
+    </label>
+    
+
+  </div>
+  
+
+
+  <div
+    class="docs-fn-container"
+  >
+    
+    
+    <div>
+      <b>
+        :display
+      </b>
+    </div>
+    
+    
+    <label
+      class="fn-radio is-display"
+      tabindex="0"
+    >
+      
+        
+      <input
+        aria-label="radio"
+        class="fn-radio__input"
+        tabindex="-1"
+        type="radio"
+      />
+      
+        
+      <span
+        class="fn-radio__checkmark"
+      />
+      
+        
+      <span
+        class="fn-radio__label"
+      >
+        Radio Button
+      </span>
+      
+    
+    </label>
+    
+
+    
+    <label
+      class="fn-radio is-display"
+      tabindex="0"
+    >
+      
+        
+      <input
+        aria-label="radio"
+        class="fn-radio__input"
+        tabindex="-1"
+        type="radio"
+      />
+      
+        
+      <span
+        class="fn-radio__checkmark"
+      />
+      
+    
+    </label>
+    
+
+    
+    <label
+      class="fn-radio is-display"
+      tabindex="0"
+    >
+      
+        
+      <input
+        aria-label="radio"
+        checked="checked"
+        class="fn-radio__input"
+        tabindex="-1"
+        type="radio"
+      />
+      
+        
+      <span
+        class="fn-radio__checkmark"
+      />
+      
+        
+      <span
+        class="fn-radio__label"
+      >
+        Radio Button
+      </span>
+      
+    
+    </label>
+    
+
+    
+    <label
+      class="fn-radio is-display"
+      tabindex="0"
+    >
+      
+        
+      <input
+        aria-label="radio"
+        checked="checked"
+        class="fn-radio__input"
+        tabindex="-1"
+        type="radio"
+      />
+      
+        
+      <span
+        class="fn-radio__checkmark"
+      />
       
     
     </label>
@@ -467,15 +1934,30 @@ exports[`Storyshots Experimental/Toggles Radio Group 1`] = `
   <style>
     
     .docs-fn-container {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+        column-gap: 0.1rem;
+        row-gap: 0.1rem;
         background: white;
-        padding: 1.5rem;
-        border-radius: 0.25rem;
-        display: flex;
-        flex-direction: column;
+        padding: 1rem;
+        justify-items: center;
+        align-items: center;
     }
 
-    .docs-fn-container label {
-        margin-bottom: 1rem;
+    .docs-fn-header-container {
+        display: flex;
+        align-items: center;
+    }
+
+    .docs-fn-header-container code {
+        margin: 0 1rem;
+    }
+
+    .docs-fn-container-group {
+        background: white;
+        padding: 1rem;
+        justify-items: center;
+        align-items: center;
     }
 
   </style>
@@ -483,25 +1965,26 @@ exports[`Storyshots Experimental/Toggles Radio Group 1`] = `
 
 
   <div
-    class="docs-fn-container"
+    class="docs-fn-container-group"
   >
     
     
-    <div
-      style="width: 10rem"
+    <fieldset
+      class="fn-fieldset"
     >
       
         
       <label
-        class="fn-radio fn-radio--group"
+        class="fn-radio"
         tabindex="0"
       >
         
             
         <input
+          aria-label="radio"
           checked="checked"
           class="fn-radio__input"
-          name="radio-group"
+          name="group1"
           tabindex="-1"
           type="radio"
         />
@@ -521,17 +2004,17 @@ exports[`Storyshots Experimental/Toggles Radio Group 1`] = `
         
       </label>
       
-
         
       <label
-        class="fn-radio fn-radio--group"
+        class="fn-radio"
         tabindex="0"
       >
         
             
         <input
+          aria-label="radio"
           class="fn-radio__input"
-          name="radio-group"
+          name="group1"
           tabindex="-1"
           type="radio"
         />
@@ -551,17 +2034,17 @@ exports[`Storyshots Experimental/Toggles Radio Group 1`] = `
         
       </label>
       
-
         
       <label
-        class="fn-radio fn-radio--group"
+        class="fn-radio"
         tabindex="0"
       >
         
             
         <input
+          aria-label="radio"
           class="fn-radio__input"
-          name="radio-group"
+          name="group1"
           tabindex="-1"
           type="radio"
         />
@@ -581,17 +2064,36 @@ exports[`Storyshots Experimental/Toggles Radio Group 1`] = `
         
       </label>
       
+    
+    </fieldset>
+    
 
+  </div>
+  
+
+
+  <div
+    class="docs-fn-container-group"
+  >
+    
+    
+    <fieldset
+      class="fn-fieldset fn-fieldset--full-width"
+      style="width: 120px;"
+    >
+      
         
       <label
-        class="fn-radio fn-radio--group is-disabled"
+        class="fn-radio"
+        tabindex="0"
       >
         
             
         <input
+          aria-label="radio"
+          checked="checked"
           class="fn-radio__input"
-          disabled=""
-          name="radio-group"
+          name="group2"
           tabindex="-1"
           type="radio"
         />
@@ -605,19 +2107,186 @@ exports[`Storyshots Experimental/Toggles Radio Group 1`] = `
         <span
           class="fn-radio__label"
         >
-          Fourth
+          First
+        </span>
+        
+        
+      </label>
+      
+        
+      <label
+        class="fn-radio"
+        tabindex="0"
+      >
+        
+            
+        <input
+          aria-label="radio"
+          class="fn-radio__input"
+          name="group2"
+          tabindex="-1"
+          type="radio"
+        />
+        
+            
+        <span
+          class="fn-radio__checkmark"
+        />
+        
+            
+        <span
+          class="fn-radio__label"
+        >
+          Second
+        </span>
+        
+        
+      </label>
+      
+        
+      <label
+        class="fn-radio"
+        tabindex="0"
+      >
+        
+            
+        <input
+          aria-label="radio"
+          class="fn-radio__input"
+          name="group2"
+          tabindex="-1"
+          type="radio"
+        />
+        
+            
+        <span
+          class="fn-radio__checkmark"
+        />
+        
+            
+        <span
+          class="fn-radio__label"
+        >
+          Third
         </span>
         
         
       </label>
       
     
-    </div>
+    </fieldset>
     
 
   </div>
   
 
+
+  <div
+    class="docs-fn-container-group"
+  >
+    
+    
+    <fieldset
+      class="fn-fieldset fn-fieldset--horizontal"
+    >
+      
+        
+      <label
+        class="fn-radio"
+        tabindex="0"
+      >
+        
+            
+        <input
+          aria-label="radio"
+          checked="checked"
+          class="fn-radio__input"
+          name="group3"
+          tabindex="-1"
+          type="radio"
+        />
+        
+            
+        <span
+          class="fn-radio__checkmark"
+        />
+        
+            
+        <span
+          class="fn-radio__label"
+        >
+          Radio Button
+        </span>
+        
+        
+      </label>
+      
+        
+      <label
+        class="fn-radio"
+        tabindex="0"
+      >
+        
+            
+        <input
+          aria-label="radio"
+          class="fn-radio__input"
+          name="group3"
+          tabindex="-1"
+          type="radio"
+        />
+        
+            
+        <span
+          class="fn-radio__checkmark"
+        />
+        
+            
+        <span
+          class="fn-radio__label"
+        >
+          Radio Button
+        </span>
+        
+        
+      </label>
+      
+        
+      <label
+        class="fn-radio"
+        tabindex="0"
+      >
+        
+            
+        <input
+          aria-label="radio"
+          class="fn-radio__input"
+          name="group3"
+          tabindex="-1"
+          type="radio"
+        />
+        
+            
+        <span
+          class="fn-radio__checkmark"
+        />
+        
+            
+        <span
+          class="fn-radio__label"
+        >
+          Radio Button
+        </span>
+        
+        
+      </label>
+      
+    
+    </fieldset>
+    
+
+  </div>
+  
 
 </section>
 `;
@@ -629,15 +2298,30 @@ exports[`Storyshots Experimental/Toggles Switch 1`] = `
   <style>
     
     .docs-fn-container {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+        column-gap: 0.1rem;
+        row-gap: 0.1rem;
         background: white;
-        padding: 1.5rem;
-        border-radius: 0.25rem;
-        display: flex;
-        flex-direction: column;
+        padding: 1rem;
+        justify-items: center;
+        align-items: center;
     }
 
-    .docs-fn-container label {
-        margin-bottom: 1rem;
+    .docs-fn-header-container {
+        display: flex;
+        align-items: center;
+    }
+
+    .docs-fn-header-container code {
+        margin: 0 1rem;
+    }
+
+    .docs-fn-container-group {
+        background: white;
+        padding: 1rem;
+        justify-items: center;
+        align-items: center;
     }
 
   </style>

--- a/stories/fn-toggles/fn-toggles.stories.js
+++ b/stories/fn-toggles/fn-toggles.stories.js
@@ -4,50 +4,189 @@ export default {
         description: `
 
         `,
-        components: ['fn-checkbox', 'fn-radio', 'fn-switch']
+        components: ['fn-checkbox', 'fn-fieldset', 'fn-radio', 'fn-switch']
     }
 };
 
 const localStyles = `
 <style>
     .docs-fn-container {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+        column-gap: 0.1rem;
+        row-gap: 0.1rem;
         background: white;
-        padding: 1.5rem;
-        border-radius: 0.25rem;
-        display: flex;
-        flex-direction: column;
+        padding: 1rem;
+        justify-items: center;
+        align-items: center;
     }
 
-    .docs-fn-container label {
-        margin-bottom: 1rem;
+    .docs-fn-header-container {
+        display: flex;
+        align-items: center;
+    }
+
+    .docs-fn-header-container code {
+        margin: 0 1rem;
+    }
+
+    .docs-fn-container-group {
+        background: white;
+        padding: 1rem;
+        justify-items: center;
+        align-items: center;
     }
 </style>
 `;
 
 export const checkbox = () => `${localStyles}
 <div class="docs-fn-container">
+    <div><b>:normal</b></div>
     <label class="fn-checkbox" tabindex="0">
-        <input class="fn-checkbox__input" type="checkbox" checked="checked" tabindex="-1">
+        <input class="fn-checkbox__input" type="checkbox" tabindex="-1" aria-label="checkbox">
         <span class="fn-checkbox__checkmark"></span>
-        <span class="fn-checkbox__label">First</span>
+        <span class="fn-checkbox__label">Checkbox</span>
     </label>
 
     <label class="fn-checkbox" tabindex="0">
-        <input class="fn-checkbox__input" type="checkbox" tabindex="-1">
+        <input class="fn-checkbox__input" type="checkbox" tabindex="-1" aria-label="checkbox">
         <span class="fn-checkbox__checkmark"></span>
-        <span class="fn-checkbox__label">Second</span>
     </label>
 
     <label class="fn-checkbox" tabindex="0">
-        <input class="fn-checkbox__input" type="checkbox" tabindex="-1">
+        <input class="fn-checkbox__input" type="checkbox" checked="checked" tabindex="-1" aria-label="checkbox">
         <span class="fn-checkbox__checkmark"></span>
-        <span class="fn-checkbox__label">Third</span>
+        <span class="fn-checkbox__label">Checkbox</span>
+    </label>
+
+    <label class="fn-checkbox" tabindex="0">
+        <input class="fn-checkbox__input" type="checkbox" checked="checked" tabindex="-1" aria-label="checkbox">
+        <span class="fn-checkbox__checkmark"></span>
+    </label>
+</div>
+
+<div class="docs-fn-container">
+    <div><b>:hover</b></div>
+    <label class="fn-checkbox is-hover" tabindex="0">
+        <input class="fn-checkbox__input" type="checkbox" tabindex="-1" aria-label="checkbox">
+        <span class="fn-checkbox__checkmark"></span>
+        <span class="fn-checkbox__label">Checkbox</span>
+    </label>
+
+    <label class="fn-checkbox is-hover" tabindex="0">
+        <input class="fn-checkbox__input" type="checkbox" tabindex="-1" aria-label="checkbox">
+        <span class="fn-checkbox__checkmark"></span>
+    </label>
+
+    <label class="fn-checkbox is-hover" tabindex="0">
+        <input class="fn-checkbox__input" type="checkbox" checked="checked" tabindex="-1" aria-label="checkbox">
+        <span class="fn-checkbox__checkmark"></span>
+        <span class="fn-checkbox__label">Checkbox</span>
+    </label>
+
+    <label class="fn-checkbox is-hover" tabindex="0">
+        <input class="fn-checkbox__input" type="checkbox" checked="checked" tabindex="-1" aria-label="checkbox">
+        <span class="fn-checkbox__checkmark"></span>
+    </label>
+</div>
+
+<div class="docs-fn-container">
+    <div><b>:focus</b></div>
+    <label class="fn-checkbox is-focus" tabindex="0">
+        <input class="fn-checkbox__input" type="checkbox" tabindex="-1" aria-label="checkbox">
+        <span class="fn-checkbox__checkmark"></span>
+        <span class="fn-checkbox__label">Checkbox</span>
+    </label>
+
+    <label class="fn-checkbox is-focus" tabindex="0">
+        <input class="fn-checkbox__input" type="checkbox" tabindex="-1" aria-label="checkbox">
+        <span class="fn-checkbox__checkmark"></span>
+    </label>
+
+    <label class="fn-checkbox is-focus" tabindex="0">
+        <input class="fn-checkbox__input" type="checkbox" checked="checked" tabindex="-1" aria-label="checkbox">
+        <span class="fn-checkbox__checkmark"></span>
+        <span class="fn-checkbox__label">Checkbox</span>
+    </label>
+
+    <label class="fn-checkbox is-focus" tabindex="0">
+        <input class="fn-checkbox__input" type="checkbox" checked="checked" tabindex="-1" aria-label="checkbox">
+        <span class="fn-checkbox__checkmark"></span>
+    </label>
+</div>
+
+<div class="docs-fn-container">
+    <div><b>:disabled</b></div>
+    <label class="fn-checkbox is-disabled">
+        <input class="fn-checkbox__input" type="checkbox" tabindex="-1" aria-label="checkbox" disabled>
+        <span class="fn-checkbox__checkmark"></span>
+        <span class="fn-checkbox__label">Checkbox</span>
     </label>
 
     <label class="fn-checkbox is-disabled">
-        <input class="fn-checkbox__input" type="checkbox" disabled tabindex="-1">
+        <input class="fn-checkbox__input" type="checkbox" tabindex="-1" aria-label="checkbox" disabled>
         <span class="fn-checkbox__checkmark"></span>
-        <span class="fn-checkbox__label">Fourth</span>
+    </label>
+
+    <label class="fn-checkbox is-disabled">
+        <input class="fn-checkbox__input" type="checkbox" checked="checked" tabindex="-1" aria-label="checkbox" disabled>
+        <span class="fn-checkbox__checkmark"></span>
+        <span class="fn-checkbox__label">Checkbox</span>
+    </label>
+
+    <label class="fn-checkbox is-disabled">
+        <input class="fn-checkbox__input" type="checkbox" checked="checked" tabindex="-1" aria-label="checkbox" disabled>
+        <span class="fn-checkbox__checkmark"></span>
+    </label>
+</div>
+
+<div class="docs-fn-container">
+    <div><b>:read-only</b></div>
+    <label class="fn-checkbox is-readonly">
+        <input class="fn-checkbox__input" type="checkbox" tabindex="-1" aria-label="checkbox" readonly disabled>
+        <span class="fn-checkbox__checkmark"></span>
+        <span class="fn-checkbox__label">Checkbox</span>
+    </label>
+
+    <label class="fn-checkbox is-readonly">
+        <input class="fn-checkbox__input" type="checkbox" tabindex="-1" aria-label="checkbox" readonly disabled>
+        <span class="fn-checkbox__checkmark"></span>
+    </label>
+
+    <label class="fn-checkbox is-readonly">
+        <input class="fn-checkbox__input" type="checkbox" checked="checked" tabindex="-1" aria-label="checkbox" readonly disabled>
+        <span class="fn-checkbox__checkmark"></span>
+        <span class="fn-checkbox__label">Checkbox</span>
+    </label>
+
+    <label class="fn-checkbox is-readonly">
+        <input class="fn-checkbox__input" type="checkbox" checked="checked" tabindex="-1" aria-label="checkbox" readonly disabled>
+        <span class="fn-checkbox__checkmark"></span>
+    </label>
+</div>
+
+<div class="docs-fn-container">
+    <div><b>:display</b></div>
+    <label class="fn-checkbox is-display" tabindex="0">
+        <input class="fn-checkbox__input" type="checkbox" tabindex="-1" aria-label="checkbox">
+        <span class="fn-checkbox__checkmark"></span>
+        <span class="fn-checkbox__label">Checkbox</span>
+    </label>
+
+    <label class="fn-checkbox is-display" tabindex="0">
+        <input class="fn-checkbox__input" type="checkbox" tabindex="-1" aria-label="checkbox">
+        <span class="fn-checkbox__checkmark"></span>
+    </label>
+
+    <label class="fn-checkbox is-display" tabindex="0">
+        <input class="fn-checkbox__input" type="checkbox" checked="checked" tabindex="-1" aria-label="checkbox">
+        <span class="fn-checkbox__checkmark"></span>
+        <span class="fn-checkbox__label">Checkbox</span>
+    </label>
+
+    <label class="fn-checkbox is-display" tabindex="0">
+        <input class="fn-checkbox__input" type="checkbox" checked="checked" tabindex="-1" aria-label="checkbox">
+        <span class="fn-checkbox__checkmark"></span>
     </label>
 </div>
 `;
@@ -60,32 +199,121 @@ checkbox.parameters = {
 };
 
 export const checkboxGroup = () => `${localStyles}
-<div class="docs-fn-container">
-    <div style="width: 10rem">
-        <label class="fn-checkbox fn-checkbox--group" tabindex="0">
-            <input class="fn-checkbox__input" type="checkbox" checked="checked" tabindex="-1">
+<div class="docs-fn-container-group">
+    <fieldset class="fn-fieldset">
+        <label class="fn-checkbox" tabindex="0">
+            <input 
+                class="fn-checkbox__input" 
+                type="checkbox" 
+                name="checkbox_group" 
+                tabindex="-1" 
+                aria-label="checkbox" 
+                checked="checked"
+            >
             <span class="fn-checkbox__checkmark"></span>
             <span class="fn-checkbox__label">First</span>
         </label>
-
-        <label class="fn-checkbox fn-checkbox--group" tabindex="0">
-            <input class="fn-checkbox__input" type="checkbox" tabindex="-1">
+        <label class="fn-checkbox" tabindex="0">
+            <input 
+                class="fn-checkbox__input" 
+                type="checkbox" 
+                name="checkbox_group" 
+                tabindex="-1" 
+                aria-label="checkbox"
+            >
             <span class="fn-checkbox__checkmark"></span>
             <span class="fn-checkbox__label">Second</span>
         </label>
-
-        <label class="fn-checkbox fn-checkbox--group" tabindex="0">
-            <input class="fn-checkbox__input" type="checkbox" tabindex="-1">
+        <label class="fn-checkbox" tabindex="0">
+            <input 
+                class="fn-checkbox__input" 
+                type="checkbox" 
+                name="checkbox_group" 
+                tabindex="-1" 
+                aria-label="checkbox"
+            >
             <span class="fn-checkbox__checkmark"></span>
             <span class="fn-checkbox__label">Third</span>
         </label>
+    </fieldset>
+</div>
 
-        <label class="fn-checkbox fn-checkbox--group is-disabled">
-            <input class="fn-checkbox__input" type="checkbox" disabled tabindex="-1">
+<div class="docs-fn-container-group">
+    <fieldset class="fn-fieldset fn-fieldset--full-width" style="width: 120px;">
+        <label class="fn-checkbox" tabindex="0">
+            <input 
+                class="fn-checkbox__input" 
+                type="checkbox" 
+                name="checkbox_group_width" 
+                tabindex="-1" 
+                aria-label="checkbox" 
+                checked="checked"
+            >
             <span class="fn-checkbox__checkmark"></span>
-            <span class="fn-checkbox__label">Fourth</span>
+            <span class="fn-checkbox__label">First</span>
         </label>
-    </div>
+        <label class="fn-checkbox" tabindex="0">
+            <input 
+                class="fn-checkbox__input" 
+                type="checkbox" 
+                name="checkbox_group_width" 
+                tabindex="-1" 
+                aria-label="checkbox"
+            >
+            <span class="fn-checkbox__checkmark"></span>
+            <span class="fn-checkbox__label">Second</span>
+        </label>
+        <label class="fn-checkbox" tabindex="0">
+            <input 
+                class="fn-checkbox__input" 
+                type="checkbox" 
+                name="checkbox_group_width" 
+                tabindex="-1" 
+                aria-label="checkbox"
+            >
+            <span class="fn-checkbox__checkmark"></span>
+            <span class="fn-checkbox__label">Third</span>
+        </label>
+    </fieldset>
+</div>
+
+<div class="docs-fn-container-group">
+    <fieldset class="fn-fieldset fn-fieldset--horizontal">
+        <label class="fn-checkbox" tabindex="0">
+            <input 
+                class="fn-checkbox__input" 
+                type="checkbox" 
+                name="checkbox_group_horizontal" 
+                tabindex="-1" 
+                aria-label="checkbox" 
+                checked="checked"
+            >
+            <span class="fn-checkbox__checkmark"></span>
+            <span class="fn-checkbox__label">Checkbox</span>
+        </label>
+        <label class="fn-checkbox" tabindex="0">
+            <input 
+                class="fn-checkbox__input" 
+                type="checkbox" 
+                name="checkbox_group_horizontal" 
+                tabindex="-1" 
+                aria-label="checkbox"
+            >
+            <span class="fn-checkbox__checkmark"></span>
+            <span class="fn-checkbox__label">Checkbox</span>
+        </label>
+        <label class="fn-checkbox" tabindex="0">
+            <input 
+                class="fn-checkbox__input" 
+                type="checkbox" 
+                name="checkbox_group_horizontal" 
+                tabindex="-1" 
+                aria-label="checkbox"
+            >
+            <span class="fn-checkbox__checkmark"></span>
+            <span class="fn-checkbox__label">Checkbox</span>
+        </label>
+    </fieldset>
 </div>
 `;
 
@@ -93,34 +321,158 @@ checkboxGroup.storyName = 'Checkbox Group';
 checkboxGroup.parameters = {
     docs: {
         iframeHeight: 500,
-        storyDescription: 'By default, the width of the checkbox input is `fit-content`. Use the `.fn-checkbox--group` modifier class to make all the controls within a group the same width. In this case the checkbox control will take the width of the parent element.'
+        storyDescription: 'Use the `<fieldset>` HTML element with class `.fn-fieldset` to group checkbox controls. The controls are displayed vertically and have `fit-content` width. The `.fn-fieldset--full-width` modifier class will display the checkbox controls with the same width as the parent element. To display the controls horizontally apply the `.fn-fieldset--horizontal` modifier class.'
     }
 };
 
 export const radio = () => `${localStyles}
 <div class="docs-fn-container">
+    <div><b>:normal</b></div>
     <label class="fn-radio" tabindex="0">
-        <input class="fn-radio__input" type="radio" checked="checked" name="radio" tabindex="-1">
+        <input class="fn-radio__input" type="radio" tabindex="-1" aria-label="radio">
         <span class="fn-radio__checkmark"></span>
-        <span class="fn-radio__label">First</span>
+        <span class="fn-radio__label">Radio Button</span>
     </label>
 
     <label class="fn-radio" tabindex="0">
-        <input class="fn-radio__input" type="radio" name="radio" tabindex="-1">
+        <input class="fn-radio__input" type="radio" tabindex="-1" aria-label="radio">
         <span class="fn-radio__checkmark"></span>
-        <span class="fn-radio__label">Second</span>
     </label>
 
     <label class="fn-radio" tabindex="0">
-        <input class="fn-radio__input" type="radio" name="radio" tabindex="-1">
+        <input class="fn-radio__input" type="radio" checked="checked" tabindex="-1" aria-label="radio">
         <span class="fn-radio__checkmark"></span>
-        <span class="fn-radio__label">Third</span>
+        <span class="fn-radio__label">Radio Button</span>
+    </label>
+
+    <label class="fn-radio" tabindex="0">
+        <input class="fn-radio__input" type="radio" checked="checked" tabindex="-1" aria-label="radio">
+        <span class="fn-radio__checkmark"></span>
+    </label>
+</div>
+
+<div class="docs-fn-container">
+    <div><b>:hover</b></div>
+    <label class="fn-radio is-hover" tabindex="0">
+        <input class="fn-radio__input" type="radio" tabindex="-1" aria-label="radio">
+        <span class="fn-radio__checkmark"></span>
+        <span class="fn-radio__label">Radio Button</span>
+    </label>
+
+    <label class="fn-radio is-hover" tabindex="0">
+        <input class="fn-radio__input" type="radio" tabindex="-1" aria-label="radio">
+        <span class="fn-radio__checkmark"></span>
+    </label>
+
+    <label class="fn-radio is-hover" tabindex="0">
+        <input class="fn-radio__input" type="radio" checked="checked" tabindex="-1" aria-label="radio">
+        <span class="fn-radio__checkmark"></span>
+        <span class="fn-radio__label">Radio Button</span>
+    </label>
+
+    <label class="fn-radio is-hover" tabindex="0">
+        <input class="fn-radio__input" type="radio" checked="checked" tabindex="-1" aria-label="radio">
+        <span class="fn-radio__checkmark"></span>
+    </label>
+</div>
+
+<div class="docs-fn-container">
+    <div><b>:focus</b></div>
+    <label class="fn-radio is-focus" tabindex="0">
+        <input class="fn-radio__input" type="radio" tabindex="-1" aria-label="radio">
+        <span class="fn-radio__checkmark"></span>
+        <span class="fn-radio__label">Radio Button</span>
+    </label>
+
+    <label class="fn-radio is-focus" tabindex="0">
+        <input class="fn-radio__input" type="radio" tabindex="-1" aria-label="radio">
+        <span class="fn-radio__checkmark"></span>
+    </label>
+
+    <label class="fn-radio is-focus" tabindex="0">
+        <input class="fn-radio__input" type="radio" checked="checked" tabindex="-1" aria-label="radio">
+        <span class="fn-radio__checkmark"></span>
+        <span class="fn-radio__label">Radio Button</span>
+    </label>
+
+    <label class="fn-radio is-focus" tabindex="0">
+        <input class="fn-radio__input" type="radio" checked="checked" tabindex="-1" aria-label="radio">
+        <span class="fn-radio__checkmark"></span>
+    </label>
+</div>
+
+<div class="docs-fn-container">
+    <div><b>:disabled</b></div>
+    <label class="fn-radio is-disabled">
+        <input class="fn-radio__input" type="radio" tabindex="-1" aria-label="radio" disabled>
+        <span class="fn-radio__checkmark"></span>
+        <span class="fn-radio__label">Radio Button</span>
     </label>
 
     <label class="fn-radio is-disabled">
-        <input class="fn-radio__input" type="radio" disabled name="radio" tabindex="-1">
+        <input class="fn-radio__input" type="radio" tabindex="-1" aria-label="radio" disabled>
         <span class="fn-radio__checkmark"></span>
-        <span class="fn-radio__label">Fourth</span>
+    </label>
+
+    <label class="fn-radio is-disabled">
+        <input class="fn-radio__input" type="radio" checked="checked" tabindex="-1" aria-label="radio" disabled>
+        <span class="fn-radio__checkmark"></span>
+        <span class="fn-radio__label">Radio Button</span>
+    </label>
+
+    <label class="fn-radio is-disabled">
+        <input class="fn-radio__input" type="radio" checked="checked" tabindex="-1" aria-label="radio" disabled>
+        <span class="fn-radio__checkmark"></span>
+    </label>
+</div>
+
+<div class="docs-fn-container">
+    <div><b>:read-only</b></div>
+    <label class="fn-radio is-readonly">
+        <input class="fn-radio__input" type="radio" tabindex="-1" aria-label="radio" readonly disabled>
+        <span class="fn-radio__checkmark"></span>
+        <span class="fn-radio__label">Radio Button</span>
+    </label>
+
+    <label class="fn-radio is-readonly">
+        <input class="fn-radio__input" type="radio" tabindex="-1" aria-label="radio" readonly disabled>
+        <span class="fn-radio__checkmark"></span>
+    </label>
+
+    <label class="fn-radio is-readonly">
+        <input class="fn-radio__input" type="radio" checked="checked" tabindex="-1" aria-label="radio" readonly disabled>
+        <span class="fn-radio__checkmark"></span>
+        <span class="fn-radio__label">Radio Button</span>
+    </label>
+
+    <label class="fn-radio is-readonly">
+        <input class="fn-radio__input" type="radio" checked="checked" tabindex="-1" aria-label="radio" readonly disabled>
+        <span class="fn-radio__checkmark"></span>
+    </label>
+</div>
+
+<div class="docs-fn-container">
+    <div><b>:display</b></div>
+    <label class="fn-radio is-display" tabindex="0">
+        <input class="fn-radio__input" type="radio" tabindex="-1" aria-label="radio">
+        <span class="fn-radio__checkmark"></span>
+        <span class="fn-radio__label">Radio Button</span>
+    </label>
+
+    <label class="fn-radio is-display" tabindex="0">
+        <input class="fn-radio__input" type="radio" tabindex="-1" aria-label="radio">
+        <span class="fn-radio__checkmark"></span>
+    </label>
+
+    <label class="fn-radio is-display" tabindex="0">
+        <input class="fn-radio__input" type="radio" checked="checked" tabindex="-1" aria-label="radio">
+        <span class="fn-radio__checkmark"></span>
+        <span class="fn-radio__label">Radio Button</span>
+    </label>
+
+    <label class="fn-radio is-display" tabindex="0">
+        <input class="fn-radio__input" type="radio" checked="checked" tabindex="-1" aria-label="radio">
+        <span class="fn-radio__checkmark"></span>
     </label>
 </div>
 
@@ -134,41 +486,72 @@ radio.parameters = {
 };
 
 export const radioGroup = () => `${localStyles}
-<div class="docs-fn-container">
-    <div style="width: 10rem">
-        <label class="fn-radio fn-radio--group" tabindex="0">
-            <input class="fn-radio__input" type="radio" checked="checked" name="radio-group" tabindex="-1">
+<div class="docs-fn-container-group">
+    <fieldset class="fn-fieldset">
+        <label class="fn-radio" tabindex="0">
+            <input class="fn-radio__input" type="radio" tabindex="-1" aria-label="radio"  checked="checked" name="group1">
             <span class="fn-radio__checkmark"></span>
             <span class="fn-radio__label">First</span>
         </label>
-
-        <label class="fn-radio fn-radio--group" tabindex="0">
-            <input class="fn-radio__input" type="radio" name="radio-group" tabindex="-1">
+        <label class="fn-radio" tabindex="0">
+            <input class="fn-radio__input" type="radio" tabindex="-1" aria-label="radio" name="group1">
             <span class="fn-radio__checkmark"></span>
             <span class="fn-radio__label">Second</span>
         </label>
-
-        <label class="fn-radio fn-radio--group" tabindex="0">
-            <input class="fn-radio__input" type="radio" name="radio-group" tabindex="-1">
+        <label class="fn-radio" tabindex="0">
+            <input class="fn-radio__input" type="radio" tabindex="-1" aria-label="radio" name="group1">
             <span class="fn-radio__checkmark"></span>
             <span class="fn-radio__label">Third</span>
         </label>
-
-        <label class="fn-radio fn-radio--group is-disabled">
-            <input class="fn-radio__input" type="radio" disabled name="radio-group" tabindex="-1">
-            <span class="fn-radio__checkmark"></span>
-            <span class="fn-radio__label">Fourth</span>
-        </label>
-    </div>
+    </fieldset>
 </div>
 
+<div class="docs-fn-container-group">
+    <fieldset class="fn-fieldset fn-fieldset--full-width" style="width: 120px;">
+        <label class="fn-radio" tabindex="0">
+            <input class="fn-radio__input" type="radio" tabindex="-1" aria-label="radio"  checked="checked" name="group2">
+            <span class="fn-radio__checkmark"></span>
+            <span class="fn-radio__label">First</span>
+        </label>
+        <label class="fn-radio" tabindex="0">
+            <input class="fn-radio__input" type="radio" tabindex="-1" aria-label="radio" name="group2">
+            <span class="fn-radio__checkmark"></span>
+            <span class="fn-radio__label">Second</span>
+        </label>
+        <label class="fn-radio" tabindex="0">
+            <input class="fn-radio__input" type="radio" tabindex="-1" aria-label="radio" name="group2">
+            <span class="fn-radio__checkmark"></span>
+            <span class="fn-radio__label">Third</span>
+        </label>
+    </fieldset>
+</div>
+
+<div class="docs-fn-container-group">
+    <fieldset class="fn-fieldset fn-fieldset--horizontal">
+        <label class="fn-radio" tabindex="0">
+            <input class="fn-radio__input" type="radio" tabindex="-1" aria-label="radio"  checked="checked" name="group3">
+            <span class="fn-radio__checkmark"></span>
+            <span class="fn-radio__label">Radio Button</span>
+        </label>
+        <label class="fn-radio" tabindex="0">
+            <input class="fn-radio__input" type="radio" tabindex="-1" aria-label="radio" name="group3">
+            <span class="fn-radio__checkmark"></span>
+            <span class="fn-radio__label">Radio Button</span>
+        </label>
+        <label class="fn-radio" tabindex="0">
+            <input class="fn-radio__input" type="radio" tabindex="-1" aria-label="radio" name="group3">
+            <span class="fn-radio__checkmark"></span>
+            <span class="fn-radio__label">Radio Button</span>
+        </label>
+    </fieldset>
+</div>
 `;
 
 radioGroup.storyName = 'Radio Group';
 radioGroup.parameters = {
     docs: {
         iframeHeight: 500,
-        storyDescription: 'By default, the width of the radio input is `fit-content`. Use the `.fn-radio--group` modifier class to make all the controls within a group the same width. In this case the radio control will take the width of the parent element.'
+        storyDescription: 'Use the `<fieldset>` HTML element with class `.fn-fieldset` to group radio button controls. The controls are displayed vertically and have `fit-content` width. The `.fn-fieldset--full-width` modifier class will display the radio buttons with the same width as the parent element. To display the controls horizontally apply the `.fn-fieldset--horizontal` modifier class.'
     }
 };
 


### PR DESCRIPTION
## Description
- update Radio buttons and Checkbox to latest Fiori Next design
- introduce `read-only` and `display` states
- introduce a new class `.fn-fieldset`  for the `<fieldset>` wrapper to form Radio group and Checkbox group. 

BREAKING CHANGE:
`.fn-checkbox--group` modifier class is no longer used for checkbox and radio button groups.
New markup for checkbox and radio button groups.

Before:
```
<div style="width: 10rem">
    <label class="fn-checkbox fn-checkbox--group" tabindex="0">
      <input class="fn-checkbox__input" type="checkbox" checked="checked" tabindex="-1">
      <span class="fn-checkbox__checkmark"></span>
      <span class="fn-checkbox__label">First</span>
    </label>
    <label class="fn-checkbox fn-checkbox--group" tabindex="0">
      <input class="fn-checkbox__input" type="checkbox" tabindex="-1">
      <span class="fn-checkbox__checkmark"></span>
      <span class="fn-checkbox__label">Second</span>
    </label>
  </div>
```

After:
```
<fieldset class="fn-fieldset">
    <label class="fn-checkbox" tabindex="0">
      <input class="fn-checkbox__input" type="checkbox" name="checkbox_group" tabindex="-1" aria-label="checkbox" checked="checked">
      <span class="fn-checkbox__checkmark"></span>
      <span class="fn-checkbox__label">First</span>
    </label>
    <label class="fn-checkbox" tabindex="0">
      <input class="fn-checkbox__input" type="checkbox" name="checkbox_group" tabindex="-1" aria-label="checkbox">
      <span class="fn-checkbox__checkmark"></span>
      <span class="fn-checkbox__label">Second</span>
    </label>
  </fieldset>
```