### PR TITLE
fix(fn): adjust slider handle position [ci visual]

### DIFF
--- a/src/fn/fn-slider.scss
+++ b/src/fn/fn-slider.scss
@@ -3,6 +3,7 @@
 $block: #{$fn-namespace}-slider;
 $tag-border-width: 0.125rem;
 $slider-handle-width: 2.25rem;
+$slider-wrapper-offset: $slider-handle-width * 0.5;
 $slider-handle-height: 1.625rem;
 $slider-dot-size: 0.25rem;
 $slider-height: 0.5rem;
@@ -48,6 +49,14 @@ $slider-height: 0.5rem;
     opacity: $fn-disabled-opacity;
   }
 
+  &__wrapper {
+    @include fn-reset();
+
+    position: relative;
+    margin-left: $slider-wrapper-offset;
+    margin-right: $slider-wrapper-offset;
+  }
+
   &__track {
     @include fn-reset();
 
@@ -59,10 +68,10 @@ $slider-height: 0.5rem;
 
   &__track-range {
     @include fn-reset();
-    @include fn-set-position-left(0);
 
     z-index: 2;
-    width: 100%;
+    left: -$slider-wrapper-offset;
+    right: -$slider-wrapper-offset;
     top: 0.4375rem;
     height: 0.75rem;
     position: absolute;
@@ -111,14 +120,6 @@ $slider-height: 0.5rem;
       }
     }
 
-    &[aria-valuenow="0"] {
-      transform: translateX(0);
-    }
-
-    &[aria-valuenow="100"] {
-      transform: translateX(-100%);
-    }
-
     @include fn-focus() {
       outline: none;
     }
@@ -153,6 +154,10 @@ $slider-height: 0.5rem;
 
     @include fn-focus-visible() {
       box-shadow: $fn-focus-outline-shadow-blue;
+    }
+
+    @include fn-rtl() {
+      transform: translateX(50%);
     }
   }
 

--- a/stories/fn-slider/__snapshots__/fn-slider.stories.storyshot
+++ b/stories/fn-slider/__snapshots__/fn-slider.stories.storyshot
@@ -41,59 +41,67 @@ exports[`Storyshots FN Components/Slider Range Slider 1`] = `
       
         
       <div
-        class="fn-slider__track"
-        style="width: 30%; left: 0"
+        class="fn-slider__wrapper"
       >
         
             
         <div
-          aria-label="slider handle"
-          aria-valuemax="100"
-          aria-valuemin="1"
-          aria-valuenow="0"
-          class="fn-slider__handle"
-          role="slider"
-          tabindex="0"
+          class="fn-slider__track"
+          style="width: 30%; left: 0"
         >
           
                 
-          <span
-            class="sap-icon sap-icon--megamenu"
+          <div
+            aria-label="slider handle"
+            aria-valuemax="100"
+            aria-valuemin="1"
+            aria-valuenow="0"
+            class="fn-slider__handle"
+            role="slider"
+            tabindex="0"
+          >
+            
+                    
+            <span
+              class="sap-icon sap-icon--megamenu"
+            />
+            
+                    
+            <span
+              class="sap-icon sap-icon--megamenu"
+            />
+            
+                
+          </div>
+          
+                
+          <div
+            class="fn-slider__track-range"
           />
           
                 
-          <span
-            class="sap-icon sap-icon--megamenu"
-          />
-          
+          <div
+            aria-label="slider handle"
+            aria-valuemax="100"
+            aria-valuemin="1"
+            aria-valuenow="30"
+            class="fn-slider__handle"
+            role="slider"
+            tabindex="0"
+          >
             
-        </div>
-        
+                    
+            <span
+              class="sap-icon sap-icon--megamenu"
+            />
             
-        <div
-          class="fn-slider__track-range"
-        />
-        
+                    
+            <span
+              class="sap-icon sap-icon--megamenu"
+            />
             
-        <div
-          aria-label="slider handle"
-          aria-valuemax="100"
-          aria-valuemin="1"
-          aria-valuenow="30"
-          class="fn-slider__handle"
-          role="slider"
-          tabindex="0"
-        >
-          
                 
-          <span
-            class="sap-icon sap-icon--megamenu"
-          />
-          
-                
-          <span
-            class="sap-icon sap-icon--megamenu"
-          />
+          </div>
           
             
         </div>
@@ -127,59 +135,67 @@ exports[`Storyshots FN Components/Slider Range Slider 1`] = `
       
         
       <div
