### PR TITLE
fix(fn): add fix for Link states and docs improvements for Title

### DIFF
--- a/src/fn/_fn-new-variables.scss
+++ b/src/fn/_fn-new-variables.scss
@@ -148,6 +148,7 @@ $fn-color-crimson-800: #71014b;
 $fn-color-crimson-900: #510136;
 
 // Border radius
+$fn-border-radius-2: 0.125rem;  // 2px
 $fn-border-radius-4: 0.25rem;   // 4px
 $fn-border-radius-6: 0.375rem;  // 6px
 $fn-border-radius-8: 0.5rem;    // 8px

--- a/src/fn/fn-link.scss
+++ b/src/fn/fn-link.scss
@@ -4,32 +4,41 @@ $block: #{$fn-namespace}-link;
 
 .#{$block} {
   @include fn-reset();
+  @include fn-set-paddings-x-equal(0.1875rem);
 
-  color: $fn-color-blue-500;
-  text-decoration: none;
-  padding-left: 0.1875rem;
-  padding-right: 0.1875rem;
-  border-radius: 0.125rem;
   width: fit-content;
   height: fit-content;
   display: inline-block;
+  text-decoration: none;
+  color: $fn-color-blue-500;
+  border-radius: $fn-border-radius-2;
 
   @include fn-hover() {
     text-decoration: underline;
   }
 
   @include fn-is-focus() {
+    outline: none;
     text-decoration: none;
-    box-shadow: $fn-focus-outline-shadow-blue, $fn-focus-outline-inner-shadow;
+    box-shadow: $fn-focus-outline-shadow-blue;
   }
 
   @include fn-not-focus-visible() {
     text-decoration: none;
+
+    @include fn-hover() {
+      text-decoration: underline;
+    }
+
+    @include fn-active() {
+      text-decoration: underline;
+    }
   }
 
   @include fn-focus-visible() {
+    outline: none;
     text-decoration: none;
-    box-shadow: $fn-focus-outline-shadow-blue, $fn-focus-outline-inner-shadow;
+    box-shadow: $fn-focus-outline-shadow-blue;
   }
 
   @include fn-active() {
@@ -37,6 +46,8 @@ $block: #{$fn-namespace}-link;
   }
 
   @include fn-disabled() {
+    outline: none;
+    box-shadow: none;
     pointer-events: none;
     opacity: $fn-disabled-opacity;
   }

--- a/stories/fn-link/__snapshots__/fn-link.stories.storyshot
+++ b/stories/fn-link/__snapshots__/fn-link.stories.storyshot
@@ -200,6 +200,7 @@ exports[`Storyshots Experimental/Link Links 1`] = `
       aria-disabled="true"
       class="fn-link fn-link--emphasized"
       href="https://sap.github.io/fundamental-styles"
+      role="link"
     >
       Ñagçyfox
     </a>
@@ -209,6 +210,7 @@ exports[`Storyshots Experimental/Link Links 1`] = `
       aria-disabled="true"
       class="fn-link"
       href="https://sap.github.io/fundamental-styles"
+      role="link"
     >
       Ñagçyfox
     </a>

--- a/stories/fn-link/fn-link.stories.js
+++ b/stories/fn-link/fn-link.stories.js
@@ -73,8 +73,8 @@ export const primary = () => `${localStyles}
 
 <div class="docs-fn-container">
     <div><b>:disabled</b></div>
-    <a href="https://sap.github.io/fundamental-styles" class="fn-link fn-link--emphasized" aria-disabled="true">Ñagçyfox</a>
-    <a href="https://sap.github.io/fundamental-styles" class="fn-link" aria-disabled="true">Ñagçyfox</a>
+    <a role="link" href="https://sap.github.io/fundamental-styles" class="fn-link fn-link--emphasized" aria-disabled="true">Ñagçyfox</a>
+    <a role="link" href="https://sap.github.io/fundamental-styles" class="fn-link" aria-disabled="true">Ñagçyfox</a>
 </div>
 
 `;

