### PR TITLE
fix: rating-indicator styles [ci visual]

### DIFF
--- a/src/styles/rating-indicator.scss
+++ b/src/styles/rating-indicator.scss
@@ -3,11 +3,6 @@
 
 $block: #{$fd-namespace}-rating-indicator;
 
-:root {
-  --sapRating-indicator-icon-rated: none;
-  --sapRating-indicator-icon-unrated: none;
-}
-
 .#{$block} {
   $fd-rating-indicator-sizes: (
     "cozy": ("fontSize": 1.5rem, "spacingBetweenIcons": 0.1875rem, "controlMargin": 0.8125rem 0),
@@ -33,7 +28,7 @@ $block: #{$fd-namespace}-rating-indicator;
     .#{$block}__label {
       margin-right: 0;
 
-      &:nth-child(4n+4) {
+      &:nth-child(4n+6) {
         margin-right: $spacingBetweenIcons;
         flex-direction: row-reverse;
 
@@ -52,20 +47,12 @@ $block: #{$fd-namespace}-rating-indicator;
       }
 
       overflow: hidden;
-      width: $iconFontSize / 2 !important;
+      width: $iconFontSize / 2;
     }
 
-    &.#{$block}--icon .#{$block}__label {
-      @include fd-rtl() {
-        background-position: right;
-      }
-
-      &:nth-child(4n+4) {
-        background-position: right;
-
-        @include fd-rtl() {
-          background-position: left;
-        }
+    &.#{$block}--icon {
+      .#{$block}__label {
+        width: $iconFontSize / 2;
       }
     }
   }
@@ -158,7 +145,7 @@ $block: #{$fd-namespace}-rating-indicator;
     margin-left: $fd-rating-indicator-dynamic-text-space;
   }
 
-  &__hide-dynamic-text {
+  &--hide-dynamic-text {
     > .#{$block}__dynamic-text {
       display: none;
     }
@@ -177,8 +164,7 @@ $block: #{$fd-namespace}-rating-indicator;
       }
     }
 
-    .fd-rating-indicator__dynamic-text,
-    .#{$block}___dynamic-text {
+    .#{$block}__dynamic-text {
       margin-left: 0;
       margin-right: $fd-rating-indicator-dynamic-text-space;
     }
@@ -228,8 +214,16 @@ $block: #{$fd-namespace}-rating-indicator;
     }
   }
 
-  &--half-star {
+  &.#{$block}--half-star {
     @include fd-rating-indicator-with-half-star($fd-rating-indicator-default-font-size, $fd-rating-indicator-default-spacing-between-icons);
+  }
+
+  .#{$block}__label.#{$block}__zero-rating {
+    padding: 0 !important;
+    margin: 0 !important;
+    width: 0 !important;
+    overflow: hidden !important;
+    opacity: 0.0001 !important;
   }
 
   &.#{$block}--icon {
@@ -241,14 +235,27 @@ $block: #{$fd-namespace}-rating-indicator;
 
       width: $fd-rating-indicator-default-font-size;
       height: $fd-rating-indicator-default-font-size;
-      background-image: var(--sapRating-indicator-icon-rated);
-      background-size: cover;
-      background-position: left;
-      background-repeat: no-repeat;
+
+      .rated,
+      .unrated {
+        font-size: $fd-rating-indicator-default-font-size;
+        height: 100%;
+        line-height: 100%;
+      }
+
+      .unrated {
+        display: none;
+      }
     }
 
     @include fd-rating-indicator-labels-after-checked() {
-      background-image: var(--sapRating-indicator-icon-unrated);
+      .rated {
+        display: none;
+      }
+
+      .unrated {
+        display: block;
+      }
     }
   }
 
@@ -279,6 +286,7 @@ $block: #{$fd-namespace}-rating-indicator;
 
         &::before {
           font-size: $fd-rating-indicator-sizes-font-size;
+          line-height: $fd-rating-indicator-sizes-font-size;
         }
 
         &:last-child {
@@ -292,14 +300,19 @@ $block: #{$fd-namespace}-rating-indicator;
         }
       }
 
-      &--half-star {
+      &.#{$block}--half-star {
         @include fd-rating-indicator-with-half-star($fd-rating-indicator-sizes-font-size, $fd-rating-indicator-sizes-spacing-between-icons);
       }
 
       &.#{$block}--icon {
         .#{$block}__label {
-          width: $fd-rating-indicator-default-font-size;
-          height: $fd-rating-indicator-default-font-size;
+          width: $fd-rating-indicator-sizes-font-size;
+          height: $fd-rating-indicator-sizes-font-size;
+
+          .rated,
+          .unrated {
+            font-size: $fd-rating-indicator-sizes-font-size;
+          }
         }
       }
     }

--- a/src/styles/rating-indicator.scss
+++ b/src/styles/rating-indicator.scss
@@ -20,39 +20,41 @@ $block: #{$fd-namespace}-rating-indicator;
   $fd-rating-indicator-dynamic-text-space: 0.5rem;
 
   @mixin fd-rating-indicator-with-half-star($iconFontSize, $spacingBetweenIcons) {
-    .#{$block}__input {
-      width: $iconFontSize / 2;
-      height: $iconFontSize;
-    }
+    .#{$block} {
+      &__input {
+        width: $iconFontSize * 0.5;
+        height: $iconFontSize;
+      }
 
-    .#{$block}__label {
-      margin-right: 0;
+      &__label {
+        margin-right: 0;
 
-      &:nth-child(4n+6) {
-        margin-right: $spacingBetweenIcons;
-        flex-direction: row-reverse;
+        &:nth-child(4n+6) {
+          margin-right: $spacingBetweenIcons;
+          flex-direction: row-reverse;
 
-        @include fd-rtl() {
-          margin-right: 0;
-          margin-left: $spacingBetweenIcons;
+          @include fd-rtl() {
+            margin-right: 0;
+            margin-left: $spacingBetweenIcons;
 
-          &:last-child {
-            margin-left: 0;
+            &:last-child {
+              margin-left: 0;
+            }
           }
         }
+
+        &:last-child {
+          margin-right: 0;
+        }
+
+        overflow: hidden;
+        width: $iconFontSize * 0.5;
       }
 
-      &:last-child {
-        margin-right: 0;
-      }
-
-      overflow: hidden;
-      width: $iconFontSize / 2;
-    }
-
-    &.#{$block}--icon {
-      .#{$block}__label {
-        width: $iconFontSize / 2;
+      &--icon {
+        .#{$block}__label {
+          width: $iconFontSize * 0.5;
+        }
       }
     }
   }
@@ -187,7 +189,7 @@ $block: #{$fd-namespace}-rating-indicator;
     }
   }
 
-  &.#{$block}--display-mode {
+  &--display-mode {
     .#{$block}__label {
       margin-right: 0.125rem;
 
@@ -203,8 +205,8 @@ $block: #{$fd-namespace}-rating-indicator;
     }
   }
 
-  &.#{$block}--non-interactive,
-  &.#{$block}--display-mode {
+  &--non-interactive,
+  &--display-mode {
     pointer-events: none;
 
     @include fd-rating-indicator-labels-after-checked() {
@@ -214,19 +216,7 @@ $block: #{$fd-namespace}-rating-indicator;
     }
   }
 
-  &.#{$block}--half-star {
-    @include fd-rating-indicator-with-half-star($fd-rating-indicator-default-font-size, $fd-rating-indicator-default-spacing-between-icons);
-  }
-
-  .#{$block}__label.#{$block}__zero-rating {
-    padding: 0 !important;
-    margin: 0 !important;
-    width: 0 !important;
-    overflow: hidden !important;
-    opacity: 0.0001 !important;
-  }
-
-  &.#{$block}--icon {
+  &--icon {
     .#{$block}__label {
       &::after,
       &::before {
@@ -236,25 +226,27 @@ $block: #{$fd-namespace}-rating-indicator;
       width: $fd-rating-indicator-default-font-size;
       height: $fd-rating-indicator-default-font-size;
 
-      .rated,
-      .unrated {
+      &-rated,
+      &-unrated {
         font-size: $fd-rating-indicator-default-font-size;
         height: 100%;
-        line-height: 100%;
+        line-height: 1;
       }
 
-      .unrated {
+      &-unrated {
         display: none;
       }
     }
 
     @include fd-rating-indicator-labels-after-checked() {
-      .rated {
-        display: none;
-      }
+      .#{$block}__label {
+        &-rated {
+          display: none;
+        }
 
-      .unrated {
-        display: block;
+        &-unrated {
+          display: block;
+        }
       }
     }
   }
@@ -286,7 +278,7 @@ $block: #{$fd-namespace}-rating-indicator;
 
         &::before {
           font-size: $fd-rating-indicator-sizes-font-size;
-          line-height: $fd-rating-indicator-sizes-font-size;
+          line-height: 1;
         }
 
         &:last-child {
@@ -300,21 +292,38 @@ $block: #{$fd-namespace}-rating-indicator;
         }
       }
 
-      &.#{$block}--half-star {
-        @include fd-rating-indicator-with-half-star($fd-rating-indicator-sizes-font-size, $fd-rating-indicator-sizes-spacing-between-icons);
-      }
-
       &.#{$block}--icon {
         .#{$block}__label {
           width: $fd-rating-indicator-sizes-font-size;
           height: $fd-rating-indicator-sizes-font-size;
 
-          .rated,
-          .unrated {
+          &-rated,
+          &-unrated {
             font-size: $fd-rating-indicator-sizes-font-size;
           }
         }
       }
+
+      &.#{$block}--half-star {
+        @include fd-rating-indicator-with-half-star($fd-rating-indicator-sizes-font-size, $fd-rating-indicator-sizes-spacing-between-icons);
+      }
+    }
+  }
+
+  &--half-star {
+    @include fd-rating-indicator-with-half-star($fd-rating-indicator-default-font-size, $fd-rating-indicator-default-spacing-between-icons);
+  }
+
+  &[class*='#{$block}--'] &__input,
+  &[class*='#{$block}--'] &__label,
+  &__input,
+  &__label {
+    &--zero-rating {
+      padding: 0;
+      margin: 0;
+      width: 0;
+      overflow: hidden;
+      opacity: 0.0001;
     }
   }
 }

--- a/stories/rating-indicator/__snapshots__/rating-indicator.stories.storyshot
+++ b/stories/rating-indicator/__snapshots__/rating-indicator.stories.storyshot
@@ -8,7 +8,6 @@ exports[`Storyshots Components/Rating Indicator Custom icons 1`] = `
     
   <div
     class="fd-rating-indicator fd-rating-indicator--icon"
-    style="--sapRating-indicator-icon-rated: url('./assets/icons/rated.png'); --sapRating-indicator-icon-unrated: url('./assets/icons/unrated.png')"
   >
     
         
@@ -17,6 +16,24 @@ exports[`Storyshots Components/Rating Indicator Custom icons 1`] = `
       class="fd-rating-indicator__container"
     >
       
+            
+      <input
+        aria-label="0 star"
+        class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+        id="rating-icon-0"
+        name="rating-icon"
+        type="radio"
+        value="0"
+      />
+      
+            
+      <label
+        aria-hidden="true"
+        class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+        for="rating-icon-0"
+      />
+      
+
             
       <input
         aria-label="1 star"
@@ -31,7 +48,20 @@ exports[`Storyshots Components/Rating Indicator Custom icons 1`] = `
       <label
         class="fd-rating-indicator__label"
         for="rating-icon-1"
-      />
+      >
+        
+                
+        <i
+          class="rated sap-icon--notification"
+        />
+        
+                
+        <i
+          class="unrated sap-icon--bo-strategy-management"
+        />
+        
+            
+      </label>
       
             
             
@@ -49,7 +79,20 @@ exports[`Storyshots Components/Rating Indicator Custom icons 1`] = `
       <label
         class="fd-rating-indicator__label"
         for="rating-icon-2"
-      />
+      >
+        
+                
+        <i
+          class="rated sap-icon--notification"
+        />
+        
+                
+        <i
+          class="unrated sap-icon--bo-strategy-management"
+        />
+        
+            
+      </label>
       
             
             
@@ -66,7 +109,20 @@ exports[`Storyshots Components/Rating Indicator Custom icons 1`] = `
       <label
         class="fd-rating-indicator__label"
         for="rating-icon-3"
-      />
+      >
+        
+                
+        <i
+          class="rated sap-icon--notification"
+        />
+        
+                
+        <i
+          class="unrated sap-icon--bo-strategy-management"
+        />
+        
+            
+      </label>
       
             
             
@@ -83,7 +139,20 @@ exports[`Storyshots Components/Rating Indicator Custom icons 1`] = `
       <label
         class="fd-rating-indicator__label"
         for="rating-icon-4"
-      />
+      >
+        
+                
+        <i
+          class="rated sap-icon--notification"
+        />
+        
+                
+        <i
+          class="unrated sap-icon--bo-strategy-management"
+        />
+        
+            
+      </label>
       
             
             
