### PR TITLE
fix(fn): update Message strip to latest design [ci visual]

### DIFF
--- a/src/fn/fn-message-strip.scss
+++ b/src/fn/fn-message-strip.scss
@@ -3,7 +3,7 @@
 $block: #{$fn-namespace}-message-strip;
 
 @mixin fn-message-strip-states($background, $iconColor) {
-  background-color: $background;
+  background: $background;
 
   .#{$block}__icon {
     &::before {
@@ -14,59 +14,57 @@ $block: #{$fn-namespace}-message-strip;
 
 .#{$block} {
   @include fn-reset();
-  @include fn-set-paddings-x(0.5rem, 0.5rem);
+  @include fn-set-paddings-x-equal(0.5rem);
   @include fn-flex-vertical-center();
 
-  background-color: $fn-color-blue-1;
-  color: $fn-color-grey-9;
-  min-height: 1.75rem;
-  min-width: 20.5rem;
+  position: relative;
   width: fit-content;
+  min-height: 1.75rem;
+  background: $fn-color-blue-2;
   border-radius: $fn-border-radius-4;
+
+  &--dismissible {
+    @include fn-set-paddings-x(0.5rem, 1.75rem);
+  }
 
   &__text {
     @include fn-reset();
 
-    color: inherit;
-    max-width: 95%;
+    max-width: 100%;
+    color: $fn-color-grey-9;
+
+    &--truncate {
+      @include fn-ellipsis();
+    }
   }
 
   .#{$block}__icon {
-    @include fn-set-margin-right(0.25rem);
+    @include fn-flex-center();
+    @include fn-set-square(1.125rem);
+    @include fn-set-margin-right(0.375rem);
 
-    background-color: transparent;
+    font-size: 0.9375rem;
 
     &::before {
       color: $fn-color-blue-7;
-      display: flex;
-      margin-top: 0.125rem;
     }
   }
 
   .#{$block}__close-button {
-    @include fn-reset();
-    @include fn-set-margin-left(auto);
-    @include fn-set-square(0); // removes background / box-shadow from button class
+    @include fn-set-position-right(0.25rem);
 
-    justify-content: end;
-    color: $fn-color-grey-7;
-
-    @include fn-icon-class() {
-      &::before {
-        font-size: 0.75rem;
-      }
-    }
+    position: absolute;
   }
 
   &--success {
-    @include fn-message-strip-states($fn-color-green-1, $fn-color-green-7);
+    @include fn-message-strip-states($fn-color-green-2, $fn-color-green-7);
   }
 
   &--warning {
-    @include fn-message-strip-states($fn-color-mango-1, $fn-color-mango-6);
+    @include fn-message-strip-states($fn-color-mango-2, $fn-color-mango-6);
   }
 
   &--error {
-    @include fn-message-strip-states($fn-color-red-1, $fn-color-red-7);
+    @include fn-message-strip-states($fn-color-red-2, $fn-color-red-7);
   }
 }

--- a/stories/fn-message-strip/__snapshots__/fn-message-strip.stories.storyshot
+++ b/stories/fn-message-strip/__snapshots__/fn-message-strip.stories.storyshot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots FN Components/Message Strip Message Strip 1`] = `
+exports[`Storyshots FN Components/Message Strip Dismissible Message Strip 1`] = `
 <div
   dir="ltr"
 >
@@ -17,7 +17,7 @@ exports[`Storyshots FN Components/Message Strip Message Strip 1`] = `
 
     
   <div
-    class="fn-message-strip"
+    class="fn-message-strip fn-message-strip--dismissible"
   >
     
         
@@ -34,8 +34,8 @@ exports[`Storyshots FN Components/Message Strip Message Strip 1`] = `
     
         
     <button
-      aria-label="Close"
-      class="fn-button fn-button--layout fn-button--icon-only fn-message-strip__close-button"
+      aria-label="close"
+      class="fn-nested-button fn-message-strip__close-button"
     >
       
             
@@ -51,7 +51,7 @@ exports[`Storyshots FN Components/Message Strip Message Strip 1`] = `
   
     
   <div