-        class="fn-slider__track"
-        style="width: 30%; left: 30%"
+        class="fn-slider__wrapper"
       >
         
             
         <div
-          aria-label="slider handle"
-          aria-valuemax="100"
-          aria-valuemin="1"
-          aria-valuenow="30"
-          class="fn-slider__handle is-hover"
-          role="slider"
-          tabindex="0"
+          class="fn-slider__track"
+          style="width: 30%; left: 30%"
         >
           
                 
-          <span
-            class="sap-icon sap-icon--megamenu"
+          <div
+            aria-label="slider handle"
+            aria-valuemax="100"
+            aria-valuemin="1"
+            aria-valuenow="30"
+            class="fn-slider__handle is-hover"
+            role="slider"
+            tabindex="0"
+          >
+            
+                    
+            <span
+              class="sap-icon sap-icon--megamenu"
+            />
+            
+                    
+            <span
+              class="sap-icon sap-icon--megamenu"
+            />
+            
+                
+          </div>
+          
+                
+          <div
+            class="fn-slider__track-range"
           />
           
                 
-          <span
-            class="sap-icon sap-icon--megamenu"
-          />
-          
+          <div
+            aria-label="slider handle"
+            aria-valuemax="100"
+            aria-valuemin="1"
+            aria-valuenow="60"
+            class="fn-slider__handle is-hover"
+            role="slider"
+            tabindex="0"
+          >
             
-        </div>
-        
+                    
+            <span
+              class="sap-icon sap-icon--megamenu"
+            />
             
-        <div
-          class="fn-slider__track-range"
-        />
-        
+                    
+            <span
+              class="sap-icon sap-icon--megamenu"
+            />
             
-        <div
-          aria-label="slider handle"
-          aria-valuemax="100"
-          aria-valuemin="1"
-          aria-valuenow="60"
-          class="fn-slider__handle is-hover"
-          role="slider"
-          tabindex="0"
-        >
-          
                 
-          <span
-            class="sap-icon sap-icon--megamenu"
-          />
-          
-                
-          <span
-            class="sap-icon sap-icon--megamenu"
-          />
+          </div>
           
             
         </div>
@@ -213,59 +229,67 @@ exports[`Storyshots FN Components/Slider Range Slider 1`] = `
       
         
       <div
-        class="fn-slider__track"
-        style="width: 20%; left: 60%"
+        class="fn-slider__wrapper"
       >
         
             
         <div
-          aria-label="slider handle"
-          aria-valuemax="100"
-          aria-valuemin="1"
-          aria-valuenow="60"
-          class="fn-slider__handle"
-          role="slider"
-          tabindex="0"
+          class="fn-slider__track"
+          style="width: 20%; left: 60%"
         >
           
                 
-          <span
-            class="sap-icon sap-icon--megamenu"
+          <div
+            aria-label="slider handle"
+            aria-valuemax="100"
+            aria-valuemin="1"
+            aria-valuenow="60"
+            class="fn-slider__handle"
+            role="slider"
+            tabindex="0"
+          >
+            
+                    
+            <span
+              class="sap-icon sap-icon--megamenu"
+            />
+            
+                    
+            <span
+              class="sap-icon sap-icon--megamenu"
+            />
+            
+                
+          </div>
+          
+                
+          <div
+            class="fn-slider__track-range"
           />
           
                 
-          <span
-            class="sap-icon sap-icon--megamenu"
-          />
-          
+          <div
+            aria-label="slider handle"
+            aria-valuemax="100"
+            aria-valuemin="1"
+            aria-valuenow="80"
+            class="fn-slider__handle"
+            role="slider"
+            tabindex="0"
+          >
             
-        </div>
-        
+                    
+            <span
+              class="sap-icon sap-icon--megamenu"
+            />
             
-        <div
-          class="fn-slider__track-range"
-        />
-        
+                    
+            <span
+              class="sap-icon sap-icon--megamenu"
+            />
             
-        <div
-          aria-label="slider handle"
-          aria-valuemax="100"
-          aria-valuemin="1"
-          aria-valuenow="80"
-          class="fn-slider__handle"
-          role="slider"
-          tabindex="0"
-        >
-          
                 
-          <span
-            class="sap-icon sap-icon--megamenu"
-          />
-          
-                
-          <span
-            class="sap-icon sap-icon--megamenu"
-          />
+          </div>
           
             
         </div>
@@ -299,59 +323,67 @@ exports[`Storyshots FN Components/Slider Range Slider 1`] = `
       
         
       <div