@@ -100,7 +169,20 @@ exports[`Storyshots Components/Rating Indicator Custom icons 1`] = `
       <label
         class="fd-rating-indicator__label"
         for="rating-icon-5"
-      />
+      >
+        
+                
+        <i
+          class="rated sap-icon--notification"
+        />
+        
+                
+        <i
+          class="unrated sap-icon--bo-strategy-management"
+        />
+        
+            
+      </label>
       
         
     </div>
@@ -136,6 +218,24 @@ exports[`Storyshots Components/Rating Indicator Different values 1`] = `
         class="fd-rating-indicator__container"
       >
         
+                
+        <input
+          aria-label="0 star"
+          class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+          id="rating-max-value-5-0"
+          name="rating-max-value-5"
+          type="radio"
+          value="0"
+        />
+        
+                
+        <label
+          aria-hidden="true"
+          class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+          for="rating-max-value-5-0"
+        />
+        
+
                 
         <input
           aria-label="1 star"
@@ -254,6 +354,24 @@ exports[`Storyshots Components/Rating Indicator Different values 1`] = `
         class="fd-rating-indicator__container"
       >
         
+                
+        <input
+          aria-label="0 star"
+          class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+          id="rating-max-value-6-0"
+          name="rating-max-value-6"
+          type="radio"
+          value="0"
+        />
+        
+                
+        <label
+          aria-hidden="true"
+          class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+          for="rating-max-value-6-0"
+        />
+        
+
                 
         <input
           aria-label="1 star"
@@ -389,6 +507,24 @@ exports[`Storyshots Components/Rating Indicator Different values 1`] = `
         class="fd-rating-indicator__container"
       >
         
+                
+        <input
+          aria-label="0 star"
+          class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+          id="rating-max-value-7-0"
+          name="rating-max-value-7"
+          type="radio"
+          value="0"
+        />
+        
+                
+        <label
+          aria-hidden="true"
+          class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+          for="rating-max-value-7-0"
+        />
+        
+
                 
         <input
           aria-label="1 star"
@@ -547,6 +683,25 @@ exports[`Storyshots Components/Rating Indicator Disabled 1`] = `
       
             
       <input
+        aria-label="0 star"
+        class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+        disabled=""
+        id="rating-disabled-0"
+        name="rating-disabled"
+        type="radio"
+        value="0"
+      />
+      
+            
+      <label
+        aria-hidden="true"
+        class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+        for="rating-disabled-0"
+      />
+      
+
+            
+      <input
         aria-label="1 star"
         class="fd-rating-indicator__input"
         disabled=""
@@ -670,6 +825,25 @@ exports[`Storyshots Components/Rating Indicator Display mode 1`] = `
       
                 
       <input
+        aria-label="0 star"
+        class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+        disabled=""
+        id="rating-display-mode-0"
+        name="rating-display-mode"
+        type="radio"
+        value="0"
+      />
+      
+                
+      <label
+        aria-hidden="true"
+        class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+        for="rating-display-mode-0"
+      />
+      
+
+                
+      <input
         aria-label="1 star"
         class="fd-rating-indicator__input"
         disabled=""
