### PR TITLE
fix(fn): update Progress Bar colors [ci visual]

### DIFF
--- a/src/fn/fn-progress-bar.scss
+++ b/src/fn/fn-progress-bar.scss
@@ -4,9 +4,9 @@ $block: #{$fn-namespace}-progress-bar;
 $fn-progress-bar-offset: 0.125rem;
 
 $fn-progress-bar-colors: (
-  "positive": ("color": $fn-color-green-7, "icon": "\e1ab"),
-  "critical": ("color": $fn-color-mango-6, "icon": "\e1ae"),
-  "negative": ("color": $fn-color-red-7, "icon": "\e1ac")
+  "positive": ("color": $fn-color-green-7, "barColor": $fn-color-green-3, "icon": "\e1ab"),
+  "critical": ("color": $fn-color-mango-6, "barColor": $fn-color-mango-3, "icon": "\e1ae"),
+  "negative": ("color": $fn-color-red-7, "barColor": $fn-color-red-3, "icon": "\e1ac")
 );
 
 @mixin fn-progress-bar-dot() {
@@ -31,7 +31,7 @@ $fn-progress-bar-colors: (
   width: 100%;
   height: 0.5rem;
   position: relative;
-  background: $fn-color-grey-2;
+  background: $fn-color-grey-3;
   border-radius: $fn-border-radius-4;
 
   &::after {
@@ -85,6 +85,8 @@ $fn-progress-bar-colors: (
 
   @each $set-name, $set-color in $fn-progress-bar-colors {
     &--#{$set-name} {
+      background: map_get($set-color, "barColor");
+
       &::before {
         background: map_get($set-color, "color");
       }


### PR DESCRIPTION
## Related Issue
Part of https://github.com/SAP/fundamental-styles/issues/3166

## Description
update the colors for the Progress bar

## Screenshots
### Before:
<img width="783" alt="Screen Shot 2022-02-15 at 3 37 57 PM" src="https://user-images.githubusercontent.com/39598672/154145192-4d200865-c99b-48a8-87e5-4d00d8f82ba8.png">


### After:
<img width="748" alt="Screen Shot 2022-02-15 at 3 37 47 PM" src="https://user-images.githubusercontent.com/39598672/154145205-08c84860-73a6-4c3d-91fa-8047593e7c46.png">
