### PR TITLE
fix(styles): pagination component update due to new designs

### DIFF
--- a/src/styles/pagination.scss
+++ b/src/styles/pagination.scss
@@ -51,7 +51,8 @@ $block: #{$fd-namespace}-pagination;
   &__more,
   &__button,
   &__link,
-  &__input {
+  &__input,
+  &__label {
     @include fd-set-margins-x-equal(0.125rem);
   }
 
@@ -92,8 +93,6 @@ $block: #{$fd-namespace}-pagination;
 
   .#{$block}__label {
     display: none;
-
-    @include fd-set-margins-x-equal(0.125rem);
   }
 
   .#{$block}__button {
@@ -119,7 +118,13 @@ $block: #{$fd-namespace}-pagination;
   }
 }
 
-@media (max-width: 1024px) {
+@include fd-media-sm() {
+  .#{$block} {
+    @include fd-pagination-mobile();
+  }
+}
+
+@include fd-media-md() {
   .#{$block} {
     @include fd-pagination-mobile();
   }

--- a/src/styles/pagination.scss
+++ b/src/styles/pagination.scss
@@ -48,14 +48,6 @@ $block: #{$fd-namespace}-pagination;
     @include fd-set-margins-x-equal('auto');
   }
 
-  &__more,
-  &__button,
-  &__link,
-  &__input,
-  &__label {
-    @include fd-set-margins-x-equal(0.125rem);
-  }
-
   &__more {
     @include fd-reset();
 
@@ -65,6 +57,14 @@ $block: #{$fd-namespace}-pagination;
       width: 1.5rem;
       text-align: center;
     }
+  }
+
+  &__more,
+  &__button,
+  &__link,
+  &__input,
+  &__label {
+    @include fd-set-margins-x-equal(0.125rem);
   }
 
   .#{$block}__input {

--- a/src/styles/pagination.scss
+++ b/src/styles/pagination.scss
@@ -20,7 +20,8 @@ $block: #{$fd-namespace}-pagination;
   }
 
   .#{$block}__button--mobile,
-  .#{$block}__label {
+  .#{$block}__label,
+  .#{$block}__input {
     display: flex;
   }
 }
@@ -45,6 +46,13 @@ $block: #{$fd-namespace}-pagination;
     @include fd-reset();
     @include fd-flex-center();
     @include fd-set-margins-x-equal('auto');
+  }
+
+  &__more,
+  &__button,
+  &__link,
+  &__input {
+    @include fd-set-margins-x-equal(0.125rem);
   }
 
   &__more {
@@ -84,6 +92,8 @@ $block: #{$fd-namespace}-pagination;
 
   .#{$block}__label {
     display: none;
+
+    @include fd-set-margins-x-equal(0.125rem);
   }
 
   .#{$block}__button {
@@ -98,12 +108,18 @@ $block: #{$fd-namespace}-pagination;
     }
   }
 
+  &--short {
+    .#{$block}__input {
+      display: none;
+    }
+  }
+
   &--mobile {
     @include fd-pagination-mobile();
   }
 }
 