@@ -776,206 +950,951 @@ exports[`Storyshots Components/Rating Indicator Display mode 1`] = `
 `;
 
 exports[`Storyshots Components/Rating Indicator Half values 1`] = `
-<div
-  class="example-container"
->
-  
-    
+<section>
   <div
-    class="fd-rating-indicator fd-rating-indicator--half-star"
+    class="example-container"
   >
     
         
+    <span
+      style="min-width: 185px;"
+    >
+      Default:
+    </span>
+    
+        
     <div
-      aria-label="Star Rating (out of 5)"
-      class="fd-rating-indicator__container"
+      class="fd-rating-indicator fd-rating-indicator--half-star"
     >
       
             
-      <input
-        aria-label="half star"
-        class="fd-rating-indicator__input"
-        id="rating-half-sizes-05"
-        name="rating-half-sizes"
-        type="radio"
-        value="0.5"
-      />
+      <div
+        aria-label="Star Rating (out of 5)"
+        class="fd-rating-indicator__container"
+      >
+        
+                
+        <input
+          aria-label="0 star"
+          class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+          id="rating-half-sizes-0"
+          name="rating-half-sizes"
+          type="radio"
+          value="0"
+        />
+        
+                
+        <label
+          aria-hidden="true"
+          class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+          for="rating-half-sizes-0"
+        />
+        
+
+                
+        <input
+          aria-label="half star"
+          class="fd-rating-indicator__input"
+          id="rating-half-sizes-05"
+          name="rating-half-sizes"
+          type="radio"
+          value="0.5"
+        />
+          
+                
+        <label
+          class="fd-rating-indicator__label"
+          for="rating-half-sizes-05"
+        />
+        
+
+                
+        <input
+          aria-label="1 star"
+          class="fd-rating-indicator__input"
+          id="rating-half-sizes-1"
+          name="rating-half-sizes"
+          type="radio"
+          value="1"
+        />
+        
+                
+        <label
+          class="fd-rating-indicator__label"
+          for="rating-half-sizes-1"
+        />
+        
+                
+                
+        <input
+          aria-label="1 and half star"
+          class="fd-rating-indicator__input"
+          id="rating-half-sizes-15"
+          name="rating-half-sizes"
+          type="radio"
+          value="1.5"
+        />
+        
+                
+        <label
+          class="fd-rating-indicator__label"
+          for="rating-half-sizes-15"
+        />
+        
+                
+                
+        <input
+          aria-label="2 star"
+          class="fd-rating-indicator__input"
+          id="rating-half-sizes-2"
+          name="rating-half-sizes"
+          type="radio"
+          value="2\\""
+        />
+        
+                
+        <label
+          class="fd-rating-indicator__label"
+          for="rating-half-sizes-2"
+        />
+        
+                
+                
+        <input
+          aria-label="2 and half star"
+          checked=""
+          class="fd-rating-indicator__input"
+          id="rating-half-sizes-25"
+          name="rating-half-sizes"
+          type="radio"
+          value="2.5"
+        />
+        
+                
+        <label
+          class="fd-rating-indicator__label"
+          for="rating-half-sizes-25"
+        />
+        
+                
+                
+        <input
+          aria-label="3 star"
+          class="fd-rating-indicator__input"
+          id="rating-half-sizes-3"
+          name="rating-half-sizes"
+          type="radio"
+          value="3"
+        />
+        
+                
+        <label
+          class="fd-rating-indicator__label"
+          for="rating-half-sizes-3"
+        />
+        
+                
+                
+        <input
+          aria-label="3 and half star"
+          class="fd-rating-indicator__input"
+          id="rating-half-sizes-35"
+          name="rating-half-sizes"
+          type="radio"
+          value="3.5"
+        />
+        
+                
+        <label
+          class="fd-rating-indicator__label"
+          for="rating-half-sizes-35"
+        />
+        
+                
+                
+        <input
+          aria-label="4 star"
+          class="fd-rating-indicator__input"
+          id="rating-half-sizes-4"
+          name="rating-half-sizes"
+          type="radio"
+          value="4"
+        />
+        
+                
+        <label
+          class="fd-rating-indicator__label"
+          for="rating-half-sizes-4"
+        />
+        
+                
+                
+        <input
+          aria-label="4 and half star"
+          class="fd-rating-indicator__input"
+          id="rating-half-sizes-45"
+          name="rating-half-sizes"
+          type="radio"
+          value="4.5"
+        />
+        
+                
+        <label
+          class="fd-rating-indicator__label"
+          for="rating-half-sizes-45"
+        />
+        
+                
+                
+        <input
+          aria-label="5 star"
+          class="fd-rating-indicator__input"
+          id="rating-half-sizes-5"
+          name="rating-half-sizes"
+          type="radio"
+          value="5"
+        />
+        
+                
+        <label
+          class="fd-rating-indicator__label"
+          for="rating-half-sizes-5"
+        />
         
             
-      <label
-        class="fd-rating-indicator__label"
-        for="rating-half-sizes-05"
-      />
-      
-
-            
-      <input
-        aria-label="1 star"
-        class="fd-rating-indicator__input"
-        id="rating-half-sizes-1"
-        name="rating-half-sizes"
-        type="radio"
-        value="1"
-      />
+      </div>
       
             
-      <label
-        class="fd-rating-indicator__label"
-        for="rating-half-sizes-1"
-      />
-      
-            
-            
-      <input
-        aria-label="1 and half star"
-        class="fd-rating-indicator__input"
-        id="rating-half-sizes-15"
-        name="rating-half-sizes"
-        type="radio"
-        value="1.5"
-      />
-      
-            
-      <label
-        class="fd-rating-indicator__label"
-        for="rating-half-sizes-15"
-      />
-      
-            
-            
-      <input
-        aria-label="2 star"
-        class="fd-rating-indicator__input"
-        id="rating-half-sizes-2"
-        name="rating-half-sizes"
-        type="radio"
-        value="2\\""
-      />
-      
-            
-      <label
-        class="fd-rating-indicator__label"
-        for="rating-half-sizes-2"
-      />
-      
-            
-            
-      <input
-        aria-label="2 and half star"
-        checked=""
-        class="fd-rating-indicator__input"
-        id="rating-half-sizes-25"
-        name="rating-half-sizes"
-        type="radio"
-        value="2.5"
-      />
-      
-            
-      <label
-        class="fd-rating-indicator__label"
-        for="rating-half-sizes-25"
-      />
-      
-            
-            
-      <input
-        aria-label="3 star"
-        class="fd-rating-indicator__input"
-        id="rating-half-sizes-3"
-        name="rating-half-sizes"
-        type="radio"
-        value="3"
-      />
-      
-            
-      <label
-        class="fd-rating-indicator__label"
-        for="rating-half-sizes-3"
-      />
-      
-            
-            
-      <input
-        aria-label="3 and half star"
-        class="fd-rating-indicator__input"
-        id="rating-half-sizes-35"
-        name="rating-half-sizes"
-        type="radio"
-        value="3.5"
-      />
-      
-            
-      <label
-        class="fd-rating-indicator__label"
-        for="rating-half-sizes-35"
-      />
-      
-            
-            
-      <input
-        aria-label="4 star"
-        class="fd-rating-indicator__input"
-        id="rating-half-sizes-4"
-        name="rating-half-sizes"
-        type="radio"
-        value="4"
-      />
-      
-            
-      <label
-        class="fd-rating-indicator__label"
-        for="rating-half-sizes-4"
-      />
-      
-            
-            
-      <input
-        aria-label="4 and half star"
-        class="fd-rating-indicator__input"
-        id="rating-half-sizes-45"
-        name="rating-half-sizes"
-        type="radio"
-        value="4.5"
-      />
-      
-            
-      <label
-        class="fd-rating-indicator__label"
-        for="rating-half-sizes-45"
-      />
-      
-            
-            
-      <input
-        aria-label="5 star"
-        class="fd-rating-indicator__input"
-        id="rating-half-sizes-5"
-        name="rating-half-sizes"
-        type="radio"
-        value="5"
-      />
-      
-            
-      <label
-        class="fd-rating-indicator__label"
-        for="rating-half-sizes-5"
-      />
+      <span
+        class="fd-rating-indicator__dynamic-text"
+      >
+        (2.5 of 5)
+      </span>
       
         
     </div>
-    
-        
-    <span
-      class="fd-rating-indicator__dynamic-text"
-    >
-      (2.5 of 5)
-    </span>
     
     
   </div>
   
 
-</div>
+    
+  <div
+    class="example-container"
+  >
+    
+        
+    <span
+      style="min-width: 185px;"
+    >
+      Custome icons:
+    </span>
+    
+        
+    <div
+      class="fd-rating-indicator fd-rating-indicator--half-star fd-rating-indicator--icon"
+    >
+      
+            
+      <div
+        aria-label="Star Rating (out of 5)"
+        class="fd-rating-indicator__container"
+      >
+        
+                
+        <input
+          aria-label="0 star"
+          class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+          id="rating-half-sizes-custome-icons-0"
+          name="rating-half-sizes-custome-icons"
+          type="radio"
+          value="0"
+        />
+        
+                
+        <label
+          aria-hidden="true"
+          class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+          for="rating-half-sizes-custome-icons-0"
+        />
+        
+
+                
+        <input
+          aria-label="half star"
+          class="fd-rating-indicator__input"
+          id="rating-half-sizes-custome-icons-05"
+          name="rating-half-sizes-custome-icons"
+          type="radio"
+          value="0.5"
+        />
+          
+                
+        <label
+          class="fd-rating-indicator__label"
+          for="rating-half-sizes-custome-icons-05"
+        >
+          
+                    
+          <i
+            class="rated sap-icon--notification"
+          />
+          
+                    
+          <i
+            class="unrated sap-icon--bo-strategy-management"
+          />
+          
+                
+        </label>
+        
+
+                
+        <input
+          aria-label="1 star"
+          class="fd-rating-indicator__input"
+          id="rating-half-sizes-custome-icons-1"
+          name="rating-half-sizes-custome-icons"
+          type="radio"
+          value="1"
+        />
+        
+                
+        <label
+          class="fd-rating-indicator__label"
+          for="rating-half-sizes-custome-icons-1"
+        >
+          
+                    
+          <i
+            class="rated sap-icon--notification"
+          />
+          
+                    
+          <i
+            class="unrated sap-icon--bo-strategy-management"
+          />
+          
+                
+        </label>
+        
+                
+                
+        <input
+          aria-label="1 and half star"
+          class="fd-rating-indicator__input"
+          id="rating-half-sizes-custome-icons-15"
+          name="rating-half-sizes-custome-icons"
+          type="radio"
+          value="1.5"
+        />
+        
+                
+        <label
+          class="fd-rating-indicator__label"
+          for="rating-half-sizes-custome-icons-15"
+        >
+          
+                    
+          <i
+            class="rated sap-icon--notification"
+          />
+          
+                    
+          <i
+            class="unrated sap-icon--bo-strategy-management"
+          />
+          
+                
+        </label>
+        
+                
+                
+        <input
+          aria-label="2 star"
+          class="fd-rating-indicator__input"
+          id="rating-half-sizes-custome-icons-2"
+          name="rating-half-sizes-custome-icons"
+          type="radio"
+          value="2\\""
+        />
+        
+                
+        <label
+          class="fd-rating-indicator__label"
+          for="rating-half-sizes-custome-icons-2"
+        >
+          
+                    
+          <i
+            class="rated sap-icon--notification"
+          />
+          
+                    
+          <i
+            class="unrated sap-icon--bo-strategy-management"
+          />
+          
+                
+        </label>
+        
+                
+                
+        <input
+          aria-label="2 and half star"
+          checked=""
+          class="fd-rating-indicator__input"
+          id="rating-half-sizes-custome-icons-25"
+          name="rating-half-sizes-custome-icons"
+          type="radio"
+          value="2.5"
+        />
+        
+                
+        <label
+          class="fd-rating-indicator__label"
+          for="rating-half-sizes-custome-icons-25"
+        >
+          
+                    
+          <i
+            class="rated sap-icon--notification"
+          />
+          
+                    
+          <i
+            class="unrated sap-icon--bo-strategy-management"
+          />
+          
+                
+        </label>
+        
+                
+                
+        <input
+          aria-label="3 star"
+          class="fd-rating-indicator__input"
+          id="rating-half-sizes-custome-icons-3"
+          name="rating-half-sizes-custome-icons"
+          type="radio"
+          value="3"
+        />
+        
+                
+        <label
+          class="fd-rating-indicator__label"
+          for="rating-half-sizes-custome-icons-3"
+        >
+          
+                    
+          <i
+            class="rated sap-icon--notification"
+          />
+          
+                    
+          <i
+            class="unrated sap-icon--bo-strategy-management"
+          />
+          
+                
+        </label>
+        
+                
+                
+        <input
+          aria-label="3 and half star"
+          class="fd-rating-indicator__input"
+          id="rating-half-sizes-custome-icons-35"
+          name="rating-half-sizes-custome-icons"
+          type="radio"
+          value="3.5"
+        />
+        
+                
+        <label
+          class="fd-rating-indicator__label"
+          for="rating-half-sizes-custome-icons-35"
+        >
+          
+                    
+          <i
+            class="rated sap-icon--notification"
+          />
+          
+                    
+          <i
+            class="unrated sap-icon--bo-strategy-management"
+          />
+          
+                
+        </label>
+        
+                
+                
+        <input
+          aria-label="4 star"
+          class="fd-rating-indicator__input"
+          id="rating-half-sizes-custome-icons-4"
+          name="rating-half-sizes-custome-icons"
+          type="radio"
+          value="4"
+        />
+        
+                
+        <label
+          class="fd-rating-indicator__label"
+          for="rating-half-sizes-custome-icons-4"
+        >
+          
+                    
+          <i
+            class="rated sap-icon--notification"
+          />
+          
+                    
+          <i
+            class="unrated sap-icon--bo-strategy-management"
+          />
+          
+                
+        </label>
+        
+                
+                
+        <input
+          aria-label="4 and half star"
+          class="fd-rating-indicator__input"
+          id="rating-half-sizes-custome-icons-45"
+          name="rating-half-sizes-custome-icons"
+          type="radio"
+          value="4.5"
+        />
+        
+                
+        <label
+          class="fd-rating-indicator__label"
+          for="rating-half-sizes-custome-icons-45"
+        >
+          
+                    
+          <i
+            class="rated sap-icon--notification"
+          />
+          
+                    
+          <i
+            class="unrated sap-icon--bo-strategy-management"
+          />
+          
+                
+        </label>
+        
+                
+                
+        <input
+          aria-label="5 star"
+          class="fd-rating-indicator__input"
+          id="rating-half-sizes-custome-icons-5"
+          name="rating-half-sizes-custome-icons"
+          type="radio"
+          value="5"
+        />
+        
+                
+        <label
+          class="fd-rating-indicator__label"
+          for="rating-half-sizes-custome-icons-5"
+        >
+          
+                    
+          <i
+            class="rated sap-icon--notification"
+          />
+          
+                    
+          <i
+            class="unrated sap-icon--bo-strategy-management"
+          />
+          
+                
+        </label>
+        
+            
+      </div>
+      
+            
+      <span
+        class="fd-rating-indicator__dynamic-text"
+      >
+        (2.5 of 5)
+      </span>
+      
+        
+    </div>
+    
+    
+  </div>
+  
+
+    
+  <div
+    class="example-container"
+  >
+    
+        
+    <span
+      style="min-width: 185px;"
+    >
+      Custome icons and size --lg:
+    </span>
+    
+        
+    <div
+      class="fd-rating-indicator fd-rating-indicator--half-star fd-rating-indicator--icon fd-rating-indicator--lg"
+    >
+      
+            
+      <div
+        aria-label="Star Rating (out of 5)"
+        class="fd-rating-indicator__container"
+      >
+        
+                
+        <input
+          aria-label="0 star"
+          class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+          id="rating-half-sizes-custome-icons-lg-0"
+          name="rating-half-sizes-custome-icons-lg"
+          type="radio"
+          value="0"
+        />
+        
+                
+        <label
+          aria-hidden="true"
+          class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+          for="rating-half-sizes-custome-icons-lg-0"
+        />
+        
+
+                
+        <input
+          aria-label="half star"
+          class="fd-rating-indicator__input"
+          id="rating-half-sizes-custome-icons-lg-05"
+          name="rating-half-sizes-custome-icons-lg"
+          type="radio"
+          value="0.5"
+        />
+          
+                
+        <label
+          class="fd-rating-indicator__label"
+          for="rating-half-sizes-custome-icons-lg-05"
+        >
+          
+                    
+          <i
+            class="rated sap-icon--notification"
+          />
+          
+                    
+          <i
+            class="unrated sap-icon--bo-strategy-management"
+          />
+          
+                
+        </label>
+        
+
+                
+        <input
+          aria-label="1 star"
+          class="fd-rating-indicator__input"
+          id="rating-half-sizes-custome-icons-lg-1"
+          name="rating-half-sizes-custome-icons-lg"
+          type="radio"
+          value="1"
+        />
+        
+                
+        <label
+          class="fd-rating-indicator__label"
+          for="rating-half-sizes-custome-icons-lg-1"
+        >
+          
+                    
+          <i
+            class="rated sap-icon--notification"
+          />
+          
+                    
+          <i
+            class="unrated sap-icon--bo-strategy-management"
+          />
+          
+                
+        </label>
+        
+                
+                
+        <input
+          aria-label="1 and half star"
+          class="fd-rating-indicator__input"
+          id="rating-half-sizes-custome-icons-lg-15"
+          name="rating-half-sizes-custome-icons-lg"
+          type="radio"
+          value="1.5"
+        />
+        
+                
+        <label
+          class="fd-rating-indicator__label"
+          for="rating-half-sizes-custome-icons-lg-15"
+        >
+          
+                    
+          <i
+            class="rated sap-icon--notification"
+          />
+          
+                    
+          <i
+            class="unrated sap-icon--bo-strategy-management"
+          />
+          
+                
+        </label>
+        
+                
+                
+        <input
+          aria-label="2 star"
+          class="fd-rating-indicator__input"
+          id="rating-half-sizes-custome-icons-lg-2"
+          name="rating-half-sizes-custome-icons-lg"
+          type="radio"
+          value="2\\""
+        />
+        
+                
+        <label
+          class="fd-rating-indicator__label"
+          for="rating-half-sizes-custome-icons-lg-2"
+        >
+          
+                    
+          <i
+            class="rated sap-icon--notification"
+          />
+          
+                    
+          <i
+            class="unrated sap-icon--bo-strategy-management"
+          />
+          
+                
+        </label>
+        
+                
+                
+        <input
+          aria-label="2 and half star"
+          checked=""
+          class="fd-rating-indicator__input"
+          id="rating-half-sizes-custome-icons-lg-25"
+          name="rating-half-sizes-custome-icons-lg"
+          type="radio"
+          value="2.5"
+        />
+        
+                
+        <label
+          class="fd-rating-indicator__label"
+          for="rating-half-sizes-custome-icons-lg-25"
+        >
+          
+                    
+          <i
+            class="rated sap-icon--notification"
+          />
+          
+                    
+          <i
+            class="unrated sap-icon--bo-strategy-management"
+          />
+          
+                
+        </label>
+        
+                
+                
+        <input
+          aria-label="3 star"
+          class="fd-rating-indicator__input"
+          id="rating-half-sizes-custome-icons-lg-3"
+          name="rating-half-sizes-custome-icons-lg"
+          type="radio"
+          value="3"
+        />
+        
+                
+        <label
+          class="fd-rating-indicator__label"
+          for="rating-half-sizes-custome-icons-lg-3"
+        >
+          
+                    
+          <i
+            class="rated sap-icon--notification"
+          />
+          
+                    
+          <i
+            class="unrated sap-icon--bo-strategy-management"
+          />
+          
+                
+        </label>
+        
+                
+                
+        <input
+          aria-label="3 and half star"
+          class="fd-rating-indicator__input"
+          id="rating-half-sizes-custome-icons-lg-35"
+          name="rating-half-sizes-custome-icons-lg"
+          type="radio"
+          value="3.5"
+        />
+        
+                
+        <label
+          class="fd-rating-indicator__label"
+          for="rating-half-sizes-custome-icons-lg-35"
+        >
+          
+                    
+          <i
+            class="rated sap-icon--notification"
+          />
+          
+                    
+          <i
+            class="unrated sap-icon--bo-strategy-management"
+          />
+          
+                
+        </label>
+        
+                
+                
+        <input
+          aria-label="4 star"
+          class="fd-rating-indicator__input"
+          id="rating-half-sizes-custome-icons-lg-4"
+          name="rating-half-sizes-custome-icons-lg"
+          type="radio"
+          value="4"
+        />
+        
+                
+        <label
+          class="fd-rating-indicator__label"
+          for="rating-half-sizes-custome-icons-lg-4"
+        >
+          
+                    
+          <i
+            class="rated sap-icon--notification"
+          />
+          
+                    
+          <i
+            class="unrated sap-icon--bo-strategy-management"
+          />
+          
+                
+        </label>
+        
+                
+                
+        <input
+          aria-label="4 and half star"
+          class="fd-rating-indicator__input"
+          id="rating-half-sizes-custome-icons-lg-45"
+          name="rating-half-sizes-custome-icons-lg"
+          type="radio"
+          value="4.5"
+        />
+        
+                
+        <label
+          class="fd-rating-indicator__label"
+          for="rating-half-sizes-custome-icons-lg-45"
+        >
+          
+                    
+          <i
+            class="rated sap-icon--notification"
+          />
+          
+                    
+          <i
+            class="unrated sap-icon--bo-strategy-management"
+          />
+          
+                
+        </label>
+        
+                
+                
+        <input
+          aria-label="5 star"
+          class="fd-rating-indicator__input"
+          id="rating-half-sizes-custome-icons-lg-5"
+          name="rating-half-sizes-custome-icons-lg"
+          type="radio"
+          value="5"
+        />
+        
+                
+        <label
+          class="fd-rating-indicator__label"
+          for="rating-half-sizes-custome-icons-lg-5"
+        >
+          
+                    
+          <i
+            class="rated sap-icon--notification"
+          />
+          
+                    
+          <i
+            class="unrated sap-icon--bo-strategy-management"
+          />
+          
+                
+        </label>
+        
+            
+      </div>
+      
+            
+      <span
+        class="fd-rating-indicator__dynamic-text"
+      >
+        (2.5 of 5)
+      </span>
+      
+        
+    </div>
+    
+    
+  </div>
+  
+
+</section>
 `;
 
 exports[`Storyshots Components/Rating Indicator Non-interactive 1`] = `
@@ -994,6 +1913,25 @@ exports[`Storyshots Components/Rating Indicator Non-interactive 1`] = `
       class="fd-rating-indicator__container"
     >
       
