### PR TITLE
fix(fn): update checkbox and radio labels for long text [ci visual]

### DIFF
--- a/src/fn/fn-checkbox.scss
+++ b/src/fn/fn-checkbox.scss
@@ -4,16 +4,17 @@ $block: #{$fn-namespace}-checkbox;
 
 .#{$block} {
   @include fn-reset();
+  @include fn-flex();
   @include fn-transition();
   @include fn-user-select();
-  @include fn-flex-vertical-center();
 
+  height: auto;
   cursor: pointer;
-  height: 1.625rem;
   width: fit-content;
   position: relative;
+  min-height: 1.625rem;
   display: inline-flex;
-  padding: $fn-padding-xs;
+  padding: 0.125rem $fn-padding-xs;
   border-radius: $fn-border-radius-xs;
 
   @include fn-hover() {
@@ -120,6 +121,9 @@ $block: #{$fn-namespace}-checkbox;
 
     width: 1.125rem;
     height: 1.125rem;
+    min-width: 1.125rem;
+    min-height: 1.125rem;
+    margin-top: 0.125rem;
     border-radius: 0.25rem;
     background-color: $fn-color-grey-1;
     border: 0.125rem solid $fn-color-grey-7;
@@ -139,5 +143,9 @@ $block: #{$fn-namespace}-checkbox;
     @include fn-set-margin-left($fn-margin-xs);
 
     color: $fn-color-grey-9;
+
+    &--truncate {
+      @include fn-ellipsis();
+    }
   }
 }

--- a/src/fn/fn-radio.scss
+++ b/src/fn/fn-radio.scss
@@ -4,16 +4,17 @@ $block: #{$fn-namespace}-radio;
 
 .#{$block} {
   @include fn-reset();
+  @include fn-flex();
   @include fn-transition();
   @include fn-user-select();
-  @include fn-flex-vertical-center();
 
+  height: auto;
   cursor: pointer;
-  height: 1.625rem;
   width: fit-content;
   position: relative;
+  min-height: 1.625rem;
   display: inline-flex;
-  padding: 0.1875rem;
+  padding: 0.125rem 0.1875rem;
   border-radius: $fn-border-radius-xs;
 
   @include fn-hover() {
@@ -127,6 +128,9 @@ $block: #{$fn-namespace}-radio;
     width: 1.25rem;
     height: 1.25rem;
     border-radius: 50%;
+    min-width: 1.25rem;
+    min-height: 1.25rem;
+    margin-top: 0.0625rem;
     background-color: $fn-color-grey-1;
     border: 0.125rem solid $fn-color-grey-7;
 
@@ -147,5 +151,9 @@ $block: #{$fn-namespace}-radio;
     @include fn-set-margin-left($fn-margin-xs);
 
     color: $fn-color-grey-9;
+
+    &--truncate {
+      @include fn-ellipsis();
+    }
   }
 }

--- a/src/styles/button.scss
+++ b/src/styles/button.scss
@@ -262,6 +262,8 @@ $block: #{$fd-namespace}-button;
 @mixin buttonContainerHover() {
   @include standardHover();
 
+  box-shadow: var(--sapContent_Interaction_Shadow);
+
   &.#{$block}--toggled {
     @include standardToggledHover();
   }

--- a/stories/fn-toggles/fn-toggles.stories.js
+++ b/stories/fn-toggles/fn-toggles.stories.js
@@ -558,6 +558,48 @@ RadioGroup.parameters = {
     }
 };
 
+export const CheckboxAndRadioButtonLongText = () => `${localStyles}
+<div>
+    <div style="display: flex;">
+        <label class="fn-checkbox" tabindex="0">
+            <input class="fn-checkbox__input" type="checkbox" tabindex="-1" aria-label="checkbox">
+            <span class="fn-checkbox__checkmark"></span>
+            <span class="fn-checkbox__label">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</span>
+        </label>
+
+        <label class="fn-radio" tabindex="0">
+            <input class="fn-radio__input" type="radio" tabindex="-1" aria-label="radio" name="group3">
+            <span class="fn-radio__checkmark"></span>
+            <span class="fn-radio__label">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</span>
+        </label>
+    </div>
+    <br><br>
+    <h4>Long label with truncate</h4>
+    <div style="display: flex;">
+        <label class="fn-checkbox" tabindex="0" style="max-width: 50%;">
+            <input class="fn-checkbox__input" type="checkbox" tabindex="-1" aria-label="checkbox">
+            <span class="fn-checkbox__checkmark"></span>
+            <span class="fn-checkbox__label fn-checkbox__label--truncate">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</span>
+        </label>
+
+        <label class="fn-radio" tabindex="0" style="max-width: 50%;">
+            <input class="fn-radio__input" type="radio" tabindex="-1" aria-label="radio" name="group3">
+            <span class="fn-radio__checkmark"></span>
+            <span class="fn-radio__label fn-radio__label--truncate">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</span>
+        </label>
+    </div>
+</div>
+`;
+
+CheckboxAndRadioButtonLongText.parameters = {
+    docs: {
+        iframeHeight: 500,
+        description: {
+            story: 'By default, long checkbox and radio button label will wrap in the next line. To add ellipsis and keep the text in a single line use the `fn-radio__label--truncate` and `fn-checkbox__label--truncate` modifier classes together with the `fn-radio__label` and `fn-checkbox__label` base classes.'
+        }
+    }
+};
+
 
 export const SwitchToggle = () => `${localStyles}
 <div class="docs-fn-container">


### PR DESCRIPTION
## Related Issue
none, issue reported directly by designers

## Description
Checkbox and Radio Button labels were not handling long text properly. Updated the implementation so now long texts wrap on a new line and the checkmark stays always aligned with the first line. 
Also added possibility if users want to truncate the text and have a single line by adding a modifier class.