-@media (max-width: 599px) {
+@media (max-width: 1024px) {
   .#{$block} {
     @include fd-pagination-mobile();
   }

--- a/stories/pagination/__snapshots__/pagination.stories.storyshot
+++ b/stories/pagination/__snapshots__/pagination.stories.storyshot
@@ -239,6 +239,60 @@ exports[`Storyshots Components/Pagination Cozy 1`] = `
 
             
       <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        494
+      </a>
+      
+
+            
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        495
+      </a>
+      
+
+            
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        496
+      </a>
+      
+
+            
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        497
+      </a>
+      
+
+            
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        498
+      </a>
+      
+
+            
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        499
+      </a>
+      
+
+            
+      <a
         class="fd-button fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -249,7 +303,7 @@ exports[`Storyshots Components/Pagination Cozy 1`] = `
             
       <label
         class="fd-form-label fd-pagination__label"
-        for="cozyPageInput"
+        id="cozyPageInputPage"
       >
         Page:
       </label>
@@ -257,14 +311,23 @@ exports[`Storyshots Components/Pagination Cozy 1`] = `
 
             
       <input
+        aria-labelledby="cozyPageInputPage cozyPageInputOf"
         class="fd-input fd-pagination__input"
-        id="cozyPageInput"
         max="500"
         min="1"
         required=""
         type="number"
         value="500"
       />
+      
+
+            
+      <label
+        class="fd-form-label fd-pagination__label"
+        id="cozyPageInputOf"
+      >
+        of 500
+      </label>
       
 
             
@@ -327,459 +390,1120 @@ exports[`Storyshots Components/Pagination Cozy 1`] = `
 `;
 
 exports[`Storyshots Components/Pagination First page 1`] = `
-<div
-  class="fd-pagination"
->
-  
-    
-  <nav
-    class="fd-pagination__nav"
-  >
-    
-        
-    <a
-      aria-disabled="true"
-      aria-label="First"
-      class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
-      href="#"
-    >
-      
-            
-      <i
-        class="sap-icon sap-icon--media-rewind"
-      />
-      
-        
-    </a>
-    
-
-        
-    <a
-      aria-disabled="true"
-      aria-label="Previous"
-      class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
-      href="#"
-    >
-      
-            
-      <i
-        class="sap-icon sap-icon--navigation-left-arrow"
-      />
-      
-        
-    </a>
-    
-
-        
-    <label
-      class="fd-form-label fd-pagination__label"
-      for="firstPageInput"
-    >
-      Page:
-    </label>
-    
-
-        
-    <input
-      class="fd-input fd-input--compact fd-pagination__input"
-      id="firstPageInput"
-      max="3"
-      min="1"
-      required=""
-      type="number"
-      value="1"
-    />
-    
-
-        
-    <a
-      class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
-      href="#"
-    >
-      2
-    </a>
-    
-
-        
-    <a
-      class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
-      href="#"
-    >
-      3
-    </a>
-    
-
-        
-    <a
-      aria-disabled="false"
-      aria-label="Next"
-      class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
-      href="#"
-    >
-      
-            
-      <i
-        class="sap-icon sap-icon--navigation-right-arrow"
-      />
-      
-        
-    </a>
-    
-
-        
-    <a
-      aria-disabled="false"
-      aria-label="Last"
-      class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
-      href="#"
-    >
-      
-            
-      <i
-        class="sap-icon sap-icon--media-forward"
-      />
-      
-        
-    </a>
-    
-    
-  </nav>
+<section>
+  <h3>
+    &gt; 9 Pages
+  </h3>
   
 
-    
   <div
-    class="fd-pagination__total"
+    class="fd-pagination"
   >
     
-        
-    <span
-      class="fd-form-label fd-pagination__total-label"
+    
+    <nav
+      class="fd-pagination__nav"
+      title="pagination with more than 9 pages"
     >
-      3 Results
-    </span>
+      
+        
+      <a
+        aria-disabled="true"
+        aria-label="First"
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
+        href="#"
+      >
+        
+            
+        <i
+          class="sap-icon sap-icon--media-rewind"
+        />
+        
+        
+      </a>
+      
+
+        
+      <a
+        aria-disabled="true"
+        aria-label="Previous"
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
+        href="#"
+      >
+        
+            
+        <i
+          class="sap-icon sap-icon--navigation-left-arrow"
+        />
+        
+        
+      </a>
+      
+
+        
+      <label
+        class="fd-form-label fd-pagination__label"
+        id="firstPageInputPage"
+      >
+        Page:
+      </label>
+      
+
+        
+      <input
+        aria-labelledby="firstPageInputPage firstPageInputOf"
+        class="fd-input fd-input--compact fd-pagination__input"
+        max="500"
+        min="1"
+        required=""
+        type="number"
+        value="1"
+      />
+      
+
+        
+      <label
+        class="fd-form-label fd-pagination__label"
+        id="firstPageInputOf"
+      >
+        of 500
+      </label>
+      
+
+        
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        2
+      </a>
+      
+
+        
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        3
+      </a>
+      
+
+        
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        4
+      </a>
+      
+
+        
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        5
+      </a>
+      
+
+        
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        6
+      </a>
+      
+
+        
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        7
+      </a>
+      
+
+        
+      <span
+        class="fd-pagination__more"
+        role="presentation"
+      />
+      
+
+        
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        500
+      </a>
+      
+
+        
+      <a
+        aria-disabled="false"
+        aria-label="Next"
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
+        href="#"
+      >
+        
+            
+        <i
+          class="sap-icon sap-icon--navigation-right-arrow"
+        />
+        
+        
+      </a>
+      
+
+        
+      <a
+        aria-disabled="false"
+        aria-label="Last"
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
+        href="#"
+      >
+        
+            
+        <i
+          class="sap-icon sap-icon--media-forward"
+        />
+        
+        
+      </a>
+      
     
+    </nav>
     
+
+    
+    <div
+      class="fd-pagination__total"
+    >
+      
+        
+      <span
+        class="fd-form-label fd-pagination__total-label"
+      >
+        500 Results
+      </span>
+      
+    
+    </div>
+    
+
   </div>
   
 
-</div>
+
+  <h3>
+    &lt; 9 Pages
+  </h3>
+  
+
+
+  <div
+    class="fd-pagination fd-pagination--short"
+  >
+    
+    
+    <nav
+      class="fd-pagination__nav"
+    >
+      
+        
+      <a
+        aria-disabled="true"
+        aria-label="First"
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
+        href="#"
+      >
+        
+            
+        <i
+          class="sap-icon sap-icon--media-rewind"
+        />
+        
+        
+      </a>
+      
+
+        
+      <a
+        aria-disabled="true"
+        aria-label="Previous"
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
+        href="#"
+      >
+        
+            
+        <i
+          class="sap-icon sap-icon--navigation-left-arrow"
+        />
+        
+        
+      </a>
+      
+
+        
+      <label
+        class="fd-form-label fd-pagination__label"
+        id="firstPageInputShortPage"
+      >
+        Page:
+      </label>
+      
+
+        
+      <input
+        aria-labelledby="firstPageInputShortPage firstPageInputShortOf"
+        class="fd-input fd-input--compact fd-pagination__input"
+        max="3"
+        min="1"
+        required=""
+        type="number"
+        value="1"
+      />
+      
+
+        
+      <label
+        class="fd-form-label fd-pagination__label"
+        id="firstPageInputShortOf"
+      >
+        of 3
+      </label>
+      
+
+        
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link is-active"
+        href="#"
+      >
+        1
+      </a>
+      
+
+        
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        2
+      </a>
+      
+
+        
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        3
+      </a>
+      
+
+        
+      <a
+        aria-disabled="false"
+        aria-label="Next"
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
+        href="#"
+      >
+        
+            
+        <i
+          class="sap-icon sap-icon--navigation-right-arrow"
+        />
+        
+        
+      </a>
+      
+
+        
+      <a
+        aria-disabled="false"
+        aria-label="Last"
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
+        href="#"
+      >
+        
+            
+        <i
+          class="sap-icon sap-icon--media-forward"
+        />
+        
+        
+      </a>
+      
+    
+    </nav>
+    
+
+    
+    <div
+      class="fd-pagination__total"
+    >
+      
+        
+      <span
+        class="fd-form-label fd-pagination__total-label"
+      >
+        3 Results
+      </span>
+      
+    
+    </div>
+    
+
+  </div>
+  
+
+</section>
 `;
 
 exports[`Storyshots Components/Pagination Last page 1`] = `
-<div
-  class="fd-pagination"
->
-  
-    
-  <nav
-    class="fd-pagination__nav"
-  >
-    
-        
-    <a
-      aria-disabled="false"
-      aria-label="First"
-      class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
-      href="#"
-    >
-      
-            
-      <i
-        class="sap-icon sap-icon--media-rewind"
-      />
-      
-        
-    </a>
-    
-
-        
-    <a
-      aria-disabled="false"
-      aria-label="Previous"
-      class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
-      href="#"
-    >
-      
-            
-      <i
-        class="sap-icon sap-icon--navigation-left-arrow"
-      />
-      
-        
-    </a>
-    
-
-        
-    <a
-      class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
-      href="#"
-    >
-      1
-    </a>
-    
-
-        
-    <span
-      class="fd-pagination__more"
-      role="presentation"
-    />
-    
-
-        
-    <a
-      class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
-      href="#"
-    >
-      499
-    </a>
-    
-
-        
-    <label
-      class="fd-form-label fd-pagination__label"
-      for="lastPageInput"
-    >
-      Page:
-    </label>
-    
-
-        
-    <input
-      class="fd-input fd-input--compact fd-pagination__input"
-      id="lastPageInput"
-      max="500"
-      min="1"
-      required=""
-      type="number"
-      value="500"
-    />
-    
-
-        
-    <a
-      aria-disabled="true"
-      aria-label="Next"
-      class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
-      href="#"
-    >
-      
-            
-      <i
-        class="sap-icon sap-icon--navigation-right-arrow"
-      />
-      
-        
-    </a>
-    
-
-        
-    <a
-      aria-disabled="true"
-      aria-label="Last"
-      class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
-      href="#"
-    >
-      
-            
-      <i
-        class="sap-icon sap-icon--media-forward"
-      />
-      
-        
-    </a>
-    
-    
-  </nav>
+<section>
+  <h3>
+    &gt; 9 Pages
+  </h3>
   
 
-    
   <div
-    class="fd-pagination__total"
+    class="fd-pagination"
   >
     
-        
-    <span
-      class="fd-form-label fd-pagination__total-label"
+    
+    <nav
+      class="fd-pagination__nav"
+      title="pagination with more than 9 pages"
     >
-      500 Results
-    </span>
+      
+        
+      <a
+        aria-disabled="false"
+        aria-label="First"
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
+        href="#"
+      >
+        
+            
+        <i
+          class="sap-icon sap-icon--media-rewind"
+        />
+        
+        
+      </a>
+      
+
+        
+      <a
+        aria-disabled="false"
+        aria-label="Previous"
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
+        href="#"
+      >
+        
+            
+        <i
+          class="sap-icon sap-icon--navigation-left-arrow"
+        />
+        
+        
+      </a>
+      
+
+        
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        1
+      </a>
+      
+
+        
+      <span
+        class="fd-pagination__more"
+        role="presentation"
+      />
+      
+
+        
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        494
+      </a>
+      
+
+        
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        495
+      </a>
+      
+
+        
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        496
+      </a>
+      
+
+        
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        497
+      </a>
+      
+
+        
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        498
+      </a>
+      
+
+        
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        499
+      </a>
+      
+
+        
+      <label
+        class="fd-form-label fd-pagination__label"
+        id="lastPageInputPage"
+      >
+        Page:
+      </label>
+      
+
+        
+      <input
+        aria-labelledby="lastPageInputPage lastPageInputOf"
+        class="fd-input fd-input--compact fd-pagination__input"
+        max="500"
+        min="1"
+        required=""
+        type="number"
+        value="500"
+      />
+      
+
+        
+      <label
+        class="fd-form-label fd-pagination__label"
+        id="lastPageInputOf"
+      >
+        of 500
+      </label>
+      
+
+        
+      <a
+        aria-disabled="true"
+        aria-label="Next"
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
+        href="#"
+      >
+        
+            
+        <i
+          class="sap-icon sap-icon--navigation-right-arrow"
+        />
+        
+        
+      </a>
+      
+
+        
+      <a
+        aria-disabled="true"
+        aria-label="Last"
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
+        href="#"
+      >
+        
+            
+        <i
+          class="sap-icon sap-icon--media-forward"
+        />
+        
+        
+      </a>
+      
     
+    </nav>
     
+
+    
+    <div
+      class="fd-pagination__total"
+    >
+      
+        
+      <span
+        class="fd-form-label fd-pagination__total-label"
+      >
+        500 Results
+      </span>
+      
+    
+    </div>
+    
+
   </div>
   
 
-</div>
+
+  <h3>
+    &lt; 9 Pages
+  </h3>
+  
+
+
+  <div
+    class="fd-pagination fd-pagination--short"
+  >
+    
+    
+    <nav
+      class="fd-pagination__nav"
+    >
+      
+        
+      <a
+        aria-disabled="false"
+        aria-label="First"
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
+        href="#"
+      >
+        
+            
+        <i
+          class="sap-icon sap-icon--media-rewind"
+        />
+        
+        
+      </a>
+      
+
+        
+      <a
+        aria-disabled="false"
+        aria-label="Previous"
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
+        href="#"
+      >
+        
+            
+        <i
+          class="sap-icon sap-icon--navigation-left-arrow"
+        />
+        
+        
+      </a>
+      
+
+        
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        1
+      </a>
+      
+
+        
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        2
+      </a>
+      
+
+        
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link is-active"
+        href="#"
+      >
+        3
+      </a>
+      
+
+        
+      <label
+        class="fd-form-label fd-pagination__label"
+        id="lastPageInputShortPage"
+      >
+        Page:
+      </label>
+      
+
+        
+      <input
+        aria-labelledby="lastPageInputShortPage lastPageInputShortOf"
+        class="fd-input fd-input--compact fd-pagination__input"
+        max="3"
+        min="1"
+        required=""
+        type="number"
+        value="3"
+      />
+      
+
+        
+      <label
+        class="fd-form-label fd-pagination__label"
+        id="lastPageInputShortOf"
+      >
+        of 3
+      </label>
+      
+
+        
+      <a
+        aria-disabled="true"
+        aria-label="Next"
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
+        href="#"
+      >
+        
+            
+        <i
+          class="sap-icon sap-icon--navigation-right-arrow"
+        />
+        
+        
+      </a>
+      
+
+        
+      <a
+        aria-disabled="true"
+        aria-label="Last"
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
+        href="#"
+      >
+        
+            
+        <i
+          class="sap-icon sap-icon--media-forward"
+        />
+        
+        
+      </a>
+      
+    
+    </nav>
+    
+
+    
+    <div
+      class="fd-pagination__total"
+    >
+      
+        
+      <span
+        class="fd-form-label fd-pagination__total-label"
+      >
+        3 Results
+      </span>
+      
+    
+    </div>
+    
+
+  </div>
+  
+
+</section>
 `;
 
 exports[`Storyshots Components/Pagination Middle pages 1`] = `
-<div
-  class="fd-pagination"
->
-  
-    
-  <nav
-    class="fd-pagination__nav"
-  >
-    
-        
-    <a
-      aria-disabled="false"
-      aria-label="First"
-      class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
-      href="#"
-    >
-      
-            
-      <i
-        class="sap-icon sap-icon--media-rewind"
-      />
-      
-        
-    </a>
-    
-
-        
-    <a
-      aria-disabled="false"
-      aria-label="Previous"
-      class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
-      href="#"
-    >
-      
-            
-      <i
-        class="sap-icon sap-icon--navigation-left-arrow"
-      />
-      
-        
-    </a>
-    
-
-        
-    <a
-      class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
-      href="#"
-    >
-      1
-    </a>
-    
-
-        
-    <span
-      class="fd-pagination__more"
-      role="presentation"
-    />
-    
-
-        
-    <a
-      class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
-      href="#"
-    >
-      299
-    </a>
-    
-
-        
-    <label
-      class="fd-form-label fd-pagination__label"
-      for="middlePageInput"
-    >
-      Page:
-    </label>
-    
-
-        
-    <input
-      class="fd-input fd-input--compact fd-pagination__input"
-      id="middlePageInput"
-      max="500"
-      min="1"
-      required=""
-      type="number"
-      value="300"
-    />
-    
-
-        
-    <a
-      class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
-      href="#"
-    >
-      301
-    </a>
-    
-
-        
-    <span
-      class="fd-pagination__more"
-      role="presentation"
-    />
-    
-
-        
-    <a
-      class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
-      href="#"
-    >
-      500
-    </a>
-    
-
-        
-    <a
-      aria-disabled="false"
-      aria-label="Next"
-      class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
-      href="#"
-    >
-      
-            
-      <i
-        class="sap-icon sap-icon--navigation-right-arrow"
-      />
-      
-        
-    </a>
-    
-
-        
-    <a
-      aria-disabled="false"
-      aria-label="Last"
-      class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
-      href="#"
-    >
-      
-            
-      <i
-        class="sap-icon sap-icon--media-forward"
-      />
-      
-        
-    </a>
-    
-    
-  </nav>
+<section>
+  <h3>
+    &gt; 9 Pages
+  </h3>
   
 
-    
   <div
-    class="fd-pagination__total"
+    class="fd-pagination"
   >
     
-        
-    <span
-      class="fd-form-label fd-pagination__total-label"
+    
+    <nav
+      class="fd-pagination__nav"
+      title="pagination with more than 9 pages"
     >
-      500 Results
-    </span>
+      
+        
+      <a
+        aria-disabled="false"
+        aria-label="First"
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
+        href="#"
+      >
+        
+            
+        <i
+          class="sap-icon sap-icon--media-rewind"
+        />
+        
+        
+      </a>
+      
+
+        
+      <a
+        aria-disabled="false"
+        aria-label="Previous"
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
+        href="#"
+      >
+        
+            
+        <i
+          class="sap-icon sap-icon--navigation-left-arrow"
+        />
+        
+        
+      </a>
+      
+
+        
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        1
+      </a>
+      
+
+        
+      <span
+        class="fd-pagination__more"
+        role="presentation"
+      />
+      
+
+        
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        298
+      </a>
+      
+
+        
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        299
+      </a>
+      
+
+        
+      <label
+        class="fd-form-label fd-pagination__label"
+        id="middlePageInputPage"
+      >
+        Page:
+      </label>
+      
+
+        
+      <input
+        aria-labelledby="middlePageInputPage middlePageInputOf"
+        class="fd-input fd-input--compact fd-pagination__input"
+        max="500"
+        min="1"
+        required=""
+        type="number"
+        value="300"
+      />
+      
+
+        
+      <label
+        class="fd-form-label fd-pagination__label"
+        id="middlePageInputOf"
+      >
+        of 500
+      </label>
+      
+
+        
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        301
+      </a>
+      
+
+        
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        302
+      </a>
+      
+
+        
+      <span
+        class="fd-pagination__more"
+        role="presentation"
+      />
+      
+
+        
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        500
+      </a>
+      
+
+        
+      <a
+        aria-disabled="false"
+        aria-label="Next"
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
+        href="#"
+      >
+        
+            
+        <i
+          class="sap-icon sap-icon--navigation-right-arrow"
+        />
+        
+        
+      </a>
+      
+
+        
+      <a
+        aria-disabled="false"
+        aria-label="Last"
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
+        href="#"
+      >
+        
+            
+        <i
+          class="sap-icon sap-icon--media-forward"
+        />
+        
+        
+      </a>
+      
     
+    </nav>
     
+
+    
+    <div
+      class="fd-pagination__total"
+    >
+      
+        
+      <span
+        class="fd-form-label fd-pagination__total-label"
+      >
+        500 Results
+      </span>
+      
+    
+    </div>
+    
+
   </div>
   
 
-</div>
+
+  <h3>
+    &lt; 9 Pages
+  </h3>
+  
+
+
+  <div
+    class="fd-pagination fd-pagination--short"
+  >
+    
+    
+    <nav
+      class="fd-pagination__nav"
+    >
+      
+        
+      <a
+        aria-disabled="false"
+        aria-label="First"
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
+        href="#"
+      >
+        
+            
+        <i
+          class="sap-icon sap-icon--media-rewind"
+        />
+        
+        
+      </a>
+      
+
+        
+      <a
+        aria-disabled="false"
+        aria-label="Previous"
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
+        href="#"
+      >
+        
+            
+        <i
+          class="sap-icon sap-icon--navigation-left-arrow"
+        />
+        
+        
+      </a>
+      
+
+        
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        1
+      </a>
+      
+
+        
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link is-active"
+        href="#"
+      >
+        2
+      </a>
+      
+
+        
+      <label
+        class="fd-form-label fd-pagination__label"
+        id="middlePageInputShortPage"
+      >
+        Page:
+      </label>
+      
+
+        
+      <input
+        aria-labelledby="middlePageInputShortPage middlePageInputShortOf"
+        class="fd-input fd-input--compact fd-pagination__input"
+        max="3"
+        min="1"
+        required=""
+        type="number"
+        value="2"
+      />
+      
+
+        
+      <label
+        class="fd-form-label fd-pagination__label"
+        id="middlePageInputShortOf"
+      >
+        of 3
+      </label>
+      
+
+        
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        3
+      </a>
+      
+
+        
+      <a
+        aria-disabled="false"
+        aria-label="Next"
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
+        href="#"
+      >
+        
+            
+        <i
+          class="sap-icon sap-icon--navigation-right-arrow"
+        />
+        
+        
+      </a>
+      
+
+        
+      <a
+        aria-disabled="false"
+        aria-label="Last"
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
+        href="#"
+      >
+        
+            
+        <i
+          class="sap-icon sap-icon--media-forward"
+        />
+        
+        
+      </a>
+      
+    
+    </nav>
+    
+
+    
+    <div
+      class="fd-pagination__total"
+    >
+      
+        
+      <span
+        class="fd-form-label fd-pagination__total-label"
+      >
+        3 Results
+      </span>
+      
+    
+    </div>
+    
+
+  </div>
+  
+
+</section>
 `;
 
 exports[`Storyshots Components/Pagination Mobile 1`] = `
@@ -1031,7 +1755,7 @@ exports[`Storyshots Components/Pagination Mobile 1`] = `
             
       <label
         class="fd-form-label fd-pagination__label"
-        for="cozyPageInput"
+        id="cozyPageInputPage"
       >
         Page:
       </label>
@@ -1039,14 +1763,23 @@ exports[`Storyshots Components/Pagination Mobile 1`] = `
 
             
       <input
+        aria-labelledby="cozyPageInputPage cozyPageInputOf"
         class="fd-input fd-pagination__input"
-        id="cozyPageInput"
         max="500"
         min="1"
         required=""
         type="number"
         value="500"
       />
+      
+
+            
+      <label
+        class="fd-form-label fd-pagination__label"
+        id="cozyPageInputOf"
+      >
+        of 500
+      </label>
       
 
             
@@ -1100,152 +1833,6 @@ exports[`Storyshots Components/Pagination Mobile 1`] = `
       
         
     </div>
-    
-    
-  </div>
-  
-
-</div>
-`;
-
-exports[`Storyshots Components/Pagination Multiple pages 1`] = `
-<div
-  class="fd-pagination"
->
-  
-    
-  <nav
-    class="fd-pagination__nav"
-  >
-    
-        
-    <a
-      aria-disabled="true"
-      aria-label="First"
-      class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
-      href="#"
-    >
-      
-            
-      <i
-        class="sap-icon sap-icon--media-rewind"
-      />
-      
-        
-    </a>
-    
-
-        
-    <a
-      aria-disabled="true"
-      aria-label="Previous"
-      class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
-      href="#"
-    >
-      
-            
-      <i
-        class="sap-icon sap-icon--navigation-left-arrow"
-      />
-      
-        
-    </a>
-    
-
-        
-    <label
-      class="fd-form-label fd-pagination__label"
-      for="multiplePageInput"
-    >
-      Page:
-    </label>
-    
-
-        
-    <input
-      class="fd-input fd-input--compact fd-pagination__input"
-      id="multiplePageInput"
-      max="500"
-      min="1"
-      required=""
-      type="number"
-      value="1"
-    />
-    
-
-        
-    <a
-      class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
-      href="#"
-    >
-      2
-    </a>
-    
-
-        
-    <span
-      class="fd-pagination__more"
-      role="presentation"
-    />
-    
-
-        
-    <a
-      class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
-      href="#"
-    >
-      500
-    </a>
-    
-
-        
-    <a
-      aria-disabled="false"
-      aria-label="Next"
-      class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
-      href="#"
-    >
-      
-            
-      <i
-        class="sap-icon sap-icon--navigation-right-arrow"
-      />
-      
-        
-    </a>
-    
-
-        
-    <a
-      aria-disabled="false"
-      aria-label="Last"
-      class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
-      href="#"
-    >
-      
-            
-      <i
-        class="sap-icon sap-icon--media-forward"
-      />
-      
-        
-    </a>
-    
-    
-  </nav>
-  
-
-    
-  <div
-    class="fd-pagination__total"
-  >
-    
-        
-    <span
-      class="fd-form-label fd-pagination__total-label"
-    >
-      500 Results
-    </span>
     
     
   </div>
@@ -1496,6 +2083,51 @@ exports[`Storyshots Components/Pagination Per page 1`] = `
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
+        494
+      </a>
+      
+
+            
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        495
+      </a>
+      
+
+            
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        496
+      </a>
+      
+
+            
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        497
+      </a>
+      
+
+            
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
+        498
+      </a>
+      
+
+            
+      <a
+        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        href="#"
+      >
         499
       </a>
       
@@ -1503,7 +2135,7 @@ exports[`Storyshots Components/Pagination Per page 1`] = `
             
       <label
         class="fd-form-label fd-pagination__label"
-        for="perPageInput"
+        id="perPageInputPage"
       >
         Page:
       </label>
@@ -1511,14 +2143,23 @@ exports[`Storyshots Components/Pagination Per page 1`] = `
 
             
       <input
+        aria-labelledby="perPageInputPage perPageInputOf"
         class="fd-input fd-input--compact fd-pagination__input"
-        id="perPageInput"
         max="500"
         min="1"
         required=""
         type="number"
         value="500"
       />
+      
+
+            
+      <label
+        class="fd-form-label fd-pagination__label"
+        id="perPageInputOf"
+      >
+        of 500
+      </label>
       
 
             
@@ -1572,145 +2213,6 @@ exports[`Storyshots Components/Pagination Per page 1`] = `
       
         
     </div>
-    
-    
-  </div>
-  
-
-</div>
-`;
-
-exports[`Storyshots Components/Pagination Second page 1`] = `
-<div
-  class="fd-pagination"
->
-  
-    
-  <nav
-    class="fd-pagination__nav"
-  >
-    
-        
-    <a
-      aria-disabled="false"
-      aria-label="First"
-      class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
-      href="#"
-    >
-      
-            
-      <i
-        class="sap-icon sap-icon--media-rewind"
-      />
-      
-        
-    </a>
-    
-
-        
-    <a
-      aria-disabled="false"
-      aria-label="Previous"
-      class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
-      href="#"
-    >
-      
-            
-      <i
-        class="sap-icon sap-icon--navigation-left-arrow"
-      />
-      
-        
-    </a>
-    
-
-        
-    <a
-      class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
-      href="#"
-    >
-      1
-    </a>
-    
-
-        
-    <label
-      class="fd-form-label fd-pagination__label"
-      for="secondPageInput"
-    >
-      Page:
-    </label>
-    
-
-        
-    <input
-      class="fd-input fd-input--compact fd-pagination__input"
-      id="secondPageInput"
-      max="3"
-      min="1"
-      required=""
-      type="number"
-      value="2"
-    />
-    
-
-        
-    <a
-      class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
-      href="#"
-    >
-      3
-    </a>
-    
-
-        
-    <a
-      aria-disabled="false"
-      aria-label="Next"
-      class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
-      href="#"
-    >
-      
-            
-      <i
-        class="sap-icon sap-icon--navigation-right-arrow"
-      />
-      
-        
-    </a>
-    
-
-        
-    <a
-      aria-disabled="false"
-      aria-label="Last"
-      class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
-      href="#"
-    >
-      
-            
-      <i
-        class="sap-icon sap-icon--media-forward"
-      />
-      
-        
-    </a>
-    
-    
-  </nav>
-  
-
-    
-  <div
-    class="fd-pagination__total"
-  >
-    
-        
-    <span
-      class="fd-form-label fd-pagination__total-label"
-    >
-      3 Results
-    </span>
     
     
   </div>

--- a/stories/pagination/__snapshots__/pagination.stories.storyshot
+++ b/stories/pagination/__snapshots__/pagination.stories.storyshot
@@ -184,13 +184,15 @@ exports[`Storyshots Components/Pagination Cozy 1`] = `
 
         
     <nav
+      aria-label="cozy mode example, pagination with more than 9 pages"
       class="fd-pagination__nav"
+      role="navigation"
     >
       
             
       <a
         aria-disabled="false"
-        aria-label="First"
+        aria-label="First page"
         class="fd-button fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
         href="#"
       >
@@ -207,7 +209,7 @@ exports[`Storyshots Components/Pagination Cozy 1`] = `
             
       <a
         aria-disabled="false"
-        aria-label="Previous"
+        aria-label="Previous page"
         class="fd-button fd-button--transparent fd-pagination__button"
         href="#"
       >
@@ -239,7 +241,8 @@ exports[`Storyshots Components/Pagination Cozy 1`] = `
 
             
       <a
-        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        aria-label="Goto page 494"
+        class="fd-button fd-button--transparent fd-pagination__link"
         href="#"
       >
         494
@@ -248,7 +251,8 @@ exports[`Storyshots Components/Pagination Cozy 1`] = `
 
             
       <a
-        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        aria-label="Goto page 495"
+        class="fd-button fd-button--transparent fd-pagination__link"
         href="#"
       >
         495
@@ -257,7 +261,8 @@ exports[`Storyshots Components/Pagination Cozy 1`] = `
 
             
       <a
-        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        aria-label="Goto page 496"
+        class="fd-button fd-button--transparent fd-pagination__link"
         href="#"
       >
         496
@@ -266,7 +271,8 @@ exports[`Storyshots Components/Pagination Cozy 1`] = `
 
             
       <a
-        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        aria-label="Goto page 497"
+        class="fd-button fd-button--transparent fd-pagination__link"
         href="#"
       >
         497
@@ -275,7 +281,8 @@ exports[`Storyshots Components/Pagination Cozy 1`] = `
 
             
       <a
-        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
+        aria-label="Goto page 498"
+        class="fd-button fd-button--transparent fd-pagination__link"
         href="#"
       >
         498
@@ -284,15 +291,7 @@ exports[`Storyshots Components/Pagination Cozy 1`] = `
 
             
       <a
-        class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
-        href="#"
-      >
-        499
-      </a>
-      
-
-            
-      <a
+        aria-label="Goto page 499"
         class="fd-button fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -302,6 +301,7 @@ exports[`Storyshots Components/Pagination Cozy 1`] = `
 
             
       <label
+        aria-label="Page input, Current page, Page 500"
         class="fd-form-label fd-pagination__label"
         id="cozyPageInputPage"
       >
@@ -333,7 +333,7 @@ exports[`Storyshots Components/Pagination Cozy 1`] = `
             
       <a
         aria-disabled="true"
-        aria-label="Next"
+        aria-label="Next page"
         class="fd-button fd-button--transparent fd-pagination__button"
         href="#"
       >
@@ -350,7 +350,7 @@ exports[`Storyshots Components/Pagination Cozy 1`] = `
             
       <a
         aria-disabled="true"
-        aria-label="Last"
+        aria-label="Last page"
         class="fd-button fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
         href="#"
       >
@@ -402,14 +402,15 @@ exports[`Storyshots Components/Pagination First page 1`] = `
     
     
     <nav
+      aria-label="first page example, pagination with more than 9 pages"
       class="fd-pagination__nav"
-      title="pagination with more than 9 pages"
+      role="navigation"
     >
       
         
       <a
         aria-disabled="true"
-        aria-label="First"
+        aria-label="First page"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
         href="#"
       >
@@ -426,7 +427,7 @@ exports[`Storyshots Components/Pagination First page 1`] = `
         
       <a
         aria-disabled="true"
-        aria-label="Previous"
+        aria-label="Previous page"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
         href="#"
       >
@@ -442,6 +443,7 @@ exports[`Storyshots Components/Pagination First page 1`] = `
 
         
       <label
+        aria-label="Page input, Current page, Page 1"
         class="fd-form-label fd-pagination__label"
         id="firstPageInputPage"
       >
@@ -472,6 +474,7 @@ exports[`Storyshots Components/Pagination First page 1`] = `
 
         
       <a
+        aria-label="Goto page 2"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -481,6 +484,7 @@ exports[`Storyshots Components/Pagination First page 1`] = `
 
         
       <a
+        aria-label="Goto page 3"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -490,6 +494,7 @@ exports[`Storyshots Components/Pagination First page 1`] = `
 
         
       <a
+        aria-label="Goto page 4"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -499,6 +504,7 @@ exports[`Storyshots Components/Pagination First page 1`] = `
 
         
       <a
+        aria-label="Goto page 5"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -508,6 +514,7 @@ exports[`Storyshots Components/Pagination First page 1`] = `
 
         
       <a
+        aria-label="Goto page 6"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -517,6 +524,7 @@ exports[`Storyshots Components/Pagination First page 1`] = `
 
         
       <a
+        aria-label="Goto page 7"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -533,6 +541,7 @@ exports[`Storyshots Components/Pagination First page 1`] = `
 
         
       <a
+        aria-label="Goto page 500"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -543,7 +552,7 @@ exports[`Storyshots Components/Pagination First page 1`] = `
         
       <a
         aria-disabled="false"
-        aria-label="Next"
+        aria-label="Next page"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
         href="#"
       >
@@ -560,7 +569,7 @@ exports[`Storyshots Components/Pagination First page 1`] = `
         
       <a
         aria-disabled="false"
-        aria-label="Last"
+        aria-label="Last page"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
         href="#"
       >
@@ -609,13 +618,15 @@ exports[`Storyshots Components/Pagination First page 1`] = `
     
     
     <nav
+      aria-label="first page example, pagination with less than 9 pages"
       class="fd-pagination__nav"
+      role="navigation"
     >
       
         
       <a
         aria-disabled="true"
-        aria-label="First"
+        aria-label="First page"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
         href="#"
       >
@@ -632,7 +643,7 @@ exports[`Storyshots Components/Pagination First page 1`] = `
         
       <a
         aria-disabled="true"
-        aria-label="Previous"
+        aria-label="Previous page"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
         href="#"
       >
@@ -648,6 +659,7 @@ exports[`Storyshots Components/Pagination First page 1`] = `
 
         
       <label
+        aria-label="Page input, Current page, Page 1"
         class="fd-form-label fd-pagination__label"
         id="firstPageInputShortPage"
       >
@@ -678,6 +690,8 @@ exports[`Storyshots Components/Pagination First page 1`] = `
 
         
       <a
+        aria-current="true"
+        aria-label="Current Page, Page 1"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link is-active"
         href="#"
       >
@@ -687,6 +701,7 @@ exports[`Storyshots Components/Pagination First page 1`] = `
 
         
       <a
+        aria-label="Goto page 2"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -696,6 +711,7 @@ exports[`Storyshots Components/Pagination First page 1`] = `
 
         
       <a
+        aria-label="Goto page 3"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -706,7 +722,7 @@ exports[`Storyshots Components/Pagination First page 1`] = `
         
       <a
         aria-disabled="false"
-        aria-label="Next"
+        aria-label="Next page"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
         href="#"
       >
@@ -723,7 +739,7 @@ exports[`Storyshots Components/Pagination First page 1`] = `
         
       <a
         aria-disabled="false"
-        aria-label="Last"
+        aria-label="Last page"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
         href="#"
       >
@@ -775,14 +791,15 @@ exports[`Storyshots Components/Pagination Last page 1`] = `
     
     
     <nav
+      aria-label="last page example, pagination with more than 9 pages"
       class="fd-pagination__nav"
-      title="pagination with more than 9 pages"
+      role="navigation"
     >
       
         
       <a
         aria-disabled="false"
-        aria-label="First"
+        aria-label="First page"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
         href="#"
       >
@@ -799,7 +816,7 @@ exports[`Storyshots Components/Pagination Last page 1`] = `
         
       <a
         aria-disabled="false"
-        aria-label="Previous"
+        aria-label="Previous page"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
         href="#"
       >
@@ -815,6 +832,7 @@ exports[`Storyshots Components/Pagination Last page 1`] = `
 
         
       <a
+        aria-label="Goto page 1"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -831,6 +849,7 @@ exports[`Storyshots Components/Pagination Last page 1`] = `
 
         
       <a
+        aria-label="Goto page 494"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -840,6 +859,7 @@ exports[`Storyshots Components/Pagination Last page 1`] = `
 
         
       <a
+        aria-label="Goto page 495"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -849,6 +869,7 @@ exports[`Storyshots Components/Pagination Last page 1`] = `
 
         
       <a
+        aria-label="Goto page 496"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -858,6 +879,7 @@ exports[`Storyshots Components/Pagination Last page 1`] = `
 
         
       <a
+        aria-label="Goto page 497"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -867,6 +889,7 @@ exports[`Storyshots Components/Pagination Last page 1`] = `
 
         
       <a
+        aria-label="Goto page 498"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -876,6 +899,7 @@ exports[`Storyshots Components/Pagination Last page 1`] = `
 
         
       <a
+        aria-label="Goto page 499"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -885,6 +909,7 @@ exports[`Storyshots Components/Pagination Last page 1`] = `
 
         
       <label
+        aria-label="Page input, Current page, Page 500"
         class="fd-form-label fd-pagination__label"
         id="lastPageInputPage"
       >
@@ -916,7 +941,7 @@ exports[`Storyshots Components/Pagination Last page 1`] = `
         
       <a
         aria-disabled="true"
-        aria-label="Next"
+        aria-label="Next page"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
         href="#"
       >
@@ -933,7 +958,7 @@ exports[`Storyshots Components/Pagination Last page 1`] = `
         
       <a
         aria-disabled="true"
-        aria-label="Last"
+        aria-label="Last page"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
         href="#"
       >
@@ -982,13 +1007,15 @@ exports[`Storyshots Components/Pagination Last page 1`] = `
     
     
     <nav
+      aria-label="last page example, pagination with less than 9 pages"
       class="fd-pagination__nav"
+      role="navigation"
     >
       
         
       <a
         aria-disabled="false"
-        aria-label="First"
+        aria-label="First page"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
         href="#"
       >
@@ -1005,7 +1032,7 @@ exports[`Storyshots Components/Pagination Last page 1`] = `
         
       <a
         aria-disabled="false"
-        aria-label="Previous"
+        aria-label="Previous page"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
         href="#"
       >
@@ -1021,6 +1048,7 @@ exports[`Storyshots Components/Pagination Last page 1`] = `
 
         
       <a
+        aria-label="Goto page 1"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -1030,6 +1058,7 @@ exports[`Storyshots Components/Pagination Last page 1`] = `
 
         
       <a
+        aria-label="Goto page 2"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -1039,6 +1068,8 @@ exports[`Storyshots Components/Pagination Last page 1`] = `
 
         
       <a
+        aria-current="true"
+        aria-label="Current Page, page 3"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link is-active"
         href="#"
       >
@@ -1048,6 +1079,7 @@ exports[`Storyshots Components/Pagination Last page 1`] = `
 
         
       <label
+        aria-label="Page input, Current page, Page 3"
         class="fd-form-label fd-pagination__label"
         id="lastPageInputShortPage"
       >
@@ -1079,7 +1111,7 @@ exports[`Storyshots Components/Pagination Last page 1`] = `
         
       <a
         aria-disabled="true"
-        aria-label="Next"
+        aria-label="Next page"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
         href="#"
       >
@@ -1096,7 +1128,7 @@ exports[`Storyshots Components/Pagination Last page 1`] = `
         
       <a
         aria-disabled="true"
-        aria-label="Last"
+        aria-label="Last page"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
         href="#"
       >
@@ -1148,14 +1180,15 @@ exports[`Storyshots Components/Pagination Middle pages 1`] = `
     
     
     <nav
+      aria-label="middle page example, pagination with more than 9 pages"
       class="fd-pagination__nav"
-      title="pagination with more than 9 pages"
+      role="navigation"
     >
       
         
       <a
         aria-disabled="false"
-        aria-label="First"
+        aria-label="First page"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
         href="#"
       >
@@ -1172,7 +1205,7 @@ exports[`Storyshots Components/Pagination Middle pages 1`] = `
         
       <a
         aria-disabled="false"
-        aria-label="Previous"
+        aria-label="Previous page"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
         href="#"
       >
@@ -1188,6 +1221,7 @@ exports[`Storyshots Components/Pagination Middle pages 1`] = `
 
         
       <a
+        aria-label="Goto page 1"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -1204,6 +1238,7 @@ exports[`Storyshots Components/Pagination Middle pages 1`] = `
 
         
       <a
+        aria-label="Goto page 298"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -1213,6 +1248,7 @@ exports[`Storyshots Components/Pagination Middle pages 1`] = `
 
         
       <a
+        aria-label="Goto page 299"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -1222,6 +1258,7 @@ exports[`Storyshots Components/Pagination Middle pages 1`] = `
 
         
       <label
+        aria-label="Page input, Current page, Page 300"
         class="fd-form-label fd-pagination__label"
         id="middlePageInputPage"
       >
@@ -1252,6 +1289,7 @@ exports[`Storyshots Components/Pagination Middle pages 1`] = `
 
         
       <a
+        aria-label="Goto page 301"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -1261,6 +1299,7 @@ exports[`Storyshots Components/Pagination Middle pages 1`] = `
 
         
       <a
+        aria-label="Goto page 302"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -1277,6 +1316,7 @@ exports[`Storyshots Components/Pagination Middle pages 1`] = `
 
         
       <a
+        aria-label="Goto page 500"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -1287,7 +1327,7 @@ exports[`Storyshots Components/Pagination Middle pages 1`] = `
         
       <a
         aria-disabled="false"
-        aria-label="Next"
+        aria-label="Next page"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
         href="#"
       >
@@ -1304,7 +1344,7 @@ exports[`Storyshots Components/Pagination Middle pages 1`] = `
         
       <a
         aria-disabled="false"
-        aria-label="Last"
+        aria-label="Last page"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
         href="#"
       >
@@ -1353,13 +1393,15 @@ exports[`Storyshots Components/Pagination Middle pages 1`] = `
     
     
     <nav
+      aria-label="middle page example, pagination with less than 9 pages"
       class="fd-pagination__nav"
+      role="navigation"
     >
       
         
       <a
         aria-disabled="false"
-        aria-label="First"
+        aria-label="First page"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
         href="#"
       >
@@ -1376,7 +1418,7 @@ exports[`Storyshots Components/Pagination Middle pages 1`] = `
         
       <a
         aria-disabled="false"
-        aria-label="Previous"
+        aria-label="Previous page"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
         href="#"
       >
@@ -1392,6 +1434,7 @@ exports[`Storyshots Components/Pagination Middle pages 1`] = `
 
         
       <a
+        aria-label="Goto page 1"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -1401,6 +1444,8 @@ exports[`Storyshots Components/Pagination Middle pages 1`] = `
 
         
       <a
+        aria-current="true"
+        aria-label="Current page, Page 2"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link is-active"
         href="#"
       >
@@ -1410,6 +1455,7 @@ exports[`Storyshots Components/Pagination Middle pages 1`] = `
 
         
       <label
+        aria-label="Page input, Current page, Page 1"
         class="fd-form-label fd-pagination__label"
         id="middlePageInputShortPage"
       >
@@ -1440,6 +1486,7 @@ exports[`Storyshots Components/Pagination Middle pages 1`] = `
 
         
       <a
+        aria-label="Goto page 3"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -1450,7 +1497,7 @@ exports[`Storyshots Components/Pagination Middle pages 1`] = `
         
       <a
         aria-disabled="false"
-        aria-label="Next"
+        aria-label="Next page"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
         href="#"
       >
@@ -1467,7 +1514,7 @@ exports[`Storyshots Components/Pagination Middle pages 1`] = `
         
       <a
         aria-disabled="false"
-        aria-label="Last"
+        aria-label="Last page"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
         href="#"
       >
@@ -1690,13 +1737,15 @@ exports[`Storyshots Components/Pagination Mobile 1`] = `
 
         
     <nav
+      aria-label="mobile mode example, pagination with more than 9 pages"
       class="fd-pagination__nav"
+      role="navigation"
     >
       
             
       <a
         aria-disabled="false"
-        aria-label="First"
+        aria-label="First page"
         class="fd-button fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
         href="#"
       >
@@ -1713,7 +1762,7 @@ exports[`Storyshots Components/Pagination Mobile 1`] = `
             
       <a
         aria-disabled="false"
-        aria-label="Previous"
+        aria-label="Previous page"
         class="fd-button fd-button--transparent fd-pagination__button"
         href="#"
       >
@@ -1728,34 +1777,10 @@ exports[`Storyshots Components/Pagination Mobile 1`] = `
       
 
             
-      <a
-        class="fd-button fd-button--transparent fd-pagination__link"
-        href="#"
-      >
-        1
-      </a>
-      
-
-            
-      <span
-        class="fd-pagination__more"
-        role="presentation"
-      />
-      
-
-            
-      <a
-        class="fd-button fd-button--transparent fd-pagination__link"
-        href="#"
-      >
-        499
-      </a>
-      
-
-            
       <label
+        aria-label="Page input, Current page, Page 500"
         class="fd-form-label fd-pagination__label"
-        id="cozyPageInputPage"
+        id="mobilePageInputPage"
       >
         Page:
       </label>
@@ -1763,7 +1788,7 @@ exports[`Storyshots Components/Pagination Mobile 1`] = `
 
             
       <input
-        aria-labelledby="cozyPageInputPage cozyPageInputOf"
+        aria-labelledby="mobilePageInputPage cozyPageInputOf"
         class="fd-input fd-pagination__input"
         max="500"
         min="1"
@@ -1776,7 +1801,7 @@ exports[`Storyshots Components/Pagination Mobile 1`] = `
             
       <label
         class="fd-form-label fd-pagination__label"
-        id="cozyPageInputOf"
+        id="mobilePageInputOf"
       >
         of 500
       </label>
@@ -1785,7 +1810,7 @@ exports[`Storyshots Components/Pagination Mobile 1`] = `
             
       <a
         aria-disabled="true"
-        aria-label="Next"
+        aria-label="Next page"
         class="fd-button fd-button--transparent fd-pagination__button"
         href="#"
       >
@@ -1802,7 +1827,7 @@ exports[`Storyshots Components/Pagination Mobile 1`] = `
             
       <a
         aria-disabled="true"
-        aria-label="Last"
+        aria-label="Last page"
         class="fd-button fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
         href="#"
       >
@@ -2025,13 +2050,15 @@ exports[`Storyshots Components/Pagination Per page 1`] = `
 
         
     <nav
+      aria-label="per page page example, pagination with more than 9 pages"
       class="fd-pagination__nav"
+      role="navigation"
     >
       
             
       <a
         aria-disabled="false"
-        aria-label="First"
+        aria-label="First page"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
         href="#"
       >
@@ -2048,7 +2075,7 @@ exports[`Storyshots Components/Pagination Per page 1`] = `
             
       <a
         aria-disabled="false"
-        aria-label="Previous"
+        aria-label="Previous page"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
         href="#"
       >
@@ -2064,6 +2091,7 @@ exports[`Storyshots Components/Pagination Per page 1`] = `
 
             
       <a
+        aria-label="Goto page 1"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -2080,6 +2108,7 @@ exports[`Storyshots Components/Pagination Per page 1`] = `
 
             
       <a
+        aria-label="Goto page 494"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -2089,6 +2118,7 @@ exports[`Storyshots Components/Pagination Per page 1`] = `
 
             
       <a
+        aria-label="Goto page 495"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -2098,6 +2128,7 @@ exports[`Storyshots Components/Pagination Per page 1`] = `
 
             
       <a
+        aria-label="Goto page 496"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -2107,6 +2138,7 @@ exports[`Storyshots Components/Pagination Per page 1`] = `
 
             
       <a
+        aria-label="Goto page 497"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -2116,6 +2148,7 @@ exports[`Storyshots Components/Pagination Per page 1`] = `
 
             
       <a
+        aria-label="Goto page 498"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -2125,6 +2158,7 @@ exports[`Storyshots Components/Pagination Per page 1`] = `
 
             
       <a
+        aria-label="Goto page 499"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__link"
         href="#"
       >
@@ -2134,6 +2168,7 @@ exports[`Storyshots Components/Pagination Per page 1`] = `
 
             
       <label
+        aria-label="Page input, Current page, Page 500"
         class="fd-form-label fd-pagination__label"
         id="perPageInputPage"
       >
@@ -2165,7 +2200,7 @@ exports[`Storyshots Components/Pagination Per page 1`] = `
             
       <a
         aria-disabled="true"
-        aria-label="Next"
+        aria-label="Next page"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__button"
         href="#"
       >
@@ -2182,7 +2217,7 @@ exports[`Storyshots Components/Pagination Per page 1`] = `
             
       <a
         aria-disabled="true"
-        aria-label="Last"
+        aria-label="Last page"
         class="fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile"
         href="#"
       >

--- a/stories/pagination/pagination.stories.js
+++ b/stories/pagination/pagination.stories.js
@@ -44,42 +44,42 @@ Per page label | \`fd-pagination__per-page-label\` | Per page section label. Hid
 
 export const firstPage = () => `<h3>> 9 Pages</h3>
 <div class='fd-pagination'>
-    <nav class='fd-pagination__nav' title="pagination with more than 9 pages">
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='First' aria-disabled='true'>
+    <nav class='fd-pagination__nav' role='navigation' aria-label='first page example, pagination with more than 9 pages'>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='First page' aria-disabled='true'>
             <i class='sap-icon sap-icon--media-rewind'></i>
         </a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Previous' aria-disabled='true'>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Previous page' aria-disabled='true'>
             <i class='sap-icon sap-icon--navigation-left-arrow'></i>
         </a>
 
-        <label class='fd-form-label fd-pagination__label' id='firstPageInputPage'>Page:</label>
+        <label class='fd-form-label fd-pagination__label' id='firstPageInputPage' aria-label='Page input, Current page, Page 1'>Page:</label>
 
         <input aria-labelledby='firstPageInputPage firstPageInputOf' class='fd-input fd-input--compact fd-pagination__input' type='number' min='1' max='500' value='1' required />
 
         <label class='fd-form-label fd-pagination__label' id='firstPageInputOf'>of 500</label>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>2</a>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 2'>2</a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>3</a>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 3'>3</a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>4</a>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 4'>4</a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>5</a>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 5'>5</a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>6</a>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 6'>6</a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>7</a>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 7'>7</a>
 
         <span class='fd-pagination__more' role='presentation'></span>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>500</a>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 500'>500</a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Next' aria-disabled='false'>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Next page' aria-disabled='false'>
             <i class='sap-icon sap-icon--navigation-right-arrow'></i>
         </a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='Last' aria-disabled='false'>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='Last page' aria-disabled='false'>
             <i class='sap-icon sap-icon--media-forward'></i>
         </a>
     </nav>
@@ -92,32 +92,32 @@ export const firstPage = () => `<h3>> 9 Pages</h3>
 <h3>< 9 Pages</h3>
 
 <div class='fd-pagination fd-pagination--short'>
-    <nav class='fd-pagination__nav'>
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='First' aria-disabled='true'>
+    <nav class='fd-pagination__nav' role='navigation' aria-label='first page example, pagination with less than 9 pages'>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='First page' aria-disabled='true'>
             <i class='sap-icon sap-icon--media-rewind'></i>
         </a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Previous' aria-disabled='true'>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Previous page' aria-disabled='true'>
             <i class='sap-icon sap-icon--navigation-left-arrow'></i>
         </a>
 
-        <label class='fd-form-label fd-pagination__label' id='firstPageInputShortPage'>Page:</label>
+        <label class='fd-form-label fd-pagination__label' id='firstPageInputShortPage' aria-label='Page input, Current page, Page 1'>Page:</label>
 
         <input aria-labelledby="firstPageInputShortPage firstPageInputShortOf" class='fd-input fd-input--compact fd-pagination__input' type='number' min='1' max='3' value='1' required />
 
         <label class='fd-form-label fd-pagination__label' id='firstPageInputShortOf'>of 3</label>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link is-active'>1</a>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link is-active' aria-label='Current Page, Page 1' aria-current='true'>1</a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>2</a>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 2'>2</a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>3</a>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 3'>3</a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Next' aria-disabled='false'>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Next page' aria-disabled='false'>
             <i class='sap-icon sap-icon--navigation-right-arrow'></i>
         </a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='Last' aria-disabled='false'>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='Last page' aria-disabled='false'>
             <i class='sap-icon sap-icon--media-forward'></i>
         </a>
     </nav>
@@ -140,42 +140,42 @@ firstPage.parameters = {
 
 export const middlePage = () => `<h3>> 9 Pages</h3>
 <div class='fd-pagination'>
-    <nav class='fd-pagination__nav' title="pagination with more than 9 pages">
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='First' aria-disabled='false'>
+    <nav class='fd-pagination__nav' role='navigation' aria-label='middle page example, pagination with more than 9 pages'>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='First page' aria-disabled='false'>
             <i class='sap-icon sap-icon--media-rewind'></i>
         </a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Previous' aria-disabled='false'>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Previous page' aria-disabled='false'>
             <i class='sap-icon sap-icon--navigation-left-arrow'></i>
         </a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>1</a>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 1'>1</a>
 
         <span class='fd-pagination__more' role='presentation'></span>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>298</a>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 298'>298</a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>299</a>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 299'>299</a>
 
-        <label class='fd-form-label fd-pagination__label' id='middlePageInputPage'>Page:</label>
+        <label class='fd-form-label fd-pagination__label' id='middlePageInputPage' aria-label='Page input, Current page, Page 300'>Page:</label>
 
         <input aria-labelledby='middlePageInputPage middlePageInputOf' class='fd-input fd-input--compact fd-pagination__input' type='number' min='1' max='500' value='300' required />
 
         <label class='fd-form-label fd-pagination__label' id='middlePageInputOf'>of 500</label>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>301</a>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 301'>301</a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>302</a>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 302'>302</a>
 
         <span class='fd-pagination__more' role='presentation'></span>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>500</a>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 500'>500</a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Next' aria-disabled='false'>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Next page' aria-disabled='false'>
             <i class='sap-icon sap-icon--navigation-right-arrow'></i>
         </a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='Last' aria-disabled='false'>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='Last page' aria-disabled='false'>
             <i class='sap-icon sap-icon--media-forward'></i>
         </a>
     </nav>
@@ -188,32 +188,32 @@ export const middlePage = () => `<h3>> 9 Pages</h3>
 <h3>< 9 Pages</h3>
 
 <div class='fd-pagination fd-pagination--short'>
-    <nav class='fd-pagination__nav'>
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='First' aria-disabled='false'>
+    <nav class='fd-pagination__nav'  role='navigation' aria-label='middle page example, pagination with less than 9 pages'>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='First page' aria-disabled='false'>
             <i class='sap-icon sap-icon--media-rewind'></i>
         </a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Previous' aria-disabled='false'>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Previous page' aria-disabled='false'>
             <i class='sap-icon sap-icon--navigation-left-arrow'></i>
         </a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>1</a>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 1'>1</a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link is-active'>2</a>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link is-active' aria-label='Current page, Page 2' aria-current='true'>2</a>
 
-        <label class='fd-form-label fd-pagination__label' id='middlePageInputShortPage'>Page:</label>
+        <label class='fd-form-label fd-pagination__label' id='middlePageInputShortPage' aria-label='Page input, Current page, Page 1'>Page:</label>
 
         <input aria-labelledby='middlePageInputShortPage middlePageInputShortOf' class='fd-input fd-input--compact fd-pagination__input' type='number' min='1' max='3' value='2' required />
 
         <label class='fd-form-label fd-pagination__label' id='middlePageInputShortOf'>of 3</label>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>3</a>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 3'>3</a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Next' aria-disabled='false'>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Next page' aria-disabled='false'>
             <i class='sap-icon sap-icon--navigation-right-arrow'></i>
         </a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='Last' aria-disabled='false'>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='Last page' aria-disabled='false'>
             <i class='sap-icon sap-icon--media-forward'></i>
         </a>
     </nav>
@@ -238,42 +238,42 @@ middlePage.parameters = {
 
 export const lastPage = () => `<h3>> 9 Pages</h3>
 <div class='fd-pagination'>
-    <nav class='fd-pagination__nav' title="pagination with more than 9 pages">
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='First' aria-disabled='false'>
+    <nav class='fd-pagination__nav' role='navigation' aria-label='last page example, pagination with more than 9 pages'>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='First page' aria-disabled='false'>
             <i class='sap-icon sap-icon--media-rewind'></i>
         </a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Previous' aria-disabled='false'>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Previous page' aria-disabled='false'>
             <i class='sap-icon sap-icon--navigation-left-arrow'></i>
         </a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>1</a>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 1'>1</a>
 
         <span class='fd-pagination__more' role='presentation'></span>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>494</a>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 494'>494</a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>495</a>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 495'>495</a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>496</a>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 496'>496</a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>497</a>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 497'>497</a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>498</a>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 498'>498</a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>499</a>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 499'>499</a>
 
-        <label class='fd-form-label fd-pagination__label' id='lastPageInputPage'>Page:</label>
+        <label class='fd-form-label fd-pagination__label' id='lastPageInputPage' aria-label='Page input, Current page, Page 500'>Page:</label>
 
         <input aria-labelledby='lastPageInputPage lastPageInputOf' class='fd-input fd-input--compact fd-pagination__input' type='number' min='1' max='500' value='500' required />
 
         <label class='fd-form-label fd-pagination__label' id='lastPageInputOf'>of 500</label>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Next' aria-disabled='true'>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Next page' aria-disabled='true'>
             <i class='sap-icon sap-icon--navigation-right-arrow'></i>
         </a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='Last' aria-disabled='true'>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='Last page' aria-disabled='true'>
             <i class='sap-icon sap-icon--media-forward'></i>
         </a>
     </nav>
@@ -286,32 +286,32 @@ export const lastPage = () => `<h3>> 9 Pages</h3>
 <h3>< 9 Pages</h3>
 
 <div class='fd-pagination fd-pagination--short'>
-    <nav class='fd-pagination__nav'>
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='First' aria-disabled='false'>
+    <nav class='fd-pagination__nav' role='navigation' aria-label='last page example, pagination with less than 9 pages'>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='First page' aria-disabled='false'>
             <i class='sap-icon sap-icon--media-rewind'></i>
         </a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Previous' aria-disabled='false'>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Previous page' aria-disabled='false'>
             <i class='sap-icon sap-icon--navigation-left-arrow'></i>
         </a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>1</a>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 1'>1</a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>2</a>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'  aria-label='Goto page 2'>2</a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link is-active'>3</a>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link is-active' aria-label='Current Page, page 3' aria-current='true'>3</a>
 
-        <label class='fd-form-label fd-pagination__label' id='lastPageInputShortPage'>Page:</label>
+        <label class='fd-form-label fd-pagination__label' id='lastPageInputShortPage' aria-label='Page input, Current page, Page 3'>Page:</label>
 
         <input aria-labelledby='lastPageInputShortPage lastPageInputShortOf' class='fd-input fd-input--compact fd-pagination__input' type='number' min='1' max='3' value='3' required />
 
         <label class='fd-form-label fd-pagination__label' id='lastPageInputShortOf'>of 3</label>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Next' aria-disabled='true'>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Next page' aria-disabled='true'>
             <i class='sap-icon sap-icon--navigation-right-arrow'></i>
         </a>
 
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='Last' aria-disabled='true'>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='Last page' aria-disabled='true'>
             <i class='sap-icon sap-icon--media-forward'></i>
         </a>
     </nav>
@@ -371,42 +371,42 @@ export const perPage = () => `<div style='height: 175px'>
             </div>
         </div>
 
-        <nav class='fd-pagination__nav'>
-            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='First' aria-disabled='false'>
+        <nav class='fd-pagination__nav' role='navigation' aria-label='per page page example, pagination with more than 9 pages'>
+            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='First page' aria-disabled='false'>
                 <i class='sap-icon sap-icon--media-rewind'></i>
             </a>
 
-            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Previous' aria-disabled='false'>
+            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Previous page' aria-disabled='false'>
                 <i class='sap-icon sap-icon--navigation-left-arrow'></i>
             </a>
 
-            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>1</a>
+            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 1'>1</a>
 
             <span class='fd-pagination__more' role='presentation'></span>
 
-            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>494</a>
+            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 494'>494</a>
 
-            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>495</a>
+            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 495'>495</a>
 
-            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>496</a>
+            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 496'>496</a>
 
-            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>497</a>
+            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 497'>497</a>
 
-            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>498</a>
+            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 498'>498</a>
 
-            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>499</a>
+            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 499'>499</a>
 
-            <label class='fd-form-label fd-pagination__label' id='perPageInputPage'>Page:</label>
+            <label class='fd-form-label fd-pagination__label' id='perPageInputPage' aria-label='Page input, Current page, Page 500'>Page:</label>
 
             <input aria-labelledby='perPageInputPage perPageInputOf' class='fd-input fd-input--compact fd-pagination__input' type='number' min='1' max='500' value='500' required />
 
             <label class='fd-form-label fd-pagination__label' id='perPageInputOf'>of 500</label>
 
-            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Next' aria-disabled='true'>
+            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Next page' aria-disabled='true'>
                 <i class='sap-icon sap-icon--navigation-right-arrow'></i>
             </a>
 
-            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='Last' aria-disabled='true'>
+            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='Last page' aria-disabled='true'>
                 <i class='sap-icon sap-icon--media-forward'></i>
             </a>
         </nav>
@@ -467,12 +467,12 @@ export const cozy = () => `<div style='height: 200px'>
             </div>
         </div>
 
-        <nav class='fd-pagination__nav'>
-            <a href='#' class='fd-button fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='First' aria-disabled='false'>
+        <nav class='fd-pagination__nav' role='navigation' aria-label='cozy mode example, pagination with more than 9 pages'>
+            <a href='#' class='fd-button fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='First page' aria-disabled='false'>
                 <i class='sap-icon sap-icon--media-rewind'></i>
             </a>
 
-            <a href='#' class='fd-button fd-button--transparent fd-pagination__button' aria-label='Previous' aria-disabled='false'>
+            <a href='#' class='fd-button fd-button--transparent fd-pagination__button' aria-label='Previous page' aria-disabled='false'>
                 <i class='sap-icon sap-icon--navigation-left-arrow'></i>
             </a>
 
@@ -480,31 +480,29 @@ export const cozy = () => `<div style='height: 200px'>
 
             <span class='fd-pagination__more' role='presentation'></span>
 
-            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>494</a>
+            <a href='#' class='fd-button fd-button--transparent fd-pagination__link' aria-label='Goto page 494'>494</a>
 
-            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>495</a>
+            <a href='#' class='fd-button fd-button--transparent fd-pagination__link' aria-label='Goto page 495'>495</a>
 
-            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>496</a>
+            <a href='#' class='fd-button fd-button--transparent fd-pagination__link' aria-label='Goto page 496'>496</a>
 
-            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>497</a>
+            <a href='#' class='fd-button fd-button--transparent fd-pagination__link' aria-label='Goto page 497'>497</a>
 
-            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>498</a>
+            <a href='#' class='fd-button fd-button--transparent fd-pagination__link' aria-label='Goto page 498'>498</a>
 
-            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>499</a>
+            <a href='#' class='fd-button fd-button--transparent fd-pagination__link' aria-label='Goto page 499'>499</a>
 
-            <a href='#' class='fd-button fd-button--transparent fd-pagination__link'>499</a>
-
-            <label class='fd-form-label fd-pagination__label' id='cozyPageInputPage'>Page:</label>
+            <label class='fd-form-label fd-pagination__label' id='cozyPageInputPage' aria-label='Page input, Current page, Page 500'>Page:</label>
 
             <input aria-labelledby='cozyPageInputPage cozyPageInputOf' class='fd-input fd-pagination__input' type='number' min='1' max='500' value='500' required />
 
             <label class='fd-form-label fd-pagination__label' id='cozyPageInputOf'>of 500</label>
 
-            <a href='#' class='fd-button fd-button--transparent fd-pagination__button' aria-label='Next' aria-disabled='true'>
+            <a href='#' class='fd-button fd-button--transparent fd-pagination__button' aria-label='Next page' aria-disabled='true'>
                 <i class='sap-icon sap-icon--navigation-right-arrow'></i>
             </a>
 
-            <a href='#' class='fd-button fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='Last' aria-disabled='true'>
+            <a href='#' class='fd-button fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='Last page' aria-disabled='true'>
                 <i class='sap-icon sap-icon--media-forward'></i>
             </a>
         </nav>
@@ -565,32 +563,26 @@ export const mobile = () => `<div style="height: 200px;">
             </div>
         </div>
 
-        <nav class='fd-pagination__nav'>
-            <a href='#' class='fd-button fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='First' aria-disabled='false'>
+        <nav class='fd-pagination__nav' role='navigation' aria-label='mobile mode example, pagination with more than 9 pages'>
+            <a href='#' class='fd-button fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='First page' aria-disabled='false'>
                 <i class='sap-icon sap-icon--media-rewind'></i>
             </a>
 
-            <a href='#' class='fd-button fd-button--transparent fd-pagination__button' aria-label='Previous' aria-disabled='false'>
+            <a href='#' class='fd-button fd-button--transparent fd-pagination__button' aria-label='Previous page' aria-disabled='false'>
                 <i class='sap-icon sap-icon--navigation-left-arrow'></i>
             </a>
 
-            <a href='#' class='fd-button fd-button--transparent fd-pagination__link'>1</a>
+            <label class='fd-form-label fd-pagination__label' id='mobilePageInputPage' aria-label='Page input, Current page, Page 500'>Page:</label>
 
-            <span class='fd-pagination__more' role='presentation'></span>
+            <input aria-labelledby='mobilePageInputPage cozyPageInputOf' class='fd-input fd-pagination__input' type='number' min='1' max='500' value='500' required />
 
-            <a href='#' class='fd-button fd-button--transparent fd-pagination__link'>499</a>
+            <label class='fd-form-label fd-pagination__label' id='mobilePageInputOf'>of 500</label>
 
-            <label class='fd-form-label fd-pagination__label' id='cozyPageInputPage'>Page:</label>
-
-            <input aria-labelledby='cozyPageInputPage cozyPageInputOf' class='fd-input fd-pagination__input' type='number' min='1' max='500' value='500' required />
-
-            <label class='fd-form-label fd-pagination__label' id='cozyPageInputOf'>of 500</label>
-
-            <a href='#' class='fd-button fd-button--transparent fd-pagination__button' aria-label='Next' aria-disabled='true'>
+            <a href='#' class='fd-button fd-button--transparent fd-pagination__button' aria-label='Next page' aria-disabled='true'>
                 <i class='sap-icon sap-icon--navigation-right-arrow'></i>
             </a>
 
-            <a href='#' class='fd-button fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='Last' aria-disabled='true'>
+            <a href='#' class='fd-button fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='Last page' aria-disabled='true'>
                 <i class='sap-icon sap-icon--media-forward'></i>
             </a>
         </nav>

--- a/stories/pagination/pagination.stories.js
+++ b/stories/pagination/pagination.stories.js
@@ -11,6 +11,10 @@ export default {
 - You want to allow users to bookmark pages
 - You want your content to be optimized for search
 
+##Details
+- > 9 pages: 9 elements should be shown (including pages, more symbols and the current page), use input for the current page
+- < 9 pages, add \`.fd-pagination--short\` class: all pages should be shown, button in active state shown for the current page
+
 ##Elements
 The pagination component consists of the following elements:
 
@@ -21,7 +25,8 @@ Navigation | \`fd-pagination__nav\` | The navigation area
 Total page count | \`fd-pagination__total\` | The area where total pages information is placed
 Total page count label | \`fd-pagination__total-label\` | The total number of pages label
 Links | \`fd-pagination__link\` | The page number links that users can select to navigate to a different pages
-Selected page | \`fd-pagination__input\` | The input with the page that is currently selected, can be used to navigate to the specific page
+Selected page (> 9 pages) | \`fd-pagination__input\` | The input with the page that is currently selected, can be used to navigate to the specific page
+Selected page (< 9 pages) | \`fd-pagination__link.is-active\` | The button with the page number that is currently selected
 Selected page label | \`fd-pagination__label\` | The label of the selected page input. Shown only on mobile.
 First page button | \`fd-pagination__button--mobile\` | The first page button that users can use to navigate to the first page. This button is disabled when on the first page. Shown only on mobile.
 Previous page button | \`fd-pagination__button\` | The previous page button that users can use to navigate backward. This button is disabled when on the first page.
@@ -31,14 +36,62 @@ Per page | \`fd-pagination__per-page\` | The area where items per page select & 
 Per page label | \`fd-pagination__per-page-label\` | Per page section label. Hidden on mobile.
 <br>
 <br>
-
       `,
         tags: ['a11y', 'theme'],
         components: ['select', 'button', 'icon', 'form-label', 'input', 'pagination', 'popover', 'list']
     }
 };
 