-        class="fn-slider__track"
-        style="width: 70%; left: 30%"
+        class="fn-slider__wrapper"
       >
         
             
         <div
-          aria-label="slider handle"
-          aria-valuemax="100"
-          aria-valuemin="1"
-          aria-valuenow="30"
-          class="fn-slider__handle is-focus"
-          role="slider"
-          tabindex="0"
+          class="fn-slider__track"
+          style="width: 70%; left: 30%"
         >
           
                 
-          <span
-            class="sap-icon sap-icon--megamenu"
+          <div
+            aria-label="slider handle"
+            aria-valuemax="100"
+            aria-valuemin="1"
+            aria-valuenow="30"
+            class="fn-slider__handle is-focus"
+            role="slider"
+            tabindex="0"
+          >
+            
+                    
+            <span
+              class="sap-icon sap-icon--megamenu"
+            />
+            
+                    
+            <span
+              class="sap-icon sap-icon--megamenu"
+            />
+            
+                
+          </div>
+          
+                
+          <div
+            class="fn-slider__track-range"
           />
           
                 
-          <span
-            class="sap-icon sap-icon--megamenu"
-          />
-          
+          <div
+            aria-label="slider handle"
+            aria-valuemax="100"
+            aria-valuemin="1"
+            aria-valuenow="100"
+            class="fn-slider__handle is-focus"
+            role="slider"
+            tabindex="0"
+          >
             
-        </div>
-        
+                    
+            <span
+              class="sap-icon sap-icon--megamenu"
+            />
             
-        <div
-          class="fn-slider__track-range"
-        />
-        
+                    
+            <span
+              class="sap-icon sap-icon--megamenu"
+            />
             
-        <div
-          aria-label="slider handle"
-          aria-valuemax="100"
-          aria-valuemin="1"
-          aria-valuenow="100"
-          class="fn-slider__handle is-focus"
-          role="slider"
-          tabindex="0"
-        >
-          
                 
-          <span
-            class="sap-icon sap-icon--megamenu"
-          />
-          
-                
-          <span
-            class="sap-icon sap-icon--megamenu"
-          />
+          </div>
           
             
         </div>
@@ -385,57 +417,65 @@ exports[`Storyshots FN Components/Slider Range Slider 1`] = `
       
         
       <div
-        class="fn-slider__track"
-        style="width: 100%; left: 0%"
+        class="fn-slider__wrapper"
       >
         
             
         <div
-          aria-label="slider handle"
-          aria-valuemax="100"
-          aria-valuemin="1"
-          aria-valuenow="0"
-          class="fn-slider__handle"
-          role="slider"
+          class="fn-slider__track"
+          style="width: 100%; left: 0%"
         >
           
                 
-          <span
-            class="sap-icon sap-icon--megamenu"
+          <div
+            aria-label="slider handle"
+            aria-valuemax="100"
+            aria-valuemin="1"
+            aria-valuenow="0"
+            class="fn-slider__handle"
+            role="slider"
+          >
+            
+                    
+            <span
+              class="sap-icon sap-icon--megamenu"
+            />
+            
+                    
+            <span
+              class="sap-icon sap-icon--megamenu"
+            />
+            
+                
+          </div>
+          
+                
+          <div
+            class="fn-slider__track-range"
           />
           
                 
-          <span
-            class="sap-icon sap-icon--megamenu"
-          />
-          
+          <div
+            aria-label="slider handle"
+            aria-valuemax="100"
+            aria-valuemin="1"
+            aria-valuenow="100"
+            class="fn-slider__handle"
+            role="slider"
+          >
             
-        </div>
-        
+                    
+            <span
+              class="sap-icon sap-icon--megamenu"
+            />
             
-        <div
-          class="fn-slider__track-range"
-        />
-        
+                    
+            <span
+              class="sap-icon sap-icon--megamenu"
+            />
             
-        <div
-          aria-label="slider handle"
-          aria-valuemax="100"
-          aria-valuemin="1"
-          aria-valuenow="100"
-          class="fn-slider__handle"
-          role="slider"
-        >
-          
                 
-          <span
-            class="sap-icon sap-icon--megamenu"
-          />
-          
-                
-          <span
-            class="sap-icon sap-icon--megamenu"
-          />
+          </div>
           
             
         </div>
@@ -494,38 +534,46 @@ exports[`Storyshots FN Components/Slider Slider 1`] = `
       
         
       <div
