### PR TITLE
fix(fn): update the width of the input messages [ci visual]

### DIFF
--- a/src/fn/fn-input-message.scss
+++ b/src/fn/fn-input-message.scss
@@ -1,6 +1,7 @@
 @import "./fn-settings";
 
 $block: #{$fn-namespace}-input-message;
+$fn-input-message-width: calc(100% + 0.25rem);
 
 $fn-input-message-states: (
   "positive": ("background": $fn-color-green-2),
@@ -11,13 +12,14 @@ $fn-input-message-states: (
 
 .#{$block} {
   @include fn-reset();
+  @include fn-set-position-left(-0.125rem);
 
-  width: 100%;
-  max-width: 100%;
+  z-index: 1;
   position: absolute;
   top: calc(100% - 0.3125rem);
-  z-index: 1;
+  width: $fn-input-message-width;
   min-height: $fn-control-height;
+  max-width: $fn-input-message-width;
   padding: 0.625rem 0.625rem 0.375rem 0.625rem;
   border-radius: 0 0 $fn-border-radius-6 $fn-border-radius-6;
 


### PR DESCRIPTION
## Description
updates the width of the input messages to take into account the focus outline width

## Screenshots

### Before:
<img width="613" alt="Screen Shot 2022-03-07 at 2 03 39 PM" src="https://user-images.githubusercontent.com/39598672/157100841-e48f2336-b691-49a2-80a1-cfca7a41f16a.png">


### After:
<img width="460" alt="Screen Shot 2022-03-07 at 2 03 05 PM" src="https://user-images.githubusercontent.com/39598672/157100874-81256284-5b0a-4c2f-a89b-7a8d299062ab.png">

