### PR TITLE
feat(styles): add delta horizon theming for Message Page [ci visual]

### DIFF
--- a/src/styles/message-page.scss
+++ b/src/styles/message-page.scss
@@ -9,7 +9,6 @@ $block: #{$fd-namespace}-message-page;
 
   width: 100%;
   height: 100%;
-  padding: 1rem;
   background: var(--sapBackgroundColor);
 
   &__container,
@@ -28,7 +27,17 @@ $block: #{$fd-namespace}-message-page;
       align-items: center;
     }
 
+    padding: 1rem;
     transform: translateY(-1rem);
+    background: var(--fdMessage_Page_Container_Background);
+    border-radius: var(--fdMessage_Page_Container_Corner_Radius);
+  }
+
+  &__illustration-container {
+    @include fd-reset();
+
+    max-width: 20rem;
+    max-height: 15rem;
   }
 
   &__icon-container {
@@ -57,7 +66,8 @@ $block: #{$fd-namespace}-message-page;
   }
 
   &__title {
-    margin: 1rem 0;
+    margin-top: var(--fdMessage_Page_Title_Margin_Top);
+    margin-bottom: var(--fdMessage_Page_Title_Margin_Bottom);
     text-align: center;
     font-size: var(--sapFontHeader2Size);
     color: var(--sapGroup_TitleTextColor);

--- a/src/styles/theming/sap_fiori_3.scss
+++ b/src/styles/theming/sap_fiori_3.scss
@@ -402,4 +402,10 @@
   --fdShellbar_Input_Placeholder_Color: var(--sapShell_InteractiveTextColor);
   --fdShellbar_Input_Border_Radius: var(--sapField_BorderCornerRadius);
   --fdShellbar_Input_Addon_Dimension: 2.25rem;
+
+  /** Message Page */
+  --fdMessage_Page_Container_Background: transparent;
+  --fdMessage_Page_Container_Corner_Radius: 0;
+  --fdMessage_Page_Title_Margin_Top: 1rem;
+  --fdMessage_Page_Title_Margin_Bottom: 1rem;
 }

--- a/src/styles/theming/sap_fiori_3_dark.scss
+++ b/src/styles/theming/sap_fiori_3_dark.scss
@@ -401,4 +401,10 @@
   --fdShellbar_Input_Placeholder_Color: var(--sapShell_InteractiveTextColor);
   --fdShellbar_Input_Border_Radius: var(--sapField_BorderCornerRadius);
   --fdShellbar_Input_Addon_Dimension: 2.25rem;
+
+  /** Message Page */
+  --fdMessage_Page_Container_Background: transparent;
+  --fdMessage_Page_Container_Corner_Radius: 0;
+  --fdMessage_Page_Title_Margin_Top: 1rem;
+  --fdMessage_Page_Title_Margin_Bottom: 1rem;
 }

--- a/src/styles/theming/sap_fiori_3_hcb.scss
+++ b/src/styles/theming/sap_fiori_3_hcb.scss
@@ -401,4 +401,10 @@
   --fdShellbar_Input_Placeholder_Color: var(--sapShell_InteractiveTextColor);
   --fdShellbar_Input_Border_Radius: var(--sapField_BorderCornerRadius);
   --fdShellbar_Input_Addon_Dimension: 2.25rem;
+
+  /** Message Page */
+  --fdMessage_Page_Container_Background: transparent;
+  --fdMessage_Page_Container_Corner_Radius: 0;
+  --fdMessage_Page_Title_Margin_Top: 1rem;
+  --fdMessage_Page_Title_Margin_Bottom: 1rem;
 }

--- a/src/styles/theming/sap_fiori_3_hcw.scss
+++ b/src/styles/theming/sap_fiori_3_hcw.scss
@@ -403,4 +403,10 @@
   --fdShellbar_Input_Placeholder_Color: var(--sapShell_InteractiveTextColor);
   --fdShellbar_Input_Border_Radius: var(--sapField_BorderCornerRadius);
   --fdShellbar_Input_Addon_Dimension: 2.25rem;
+
+  /** Message Page */
+  --fdMessage_Page_Container_Background: transparent;
+  --fdMessage_Page_Container_Corner_Radius: 0;
+  --fdMessage_Page_Title_Margin_Top: 1rem;
+  --fdMessage_Page_Title_Margin_Bottom: 1rem;
 }