-export const firstPage = () => `<div class='fd-pagination'>
+export const firstPage = () => `<h3>> 9 Pages</h3>
+<div class='fd-pagination'>
+    <nav class='fd-pagination__nav' title="pagination with more than 9 pages">
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='First' aria-disabled='true'>
+            <i class='sap-icon sap-icon--media-rewind'></i>
+        </a>
+
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Previous' aria-disabled='true'>
+            <i class='sap-icon sap-icon--navigation-left-arrow'></i>
+        </a>
+
+        <label class='fd-form-label fd-pagination__label' id='firstPageInputPage'>Page:</label>
+
+        <input aria-labelledby='firstPageInputPage firstPageInputOf' class='fd-input fd-input--compact fd-pagination__input' type='number' min='1' max='500' value='1' required />
+
+        <label class='fd-form-label fd-pagination__label' id='firstPageInputOf'>of 500</label>
+
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>2</a>
+
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>3</a>
+
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>4</a>
+
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>5</a>
+
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>6</a>
+
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>7</a>
+
+        <span class='fd-pagination__more' role='presentation'></span>
+
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>500</a>
+
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Next' aria-disabled='false'>
+            <i class='sap-icon sap-icon--navigation-right-arrow'></i>
+        </a>
+
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='Last' aria-disabled='false'>
+            <i class='sap-icon sap-icon--media-forward'></i>
+        </a>
+    </nav>
+
+    <div class='fd-pagination__total'>
+        <span class='fd-form-label fd-pagination__total-label'>500 Results</span>
+    </div>
+</div>
+
+<h3>< 9 Pages</h3>
+
+<div class='fd-pagination fd-pagination--short'>
     <nav class='fd-pagination__nav'>
         <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='First' aria-disabled='true'>
             <i class='sap-icon sap-icon--media-rewind'></i>