-    class="fn-message-strip fn-message-strip--success"
+    class="fn-message-strip fn-message-strip--dismissible fn-message-strip--success"
   >
     
         
@@ -68,8 +68,8 @@ exports[`Storyshots FN Components/Message Strip Message Strip 1`] = `
     
         
     <button
-      aria-label="Close"
-      class="fn-button fn-button--layout fn-button--icon-only fn-message-strip__close-button"
+      aria-label="close"
+      class="fn-nested-button fn-message-strip__close-button"
     >
       
             
@@ -85,7 +85,7 @@ exports[`Storyshots FN Components/Message Strip Message Strip 1`] = `
   
     
   <div
-    class="fn-message-strip fn-message-strip--warning"
+    class="fn-message-strip fn-message-strip--dismissible fn-message-strip--warning"
   >
     
         
@@ -102,8 +102,8 @@ exports[`Storyshots FN Components/Message Strip Message Strip 1`] = `
     
         
     <button
-      aria-label="Close"
-      class="fn-button fn-button--layout fn-button--icon-only fn-message-strip__close-button"
+      aria-label="close"
+      class="fn-nested-button fn-message-strip__close-button"
     >
       
             
@@ -119,7 +119,7 @@ exports[`Storyshots FN Components/Message Strip Message Strip 1`] = `
   
     
   <div
-    class="fn-message-strip fn-message-strip--error"
+    class="fn-message-strip fn-message-strip--dismissible fn-message-strip--error"
   >
     
         
@@ -136,8 +136,8 @@ exports[`Storyshots FN Components/Message Strip Message Strip 1`] = `
     
         
     <button
-      aria-label="Close"
-      class="fn-button fn-button--layout fn-button--icon-only fn-message-strip__close-button"
+      aria-label="close"
+      class="fn-nested-button fn-message-strip__close-button"
     >
       
             
@@ -172,7 +172,7 @@ exports[`Storyshots FN Components/Message Strip Message Strip with No Icon 1`] =
 
     
   <div
-    class="fn-message-strip"
+    class="fn-message-strip fn-message-strip--dismissible"
   >
     
         
@@ -184,8 +184,8 @@ exports[`Storyshots FN Components/Message Strip Message Strip with No Icon 1`] =
     
         
     <button
-      aria-label="Close"
-      class="fn-button fn-button--layout fn-button--icon-only fn-message-strip__close-button"
+      aria-label="close"
+      class="fn-nested-button fn-message-strip__close-button"
     >
       
             
@@ -201,7 +201,7 @@ exports[`Storyshots FN Components/Message Strip Message Strip with No Icon 1`] =
   
     
   <div
-    class="fn-message-strip fn-message-strip--success"
+    class="fn-message-strip fn-message-strip--dismissible fn-message-strip--success"
   >
     
         
@@ -213,8 +213,8 @@ exports[`Storyshots FN Components/Message Strip Message Strip with No Icon 1`] =
     
         
     <button
-      aria-label="Close"
-      class="fn-button fn-button--layout fn-button--icon-only fn-message-strip__close-button"
+      aria-label="close"
+      class="fn-nested-button fn-message-strip__close-button"
     >
       
             
@@ -230,7 +230,7 @@ exports[`Storyshots FN Components/Message Strip Message Strip with No Icon 1`] =
   
     
   <div
-    class="fn-message-strip fn-message-strip--warning"
+    class="fn-message-strip fn-message-strip--dismissible fn-message-strip--warning"
   >
     
         
@@ -242,8 +242,8 @@ exports[`Storyshots FN Components/Message Strip Message Strip with No Icon 1`] =
     
         
     <button
-      aria-label="Close"
-      class="fn-button fn-button--layout fn-button--icon-only fn-message-strip__close-button"
+      aria-label="close"
+      class="fn-nested-button fn-message-strip__close-button"
     >
       
             
@@ -259,7 +259,7 @@ exports[`Storyshots FN Components/Message Strip Message Strip with No Icon 1`] =
   
     
   <div
-    class="fn-message-strip fn-message-strip--error"
+    class="fn-message-strip fn-message-strip--dismissible fn-message-strip--error"
   >
     
         
@@ -271,8 +271,8 @@ exports[`Storyshots FN Components/Message Strip Message Strip with No Icon 1`] =
     
         
     <button
-      aria-label="Close"
-      class="fn-button fn-button--layout fn-button--icon-only fn-message-strip__close-button"
+      aria-label="close"
+      class="fn-nested-button fn-message-strip__close-button"
     >
       
             
@@ -348,6 +348,7 @@ exports[`Storyshots FN Components/Message Strip Non-Dismissible Message Strip 1`
     
   <div
     class="fn-message-strip fn-message-strip--warning"
+    style="max-width: 300px;"
   >
     
         
@@ -357,9 +358,9 @@ exports[`Storyshots FN Components/Message Strip Non-Dismissible Message Strip 1`
     
         
     <span
-      class="fn-message-strip__text"
+      class="fn-message-strip__text fn-message-strip__text--truncate"
     >
-      Warning Message Strip Text
+      Warning Message Strip very long text with truncation
     </span>
     
     
@@ -368,6 +369,7 @@ exports[`Storyshots FN Components/Message Strip Non-Dismissible Message Strip 1`
     
   <div
     class="fn-message-strip fn-message-strip--error"
+    style="max-width: 300px;"
   >
     
         
@@ -379,7 +381,7 @@ exports[`Storyshots FN Components/Message Strip Non-Dismissible Message Strip 1`
     <span
       class="fn-message-strip__text"
     >
-      Error Message Strip Text
+      Error Message Strip very long text without truncation
     </span>
     
     

--- a/stories/fn-message-strip/fn-message-strip.stories.js
+++ b/stories/fn-message-strip/fn-message-strip.stories.js
@@ -3,17 +3,23 @@ export default {
     parameters: {
         description: `**Modifier classes for Message Strip:**
 