--- a/stories/fn-title/__snapshots__/title.stories.storyshot
+++ b/stories/fn-title/__snapshots__/title.stories.storyshot
@@ -5,42 +5,57 @@ exports[`Storyshots Experimental/Title Semantic Level 1`] = `
   <h1
     class="fn-title fn-title--h1"
   >
-    "Have no fear of perfection - you’ll never reach it." - Salvador Dali
+    Title Heading 1
   </h1>
+  
+
+  <br />
   
 
   <h2
     class="fn-title fn-title--h2"
   >
-    "Have no fear of perfection - you’ll never reach it." - Salvador Dali
+    Title Heading 2
   </h2>
+  
+
+  <br />
   
 
   <h3
     class="fn-title fn-title--h3"
   >
-    "Have no fear of perfection - you’ll never reach it." - Salvador Dali
+    Title Heading 3
   </h3>
+  
+
+  <br />
   
 
   <h4
     class="fn-title fn-title--h4"
   >
-    "Have no fear of perfection - you’ll never reach it." - Salvador Dali
+    Title Heading 4
   </h4>
+  
+
+  <br />
   
 
   <h5
     class="fn-title fn-title--h5"
   >
-    "Have no fear of perfection - you’ll never reach it." - Salvador Dali
+    Title Heading 5
   </h5>
+  
+
+  <br />
   
 
   <h6
     class="fn-title fn-title--h6"
   >
-    "Have no fear of perfection - you’ll never reach it." - Salvador Dali
+    Title Heading 6
   </h6>
   
 
@@ -60,11 +75,21 @@ exports[`Storyshots Experimental/Title Text Wrapping 1`] = `
   </h1>
   
     
+  <br />
+  <br />
+  <br />
+  
+    
   <h2
     class="fn-title fn-title--h2 fn-title--wrap"
   >
     "Insanity: doing the same thing over and over again and expecting different results." - Albert Einstein
   </h2>
+  
+    
+  <br />
+  <br />
+  <br />
   
     
   <h3
@@ -74,6 +99,11 @@ exports[`Storyshots Experimental/Title Text Wrapping 1`] = `
   </h3>
   
     
+  <br />
+  <br />
+  <br />
+  
+    
   <h4
     class="fn-title fn-title--h4 fn-title--wrap"
   >
@@ -81,11 +111,21 @@ exports[`Storyshots Experimental/Title Text Wrapping 1`] = `
   </h4>
   
     
+  <br />
+  <br />
+  <br />
+  
+    
   <h5
     class="fn-title fn-title--h5 fn-title--wrap"
   >
     "Insanity: doing the same thing over and over again and expecting different results." - Albert Einstein
   </h5>
+  
+    
+  <br />
+  <br />
+  <br />
   
     
   <h6
@@ -103,42 +143,57 @@ exports[`Storyshots Experimental/Title Visual Level 1`] = `
   <h1
     class="fn-title fn-title--h6"
   >
-    "You never fail until you stop trying." - Albert Einstein
+    Title Heading 1
   </h1>
+  
+
+  <br />
   
 
   <h2
     class="fn-title fn-title--h5"
   >
-    "You never fail until you stop trying." - Albert Einstein
+    Title Heading 2
   </h2>
+  
+
+  <br />
   
 
   <h3
     class="fn-title fn-title--h4"
   >
-    "You never fail until you stop trying." - Albert Einstein
+    Title Heading 3
   </h3>
+  
+
+  <br />
   
 
   <h4
     class="fn-title fn-title--h3"
   >
-    "You never fail until you stop trying." - Albert Einstein
+    Title Heading 4
   </h4>
+  
+
+  <br />
   
 
   <h5
     class="fn-title fn-title--h2"
   >
-    "You never fail until you stop trying." - Albert Einstein
+    Title Heading 5
   </h5>
+  
+
+  <br />
   
 
   <h6
     class="fn-title fn-title--h1"
   >
-    "You never fail until you stop trying." - Albert Einstein
+    Title Heading 6
   </h6>
   
 

--- a/stories/fn-title/title.stories.js
+++ b/stories/fn-title/title.stories.js
@@ -7,12 +7,17 @@ A title component whose semantic level and visual appearance can be set separate
     }
 };
 
-export const levels = () => `<h1 class="fn-title fn-title--h1">"Have no fear of perfection - you’ll never reach it." - Salvador Dali</h1>
-<h2 class="fn-title fn-title--h2">"Have no fear of perfection - you’ll never reach it." - Salvador Dali</h2>
-<h3 class="fn-title fn-title--h3">"Have no fear of perfection - you’ll never reach it." - Salvador Dali</h3>
-<h4 class="fn-title fn-title--h4">"Have no fear of perfection - you’ll never reach it." - Salvador Dali</h4>
-<h5 class="fn-title fn-title--h5">"Have no fear of perfection - you’ll never reach it." - Salvador Dali</h5>
-<h6 class="fn-title fn-title--h6">"Have no fear of perfection - you’ll never reach it." - Salvador Dali</h6>
+export const levels = () => `<h1 class="fn-title fn-title--h1">Title Heading 1</h1>
+<br>
+<h2 class="fn-title fn-title--h2">Title Heading 2</h2>
+<br>
+<h3 class="fn-title fn-title--h3">Title Heading 3</h3>
+<br>
+<h4 class="fn-title fn-title--h4">Title Heading 4</h4>
+<br>
+<h5 class="fn-title fn-title--h5">Title Heading 5</h5>
+<br>
+<h6 class="fn-title fn-title--h6">Title Heading 6</h6>
 `;
 
 levels.storyName = 'Semantic Level';
