### PR TITLE
fix(styles): fix nested list button bgd issue and popover radius 

### DIFF
--- a/src/styles/nested-list.scss
+++ b/src/styles/nested-list.scss
@@ -5,7 +5,7 @@ $block: #{$fd-namespace}-nested-list;
 $button: #{$fd-namespace}-button;
 
 .#{$block} {
-  $fd-nested-list-border-radius: 0.25rem;
+  $fd-nested-list-border-radius: var(--sapElement_BorderCornerRadius);
 
   @mixin fd-nested-level-padding($paddingLeft, $paddingRight) {
     .#{$block}__link,
@@ -114,6 +114,7 @@ $button: #{$fd-namespace}-button;
   &__item {
     @include fd-reset();
 
+    display: block;
     background: var(--sapList_Background);
     text-shadow: var(--fdVerticalNav_Text_Shadow);
 
@@ -213,10 +214,16 @@ $button: #{$fd-namespace}-button;
     }
   }
 
+  &__link {
+    cursor: pointer;
+  }
+
   &__button.#{$button} {
     @include set-height(100%);
 
     border: none;
+    outline: none;
+    background: none;
     min-width: 2.5rem;
     text-decoration: none;
     color: var(--sapContent_IconColor);


### PR DESCRIPTION
## Related Issue
none

## Description
- changed the hardcoded value for border radius to a variable 
- moved the custom css in fund-ngx to fund-styles

## Screenshots
### Before:

<img width="306" alt="Screen Shot 2022-02-09 at 12 48 43 PM" src="https://user-images.githubusercontent.com/39598672/153259789-702cf2f2-4c12-4412-9d03-bb6119c4f71b.png">
<img width="398" alt="Screen Shot 2022-02-09 at 12 48 38 PM" src="https://user-images.githubusercontent.com/39598672/153259793-74e9696a-6277-4188-b9e9-f7b4461eb8b6.png">

### After:
<img width="251" alt="Screen Shot 2022-02-09 at 12 47 53 PM" src="https://user-images.githubusercontent.com/39598672/153259816-ba2179cf-65b5-452f-8056-b1293362e682.png">
<img width="438" alt="Screen Shot 2022-02-09 at 12 48 01 PM" src="https://user-images.githubusercontent.com/39598672/153259819-57030a1e-159a-4df9-acdb-d8c41987c59e.png">