+                
+      <input
+        aria-label="0 star"
+        class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+        disabled=""
+        id="rating-non-interactive-mode-0"
+        name="rating-non-interactive-mode"
+        type="radio"
+        value="0"
+      />
+      
+                
+      <label
+        aria-hidden="true"
+        class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+        for="rating-non-interactive-mode-0"
+      />
+      
+
                 
       <input
         aria-label="1 star"
@@ -1127,6 +2065,24 @@ exports[`Storyshots Components/Rating Indicator Sizes 1`] = `
         
                 
         <input
+          aria-label="0 star"
+          class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+          id="rating-0"
+          name="rating"
+          type="radio"
+          value="0"
+        />
+        
+                
+        <label
+          aria-hidden="true"
+          class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+          for="rating-0"
+        />
+        
+
+                
+        <input
           aria-label="1 star"
           class="fd-rating-indicator__input"
           id="rating-1"
@@ -1250,6 +2206,24 @@ exports[`Storyshots Components/Rating Indicator Sizes 1`] = `
         class="fd-rating-indicator__container"
       >
         
+                
+        <input
+          aria-label="0 star"
+          class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+          id="rating-xs-0"
+          name="rating-xs"
+          type="radio"
+          value="0"
+        />
+        
+                
+        <label
+          aria-hidden="true"
+          class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+          for="rating-xs-0"
+        />
+        
+
                 
         <input
           aria-label="1 star"
@@ -1378,6 +2352,24 @@ exports[`Storyshots Components/Rating Indicator Sizes 1`] = `
         
                 
         <input
+          aria-label="0 star"
+          class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+          id="rating-s-0"
+          name="rating-s"
+          type="radio"
+          value="0"
+        />
+        
+                
+        <label
+          aria-hidden="true"
+          class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+          for="rating-s-0"
+        />
+        
+
+                
+        <input
           aria-label="1 star"
           class="fd-rating-indicator__input"
           id="rating-s-1"
@@ -1502,6 +2494,24 @@ exports[`Storyshots Components/Rating Indicator Sizes 1`] = `
         class="fd-rating-indicator__container"
       >
         
+                
+        <input
+          aria-label="0 star"
+          class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+          id="rating-l-0"
+          name="rating-l"
+          type="radio"
+          value="0"
+        />
+        
+                
+        <label
+          aria-hidden="true"
+          class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+          for="rating-l-0"
+        />
+        
+
                 
         <input
           aria-label="1 star"
@@ -1629,6 +2639,24 @@ exports[`Storyshots Components/Rating Indicator Sizes 1`] = `
         
                 
         <input
+          aria-label="0 star"
+          class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+          id="rating-cozy-0"
+          name="rating-cozy"
+          type="radio"
+          value="0"
+        />
+        
+                
+        <label
+          aria-hidden="true"
+          class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+          for="rating-cozy-0"
+        />
+        
+
+                
+        <input
           aria-label="1 star"
           class="fd-rating-indicator__input"
           id="rating-cozy-1"
@@ -1754,6 +2782,24 @@ exports[`Storyshots Components/Rating Indicator Sizes 1`] = `
         
                 
         <input
+          aria-label="0 star"
+          class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+          id="rating-compact-0"
+          name="rating-compact"
+          type="radio"
+          value="0"
+        />
+        
+                
+        <label
+          aria-hidden="true"
+          class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+          for="rating-compact-0"
+        />
+        
+
+                
+        <input
           aria-label="1 star"
           class="fd-rating-indicator__input"
           id="rating-compact-1"
@@ -1877,6 +2923,24 @@ exports[`Storyshots Components/Rating Indicator Sizes 1`] = `
         class="fd-rating-indicator__container"
       >
         
+                
+        <input
+          aria-label="0 star"
+          class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+          id="rating-condensed-0"
+          name="rating-condensed"
+          type="radio"
+          value="0"
+        />
+        
+                
+        <label
+          aria-hidden="true"
+          class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+          for="rating-condensed-0"
+        />
+        
+
                 
         <input
           aria-label="1 star"

--- a/stories/rating-indicator/__snapshots__/rating-indicator.stories.storyshot
+++ b/stories/rating-indicator/__snapshots__/rating-indicator.stories.storyshot
@@ -19,7 +19,7 @@ exports[`Storyshots Components/Rating Indicator Custom icons 1`] = `
             
       <input
         aria-label="0 star"
-        class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+        class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating"
         id="rating-icon-0"
         name="rating-icon"
         type="radio"
@@ -29,7 +29,7 @@ exports[`Storyshots Components/Rating Indicator Custom icons 1`] = `
             
       <label
         aria-hidden="true"
-        class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+        class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating"
         for="rating-icon-0"
       />
       
@@ -52,12 +52,12 @@ exports[`Storyshots Components/Rating Indicator Custom icons 1`] = `
         
                 
         <i
-          class="rated sap-icon--notification"
+          class="fd-rating-indicator__label-rated sap-icon--notification"
         />
         
                 
         <i
-          class="unrated sap-icon--bo-strategy-management"
+          class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"
         />
         
             
@@ -83,12 +83,12 @@ exports[`Storyshots Components/Rating Indicator Custom icons 1`] = `
         
                 
         <i
-          class="rated sap-icon--notification"
+          class="fd-rating-indicator__label-rated sap-icon--notification"
         />
         
                 
         <i
-          class="unrated sap-icon--bo-strategy-management"
+          class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"
         />
         
             
@@ -113,12 +113,12 @@ exports[`Storyshots Components/Rating Indicator Custom icons 1`] = `
         
                 
         <i
-          class="rated sap-icon--notification"
+          class="fd-rating-indicator__label-rated sap-icon--notification"
         />
         
                 
         <i
-          class="unrated sap-icon--bo-strategy-management"
+          class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"
         />
         
             
@@ -143,12 +143,12 @@ exports[`Storyshots Components/Rating Indicator Custom icons 1`] = `
         
                 
         <i
-          class="rated sap-icon--notification"
+          class="fd-rating-indicator__label-rated sap-icon--notification"
         />
         
                 
         <i
-          class="unrated sap-icon--bo-strategy-management"
+          class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"
         />
         
             
@@ -173,12 +173,12 @@ exports[`Storyshots Components/Rating Indicator Custom icons 1`] = `
         
                 
         <i
-          class="rated sap-icon--notification"
+          class="fd-rating-indicator__label-rated sap-icon--notification"
         />
         
                 
         <i
-          class="unrated sap-icon--bo-strategy-management"
+          class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"
         />
         
             
@@ -221,7 +221,7 @@ exports[`Storyshots Components/Rating Indicator Different values 1`] = `
                 
         <input
           aria-label="0 star"
-          class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+          class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating"
           id="rating-max-value-5-0"
           name="rating-max-value-5"
           type="radio"
@@ -231,7 +231,7 @@ exports[`Storyshots Components/Rating Indicator Different values 1`] = `
                 
         <label
           aria-hidden="true"
-          class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+          class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating"
           for="rating-max-value-5-0"
         />
         
@@ -357,7 +357,7 @@ exports[`Storyshots Components/Rating Indicator Different values 1`] = `
                 
         <input
           aria-label="0 star"
-          class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+          class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating"
           id="rating-max-value-6-0"
           name="rating-max-value-6"
           type="radio"
@@ -367,7 +367,7 @@ exports[`Storyshots Components/Rating Indicator Different values 1`] = `
                 
         <label
           aria-hidden="true"
-          class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+          class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating"
           for="rating-max-value-6-0"
         />
         
@@ -510,7 +510,7 @@ exports[`Storyshots Components/Rating Indicator Different values 1`] = `
                 
         <input
           aria-label="0 star"
-          class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+          class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating"
           id="rating-max-value-7-0"
           name="rating-max-value-7"
           type="radio"
@@ -520,7 +520,7 @@ exports[`Storyshots Components/Rating Indicator Different values 1`] = `
                 
         <label
           aria-hidden="true"
-          class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+          class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating"
           for="rating-max-value-7-0"
         />
         
@@ -684,7 +684,7 @@ exports[`Storyshots Components/Rating Indicator Disabled 1`] = `
             
       <input
         aria-label="0 star"
-        class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+        class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating"
         disabled=""
         id="rating-disabled-0"
         name="rating-disabled"
@@ -695,7 +695,7 @@ exports[`Storyshots Components/Rating Indicator Disabled 1`] = `
             
       <label
         aria-hidden="true"
-        class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+        class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating"
         for="rating-disabled-0"
       />
       
@@ -826,7 +826,7 @@ exports[`Storyshots Components/Rating Indicator Display mode 1`] = `
                 
       <input
         aria-label="0 star"
-        class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+        class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating"
         disabled=""
         id="rating-display-mode-0"
         name="rating-display-mode"
@@ -837,7 +837,7 @@ exports[`Storyshots Components/Rating Indicator Display mode 1`] = `
                 
       <label
         aria-hidden="true"
-        class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+        class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating"
         for="rating-display-mode-0"
       />
       
@@ -976,7 +976,7 @@ exports[`Storyshots Components/Rating Indicator Half values 1`] = `
                 
         <input
           aria-label="0 star"
-          class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+          class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating"
           id="rating-half-sizes-0"
           name="rating-half-sizes"
           type="radio"
@@ -986,7 +986,7 @@ exports[`Storyshots Components/Rating Indicator Half values 1`] = `
                 
         <label
           aria-hidden="true"
-          class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+          class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating"
           for="rating-half-sizes-0"
         />
         
@@ -1204,7 +1204,7 @@ exports[`Storyshots Components/Rating Indicator Half values 1`] = `
                 
         <input
           aria-label="0 star"
-          class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+          class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating"
           id="rating-half-sizes-custome-icons-0"
           name="rating-half-sizes-custome-icons"
           type="radio"
@@ -1214,7 +1214,7 @@ exports[`Storyshots Components/Rating Indicator Half values 1`] = `
                 
         <label
           aria-hidden="true"
-          class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+          class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating"
           for="rating-half-sizes-custome-icons-0"
         />
         
@@ -1237,12 +1237,12 @@ exports[`Storyshots Components/Rating Indicator Half values 1`] = `
           
                     
           <i
-            class="rated sap-icon--notification"
+            class="fd-rating-indicator__label-rated sap-icon--notification"
           />
           
                     
           <i
-            class="unrated sap-icon--bo-strategy-management"
+            class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"
           />
           
                 
@@ -1267,12 +1267,12 @@ exports[`Storyshots Components/Rating Indicator Half values 1`] = `
           
                     
           <i
-            class="rated sap-icon--notification"
+            class="fd-rating-indicator__label-rated sap-icon--notification"
           />
           
                     
           <i
-            class="unrated sap-icon--bo-strategy-management"
+            class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"
           />
           
                 
@@ -1297,12 +1297,12 @@ exports[`Storyshots Components/Rating Indicator Half values 1`] = `
           
                     
           <i
-            class="rated sap-icon--notification"
+            class="fd-rating-indicator__label-rated sap-icon--notification"
           />
           
                     
           <i
-            class="unrated sap-icon--bo-strategy-management"
+            class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"
           />
           
                 
@@ -1327,12 +1327,12 @@ exports[`Storyshots Components/Rating Indicator Half values 1`] = `
           
                     
           <i
-            class="rated sap-icon--notification"
+            class="fd-rating-indicator__label-rated sap-icon--notification"
           />
           
                     
           <i
-            class="unrated sap-icon--bo-strategy-management"
+            class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"
           />
           
                 
@@ -1358,12 +1358,12 @@ exports[`Storyshots Components/Rating Indicator Half values 1`] = `
           
                     
           <i
-            class="rated sap-icon--notification"
+            class="fd-rating-indicator__label-rated sap-icon--notification"
           />
           
                     
           <i
-            class="unrated sap-icon--bo-strategy-management"
+            class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"
           />
           
                 
@@ -1388,12 +1388,12 @@ exports[`Storyshots Components/Rating Indicator Half values 1`] = `
           
                     
           <i
-            class="rated sap-icon--notification"
+            class="fd-rating-indicator__label-rated sap-icon--notification"
           />
           
                     
           <i
-            class="unrated sap-icon--bo-strategy-management"
+            class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"
           />
           
                 
@@ -1418,12 +1418,12 @@ exports[`Storyshots Components/Rating Indicator Half values 1`] = `
           
                     
           <i
-            class="rated sap-icon--notification"
+            class="fd-rating-indicator__label-rated sap-icon--notification"
           />
           
                     
           <i
-            class="unrated sap-icon--bo-strategy-management"
+            class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"
           />
           
                 
@@ -1448,12 +1448,12 @@ exports[`Storyshots Components/Rating Indicator Half values 1`] = `
           
                     
           <i
