### PR TITLE
feat(styles): add delta theming for Bar [ci visual]

### DIFF
--- a/src/styles/bar.scss
+++ b/src/styles/bar.scss
@@ -4,7 +4,7 @@
 $block: #{$fd-namespace}-bar;
 
 .#{$block} {
-  $fd-bar-padding-x: 0.5rem !default;
+  $fd-bar-padding-x: 1rem !default;
   $fd-bar-element-spacing: 0.5rem !default;
   $fd-bar-floating-footer-z-index: map-get($fd-z-index-levels, "top") !default;
 
@@ -50,7 +50,7 @@ $block: #{$fd-namespace}-bar;
   }
 
   &__middle {
-    padding: 0 $fd-bar-padding-x;
+    padding: 0 var(--fdBar_Middle_Area_Padding_X);
     justify-content: center;
   }
 
@@ -58,7 +58,13 @@ $block: #{$fd-namespace}-bar;
     padding: 0;
   }
 
+  &__left {
+    @include fd-set-paddings-x(0, var(--fdBar_Left_Area_Padding_Right));
+  }
+
   &__right {
+    @include fd-set-paddings-x(--fdBar_Right_Area_Padding_Left, 0);
+
     justify-content: flex-end;
   }
 
@@ -75,10 +81,6 @@ $block: #{$fd-namespace}-bar;
     @include fd-rtl() {
       margin-right: 0;
       margin-left: $fd-bar-element-spacing;
-    }
-
-    &--title {
-      @include fd-set-paddings-x(0.5rem,0);
     }
   }
 

--- a/src/styles/theming/sap_fiori_3.scss
+++ b/src/styles/theming/sap_fiori_3.scss
@@ -408,4 +408,9 @@
   --fdMessage_Page_Container_Corner_Radius: 0;
   --fdMessage_Page_Title_Margin_Top: 1rem;
   --fdMessage_Page_Title_Margin_Bottom: 1rem;
+
+  /** Bar */
+  --fdBar_Left_Area_Padding_Right: 0;
+  --fdBar_Middle_Area_Padding_X: 0.5rem;
+  --fdBar_Right_Area_Padding_Left: 0;
 }

--- a/src/styles/theming/sap_fiori_3_dark.scss
+++ b/src/styles/theming/sap_fiori_3_dark.scss
@@ -407,4 +407,9 @@
   --fdMessage_Page_Container_Corner_Radius: 0;
   --fdMessage_Page_Title_Margin_Top: 1rem;
   --fdMessage_Page_Title_Margin_Bottom: 1rem;
+
+  /** Bar */
+  --fdBar_Left_Area_Padding_Right: 0;
+  --fdBar_Middle_Area_Padding_X: 0.5rem;
+  --fdBar_Right_Area_Padding_Left: 0;
 }

--- a/src/styles/theming/sap_fiori_3_hcb.scss
+++ b/src/styles/theming/sap_fiori_3_hcb.scss
@@ -407,4 +407,9 @@
   --fdMessage_Page_Container_Corner_Radius: 0;
   --fdMessage_Page_Title_Margin_Top: 1rem;
   --fdMessage_Page_Title_Margin_Bottom: 1rem;
+
+  /** Bar */
+  --fdBar_Left_Area_Padding_Right: 0;
+  --fdBar_Middle_Area_Padding_X: 0.5rem;
+  --fdBar_Right_Area_Padding_Left: 0;
 }

--- a/src/styles/theming/sap_fiori_3_hcw.scss
+++ b/src/styles/theming/sap_fiori_3_hcw.scss
@@ -409,4 +409,9 @@
   --fdMessage_Page_Container_Corner_Radius: 0;
   --fdMessage_Page_Title_Margin_Top: 1rem;
   --fdMessage_Page_Title_Margin_Bottom: 1rem;
+
+  /** Bar */
+  --fdBar_Left_Area_Padding_Right: 0;
+  --fdBar_Middle_Area_Padding_X: 0.5rem;
+  --fdBar_Right_Area_Padding_Left: 0;
 }

--- a/src/styles/theming/sap_fiori_3_light_dark.scss
+++ b/src/styles/theming/sap_fiori_3_light_dark.scss
@@ -407,4 +407,9 @@
   --fdMessage_Page_Container_Corner_Radius: 0;
   --fdMessage_Page_Title_Margin_Top: 1rem;
   --fdMessage_Page_Title_Margin_Bottom: 1rem;
+
+  /** Bar */
+  --fdBar_Left_Area_Padding_Right: 0;
+  --fdBar_Middle_Area_Padding_X: 0.5rem;
+  --fdBar_Right_Area_Padding_Left: 0;
 }