@@ -48,9 +101,13 @@ export const firstPage = () => `<div class='fd-pagination'>
             <i class='sap-icon sap-icon--navigation-left-arrow'></i>
         </a>
 
-        <label class='fd-form-label fd-pagination__label' for='firstPageInput'>Page:</label>
+        <label class='fd-form-label fd-pagination__label' id='firstPageInputShortPage'>Page:</label>
 
-        <input id='firstPageInput' class='fd-input fd-input--compact fd-pagination__input' type='number' min='1' max='3' value='1' required />
+        <input aria-labelledby="firstPageInputShortPage firstPageInputShortOf" class='fd-input fd-input--compact fd-pagination__input' type='number' min='1' max='3' value='1' required />
+
+        <label class='fd-form-label fd-pagination__label' id='firstPageInputShortOf'>of 3</label>
+
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link is-active'>1</a>
 
         <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>2</a>
 
@@ -81,7 +138,56 @@ firstPage.parameters = {
     }
 };
 
-export const secondPage = () => `<div class='fd-pagination'>
+export const middlePage = () => `<h3>> 9 Pages</h3>
+<div class='fd-pagination'>
+    <nav class='fd-pagination__nav' title="pagination with more than 9 pages">
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='First' aria-disabled='false'>
+            <i class='sap-icon sap-icon--media-rewind'></i>
+        </a>
+
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Previous' aria-disabled='false'>
+            <i class='sap-icon sap-icon--navigation-left-arrow'></i>
+        </a>
+
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>1</a>
+
+        <span class='fd-pagination__more' role='presentation'></span>
+
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>298</a>
+
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>299</a>
+
+        <label class='fd-form-label fd-pagination__label' id='middlePageInputPage'>Page:</label>
+
+        <input aria-labelledby='middlePageInputPage middlePageInputOf' class='fd-input fd-input--compact fd-pagination__input' type='number' min='1' max='500' value='300' required />
+
+        <label class='fd-form-label fd-pagination__label' id='middlePageInputOf'>of 500</label>
+
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>301</a>
+
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>302</a>
+
+        <span class='fd-pagination__more' role='presentation'></span>
+
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>500</a>
+
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Next' aria-disabled='false'>
+            <i class='sap-icon sap-icon--navigation-right-arrow'></i>
+        </a>
+
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='Last' aria-disabled='false'>
+            <i class='sap-icon sap-icon--media-forward'></i>
+        </a>
+    </nav>
+
+    <div class='fd-pagination__total'>
+        <span class='fd-form-label fd-pagination__total-label'>500 Results</span>
+    </div>
+</div>
+
+<h3>< 9 Pages</h3>
+
+<div class='fd-pagination fd-pagination--short'>
     <nav class='fd-pagination__nav'>
         <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='First' aria-disabled='false'>
             <i class='sap-icon sap-icon--media-rewind'></i>
@@ -93,9 +199,13 @@ export const secondPage = () => `<div class='fd-pagination'>
 
         <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>1</a>
 
