### PR TITLE
feat(styles): horizon theming for Switch component

### DIFF
--- a/src/styles/switch.scss
+++ b/src/styles/switch.scss
@@ -8,19 +8,22 @@
 */
 $block: #{$fd-namespace}-switch;
 
+@mixin fd-slider-track-position($off-position, $on-position) {
+  .#{$block}__track {
+    transform: translate($off-position, -50%);
+  }
+
+  .#{$block}__input:checked + .#{$block}__slider {
+    .#{$block}__track {
+      transform: translate($on-position, -50%);
+    }
+  }
+}
+
 .#{$block} {
 
   $fd-switch-off-opacity: 0;
   $fd-switch-transition: all 0.1s;
-  $fd-switch-active-border-color: var(--sapButton_Selected_BorderColor);
-  $fd-switch-inactive-border-color: var(--sapContent_ForegroundBorderColor);
-  $fd-switch-inactive-handle-background: var(--sapButton_Background);
-
-  $fd-switch-hover-border-color: var(--sapButton_Hover_BorderColor);
-  $fd-switch-hover-selected-border-color: var(--sapButton_Selected_Hover_BorderColor);
-  $fd-switch-success-border-color: var(--sapSuccessBorderColor);
-  $fd-switch-error-border-color: var(--sapErrorBorderColor);
-  $fd-switch-border-width: var(--sapButton_BorderWidth);
 
   $fd-switch-label-width: 1.75rem;
 
@@ -28,9 +31,49 @@ $block: #{$fd-namespace}-switch;
   $fd-switch-handle-compact-size: 1.5rem;
 
   $fd-switch-track-compact-offset: 0.8125rem;
-  $fd-switch-track-offset: 1.1875rem;
-  $fd-switch-track-semantic-offset: 1.9375rem;
-  $fd-switch-track-border-offset: 0.0625rem;
+
+  $fd-switch-handle-offset: (
+    "default": (
+      "ltr": (
+        "off": calc(var(--fdSwitch_Handle_Offset) * -1),
+        "on": calc(var(--fdSwitch_Active_Handle_Offset) * -1)
+      ),
+      "rtl": (
+        "off": var(--fdSwitch_Handle_Offset),
+        "on": var(--fdSwitch_Active_Handle_Offset)
+      )
+    ),
+    "compact": (
+      "ltr": (
+        "off": -$fd-switch-track-compact-offset,
+        "on": calc(var(--fdSwitch_Compact_Active_Handle_Offset) * -1)
+      ),
+      "rtl": (
+        "off": $fd-switch-track-compact-offset,
+        "on": var(--fdSwitch_Compact_Semantic_Active_Handle_Offset_Rtl)
+      )
+    ),
+    "semantic": (
+      "ltr": (
+        "off": calc(var(--fdSwitch_Semantic_Handle_Offset) * -1),
+        "on": calc(var(--fdSwitch_Semantic_Handle_Active_Offset) * -1)
+      ),
+      "rtl": (
+        "off": var(--fdSwitch_Semantic_Handle_Offset),
+        "on": var(--fdSwitch_Semantic_Handle_Active_Offset)
+      )
+    ),
+    "compactSemantic": (
+      "ltr": (
+        "off": var(--fdSwitch_Compact_Semantic_Handle_Offset),
+        "on": calc(var(--fdSwitch_Compact_Semantic_Active_Handle_Offset) * -1)
+      ),
+      "rtl": (
+        "off": calc(var(--fdSwitch_Compact_Semantic_Handle_Offset) * -1),
+        "on": var(--fdSwitch_Compact_Semantic_Active_Handle_Offset)
+      )
+    )
+  );
 
   @include fd-reset();
   @include fd-form-label();
@@ -39,7 +82,7 @@ $block: #{$fd-namespace}-switch;
   display: flex;
   align-items: center;
   cursor: pointer;