@@ -23,12 +28,17 @@ levels.parameters = {
     }
 };
 
-export const visualLevel = () => `<h1 class="fn-title fn-title--h6">"You never fail until you stop trying." - Albert Einstein</h1>
-<h2 class="fn-title fn-title--h5">"You never fail until you stop trying." - Albert Einstein</h2>
-<h3 class="fn-title fn-title--h4">"You never fail until you stop trying." - Albert Einstein</h3>
-<h4 class="fn-title fn-title--h3">"You never fail until you stop trying." - Albert Einstein</h4>
-<h5 class="fn-title fn-title--h2">"You never fail until you stop trying." - Albert Einstein</h5>
-<h6 class="fn-title fn-title--h1">"You never fail until you stop trying." - Albert Einstein</h6>
+export const visualLevel = () => `<h1 class="fn-title fn-title--h6">Title Heading 1</h1>
+<br>
+<h2 class="fn-title fn-title--h5">Title Heading 2</h2>
+<br>
+<h3 class="fn-title fn-title--h4">Title Heading 3</h3>
+<br>
+<h4 class="fn-title fn-title--h3">Title Heading 4</h4>
+<br>
+<h5 class="fn-title fn-title--h2">Title Heading 5</h5>
+<br>
+<h6 class="fn-title fn-title--h1">Title Heading 6</h6>
 `;
 
 visualLevel.storyName = 'Visual Level';
@@ -42,10 +52,15 @@ visualLevel.parameters = {
 
 export const wrapping = () => `<div style="width: 600px">
     <h1 class="fn-title fn-title--h1 fn-title--wrap">"Insanity: doing the same thing over and over again and expecting different results." - Albert Einstein</h1>
+    <br><br><br>
     <h2 class="fn-title fn-title--h2 fn-title--wrap">"Insanity: doing the same thing over and over again and expecting different results." - Albert Einstein</h2>
+    <br><br><br>
     <h3 class="fn-title fn-title--h3 fn-title--wrap">"Insanity: doing the same thing over and over again and expecting different results." - Albert Einstein</h3>
+    <br><br><br>
     <h4 class="fn-title fn-title--h4 fn-title--wrap">"Insanity: doing the same thing over and over again and expecting different results." - Albert Einstein</h4>
+    <br><br><br>
     <h5 class="fn-title fn-title--h5 fn-title--wrap">"Insanity: doing the same thing over and over again and expecting different results." - Albert Einstein</h5>
+    <br><br><br>
     <h6 class="fn-title fn-title--h6 fn-title--wrap">"Insanity: doing the same thing over and over again and expecting different results." - Albert Einstein</h6>
 </div>
 `;


### PR DESCRIPTION
## Related Issue
none

## Description
Code improvements:
- Link: remove the focus outline on tab when the link is disabled, corrected the states and removed the default outline as it was resulting in the wrong color on focus
- Link: moved border-radius value to a variable and used mixin for horizontal padding


Docs improvements:
- added role to the link when it's used with aria-disabled. For more info you can read here: https://www.scottohara.me/blog/2021/05/28/disabled-links.html
- for Title changed a bit the text so it's more clear for the user which heading is used.