-        class="fn-slider__track"
-        style="width: 0%;"
+        class="fn-slider__wrapper"
       >
         
             
         <div
-          aria-label="slider handle"
-          aria-valuemax="100"
-          aria-valuemin="1"
-          aria-valuenow="0"
-          class="fn-slider__handle"
-          role="slider"
-          tabindex="0"
+          class="fn-slider__track"
+          style="width: 0%;"
         >
           
                 
-          <span
-            class="sap-icon sap-icon--megamenu"
-          />
+          <div
+            aria-label="slider handle"
+            aria-valuemax="100"
+            aria-valuemin="1"
+            aria-valuenow="0"
+            class="fn-slider__handle"
+            role="slider"
+            tabindex="0"
+          >
+            
+                    
+            <span
+              class="sap-icon sap-icon--megamenu"
+            />
+            
+                    
+            <span
+              class="sap-icon sap-icon--megamenu"
+            />
+            
+                
+          </div>
           
                 
-          <span
-            class="sap-icon sap-icon--megamenu"
+          <div
+            class="fn-slider__track-range"
           />
           
             
         </div>
-        
-            
-        <div
-          class="fn-slider__track-range"
-        />
         
         
       </div>
@@ -556,38 +604,46 @@ exports[`Storyshots FN Components/Slider Slider 1`] = `
       
         
       <div
-        class="fn-slider__track"
-        style="width: 25%;"
+        class="fn-slider__wrapper"
       >
         
             
         <div
-          aria-label="slider handle"
-          aria-valuemax="100"
-          aria-valuemin="1"
-          aria-valuenow="25"
-          class="fn-slider__handle is-hover"
-          role="slider"
-          tabindex="0"
+          class="fn-slider__track"
+          style="width: 25%;"
         >
           
                 
-          <span
-            class="sap-icon sap-icon--megamenu"
-          />
+          <div
+            aria-label="slider handle"
+            aria-valuemax="100"
+            aria-valuemin="1"
+            aria-valuenow="25"
+            class="fn-slider__handle is-hover"
+            role="slider"
+            tabindex="0"
+          >
+            
+                    
+            <span
+              class="sap-icon sap-icon--megamenu"
+            />
+            
+                    
+            <span
+              class="sap-icon sap-icon--megamenu"
+            />
+            
+                
+          </div>
           
                 
-          <span
-            class="sap-icon sap-icon--megamenu"
+          <div
+            class="fn-slider__track-range"
           />
           
             
         </div>
-        
-            
-        <div
-          class="fn-slider__track-range"
-        />
         
         
       </div>
@@ -618,38 +674,46 @@ exports[`Storyshots FN Components/Slider Slider 1`] = `
       
         
       <div
-        class="fn-slider__track"
-        style="width: 50%;"
+        class="fn-slider__wrapper"
       >
         
             
         <div
-          aria-label="slider handle"
-          aria-valuemax="100"
-          aria-valuemin="1"
-          aria-valuenow="50"
-          class="fn-slider__handle is-active"
-          role="slider"
-          tabindex="0"
+          class="fn-slider__track"
+          style="width: 50%;"
         >
           
                 
-          <span
-            class="sap-icon sap-icon--megamenu"
-          />
+          <div
+            aria-label="slider handle"
+            aria-valuemax="100"
+            aria-valuemin="1"
+            aria-valuenow="50"
+            class="fn-slider__handle is-active"
+            role="slider"
+            tabindex="0"
+          >
+            
+                    
+            <span
+              class="sap-icon sap-icon--megamenu"
+            />
+            
+                    
+            <span
+              class="sap-icon sap-icon--megamenu"
+            />
+            
+                
+          </div>
           
                 
-          <span
-            class="sap-icon sap-icon--megamenu"
+          <div
+            class="fn-slider__track-range"
           />
           
             
         </div>
-        
-            
-        <div
-          class="fn-slider__track-range"
-        />
         
         
       </div>