-  padding: 0;
+  padding: var(--fdSwitch_Padding);
 
   @include fd-disabled() {
     cursor: auto;
@@ -50,7 +93,6 @@ $block: #{$fd-namespace}-switch;
   &__control {
     display: inline-block;
     position: relative;
-    padding: 0.375rem 0;
   }
 
   &__slider {
@@ -58,11 +100,12 @@ $block: #{$fd-namespace}-switch;
 
     background-color: var(--sapButton_Track_Background);
     box-sizing: content-box;
-    width: 3.125rem;
-    height: 1.25rem;
-    border: $fd-switch-border-width solid $fd-switch-inactive-border-color;
+    width: var(--fdSwitch_Width);
+    height: var(--fdSwitch_Height);
+    border: var(--fdSwitch_Border);
     transition: $fd-switch-transition;
-    border-radius: 0.75rem;
+    border-radius: var(--fdSwitch_Border_Radius);
+    box-shadow: var(--fdSwitch_Shadow);
   }
 
   &__track {
@@ -73,10 +116,11 @@ $block: #{$fd-namespace}-switch;
     justify-content: center;
     align-items: center;
     top: 50%;
-    transform: translate(-$fd-switch-track-offset, -50%);
     transition: $fd-switch-transition;
     min-width: 4.25rem;
   }
+
+  @include fd-slider-track-position(map-get($fd-switch-handle-offset, "default", "ltr", "off"), map-get($fd-switch-handle-offset, "default", "ltr", "on"));
 
   &__text {
     @include fd-form-label();
@@ -86,12 +130,14 @@ $block: #{$fd-namespace}-switch;
   }
 
   &__icon {
+    position: var(--fdSwitch_Semantic_Icon_Position);
+
     @include fd-icon-selector() {
       @include fd-flex-center();
 
       width: $fd-switch-label-width;
       min-width: $fd-switch-label-width;
-      font-size: 0.75rem;
+      font-size: var(--fdSwitch_Icon_Size);
       line-height: 1.375rem;
       transition: visibility 0s ease 0.03s, opacity 0s ease 0.03s;
     }
@@ -99,14 +145,14 @@ $block: #{$fd-namespace}-switch;
     &--off {
       @include fd-icon-selector() {
         color: var(--sapNegativeElementColor);
-        margin: 0 0.125rem 0 0;
+        margin: var(--fdSwitch_Icon_Error_Margin);
       }
     }
 
     &--on {
       @include fd-icon-selector() {
         color: var(--sapPositiveElementColor);
-        margin: 0 0 0 0.125rem;
+        margin: var(--fdSwitch_Icon_Success_Margin);
         visibility: hidden;
         opacity: $fd-switch-off-opacity;
       }
@@ -116,12 +162,12 @@ $block: #{$fd-namespace}-switch;
   &__handle {
     @include fd-reset();
 
-    box-sizing: content-box;
-    border: var(--fdSwitch_Handle_Border_Width) solid $fd-switch-inactive-border-color;
-    background-color: $fd-switch-inactive-handle-background;
-    min-width: $fd-switch-handle-size;
-    min-height: $fd-switch-handle-size;
-    border-radius: 1rem;
+    box-sizing: var(--fdSwitch_Slider_Box_Sizing);
+    border: var(--fdSwitch_Handle_Border_Width) solid var(--fdSwitch_Handle_Border_Color);
+    background-color: var(--fdSwitch_Handle_Background);
+    min-width: var(--fdSwitch_Handle_Width);
+    min-height: var(--fdSwitch_Handle_Height);
+    border-radius: var(--fdSwitch_Handle_Border_Radius);
     background-clip: padding-box;
   }
 
@@ -150,16 +196,21 @@ $block: #{$fd-namespace}-switch;
   }
 
   &__input:focus + .#{$block}__slider {
+    outline-offset: 0.125rem;
+    outline-width: 0.125rem;
+    outline-style: solid;
+    outline-color: var(--fdSwitch_Focus_Outline_Color);
+
     &::before {
       position: absolute;
-      display: block;
+      display: var(--fdSwitch_Focus_Border_Display);
       outline-offset: -0.0625rem;
       border-width: var(--sapContent_FocusWidth);
       border-color: var(--sapContent_FocusColor);
       border-style: var(--sapContent_FocusStyle);
       content: '';
-      top: 0;
-      bottom: 0;
+      top: var(--fdSwitch_Focus_Outline_Vertical_Offset);
+      bottom: var(--fdSwitch_Focus_Outline_Vertical_Offset);
       left: 0;
       right: 0;
     }
@@ -167,15 +218,12 @@ $block: #{$fd-namespace}-switch;
 
   &__input:checked + &__slider {
     background-color: var(--sapButton_Track_Selected_Background);
-    border-color: $fd-switch-active-border-color;
+    border-color: var(--sapButton_Selected_BorderColor);
+    box-shadow: var(--fdSwitch_Active_Shadow);
 
     .#{$block}__handle {
       background-color: var(--sapButton_Selected_Background);
-      border-color: $fd-switch-active-border-color;
-    }
-
-    .#{$block}__track {
-      transform: translate($fd-switch-track-border-offset, -50%);
+      border-color: var(--sapButton_Selected_BorderColor);
     }
 
     .#{$block}__icon {
@@ -198,32 +246,24 @@ $block: #{$fd-namespace}-switch;
   @include fd-rtl() {
     .#{$block}__icon {
       &--on {
-        margin: 0 0.125rem 0 0;
+        margin: var(--fdSwitch_Icon_Error_Margin);
       }
 
       &--off {
-        margin: 0 0 0 0.125rem;
+        margin: var(--fdSwitch_Icon_Success_Margin);
       }
     }
 
-    .#{$block}__track {
-      transform: translate($fd-switch-track-offset, -50%);
-    }
-
-    .#{$block}__input:checked + .#{$block}__slider {
-      .#{$block}__track {
-        transform: translate(-$fd-switch-track-border-offset, -50%);
-      }
-    }
+    @include fd-slider-track-position(map-get($fd-switch-handle-offset, "default", "rtl", "off"), map-get($fd-switch-handle-offset, "default", "rtl", "on"));
   }
 
   @include fd-hover() {
     .#{$block}__slider {
-      border-color: $fd-switch-hover-border-color;
+      border-color: var(--fdSwitch_Handle_Hover_Border_Color);
     }
 
     .#{$block}__handle {
-      border-color: $fd-switch-hover-border-color;
+      border-color: var(--fdSwitch_Handle_Hover_Border_Color);
       background-color: var(--sapButton_Hover_Background);
     }
 
@@ -231,65 +271,62 @@ $block: #{$fd-namespace}-switch;
       background-color: var(--fdSwitch_On_Hover_Slider_Background);
 
       .#{$block}__handle {
-        border-color: $fd-switch-hover-selected-border-color;
+        border-color: var(--fdSwitch_Handle_Selected_Hover_Border_Color);
         background-color: var(--sapButton_Selected_Hover_Background);
       }
     }
   }
 
   &--compact {
-    padding: 0.25rem 0;
+    padding: var(--fdSwitch_Compact_Padding);
 
     .#{$block}__handle {
-      min-width: $fd-switch-handle-compact-size;
-      min-height: $fd-switch-handle-compact-size;
-    }
-
-    .#{$block}__slider {
-      width: 2.375rem;
-      height: 1rem;
+      min-width: var(--fdSwitch_Compact_Handle_Width);
+      min-height: var(--fdSwitch_Compact_Handle_Height);
     }
 
     .#{$block}__track {