-            class="rated sap-icon--notification"
+            class="fd-rating-indicator__label-rated sap-icon--notification"
           />
           
                     
           <i
-            class="unrated sap-icon--bo-strategy-management"
+            class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"
           />
           
                 
@@ -1478,12 +1478,12 @@ exports[`Storyshots Components/Rating Indicator Half values 1`] = `
           
                     
           <i
-            class="rated sap-icon--notification"
+            class="fd-rating-indicator__label-rated sap-icon--notification"
           />
           
                     
           <i
-            class="unrated sap-icon--bo-strategy-management"
+            class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"
           />
           
                 
@@ -1508,12 +1508,12 @@ exports[`Storyshots Components/Rating Indicator Half values 1`] = `
           
                     
           <i
-            class="rated sap-icon--notification"
+            class="fd-rating-indicator__label-rated sap-icon--notification"
           />
           
                     
           <i
-            class="unrated sap-icon--bo-strategy-management"
+            class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"
           />
           
                 
@@ -1562,7 +1562,7 @@ exports[`Storyshots Components/Rating Indicator Half values 1`] = `
                 
         <input
           aria-label="0 star"
-          class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+          class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating"
           id="rating-half-sizes-custome-icons-lg-0"
           name="rating-half-sizes-custome-icons-lg"
           type="radio"
@@ -1572,7 +1572,7 @@ exports[`Storyshots Components/Rating Indicator Half values 1`] = `
                 
         <label
           aria-hidden="true"
-          class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+          class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating"
           for="rating-half-sizes-custome-icons-lg-0"
         />
         
@@ -1595,12 +1595,12 @@ exports[`Storyshots Components/Rating Indicator Half values 1`] = `
           
                     
           <i
-            class="rated sap-icon--notification"
+            class="fd-rating-indicator__label-rated sap-icon--notification"
           />
           
                     
           <i
-            class="unrated sap-icon--bo-strategy-management"
+            class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"
           />
           
                 
@@ -1625,12 +1625,12 @@ exports[`Storyshots Components/Rating Indicator Half values 1`] = `
           
                     
           <i
-            class="rated sap-icon--notification"
+            class="fd-rating-indicator__label-rated sap-icon--notification"
           />
           
                     
           <i
-            class="unrated sap-icon--bo-strategy-management"
+            class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"
           />
           
                 
@@ -1655,12 +1655,12 @@ exports[`Storyshots Components/Rating Indicator Half values 1`] = `
           
                     
           <i
-            class="rated sap-icon--notification"
+            class="fd-rating-indicator__label-rated sap-icon--notification"
           />
           
                     
           <i
-            class="unrated sap-icon--bo-strategy-management"
+            class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"
           />
           
                 
@@ -1685,12 +1685,12 @@ exports[`Storyshots Components/Rating Indicator Half values 1`] = `
           
                     
           <i
-            class="rated sap-icon--notification"
+            class="fd-rating-indicator__label-rated sap-icon--notification"
           />
           
                     
           <i
-            class="unrated sap-icon--bo-strategy-management"
+            class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"
           />
           
                 
@@ -1716,12 +1716,12 @@ exports[`Storyshots Components/Rating Indicator Half values 1`] = `
           
                     
           <i
-            class="rated sap-icon--notification"
+            class="fd-rating-indicator__label-rated sap-icon--notification"
           />
           
                     
           <i
-            class="unrated sap-icon--bo-strategy-management"
+            class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"
           />
           
                 
@@ -1746,12 +1746,12 @@ exports[`Storyshots Components/Rating Indicator Half values 1`] = `
           
                     
           <i
-            class="rated sap-icon--notification"
+            class="fd-rating-indicator__label-rated sap-icon--notification"
           />
           
                     
           <i
-            class="unrated sap-icon--bo-strategy-management"
+            class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"
           />
           
                 
@@ -1776,12 +1776,12 @@ exports[`Storyshots Components/Rating Indicator Half values 1`] = `
           
                     
           <i
-            class="rated sap-icon--notification"
+            class="fd-rating-indicator__label-rated sap-icon--notification"
           />
           
                     
           <i
-            class="unrated sap-icon--bo-strategy-management"
+            class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"
           />
           
                 
@@ -1806,12 +1806,12 @@ exports[`Storyshots Components/Rating Indicator Half values 1`] = `
           
                     
           <i
-            class="rated sap-icon--notification"
+            class="fd-rating-indicator__label-rated sap-icon--notification"
           />
           
                     
           <i
-            class="unrated sap-icon--bo-strategy-management"
+            class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"
           />
           
                 
@@ -1836,12 +1836,12 @@ exports[`Storyshots Components/Rating Indicator Half values 1`] = `
           
                     
           <i
-            class="rated sap-icon--notification"
+            class="fd-rating-indicator__label-rated sap-icon--notification"
           />
           
                     
           <i
-            class="unrated sap-icon--bo-strategy-management"
+            class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"
           />
           
                 
@@ -1866,12 +1866,12 @@ exports[`Storyshots Components/Rating Indicator Half values 1`] = `
           
                     
           <i
-            class="rated sap-icon--notification"
+            class="fd-rating-indicator__label-rated sap-icon--notification"
           />
           
                     
           <i
-            class="unrated sap-icon--bo-strategy-management"
+            class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"
           />
           
                 
@@ -1916,7 +1916,7 @@ exports[`Storyshots Components/Rating Indicator Non-interactive 1`] = `
                 
       <input
         aria-label="0 star"
-        class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+        class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating"
         disabled=""
         id="rating-non-interactive-mode-0"
         name="rating-non-interactive-mode"
@@ -1927,7 +1927,7 @@ exports[`Storyshots Components/Rating Indicator Non-interactive 1`] = `
                 
       <label
         aria-hidden="true"
-        class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+        class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating"
         for="rating-non-interactive-mode-0"
       />
       
@@ -2066,7 +2066,7 @@ exports[`Storyshots Components/Rating Indicator Sizes 1`] = `
                 
         <input
           aria-label="0 star"
-          class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+          class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating"
           id="rating-0"
           name="rating"
           type="radio"
@@ -2076,7 +2076,7 @@ exports[`Storyshots Components/Rating Indicator Sizes 1`] = `
                 
         <label
           aria-hidden="true"
-          class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+          class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating"
           for="rating-0"
         />
         
@@ -2209,7 +2209,7 @@ exports[`Storyshots Components/Rating Indicator Sizes 1`] = `
                 
         <input
           aria-label="0 star"
-          class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+          class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating"
           id="rating-xs-0"
           name="rating-xs"
           type="radio"
@@ -2219,7 +2219,7 @@ exports[`Storyshots Components/Rating Indicator Sizes 1`] = `
                 
         <label
           aria-hidden="true"
-          class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+          class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating"
           for="rating-xs-0"
         />
         
@@ -2353,7 +2353,7 @@ exports[`Storyshots Components/Rating Indicator Sizes 1`] = `
                 
         <input
           aria-label="0 star"
-          class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+          class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating"
           id="rating-s-0"
           name="rating-s"
           type="radio"
@@ -2363,7 +2363,7 @@ exports[`Storyshots Components/Rating Indicator Sizes 1`] = `
                 
         <label
           aria-hidden="true"
-          class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+          class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating"
           for="rating-s-0"
         />
         
@@ -2497,7 +2497,7 @@ exports[`Storyshots Components/Rating Indicator Sizes 1`] = `
                 
         <input
           aria-label="0 star"
-          class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+          class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating"
           id="rating-l-0"
           name="rating-l"
           type="radio"
@@ -2507,7 +2507,7 @@ exports[`Storyshots Components/Rating Indicator Sizes 1`] = `
                 
         <label
           aria-hidden="true"
-          class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+          class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating"
           for="rating-l-0"
         />
         
@@ -2640,7 +2640,7 @@ exports[`Storyshots Components/Rating Indicator Sizes 1`] = `
                 
         <input
           aria-label="0 star"
-          class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+          class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating"
           id="rating-cozy-0"
           name="rating-cozy"
           type="radio"
@@ -2650,7 +2650,7 @@ exports[`Storyshots Components/Rating Indicator Sizes 1`] = `
                 
         <label
           aria-hidden="true"
-          class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+          class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating"
           for="rating-cozy-0"
         />
         
@@ -2783,7 +2783,7 @@ exports[`Storyshots Components/Rating Indicator Sizes 1`] = `
                 
         <input
           aria-label="0 star"
-          class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+          class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating"
           id="rating-compact-0"
           name="rating-compact"
           type="radio"
@@ -2793,7 +2793,7 @@ exports[`Storyshots Components/Rating Indicator Sizes 1`] = `
                 
         <label
           aria-hidden="true"
-          class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+          class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating"
           for="rating-compact-0"
         />
         
@@ -2926,7 +2926,7 @@ exports[`Storyshots Components/Rating Indicator Sizes 1`] = `
                 
         <input
           aria-label="0 star"
-          class="fd-rating-indicator__input fd-rating-indicator__zero-rating"
+          class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating"
           id="rating-condensed-0"
           name="rating-condensed"
           type="radio"
@@ -2936,7 +2936,7 @@ exports[`Storyshots Components/Rating Indicator Sizes 1`] = `
                 
         <label
           aria-hidden="true"
-          class="fd-rating-indicator__zero-rating fd-rating-indicator__label"
+          class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating"
           for="rating-condensed-0"
         />
         

--- a/stories/rating-indicator/rating-indicator.stories.js
+++ b/stories/rating-indicator/rating-indicator.stories.js
@@ -18,8 +18,8 @@ export const Sizes = () => `<div class="example-container">
         <span style="min-width: 150px;">Default (Medium):</span>
         <div class="fd-rating-indicator fd-rating-indicator--hide-dynamic-text">
             <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
-                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-0" name="rating" value="0">
-                <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-0" aria-hidden="true"></label>
+                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating" id="rating-0" name="rating" value="0">
+                <label class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating" for="rating-0" aria-hidden="true"></label>
 
                 <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-1" name="rating" value="1">  
                 <label class="fd-rating-indicator__label" for="rating-1"></label>
@@ -44,8 +44,8 @@ export const Sizes = () => `<div class="example-container">
         <span style="min-width: 150px;">Extra small:</span>
         <div class="fd-rating-indicator fd-rating-indicator--xs">
             <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
-                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-xs-0" name="rating-xs" value="0">
-                <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-xs-0" aria-hidden="true"></label>
+                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating" id="rating-xs-0" name="rating-xs" value="0">
+                <label class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating" for="rating-xs-0" aria-hidden="true"></label>
 
                 <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-xs-1" name="rating-xs" value="1">  
                 <label class="fd-rating-indicator__label" for="rating-xs-1"></label>
@@ -71,8 +71,8 @@ export const Sizes = () => `<div class="example-container">
         <span style="min-width: 150px;">Small:</span>
         <div class="fd-rating-indicator fd-rating-indicator--sm">
             <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
-                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-s-0" name="rating-s" value="0">
-                <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-s-0" aria-hidden="true"></label>
+                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating" id="rating-s-0" name="rating-s" value="0">
+                <label class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating" for="rating-s-0" aria-hidden="true"></label>
 
                 <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-s-1" name="rating-s" value="1">  
                 <label class="fd-rating-indicator__label" for="rating-s-1"></label>
@@ -98,8 +98,8 @@ export const Sizes = () => `<div class="example-container">
         <span style="min-width: 150px;">Large:</span>
         <div class="fd-rating-indicator fd-rating-indicator--lg">
             <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
-                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-l-0" name="rating-l" value="0">
-                <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-l-0" aria-hidden="true"></label>
+                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating" id="rating-l-0" name="rating-l" value="0">
+                <label class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating" for="rating-l-0" aria-hidden="true"></label>
 
                 <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-l-1" name="rating-l" value="1">  
                 <label class="fd-rating-indicator__label" for="rating-l-1"></label>
@@ -124,8 +124,8 @@ export const Sizes = () => `<div class="example-container">
         <span style="min-width: 150px;">Cozy:</span>
         <div class="fd-rating-indicator fd-rating-indicator--cozy">
             <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
-                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-cozy-0" name="rating-cozy" value="0">
-                <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-cozy-0" aria-hidden="true"></label>
+                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating" id="rating-cozy-0" name="rating-cozy" value="0">
+                <label class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating" for="rating-cozy-0" aria-hidden="true"></label>
 
                 <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-cozy-1" name="rating-cozy" value="1">  
                 <label class="fd-rating-indicator__label" for="rating-cozy-1"></label>
@@ -150,8 +150,8 @@ export const Sizes = () => `<div class="example-container">
         <span style="min-width: 150px;">Compact:</span>
         <div class="fd-rating-indicator fd-rating-indicator--compact">
             <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