@@ -680,38 +744,46 @@ exports[`Storyshots FN Components/Slider Slider 1`] = `
       
         
       <div
-        class="fn-slider__track"
-        style="width: 75%;"
+        class="fn-slider__wrapper"
       >
         
             
         <div
-          aria-label="slider handle"
-          aria-valuemax="100"
-          aria-valuemin="1"
-          aria-valuenow="75"
-          class="fn-slider__handle is-focus"
-          role="slider"
-          tabindex="0"
+          class="fn-slider__track"
+          style="width: 75%;"
         >
           
                 
-          <span
-            class="sap-icon sap-icon--megamenu"
-          />
+          <div
+            aria-label="slider handle"
+            aria-valuemax="100"
+            aria-valuemin="1"
+            aria-valuenow="75"
+            class="fn-slider__handle is-focus"
+            role="slider"
+            tabindex="0"
+          >
+            
+                    
+            <span
+              class="sap-icon sap-icon--megamenu"
+            />
+            
+                    
+            <span
+              class="sap-icon sap-icon--megamenu"
+            />
+            
+                
+          </div>
           
                 
-          <span
-            class="sap-icon sap-icon--megamenu"
+          <div
+            class="fn-slider__track-range"
           />
           
             
         </div>
-        
-            
-        <div
-          class="fn-slider__track-range"
-        />
         
         
       </div>
@@ -742,37 +814,45 @@ exports[`Storyshots FN Components/Slider Slider 1`] = `
       
         
       <div
-        class="fn-slider__track"
-        style="width: 100%;"
+        class="fn-slider__wrapper"
       >
         
             
         <div
-          aria-label="slider handle"
-          aria-valuemax="100"
-          aria-valuemin="1"
-          aria-valuenow="100"
-          class="fn-slider__handle is-hover"
-          role="slider"
+          class="fn-slider__track"
+          style="width: 100%;"
         >
           
                 
-          <span
-            class="sap-icon sap-icon--megamenu"
-          />
+          <div
+            aria-label="slider handle"
+            aria-valuemax="100"
+            aria-valuemin="1"
+            aria-valuenow="100"
+            class="fn-slider__handle is-hover"
+            role="slider"
+          >
+            
+                    
+            <span
+              class="sap-icon sap-icon--megamenu"
+            />
+            
+                    
+            <span
+              class="sap-icon sap-icon--megamenu"
+            />
+            
+                
+          </div>
           
                 
-          <span
-            class="sap-icon sap-icon--megamenu"
+          <div
+            class="fn-slider__track-range"
           />
           
             
         </div>
-        
-            
-        <div
-          class="fn-slider__track-range"
-        />
         
         
       </div>

--- a/stories/fn-slider/fn-slider.stories.js
+++ b/stories/fn-slider/fn-slider.stories.js
@@ -32,12 +32,14 @@ export const Slider = () => `${localStyles}
 <div class="docs-fn-container">
     <div><b>normal</b></div>
     <div class="fn-slider">
-        <div class="fn-slider__track" style="width: 0%;">
-            <div class="fn-slider__handle" tabindex="0" role="slider" aria-label="slider handle" aria-valuemin="1" aria-valuemax="100" aria-valuenow="0">
-                <span class="sap-icon sap-icon--megamenu"></span>
-                <span class="sap-icon sap-icon--megamenu"></span>
+        <div class="fn-slider__wrapper">
+            <div class="fn-slider__track" style="width: 0%;">
+                <div class="fn-slider__handle" tabindex="0" role="slider" aria-label="slider handle" aria-valuemin="1" aria-valuemax="100" aria-valuenow="0">
+                    <span class="sap-icon sap-icon--megamenu"></span>
+                    <span class="sap-icon sap-icon--megamenu"></span>
+                </div>
+                <div class="fn-slider__track-range"></div>
             </div>
-            <div class="fn-slider__track-range"></div>
         </div>
     </div>
 </div>
@@ -45,12 +47,14 @@ export const Slider = () => `${localStyles}
 <div class="docs-fn-container">
     <div><b>hover</b></div>
     <div class="fn-slider">
-        <div class="fn-slider__track" style="width: 25%;">
-            <div class="fn-slider__handle is-hover" tabindex="0" role="slider" aria-label="slider handle" aria-valuemin="1" aria-valuemax="100" aria-valuenow="25">
-                <span class="sap-icon sap-icon--megamenu"></span>
-                <span class="sap-icon sap-icon--megamenu"></span>
+        <div class="fn-slider__wrapper">
+            <div class="fn-slider__track" style="width: 25%;">
+                <div class="fn-slider__handle is-hover" tabindex="0" role="slider" aria-label="slider handle" aria-valuemin="1" aria-valuemax="100" aria-valuenow="25">
+                    <span class="sap-icon sap-icon--megamenu"></span>
+                    <span class="sap-icon sap-icon--megamenu"></span>
+                </div>
+                <div class="fn-slider__track-range"></div>
             </div>
