### PR TITLE
fix: remove active page link when in long mode

### DIFF
--- a/src/styles/pagination.scss
+++ b/src/styles/pagination.scss
@@ -24,6 +24,12 @@ $block: #{$fd-namespace}-pagination;
   .#{$block}__input {
     display: flex;
   }
+
+  .#{$block}__link {
+    @include fd-active() {
+      display: none;
+    }
+  }
 }
 
 .#{$block} {
@@ -95,6 +101,12 @@ $block: #{$fd-namespace}-pagination;
     display: none;
   }
 
+  .#{$block}__link {
+    @include fd-active() {
+      display: none;
+    }
+  }
+
   .#{$block}__button {
     [class*='sap-icon'] {
       @include fd-rtl() {
@@ -108,6 +120,12 @@ $block: #{$fd-namespace}-pagination;
   }
 
   &--short {
+    .#{$block}__link {
+      @include fd-active() {
+        display: flex;
+      }
+    }
+
     .#{$block}__input {
       display: none;
     }

--- a/src/styles/pagination.scss
+++ b/src/styles/pagination.scss
@@ -66,10 +66,10 @@ $block: #{$fd-namespace}-pagination;
   }
 
   &__more,
-  &__button,
-  &__link,
-  &__input,
-  &__label {
+  .#{$block}__button,
+  .#{$block}__link,
+  .#{$block}__input,
+  .#{$block}__label {
     @include fd-set-margins-x-equal(0.125rem);
   }
 
@@ -99,6 +99,10 @@ $block: #{$fd-namespace}-pagination;
 
   .#{$block}__label {
     display: none;
+  }
+
+  .#{$block}__total-label {
+    margin: 0;
   }
 
   .#{$block}__link {


### PR DESCRIPTION
## Description

Remove from displaying active page link if pagination component in long (> 9 pages) mode. This needed to avoid any extra code logic on ngx side when showing pagination component.

## Screenshots

### Before:

<img width="464" alt="Screenshot 2021-12-20 at 19 53 31" src="https://user-images.githubusercontent.com/20265336/146811412-631ea954-3bd3-4445-b732-a56a382d8e6b.png">

### After:

<img width="454" alt="Screenshot 2021-12-20 at 19 53 03" src="https://user-images.githubusercontent.com/20265336/146811424-5dfc2d04-ce74-459a-a2f6-dfdbf7f3e264.png">