### PR TITLE
fix(styles): add overflow modifier classes for Menu and VertNav

### DIFF
--- a/src/styles/menu.scss
+++ b/src/styles/menu.scss
@@ -52,7 +52,7 @@ $block: #{$fd-namespace}-menu;
   // BLOCK BASE *******************************************
   @include fd-reset();
 
-  width: 100%;
+  width: fit-content;
   max-width: 20rem;
 
   &__list,
@@ -95,6 +95,11 @@ $block: #{$fd-namespace}-menu;
   &__list > .#{$block}__item {
     width: 100%;
     position: relative;
+  }
+
+  &__list--overflow {
+    overflow-y: scroll;
+    flex-wrap: nowrap;
   }
 
   &__separator {
@@ -247,6 +252,12 @@ $block: #{$fd-namespace}-menu;
     }
   }
 
+  &--overflow {
+    overflow-y: scroll;
+    box-shadow: var(--sapContent_Shadow1);
+    border-radius: $fd-menu-border-radius;
+  }
+
   &--full-width {
     max-width: 100%;
   }
@@ -284,6 +295,7 @@ $block: #{$fd-namespace}-menu;
 
   &--mobile {
     max-width: 100%;
+    width: 100%;
 
     .#{$block}__list,
     .#{$block}__sublist {

--- a/src/styles/vertical-nav.scss
+++ b/src/styles/vertical-nav.scss
@@ -16,6 +16,10 @@ $block: #{$fd-namespace}-vertical-nav;
   box-shadow: var(--sapContent_Shadow0);
   height: 100%;
 
+  &--overflow {
+    overflow-y: scroll;
+  }
+
   &__main-navigation {
     @include fd-reset();
   }

--- a/stories/menu/__snapshots__/menu.stories.storyshot
+++ b/stories/menu/__snapshots__/menu.stories.storyshot
@@ -274,6 +274,594 @@ exports[`Storyshots Components/Menu Desktop and Tablet Modes 1`] = `
 </section>
 `;
 
+exports[`Storyshots Components/Menu Desktop and Tablet Modes with vertical overflow 1`] = `
+<section>
+  
+
+  <label
+    class="fd-form-label"
+  >
+    Combobox Tablet Cozy Mode - default mode
+  </label>
+  <br />
+  <br />
+  
+
+
+  <nav
+    aria-label="navigation menu"
+    class="fd-menu fd-menu--overflow"
+    style="max-height: 200px;"
+  >
+    
+    
+    <ul
+      class="fd-menu__list"
+      role="menu"
+    >
+      
+        
+      <li
+        class="fd-menu__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-menu__link"
+          href="#"
+          role="menuitem"
+        >
+          
+                
+          <span
+            class="fd-menu__title"
+          >
+            Option 1
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-menu__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-menu__link"
+          href="#"
+          role="menuitem"
+        >
+          
+                
+          <span
+            class="fd-menu__title"
+          >
+            Option 2
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-menu__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-menu__link"
+          href="#"
+          role="menuitem"
+        >
+          
+                
+          <span
+            class="fd-menu__title"
+          >
+            Option 3
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-menu__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-menu__link"
+          href="#"
+          role="menuitem"
+        >
+          
+                
+          <span
+            class="fd-menu__title"
+          >
+            Option 4
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-menu__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-menu__link"
+          href="#"
+          role="menuitem"
+        >
+          
+                
+          <span
+            class="fd-menu__title"
+          >
+            Option 5
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-menu__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-menu__link"
+          href="#"
+          role="menuitem"
+        >
+          
+                
+          <span
+            class="fd-menu__title"
+          >
+            Option 6
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-menu__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-menu__link"
+          href="#"
+          role="menuitem"
+        >
+          
+                
+          <span
+            class="fd-menu__title"
+          >
+            Option 7
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-menu__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-menu__link"
+          href="#"
+          role="menuitem"
+        >
+          
+                
+          <span
+            class="fd-menu__title"
+          >
+            Option 8
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-menu__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-menu__link"
+          href="#"
+          role="menuitem"
+        >
+          
+                
+          <span
+            class="fd-menu__title"
+          >
+            Option 9
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-menu__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-menu__link"
+          href="#"
+          role="menuitem"
+        >
+          
+                
+          <span
+            class="fd-menu__title"
+          >
+            Option 10
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+    
+    </ul>
+    
+
+  </nav>
+  
+
+
+  <br />
+  
+
+  <label
+    class="fd-form-label"
+  >
+    Combobox Desktop Compact Mode
+  </label>
+  <br />
+  <br />
+  
+
+
+  <nav
+    class="fd-menu fd-menu--compact fd-menu--overflow"
+    style="max-height: 120px;"
+  >
+    
+    
+    <ul
+      class="fd-menu__list"
+      role="menu"
+    >
+      
+        
+      <li
+        class="fd-menu__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-menu__link"
+          href="#"
+          role="menuitem"
+        >
+          
+                
+          <span
+            class="fd-menu__title"
+          >
+            Option 1
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-menu__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-menu__link"
+          href="#"
+          role="menuitem"
+        >
+          
+                
+          <span
+            class="fd-menu__title"
+          >
+            Option 2
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-menu__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-menu__link"
+          href="#"
+          role="menuitem"
+        >
+          
+                
+          <span
+            class="fd-menu__title"
+          >
+            Option 3
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-menu__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-menu__link"
+          href="#"
+          role="menuitem"
+        >
+          
+                
+          <span
+            class="fd-menu__title"
+          >
+            Option 4
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-menu__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-menu__link"
+          href="#"
+          role="menuitem"
+        >
+          
+                
+          <span
+            class="fd-menu__title"
+          >
+            Option 5
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-menu__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-menu__link"
+          href="#"
+          role="menuitem"
+        >
+          
+                
+          <span
+            class="fd-menu__title"
+          >
+            Option 6
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-menu__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-menu__link"
+          href="#"
+          role="menuitem"
+        >
+          
+                
+          <span
+            class="fd-menu__title"
+          >
+            Option 7
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-menu__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-menu__link"
+          href="#"
+          role="menuitem"
+        >
+          
+                
+          <span
+            class="fd-menu__title"
+          >
+            Option 8
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-menu__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-menu__link"
+          href="#"
+          role="menuitem"
+        >
+          
+                
+          <span
+            class="fd-menu__title"
+          >
+            Option 9
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+        
+      <li
+        class="fd-menu__item"
+        role="presentation"
+      >
+        
+            
+        <a
+          class="fd-menu__link"
+          href="#"
+          role="menuitem"
+        >
+          
+                
+          <span
+            class="fd-menu__title"
+          >
+            Option 10
+          </span>
+          
+            
+        </a>
+        
+        
+      </li>
+      
+    
+    </ul>
+    
+
+  </nav>
+  
+
+</section>
+`;
+
 exports[`Storyshots Components/Menu List different states 1`] = `
 <section>
   <div

--- a/stories/menu/menu.stories.js
+++ b/stories/menu/menu.stories.js
@@ -79,6 +79,133 @@ DesktopAndTablet.parameters = {
     }
 };
 
+export const DesktopAndTabletOverflow = () => `
+<label class="fd-form-label">Combobox Tablet Cozy Mode - default mode</label><br/><br/>
+
+<nav aria-label="navigation menu" class="fd-menu fd-menu--overflow" style="max-height: 200px;">
+    <ul class="fd-menu__list" role="menu">
+        <li class="fd-menu__item" role="presentation">
+            <a class="fd-menu__link" href="#" role="menuitem">
+                <span class="fd-menu__title">Option 1</span>
+            </a>
+        </li>
+        <li class="fd-menu__item" role="presentation">
+            <a class="fd-menu__link" href="#" role="menuitem">
+                <span class="fd-menu__title">Option 2</span>
+            </a>
+        </li>
+        <li class="fd-menu__item" role="presentation">
+            <a class="fd-menu__link" href="#" role="menuitem">
+                <span class="fd-menu__title">Option 3</span>
+            </a>
+        </li>
+        <li class="fd-menu__item" role="presentation">
+            <a class="fd-menu__link" href="#" role="menuitem">
+                <span class="fd-menu__title">Option 4</span>
+            </a>
+        </li>
+        <li class="fd-menu__item" role="presentation">
+            <a class="fd-menu__link" href="#" role="menuitem">
+                <span class="fd-menu__title">Option 5</span>
+            </a>
+        </li>
+        <li class="fd-menu__item" role="presentation">
+            <a class="fd-menu__link" href="#" role="menuitem">
+                <span class="fd-menu__title">Option 6</span>
+            </a>
+        </li>
+        <li class="fd-menu__item" role="presentation">
+            <a class="fd-menu__link" href="#" role="menuitem">
+                <span class="fd-menu__title">Option 7</span>
+            </a>
+        </li>
+        <li class="fd-menu__item" role="presentation">
+            <a class="fd-menu__link" href="#" role="menuitem">
+                <span class="fd-menu__title">Option 8</span>
+            </a>
+        </li>
+        <li class="fd-menu__item" role="presentation">
+            <a class="fd-menu__link" href="#" role="menuitem">
+                <span class="fd-menu__title">Option 9</span>
+            </a>
+        </li>
+        <li class="fd-menu__item" role="presentation">
+            <a class="fd-menu__link" href="#" role="menuitem">
+                <span class="fd-menu__title">Option 10</span>
+            </a>
+        </li>
+    </ul>
+</nav>
+
+<br>
+<label class="fd-form-label">Combobox Desktop Compact Mode</label><br/><br/>
+
+<nav class="fd-menu fd-menu--compact fd-menu--overflow" style="max-height: 120px;">
+    <ul class="fd-menu__list" role="menu">
+        <li class="fd-menu__item" role="presentation">
+            <a class="fd-menu__link" href="#" role="menuitem">
+                <span class="fd-menu__title">Option 1</span>
+            </a>
+        </li>
+        <li class="fd-menu__item" role="presentation">
+            <a class="fd-menu__link" href="#" role="menuitem">
+                <span class="fd-menu__title">Option 2</span>
+            </a>
+        </li>
+        <li class="fd-menu__item" role="presentation">
+            <a class="fd-menu__link" href="#" role="menuitem">
+                <span class="fd-menu__title">Option 3</span>
+            </a>
+        </li>
+        <li class="fd-menu__item" role="presentation">
+            <a class="fd-menu__link" href="#" role="menuitem">
+                <span class="fd-menu__title">Option 4</span>
+            </a>
+        </li>
+        <li class="fd-menu__item" role="presentation">
+            <a class="fd-menu__link" href="#" role="menuitem">
+                <span class="fd-menu__title">Option 5</span>
+            </a>
+        </li>
+        <li class="fd-menu__item" role="presentation">
+            <a class="fd-menu__link" href="#" role="menuitem">
+                <span class="fd-menu__title">Option 6</span>
+            </a>
+        </li>
+        <li class="fd-menu__item" role="presentation">
+            <a class="fd-menu__link" href="#" role="menuitem">
+                <span class="fd-menu__title">Option 7</span>
+            </a>
+        </li>
+        <li class="fd-menu__item" role="presentation">
+            <a class="fd-menu__link" href="#" role="menuitem">
+                <span class="fd-menu__title">Option 8</span>
+            </a>
+        </li>
+        <li class="fd-menu__item" role="presentation">
+            <a class="fd-menu__link" href="#" role="menuitem">
+                <span class="fd-menu__title">Option 9</span>
+            </a>
+        </li>
+        <li class="fd-menu__item" role="presentation">
+            <a class="fd-menu__link" href="#" role="menuitem">
+                <span class="fd-menu__title">Option 10</span>
+            </a>
+        </li>
+    </ul>
+</nav>
+`;
+
+DesktopAndTabletOverflow.storyName = 'Desktop and Tablet Modes with vertical overflow';
+DesktopAndTabletOverflow.parameters = {
+    docs: {
+        iframeHeight: 300,
+        description: {
+            story: 'The `fd-menu--overflow` modifier class will clip the content and add a vertical scroll to the element. You need to manually set the max-height of the element on the `fd-menu` level. For example: `style="max-height: 120px;"`. <br><b>Important: </b>this modifier class cannot be used in cases where the menu has a submenu.'
+        }
+    }
+};
+
 export const MobileCozyMode = () => `<div style="width: 50%; display: inline-block" class="fd-dialog fd-dialog-docs-static fd-select-docs-max-height fd-dialog--active" id="select-dialog-example">
     <section
         aria-labelledby="exampleSubMenuHeader"

--- a/stories/vertical-navigation/__snapshots__/vertical-navigation.stories.storyshot
+++ b/stories/vertical-navigation/__snapshots__/vertical-navigation.stories.storyshot
@@ -624,6 +624,309 @@ exports[`Storyshots Components/Vertical Navigation Grouping 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/Vertical Navigation Grouping with Overflow 1`] = `
+<div
+  class="fd-vertical-nav fd-vertical-nav--overflow"
+  style="max-height: 200px;"
+>
+  
+    
+  <nav
+    aria-label="Main Menu 5"
+    class="fd-vertical-nav__main-navigation"
+  >
+    
+        
+    <ul
+      aria-label="Main Menu List 5"
+      class="fd-list"
+    >
+      
+            
+      <li
+        class="fd-list__navigation-item"
+        tabindex="0"
+      >
+        
+                
+        <i
+          class="fd-list__navigation-item-icon sap-icon--home"
+          role="presentation"
+        />
+        
+                
+        <span
+          class="fd-list__navigation-item-text"
+        >
+          Overview
+        </span>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-list__navigation-item fd-list__navigation-item--expandable"
+        onclick="toggleVerticalNavSubmenu(event)"
+      >
+        
+                
+        <i
+          class="fd-list__navigation-item-icon sap-icon--calendar"
+          role="presentation"
+        />
+        
+                
+        <span
+          class="fd-list__navigation-item-text"
+        >
+          Calendar
+        </span>
+        
+                
+        <button
+          aria-label="Expand second submenu 3"
+          class="fd-list__navigation-item-arrow sap-icon--navigation-right-arrow"
+        />
+        
+                
+        <ul
+          class="fd-list"
+        >
+          
+                    
+          <li
+            class="fd-list__navigation-item fd-list__navigation-item--indicated"
+          >
+            
+                        
+            <span
+              class="fd-list__navigation-item-text"
+            >
+              Second level item 1
+            </span>
+            
+                        
+            <span
+              class="fd-list__navigation-item-indicator"
+            />
+            
+                    
+          </li>
+          
+                    
+          <li
+            class="fd-list__navigation-item"
+            tabindex="0"
+          >
+            
+                        
+            <span
+              class="fd-list__navigation-item-text"
+            >
+              Second level item 2
+            </span>
+            
+                    
+          </li>
+          
+                
+        </ul>
+        
+                
+        <span
+          class="fd-list__navigation-item-indicator"
+        />
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-list__navigation-item"
+        tabindex="0"
+      >
+        
+                
+        <i
+          class="fd-list__navigation-item-icon sap-icon--course-book"
+          role="presentation"
+        />
+        
+                
+        <span
+          class="fd-list__navigation-item-text"
+        >
+          Deliveries
+        </span>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-list__navigation-item"
+        tabindex="0"
+      >
+        
+                
+        <i
+          class="fd-list__navigation-item-icon sap-icon--employee"
+          role="presentation"
+        />
+        
+                
+        <span
+          class="fd-list__navigation-item-text"
+        >
+          Customers
+        </span>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-list__navigation-item fd-list__navigation-item--indicated"
+        tabindex="0"
+      >
+        
+                
+        <i
+          class="fd-list__navigation-item-icon sap-icon--lead
+                "
+          role="presentation"
+        />
+        
+                
+        <span
+          class="fd-list__navigation-item-text"
+        >
+          Sales
+        </span>
+        
+                
+        <span
+          class="fd-list__navigation-item-indicator"
+        />
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-list__navigation-item"
+        tabindex="0"
+      >
+        
+                
+        <i
+          class="fd-list__navigation-item-icon sap-icon--filter-analytics"
+          role="presentation"
+        />
+        
+                
+        <span
+          class="fd-list__navigation-item-text"
+        >
+          Analytics
+        </span>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-list__group-header fd-vertical-nav__group-header"
+        role="listitem"
+      >
+        
+                
+        <span
+          class="fd-list__title"
+        >
+          Employee Services
+        </span>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-list__navigation-item"
+        tabindex="0"
+      >
+        
+                
+        <i
+          class="fd-list__navigation-item-icon sap-icon--headset"
+          role="presentation"
+        />
+        
+                
+        <span
+          class="fd-list__navigation-item-text"
+        >
+          Support
+        </span>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-list__navigation-item"
+        tabindex="0"
+      >
+        
+                
+        <i
+          class="fd-list__navigation-item-icon sap-icon--nutrition-activity"
+          role="presentation"
+        />
+        
+                
+        <span
+          class="fd-list__navigation-item-text"
+        >
+          Lunch
+        </span>
+        
+            
+      </li>
+      
+            
+      <li
+        class="fd-list__navigation-item"
+        tabindex="0"
+      >
+        
+                
+        <i
+          class="fd-list__navigation-item-icon sap-icon--stethoscope"
+          role="presentation"
+        />
+        
+                
+        <span
+          class="fd-list__navigation-item-text"
+        >
+          Health
+        </span>
+        
+            
+      </li>
+      
+        
+    </ul>
+    
+    
+  </nav>
+  
+
+</div>
+`;
+
 exports[`Storyshots Components/Vertical Navigation Navigation Indication 1`] = `
 <section>
   <div

--- a/stories/vertical-navigation/vertical-navigation.stories.js
+++ b/stories/vertical-navigation/vertical-navigation.stories.js
@@ -327,3 +327,74 @@ Grouping.parameters = {
         }
     }
 };
+
+export const GroupingOverflow = () => `<div class="fd-vertical-nav fd-vertical-nav--overflow" style="max-height: 200px;">
+    <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu 5">
+        <ul class="fd-list" aria-label="Main Menu List 5">
+            <li class="fd-list__navigation-item" tabindex="0">
+                <i role="presentation" class="fd-list__navigation-item-icon sap-icon--home"></i>
+                <span class="fd-list__navigation-item-text">Overview</span>
+            </li>
+            <li class="fd-list__navigation-item fd-list__navigation-item--expandable" onclick="toggleVerticalNavSubmenu(event)">
+                <i role="presentation" class="fd-list__navigation-item-icon sap-icon--calendar"></i>
+                <span class="fd-list__navigation-item-text">Calendar</span>
+                <button class="fd-list__navigation-item-arrow sap-icon--navigation-right-arrow" aria-label="Expand second submenu 3"></button>
+                <ul class="fd-list">
+                    <li class="fd-list__navigation-item fd-list__navigation-item--indicated">
+                        <span class="fd-list__navigation-item-text">Second level item 1</span>
+                        <span class="fd-list__navigation-item-indicator"></span>
+                    </li>
+                    <li class="fd-list__navigation-item" tabindex="0">
+                        <span class="fd-list__navigation-item-text">Second level item 2</span>
+                    </li>
+                </ul>
+                <span class="fd-list__navigation-item-indicator"></span>
+            </li>
+            <li class="fd-list__navigation-item" tabindex="0">
+                <i role="presentation" class="fd-list__navigation-item-icon sap-icon--course-book"></i>
+                <span class="fd-list__navigation-item-text">Deliveries</span>
+            </li>
+            <li class="fd-list__navigation-item" tabindex="0">
+                <i role="presentation" class="fd-list__navigation-item-icon sap-icon--employee"></i>
+                <span class="fd-list__navigation-item-text">Customers</span>
+            </li>
+            <li class="fd-list__navigation-item fd-list__navigation-item--indicated" tabindex="0">
+                <i role="presentation" class="fd-list__navigation-item-icon sap-icon--lead
+                "></i>
+                <span class="fd-list__navigation-item-text">Sales</span>
+                <span class="fd-list__navigation-item-indicator"></span>
+            </li>
+            <li class="fd-list__navigation-item" tabindex="0">
+                <i role="presentation" class="fd-list__navigation-item-icon sap-icon--filter-analytics"></i>
+                <span class="fd-list__navigation-item-text">Analytics</span>
+            </li>
+            <li role="listitem" class="fd-list__group-header fd-vertical-nav__group-header">
+                <span class="fd-list__title">Employee Services</span>
+            </li>
+            <li class="fd-list__navigation-item" tabindex="0">
+                <i role="presentation" class="fd-list__navigation-item-icon sap-icon--headset"></i>
+                <span class="fd-list__navigation-item-text">Support</span>
+            </li>
+            <li class="fd-list__navigation-item" tabindex="0">
+                <i role="presentation" class="fd-list__navigation-item-icon sap-icon--nutrition-activity"></i>
+                <span class="fd-list__navigation-item-text">Lunch</span>
+            </li>
+            <li class="fd-list__navigation-item" tabindex="0">
+                <i role="presentation" class="fd-list__navigation-item-icon sap-icon--stethoscope"></i>
+                <span class="fd-list__navigation-item-text">Health</span>
+            </li>
+        </ul>
+    </nav>
+</div>
+`;
+
+GroupingOverflow.storyName = 'Grouping with Overflow';
+GroupingOverflow.parameters = {
+    docs: {
+        iframeHeight: 700,
+        description: {
+            story: `To clip the content and add a vertical scroll to the Vertical Navigation add the  \`fd-vertical-nav--overflow\` modifier class to the \`fd-vertical-nav\` base class. You need to manually set the max-height of the element on the \`fd-vertical-nav\` level. For example: \`style="max-height: 200px;"\`.
+        `
+        }
+    }
+};


### PR DESCRIPTION
## Description
- added modifier class to Menu component to allow vertical scroll - `fd-menu--overflow`
- fixed the width of Menu item to be `fit-content` and not the max-width as it was before
- added modifier class to Vertical Navigation component to allow vertical scroll  - `.fd-vertical-nav--overflow`