-                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-compact-0" name="rating-compact" value="0">
-                <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-compact-0" aria-hidden="true"></label>
+                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating" id="rating-compact-0" name="rating-compact" value="0">
+                <label class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating" for="rating-compact-0" aria-hidden="true"></label>
 
                 <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-compact-1" name="rating-compact" value="1">  
                 <label class="fd-rating-indicator__label" for="rating-compact-1"></label>
@@ -176,8 +176,8 @@ export const Sizes = () => `<div class="example-container">
         <span style="min-width: 150px;">Condensed:</span>
         <div class="fd-rating-indicator fd-rating-indicator--condensed">
             <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
-                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-condensed-0" name="rating-condensed" value="0">
-                <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-condensed-0" aria-hidden="true"></label>
+                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating" id="rating-condensed-0" name="rating-condensed" value="0">
+                <label class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating" for="rating-condensed-0" aria-hidden="true"></label>
 
                 <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-condensed-1" name="rating-condensed" value="1">  
                 <label class="fd-rating-indicator__label" for="rating-condensed-1"></label>
@@ -219,37 +219,37 @@ Sizes.parameters = {
 export const CustomIcons = () => `<div class="example-container">
     <div class="fd-rating-indicator fd-rating-indicator--icon">
         <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
-            <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-icon-0" name="rating-icon" value="0">
-            <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-icon-0" aria-hidden="true"></label>
+            <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating" id="rating-icon-0" name="rating-icon" value="0">
+            <label class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating" for="rating-icon-0" aria-hidden="true"></label>
 
             <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-icon-1" name="rating-icon" value="1">
             <label class="fd-rating-indicator__label" for="rating-icon-1">
-                <i class="rated sap-icon--notification"></i>
-                <i class="unrated sap-icon--bo-strategy-management"></i>
+                <i class="fd-rating-indicator__label-rated sap-icon--notification"></i>
+                <i class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"></i>
             </label>
             
             <input aria-label="2 star" type="radio" class="fd-rating-indicator__input" id="rating-icon-2" name="rating-icon" value=2" checked>
             <label class="fd-rating-indicator__label" for="rating-icon-2">
-                <i class="rated sap-icon--notification"></i>
-                <i class="unrated sap-icon--bo-strategy-management"></i>
+                <i class="fd-rating-indicator__label-rated sap-icon--notification"></i>
+                <i class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"></i>
             </label>
             
             <input aria-label="3 star" type="radio" class="fd-rating-indicator__input" id="rating-icon-3" name="rating-icon" value="3">
             <label class="fd-rating-indicator__label" for="rating-icon-3">
-                <i class="rated sap-icon--notification"></i>
-                <i class="unrated sap-icon--bo-strategy-management"></i>
+                <i class="fd-rating-indicator__label-rated sap-icon--notification"></i>
+                <i class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"></i>
             </label>
             
             <input aria-label="4 star" type="radio" class="fd-rating-indicator__input" id="rating-icon-4" name="rating-icon" value="4">
             <label class="fd-rating-indicator__label" for="rating-icon-4">
-                <i class="rated sap-icon--notification"></i>
-                <i class="unrated sap-icon--bo-strategy-management"></i>
+                <i class="fd-rating-indicator__label-rated sap-icon--notification"></i>
+                <i class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"></i>
             </label>
             
             <input aria-label="5 star" type="radio" class="fd-rating-indicator__input" id="rating-icon-5" name="rating-icon" value="5">
             <label class="fd-rating-indicator__label" for="rating-icon-5">
-                <i class="rated sap-icon--notification"></i>
-                <i class="unrated sap-icon--bo-strategy-management"></i>
+                <i class="fd-rating-indicator__label-rated sap-icon--notification"></i>
+                <i class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"></i>
             </label>
         </div>
         <span class="fd-rating-indicator__dynamic-text">(2 of 5)</span>
@@ -272,8 +272,8 @@ export const HalfValues = () => `<div class="example-container">
         <span style="min-width: 185px;">Default:</span>
         <div class="fd-rating-indicator fd-rating-indicator--half-star">
             <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
-                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-half-sizes-0" name="rating-half-sizes" value="0">
-                <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-half-sizes-0" aria-hidden="true"></label>
+                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating" id="rating-half-sizes-0" name="rating-half-sizes" value="0">
+                <label class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating" for="rating-half-sizes-0" aria-hidden="true"></label>
 
                 <input aria-label="half star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-05" name="rating-half-sizes" value="0.5">  
                 <label class="fd-rating-indicator__label" for="rating-half-sizes-05"></label>
@@ -313,67 +313,67 @@ export const HalfValues = () => `<div class="example-container">
         <span style="min-width: 185px;">Custome icons:</span>
         <div class="fd-rating-indicator fd-rating-indicator--half-star fd-rating-indicator--icon">
             <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
-                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-half-sizes-custome-icons-0" name="rating-half-sizes-custome-icons" value="0">
-                <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-half-sizes-custome-icons-0" aria-hidden="true"></label>
+                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating" id="rating-half-sizes-custome-icons-0" name="rating-half-sizes-custome-icons" value="0">
+                <label class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating" for="rating-half-sizes-custome-icons-0" aria-hidden="true"></label>
 
                 <input aria-label="half star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-05" name="rating-half-sizes-custome-icons" value="0.5">  
                 <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-05">
-                    <i class="rated sap-icon--notification"></i>
-                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                    <i class="fd-rating-indicator__label-rated sap-icon--notification"></i>
+                    <i class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"></i>
                 </label>
 
                 <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-1" name="rating-half-sizes-custome-icons" value="1">
                 <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-1">
-                    <i class="rated sap-icon--notification"></i>
-                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                    <i class="fd-rating-indicator__label-rated sap-icon--notification"></i>
+                    <i class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"></i>
                 </label>
                 
                 <input aria-label="1 and half star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-15" name="rating-half-sizes-custome-icons" value="1.5">
                 <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-15">
-                    <i class="rated sap-icon--notification"></i>
-                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                    <i class="fd-rating-indicator__label-rated sap-icon--notification"></i>
+                    <i class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"></i>
                 </label>
                 
                 <input aria-label="2 star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-2" name="rating-half-sizes-custome-icons" value=2">
                 <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-2">
-                    <i class="rated sap-icon--notification"></i>
-                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                    <i class="fd-rating-indicator__label-rated sap-icon--notification"></i>
+                    <i class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"></i>
                 </label>
                 
                 <input aria-label="2 and half star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-25" name="rating-half-sizes-custome-icons" value="2.5" checked>
                 <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-25">
-                    <i class="rated sap-icon--notification"></i>
-                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                    <i class="fd-rating-indicator__label-rated sap-icon--notification"></i>
+                    <i class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"></i>
                 </label>
                 
                 <input aria-label="3 star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-3" name="rating-half-sizes-custome-icons" value="3">
                 <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-3">
-                    <i class="rated sap-icon--notification"></i>
-                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                    <i class="fd-rating-indicator__label-rated sap-icon--notification"></i>
+                    <i class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"></i>
                 </label>
                 
                 <input aria-label="3 and half star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-35" name="rating-half-sizes-custome-icons" value="3.5">
                 <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-35">
-                    <i class="rated sap-icon--notification"></i>
-                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                    <i class="fd-rating-indicator__label-rated sap-icon--notification"></i>
+                    <i class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"></i>
                 </label>
                 
                 <input aria-label="4 star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-4" name="rating-half-sizes-custome-icons" value="4">
                 <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-4">
-                    <i class="rated sap-icon--notification"></i>
-                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                    <i class="fd-rating-indicator__label-rated sap-icon--notification"></i>
+                    <i class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"></i>
                 </label>
                 
                 <input aria-label="4 and half star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-45" name="rating-half-sizes-custome-icons" value="4.5">
                 <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-45">
-                    <i class="rated sap-icon--notification"></i>
-                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                    <i class="fd-rating-indicator__label-rated sap-icon--notification"></i>
+                    <i class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"></i>
                 </label>
                 
                 <input aria-label="5 star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-5" name="rating-half-sizes-custome-icons" value="5">
                 <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-5">
-                    <i class="rated sap-icon--notification"></i>
-                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                    <i class="fd-rating-indicator__label-rated sap-icon--notification"></i>
+                    <i class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"></i>
                 </label>
             </div>
             <span class="fd-rating-indicator__dynamic-text">(2.5 of 5)</span>
@@ -384,67 +384,67 @@ export const HalfValues = () => `<div class="example-container">
         <span style="min-width: 185px;">Custome icons and size --lg:</span>
         <div class="fd-rating-indicator fd-rating-indicator--half-star fd-rating-indicator--icon fd-rating-indicator--lg">
             <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
-                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-half-sizes-custome-icons-lg-0" name="rating-half-sizes-custome-icons-lg" value="0">
-                <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-half-sizes-custome-icons-lg-0" aria-hidden="true"></label>
+                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating" id="rating-half-sizes-custome-icons-lg-0" name="rating-half-sizes-custome-icons-lg" value="0">
+                <label class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating" for="rating-half-sizes-custome-icons-lg-0" aria-hidden="true"></label>
 
                 <input aria-label="half star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-lg-05" name="rating-half-sizes-custome-icons-lg" value="0.5">  
                 <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-lg-05">
-                    <i class="rated sap-icon--notification"></i>
-                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                    <i class="fd-rating-indicator__label-rated sap-icon--notification"></i>
+                    <i class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"></i>
                 </label>
 
                 <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-lg-1" name="rating-half-sizes-custome-icons-lg" value="1">
                 <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-lg-1">
-                    <i class="rated sap-icon--notification"></i>
-                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                    <i class="fd-rating-indicator__label-rated sap-icon--notification"></i>
+                    <i class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"></i>
                 </label>
                 
                 <input aria-label="1 and half star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-lg-15" name="rating-half-sizes-custome-icons-lg" value="1.5">
                 <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-lg-15">
-                    <i class="rated sap-icon--notification"></i>
-                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                    <i class="fd-rating-indicator__label-rated sap-icon--notification"></i>
+                    <i class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"></i>
                 </label>
                 
                 <input aria-label="2 star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-lg-2" name="rating-half-sizes-custome-icons-lg" value=2">
                 <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-lg-2">
-                    <i class="rated sap-icon--notification"></i>
-                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                    <i class="fd-rating-indicator__label-rated sap-icon--notification"></i>
+                    <i class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"></i>
                 </label>
                 
                 <input aria-label="2 and half star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-lg-25" name="rating-half-sizes-custome-icons-lg" value="2.5" checked>
                 <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-lg-25">
-                    <i class="rated sap-icon--notification"></i>
-                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                    <i class="fd-rating-indicator__label-rated sap-icon--notification"></i>
+                    <i class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"></i>
                 </label>
                 
                 <input aria-label="3 star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-lg-3" name="rating-half-sizes-custome-icons-lg" value="3">
                 <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-lg-3">
-                    <i class="rated sap-icon--notification"></i>
-                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                    <i class="fd-rating-indicator__label-rated sap-icon--notification"></i>
+                    <i class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"></i>
                 </label>
                 
                 <input aria-label="3 and half star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-lg-35" name="rating-half-sizes-custome-icons-lg" value="3.5">
                 <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-lg-35">
-                    <i class="rated sap-icon--notification"></i>
-                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                    <i class="fd-rating-indicator__label-rated sap-icon--notification"></i>
+                    <i class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"></i>
                 </label>
                 
                 <input aria-label="4 star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-lg-4" name="rating-half-sizes-custome-icons-lg" value="4">
                 <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-lg-4">
-                    <i class="rated sap-icon--notification"></i>
-                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                    <i class="fd-rating-indicator__label-rated sap-icon--notification"></i>
+                    <i class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"></i>
                 </label>
                 
                 <input aria-label="4 and half star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-lg-45" name="rating-half-sizes-custome-icons-lg" value="4.5">
                 <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-lg-45">
-                    <i class="rated sap-icon--notification"></i>
-                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                    <i class="fd-rating-indicator__label-rated sap-icon--notification"></i>
+                    <i class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"></i>
                 </label>
                 
                 <input aria-label="5 star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-lg-5" name="rating-half-sizes-custome-icons-lg" value="5">
                 <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-lg-5">
-                    <i class="rated sap-icon--notification"></i>
-                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                    <i class="fd-rating-indicator__label-rated sap-icon--notification"></i>
+                    <i class="fd-rating-indicator__label-unrated sap-icon--bo-strategy-management"></i>
                 </label>
             </div>
             <span class="fd-rating-indicator__dynamic-text">(2.5 of 5)</span>
@@ -465,8 +465,8 @@ modifier class together with the \`fd-rating-indicator\` class.
 export const Disabled = () => `<div class="example-container">
     <div class="fd-rating-indicator" aria-disabled="true">
         <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