-            <div class="fn-slider__track-range"></div>
         </div>
     </div>
 </div>
@@ -58,12 +62,14 @@ export const Slider = () => `${localStyles}
 <div class="docs-fn-container">
     <div><b>active</b></div>
     <div class="fn-slider">
-        <div class="fn-slider__track" style="width: 50%;">
-            <div class="fn-slider__handle is-active" tabindex="0" role="slider" aria-label="slider handle" aria-valuemin="1" aria-valuemax="100" aria-valuenow="50">
-                <span class="sap-icon sap-icon--megamenu"></span>
-                <span class="sap-icon sap-icon--megamenu"></span>
+        <div class="fn-slider__wrapper">
+            <div class="fn-slider__track" style="width: 50%;">
+                <div class="fn-slider__handle is-active" tabindex="0" role="slider" aria-label="slider handle" aria-valuemin="1" aria-valuemax="100" aria-valuenow="50">
+                    <span class="sap-icon sap-icon--megamenu"></span>
+                    <span class="sap-icon sap-icon--megamenu"></span>
+                </div>
+                <div class="fn-slider__track-range"></div>
             </div>
-            <div class="fn-slider__track-range"></div>
         </div>
     </div>
 </div>
@@ -71,12 +77,14 @@ export const Slider = () => `${localStyles}
 <div class="docs-fn-container">
     <div><b>focus</b></div>
     <div class="fn-slider">
-        <div class="fn-slider__track" style="width: 75%;">
-            <div class="fn-slider__handle is-focus" tabindex="0" role="slider" aria-label="slider handle" aria-valuemin="1" aria-valuemax="100" aria-valuenow="75">
-                <span class="sap-icon sap-icon--megamenu"></span>
-                <span class="sap-icon sap-icon--megamenu"></span>
+        <div class="fn-slider__wrapper">
+            <div class="fn-slider__track" style="width: 75%;">
+                <div class="fn-slider__handle is-focus" tabindex="0" role="slider" aria-label="slider handle" aria-valuemin="1" aria-valuemax="100" aria-valuenow="75">
+                    <span class="sap-icon sap-icon--megamenu"></span>
+                    <span class="sap-icon sap-icon--megamenu"></span>
+                </div>
+                <div class="fn-slider__track-range"></div>
             </div>
-            <div class="fn-slider__track-range"></div>
         </div>
     </div>
 </div>
@@ -84,12 +92,14 @@ export const Slider = () => `${localStyles}
 <div class="docs-fn-container">
     <div><b>disabled</b></div>
     <div class="fn-slider is-disabled">
-        <div class="fn-slider__track" style="width: 100%;">
-            <div class="fn-slider__handle is-hover" role="slider" aria-label="slider handle" aria-valuemin="1" aria-valuemax="100" aria-valuenow="100">
-                <span class="sap-icon sap-icon--megamenu"></span>
-                <span class="sap-icon sap-icon--megamenu"></span>
+        <div class="fn-slider__wrapper">
+            <div class="fn-slider__track" style="width: 100%;">
+                <div class="fn-slider__handle is-hover" role="slider" aria-label="slider handle" aria-valuemin="1" aria-valuemax="100" aria-valuenow="100">
+                    <span class="sap-icon sap-icon--megamenu"></span>
+                    <span class="sap-icon sap-icon--megamenu"></span>
+                </div>
+                <div class="fn-slider__track-range"></div>
             </div>
-            <div class="fn-slider__track-range"></div>
         </div>
     </div>
 </div>
@@ -105,15 +115,17 @@ export const RangeSlider = () => `${localStyles}
 <div class="docs-fn-container">
     <div><b>normal</b></div>
     <div class="fn-slider fn-slider--range">
