### PR TITLE
fix: remove "pointer-events: none" from disabled form controls 

### DIFF
--- a/src/styles/mixins/_forms.scss
+++ b/src/styles/mixins/_forms.scss
@@ -100,7 +100,6 @@
   }
 
   @include fd-disabled() {
-    pointer-events: none;
     opacity: var(--sapContent_DisabledOpacity);
 
     &::placeholder {

--- a/src/styles/select.scss
+++ b/src/styles/select.scss
@@ -67,6 +67,10 @@ $block: #{$fd-namespace}-select;
       text-align: right;
     }
 
+    @include fd-disabled() {
+      pointer-events: none;
+    }
+
     width: 100%;
     height: $fd-form-input-height;
     text-align: left;


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-ngx/issues/7246

## Description
In the textarea, we could have several lines. If the component is disabled, then it is not more possible to scroll through the lines. 

![Screenshot 2021-11-25 at 16 53 27](https://user-images.githubusercontent.com/26272656/143471673-490bc3d4-9f4d-478d-aa77-92aa2f6bb107.png)

This PR removes "pointer-events: none" from form controls at all. Preserving it on "select" component, as the button handle should not be clickable

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:


### After:

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [n/a] Verified all styles in IE11
- [n/a] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [n/a] Storybook documentation has been created/updated
- [n/a] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