-      transform: translate(-$fd-switch-track-compact-offset, -50%);
       min-width: 3.125rem;
     }
 
+    .#{$block}__slider {
+      width: var(--fdSwitch_Compact_Width);
+      height: var(--fdSwitch_Compact_Height);
+    }
+
+    @include fd-slider-track-position(map-get($fd-switch-handle-offset, "compact", "ltr", "off"), map-get($fd-switch-handle-offset, "compact", "ltr", "on"));
+
     @include fd-rtl() {
-      .#{$block}__track {
-        transform: translate($fd-switch-track-compact-offset, -50%);
-      }
+      @include fd-slider-track-position(map-get($fd-switch-handle-offset, "compact", "rtl", "off"), map-get($fd-switch-handle-offset, "compact", "rtl", "on"));
     }
   }
 
   &--semantic {
     .#{$block}__slider {
-      width: 3.75rem;
-      height: 1.25rem;
-      border-color: $fd-switch-error-border-color;
-      background-color: var(--sapErrorBackground);
+      width: var(--fdSwitch_Semantic_Width);
+      height: var(--fdSwitch_Semantic_Height);
+      border-color: var(--sapErrorBorderColor);
+      background-color: var(--fdSwitch_Semantic_Error_Background_Color);
+      box-shadow: var(--fdSwitch_Semantic_Error_Box_Shadow);
     }
 
-    .#{$block}__track {
-      transform: translate(-$fd-switch-track-semantic-offset, -50%);
-    }
+    @include fd-slider-track-position(map-get($fd-switch-handle-offset, "semantic", "ltr", "off"), map-get($fd-switch-handle-offset, "semantic", "ltr", "on"));
 
     .#{$block}__handle {
-      background-color: $fd-switch-inactive-handle-background;
-      border-color: $fd-switch-error-border-color;
+      background-color: var(--fdSwitch_Handle_Background);
+      background-color: var(--fdSwitch_Semantic_Error_Handle_Background_Color);
+      border-color: var(--fdSwitch_Semantic_Error_Handle_Border_Color);
     }
 
     .#{$block}__input:checked + .#{$block}__slider {
       background-color: var(--fdSwitch_Semantic_Success_Background_Color);
-      border-color: $fd-switch-success-border-color;
-
-      .#{$block}__track {
-        transform: translate(-$fd-switch-track-border-offset, -50%);
-      }
+      border-color: var(--sapSuccessBorderColor);
+      box-shadow: var(--fdSwitch_Semantic_Success_Box_Shadow);
 
       .#{$block}__handle {
-        border-color: $fd-switch-success-border-color;
-        background-color: $fd-switch-inactive-handle-background;
+        border-color: var(--fdSwitch_Semantic_Success_Handle_Border_Color);
+        background-color: var(--fdSwitch_Handle_Background);
+        background-color: var(--fdSwitch_Semantic_Success_Handle_Background_Color);
       }
     }
 
@@ -297,15 +334,17 @@ $block: #{$fd-namespace}-switch;
       padding: 0.1875rem 0;
 
       .#{$block}__slider {
-        width: 3.375rem;
-        height: 1.25rem;
+        width: var(--fdSwitch_Compact_Semantic_Width);
+        height: var(--fdSwitch_Compact_Semantic_Height);
       }
+
+      @include fd-slider-track-position(map-get($fd-switch-handle-offset, "compactSemantic", "ltr", "off"), map-get($fd-switch-handle-offset, "compactSemantic", "ltr", "on"));
     }
 
     @include fd-hover() {
 
       .#{$block}__icon {
-        color: var(--fdSwitch_Semantic_Error_Color);
+        color: var(--fdSwitch_Semantic_Icon_Error_Color);
       }
 
       .#{$block}__slider {
@@ -313,8 +352,8 @@ $block: #{$fd-namespace}-switch;
       }
 
       .#{$block}__handle {
-        background-color: var(--fdSwitch_Semantic_Error_Background_Color);
-        border-color: var(--fdSwitch_Semantic_Error_Color);
+        background-color: var(--fdSwitch_Semantic_Error_Handle_Hover_Background_Color);
+        border-color: var(--fdSwitch_Semantic_Error_Handle_Hover_Border_Color);
       }
 
       .#{$block}__input:checked + .#{$block}__slider {
@@ -322,23 +361,19 @@ $block: #{$fd-namespace}-switch;
         border-color: var(--fdSwitch_Semantic_Success_Border_Color);
         .#{$block}__handle {
           background-color: var(--fdSwitch_Semantic_Success_Handle_Hover_Background_Color);
-          border-color: var(--fdSwitch_Semantic_Success_Border_Color);
+          border-color: var(--fdSwitch_Semantic_Success_Handle_Hover_Border_Color);
         }
         .#{$block}__icon {
-          color: var(--fdSwitch_Semantic_Success_Border_Color);
+          color: var(--fdSwitch_Semantic_Icon_Success_Color);
         }
       }
     }
 
     @include fd-rtl() {
-      .#{$block}__track {
-        transform: translate($fd-switch-track-semantic-offset, -50%);
-      }
+      @include fd-slider-track-position(map-get($fd-switch-handle-offset, "semantic", "rtl", "off"), map-get($fd-switch-handle-offset, "semantic", "rtl", "on"));
 
