### PR TITLE
fix(fn): update the position of the icon on multi line for Message Strip

### DIFF
--- a/src/fn/fn-message-strip.scss
+++ b/src/fn/fn-message-strip.scss
@@ -14,35 +14,49 @@ $block: #{$fn-namespace}-message-strip;
 
 .#{$block} {
   @include fn-reset();
-  @include fn-set-paddings-x-equal(0.5rem);
   @include fn-flex-vertical-center();
+  @include fn-set-paddings-y-equal(0.1875rem);
 
   position: relative;
   width: fit-content;
-  min-height: 1.75rem;
+  min-height: 1.875rem;
   background: $fn-color-blue-2;
   border-radius: $fn-border-radius-4;
 
   &--dismissible {
-    @include fn-set-paddings-x(0.5rem, 1.75rem);
+    .#{$block}__text {
+      @include fn-set-paddings-x(2rem, 1.75rem);
+
+      &:first-child {
+        @include fn-set-paddings-x(0.5rem, 1.75rem);
+      }
+    }
   }
 
   &__text {
     @include fn-reset();
+    @include fn-set-paddings-x(2rem, 0.5rem);
 
     max-width: 100%;
+    line-height: 1.5rem;
     color: $fn-color-grey-9;
 
     &--truncate {
       @include fn-ellipsis();
     }
+
+    &:first-child {
+      @include fn-set-paddings-x-equal(0.5rem);
+    }
   }
 
   .#{$block}__icon {
     @include fn-flex-center();
-    @include fn-set-margin-right(0.375rem);
+    @include fn-set-position-left(0.5rem);
     @include fn-set-square-min-width(1.125rem);
 
+    top: 0.375rem;
+    position: absolute;
     font-size: 0.9375rem;
 
     &::before {
@@ -53,6 +67,7 @@ $block: #{$fn-namespace}-message-strip;
   .#{$block}__close-button {
     @include fn-set-position-right(0.25rem);
 
+    top: 0.375rem;
     position: absolute;
   }
 

--- a/stories/fn-message-strip/fn-message-strip.stories.js
+++ b/stories/fn-message-strip/fn-message-strip.stories.js
@@ -59,7 +59,7 @@ export const Primary = () => `${localStyles}
     </div>
     <div class="fn-message-strip fn-message-strip--dismissible fn-message-strip--error">
         <span class="sap-icon sap-icon--message-error fn-message-strip__icon"></span>
-        <span class="fn-message-strip__text">Error Message Strip Text</span>
+        <span class="fn-message-strip__text">Error Message Strip Very Long Text lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</span>
         <button class="fn-nested-button fn-message-strip__close-button" aria-label="close">
             <span class="sap-icon sap-icon--decline"></span>
         </button>


### PR DESCRIPTION
## Related Issue
none, reported bug by Alex

## Description
- use position `absolute` to ensure that the icon and the close button always stay aligned with the first line of the text.

## Screenshots

### Before:
<img width="926" alt="Screen Shot 2022-03-14 at 4 15 29 PM" src="https://user-images.githubusercontent.com/39598672/158253877-dc86f044-e225-4200-84b2-621ff14e9b41.png">
<img width="333" alt="Screen Shot 2022-03-14 at 4 15 08 PM" src="https://user-images.githubusercontent.com/39598672/158253880-1fba7573-bf82-44b8-8282-9eacd9e828fa.png">

### After:
<img width="729" alt="Screen Shot 2022-03-14 at 4 14 59 PM" src="https://user-images.githubusercontent.com/39598672/158253905-6e0d4775-fc0c-4997-9b63-7a2b57c03bdc.png">
<img width="332" alt="Screen Shot 2022-03-14 at 4 14 54 PM" src="https://user-images.githubusercontent.com/39598672/158253907-aa1cfaf6-80ba-419a-9c7b-21bbac3ffe96.png">