-| Style&nbsp;&nbsp;&nbsp;&nbsp;      | Modifier class                |
-| ---------------------------------- | ----------------------------- |
-| fn-message-strip    | \`Default ("information") message strip.\`                      |
-| fn-message-strip--success    | \`The "success" message strip.\`                      |
-| fn-message-strip--warning    | \`The "warning" message strip.\`                      |
-| fn-message-strip--error    | \`The "error" message strip.\`                      |
-| fn-message-strip__icon    | \`Class applied to the icon for the message strip.\`                      |
-| fn-message-strip__text    | \`Class applied to the text for the message strip.\`                      |
+| Modifier                                                      | Message Strip Type              |
+| ------------------------------------------------------------- | ------------------------------- |
+| \`.fn-message-strip\` &nbsp;&nbsp;&nbsp;&nbsp;                | default ("information")         |
+| \`.fn-message-strip--success\` &nbsp;&nbsp;&nbsp;&nbsp;       | success                         |
+| \`.fn-message-strip--warning\` &nbsp;&nbsp;&nbsp;&nbsp;       | warning                         |
+| \`.fn-message-strip--error\` &nbsp;&nbsp;&nbsp;&nbsp;         | error                           |
+| \`.fn-message-strip--dismissible\` &nbsp;&nbsp;&nbsp;&nbsp;   | dismissible (with close button) |
 
+
+## Structure
+
+- \`.fn-message-strip\`. Modifier classes: \`.fn-message-strip--success\`, \`.fn-message-strip--warning\`, \`.fn-message-strip--error\`, \`.fn-message-strip--dismissible\`.
+    - \`.fn-message-strip__text\`. Modifier classes: \`fn-message-strip__text--truncate\`.
+    - \`.fn-message-strip__icon\`.
+    - \`.fn-message-strip__close-button\`.
         `,
-        components: ['fn-message-strip', 'fn-button', 'icon']
+        components: ['fn-message-strip', 'fn-button', 'fn-nested-button', 'icon']
     }
 };
 
