### PR TITLE
fix: select min-width fix, overflow fix

### DIFF
--- a/src/styles/popover.scss
+++ b/src/styles/popover.scss
@@ -25,6 +25,7 @@ $block: #{$fd-namespace}-popover;
 
   position: relative;
   display: inline-block;
+  max-width: 100%;
   text-shadow: var(--fdPopover_Text_Shadow);
 
   &__control {

--- a/src/styles/select.scss
+++ b/src/styles/select.scss
@@ -29,6 +29,10 @@ $block: #{$fd-namespace}-select;
     }
   }
 
+  @mixin fd-select-set-min-width($width) {
+    min-width: calc(#{$width} - var(--sapField_BorderWidth) * 2);
+  }
+
   @include fd-reset();
 
   text-shadow: var(--fdSelect_Text_Shadow);
@@ -89,19 +93,18 @@ $block: #{$fd-namespace}-select;
 
       .#{$block}__text-content {
         @include fd-set-paddings-x-equal($fd-select-padding-x);
-
-        min-width: calc(5rem - var(--sapField_BorderWidth) * 2);
+        @include fd-select-set-min-width(5rem);
       }
     }
   }
 
   &__text-content {
     @include fd-reset();
-    @include fd-set-padding-left($fd-select-padding-x);
     @include fd-ellipsis();
+    @include fd-set-padding-left($fd-select-padding-x);
+    @include fd-select-set-min-width(2.5rem);
 
     display: inline-block;
-    min-width: calc(2.5rem - var(--sapField_BorderWidth) * 2);
   }
 
   &--compact {
@@ -110,8 +113,7 @@ $block: #{$fd-namespace}-select;
 
       .#{$block}__text-content {
         @include fd-set-padding-left($fd-select-padding-x-compact);
-
-        min-width: calc(2.75rem - var(--sapField_BorderWidth) * 2);
+        @include fd-select-set-min-width(2.75rem);
       }
 
       &.is-readonly {

--- a/src/styles/select.scss
+++ b/src/styles/select.scss
@@ -89,6 +89,8 @@ $block: #{$fd-namespace}-select;
 
       .#{$block}__text-content {
         @include fd-set-paddings-x-equal($fd-select-padding-x);
+
+        min-width: calc(5rem - var(--sapField_BorderWidth) * 2);
       }
     }
   }
@@ -96,8 +98,10 @@ $block: #{$fd-namespace}-select;
   &__text-content {
     @include fd-reset();
     @include fd-set-padding-left($fd-select-padding-x);
+    @include fd-ellipsis();
 
-    min-width: 2.75rem;
+    display: inline-block;
+    min-width: calc(2.5rem - var(--sapField_BorderWidth) * 2);
   }
 
   &--compact {
@@ -107,7 +111,7 @@ $block: #{$fd-namespace}-select;
       .#{$block}__text-content {
         @include fd-set-padding-left($fd-select-padding-x-compact);
 
-        min-width: 2rem;
+        min-width: calc(2.75rem - var(--sapField_BorderWidth) * 2);
       }
 
       &.is-readonly {

--- a/stories/pagination/pagination.stories.js
+++ b/stories/pagination/pagination.stories.js
@@ -351,7 +351,7 @@ export const PerPage = () => `<div style='height: 175px'>
                                         toggleElAttrs('compactSelectCombobox', ['aria-expanded']);
                                     " class='fd-select__control' tabindex='0' aria-labelledby='compactSelectLabel compactSelectValue' aria-expanded='true' aria-haspopup='listbox'>
                           <span id='compactSelectValue' class='fd-select__text-content'>4</span>
-                          <span class='fd-button fd-button--transparent fd-select__button'>
+                          <span class='fd-button fd-button--transparent fd-button--compact fd-select__button'>
                                         <i class='sap-icon--slim-arrow-down'></i>
                                     </span>
                         </button>


### PR DESCRIPTION
## Related Issue

Relates to https://github.com/SAP/fundamental-ngx/issues/7929

## Description

Select component:
* Min-width fix,
* Selected item overflow.

## Screenshots

### Before:

<img width="993" alt="image" src="https://user-images.githubusercontent.com/20265336/161795166-ad10593d-6e76-49b3-89ab-d915f2444a6c.png">

<img width="327" alt="image" src="https://user-images.githubusercontent.com/20265336/161794453-e77158c9-9a8c-4323-9dc6-73fe5dd0ba80.png">

### After:

<img width="1001" alt="image" src="https://user-images.githubusercontent.com/20265336/161795197-ca4b3bac-91ae-4727-a81b-85e09910afb8.png">

<img width="346" alt="image" src="https://user-images.githubusercontent.com/20265336/161794945-b27c8fee-4534-4cef-9b29-1764fb6cbcc2.png">