-        <label class='fd-form-label fd-pagination__label' for='secondPageInput'>Page:</label>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link is-active'>2</a>
 
-        <input id='secondPageInput' class='fd-input fd-input--compact fd-pagination__input' type='number' min='1' max='3' value='2' required />
+        <label class='fd-form-label fd-pagination__label' id='middlePageInputShortPage'>Page:</label>
+
+        <input aria-labelledby='middlePageInputShortPage middlePageInputShortOf' class='fd-input fd-input--compact fd-pagination__input' type='number' min='1' max='3' value='2' required />
+
+        <label class='fd-form-label fd-pagination__label' id='middlePageInputShortOf'>of 3</label>
 
         <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>3</a>
 
@@ -111,103 +221,6 @@ export const secondPage = () => `<div class='fd-pagination'>
     <div class='fd-pagination__total'>
         <span class='fd-form-label fd-pagination__total-label'>3 Results</span>
     </div>
-</div>`;
-
-secondPage.storyName = 'Second page';
-
-secondPage.parameters = {
-    docs: {
-        iframeHeight: 500,
-        storyDescription: `When the user is not on first or last page, the previous and next buttons are enabled.
-    `
-    }
-};
-
-export const multiplePages = () => `<div class='fd-pagination'>
-    <nav class='fd-pagination__nav'>
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='First' aria-disabled='true'>
-            <i class='sap-icon sap-icon--media-rewind'></i>
-        </a>
-
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Previous' aria-disabled='true'>
-            <i class='sap-icon sap-icon--navigation-left-arrow'></i>
-        </a>
-
-        <label class='fd-form-label fd-pagination__label' for='multiplePageInput'>Page:</label>
-
-        <input id='multiplePageInput' class='fd-input fd-input--compact fd-pagination__input' type='number' min='1' max='500' value='1' required />
-
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>2</a>
-
-        <span class='fd-pagination__more' role='presentation'></span>
-
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>500</a>
-
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Next' aria-disabled='false'>
-            <i class='sap-icon sap-icon--navigation-right-arrow'></i>
-        </a>
-
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='Last' aria-disabled='false'>
-            <i class='sap-icon sap-icon--media-forward'></i>
-        </a>
-    </nav>
-
-    <div class='fd-pagination__total'>
-        <span class='fd-form-label fd-pagination__total-label'>500 Results</span>
-    </div>
-</div>
-`;
-
-multiplePages.storyName = 'Multiple pages';
-
-multiplePages.parameters = {
-    docs: {
-        iframeHeight: 500,
-        storyDescription: `The pagination component displays a certain number of pages before an ellipsis appears followed by the last page number.
-        The general rule is that if there is a lot of screen space, pagination can display several page numbers to select from.
-        For mobile, page numbers and total pages section are not shown. Instead First & Last page buttons are shown.
-    `
-    }
-};
-
-export const middlePage = () => `<div class='fd-pagination'>
-    <nav class='fd-pagination__nav'>
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='First' aria-disabled='false'>
-            <i class='sap-icon sap-icon--media-rewind'></i>
-        </a>
-
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Previous' aria-disabled='false'>
-            <i class='sap-icon sap-icon--navigation-left-arrow'></i>
-        </a>
-
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>1</a>
-
-        <span class='fd-pagination__more' role='presentation'></span>
-
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>299</a>
-
-        <label class='fd-form-label fd-pagination__label' for='middlePageInput'>Page:</label>
-
-        <input id='middlePageInput' class='fd-input fd-input--compact fd-pagination__input' type='number' min='1' max='500' value='300' required />
-
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>301</a>
-
-        <span class='fd-pagination__more' role='presentation'></span>
-
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>500</a>
-
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Next' aria-disabled='false'>
-            <i class='sap-icon sap-icon--navigation-right-arrow'></i>
-        </a>
-
-        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='Last' aria-disabled='false'>
-            <i class='sap-icon sap-icon--media-forward'></i>
-        </a>
-    </nav>
-
-    <div class='fd-pagination__total'>
-        <span class='fd-form-label fd-pagination__total-label'>500 Results</span>
-    </div>
 </div>
 `;
 
