### PR TITLE
fix(styles): fix issues with progress indicator overflow text wrapping

### DIFF
--- a/src/styles/progress-indicator.scss
+++ b/src/styles/progress-indicator.scss
@@ -100,8 +100,9 @@ $fd-progress-indicator-states: (
 
     @include fd-set-padding-left(0.5rem);
 
-    line-height: 1;
+    max-width: 95vw;
     overflow: hidden;
+    white-space: normal;
   }
 
   &__overflow-close {


### PR DESCRIPTION
Small fixes that enable correct overflow behavior for the progress indicator text, mostly on small screens.

Before:
<img width="298" alt="Screen Shot 2021-11-29 at 3 38 39 PM" src="https://user-images.githubusercontent.com/2471874/143939595-704de766-6aec-489c-989f-c0df1e7e5395.png">

After:
<img width="303" alt="Screen Shot 2021-11-29 at 3 37 31 PM" src="https://user-images.githubusercontent.com/2471874/143939413-c1ed378f-b486-451a-a9a7-f313d4b31969.png">