@@ -26,68 +32,67 @@ const localStyles = `
 `;
 
 export const Primary = () => `${localStyles}
-    <div class="fn-message-strip">
+    <div class="fn-message-strip fn-message-strip--dismissible">
         <span class="sap-icon sap-icon--message-information fn-message-strip__icon"></span>
         <span class="fn-message-strip__text">Information (default) Message Strip Text</span>
-        <button class="fn-button fn-button--layout fn-button--icon-only fn-message-strip__close-button" aria-label="Close">
+        <button class="fn-nested-button fn-message-strip__close-button" aria-label="close">
             <span class="sap-icon sap-icon--decline"></span>
         </button>
     </div>
-    <div class="fn-message-strip fn-message-strip--success">
+    <div class="fn-message-strip fn-message-strip--dismissible fn-message-strip--success">
         <span class="sap-icon sap-icon--message-success fn-message-strip__icon"></span>
         <span class="fn-message-strip__text">Success Message Strip Text</span>
-        <button class="fn-button fn-button--layout fn-button--icon-only fn-message-strip__close-button" aria-label="Close">
+        <button class="fn-nested-button fn-message-strip__close-button" aria-label="close">
             <span class="sap-icon sap-icon--decline"></span>
         </button>
     </div>
-    <div class="fn-message-strip fn-message-strip--warning">
+    <div class="fn-message-strip fn-message-strip--dismissible fn-message-strip--warning">
         <span class="sap-icon sap-icon--message-warning fn-message-strip__icon"></span>
         <span class="fn-message-strip__text">Warning Message Strip Text</span>
-        <button class="fn-button fn-button--layout fn-button--icon-only fn-message-strip__close-button" aria-label="Close">
+        <button class="fn-nested-button fn-message-strip__close-button" aria-label="close">
             <span class="sap-icon sap-icon--decline"></span>
         </button>
     </div>
-    <div class="fn-message-strip fn-message-strip--error">
+    <div class="fn-message-strip fn-message-strip--dismissible fn-message-strip--error">
         <span class="sap-icon sap-icon--message-error fn-message-strip__icon"></span>
         <span class="fn-message-strip__text">Error Message Strip Text</span>
-        <button class="fn-button fn-button--layout fn-button--icon-only fn-message-strip__close-button" aria-label="Close">
+        <button class="fn-nested-button fn-message-strip__close-button" aria-label="close">
             <span class="sap-icon sap-icon--decline"></span>
         </button>
     </div>
 `;
 
-Primary.storyName = 'Message Strip';
-
+Primary.storyName = 'Dismissible Message Strip';
 Primary.parameters = {
     docs: {
         description: {
-            story: 'The message strip displays information bars with semantic colors and icons, indicating different levels of urgency and/or action required by the user. The message strip is fully responsive, with an icon and close button on opposite sides of the message text. Text and links behave differently, and wrap if space is limited.'
+            story: 'The message strip displays information bars with semantic colors and icons, indicating different levels of urgency and/or action required by the user. The message strip is fully responsive, with an icon and close button on opposite sides of the message text. Text and links behave differently, and wrap if space is limited. For dismissible message strip add the `.fn-message-strip--dismissible` modifier class to `.fn-message-strip` base class.'
         }
     }
 };
 
 export const NoIcon = () => `${localStyles}
-    <div class="fn-message-strip">
+    <div class="fn-message-strip fn-message-strip--dismissible">
         <span class="fn-message-strip__text">Information (default) Message Strip Text</span>
-        <button class="fn-button fn-button--layout fn-button--icon-only fn-message-strip__close-button" aria-label="Close">
+        <button class="fn-nested-button fn-message-strip__close-button" aria-label="close">
             <span class="sap-icon sap-icon--decline"></span>
         </button>
     </div>
-    <div class="fn-message-strip fn-message-strip--success">
+    <div class="fn-message-strip fn-message-strip--dismissible fn-message-strip--success">
         <span class="fn-message-strip__text">Success Message Strip Text</span>
-        <button class="fn-button fn-button--layout fn-button--icon-only fn-message-strip__close-button" aria-label="Close">
+        <button class="fn-nested-button fn-message-strip__close-button" aria-label="close">
             <span class="sap-icon sap-icon--decline"></span>
         </button>
     </div>
-    <div class="fn-message-strip fn-message-strip--warning">
+    <div class="fn-message-strip fn-message-strip--dismissible fn-message-strip--warning">
         <span class="fn-message-strip__text">Warning Message Strip Text</span>
-        <button class="fn-button fn-button--layout fn-button--icon-only fn-message-strip__close-button" aria-label="Close">
+        <button class="fn-nested-button fn-message-strip__close-button" aria-label="close">
             <span class="sap-icon sap-icon--decline"></span>
         </button>
     </div>
-    <div class="fn-message-strip fn-message-strip--error">
+    <div class="fn-message-strip fn-message-strip--dismissible fn-message-strip--error">
         <span class="fn-message-strip__text">Error Message Strip Text</span>
-        <button class="fn-button fn-button--layout fn-button--icon-only fn-message-strip__close-button" aria-label="Close">
+        <button class="fn-nested-button fn-message-strip__close-button" aria-label="close">
             <span class="sap-icon sap-icon--decline"></span>
         </button>
     </div>
@@ -104,14 +109,21 @@ export const NoDismiss = () => `${localStyles}
         <span class="sap-icon sap-icon--message-success fn-message-strip__icon"></span>
         <span class="fn-message-strip__text">Success Message Strip Text</span>
     </div>
