### PR TITLE
fix: layout grid row overflow-y: hidden

### DIFF
--- a/src/styles/layout-grid.scss
+++ b/src/styles/layout-grid.scss
@@ -70,6 +70,7 @@ $cols: 12;
   flex-wrap: wrap;
   flex: 0 0 100%;
   position: relative;
+  overflow-y: hidden;
   padding: 0 $horizontal-gutter-small;
 
   &.#{$blockContainer}--no-horizontal-gap,


### PR DESCRIPTION
## Related Issue

Part of https://github.com/SAP/fundamental-ngx/issues/7815

## Description

_Preamble: The layout grid component is currently done in the way where the column element has padding-top and we have a lot of places that rely on this. It's not the right approach, but nothing we can do about it (in an adequate amount of time). To compensate this padding row element has a negative margin-top that creates an overlap with the content above the grid._ 

Set `overflow-y: hidden` for the container element to make the overlap area interactable (because it will be hidden actually).

## Screenshots

### Before:

<img width="326" alt="image" src="https://user-images.githubusercontent.com/20265336/157052392-6fe4bb16-bb26-4de4-a193-a50af802a326.png">

### After:

<img width="326" alt="Screenshot 2022-03-07 at 16 22 21" src="https://user-images.githubusercontent.com/20265336/157052475-a764d344-a09c-4f66-86fc-5837a7879a20.png">
