### PR TITLE
fix(styles): pagination more element size, improvements

### DIFF
--- a/src/styles/pagination.scss
+++ b/src/styles/pagination.scss
@@ -60,8 +60,12 @@ $block: #{$fd-namespace}-pagination;
     &::before {
       content: "...";
       display: block;
-      width: 1.5rem;
+      width: 2.25rem;
       text-align: center;
+    }
+
+    &--compact::before {
+      width: 2rem;
     }
   }
 
@@ -106,7 +110,8 @@ $block: #{$fd-namespace}-pagination;
   }
 
   .#{$block}__link {
-    @include fd-active() {
+    /** :active links still should be displayed */
+    &.is-active {
       display: none;
     }
   }

--- a/stories/pagination/__snapshots__/pagination.stories.storyshot
+++ b/stories/pagination/__snapshots__/pagination.stories.storyshot
@@ -534,7 +534,7 @@ exports[`Storyshots Components/Pagination First page 1`] = `
 
         
       <span
-        class="fd-pagination__more"
+        class="fd-pagination__more fd-pagination__more--compact"
         role="presentation"
       />
       
@@ -842,7 +842,7 @@ exports[`Storyshots Components/Pagination Last page 1`] = `
 
         
       <span
-        class="fd-pagination__more"
+        class="fd-pagination__more fd-pagination__more--compact"
         role="presentation"
       />
       
@@ -1231,7 +1231,7 @@ exports[`Storyshots Components/Pagination Middle pages 1`] = `
 
         
       <span
-        class="fd-pagination__more"
+        class="fd-pagination__more fd-pagination__more--compact"
         role="presentation"
       />
       
@@ -1309,7 +1309,7 @@ exports[`Storyshots Components/Pagination Middle pages 1`] = `
 
         
       <span
-        class="fd-pagination__more"
+        class="fd-pagination__more fd-pagination__more--compact"
         role="presentation"
       />
       
@@ -2101,7 +2101,7 @@ exports[`Storyshots Components/Pagination Per page 1`] = `
 
             
       <span
-        class="fd-pagination__more"
+        class="fd-pagination__more fd-pagination__more--compact"
         role="presentation"
       />
       

--- a/stories/pagination/pagination.stories.js
+++ b/stories/pagination/pagination.stories.js
@@ -71,7 +71,7 @@ export const FirstPage = () => `<h3>> 9 Pages</h3>
 
         <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 7'>7</a>
 
-        <span class='fd-pagination__more' role='presentation'></span>
+        <span class='fd-pagination__more fd-pagination__more--compact' role='presentation'></span>
 
         <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 500'>500</a>
 
@@ -153,7 +153,7 @@ export const MiddlePage = () => `<h3>> 9 Pages</h3>
 
         <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 1'>1</a>
 
-        <span class='fd-pagination__more' role='presentation'></span>
+        <span class='fd-pagination__more fd-pagination__more--compact' role='presentation'></span>
 
         <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 298'>298</a>
 
@@ -169,7 +169,7 @@ export const MiddlePage = () => `<h3>> 9 Pages</h3>
 
         <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 302'>302</a>
 
-        <span class='fd-pagination__more' role='presentation'></span>
+        <span class='fd-pagination__more fd-pagination__more--compact' role='presentation'></span>
 
         <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 500'>500</a>
 
@@ -253,7 +253,7 @@ export const LastPage = () => `<h3>> 9 Pages</h3>
 
         <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 1'>1</a>
 
-        <span class='fd-pagination__more' role='presentation'></span>
+        <span class='fd-pagination__more fd-pagination__more--compact' role='presentation'></span>
 
         <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 494'>494</a>
 
@@ -388,7 +388,7 @@ export const PerPage = () => `<div style='height: 175px'>
 
             <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 1'>1</a>
 
-            <span class='fd-pagination__more' role='presentation'></span>
+            <span class='fd-pagination__more fd-pagination__more--compact' role='presentation'></span>
 
             <a href='#' class='fd-button fd-button--compact fd-button--transparent fd-pagination__link' aria-label='Goto page 494'>494</a>
 


### PR DESCRIPTION
replaces #3067 

## Related Issue

None

## Description

Pagination component:

* More element cozy & compact modes support implemented.
* Active link fixes.

## Screenshots

### Before:

![image](https://user-images.githubusercontent.com/20265336/149143693-20d94329-4b95-4651-895a-9897333635ff.png)

### After:

![image](https://user-images.githubusercontent.com/20265336/149143608-1ab01f3b-a74d-4e76-9d28-a8719ab1500e.png)

## Breaking changes:

Now `fd-pagination__more--compact` class should be applied to More element in compact mode.