### PR TITLE
test(fn): exclude fn-tabs from a11y tests

### DIFF
--- a/scripts/build-accessibility-tests.js
+++ b/scripts/build-accessibility-tests.js
@@ -31,7 +31,8 @@ const componentsToExclude = [
     'side-navigation',
     'multi-combo-box',
     'generic-tile',
-    'dynamic-page'
+    'dynamic-page',
+    'fn-tabs'
 ];
 
 rimraf('**/*.accessibility.test.js', (rimRafError) => {

--- a/stories/fn-tabs/__snapshots__/fn-tabs.stories.storyshot
+++ b/stories/fn-tabs/__snapshots__/fn-tabs.stories.storyshot
@@ -154,6 +154,7 @@ exports[`Storyshots Experimental/Tabs Default 1`] = `
       <li
         class="fn-tabs__item"
         role="tab"
+        tabindex="0"
       >
            
             


### PR DESCRIPTION
## Related Issue
exclude fn-tabs from a11y tests

## Description
remove `fn-tabs` from `build-accessibility-tests.js` - line 35
and run:
```
npm run test:accessibility
```