-      .#{$block}__input:checked + .#{$block}__slider {
-        .#{$block}__track {
-          transform: translate($fd-switch-track-border-offset, -50%);
-        }
+      &.#{$block}--compact {
+        @include fd-slider-track-position(map-get($fd-switch-handle-offset, "compactSemantic", "rtl", "off"), map-get($fd-switch-handle-offset, "compactSemantic", "rtl", "on"));
       }
     }
   }

--- a/src/styles/theming/common/switch/_sap_fiori.scss
+++ b/src/styles/theming/common/switch/_sap_fiori.scss
@@ -1,0 +1,73 @@
+:root {
+  --fdSwitch_Handle_Border_Width: var(--sapButton_BorderWidth);
+  --fdSwitch_On_Hover_Slider_Background: var(--sapButton_Track_Selected_Background);
+  --fdSwitch_Handle_Width: 1.875rem;
+  --fdSwitch_Handle_Height: 1.875rem;
+  --fdSwitch_Handle_Border_Radius: 1rem;
+  --fdSwitch_Handle_Offset: 1.1875rem;
+  --fdSwitch_Active_Handle_Offset: -0.0625rem;
+  --fdSwitch_Compact_Active_Handle_Offset: var(--fdSwitch_Active_Handle_Offset);
+  --fdSwitch_Handle_Border_Color: var(--sapContent_ForegroundBorderColor);
+  --fdSwitch_Handle_Hover_Border_Color: var(--sapButton_Hover_BorderColor);
+  --fdSwitch_Handle_Selected_Hover_Border_Color: var(--sapButton_Selected_Hover_BorderColor);
+  --fdSwitch_Width: 3.125rem;
+  --fdSwitch_Height: 1.25rem;
+  --fdSwitch_Border_Radius: 0.75rem;
+  --fdSwitch_Handle_Background: var(--sapButton_Background);
+  --fdSwitch_Border_Width: var(--sapButton_BorderWidth);
+  --fdSwitch_Shadow: none;
+  --fdSwitch_Active_Shadow: none;
+  --fdSwitch_Border: var(--fdSwitch_Border_Width) solid var(--fdSwitch_Handle_Border_Color);
+  --fdSwitch_Slider_Box_Sizing: content-box;
+  --fdSwitch_Focus_Border_Display: block;
+  --fdSwitch_Focus_Outline_Color: transparent;
+  --fdSwitch_Padding: 0.625rem 0;
+  --fdSwitch_Focus_Outline_Vertical_Offset: -0.375rem;
+
+  // Compact mode
+  --fdSwitch_Compact_Width: 2.375rem;
+  --fdSwitch_Compact_Height: 1rem;
+  --fdSwitch_Compact_Handle_Width: 1.5rem;
+  --fdSwitch_Compact_Handle_Height: var(--fdSwitch_Compact_Handle_Width);
+  --fdSwitch_Compact_Handle_Offset: 0.8125rem;
+  --fdSwitch_Compact_Padding: 0.625rem 0;
+
+  // Semantic switch
+  --fdSwitch_Semantic_Success_Border_Color: var(--sapSuccessColor);
+  --fdSwitch_Semantic_Success_Background_Color: var(--sapSuccessBackground);
+  --fdSwitch_Semantic_Error_Background_Color: var(--sapErrorBackground);
+  --fdSwitch_Semantic_Icon_Error_Color: var(--sapErrorBorderColor);
+  --fdSwitch_Semantic_Error_Box_Shadow: none;
+  --fdSwitch_Semantic_Success_Box_Shadow: none;
+  --fdSwitch_Semantic_Width: 3.75rem;
+  --fdSwitch_Semantic_Height: 1.25rem;
+
+  // Semantic switch handle
+  --fdSwitch_Semantic_Handle_Box_Sizing: content-box;
+  --fdSwitch_Semantic_Slider_Error_Background_Color: var(--sapButton_Track_Negative_Background);
+  --fdSwitch_Semantic_Success_Handle_Background_Color: var(--sapButton_Handle_Positive_Background);
+  --fdSwitch_Semantic_Success_Handle_Hover_Background_Color: var(--sapButton_Handle_Positive_Hover_Background);
+  --fdSwitch_Semantic_Error_Handle_Background_Color: var(--sapButton_Handle_Negative_Background);
+  --fdSwitch_Semantic_Error_Handle_Hover_Background_Color: var(--sapButton_Handle_Negative_Hover_Background);
+  --fdSwitch_Semantic_Success_Handle_Border_Color: var(--sapSuccessBorderColor);
+  --fdSwitch_Semantic_Success_Handle_Hover_Border_Color: var(--sapSuccessBorderColor);
+  --fdSwitch_Semantic_Error_Handle_Border_Color: var(--sapErrorBorderColor);
+  --fdSwitch_Semantic_Error_Handle_Hover_Border_Color: var(--sapErrorBorderColor);
+  --fdSwitch_Semantic_Handle_Offset: 1.9375rem;
+  --fdSwitch_Semantic_Handle_Active_Offset: 0.0625rem;
+  --fdSwitch_Semantic_Icon_Position: static;
+
+  // Semantic switch icon
+  --fdSwitch_Icon_Size: 0.75rem;
+  --fdSwitch_Icon_Error_Margin: 0 0.125rem 0 0;
+  --fdSwitch_Icon_Success_Margin: 0 0 0 0.125rem;
+
+  // Semantic switch Compact mode
+  --fdSwitch_Compact_Semantic_Width: 3.375rem;
+  --fdSwitch_Compact_Semantic_Height: 1.25rem;
+  --fdSwitch_Compact_Semantic_Handle_Width: var(--fdSwitch_Compact_Handle_Width);
+  --fdSwitch_Compact_Semantic_Handle_Height: var(--fdSwitch_Compact_Handle_Height);
+  --fdSwitch_Compact_Semantic_Handle_Offset: -1.9375rem;
+  --fdSwitch_Compact_Semantic_Active_Handle_Offset: 0.0625rem;
+  --fdSwitch_Compact_Semantic_Active_Handle_Offset_Rtl: var(--fdSwitch_Active_Handle_Offset);
+}