@@ -217,13 +230,15 @@ middlePage.parameters = {
     docs: {
         iframeHeight: 500,
         storyDescription: `Pagination can display middle pages to increase reachability.
-        The ellipsis will not only display before the last page but also after the first page, showing three page numbers in the middle.
+        The ellipsis will not only display before the last page but also after the first page, showing two pages before & two after the current page.
+        In sum 9 elements are shown: first page + more + 2 pages before + current page + 2 pages after + more + last page.
     `
     }
 };
 
-export const lastPage = () => `<div class='fd-pagination'>
-    <nav class='fd-pagination__nav'>
+export const lastPage = () => `<h3>> 9 Pages</h3>
+<div class='fd-pagination'>
+    <nav class='fd-pagination__nav' title="pagination with more than 9 pages">
         <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='First' aria-disabled='false'>
             <i class='sap-icon sap-icon--media-rewind'></i>
         </a>
@@ -236,11 +251,23 @@ export const lastPage = () => `<div class='fd-pagination'>
 
         <span class='fd-pagination__more' role='presentation'></span>
 
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>494</a>
+
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>495</a>
+
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>496</a>
+
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>497</a>
+
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>498</a>
+
         <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>499</a>
 
-        <label class='fd-form-label fd-pagination__label' for='lastPageInput'>Page:</label>
+        <label class='fd-form-label fd-pagination__label' id='lastPageInputPage'>Page:</label>
 
-        <input id='lastPageInput' class='fd-input fd-input--compact fd-pagination__input' type='number' min='1' max='500' value='500' required />
+        <input aria-labelledby='lastPageInputPage lastPageInputOf' class='fd-input fd-input--compact fd-pagination__input' type='number' min='1' max='500' value='500' required />
+
+        <label class='fd-form-label fd-pagination__label' id='lastPageInputOf'>of 500</label>
 
         <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Next' aria-disabled='true'>
             <i class='sap-icon sap-icon--navigation-right-arrow'></i>
@@ -253,6 +280,44 @@ export const lastPage = () => `<div class='fd-pagination'>
 
     <div class='fd-pagination__total'>
         <span class='fd-form-label fd-pagination__total-label'>500 Results</span>