-        <div class="fn-slider__track" style="width: 30%; left: 0">
-            <div class="fn-slider__handle" role="slider" tabindex="0" aria-label="slider handle" aria-valuemin="1" aria-valuemax="100" aria-valuenow="0">
-                <span class="sap-icon sap-icon--megamenu"></span>
-                <span class="sap-icon sap-icon--megamenu"></span>
-            </div>
-            <div class="fn-slider__track-range"></div>
-            <div class="fn-slider__handle" role="slider" tabindex="0" aria-label="slider handle" aria-valuemin="1" aria-valuemax="100" aria-valuenow="30">
-                <span class="sap-icon sap-icon--megamenu"></span>
-                <span class="sap-icon sap-icon--megamenu"></span>
+        <div class="fn-slider__wrapper">
+            <div class="fn-slider__track" style="width: 30%; left: 0">
+                <div class="fn-slider__handle" role="slider" tabindex="0" aria-label="slider handle" aria-valuemin="1" aria-valuemax="100" aria-valuenow="0">
+                    <span class="sap-icon sap-icon--megamenu"></span>
+                    <span class="sap-icon sap-icon--megamenu"></span>
+                </div>
+                <div class="fn-slider__track-range"></div>
+                <div class="fn-slider__handle" role="slider" tabindex="0" aria-label="slider handle" aria-valuemin="1" aria-valuemax="100" aria-valuenow="30">
+                    <span class="sap-icon sap-icon--megamenu"></span>
+                    <span class="sap-icon sap-icon--megamenu"></span>
+                </div>
             </div>
         </div>
     </div>
@@ -122,15 +134,17 @@ export const RangeSlider = () => `${localStyles}
 <div class="docs-fn-container">
     <div><b>hover</b></div>
     <div class="fn-slider fn-slider--range">
-        <div class="fn-slider__track" style="width: 30%; left: 30%">
-            <div class="fn-slider__handle is-hover" role="slider" tabindex="0" aria-label="slider handle" aria-valuemin="1" aria-valuemax="100" aria-valuenow="30">
-                <span class="sap-icon sap-icon--megamenu"></span>
-                <span class="sap-icon sap-icon--megamenu"></span>
-            </div>
-            <div class="fn-slider__track-range"></div>
-            <div class="fn-slider__handle is-hover" role="slider" tabindex="0" aria-label="slider handle" aria-valuemin="1" aria-valuemax="100" aria-valuenow="60">
-                <span class="sap-icon sap-icon--megamenu"></span>
-                <span class="sap-icon sap-icon--megamenu"></span>
+        <div class="fn-slider__wrapper">
+            <div class="fn-slider__track" style="width: 30%; left: 30%">
+                <div class="fn-slider__handle is-hover" role="slider" tabindex="0" aria-label="slider handle" aria-valuemin="1" aria-valuemax="100" aria-valuenow="30">
+                    <span class="sap-icon sap-icon--megamenu"></span>
+                    <span class="sap-icon sap-icon--megamenu"></span>
+                </div>
+                <div class="fn-slider__track-range"></div>
+                <div class="fn-slider__handle is-hover" role="slider" tabindex="0" aria-label="slider handle" aria-valuemin="1" aria-valuemax="100" aria-valuenow="60">
+                    <span class="sap-icon sap-icon--megamenu"></span>
+                    <span class="sap-icon sap-icon--megamenu"></span>
+                </div>
             </div>
         </div>
     </div>
@@ -139,15 +153,17 @@ export const RangeSlider = () => `${localStyles}
 <div class="docs-fn-container">
     <div><b>active</b></div>
     <div class="fn-slider fn-slider--range">
-        <div class="fn-slider__track" style="width: 20%; left: 60%">
-            <div class="fn-slider__handle" role="slider" tabindex="0" aria-label="slider handle" aria-valuemin="1" aria-valuemax="100" aria-valuenow="60">
-                <span class="sap-icon sap-icon--megamenu"></span>
-                <span class="sap-icon sap-icon--megamenu"></span>
-            </div>
-            <div class="fn-slider__track-range"></div>
-            <div class="fn-slider__handle" role="slider" tabindex="0" aria-label="slider handle" aria-valuemin="1" aria-valuemax="100" aria-valuenow="80" >
-                <span class="sap-icon sap-icon--megamenu"></span>
-                <span class="sap-icon sap-icon--megamenu"></span>
+        <div class="fn-slider__wrapper">
+            <div class="fn-slider__track" style="width: 20%; left: 60%">
+                <div class="fn-slider__handle" role="slider" tabindex="0" aria-label="slider handle" aria-valuemin="1" aria-valuemax="100" aria-valuenow="60">
+                    <span class="sap-icon sap-icon--megamenu"></span>
+                    <span class="sap-icon sap-icon--megamenu"></span>
+                </div>
+                <div class="fn-slider__track-range"></div>
+                <div class="fn-slider__handle" role="slider" tabindex="0" aria-label="slider handle" aria-valuemin="1" aria-valuemax="100" aria-valuenow="80" >
+                    <span class="sap-icon sap-icon--megamenu"></span>
+                    <span class="sap-icon sap-icon--megamenu"></span>
+                </div>
             </div>
         </div>
     </div>
