### PR TITLE
fix(styles): use the theming variable for focus style

### DIFF
--- a/src/styles/carousel.scss
+++ b/src/styles/carousel.scss
@@ -7,7 +7,7 @@ $button: #{$fd-namespace}-button;
 
 #{$block} {
   @include fd-focus() {
-    outline: 0.0625rem dotted;
+    outline: 0.0625rem var(--sapContent_FocusStyle);
   }
 }
 

--- a/src/styles/mixins/button/_button-helper.scss
+++ b/src/styles/mixins/button/_button-helper.scss
@@ -7,7 +7,7 @@ $block: #{$fd-namespace}-button;
 }
 
 @mixin buttonFocus($fd-button-outline-offset: -0.1875rem) {
-  outline: var(--sapContent_FocusWidth) dotted var(--sapContent_FocusColor);
+  outline: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
   outline-offset: $fd-button-outline-offset;
   @content;
 

--- a/src/styles/popover.scss
+++ b/src/styles/popover.scss
@@ -35,7 +35,7 @@ $block: #{$fd-namespace}-popover;
     margin-left: 0;
 
     &:focus-visible {
-      outline: var(--sapContent_FocusWidth) dotted var(--sapContent_FocusColor);
+      outline: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
     }
 
     &.#{$fd-namespace}-input:last-child {

--- a/src/styles/slider.scss
+++ b/src/styles/slider.scss
@@ -130,7 +130,7 @@ $slider-x-paddings--lg: $handle-mobile-dimensions / 2;
     }
 
     &:focus {
-      outline: $handle-outline-width dotted var(--sapButton_Hover_BorderColor);
+      outline: $handle-outline-width var(--sapContent_FocusStyle) var(--sapButton_Hover_BorderColor);
       outline-offset: $handle-outline-offset;
     }
 

--- a/src/styles/tree.scss
+++ b/src/styles/tree.scss
@@ -82,7 +82,7 @@ $fd-tree-item-selected-border-bottom: var(--sapList_BorderWidth) solid var(--sap
 }
 
 @mixin tree-focus() {
-  outline-style: dotted;
+  outline-style: var(--sapContent_FocusStyle);
   outline-width: var(--sapContent_FocusWidth);
   outline-color: var(--sapContent_FocusColor);
   outline-offset: -0.125rem;


### PR DESCRIPTION
## Related Issue
fixes: #2926 

## Description
replace focus style hardcoded value with the right theming variable in carousel, button, popover, slider, and tree