--- a/src/styles/theming/common/switch/_sap_horizon.scss
+++ b/src/styles/theming/common/switch/_sap_horizon.scss
@@ -1,0 +1,79 @@
+:root {
+  // Compact mode
+  --fdSwitch_Compact_Width: 2rem;
+  --fdSwitch_Compact_Height: 1.25rem;
+  --fdSwitch_Compact_Handle_Width: 1.25rem;
+  --fdSwitch_Compact_Handle_Height: 1rem;
+  --fdSwitch_Compact_Handle_Offset: 0.3075rem;
+  --fdSwitch_Compact_Active_Handle_Offset: var(--fdSwitch_Compact_Handle_Offset);
+  --fdSwitch_Compact_Padding: 0.375rem 0;
+
+  // Standard
+  --fdSwitch_Handle_Border_Width: 0.125rem;
+  --fdSwitch_On_Hover_Slider_Background: var(--sapButton_Track_Selected_Background);
+  --fdSwitch_Border_Width: 0;
+  --fdSwitch_Width: 2.5rem;
+  --fdSwitch_Height: 1.5rem;
+  --fdSwitch_Border_Radius: 0.75rem;
+  --fdSwitch_Handle_Width: 1.5rem;
+  --fdSwitch_Handle_Height: 1.25rem;
+  --fdSwitch_Handle_Border_Radius: 0.75rem;
+  --fdSwitch_Handle_Background: var(--sapButton_Handle_Background);
+  --fdSwitch_Handle_Offset: 1.2475rem;
+  --fdSwitch_Active_Handle_Offset: 0.5075rem;
+  --fdSwitch_Shadow: inset 0 0 0 0.0625rem var(--sapButton_Track_BorderColor);
+  --fdSwitch_Active_Shadow: inset 0 0 0 0.0625rem var(--sapButton_Selected_BorderColor);
+  --fdSwitch_Border: none;
+  --fdSwitch_Slider_Box_Sizing: content-box;
+  --fdSwitch_Focus_Border_Display: none;
+  --fdSwitch_Focus_Outline_Color: var(--sapContent_FocusColor);
+  --fdSwitch_Padding: 0.625rem 0;
+  --fdSwitch_Focus_Outline_Vertical_Offset: 0;
+
+  // Switch borders
+  --fdSwitch_Handle_Border_Color: var(--sapButton_Track_BorderColor);
+  --fdSwitch_Handle_Hover_Border_Color: var(--sapButton_Handle_Hover_BorderColor);
+  --fdSwitch_Handle_Selected_Hover_Border_Color: var(--sapButton_Handle_Selected_Hover_BorderColor);
+
+  // Semantic switch
+  --fdSwitch_Semantic_Success_Border_Color: var(--sapButton_Track_Positive_BorderColor);
+  --fdSwitch_Semantic_Success_Background_Color: var(--sapButton_Track_Positive_Background);
+  --fdSwitch_Semantic_Error_Background_Color: var(--sapButton_Track_Negative_Background);
+  --fdSwitch_Semantic_Error_Border_Color: var(--sapButton_Track_Negative_BorderColor);
+  --fdSwitch_Semantic_Icon_Success_Color: var(--sapButton_Handle_Positive_TextColor);
+  --fdSwitch_Semantic_Icon_Error_Color: var(--sapButton_Handle_Negative_TextColor);
+  --fdSwitch_Semantic_Error_Box_Shadow: inset 0 0 0 0.0625rem var(--sapButton_Track_Negative_BorderColor);
+  --fdSwitch_Semantic_Success_Box_Shadow: inset 0 0 0 0.0625rem var(--sapButton_Track_Positive_BorderColor);
+  --fdSwitch_Semantic_Width: var(--fdSwitch_Width);
+  --fdSwitch_Semantic_Height: var(--fdSwitch_Height);
+
+  // Semantic switch handle
+  --fdSwitch_Semantic_Handle_Offset: var(--fdSwitch_Handle_Offset);
+  --fdSwitch_Semantic_Handle_Active_Offset: var(--fdSwitch_Active_Handle_Offset);
+  --fdSwitch_Semantic_Compact_Active_Handle_Offset: var(--fdSwitch_Semantic_Handle_Offset);
+  --fdSwitch_Semantic_Handle_Box_Sizing: border-box;
+  --fdSwitch_Semantic_Slider_Error_Background_Color: var(--sapButton_Track_Negative_Background);
+  --fdSwitch_Semantic_Success_Handle_Background_Color: var(--sapButton_Handle_Positive_Background);
+  --fdSwitch_Semantic_Success_Handle_Hover_Background_Color: var(--sapButton_Handle_Positive_Hover_Background);
+  --fdSwitch_Semantic_Error_Handle_Background_Color: var(--sapButton_Handle_Negative_Background);
+  --fdSwitch_Semantic_Error_Handle_Hover_Background_Color: var(--sapButton_Handle_Negative_Hover_Background);
+  --fdSwitch_Semantic_Success_Handle_Border_Color: var(--sapButton_Handle_Positive_BorderColor);
+  --fdSwitch_Semantic_Success_Handle_Hover_Border_Color: var(--sapButton_Handle_Positive_Hover_BorderColor);
+  --fdSwitch_Semantic_Error_Handle_Border_Color: var(--sapButton_Handle_Negative_BorderColor);
+  --fdSwitch_Semantic_Error_Handle_Hover_Border_Color: var(--sapButton_Handle_Negative_Hover_BorderColor);
+
+  // Semantic switch icon
+  --fdSwitch_Semantic_Icon_Position: absolute;
+  --fdSwitch_Icon_Size: var(--sapFontSize);
+  --fdSwitch_Icon_Error_Margin: 0;
+  --fdSwitch_Icon_Success_Margin: 0;
+
+  // Semantic switch Compact mode
+  --fdSwitch_Compact_Semantic_Width: var(--fdSwitch_Compact_Width);
+  --fdSwitch_Compact_Semantic_Height: var(--fdSwitch_Compact_Height);
+  --fdSwitch_Compact_Semantic_Handle_Width: var(--fdSwitch_Compact_Handle_Width);
+  --fdSwitch_Compact_Semantic_Handle_Height: var(--fdSwitch_Compact_Handle_Height);
+  --fdSwitch_Compact_Semantic_Handle_Offset: -0.8125rem;
+  --fdSwitch_Compact_Semantic_Active_Handle_Offset: var(--fdSwitch_Compact_Active_Handle_Offset);
+  --fdSwitch_Compact_Semantic_Active_Handle_Offset_Rtl: var(--fdSwitch_Compact_Handle_Offset);
+}

