### PR TITLE
fix: table text shadow removal

### DIFF
--- a/src/styles/table.scss
+++ b/src/styles/table.scss
@@ -15,15 +15,17 @@ $block: #{$fd-namespace}-table;
   @mixin fd-table-active() {
     background-color: var(--sapList_Active_Background);
     color: var(--sapList_Active_TextColor);
-    text-shadow: none;
 
     .#{$block}__cell {
       border-bottom-color: var(--sapList_SelectionBorderColor);
-      text-shadow: none;
 
       @include fd-hover() {
         background-color: var(--sapList_Active_Background);
       }
+    }
+
+    .#{$block}__text {
+      text-shadow: none;
     }
 
     .#{$block}__icon {
@@ -194,6 +196,7 @@ $block: #{$fd-namespace}-table;
 
     word-break: break-word;
     white-space: normal;
+    text-shadow: var(--sapContent_TextShadow);
 
     &--no-wrap {
       white-space: nowrap;
@@ -202,7 +205,6 @@ $block: #{$fd-namespace}-table;
 
   &__cell {
     text-align: left;
-    text-shadow: var(--sapContent_TextShadow);
     height: $fd-table-cozy-cell-height;
     padding: 0 $fd-table-cell-padding;
     color: inherit;

--- a/stories/table/table.stories.js
+++ b/stories/table/table.stories.js
@@ -771,9 +771,9 @@ export const Checkbox = () => `<div class="fd-toolbar fd-toolbar--solid fd-toolb
                 <label class="fd-checkbox__label fd-table__checkbox-label" for="Ai4ez615"></label>
             </td>
             <td class="fd-table__cell"><a class="fd-link">user.name@email.com</a></td>
-            <td class="fd-table__cell">First Name</td>
-            <td class="fd-table__cell">Last Name</td>
-            <td class="fd-table__cell">01/26/17</td>
+            <td class="fd-table__cell"><span class="fd-table__text">First Name</span></td>
+            <td class="fd-table__cell"><span class="fd-table__text">Last Name</span></td>
+            <td class="fd-table__cell"><span class="fd-table__text">01/26/17</span></td>
         </tr>
         <tr class="fd-table__row">
             <td class="fd-table__cell fd-table__cell--checkbox">
@@ -836,9 +836,9 @@ export const CompactCheckbox = () => `<div class="fd-toolbar fd-toolbar--solid f
                 <label class="fd-checkbox__label fd-table__checkbox-label" for="Ai4HFHG1"></label>
             </td>
             <td class="fd-table__cell"><a class="fd-link">user.name@email.com</a></td>
-            <td class="fd-table__cell">First Name</td>
-            <td class="fd-table__cell">Last Name</td>
-            <td class="fd-table__cell">01/26/17</td>
+            <td class="fd-table__cell"><span class="fd-table__text">First Name</span></td>
+            <td class="fd-table__cell"><span class="fd-table__text">Last Name</span></td>
+            <td class="fd-table__cell"><span class="fd-table__text">01/26/17</span></td>
         </tr>
         <tr class="fd-table__row">
             <td class="fd-table__cell fd-table__cell--checkbox">
@@ -902,9 +902,9 @@ export const CondensedCheckbox = () => `<div class="fd-toolbar fd-toolbar--solid
                 <label class="fd-checkbox__label fd-table__checkbox-label" for="Ai4JHf87"></label>
             </td>
             <td class="fd-table__cell"><a class="fd-link">user.name@email.com</a></td>
-            <td class="fd-table__cell">First Name</td>
-            <td class="fd-table__cell">Last Name</td>
-            <td class="fd-table__cell">01/26/17</td>
+            <td class="fd-table__cell"><span class="fd-table__text">First Name</span></td>
+            <td class="fd-table__cell"><span class="fd-table__text">Last Name</span></td>
+            <td class="fd-table__cell"><span class="fd-table__text">01/26/17</span></td>
         </tr>
         <tr class="fd-table__row">
             <td class="fd-table__cell fd-table__cell--checkbox">
@@ -1689,9 +1689,9 @@ export const NavIndicators = () => `<div class="fd-toolbar fd-toolbar--solid fd-
                 <label class="fd-checkbox__label" for="EWuzWh33"></label>
             </td>
             <td class="fd-table__cell"><a class="fd-link">user.name@email.com</a></td>
-            <td class="fd-table__cell">First Name</td>
-            <td class="fd-table__cell">Last Name</td>
-            <td class="fd-table__cell">01/26/17</td>
+            <td class="fd-table__cell"><span class="fd-table__text">First Name</span></td>
+            <td class="fd-table__cell"><span class="fd-table__text">Last Name</span></td>
+            <td class="fd-table__cell"><span class="fd-table__text">01/26/17</span></td>
             <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--no-padding">
                 <i class="fd-table__icon fd-table__icon--navigation sap-icon--slim-arrow-right" role="presentation"></i>
             </td>
@@ -1702,9 +1702,9 @@ export const NavIndicators = () => `<div class="fd-toolbar fd-toolbar--solid fd-
                 <label class="fd-checkbox__label" for="EWuzWh334"></label>
             </td>
             <td class="fd-table__cell"><a class="fd-link">user.name@email.com</a></td>
-            <td class="fd-table__cell">First Name</td>
-            <td class="fd-table__cell">Last Name</td>
-            <td class="fd-table__cell">01/26/17</td>
+            <td class="fd-table__cell"><span class="fd-table__text">First Name</span></td>
+            <td class="fd-table__cell"><span class="fd-table__text">Last Name</span></td>
+            <td class="fd-table__cell"><span class="fd-table__text">01/26/17</span></td>
             <td class="fd-table__cell fd-table__cell--fit-content fd-table__cell--navigated fd-table__cell--no-padding">
                 <i class="fd-table__icon fd-table__icon--navigation sap-icon--slim-arrow-right" role="presentation"></i>
             </td>


### PR DESCRIPTION
## Related Issue

Relates to https://github.com/SAP/fundamental-ngx/issues/7930

## Description

Text shadow moved from the table to the table text element. 

Previously it was added to the cells in pr https://github.com/SAP/fundamental-styles/pull/1571 but in that way it breaks other components styles, see the mentioned issue. 

## Screenshots

### Before

<img width="953" alt="image" src="https://user-images.githubusercontent.com/20265336/161911954-4527c481-1d60-41d7-a8f2-ec7b0f6a1810.png">

### After

<img width="958" alt="image" src="https://user-images.githubusercontent.com/20265336/161911823-cd558025-8269-4f87-8803-ba3fd2672bc7.png">

## BREAKING CHANGE

* Now you should wrap text in element with `fd-table__text` class to apply text shadow to it. 