@@ -156,15 +172,17 @@ export const RangeSlider = () => `${localStyles}
 <div class="docs-fn-container">
     <div><b>focus</b></div>
     <div class="fn-slider fn-slider--range">
-        <div class="fn-slider__track" style="width: 70%; left: 30%">
-            <div class="fn-slider__handle is-focus" tabindex="0" role="slider" aria-label="slider handle" aria-valuemin="1" aria-valuemax="100" aria-valuenow="30">
-                <span class="sap-icon sap-icon--megamenu"></span>
-                <span class="sap-icon sap-icon--megamenu"></span>
-            </div>
-            <div class="fn-slider__track-range"></div>
-            <div class="fn-slider__handle is-focus" tabindex="0" role="slider" aria-label="slider handle" aria-valuemin="1" aria-valuemax="100" aria-valuenow="100" >
-                <span class="sap-icon sap-icon--megamenu"></span>
-                <span class="sap-icon sap-icon--megamenu"></span>
+        <div class="fn-slider__wrapper">
+            <div class="fn-slider__track" style="width: 70%; left: 30%">
+                <div class="fn-slider__handle is-focus" tabindex="0" role="slider" aria-label="slider handle" aria-valuemin="1" aria-valuemax="100" aria-valuenow="30">
+                    <span class="sap-icon sap-icon--megamenu"></span>
+                    <span class="sap-icon sap-icon--megamenu"></span>
+                </div>
+                <div class="fn-slider__track-range"></div>
+                <div class="fn-slider__handle is-focus" tabindex="0" role="slider" aria-label="slider handle" aria-valuemin="1" aria-valuemax="100" aria-valuenow="100" >
+                    <span class="sap-icon sap-icon--megamenu"></span>
+                    <span class="sap-icon sap-icon--megamenu"></span>
+                </div>
             </div>
         </div>
     </div>
@@ -173,15 +191,17 @@ export const RangeSlider = () => `${localStyles}
 <div class="docs-fn-container">
     <div><b>disabled</b></div>
     <div class="fn-slider fn-slider--range is-disabled">
-        <div class="fn-slider__track" style="width: 100%; left: 0%">
-            <div class="fn-slider__handle" role="slider" aria-label="slider handle" aria-valuemin="1" aria-valuemax="100" aria-valuenow="0">
-                <span class="sap-icon sap-icon--megamenu"></span>
-                <span class="sap-icon sap-icon--megamenu"></span>
-            </div>
-            <div class="fn-slider__track-range"></div>
-            <div class="fn-slider__handle" role="slider" aria-label="slider handle" aria-valuemin="1" aria-valuemax="100" aria-valuenow="100" >
-                <span class="sap-icon sap-icon--megamenu"></span>
-                <span class="sap-icon sap-icon--megamenu"></span>
+        <div class="fn-slider__wrapper">
+            <div class="fn-slider__track" style="width: 100%; left: 0%">
+                <div class="fn-slider__handle" role="slider" aria-label="slider handle" aria-valuemin="1" aria-valuemax="100" aria-valuenow="0">
+                    <span class="sap-icon sap-icon--megamenu"></span>
+                    <span class="sap-icon sap-icon--megamenu"></span>
+                </div>
+                <div class="fn-slider__track-range"></div>
+                <div class="fn-slider__handle" role="slider" aria-label="slider handle" aria-valuemin="1" aria-valuemax="100" aria-valuenow="100" >
+                    <span class="sap-icon sap-icon--megamenu"></span>
+                    <span class="sap-icon sap-icon--megamenu"></span>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Related Issue
none

## Description
Previously, slider handle was "tweaked" based on aria-valuenow property, which can be different in real-case scenario. Added wrapper which compensates handle offset so at the edge positions of the slider, handle would fit into the size of the slider itself.

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- n/a Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