-            <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-disabled-0" name="rating-disabled" value="0" disabled>
-            <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-disabled-0" aria-hidden="true"></label>
+            <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating" id="rating-disabled-0" name="rating-disabled" value="0" disabled>
+            <label class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating" for="rating-disabled-0" aria-hidden="true"></label>
 
             <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-disabled-1" name="rating-disabled" value="1" disabled>  
             <label class="fd-rating-indicator__label" for="rating-disabled-1"></label>
@@ -504,8 +504,8 @@ Additionally, one of the selectors listed below needs to be added to the \`fd-ra
 export const DisplayMode = () => `<div class="example-container">
         <div class="fd-rating-indicator fd-rating-indicator--display-mode">
             <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
-                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-display-mode-0" name="rating-display-mode" value="0" disabled>
-                <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-display-mode-0" aria-hidden="true"></label>
+                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating" id="rating-display-mode-0" name="rating-display-mode" value="0" disabled>
+                <label class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating" for="rating-display-mode-0" aria-hidden="true"></label>
 
                 <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-display-mode-1" name="rating-display-mode" value="1" disabled>  
                 <label class="fd-rating-indicator__label" for="rating-display-mode-1"></label>
@@ -540,8 +540,8 @@ If you want to include a rating indicator in a display-only form, add the \`.fd-
 export const NonInteractive = () => `<div class="example-container">
         <div class="fd-rating-indicator fd-rating-indicator--non-interactive">
             <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
-                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-non-interactive-mode-0" name="rating-non-interactive-mode" value="0" disabled>
-                <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-non-interactive-mode-0" aria-hidden="true"></label>
+                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating" id="rating-non-interactive-mode-0" name="rating-non-interactive-mode" value="0" disabled>
+                <label class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating" for="rating-non-interactive-mode-0" aria-hidden="true"></label>
 
                 <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-non-interactive-mode-1" name="rating-non-interactive-mode" value="1" disabled>  
                 <label class="fd-rating-indicator__label" for="rating-non-interactive-mode-1"></label>
@@ -576,8 +576,8 @@ add the \`.fd-rating-indicator--non-interactive\` class to the \`fd-rating-indic
 export const DifferentValues = () => `<div class="example-container">
         <div class="fd-rating-indicator">
             <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
-                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-max-value-5-0" name="rating-max-value-5" value="0">
-                <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-max-value-5-0" aria-hidden="true"></label>
+                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating" id="rating-max-value-5-0" name="rating-max-value-5" value="0">
+                <label class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating" for="rating-max-value-5-0" aria-hidden="true"></label>
 
                 <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-max-value-5-1" name="rating-max-value-5" value="1">  
                 <label class="fd-rating-indicator__label" for="rating-max-value-5-1"></label>
@@ -601,8 +601,8 @@ export const DifferentValues = () => `<div class="example-container">
     <div class="example-container">
         <div class="fd-rating-indicator">
             <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
-                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-max-value-6-0" name="rating-max-value-6" value="0">
-                <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-max-value-6-0" aria-hidden="true"></label>
+                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating" id="rating-max-value-6-0" name="rating-max-value-6" value="0">
+                <label class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating" for="rating-max-value-6-0" aria-hidden="true"></label>
 
                 <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-max-value-6-1" name="rating-max-value-6" value="1">  
                 <label class="fd-rating-indicator__label" for="rating-max-value-6-1"></label>
@@ -629,8 +629,8 @@ export const DifferentValues = () => `<div class="example-container">
     <div class="example-container">
         <div class="fd-rating-indicator">
             <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
-                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-max-value-7-0" name="rating-max-value-7" value="0">
-                <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-max-value-7-0" aria-hidden="true"></label>
+                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__input--zero-rating" id="rating-max-value-7-0" name="rating-max-value-7" value="0">
+                <label class="fd-rating-indicator__label fd-rating-indicator__label--zero-rating" for="rating-max-value-7-0" aria-hidden="true"></label>
 
                 <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-max-value-7-1" name="rating-max-value-7" value="1">  
                 <label class="fd-rating-indicator__label" for="rating-max-value-7-1"></label>

--- a/stories/rating-indicator/rating-indicator.stories.js
+++ b/stories/rating-indicator/rating-indicator.stories.js
@@ -10,7 +10,7 @@ Although the maximum amount is 7 for the icons or images, it is highly recommend
 Use the rating indicator in forms, tables, or in a dialog box.
         `,
         tags: ['f3', 'a11y', 'theme'],
-        components: ['rating-indicator']
+        components: ['rating-indicator', 'icon']
     }
 };
 
@@ -18,6 +18,9 @@ export const Sizes = () => `<div class="example-container">
         <span style="min-width: 150px;">Default (Medium):</span>
         <div class="fd-rating-indicator fd-rating-indicator--hide-dynamic-text">
             <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
+                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-0" name="rating" value="0">
+                <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-0" aria-hidden="true"></label>
+
                 <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-1" name="rating" value="1">  
                 <label class="fd-rating-indicator__label" for="rating-1"></label>
                 
@@ -41,6 +44,9 @@ export const Sizes = () => `<div class="example-container">
         <span style="min-width: 150px;">Extra small:</span>
         <div class="fd-rating-indicator fd-rating-indicator--xs">
             <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
+                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-xs-0" name="rating-xs" value="0">
+                <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-xs-0" aria-hidden="true"></label>
+
                 <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-xs-1" name="rating-xs" value="1">  
                 <label class="fd-rating-indicator__label" for="rating-xs-1"></label>
     
@@ -65,6 +71,9 @@ export const Sizes = () => `<div class="example-container">
         <span style="min-width: 150px;">Small:</span>
         <div class="fd-rating-indicator fd-rating-indicator--sm">
             <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
+                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-s-0" name="rating-s" value="0">
+                <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-s-0" aria-hidden="true"></label>
+
                 <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-s-1" name="rating-s" value="1">  
                 <label class="fd-rating-indicator__label" for="rating-s-1"></label>
                 
@@ -89,6 +98,9 @@ export const Sizes = () => `<div class="example-container">
         <span style="min-width: 150px;">Large:</span>
         <div class="fd-rating-indicator fd-rating-indicator--lg">
             <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
+                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-l-0" name="rating-l" value="0">
+                <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-l-0" aria-hidden="true"></label>
+
                 <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-l-1" name="rating-l" value="1">  
                 <label class="fd-rating-indicator__label" for="rating-l-1"></label>
                 
@@ -112,6 +124,9 @@ export const Sizes = () => `<div class="example-container">
         <span style="min-width: 150px;">Cozy:</span>
         <div class="fd-rating-indicator fd-rating-indicator--cozy">
             <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
+                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-cozy-0" name="rating-cozy" value="0">
+                <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-cozy-0" aria-hidden="true"></label>
+
                 <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-cozy-1" name="rating-cozy" value="1">  
                 <label class="fd-rating-indicator__label" for="rating-cozy-1"></label>
                 
@@ -135,6 +150,9 @@ export const Sizes = () => `<div class="example-container">
         <span style="min-width: 150px;">Compact:</span>
         <div class="fd-rating-indicator fd-rating-indicator--compact">
             <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
+                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-compact-0" name="rating-compact" value="0">
+                <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-compact-0" aria-hidden="true"></label>
+
                 <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-compact-1" name="rating-compact" value="1">  
                 <label class="fd-rating-indicator__label" for="rating-compact-1"></label>
                 
@@ -158,6 +176,9 @@ export const Sizes = () => `<div class="example-container">
         <span style="min-width: 150px;">Condensed:</span>
         <div class="fd-rating-indicator fd-rating-indicator--condensed">
             <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
+                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-condensed-0" name="rating-condensed" value="0">
+                <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-condensed-0" aria-hidden="true"></label>
+
                 <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-condensed-1" name="rating-condensed" value="1">  
                 <label class="fd-rating-indicator__label" for="rating-condensed-1"></label>
                 
@@ -194,72 +215,42 @@ Sizes.parameters = {
     }
 };
 