--- a/src/styles/theming/sap_fiori_3.scss
+++ b/src/styles/theming/sap_fiori_3.scss
@@ -1,3 +1,5 @@
+@import "./common/switch/sap_fiori";
+
 :root {
   --fdInverted_Object_Border_Width: 0;
   --fdOverlay_Background_Opacity: 0.6;
@@ -204,15 +206,6 @@
   /* Page */
   --fdPage_List_Background: var(--sapGroup_ContentBackground);
   --fdPage_Transparent_Background: transparent;
-
-  /* Switch */
-  --fdSwitch_Handle_Border_Width: var(--sapButton_BorderWidth);
-  --fdSwitch_On_Hover_Slider_Background: var(--sapButton_Track_Selected_Background);
-  --fdSwitch_Semantic_Success_Border_Color: var(--sapSuccessColor);
-  --fdSwitch_Semantic_Success_Background_Color: var(--sapSuccessBackground);
-  --fdSwitch_Semantic_Error_Background_Color: var(--sapErrorBackground);
-  --fdSwitch_Semantic_Success_Handle_Hover_Background_Color: var(--sapSuccessBackground);
-  --fdSwitch_Semantic_Error_Color: var(--sapErrorBorderColor);
 
   /* Action List Item */
   --fdList_Item_Action_Border: var(--sapList_BorderWidth) solid var(--sapList_BorderColor);

--- a/src/styles/theming/sap_fiori_3_dark.scss
+++ b/src/styles/theming/sap_fiori_3_dark.scss
@@ -1,3 +1,5 @@
+@import "./common/switch/sap_fiori";
+
 :root {
   --fdInverted_Object_Border_Width: 0;
   --fdOverlay_Background_Opacity: 0.6;
@@ -203,15 +205,6 @@
   /* Page */
   --fdPage_List_Background: var(--sapGroup_ContentBackground);
   --fdPage_Transparent_Background: transparent;
-
-  /* Switch */
-  --fdSwitch_Handle_Border_Width: var(--sapButton_BorderWidth);
-  --fdSwitch_On_Hover_Slider_Background: var(--sapButton_Track_Selected_Background);
-  --fdSwitch_Semantic_Success_Border_Color: var(--sapSuccessColor);
-  --fdSwitch_Semantic_Success_Background_Color: var(--sapSuccessBackground);
-  --fdSwitch_Semantic_Error_Background_Color: var(--sapErrorBackground);
-  --fdSwitch_Semantic_Success_Handle_Hover_Background_Color: var(--sapSuccessBackground);
-  --fdSwitch_Semantic_Error_Color: var(--sapErrorBorderColor);
 
   /* Action List Item */
   --fdList_Item_Action_Border: var(--sapList_BorderWidth) solid var(--sapList_BorderColor);

--- a/src/styles/theming/sap_fiori_3_hcb.scss
+++ b/src/styles/theming/sap_fiori_3_hcb.scss
@@ -1,3 +1,5 @@
+@import "./common/switch/sap_fiori";
+
 :root {
   --fdInverted_Object_Border_Width: 0.0625rem;
   --fdOverlay_Background_Opacity: 0.8;
@@ -203,15 +205,6 @@
   /* Page */
   --fdPage_List_Background: var(--sapBackgroundColor);
   --fdPage_Transparent_Background: var(--sapBackgroundColor);
-
-  /* Switch */
-  --fdSwitch_Handle_Border_Width: 0.125rem;
-  --fdSwitch_On_Hover_Slider_Background: var(--sapButton_Background);
-  --fdSwitch_Semantic_Success_Border_Color: var(--sapButton_Hover_BorderColor);
-  --fdSwitch_Semantic_Success_Background_Color: var(--sapButton_Background);
-  --fdSwitch_Semantic_Error_Background_Color: var(--sapButton_Selected_Hover_Background);
-  --fdSwitch_Semantic_Success_Handle_Hover_Background_Color: var(--sapButton_Selected_Hover_Background);
-  --fdSwitch_Semantic_Error_Color: var(--sapButton_Hover_BorderColor);
 
   /* Action List Item */
   --fdList_Item_Action_Border: none;

--- a/src/styles/theming/sap_fiori_3_hcw.scss
+++ b/src/styles/theming/sap_fiori_3_hcw.scss
@@ -1,4 +1,5 @@
 @import "../icons/settings";
+@import "./common/switch/sap_fiori";
 
 :root {
   --fdInverted_Object_Border_Width: 0.0625rem;
@@ -205,15 +206,6 @@
   /* Page */
   --fdPage_List_Background: var(--sapBackgroundColor);
   --fdPage_Transparent_Background: var(--sapBackgroundColor);
-
-  /* Switch */
-  --fdSwitch_Handle_Border_Width: 0.125rem;
-  --fdSwitch_On_Hover_Slider_Background: var(--sapButton_Background);
-  --fdSwitch_Semantic_Success_Border_Color: var(--sapButton_Hover_BorderColor);
-  --fdSwitch_Semantic_Success_Background_Color: var(--sapButton_Background);
-  --fdSwitch_Semantic_Error_Background_Color: var(--sapButton_Selected_Hover_Background);
-  --fdSwitch_Semantic_Success_Handle_Hover_Background_Color: var(--sapButton_Selected_Hover_Background);
-  --fdSwitch_Semantic_Error_Color: var(--sapButton_Hover_BorderColor);
 
   /* Action List Item */
   --fdList_Item_Action_Border: none;

--- a/src/styles/theming/sap_fiori_3_light_dark.scss
+++ b/src/styles/theming/sap_fiori_3_light_dark.scss
@@ -1,3 +1,5 @@
+@import "./common/switch/sap_fiori";
+
 :root {
   --fdInverted_Object_Border_Width: 0;
   --fdOverlay_Background_Opacity: 0.6;
@@ -203,15 +205,6 @@
   /* Page */
   --fdPage_List_Background: var(--sapGroup_ContentBackground);
   --fdPage_Transparent_Background: transparent;
-
-  /* Switch */
-  --fdSwitch_Handle_Border_Width: var(--sapButton_BorderWidth);
-  --fdSwitch_On_Hover_Slider_Background: var(--sapButton_Track_Selected_Background);
-  --fdSwitch_Semantic_Success_Border_Color: var(--sapSuccessColor);
-  --fdSwitch_Semantic_Success_Background_Color: var(--sapSuccessBackground);
-  --fdSwitch_Semantic_Error_Background_Color: var(--sapErrorBackground);
-  --fdSwitch_Semantic_Success_Handle_Hover_Background_Color: var(--sapSuccessBackground);
-  --fdSwitch_Semantic_Error_Color: var(--sapErrorBorderColor);
 
   /* Action List Item */
   --fdList_Item_Action_Border: var(--sapList_BorderWidth) solid var(--sapList_BorderColor);

--- a/src/styles/theming/sap_horizon.scss
+++ b/src/styles/theming/sap_horizon.scss
@@ -1,4 +1,10 @@
+@import "./common/switch/sap_horizon";
+
 :root {
+  /* Switch */
+  --fdSwitch_Semantic_Error_Handle_Border_Color: var(--sapButton_Track_Negative_Background);
+  --fdSwitch_Semantic_Success_Handle_Border_Color: var(--sapButton_Track_Positive_Background);
+
   /* Rating Indicator */
   --fdInverted_Object_Border_Width: 0;
   --fdOverlay_Background_Opacity: 0.6;
@@ -239,15 +245,6 @@
   /* Page */
   --fdPage_List_Background: var(--sapGroup_ContentBackground);
   --fdPage_Transparent_Background: transparent;
-
-  /* Switch */
-  --fdSwitch_Handle_Border_Width: var(--sapButton_BorderWidth);
-  --fdSwitch_On_Hover_Slider_Background: var(--sapButton_Track_Selected_Background);
-  --fdSwitch_Semantic_Success_Border_Color: var(--sapSuccessColor);
-  --fdSwitch_Semantic_Success_Background_Color: var(--sapSuccessBackground);
-  --fdSwitch_Semantic_Error_Background_Color: var(--sapErrorBackground);
-  --fdSwitch_Semantic_Success_Handle_Hover_Background_Color: var(--sapSuccessBackground);
-  --fdSwitch_Semantic_Error_Color: var(--sapErrorBorderColor);
 
   /* Action List Item */
   --fdList_Item_Action_Border: var(--sapList_BorderWidth) solid var(--sapList_BorderColor);

--- a/src/styles/theming/sap_horizon_dark.scss
+++ b/src/styles/theming/sap_horizon_dark.scss
@@ -1,4 +1,10 @@
+@import "./common/switch/sap_horizon";
+
 :root {
+  /* Switch */
+  --fdSwitch_Semantic_Error_Handle_Border_Color: var(--sapButton_Track_Negative_Background);
+  --fdSwitch_Semantic_Success_Handle_Border_Color: var(--sapButton_Track_Positive_Background);
+
   /* Rating Indicator */
   --fdInverted_Object_Border_Width: 0;
   --fdOverlay_Background_Opacity: 0.6;
@@ -239,15 +245,6 @@
   /* Page */
   --fdPage_List_Background: var(--sapGroup_ContentBackground);
   --fdPage_Transparent_Background: transparent;
-
-  /* Switch */
-  --fdSwitch_Handle_Border_Width: var(--sapButton_BorderWidth);
-  --fdSwitch_On_Hover_Slider_Background: var(--sapButton_Track_Selected_Background);
-  --fdSwitch_Semantic_Success_Border_Color: var(--sapSuccessColor);
-  --fdSwitch_Semantic_Success_Background_Color: var(--sapSuccessBackground);
-  --fdSwitch_Semantic_Error_Background_Color: var(--sapErrorBackground);
-  --fdSwitch_Semantic_Success_Handle_Hover_Background_Color: var(--sapSuccessBackground);
-  --fdSwitch_Semantic_Error_Color: var(--sapErrorBorderColor);
 
   /* Action List Item */
   --fdList_Item_Action_Border: var(--sapList_BorderWidth) solid var(--sapList_BorderColor);

--- a/src/styles/theming/sap_horizon_hcb.scss
+++ b/src/styles/theming/sap_horizon_hcb.scss
@@ -1,4 +1,9 @@
+@import "./common/switch/sap_horizon";
+
 :root {
+  /* Switch */
+  --fdSwitch_Slider_Box_Sizing: border-box;
+
   /* Rating Indicator */
   --fdInverted_Object_Border_Width: 0;
   --fdOverlay_Background_Opacity: 0.6;
@@ -206,15 +211,6 @@
   /* Page */
   --fdPage_List_Background: var(--sapGroup_ContentBackground);
   --fdPage_Transparent_Background: transparent;
-
-  /* Switch */
-  --fdSwitch_Handle_Border_Width: var(--sapButton_BorderWidth);
-  --fdSwitch_On_Hover_Slider_Background: var(--sapButton_Track_Selected_Background);
-  --fdSwitch_Semantic_Success_Border_Color: var(--sapSuccessColor);
-  --fdSwitch_Semantic_Success_Background_Color: var(--sapSuccessBackground);
-  --fdSwitch_Semantic_Error_Background_Color: var(--sapErrorBackground);
-  --fdSwitch_Semantic_Success_Handle_Hover_Background_Color: var(--sapSuccessBackground);
-  --fdSwitch_Semantic_Error_Color: var(--sapErrorBorderColor);
 
   /* Action List Item */
   --fdList_Item_Action_Border: var(--sapList_BorderWidth) solid var(--sapList_BorderColor);

--- a/src/styles/theming/sap_horizon_hcw.scss
+++ b/src/styles/theming/sap_horizon_hcw.scss
@@ -1,4 +1,9 @@
+@import "./common/switch/sap_horizon";
+
 :root {
+  /* Switch */
+  --fdSwitch_Slider_Box_Sizing: border-box;
+
   /* Rating Indicator */
   --fdInverted_Object_Border_Width: 0;
   --fdOverlay_Background_Opacity: 0.6;
@@ -205,15 +210,6 @@
   /* Page */
   --fdPage_List_Background: var(--sapGroup_ContentBackground);
   --fdPage_Transparent_Background: transparent;
-
-  /* Switch */
-  --fdSwitch_Handle_Border_Width: var(--sapButton_BorderWidth);
-  --fdSwitch_On_Hover_Slider_Background: var(--sapButton_Track_Selected_Background);
-  --fdSwitch_Semantic_Success_Border_Color: var(--sapSuccessColor);
-  --fdSwitch_Semantic_Success_Background_Color: var(--sapSuccessBackground);
-  --fdSwitch_Semantic_Error_Background_Color: var(--sapErrorBackground);
-  --fdSwitch_Semantic_Success_Handle_Hover_Background_Color: var(--sapSuccessBackground);
-  --fdSwitch_Semantic_Error_Color: var(--sapErrorBorderColor);
 
   /* Action List Item */
   --fdList_Item_Action_Border: var(--sapList_BorderWidth) solid var(--sapList_BorderColor);

--- a/stories/switch/switch.stories.js
+++ b/stories/switch/switch.stories.js
@@ -20,7 +20,7 @@ The switch mimics a physical switch, allowing users to set individual features (
 -	It’s not clear if the control is showing a state or an action. In this case, use a **Checkbox** instead.
 
   `,
-        components: ['form-label', 'switch', 'icon', 'form']
+        components: ['form-label', 'switch', 'icon']
     }
 };
 
@@ -144,10 +144,7 @@ WithText.parameters = {
     docs: {
         iframeHeight: 350,
         description: {
-            story: `As mentioned in the previous example, a switch should always be accompanied by a label.
-
-        (code needs fixing)
-        `
+            story: 'As mentioned in the previous example, a switch should always be accompanied by a label.'
         }
     }
 };


### PR DESCRIPTION
## Related Issue
Relates #3213

## Description
Updated switch theme to reflect horizon theming.

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### After:
<img width="205" alt="image" src="https://user-images.githubusercontent.com/6586561/160100868-0e4da6f2-66dd-471b-b027-3ee6edfc6171.png">
<img width="227" alt="image" src="https://user-images.githubusercontent.com/6586561/160100936-bb904071-1f7f-4e2d-b606-72f3630b9776.png">
<img width="210" alt="image" src="https://user-images.githubusercontent.com/6586561/160100970-271d17e7-408b-46b3-a2e2-96d28bc4bf08.png">
<img width="196" alt="image" src="https://user-images.githubusercontent.com/6586561/160101020-7d1a733c-de1d-4ba5-9adf-057d166e9de7.png">
<img width="218" alt="image" src="https://user-images.githubusercontent.com/6586561/160101069-0f4df6b4-d8c2-483e-8bd7-bdc5a48f7bc0.png">
<img width="214" alt="image" src="https://user-images.githubusercontent.com/6586561/160101156-cbcac5bf-89bf-443c-9b23-75390385a14d.png">
<img width="203" alt="image" src="https://user-images.githubusercontent.com/6586561/160101196-676f584b-f155-46fe-8dc3-d1175771aaa4.png">
<img width="192" alt="image" src="https://user-images.githubusercontent.com/6586561/160101224-edb51f8d-bd38-4e7d-a63d-7e417ce6dbef.png">

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
