### PR TITLE
feat(styles): focus outline is visible now [ci visual]

### DIFF
--- a/src/styles/tabs.scss
+++ b/src/styles/tabs.scss
@@ -12,7 +12,7 @@ $block: #{$fd-namespace}-tabs;
 
 .#{$block} {
   %fd-tabs-focus {
-    outline-offset: 0.0625rem;
+    outline-offset: var(--sapContent_FocusWidth);
     outline-style: var(--sapContent_FocusStyle);
     outline-width: var(--sapContent_FocusWidth);
     outline-color: var(--sapContent_FocusColor);
@@ -134,7 +134,16 @@ $block: #{$fd-namespace}-tabs;
 
       .#{$block}__tag,
       .#{$block}__icon {
-        @extend %fd-tabs-focus;
+        &::before {
+          @extend %fd-tabs-focus;
+
+          content: '';
+          position: absolute;
+          top: 0;
+          bottom: 0;
+          right: 0;
+          left: 0;
+        }
       }
     }
   }
@@ -439,12 +448,6 @@ $block: #{$fd-namespace}-tabs;
       @include fd-focus() {
         box-shadow: none;
         outline: none;
-
-        .#{$block}__icon,
-        .#{$block}__header {
-          outline-offset: 0;
-          outline: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
-        }
       }
     }
 

--- a/src/styles/tabs.scss
+++ b/src/styles/tabs.scss
@@ -12,7 +12,7 @@ $block: #{$fd-namespace}-tabs;
 
 .#{$block} {
   %fd-tabs-focus {
-    outline-offset: -0.0625rem;
+    outline-offset: 0.0625rem;
     outline-style: var(--sapContent_FocusStyle);
     outline-width: var(--sapContent_FocusWidth);
     outline-color: var(--sapContent_FocusColor);


### PR DESCRIPTION
## Related Issue
Part of SAP/fundamental-ngx#7587

## Description
Focus outline was not visible on tab headers in case of icon tabs. This was because offset was negative exactly same as width of outline. I removed negativity and now it is visible

## Screenshots

### Before:
![before](https://user-images.githubusercontent.com/28543391/151245499-021ef1ea-55d1-4aa9-be5e-66bb9f20ba2d.png)

### After:
![after](https://user-images.githubusercontent.com/28543391/151531068-4d42afd9-4532-4c86-96c0-bdabfb1b01e2.jpg)


#### Please check whether the PR fulfills the following requirements