-    <div class="fn-message-strip fn-message-strip--warning">
+    <div class="fn-message-strip fn-message-strip--warning" style="max-width: 300px;">
         <span class="sap-icon sap-icon--message-warning fn-message-strip__icon"></span>
-        <span class="fn-message-strip__text">Warning Message Strip Text</span>
+        <span class="fn-message-strip__text fn-message-strip__text--truncate">Warning Message Strip very long text with truncation</span>
     </div>
-    <div class="fn-message-strip fn-message-strip--error">
+    <div class="fn-message-strip fn-message-strip--error" style="max-width: 300px;">
         <span class="sap-icon sap-icon--message-error fn-message-strip__icon"></span>
-        <span class="fn-message-strip__text">Error Message Strip Text</span>
+        <span class="fn-message-strip__text">Error Message Strip very long text without truncation</span>
     </div>
 `;
 
 NoDismiss.storyName = 'Non-Dismissible Message Strip';
+NoDismiss.parameters = {
+    docs: {
+        description: {
+            story: 'No modifier class is required for non-dismissible message strip. Long text wrap in multi line if the space is limited and can truncate if the `.fn-message-strip__text--truncate` modifier class is added to the `.fn-message-strip__text` base class. The width of the message strip can be controlled with inline css, for example: `style="max-width: 300px;"`'
+        }
+    }
+};


### PR DESCRIPTION
## Related Issue
Part of https://github.com/SAP/fundamental-styles/issues/3166

## Description
- added a new modifier class `.fn-message-strip--dismissible` for when the message strip is dismissible (has a close button)
- use Nested instead of Layout for the close button of the Message strip
**Before:**
```
<div class="fn-message-strip">
  <span class="fn-message-strip__text">Information (default) Message Strip Text</span>
  <button class="fn-button fn-button--layout fn-button--icon-only fn-message-strip__close-button" aria-label="Close">
    <span class="sap-icon sap-icon--decline"></span>
  </button>
</div>
```

**After:**
```
<div class="fn-message-strip fn-message-strip--dismissible">
    <span class="fn-message-strip__text">Information (default) Message Strip Text</span>
    <button class="fn-nested-button fn-message-strip__close-button" aria-label="close">
        <span class="sap-icon sap-icon--decline"></span>
    </button>
</div>
```

## Screenshots
### Before:

<img width="359" alt="Screen Shot 2022-02-15 at 2 41 45 PM" src="https://user-images.githubusercontent.com/39598672/154136688-6ad65d8e-e017-422e-b89e-bdcf44dae194.png">
<img width="360" alt="Screen Shot 2022-02-15 at 2 41 40 PM" src="https://user-images.githubusercontent.com/39598672/154136691-d035b65d-02f3-4868-8146-3cffc3629328.png">

### After:
<img width="362" alt="Screen Shot 2022-02-15 at 2 41 20 PM" src="https://user-images.githubusercontent.com/39598672/154136725-ccd62cb9-8586-4842-a276-01a5a820d551.png">
<img width="328" alt="Screen Shot 2022-02-15 at 2 41 27 PM" src="https://user-images.githubusercontent.com/39598672/154136728-b6968f57-7a78-4c79-b461-03b0f7b7c20e.png">

