### PR TITLE
fix: card header non-interactive outline

### DIFF
--- a/src/styles/card.scss
+++ b/src/styles/card.scss
@@ -60,7 +60,10 @@ $fd-card-header-outline-offset: 0.0625rem !default;
   &__header {
     @include fd-reset();
     @include fd-flex();
-    @include fake-card-outline();
+
+    &:not(.#{$block}__header--non-interactive) {
+      @include fake-card-outline();
+    }
 
     padding: 1rem;
     background: $fd-card-default-body-background-color;


### PR DESCRIPTION
## Related Issue

None.

## Description

Outline removed from the card header if it has non-interactive class.

## Screenshots

### Before:

<img width="357" alt="image" src="https://user-images.githubusercontent.com/20265336/153429071-c4304f1f-6503-4934-aef4-356fff89b982.png">

### After:

<img width="368" alt="image" src="https://user-images.githubusercontent.com/20265336/153429024-681d243e-60f5-41e8-8a42-ad2030c99224.png">