--- a/src/styles/theming/sap_horizon.scss
+++ b/src/styles/theming/sap_horizon.scss
@@ -443,4 +443,9 @@
   --fdMessage_Page_Container_Corner_Radius: var(--sapElement_BorderCornerRadius);
   --fdMessage_Page_Title_Margin_Top: 2rem;
   --fdMessage_Page_Title_Margin_Bottom: 0.5rem;
+
+  /** Bar */
+  --fdBar_Left_Area_Padding_Right: 0.25rem;
+  --fdBar_Middle_Area_Padding_X: 0.25rem;
+  --fdBar_Right_Area_Padding_Left: 0.25rem;
 }

--- a/src/styles/theming/sap_horizon_dark.scss
+++ b/src/styles/theming/sap_horizon_dark.scss
@@ -443,4 +443,9 @@
   --fdMessage_Page_Container_Corner_Radius: var(--sapElement_BorderCornerRadius);
   --fdMessage_Page_Title_Margin_Top: 2rem;
   --fdMessage_Page_Title_Margin_Bottom: 0.5rem;
+
+  /** Bar */
+  --fdBar_Left_Area_Padding_Right: 0.25rem;
+  --fdBar_Middle_Area_Padding_X: 0.25rem;
+  --fdBar_Right_Area_Padding_Left: 0.25rem;
 }

--- a/src/styles/theming/sap_horizon_hcb.scss
+++ b/src/styles/theming/sap_horizon_hcb.scss
@@ -410,4 +410,9 @@
   --fdMessage_Page_Container_Corner_Radius: var(--sapElement_BorderCornerRadius);
   --fdMessage_Page_Title_Margin_Top: 2rem;
   --fdMessage_Page_Title_Margin_Bottom: 0.5rem;
+
+  /** Bar */
+  --fdBar_Left_Area_Padding_Right: 0.25rem;
+  --fdBar_Middle_Area_Padding_X: 0.25rem;
+  --fdBar_Right_Area_Padding_Left: 0.25rem;
 }

--- a/src/styles/theming/sap_horizon_hcw.scss
+++ b/src/styles/theming/sap_horizon_hcw.scss
@@ -409,4 +409,9 @@
   --fdMessage_Page_Container_Corner_Radius: var(--sapElement_BorderCornerRadius);
   --fdMessage_Page_Title_Margin_Top: 2rem;
   --fdMessage_Page_Title_Margin_Bottom: 0.5rem;
+
+  /** Bar */
+  --fdBar_Left_Area_Padding_Right: 0.25rem;
+  --fdBar_Middle_Area_Padding_X: 0.25rem;
+  --fdBar_Right_Area_Padding_Left: 0.25rem;
 }

--- a/stories/bar/__snapshots__/bar.stories.storyshot
+++ b/stories/bar/__snapshots__/bar.stories.storyshot
@@ -228,7 +228,7 @@ exports[`Storyshots Components/Bar Default 1`] = `
       
         
       <div
-        class="fd-bar__element fd-bar__element--title"
+        class="fd-bar__element"
       >
         
             

--- a/stories/bar/bar.stories.js
+++ b/stories/bar/bar.stories.js
@@ -43,7 +43,7 @@ export const Default = () => `
 <p><b>Compact bar with compact elements</b></p>
 <div class="fd-bar">
     <div class="fd-bar__left">
-        <div class="fd-bar__element fd-bar__element--title">
+        <div class="fd-bar__element">
             <h6 class="fd-title fd-title--h6" aria-label="text">TEXT</h6>
         </div>
     </div>
@@ -123,7 +123,7 @@ Default.parameters = {
     docs: {
         iframeHeight: 200,
         description: {
-            story: 'The default bar contains a back button, page title, segmented button and product switch button. It can be displayed by using the `fd-bar` class, and is responsive to desktop screen sizes. The default bar is in compact mode. Fiori 3 doesn\'t forbid including cozy elements inside (e.g. cozy buttons). Add `--title` modifier class to bar element, if title is first element in bar.'
+            story: 'The default bar contains a back button, page title, segmented button and product switch button. It can be displayed by using the `fd-bar` class, and is responsive to desktop screen sizes. The default bar is in compact mode. Fiori 3 doesn\'t forbid including cozy elements inside (e.g. cozy buttons).'
         }
     }
 };


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-styles/issues/3213

## Description
- add delta theming for Bar
- removed unused class `fd-bar__element--title`

BREAKING CHANGE:
removed unused class `fd-bar__element--title`

Before:
```
<div class="fd-bar__element fd-bar__element--title">
      <h6 class="fd-title fd-title--h6" aria-label="text">TEXT</h6>
</div>
```

After:
```
<div class="fd-bar__element">
      <h6 class="fd-title fd-title--h6" aria-label="text">TEXT</h6>
</div>
```