--- a/src/styles/theming/sap_fiori_3_light_dark.scss
+++ b/src/styles/theming/sap_fiori_3_light_dark.scss
@@ -401,4 +401,10 @@
   --fdShellbar_Input_Placeholder_Color: var(--sapShell_InteractiveTextColor);
   --fdShellbar_Input_Border_Radius: var(--sapField_BorderCornerRadius);
   --fdShellbar_Input_Addon_Dimension: 2.25rem;
+
+  /** Message Page */
+  --fdMessage_Page_Container_Background: transparent;
+  --fdMessage_Page_Container_Corner_Radius: 0;
+  --fdMessage_Page_Title_Margin_Top: 1rem;
+  --fdMessage_Page_Title_Margin_Bottom: 1rem;
 }

--- a/src/styles/theming/sap_horizon.scss
+++ b/src/styles/theming/sap_horizon.scss
@@ -437,4 +437,10 @@
   --fdShellbar_Input_Placeholder_Color: var(--sapField_PlaceholderTextColor);
   --fdShellbar_Input_Border_Radius: 1.125rem;
   --fdShellbar_Input_Addon_Dimension: 1.75rem;
+
+  /** Message Page */
+  --fdMessage_Page_Container_Background: var(--sapGroup_ContentBackground);
+  --fdMessage_Page_Container_Corner_Radius: var(--sapElement_BorderCornerRadius);
+  --fdMessage_Page_Title_Margin_Top: 2rem;
+  --fdMessage_Page_Title_Margin_Bottom: 0.5rem;
 }

--- a/src/styles/theming/sap_horizon_dark.scss
+++ b/src/styles/theming/sap_horizon_dark.scss
@@ -437,4 +437,10 @@
   --fdShellbar_Input_Placeholder_Color: var(--sapField_PlaceholderTextColor);
   --fdShellbar_Input_Border_Radius: 1.125rem;
   --fdShellbar_Input_Addon_Dimension: 1.75rem;
+
+  /** Message Page */
+  --fdMessage_Page_Container_Background: var(--sapGroup_ContentBackground);
+  --fdMessage_Page_Container_Corner_Radius: var(--sapElement_BorderCornerRadius);
+  --fdMessage_Page_Title_Margin_Top: 2rem;
+  --fdMessage_Page_Title_Margin_Bottom: 0.5rem;
 }

--- a/src/styles/theming/sap_horizon_hcb.scss
+++ b/src/styles/theming/sap_horizon_hcb.scss
@@ -404,4 +404,10 @@
   --fdShellbar_Input_Placeholder_Color: var(--sapField_PlaceholderTextColor);
   --fdShellbar_Input_Border_Radius: 1.125rem;
   --fdShellbar_Input_Addon_Dimension: 1.75rem;
+
+  /** Message Page */
+  --fdMessage_Page_Container_Background: var(--sapGroup_ContentBackground);
+  --fdMessage_Page_Container_Corner_Radius: var(--sapElement_BorderCornerRadius);
+  --fdMessage_Page_Title_Margin_Top: 2rem;
+  --fdMessage_Page_Title_Margin_Bottom: 0.5rem;
 }

--- a/src/styles/theming/sap_horizon_hcw.scss
+++ b/src/styles/theming/sap_horizon_hcw.scss
@@ -403,4 +403,10 @@
   --fdShellbar_Input_Placeholder_Color: var(--sapField_PlaceholderTextColor);
   --fdShellbar_Input_Border_Radius: 1.125rem;
   --fdShellbar_Input_Addon_Dimension: 1.75rem;
+
+  /** Message Page */
+  --fdMessage_Page_Container_Background: var(--sapGroup_ContentBackground);
+  --fdMessage_Page_Container_Corner_Radius: var(--sapElement_BorderCornerRadius);
+  --fdMessage_Page_Title_Margin_Top: 2rem;
+  --fdMessage_Page_Title_Margin_Bottom: 0.5rem;
 }


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-styles/pull/3269

## Description
- add delta horizon theming for Message Page
- add a new class for the container holding the illustration: `.fd-message-page__illustration-container`
