### PR TITLE
fix(styles): proper margin for controls inside input-group

### DIFF
--- a/src/styles/input-group.scss
+++ b/src/styles/input-group.scss
@@ -39,6 +39,7 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
   border-radius: var(--sapField_BorderCornerRadius);
   background-color: var(--sapField_Background);
   width: 100%;
+  margin: 0.25rem 0;
   overflow: hidden;
   text-shadow: var(--fdInputGroup_Text_Shadow);
 


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-ngx/issues/7607

## Description
According to specs, inputs should have 4px margin on top and bottom.
When input is used inside the input-group, it's margin is now set to 0. So we have to use the same margin on the input-group itself

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:

![image](https://user-images.githubusercontent.com/33101123/153593373-b853db5f-7cda-4532-bf44-65abc999951c.png)

### After:
![image](https://user-images.githubusercontent.com/33101123/153593355-e4da6507-e63f-4422-a164-cc94358474d0.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [n/a] Text elements follow the truncation rules
- [n/a] hover state of the element follow design spec
- [n/a] focus state of the element follow design spec
- [n/a] active state of the element follow design spec
- [n/a] selected state of the element follow design spec
- [n/a] selected hover state of the element follow design spec
- [n/a] pressed state of the element follow design spec
- [n/a] Responsiveness rules - the component has modifier classes for all breakpoints
- [n/a] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [n/a] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [n/a] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [n/a] `fd-reset()` mixin is applied to all elements
- [n/a] Variables are used, if some value is used more than twice.
- [n/a] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [n/a] Verified all styles in IE11
- [n/a] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [n/a] Storybook documentation has been created/updated
- [n/a] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