-export const HalfValues = () => `<div class="example-container">
-    <div class="fd-rating-indicator fd-rating-indicator--half-star">
-        <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
-            <input aria-label="half star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-05" name="rating-half-sizes" value="0.5">  
-            <label class="fd-rating-indicator__label" for="rating-half-sizes-05"></label>
-
-            <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-1" name="rating-half-sizes" value="1">
-            <label class="fd-rating-indicator__label" for="rating-half-sizes-1"></label>
-            
-            <input aria-label="1 and half star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-15" name="rating-half-sizes" value="1.5">
-            <label class="fd-rating-indicator__label" for="rating-half-sizes-15"></label>
-            
-            <input aria-label="2 star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-2" name="rating-half-sizes" value=2">
-            <label class="fd-rating-indicator__label" for="rating-half-sizes-2"></label>
-            
-            <input aria-label="2 and half star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-25" name="rating-half-sizes" value="2.5" checked>
-            <label class="fd-rating-indicator__label" for="rating-half-sizes-25"></label>
-            
-            <input aria-label="3 star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-3" name="rating-half-sizes" value="3">
-            <label class="fd-rating-indicator__label" for="rating-half-sizes-3"></label>
-            
-            <input aria-label="3 and half star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-35" name="rating-half-sizes" value="3.5">
-            <label class="fd-rating-indicator__label" for="rating-half-sizes-35"></label>
-            
-            <input aria-label="4 star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-4" name="rating-half-sizes" value="4">
-            <label class="fd-rating-indicator__label" for="rating-half-sizes-4"></label>
-            
-            <input aria-label="4 and half star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-45" name="rating-half-sizes" value="4.5">
-            <label class="fd-rating-indicator__label" for="rating-half-sizes-45"></label>
-            
-            <input aria-label="5 star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-5" name="rating-half-sizes" value="5">
-            <label class="fd-rating-indicator__label" for="rating-half-sizes-5"></label>
-        </div>
-        <span class="fd-rating-indicator__dynamic-text">(2.5 of 5)</span>
-    </div>
-</div>
-`;
-
-HalfValues.storyName = 'Half values';
-HalfValues.parameters = {
-    docs: {
-        storyDescription: `
-To display half values with the rating indicator i.e 2.5 stars, add the \`fd-rating-indicator--half-star\` 
-modifier class together with the \`fd-rating-indicator\` class.
-`
-    }
-};
 
 export const CustomIcons = () => `<div class="example-container">
-    <div class="fd-rating-indicator fd-rating-indicator--icon"
-    style="--sapRating-indicator-icon-rated: url('./assets/icons/rated.png'); --sapRating-indicator-icon-unrated: url('./assets/icons/unrated.png')">
+    <div class="fd-rating-indicator fd-rating-indicator--icon">
         <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
+            <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-icon-0" name="rating-icon" value="0">
+            <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-icon-0" aria-hidden="true"></label>
+
             <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-icon-1" name="rating-icon" value="1">
-            <label class="fd-rating-indicator__label" for="rating-icon-1"></label>
+            <label class="fd-rating-indicator__label" for="rating-icon-1">
+                <i class="rated sap-icon--notification"></i>
+                <i class="unrated sap-icon--bo-strategy-management"></i>
+            </label>
             
             <input aria-label="2 star" type="radio" class="fd-rating-indicator__input" id="rating-icon-2" name="rating-icon" value=2" checked>
-            <label class="fd-rating-indicator__label" for="rating-icon-2"></label>
+            <label class="fd-rating-indicator__label" for="rating-icon-2">
+                <i class="rated sap-icon--notification"></i>
+                <i class="unrated sap-icon--bo-strategy-management"></i>
+            </label>
             
             <input aria-label="3 star" type="radio" class="fd-rating-indicator__input" id="rating-icon-3" name="rating-icon" value="3">
-            <label class="fd-rating-indicator__label" for="rating-icon-3"></label>
+            <label class="fd-rating-indicator__label" for="rating-icon-3">
+                <i class="rated sap-icon--notification"></i>
+                <i class="unrated sap-icon--bo-strategy-management"></i>
+            </label>
             
             <input aria-label="4 star" type="radio" class="fd-rating-indicator__input" id="rating-icon-4" name="rating-icon" value="4">
-            <label class="fd-rating-indicator__label" for="rating-icon-4"></label>
+            <label class="fd-rating-indicator__label" for="rating-icon-4">
+                <i class="rated sap-icon--notification"></i>
+                <i class="unrated sap-icon--bo-strategy-management"></i>
+            </label>
             
             <input aria-label="5 star" type="radio" class="fd-rating-indicator__input" id="rating-icon-5" name="rating-icon" value="5">
-            <label class="fd-rating-indicator__label" for="rating-icon-5"></label>
+            <label class="fd-rating-indicator__label" for="rating-icon-5">
+                <i class="rated sap-icon--notification"></i>
+                <i class="unrated sap-icon--bo-strategy-management"></i>
+            </label>
         </div>
         <span class="fd-rating-indicator__dynamic-text">(2 of 5)</span>
     </div>
@@ -272,7 +263,201 @@ CustomIcons.parameters = {
         storyDescription: `
 To make the rating indicator to use custom icons needs to be added class \`.fd-rating-indicator--icon\` 
 to the \`fd-rating-indicator\` element.
-Additionally, needs to set css variables \`--sapRating-indicator-icon-rated: url(...)\` and \`--sapRating-indicator-icon-unrated: url(...)\`
+Also, you need to set the icon class that will implement the icon
+`
+    }
+};
+
+export const HalfValues = () => `<div class="example-container">
+        <span style="min-width: 185px;">Default:</span>
+        <div class="fd-rating-indicator fd-rating-indicator--half-star">
+            <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
+                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-half-sizes-0" name="rating-half-sizes" value="0">
+                <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-half-sizes-0" aria-hidden="true"></label>
+
+                <input aria-label="half star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-05" name="rating-half-sizes" value="0.5">  
+                <label class="fd-rating-indicator__label" for="rating-half-sizes-05"></label>
+
+                <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-1" name="rating-half-sizes" value="1">
+                <label class="fd-rating-indicator__label" for="rating-half-sizes-1"></label>
+                
+                <input aria-label="1 and half star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-15" name="rating-half-sizes" value="1.5">
+                <label class="fd-rating-indicator__label" for="rating-half-sizes-15"></label>
+                
+                <input aria-label="2 star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-2" name="rating-half-sizes" value=2">
+                <label class="fd-rating-indicator__label" for="rating-half-sizes-2"></label>
+                
+                <input aria-label="2 and half star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-25" name="rating-half-sizes" value="2.5" checked>
+                <label class="fd-rating-indicator__label" for="rating-half-sizes-25"></label>
+                
+                <input aria-label="3 star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-3" name="rating-half-sizes" value="3">
+                <label class="fd-rating-indicator__label" for="rating-half-sizes-3"></label>
+                
+                <input aria-label="3 and half star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-35" name="rating-half-sizes" value="3.5">
+                <label class="fd-rating-indicator__label" for="rating-half-sizes-35"></label>
+                
+                <input aria-label="4 star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-4" name="rating-half-sizes" value="4">
+                <label class="fd-rating-indicator__label" for="rating-half-sizes-4"></label>
+                
+                <input aria-label="4 and half star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-45" name="rating-half-sizes" value="4.5">
+                <label class="fd-rating-indicator__label" for="rating-half-sizes-45"></label>
+                
+                <input aria-label="5 star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-5" name="rating-half-sizes" value="5">
+                <label class="fd-rating-indicator__label" for="rating-half-sizes-5"></label>
+            </div>
+            <span class="fd-rating-indicator__dynamic-text">(2.5 of 5)</span>
+        </div>
+    </div>
+
+    <div class="example-container">
+        <span style="min-width: 185px;">Custome icons:</span>
+        <div class="fd-rating-indicator fd-rating-indicator--half-star fd-rating-indicator--icon">
+            <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
+                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-half-sizes-custome-icons-0" name="rating-half-sizes-custome-icons" value="0">
+                <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-half-sizes-custome-icons-0" aria-hidden="true"></label>
+
+                <input aria-label="half star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-05" name="rating-half-sizes-custome-icons" value="0.5">  
+                <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-05">
+                    <i class="rated sap-icon--notification"></i>
+                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                </label>
+
+                <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-1" name="rating-half-sizes-custome-icons" value="1">
+                <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-1">
+                    <i class="rated sap-icon--notification"></i>
+                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                </label>
+                
+                <input aria-label="1 and half star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-15" name="rating-half-sizes-custome-icons" value="1.5">
+                <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-15">
+                    <i class="rated sap-icon--notification"></i>
+                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                </label>
+                
+                <input aria-label="2 star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-2" name="rating-half-sizes-custome-icons" value=2">
+                <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-2">
+                    <i class="rated sap-icon--notification"></i>
+                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                </label>
+                
+                <input aria-label="2 and half star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-25" name="rating-half-sizes-custome-icons" value="2.5" checked>
+                <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-25">
+                    <i class="rated sap-icon--notification"></i>
+                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                </label>
+                
+                <input aria-label="3 star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-3" name="rating-half-sizes-custome-icons" value="3">
+                <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-3">
+                    <i class="rated sap-icon--notification"></i>
+                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                </label>
+                
+                <input aria-label="3 and half star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-35" name="rating-half-sizes-custome-icons" value="3.5">
+                <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-35">
+                    <i class="rated sap-icon--notification"></i>
+                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                </label>
+                
+                <input aria-label="4 star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-4" name="rating-half-sizes-custome-icons" value="4">
+                <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-4">
+                    <i class="rated sap-icon--notification"></i>
+                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                </label>
+                
+                <input aria-label="4 and half star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-45" name="rating-half-sizes-custome-icons" value="4.5">
+                <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-45">
+                    <i class="rated sap-icon--notification"></i>
+                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                </label>
+                
+                <input aria-label="5 star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-5" name="rating-half-sizes-custome-icons" value="5">
+                <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-5">
+                    <i class="rated sap-icon--notification"></i>
+                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                </label>
+            </div>
+            <span class="fd-rating-indicator__dynamic-text">(2.5 of 5)</span>
+        </div>
+    </div>
+
+    <div class="example-container">
+        <span style="min-width: 185px;">Custome icons and size --lg:</span>
+        <div class="fd-rating-indicator fd-rating-indicator--half-star fd-rating-indicator--icon fd-rating-indicator--lg">
+            <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
+                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-half-sizes-custome-icons-lg-0" name="rating-half-sizes-custome-icons-lg" value="0">
+                <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-half-sizes-custome-icons-lg-0" aria-hidden="true"></label>
+
+                <input aria-label="half star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-lg-05" name="rating-half-sizes-custome-icons-lg" value="0.5">  
+                <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-lg-05">
+                    <i class="rated sap-icon--notification"></i>
+                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                </label>
+
+                <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-lg-1" name="rating-half-sizes-custome-icons-lg" value="1">
+                <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-lg-1">
+                    <i class="rated sap-icon--notification"></i>
+                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                </label>
+                
+                <input aria-label="1 and half star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-lg-15" name="rating-half-sizes-custome-icons-lg" value="1.5">
+                <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-lg-15">
+                    <i class="rated sap-icon--notification"></i>
+                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                </label>
+                
+                <input aria-label="2 star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-lg-2" name="rating-half-sizes-custome-icons-lg" value=2">
+                <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-lg-2">
+                    <i class="rated sap-icon--notification"></i>
+                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                </label>
+                
+                <input aria-label="2 and half star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-lg-25" name="rating-half-sizes-custome-icons-lg" value="2.5" checked>
+                <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-lg-25">
+                    <i class="rated sap-icon--notification"></i>
+                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                </label>
+                
+                <input aria-label="3 star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-lg-3" name="rating-half-sizes-custome-icons-lg" value="3">
+                <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-lg-3">
+                    <i class="rated sap-icon--notification"></i>
+                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                </label>
+                
+                <input aria-label="3 and half star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-lg-35" name="rating-half-sizes-custome-icons-lg" value="3.5">
+                <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-lg-35">
+                    <i class="rated sap-icon--notification"></i>
+                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                </label>
+                
+                <input aria-label="4 star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-lg-4" name="rating-half-sizes-custome-icons-lg" value="4">
+                <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-lg-4">
+                    <i class="rated sap-icon--notification"></i>
+                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                </label>
+                
+                <input aria-label="4 and half star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-lg-45" name="rating-half-sizes-custome-icons-lg" value="4.5">
+                <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-lg-45">
+                    <i class="rated sap-icon--notification"></i>
+                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                </label>
+                
+                <input aria-label="5 star" type="radio" class="fd-rating-indicator__input" id="rating-half-sizes-custome-icons-lg-5" name="rating-half-sizes-custome-icons-lg" value="5">
+                <label class="fd-rating-indicator__label" for="rating-half-sizes-custome-icons-lg-5">
+                    <i class="rated sap-icon--notification"></i>
+                    <i class="unrated sap-icon--bo-strategy-management"></i>
+                </label>
+            </div>
+            <span class="fd-rating-indicator__dynamic-text">(2.5 of 5)</span>
+        </div>
+    </div>
+`;
+
+HalfValues.storyName = 'Half values';
+HalfValues.parameters = {
+    docs: {
+        storyDescription: `
+To display half values with the rating indicator i.e 2.5 stars, add the \`fd-rating-indicator--half-star\` 
+modifier class together with the \`fd-rating-indicator\` class.
 `
     }
 };
@@ -280,6 +465,9 @@ Additionally, needs to set css variables \`--sapRating-indicator-icon-rated: url
 export const Disabled = () => `<div class="example-container">
     <div class="fd-rating-indicator" aria-disabled="true">
         <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
+            <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-disabled-0" name="rating-disabled" value="0" disabled>
+            <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-disabled-0" aria-hidden="true"></label>
+
             <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-disabled-1" name="rating-disabled" value="1" disabled>  
             <label class="fd-rating-indicator__label" for="rating-disabled-1"></label>
             
@@ -316,6 +504,9 @@ Additionally, one of the selectors listed below needs to be added to the \`fd-ra
 export const DisplayMode = () => `<div class="example-container">
         <div class="fd-rating-indicator fd-rating-indicator--display-mode">
             <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
+                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-display-mode-0" name="rating-display-mode" value="0" disabled>
+                <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-display-mode-0" aria-hidden="true"></label>
+
                 <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-display-mode-1" name="rating-display-mode" value="1" disabled>  
                 <label class="fd-rating-indicator__label" for="rating-display-mode-1"></label>
                 
@@ -349,6 +540,9 @@ If you want to include a rating indicator in a display-only form, add the \`.fd-
 export const NonInteractive = () => `<div class="example-container">
         <div class="fd-rating-indicator fd-rating-indicator--non-interactive">
             <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
+                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-non-interactive-mode-0" name="rating-non-interactive-mode" value="0" disabled>
+                <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-non-interactive-mode-0" aria-hidden="true"></label>
+
                 <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-non-interactive-mode-1" name="rating-non-interactive-mode" value="1" disabled>  
                 <label class="fd-rating-indicator__label" for="rating-non-interactive-mode-1"></label>
                 
@@ -382,6 +576,9 @@ add the \`.fd-rating-indicator--non-interactive\` class to the \`fd-rating-indic
 export const DifferentValues = () => `<div class="example-container">
         <div class="fd-rating-indicator">
             <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
+                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-max-value-5-0" name="rating-max-value-5" value="0">
+                <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-max-value-5-0" aria-hidden="true"></label>
+
                 <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-max-value-5-1" name="rating-max-value-5" value="1">  
                 <label class="fd-rating-indicator__label" for="rating-max-value-5-1"></label>
                 
@@ -404,6 +601,9 @@ export const DifferentValues = () => `<div class="example-container">
     <div class="example-container">
         <div class="fd-rating-indicator">
             <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
+                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-max-value-6-0" name="rating-max-value-6" value="0">
+                <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-max-value-6-0" aria-hidden="true"></label>
+
                 <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-max-value-6-1" name="rating-max-value-6" value="1">  
                 <label class="fd-rating-indicator__label" for="rating-max-value-6-1"></label>
                 
@@ -429,6 +629,9 @@ export const DifferentValues = () => `<div class="example-container">
     <div class="example-container">
         <div class="fd-rating-indicator">
             <div class="fd-rating-indicator__container" aria-label="Star Rating (out of 5)">
+                <input aria-label="0 star" type="radio" class="fd-rating-indicator__input fd-rating-indicator__zero-rating" id="rating-max-value-7-0" name="rating-max-value-7" value="0">
+                <label class="fd-rating-indicator__zero-rating fd-rating-indicator__label" for="rating-max-value-7-0" aria-hidden="true"></label>
+
                 <input aria-label="1 star" type="radio" class="fd-rating-indicator__input" id="rating-max-value-7-1" name="rating-max-value-7" value="1">  
                 <label class="fd-rating-indicator__label" for="rating-max-value-7-1"></label>
                 


### PR DESCRIPTION
## Description
Fixed rating-indicator styles for `Half values` state

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
<img width="184" alt="Screen Shot 2021-12-06 at 17 21 55" src="https://user-images.githubusercontent.com/8318592/145087334-d5d89562-468f-42c8-86ed-067bf0d9db81.png">

### After:
<img width="212" alt="Screen Shot 2021-12-06 at 17 22 39" src="https://user-images.githubusercontent.com/8318592/145087386-ada607d8-4e8d-4e97-a5de-ff9457731456.png">

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [n/a] Text elements follow the truncation rules
- [n/a] hover state of the element follow design spec
- [n/a] focus state of the element follow design spec
- [n/a] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [n/a] selected hover state of the element follow design spec
- [n/a] pressed state of the element follow design spec
- [n/a] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [n/a] Checked if current components can be reused, instead of having new code.
3. Testing
- [n/a] tested Storybook examples with "CSS Resources" `normalize` option 
- [n/a] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [n/a] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [n/a] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