+    </div>
+</div>
+
+<h3>< 9 Pages</h3>
+
+<div class='fd-pagination fd-pagination--short'>
+    <nav class='fd-pagination__nav'>
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='First' aria-disabled='false'>
+            <i class='sap-icon sap-icon--media-rewind'></i>
+        </a>
+
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Previous' aria-disabled='false'>
+            <i class='sap-icon sap-icon--navigation-left-arrow'></i>
+        </a>
+
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>1</a>
+
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>2</a>
+
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link is-active'>3</a>
+
+        <label class='fd-form-label fd-pagination__label' id='lastPageInputShortPage'>Page:</label>
+
+        <input aria-labelledby='lastPageInputShortPage lastPageInputShortOf' class='fd-input fd-input--compact fd-pagination__input' type='number' min='1' max='3' value='3' required />
+
+        <label class='fd-form-label fd-pagination__label' id='lastPageInputShortOf'>of 3</label>
+
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Next' aria-disabled='true'>
+            <i class='sap-icon sap-icon--navigation-right-arrow'></i>
+        </a>
+
+        <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button fd-pagination__button--mobile' aria-label='Last' aria-disabled='true'>
+            <i class='sap-icon sap-icon--media-forward'></i>
+        </a>
+    </nav>
+
+    <div class='fd-pagination__total'>
+        <span class='fd-form-label fd-pagination__total-label'>3 Results</span>
     </div>
 </div>
 `;
@@ -319,11 +384,23 @@ export const perPage = () => `<div style='height: 175px'>
 
             <span class='fd-pagination__more' role='presentation'></span>
 
