### PR TITLE
feat(styles): add delta horizon theming for Toolbar [ci visual]

### DIFF
--- a/src/styles/theming/sap_fiori_3.scss
+++ b/src/styles/theming/sap_fiori_3.scss
@@ -290,6 +290,7 @@
 
   /* Toolbar */
   --fdToolbar_Auto_Background: inherit;
+  --fdToolbar_Solid_Background: var(--sapBackgroundColor);
 
   /* Tool Header */
   --fdTool_Header_Icon_Color_Default: var(--sapShell_TextColor);

--- a/src/styles/theming/sap_fiori_3_dark.scss
+++ b/src/styles/theming/sap_fiori_3_dark.scss
@@ -289,6 +289,7 @@
 
   /* Toolbar */
   --fdToolbar_Auto_Background: inherit;
+  --fdToolbar_Solid_Background: var(--sapBackgroundColor);
 
   /* Tool Header */
   --fdTool_Header_Icon_Color_Default: var(--sapShell_TextColor);

--- a/src/styles/theming/sap_fiori_3_hcb.scss
+++ b/src/styles/theming/sap_fiori_3_hcb.scss
@@ -289,6 +289,7 @@
 
   /* Toolbar */
   --fdToolbar_Auto_Background: var(--sapToolbar_Background);
+  --fdToolbar_Solid_Background: var(--sapBackgroundColor);
 
   /* Tool Header */
   --fdTool_Header_Icon_Color_Default: var(--sapContent_IconColor);

--- a/src/styles/theming/sap_fiori_3_hcw.scss
+++ b/src/styles/theming/sap_fiori_3_hcw.scss
@@ -291,6 +291,7 @@
 
   /* Toolbar */
   --fdToolbar_Auto_Background: var(--sapToolbar_Background);
+  --fdToolbar_Solid_Background: var(--sapBackgroundColor);
 
   /* Tool Header */
   --fdTool_Header_Icon_Color_Default: var(--sapContent_IconColor);

--- a/src/styles/theming/sap_fiori_3_light_dark.scss
+++ b/src/styles/theming/sap_fiori_3_light_dark.scss
@@ -289,6 +289,7 @@
 
   /* Toolbar */
   --fdToolbar_Auto_Background: inherit;
+  --fdToolbar_Solid_Background: var(--sapBackgroundColor);
 
   /* Tool Header */
   --fdTool_Header_Icon_Color_Default: var(--sapShell_TextColor);

--- a/src/styles/theming/sap_horizon.scss
+++ b/src/styles/theming/sap_horizon.scss
@@ -324,7 +324,8 @@
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapInformativeElementColor);
 
   /* Toolbar */
-  --fdToolbar_Auto_Background: inherit;
+  --fdToolbar_Auto_Background: var(--sapToolbar_Background);
+  --fdToolbar_Solid_Background: var(--sapToolbar_Background);
 
   /* Tool Header */
   --fdTool_Header_Icon_Color_Default: var(--sapShell_TextColor);

--- a/src/styles/theming/sap_horizon_dark.scss
+++ b/src/styles/theming/sap_horizon_dark.scss
@@ -324,7 +324,8 @@
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapInformativeElementColor);
 
   /* Toolbar */
-  --fdToolbar_Auto_Background: inherit;
+  --fdToolbar_Auto_Background: var(--sapToolbar_Background);
+  --fdToolbar_Solid_Background: var(--sapToolbar_Background);
 
   /* Tool Header */
   --fdTool_Header_Icon_Color_Default: var(--sapShell_TextColor);

--- a/src/styles/theming/sap_horizon_hcb.scss
+++ b/src/styles/theming/sap_horizon_hcb.scss
@@ -291,7 +291,8 @@
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapInformativeElementColor);
 
   /* Toolbar */
-  --fdToolbar_Auto_Background: inherit;
+  --fdToolbar_Auto_Background: var(--sapToolbar_Background);
+  --fdToolbar_Solid_Background: var(--sapToolbar_Background);
 
   /* Tool Header */
   --fdTool_Header_Icon_Color_Default: var(--sapShell_TextColor);

--- a/src/styles/theming/sap_horizon_hcw.scss
+++ b/src/styles/theming/sap_horizon_hcw.scss
@@ -290,7 +290,8 @@
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapInformativeElementColor);
 
   /* Toolbar */
-  --fdToolbar_Auto_Background: inherit;
+  --fdToolbar_Auto_Background: var(--sapToolbar_Background);
+  --fdToolbar_Solid_Background: var(--sapToolbar_Background);
 
   /* Tool Header */
   --fdTool_Header_Icon_Color_Default: var(--sapShell_TextColor);

--- a/src/styles/toolbar.scss
+++ b/src/styles/toolbar.scss
@@ -21,11 +21,11 @@ $title-toolbar-height: 2.75rem;
 }
 
 @mixin toolbarAuto() {
-  background-color: inherit;
+  background-color: var(--fdToolbar_Auto_Background);
 }
 
 @mixin toolbarSolid() {
-  background-color: var(--sapBackgroundColor);
+  background-color: var(--fdToolbar_Solid_Background);
 }
 
 @mixin toolbarTransparent() {
@@ -201,12 +201,17 @@ $title-toolbar-height: 2.75rem;
     }
   }
 
+  &__title {
+    color: var(--sapGroup_TitleTextColor);
+  }
+
   &--cozy {
     height: $toolbar-height-cozy;
     min-height: $toolbar-height-cozy;
 
     &.#{$block}--info {
       height: $info-toolbar-height;
+      min-height: $info-toolbar-height;
     }
 
     .#{$block}__overflow {

--- a/stories/toolbar/__snapshots__/toolbar.stories.storyshot
+++ b/stories/toolbar/__snapshots__/toolbar.stories.storyshot
@@ -1135,13 +1135,15 @@ exports[`Storyshots Components/Toolbar Types 1`] = `
     >
       
         
-      <h4>
-        Producs (104)
+      <h4
+        class="fd-title fd-title--h4 fd-toolbar__title"
+      >
+        Products (104)
       </h4>
       
         
       <span
-        class="fd-toolbar__spacer "
+        class="fd-toolbar__spacer"
       />
       
         

--- a/stories/toolbar/toolbar.stories.js
+++ b/stories/toolbar/toolbar.stories.js
@@ -207,8 +207,8 @@ export const Types = () => `<div style="padding: 1rem">
     <div class="fd-toolbar fd-toolbar--info fd-toolbar--active">3 item selected</div>
     <h3>Title</h3>
     <div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
-        <h4 >Producs (104)</h4>
-        <span class="fd-toolbar__spacer "></span>
+        <h4 class="fd-title fd-title--h4 fd-toolbar__title">Products (104)</h4>
+        <span class="fd-toolbar__spacer"></span>
         <button class="fd-button fd-button--compact fd-button--transparent">Save</button>
         <button class="fd-button fd-button--compact fd-button--transparent">Delete</button>
     </div>


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-styles/issues/3213

## Description
 - add delta horizon theming for Toolbar 
 - updated Toolbar title

BREAKING CHANGE:
- updated the markup for the title element in the Toolbar with Title 
- added a new class for Title used in Toolbar: fd-toolbar__title

**Before:**
```
<h4>Producs (104)</h4>
```

**After:**
```
<h4 class="fd-title fd-title--h4 fd-toolbar__title">Products (104)</h4>
```