+            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>494</a>
+
+            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>495</a>
+
+            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>496</a>
+
+            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>497</a>
+
+            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>498</a>
+
             <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>499</a>
 
-            <label class='fd-form-label fd-pagination__label' for='perPageInput'>Page:</label>
+            <label class='fd-form-label fd-pagination__label' id='perPageInputPage'>Page:</label>
 
-            <input id='perPageInput' class='fd-input fd-input--compact fd-pagination__input' type='number' min='1' max='500' value='500' required />
+            <input aria-labelledby='perPageInputPage perPageInputOf' class='fd-input fd-input--compact fd-pagination__input' type='number' min='1' max='500' value='500' required />
+
+            <label class='fd-form-label fd-pagination__label' id='perPageInputOf'>of 500</label>
 
             <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__button' aria-label='Next' aria-disabled='true'>
                 <i class='sap-icon sap-icon--navigation-right-arrow'></i>
@@ -403,11 +480,25 @@ export const cozy = () => `<div style='height: 200px'>
 
             <span class='fd-pagination__more' role='presentation'></span>
 
+            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>494</a>
+
+            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>495</a>
+
+            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>496</a>
+
+            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>497</a>
+
+            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>498</a>
+
+            <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link'>499</a>
+
             <a href='#' class='fd-button fd-button--transparent fd-pagination__link'>499</a>
 
-            <label class='fd-form-label fd-pagination__label' for='cozyPageInput'>Page:</label>
+            <label class='fd-form-label fd-pagination__label' id='cozyPageInputPage'>Page:</label>
 
-            <input id='cozyPageInput' class='fd-input fd-pagination__input' type='number' min='1' max='500' value='500' required />
+            <input aria-labelledby='cozyPageInputPage cozyPageInputOf' class='fd-input fd-pagination__input' type='number' min='1' max='500' value='500' required />
+
+            <label class='fd-form-label fd-pagination__label' id='cozyPageInputOf'>of 500</label>
 
             <a href='#' class='fd-button fd-button--transparent fd-pagination__button' aria-label='Next' aria-disabled='true'>
                 <i class='sap-icon sap-icon--navigation-right-arrow'></i>
@@ -489,9 +580,11 @@ export const mobile = () => `<div style="height: 200px;">
 
             <a href='#' class='fd-button fd-button--transparent fd-pagination__link'>499</a>
 
-            <label class='fd-form-label fd-pagination__label' for='cozyPageInput'>Page:</label>
+            <label class='fd-form-label fd-pagination__label' id='cozyPageInputPage'>Page:</label>
 
-            <input id='cozyPageInput' class='fd-input fd-pagination__input' type='number' min='1' max='500' value='500' required />
+            <input aria-labelledby='cozyPageInputPage cozyPageInputOf' class='fd-input fd-pagination__input' type='number' min='1' max='500' value='500' required />
+
+            <label class='fd-form-label fd-pagination__label' id='cozyPageInputOf'>of 500</label>
 
             <a href='#' class='fd-button fd-button--transparent fd-pagination__button' aria-label='Next' aria-disabled='true'>
                 <i class='sap-icon sap-icon--navigation-right-arrow'></i>
@@ -514,8 +607,8 @@ mobile.storyName = 'Mobile';
 mobile.parameters = {
     docs: {
         iframeHeight: 500,
-        storyDescription: `Pagination component is responsive by default. When the screen's size is smaller than 600px in width mobile mode is shown and you have nothing to do.
-        If you want to display pagination component always in mobile mode, no matter what is the screen size, please add \`.fd-pagination--mobile\` modifier class to the component.
+        storyDescription: `Pagination component is responsive by default. When the screen's size is smaller than 1024px in width mobile mode is shown and you have nothing to do.
+        If you want to display pagination component always in mobile mode please add \`.fd-pagination--mobile\` modifier class to the component.
     `
     }
 };


### PR DESCRIPTION
## Description

Pagination component styles update due to the new design.

## Screenshots

Too many changes, please see the doc page.

## Breaking changes

- If > 9 pages then 9 elements should be shown - including page links, more, current page input. Otherwise, all pages should be shown, use the link instead of input with `.is-active` class or `aria-selected="true"` attribute for the current page. Input should still be present to be shown in the mobile mode, but it's hidden in desktop mode if < 9 pages.

- Add an additional label with class `.fd-pagination__label` after the input in the mobile mode with the number of pages available.

See on wiki page [breaking changes](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes#pagination-2973).