### PR TITLE
feat(styles): icon tabs header horizon delta theming

### DIFF
--- a/src/styles/icon-tab-bar.scss
+++ b/src/styles/icon-tab-bar.scss
@@ -1071,8 +1071,6 @@ $fd-icon-tab-bar-semantic-values: (
           }
 
           .#{$block}__label {
-            color: map_get($set-params, 'color');
-
             &::before {
               @extend %semantic-icon-base;
 

--- a/src/styles/icon-tab-bar.scss
+++ b/src/styles/icon-tab-bar.scss
@@ -522,6 +522,8 @@ $fd-icon-tab-bar-semantic-values: (
     @include fd-icon-selector() {
       font-size: 1.25rem;
       color: var(--sapContent_IconColor);
+
+      @include fd-inline-flex-center();
     }
 
     border-radius: 50%;

--- a/src/styles/icon-tab-bar.scss
+++ b/src/styles/icon-tab-bar.scss
@@ -550,8 +550,9 @@ $fd-icon-tab-bar-semantic-values: (
     @include fd-ellipsis();
 
     line-height: 0.875rem;
-    font-size: var(--sapFontSmallSize);
-    color: var(--sapContent_LabelColor);
+    font-family: var(--fdIcon_Tab_Bar_Label_Font_Family);
+    font-size: var(--fdIcon_Tab_Bar_Label_Font_Size);
+    color: var(--fdIcon_Tab_Bar_Label_Color);
   }
 
   &__separator {

--- a/src/styles/icon-tab-bar.scss
+++ b/src/styles/icon-tab-bar.scss
@@ -521,7 +521,7 @@ $fd-icon-tab-bar-semantic-values: (
 
     @include fd-icon-selector() {
       font-size: 1.25rem;
-      color: var(--sapContent_IconColor);
+      color: var(--fdIcon_Tab_Bar_Inactive_Tab_Icon_Color);
 
       @include fd-inline-flex-center();
     }

--- a/src/styles/icon-tab-bar.scss
+++ b/src/styles/icon-tab-bar.scss
@@ -1178,6 +1178,12 @@ $fd-icon-tab-bar-semantic-values: (
 
     .#{$block}__item {
       color: var(--sapShell_Navigation_TextColor);
+
+      &--overflow {
+        .#{$block}__overflow {
+          border-color: transparent;
+        }
+      }
     }
 
     .#{$block}__tab {

--- a/src/styles/icon-tab-bar.scss
+++ b/src/styles/icon-tab-bar.scss
@@ -12,8 +12,8 @@ $fd-icon-tab-bar-icon-circle-size-compact: 2rem !default;
 $fd-icon-tab-bar-multi-click-button-size: 1.5rem !default;
 $fd-icon-tab-bar-tablist-border: var(--sapContent_HeaderShadow);
 $fd-icon-tab-bar-filter-container-top-offset: 1.625rem !default;
-$fd-icon-tab-bar-overflow-button-border-radius: 0.75rem !default;
-$fd-icon-tab-bar-overflow-button-focus-offset: 0.125rem !default;
+$fd-icon-tab-bar-overflow-button-border-radius: var(--fdIcon_Tab_Bar_Overflow_Button_Border_Radius) !default;
+$fd-icon-tab-bar-overflow-button-focus-offset: var(--fdIcon_Tab_Bar_Overflow_Button_Focus_Offset) !default;
 $fd-icon-tab-bar-filter-container-top-offset-compact: 1.375rem !default;
 $fd-icon-tab-bar-dnd-separator-bar-horizontal-offset: -0.5rem !default;
 $fd-icon-tab-bar-dnd-separator-bar-vertical-offset: 0.125rem !default;
@@ -22,36 +22,36 @@ $fd-icon-tab-bar-dnd-separator-circle-vertical-offset: -0.0625rem !default;
 $fd-icon-tab-bar-dnd-separator-circle-size: 0.5rem !default;
 
 $fd-icon-tab-bar-responsive-paddings: (
-  'sm':  ('padding': 0 1rem),
-  'md':  ('padding': 0 2rem),
-  'lg':  ('padding': 0 2rem),
-  'xl':  ('padding': 0 3rem),
+  'sm': ('padding': 0 1rem),
+  'md': ('padding': 0 2rem),
+  'lg': ('padding': 0 2rem),
+  'xl': ('padding': 0 3rem),
   'xxl': ('padding': 0 3rem)
 );
 
 $fd-icon-tab-bar-semantic-values: (
-  'negative':  (
+  'negative': (
     'icon': '\e1ec',
     'iconColor': var(--sapNegativeElementColor),
     'color': var(--fdIcon_Tab_Bar_Semantic_Color_Negative),
     'badgeColor': var(--fdIcon_Tab_Bar_Semantic_Badge_Color_Negative),
     'backgroundColor': var(--fdIcon_Tab_Bar_Semantic_Background_Color_Negative)
   ),
-  'positive':  (
+  'positive': (
     'icon': '\e1c1',
     'iconColor': var(--sapPositiveElementColor),
     'color': var(--fdIcon_Tab_Bar_Semantic_Color_Positive),
     'badgeColor': var(--fdIcon_Tab_Bar_Semantic_Badge_Color_Positive),
     'backgroundColor': var(--fdIcon_Tab_Bar_Semantic_Background_Color_Positive)
   ),
-  'critical':  (
+  'critical': (
     'icon': '\e053',
     'iconColor': var(--sapCriticalElementColor),
     'color': var(--fdIcon_Tab_Bar_Semantic_Color_Critical),
     'badgeColor': var(--fdIcon_Tab_Bar_Semantic_Badge_Color_Critical),
     'backgroundColor': var(--fdIcon_Tab_Bar_Semantic_Background_Color_Critical)
   ),
-  'informative':  (
+  'informative': (
     'icon': '\e289',
     'iconColor': var(--sapInformativeElementColor),
     'color': var(--fdIcon_Tab_Bar_Semantic_Color_Informative),
@@ -332,9 +332,16 @@ $fd-icon-tab-bar-semantic-values: (
       top: 50%;
       transform: translateY(-50%);
       margin: 0;
+      padding-right: 0;
+
+      @include fd-set-padding-left(var(--fdIcon_Tab_Bar_Overflowing_Padding));
 
       &-left {
         @include fd-set-position-left(0);
+
+        padding-left: 0;
+
+        @include fd-set-padding-right(var(--fdIcon_Tab_Bar_Overflowing_Padding));
       }
 
       .#{$block}__popover {
@@ -668,6 +675,8 @@ $fd-icon-tab-bar-semantic-values: (
         var(--sapButton_Hover_TextColor),
         var(--sapButton_Hover_TextColor)
       );
+
+      box-shadow: var(--fdIcon_Tab_Bar_Overflow_Button_Hover_Box_Shadow);
     }
 
     @include fd-active() {

--- a/src/styles/icon-tab-bar.scss
+++ b/src/styles/icon-tab-bar.scss
@@ -512,7 +512,7 @@ $fd-icon-tab-bar-semantic-values: (
   &__tag {
     @extend %fd-icon-tab-bar-text;
 
-    font-family: var(--fdIcon_Tab_Bar_Label_Font_Family);
+    font-weight: var(--fdIcon_Tab_Bar_Label_Font_Weight);
     color: var(--fdIcon_Tab_Bar_Label_Color);
     font-size: var(--fdIcon_Tab_Bar_Label_Font_Size);
   }
@@ -560,7 +560,7 @@ $fd-icon-tab-bar-semantic-values: (
     @include fd-ellipsis();
 
     line-height: 0.875rem;
-    font-family: var(--fdIcon_Tab_Bar_Label_Font_Family);
+    font-weight: var(--fdIcon_Tab_Bar_Label_Font_Weight);
     font-size: var(--fdIcon_Tab_Bar_Label_Font_Size);
     color: var(--fdIcon_Tab_Bar_Label_Color);
   }

--- a/src/styles/icon-tab-bar.scss
+++ b/src/styles/icon-tab-bar.scss
@@ -472,6 +472,12 @@ $fd-icon-tab-bar-semantic-values: (
       }
     }
 
+    @include fd-hover() {
+      .#{$block}__tag {
+        color: var(--fdIcon_Tab_Bar_Label_Hover_Color);
+      }
+    }
+
     @include fd-focus() {
       box-shadow: none;
       outline: none;
@@ -505,6 +511,10 @@ $fd-icon-tab-bar-semantic-values: (
 
   &__tag {
     @extend %fd-icon-tab-bar-text;
+
+    font-family: var(--fdIcon_Tab_Bar_Label_Font_Family);
+    color: var(--fdIcon_Tab_Bar_Label_Color);
+    font-size: var(--fdIcon_Tab_Bar_Label_Font_Size);
   }
 
   &__counter {

--- a/src/styles/icon-tab-bar.scss
+++ b/src/styles/icon-tab-bar.scss
@@ -269,10 +269,6 @@ $fd-icon-tab-bar-semantic-values: (
     min-height: 2.75rem;
     position: relative;
     overflow-x: hidden;
-
-    &--left-offset {
-      @include fd-set-padding-left(3.5rem);
-    }
   }
 
   &__panel {
@@ -323,34 +319,6 @@ $fd-icon-tab-bar-semantic-values: (
 
         .#{$block}__badge {
           @include fd-set-position-right(1.625rem);
-        }
-      }
-    }
-
-    &.#{$block}__item--overflow {
-      position: absolute;
-      top: 50%;
-      transform: translateY(-50%);
-      margin: 0;
-      padding-right: 0;
-
-      @include fd-set-padding-left(var(--fdIcon_Tab_Bar_Overflowing_Padding));
-
-      &-left {
-        @include fd-set-position-left(0);
-
-        padding-left: 0;
-
-        @include fd-set-padding-right(var(--fdIcon_Tab_Bar_Overflowing_Padding));
-      }
-
-      .#{$block}__popover {
-        position: relative;
-
-        &-body {
-          @include fd-set-margin-right(-0.25rem);
-
-          margin-top: 0.375rem;
         }
       }
     }
@@ -853,6 +821,7 @@ $fd-icon-tab-bar-semantic-values: (
     }
 
     height: $fd-icon-tab-bar-icon-separator-size;
+    padding: 0 0.5rem;
 
     [class*='sap-icon'] {
       width: $fd-icon-tab-bar-icon-separator-size;
@@ -1383,6 +1352,34 @@ $fd-icon-tab-bar-semantic-values: (
     .#{$block}__header {
       @include fd-reset-paddings-y();
       @include fd-apply-responsive-paddings();
+    }
+  }
+}
+
+.#{$block},
+.#{$block}--filter,
+.#{$block}--icon,
+.#{$block}--icon-only,
+.#{$block}--navigation,
+.#{$block}--navigation-flat,
+.#{$block}--process {
+  .#{$block}__item {
+    &--overflow {
+      margin: 0;
+
+      &:last-of-type {
+        @include fd-set-margin-left(auto);
+      }
+
+      .#{$block}__popover {
+        position: relative;
+
+        &-body {
+          @include fd-set-margin-right(-0.25rem);
+
+          margin-top: 0.375rem;
+        }
+      }
     }
   }
 }

--- a/src/styles/icon-tab-bar.scss
+++ b/src/styles/icon-tab-bar.scss
@@ -20,6 +20,7 @@ $fd-icon-tab-bar-dnd-separator-bar-vertical-offset: 0.125rem !default;
 $fd-icon-tab-bar-dnd-separator-circle-horizontal-offset: -0.7rem !default;
 $fd-icon-tab-bar-dnd-separator-circle-vertical-offset: -0.0625rem !default;
 $fd-icon-tab-bar-dnd-separator-circle-size: 0.5rem !default;
+$fd-icon-tab-bar-focus-offset: var(--fdIcon_Tab_Bar_Focus_Offset) !default;
 
 $fd-icon-tab-bar-responsive-paddings: (
   'sm': ('padding': 0 1rem),
@@ -137,13 +138,22 @@ $fd-icon-tab-bar-semantic-values: (
   }
 }
 
-@mixin fd-tabs-focus($outlineColor: var(--sapContent_FocusColor), $offset: false) {
-  outline-color: $outlineColor;
-  outline-style: var(--sapContent_FocusStyle);
-  outline-width: var(--sapContent_FocusWidth);
+@mixin fd-tabs-focus($outlineColor: var(--sapContent_FocusColor), $offset: false, $placement: "after") {
+  &::#{$placement} {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: block;
+    border: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) $outlineColor;
 
-  @if $offset {
-    outline-offset: 0.0625rem;
+    @if $offset {
+      @include fd-set-equal-positions($fd-icon-tab-bar-focus-offset);
+    }
+
+    @content;
   }
 }
 
@@ -288,6 +298,8 @@ $fd-icon-tab-bar-semantic-values: (
 
         @include fd-focus() {
           .#{$block}__tab-container {
+            position: relative;
+
             @include fd-tabs-focus();
           }
 
@@ -482,10 +494,24 @@ $fd-icon-tab-bar-semantic-values: (
       box-shadow: none;
       outline: none;
 
-      .#{$block}__tag,
-      .#{$block}__icon,
+      .#{$block}__icon {
+        @include fd-tabs-focus(var(--sapContent_FocusColor), true) {
+          border-radius: var(--fdIcon_Tab_Bar_Icon_Focus_Radius);
+
+          @include fd-set-equal-positions(var(--fdIcon_Tab_Bar_Icon_Focus_Offset));
+        }
+      }
+
+      .#{$block}__tag {
+        @include fd-tabs-focus(var(--sapContent_FocusColor), true) {
+          border-radius: var(--fdIcon_Tab_Bar_Text_Focus_Radius);
+        };
+      }
+
       .#{$block}__container--filter {
-        @include fd-tabs-focus();
+        @include fd-tabs-focus(var(--sapContent_FocusColor), true, "before") {
+          border-radius: var(--fdIcon_Tab_Bar_Text_Focus_Radius);
+        };
       }
     }
 
@@ -512,6 +538,7 @@ $fd-icon-tab-bar-semantic-values: (
   &__tag {
     @extend %fd-icon-tab-bar-text;
 
+    position: relative;
     font-weight: var(--fdIcon_Tab_Bar_Label_Font_Weight);
     color: var(--fdIcon_Tab_Bar_Label_Color);
     font-size: var(--fdIcon_Tab_Bar_Label_Font_Size);
@@ -536,8 +563,9 @@ $fd-icon-tab-bar-semantic-values: (
       @include fd-inline-flex-center();
     }
 
+    position: relative;
     border-radius: 50%;
-    border: $fd-icon-tab-bar-border-thickness solid var(--fdIcon_Tab_Bar_Icon_Border_Color);
+    border: var(--fdIcon_Tab_Bar_Icon_Border_Weight) solid var(--fdIcon_Tab_Bar_Icon_Border_Color);
   }
 
   &__details {
@@ -1222,6 +1250,8 @@ $fd-icon-tab-bar-semantic-values: (
 
       @include fd-focus() {
         .#{$block}__tab-container {
+          position: relative;
+
           @include fd-tabs-focus(var(--sapShell_Navigation_TextColor), true);
 
           .#{$block}__tag {

--- a/src/styles/mixins/_mixins.scss
+++ b/src/styles/mixins/_mixins.scss
@@ -620,6 +620,13 @@
   }
 }
 
+@mixin fd-set-equal-positions($value) {
+  top: $value;
+  right: $value;
+  bottom: $value;
+  left: $value;
+}
+
 /* Fully expanded pseudo element. Requires parent to have specified position */
 @mixin fd-pseudo-expand($position: "before") {
   &::#{$position} {

--- a/src/styles/theming/common/icon-tab-bar/_sap_fiori.scss
+++ b/src/styles/theming/common/icon-tab-bar/_sap_fiori.scss
@@ -22,6 +22,7 @@
   --fdIcon_Tab_Bar_Overflow_Button_Border_Radius: 0.75rem;
   --fdIcon_Tab_Bar_Inactive_Tab_Icon_Color: var(--sapContent_IconColor);
   --fdIcon_Tab_Bar_Label_Color: var(--sapContent_LabelColor);
+  --fdIcon_Tab_Bar_Label_Hover_Color: var(--sapContent_LabelColor);
   --fdIcon_Tab_Bar_Label_Font_Family: var(--sapFontFamily);
   --fdIcon_Tab_Bar_Label_Font_Size: var(--sapFontSmallSize);
 }

--- a/src/styles/theming/common/icon-tab-bar/_sap_fiori.scss
+++ b/src/styles/theming/common/icon-tab-bar/_sap_fiori.scss
@@ -21,4 +21,7 @@
   --fdIcon_Tab_Bar_Overflow_Button_Focus_Offset: 0.125rem;
   --fdIcon_Tab_Bar_Overflow_Button_Border_Radius: 0.75rem;
   --fdIcon_Tab_Bar_Inactive_Tab_Icon_Color: var(--sapContent_IconColor);
+  --fdIcon_Tab_Bar_Label_Color: var(--sapContent_LabelColor);
+  --fdIcon_Tab_Bar_Label_Font_Family: var(--sapFontFamily);
+  --fdIcon_Tab_Bar_Label_Font_Size: var(--sapFontSmallSize);
 }

--- a/src/styles/theming/common/icon-tab-bar/_sap_fiori.scss
+++ b/src/styles/theming/common/icon-tab-bar/_sap_fiori.scss
@@ -1,0 +1,24 @@
+:root {
+  --fdIcon_Tab_Bar_Selection_Bar_Height: 0.188rem;
+  --fdIcon_Tab_Bar_Selection_Color: var(--sapSelectedColor);
+  --fdIcon_Tab_Bar_Selection_Bar_Color: var(--sapSelectedColor);
+  --fdIcon_Tab_Bar_Icon_Border_Color: var(--sapSelectedColor);
+  --fdIcon_Tab_Bar_Semantic_Icon_Display: none;
+  --fdIcon_Tab_Bar_Semantic_Color_Positive: var(--sapPositiveElementColor);
+  --fdIcon_Tab_Bar_Semantic_Color_Negative: var(--sapNegativeElementColor);
+  --fdIcon_Tab_Bar_Semantic_Color_Critical: var(--sapCriticalElementColor);
+  --fdIcon_Tab_Bar_Semantic_Color_Informative: var(--sapInformativeElementColor);
+  --fdIcon_Tab_Bar_Semantic_Background_Color_Positive: var(--sapPositiveElementColor);
+  --fdIcon_Tab_Bar_Semantic_Background_Color_Negative: var(--sapNegativeElementColor);
+  --fdIcon_Tab_Bar_Semantic_Background_Color_Critical: var(--sapCriticalElementColor);
+  --fdIcon_Tab_Bar_Semantic_Background_Color_Informative: var(--sapInformativeElementColor);
+  --fdIcon_Tab_Bar_Badge_Color: var(--sapContent_BadgeBackground);
+  --fdIcon_Tab_Bar_Semantic_Badge_Color_Positive: var(--sapPositiveElementColor);
+  --fdIcon_Tab_Bar_Semantic_Badge_Color_Negative: var(--sapNegativeElementColor);
+  --fdIcon_Tab_Bar_Semantic_Badge_Color_Critical: var(--sapCriticalElementColor);
+  --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapInformativeElementColor);
+  --fdIcon_Tab_Bar_Overflowing_Padding: 0;
+  --fdIcon_Tab_Bar_Overflow_Button_Hover_Box_Shadow: none;
+  --fdIcon_Tab_Bar_Overflow_Button_Focus_Offset: 0.125rem;
+  --fdIcon_Tab_Bar_Overflow_Button_Border_Radius: 0.75rem;
+}

--- a/src/styles/theming/common/icon-tab-bar/_sap_fiori.scss
+++ b/src/styles/theming/common/icon-tab-bar/_sap_fiori.scss
@@ -17,8 +17,8 @@
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Negative: var(--sapNegativeElementColor);
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Critical: var(--sapCriticalElementColor);
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapInformativeElementColor);
-  --fdIcon_Tab_Bar_Overflowing_Padding: 0;
   --fdIcon_Tab_Bar_Overflow_Button_Hover_Box_Shadow: none;
   --fdIcon_Tab_Bar_Overflow_Button_Focus_Offset: 0.125rem;
   --fdIcon_Tab_Bar_Overflow_Button_Border_Radius: 0.75rem;
+  --fdIcon_Tab_Bar_Inactive_Tab_Icon_Color: var(--sapContent_IconColor);
 }

--- a/src/styles/theming/common/icon-tab-bar/_sap_fiori.scss
+++ b/src/styles/theming/common/icon-tab-bar/_sap_fiori.scss
@@ -23,6 +23,6 @@
   --fdIcon_Tab_Bar_Inactive_Tab_Icon_Color: var(--sapContent_IconColor);
   --fdIcon_Tab_Bar_Label_Color: var(--sapContent_LabelColor);
   --fdIcon_Tab_Bar_Label_Hover_Color: var(--sapContent_LabelColor);
-  --fdIcon_Tab_Bar_Label_Font_Family: var(--sapFontFamily);
+  --fdIcon_Tab_Bar_Label_Font_Weight: 400;
   --fdIcon_Tab_Bar_Label_Font_Size: var(--sapFontSmallSize);
 }

--- a/src/styles/theming/common/icon-tab-bar/_sap_fiori.scss
+++ b/src/styles/theming/common/icon-tab-bar/_sap_fiori.scss
@@ -25,4 +25,9 @@
   --fdIcon_Tab_Bar_Label_Hover_Color: var(--sapContent_LabelColor);
   --fdIcon_Tab_Bar_Label_Font_Weight: 400;
   --fdIcon_Tab_Bar_Label_Font_Size: var(--sapFontSmallSize);
+  --fdIcon_Tab_Bar_Text_Focus_Radius: 0;
+  --fdIcon_Tab_Bar_Icon_Focus_Radius: 50%;
+  --fdIcon_Tab_Bar_Focus_Offset: -0.0625rem;
+  --fdIcon_Tab_Bar_Icon_Border_Weight: 0.0625rem;
+  --fdIcon_Tab_Bar_Icon_Focus_Offset: -0.125rem;
 }

--- a/src/styles/theming/common/icon-tab-bar/_sap_fiori_hc.scss
+++ b/src/styles/theming/common/icon-tab-bar/_sap_fiori_hc.scss
@@ -1,0 +1,20 @@
+:root {
+  --fdIcon_Tab_Bar_Selection_Bar_Height: 0.313rem;
+  --fdIcon_Tab_Bar_Selection_Color: var(--sapGroup_TitleTextColor);
+  --fdIcon_Tab_Bar_Selection_Bar_Color: var(--sapList_SelectionBorderColor);
+  --fdIcon_Tab_Bar_Icon_Border_Color: var(--sapList_SelectionBorderColor);
+  --fdIcon_Tab_Bar_Semantic_Icon_Display: inline;
+  --fdIcon_Tab_Bar_Semantic_Color_Positive: var(--sapContent_LabelColor);
+  --fdIcon_Tab_Bar_Semantic_Color_Negative: var(--sapContent_LabelColor);
+  --fdIcon_Tab_Bar_Semantic_Color_Critical: var(--sapContent_LabelColor);
+  --fdIcon_Tab_Bar_Semantic_Color_Informative: var(--sapContent_LabelColor);
+  --fdIcon_Tab_Bar_Semantic_Background_Color_Positive: var(--sapSelectedColor);
+  --fdIcon_Tab_Bar_Semantic_Background_Color_Negative: var(--sapSelectedColor);
+  --fdIcon_Tab_Bar_Semantic_Background_Color_Critical: var(--sapSelectedColor);
+  --fdIcon_Tab_Bar_Semantic_Background_Color_Informative: var(--sapSelectedColor);
+  --fdIcon_Tab_Bar_Badge_Color: var(--sapContent_IconColor);
+  --fdIcon_Tab_Bar_Semantic_Badge_Color_Positive: var(--sapContent_IconColor);
+  --fdIcon_Tab_Bar_Semantic_Badge_Color_Negative: var(--sapContent_IconColor);
+  --fdIcon_Tab_Bar_Semantic_Badge_Color_Critical: var(--sapContent_IconColor);
+  --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapContent_IconColor);
+}

--- a/src/styles/theming/common/icon-tab-bar/_sap_horizon.scss
+++ b/src/styles/theming/common/icon-tab-bar/_sap_horizon.scss
@@ -17,8 +17,8 @@
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Negative: var(--sapNegativeElementColor);
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Critical: var(--sapCriticalElementColor);
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapInformativeElementColor);
-  --fdIcon_Tab_Bar_Overflowing_Padding: 0.188rem;
   --fdIcon_Tab_Bar_Overflow_Button_Hover_Box_Shadow: var(--sapContent_Interaction_Shadow);
   --fdIcon_Tab_Bar_Overflow_Button_Focus_Offset: -0.25rem;
   --fdIcon_Tab_Bar_Overflow_Button_Border_Radius: 1rem;
+  --fdIcon_Tab_Bar_Inactive_Tab_Icon_Color: var(--sapContent_Selected_ForegroundColor);
 }

--- a/src/styles/theming/common/icon-tab-bar/_sap_horizon.scss
+++ b/src/styles/theming/common/icon-tab-bar/_sap_horizon.scss
@@ -23,6 +23,6 @@
   --fdIcon_Tab_Bar_Inactive_Tab_Icon_Color: var(--sapContent_Selected_ForegroundColor);
   --fdIcon_Tab_Bar_Label_Color: var(--sapTextColor);
   --fdIcon_Tab_Bar_Label_Hover_Color: var(--sapContent_Selected_ForegroundColor);
-  --fdIcon_Tab_Bar_Label_Font_Family: var(--sapFontBoldFamily);
+  --fdIcon_Tab_Bar_Label_Font_Weight: 800;
   --fdIcon_Tab_Bar_Label_Font_Size: var(--sapFontSmallSize);
 }

--- a/src/styles/theming/common/icon-tab-bar/_sap_horizon.scss
+++ b/src/styles/theming/common/icon-tab-bar/_sap_horizon.scss
@@ -21,4 +21,7 @@
   --fdIcon_Tab_Bar_Overflow_Button_Focus_Offset: -0.25rem;
   --fdIcon_Tab_Bar_Overflow_Button_Border_Radius: 1rem;
   --fdIcon_Tab_Bar_Inactive_Tab_Icon_Color: var(--sapContent_Selected_ForegroundColor);
+  --fdIcon_Tab_Bar_Label_Color: var(--sapTextColor);
+  --fdIcon_Tab_Bar_Label_Font_Family: var(--sapFontBoldFamily);
+  --fdIcon_Tab_Bar_Label_Font_Size: var(--sapFontSmallSize);
 }

--- a/src/styles/theming/common/icon-tab-bar/_sap_horizon.scss
+++ b/src/styles/theming/common/icon-tab-bar/_sap_horizon.scss
@@ -1,0 +1,24 @@
+:root {
+  --fdIcon_Tab_Bar_Selection_Bar_Height: 0.188rem;
+  --fdIcon_Tab_Bar_Selection_Color: var(--sapContent_Selected_ForegroundColor);
+  --fdIcon_Tab_Bar_Selection_Bar_Color: var(--sapContent_Selected_ForegroundColor);
+  --fdIcon_Tab_Bar_Icon_Border_Color: var(--sapContent_Selected_ForegroundColor);
+  --fdIcon_Tab_Bar_Semantic_Icon_Display: none;
+  --fdIcon_Tab_Bar_Semantic_Color_Positive: var(--sapPositiveElementColor);
+  --fdIcon_Tab_Bar_Semantic_Color_Negative: var(--sapNegativeElementColor);
+  --fdIcon_Tab_Bar_Semantic_Color_Critical: var(--sapCriticalElementColor);
+  --fdIcon_Tab_Bar_Semantic_Color_Informative: var(--sapInformativeElementColor);
+  --fdIcon_Tab_Bar_Semantic_Background_Color_Positive: var(--sapPositiveElementColor);
+  --fdIcon_Tab_Bar_Semantic_Background_Color_Negative: var(--sapNegativeElementColor);
+  --fdIcon_Tab_Bar_Semantic_Background_Color_Critical: var(--sapCriticalElementColor);
+  --fdIcon_Tab_Bar_Semantic_Background_Color_Informative: var(--sapInformativeElementColor);
+  --fdIcon_Tab_Bar_Badge_Color: var(--sapContent_BadgeBackground);
+  --fdIcon_Tab_Bar_Semantic_Badge_Color_Positive: var(--sapPositiveElementColor);
+  --fdIcon_Tab_Bar_Semantic_Badge_Color_Negative: var(--sapNegativeElementColor);
+  --fdIcon_Tab_Bar_Semantic_Badge_Color_Critical: var(--sapCriticalElementColor);
+  --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapInformativeElementColor);
+  --fdIcon_Tab_Bar_Overflowing_Padding: 0.188rem;
+  --fdIcon_Tab_Bar_Overflow_Button_Hover_Box_Shadow: var(--sapContent_Interaction_Shadow);
+  --fdIcon_Tab_Bar_Overflow_Button_Focus_Offset: -0.25rem;
+  --fdIcon_Tab_Bar_Overflow_Button_Border_Radius: 1rem;
+}

--- a/src/styles/theming/common/icon-tab-bar/_sap_horizon.scss
+++ b/src/styles/theming/common/icon-tab-bar/_sap_horizon.scss
@@ -25,4 +25,9 @@
   --fdIcon_Tab_Bar_Label_Hover_Color: var(--sapContent_Selected_ForegroundColor);
   --fdIcon_Tab_Bar_Label_Font_Weight: 800;
   --fdIcon_Tab_Bar_Label_Font_Size: var(--sapFontSmallSize);
+  --fdIcon_Tab_Bar_Text_Focus_Radius: 0.375rem;
+  --fdIcon_Tab_Bar_Icon_Focus_Radius: 50%;
+  --fdIcon_Tab_Bar_Focus_Offset: -0.25rem;
+  --fdIcon_Tab_Bar_Icon_Border_Weight: 0.125rem;
+  --fdIcon_Tab_Bar_Icon_Focus_Offset: -0.3125rem;
 }

--- a/src/styles/theming/common/icon-tab-bar/_sap_horizon.scss
+++ b/src/styles/theming/common/icon-tab-bar/_sap_horizon.scss
@@ -22,6 +22,7 @@
   --fdIcon_Tab_Bar_Overflow_Button_Border_Radius: 1rem;
   --fdIcon_Tab_Bar_Inactive_Tab_Icon_Color: var(--sapContent_Selected_ForegroundColor);
   --fdIcon_Tab_Bar_Label_Color: var(--sapTextColor);
+  --fdIcon_Tab_Bar_Label_Hover_Color: var(--sapContent_Selected_ForegroundColor);
   --fdIcon_Tab_Bar_Label_Font_Family: var(--sapFontBoldFamily);
   --fdIcon_Tab_Bar_Label_Font_Size: var(--sapFontSmallSize);
 }

--- a/src/styles/theming/common/icon-tab-bar/_sap_horizon_hc.scss
+++ b/src/styles/theming/common/icon-tab-bar/_sap_horizon_hc.scss
@@ -1,4 +1,5 @@
 :root {
   --fdIcon_Tab_Bar_Selection_Bar_Height: 0.313rem;
   --fdIcon_Tab_Bar_Semantic_Icon_Display: inline;
+  --fdIcon_Tab_Bar_Badge_Color: var(--sapContent_IconColor);
 }

--- a/src/styles/theming/common/icon-tab-bar/_sap_horizon_hc.scss
+++ b/src/styles/theming/common/icon-tab-bar/_sap_horizon_hc.scss
@@ -1,0 +1,4 @@
+:root {
+  --fdIcon_Tab_Bar_Selection_Bar_Height: 0.313rem;
+  --fdIcon_Tab_Bar_Semantic_Icon_Display: inline;
+}

--- a/src/styles/theming/sap_fiori_3.scss
+++ b/src/styles/theming/sap_fiori_3.scss
@@ -1,5 +1,6 @@
 @import "./common/switch/sap_fiori";
 @import "./common/button/sap_fiori";
+@import "./common/icon-tab-bar/sap_fiori";
 
 :root {
   --fdInverted_Object_Border_Width: 0;
@@ -279,30 +280,6 @@
   --fdSlide_Tile_Indicator_Active_Dot_Color: var(--sapTile_TitleTextColor);
   --fdSlide_Tile_Indicator_Dot_Border: none;
   --fdSlide_Tile_Indicator_Active_Dot_Border: none;
-
-  /* Icon Tab Bar */
-  --fdIcon_Tab_Bar_Selection_Bar_Height: 0.188rem;
-  --fdIcon_Tab_Bar_Selection_Color: var(--sapSelectedColor);
-  --fdIcon_Tab_Bar_Selection_Bar_Color: var(--sapSelectedColor);
-  --fdIcon_Tab_Bar_Icon_Border_Color: var(--sapSelectedColor);
-  --fdIcon_Tab_Bar_Semantic_Icon_Display: none;
-  --fdIcon_Tab_Bar_Semantic_Color_Positive: var(--sapPositiveElementColor);
-  --fdIcon_Tab_Bar_Semantic_Color_Negative: var(--sapNegativeElementColor);
-  --fdIcon_Tab_Bar_Semantic_Color_Critical: var(--sapCriticalElementColor);
-  --fdIcon_Tab_Bar_Semantic_Color_Informative: var(--sapInformativeElementColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Positive: var(--sapPositiveElementColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Negative: var(--sapNegativeElementColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Critical: var(--sapCriticalElementColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Informative: var(--sapInformativeElementColor);
-  --fdIcon_Tab_Bar_Badge_Color: var(--sapContent_BadgeBackground);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Positive: var(--sapPositiveElementColor);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Negative: var(--sapNegativeElementColor);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Critical: var(--sapCriticalElementColor);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapInformativeElementColor);
-  --fdIcon_Tab_Bar_Overflowing_Padding: 0;
-  --fdIcon_Tab_Bar_Overflow_Button_Hover_Box_Shadow: none;
-  --fdIcon_Tab_Bar_Overflow_Button_Focus_Offset: 0.125rem;
-  --fdIcon_Tab_Bar_Overflow_Button_Border_Radius: 0.75rem;
 
   /* Toolbar */
   --fdToolbar_Auto_Background: inherit;

--- a/src/styles/theming/sap_fiori_3.scss
+++ b/src/styles/theming/sap_fiori_3.scss
@@ -299,6 +299,10 @@
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Negative: var(--sapNegativeElementColor);
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Critical: var(--sapCriticalElementColor);
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapInformativeElementColor);
+  --fdIcon_Tab_Bar_Overflowing_Padding: 0;
+  --fdIcon_Tab_Bar_Overflow_Button_Hover_Box_Shadow: none;
+  --fdIcon_Tab_Bar_Overflow_Button_Focus_Offset: 0.125rem;
+  --fdIcon_Tab_Bar_Overflow_Button_Border_Radius: 0.75rem;
 
   /* Toolbar */
   --fdToolbar_Auto_Background: inherit;

--- a/src/styles/theming/sap_fiori_3_dark.scss
+++ b/src/styles/theming/sap_fiori_3_dark.scss
@@ -1,5 +1,6 @@
 @import "./common/switch/sap_fiori";
 @import "./common/button/sap_fiori";
+@import "./common/icon-tab-bar/sap_fiori";
 
 :root {
   --fdInverted_Object_Border_Width: 0;
@@ -281,26 +282,6 @@
   --fdSlide_Tile_Indicator_Active_Dot_Color: var(--sapTile_TitleTextColor);
   --fdSlide_Tile_Indicator_Dot_Border: none;
   --fdSlide_Tile_Indicator_Active_Dot_Border: none;
-
-  /* Icon Tab Bar */
-  --fdIcon_Tab_Bar_Selection_Bar_Height: 0.188rem;
-  --fdIcon_Tab_Bar_Selection_Color: var(--sapSelectedColor);
-  --fdIcon_Tab_Bar_Selection_Bar_Color: var(--sapSelectedColor);
-  --fdIcon_Tab_Bar_Icon_Border_Color: var(--sapSelectedColor);
-  --fdIcon_Tab_Bar_Semantic_Icon_Display: none;
-  --fdIcon_Tab_Bar_Semantic_Color_Positive: var(--sapPositiveElementColor);
-  --fdIcon_Tab_Bar_Semantic_Color_Negative: var(--sapNegativeElementColor);
-  --fdIcon_Tab_Bar_Semantic_Color_Critical: var(--sapCriticalElementColor);
-  --fdIcon_Tab_Bar_Semantic_Color_Informative: var(--sapInformativeElementColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Positive: var(--sapPositiveElementColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Negative: var(--sapNegativeElementColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Critical: var(--sapCriticalElementColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Informative: var(--sapInformativeElementColor);
-  --fdIcon_Tab_Bar_Badge_Color: var(--sapContent_BadgeBackground);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Positive: var(--sapPositiveElementColor);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Negative: var(--sapNegativeElementColor);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Critical: var(--sapCriticalElementColor);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapInformativeElementColor);
 
   /* Toolbar */
   --fdToolbar_Auto_Background: inherit;

--- a/src/styles/theming/sap_fiori_3_hcb.scss
+++ b/src/styles/theming/sap_fiori_3_hcb.scss
@@ -301,6 +301,10 @@
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Negative: var(--sapContent_IconColor);
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Critical: var(--sapContent_IconColor);
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapContent_IconColor);
+  --fdIcon_Tab_Bar_Overflowing_Padding: 0;
+  --fdIcon_Tab_Bar_Overflow_Button_Hover_Box_Shadow: none;
+  --fdIcon_Tab_Bar_Overflow_Button_Focus_Offset: 0.125rem;
+  --fdIcon_Tab_Bar_Overflow_Button_Border_Radius: 0.75rem;
 
   /* Toolbar */
   --fdToolbar_Auto_Background: var(--sapToolbar_Background);

--- a/src/styles/theming/sap_fiori_3_hcb.scss
+++ b/src/styles/theming/sap_fiori_3_hcb.scss
@@ -1,5 +1,7 @@
 @import "./common/switch/sap_fiori";
 @import "./common/button/sap_fiori";
+@import "./common/icon-tab-bar/sap_fiori";
+@import "./common/icon-tab-bar/sap_fiori_hc";
 
 :root {
   --fdInverted_Object_Border_Width: 0.0625rem;
@@ -281,30 +283,6 @@
   --fdSlide_Tile_Indicator_Active_Dot_Color: var(--sapContent_NonInteractiveIconColor);
   --fdSlide_Tile_Indicator_Dot_Border: solid 0.0625rem var(--sapContent_NonInteractiveIconColor);
   --fdSlide_Tile_Indicator_Active_Dot_Border: solid 0.0625rem var(--sapContent_NonInteractiveIconColor);
-
-  /* Icon Tab Bar */
-  --fdIcon_Tab_Bar_Selection_Bar_Height: 0.313rem;
-  --fdIcon_Tab_Bar_Selection_Color: var(--sapGroup_TitleTextColor);
-  --fdIcon_Tab_Bar_Selection_Bar_Color: var(--sapList_SelectionBorderColor);
-  --fdIcon_Tab_Bar_Icon_Border_Color: var(--sapList_SelectionBorderColor);
-  --fdIcon_Tab_Bar_Semantic_Icon_Display: inline;
-  --fdIcon_Tab_Bar_Semantic_Color_Positive: var(--sapContent_LabelColor);
-  --fdIcon_Tab_Bar_Semantic_Color_Negative: var(--sapContent_LabelColor);
-  --fdIcon_Tab_Bar_Semantic_Color_Critical: var(--sapContent_LabelColor);
-  --fdIcon_Tab_Bar_Semantic_Color_Informative: var(--sapContent_LabelColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Positive: var(--sapSelectedColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Negative: var(--sapSelectedColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Critical: var(--sapSelectedColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Informative: var(--sapSelectedColor);
-  --fdIcon_Tab_Bar_Badge_Color: var(--sapContent_IconColor);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Positive: var(--sapContent_IconColor);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Negative: var(--sapContent_IconColor);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Critical: var(--sapContent_IconColor);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapContent_IconColor);
-  --fdIcon_Tab_Bar_Overflowing_Padding: 0;
-  --fdIcon_Tab_Bar_Overflow_Button_Hover_Box_Shadow: none;
-  --fdIcon_Tab_Bar_Overflow_Button_Focus_Offset: 0.125rem;
-  --fdIcon_Tab_Bar_Overflow_Button_Border_Radius: 0.75rem;
 
   /* Toolbar */
   --fdToolbar_Auto_Background: var(--sapToolbar_Background);

--- a/src/styles/theming/sap_fiori_3_hcw.scss
+++ b/src/styles/theming/sap_fiori_3_hcw.scss
@@ -302,6 +302,10 @@
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Negative: var(--sapContent_IconColor);
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Critical: var(--sapContent_IconColor);
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapContent_IconColor);
+  --fdIcon_Tab_Bar_Overflowing_Padding: 0;
+  --fdIcon_Tab_Bar_Overflow_Button_Hover_Box_Shadow: none;
+  --fdIcon_Tab_Bar_Overflow_Button_Focus_Offset: 0.125rem;
+  --fdIcon_Tab_Bar_Overflow_Button_Border_Radius: 0.75rem;
 
   /* Toolbar */
   --fdToolbar_Auto_Background: var(--sapToolbar_Background);

--- a/src/styles/theming/sap_fiori_3_hcw.scss
+++ b/src/styles/theming/sap_fiori_3_hcw.scss
@@ -1,6 +1,8 @@
 @import "../icons/settings";
 @import "./common/switch/sap_fiori";
 @import "./common/button/sap_fiori";
+@import "./common/icon-tab-bar/sap_fiori";
+@import "./common/icon-tab-bar/sap_fiori_hc";
 
 :root {
   --fdInverted_Object_Border_Width: 0.0625rem;
@@ -282,30 +284,6 @@
   --fdSlide_Tile_Indicator_Active_Dot_Color: var(--sapContent_NonInteractiveIconColor);
   --fdSlide_Tile_Indicator_Dot_Border: solid 0.0625rem var(--sapContent_NonInteractiveIconColor);
   --fdSlide_Tile_Indicator_Active_Dot_Border: solid 0.0625rem var(--sapContent_NonInteractiveIconColor);
-
-  /* Icon Tab Bar */
-  --fdIcon_Tab_Bar_Selection_Bar_Height: 0.313rem;
-  --fdIcon_Tab_Bar_Selection_Color: var(--sapGroup_TitleTextColor);
-  --fdIcon_Tab_Bar_Selection_Bar_Color: var(--sapList_SelectionBorderColor);
-  --fdIcon_Tab_Bar_Icon_Border_Color: var(--sapList_SelectionBorderColor);
-  --fdIcon_Tab_Bar_Semantic_Icon_Display: inline;
-  --fdIcon_Tab_Bar_Semantic_Color_Positive: var(--sapContent_LabelColor);
-  --fdIcon_Tab_Bar_Semantic_Color_Negative: var(--sapContent_LabelColor);
-  --fdIcon_Tab_Bar_Semantic_Color_Critical: var(--sapContent_LabelColor);
-  --fdIcon_Tab_Bar_Semantic_Color_Informative: var(--sapContent_LabelColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Positive: var(--sapSelectedColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Negative: var(--sapSelectedColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Critical: var(--sapSelectedColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Informative: var(--sapSelectedColor);
-  --fdIcon_Tab_Bar_Badge_Color: var(--sapContent_IconColor);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Positive: var(--sapContent_IconColor);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Negative: var(--sapContent_IconColor);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Critical: var(--sapContent_IconColor);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapContent_IconColor);
-  --fdIcon_Tab_Bar_Overflowing_Padding: 0;
-  --fdIcon_Tab_Bar_Overflow_Button_Hover_Box_Shadow: none;
-  --fdIcon_Tab_Bar_Overflow_Button_Focus_Offset: 0.125rem;
-  --fdIcon_Tab_Bar_Overflow_Button_Border_Radius: 0.75rem;
 
   /* Toolbar */
   --fdToolbar_Auto_Background: var(--sapToolbar_Background);

--- a/src/styles/theming/sap_fiori_3_light_dark.scss
+++ b/src/styles/theming/sap_fiori_3_light_dark.scss
@@ -1,5 +1,6 @@
 @import "./common/switch/sap_fiori";
 @import "./common/button/sap_fiori";
+@import "./common/icon-tab-bar/sap_fiori";
 
 :root {
   --fdInverted_Object_Border_Width: 0;
@@ -281,30 +282,6 @@
   --fdSlide_Tile_Indicator_Active_Dot_Color: var(--sapTile_TitleTextColor);
   --fdSlide_Tile_Indicator_Dot_Border: none;
   --fdSlide_Tile_Indicator_Active_Dot_Border: none;
-
-  /* Icon Tab Bar */
-  --fdIcon_Tab_Bar_Selection_Bar_Height: 0.188rem;
-  --fdIcon_Tab_Bar_Selection_Color: var(--sapSelectedColor);
-  --fdIcon_Tab_Bar_Selection_Bar_Color: var(--sapSelectedColor);
-  --fdIcon_Tab_Bar_Icon_Border_Color: var(--sapSelectedColor);
-  --fdIcon_Tab_Bar_Semantic_Icon_Display: none;
-  --fdIcon_Tab_Bar_Semantic_Color_Positive: var(--sapPositiveElementColor);
-  --fdIcon_Tab_Bar_Semantic_Color_Negative: var(--sapNegativeElementColor);
-  --fdIcon_Tab_Bar_Semantic_Color_Critical: var(--sapCriticalElementColor);
-  --fdIcon_Tab_Bar_Semantic_Color_Informative: var(--sapInformativeElementColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Positive: var(--sapPositiveElementColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Negative: var(--sapNegativeElementColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Critical: var(--sapCriticalElementColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Informative: var(--sapInformativeElementColor);
-  --fdIcon_Tab_Bar_Badge_Color: var(--sapContent_BadgeBackground);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Positive: var(--sapPositiveElementColor);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Negative: var(--sapNegativeElementColor);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Critical: var(--sapCriticalElementColor);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapInformativeElementColor);
-  --fdIcon_Tab_Bar_Overflowing_Padding: 0;
-  --fdIcon_Tab_Bar_Overflow_Button_Hover_Box_Shadow: none;
-  --fdIcon_Tab_Bar_Overflow_Button_Focus_Offset: 0.125rem;
-  --fdIcon_Tab_Bar_Overflow_Button_Border_Radius: 0.75rem;
 
   /* Toolbar */
   --fdToolbar_Auto_Background: inherit;

--- a/src/styles/theming/sap_fiori_3_light_dark.scss
+++ b/src/styles/theming/sap_fiori_3_light_dark.scss
@@ -301,6 +301,10 @@
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Negative: var(--sapNegativeElementColor);
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Critical: var(--sapCriticalElementColor);
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapInformativeElementColor);
+  --fdIcon_Tab_Bar_Overflowing_Padding: 0;
+  --fdIcon_Tab_Bar_Overflow_Button_Hover_Box_Shadow: none;
+  --fdIcon_Tab_Bar_Overflow_Button_Focus_Offset: 0.125rem;
+  --fdIcon_Tab_Bar_Overflow_Button_Border_Radius: 0.75rem;
 
   /* Toolbar */
   --fdToolbar_Auto_Background: inherit;

--- a/src/styles/theming/sap_horizon.scss
+++ b/src/styles/theming/sap_horizon.scss
@@ -1,5 +1,6 @@
 @import "./common/switch/sap_horizon";
 @import "./common/button/sap_horizon";
+@import "./common/icon-tab-bar/sap_horizon";
 
 :root {
   /* Switch */
@@ -318,30 +319,6 @@
   --fdSlide_Tile_Indicator_Active_Dot_Color: var(--sapTile_TitleTextColor);
   --fdSlide_Tile_Indicator_Dot_Border: none;
   --fdSlide_Tile_Indicator_Active_Dot_Border: none;
-
-  /* Icon Tab Bar */
-  --fdIcon_Tab_Bar_Selection_Bar_Height: 0.188rem;
-  --fdIcon_Tab_Bar_Selection_Color: var(--sapContent_Selected_ForegroundColor);
-  --fdIcon_Tab_Bar_Selection_Bar_Color: var(--sapContent_Selected_ForegroundColor);
-  --fdIcon_Tab_Bar_Icon_Border_Color: var(--sapContent_Selected_ForegroundColor);
-  --fdIcon_Tab_Bar_Semantic_Icon_Display: none;
-  --fdIcon_Tab_Bar_Semantic_Color_Positive: var(--sapPositiveElementColor);
-  --fdIcon_Tab_Bar_Semantic_Color_Negative: var(--sapNegativeElementColor);
-  --fdIcon_Tab_Bar_Semantic_Color_Critical: var(--sapCriticalElementColor);
-  --fdIcon_Tab_Bar_Semantic_Color_Informative: var(--sapInformativeElementColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Positive: var(--sapPositiveElementColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Negative: var(--sapNegativeElementColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Critical: var(--sapCriticalElementColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Informative: var(--sapInformativeElementColor);
-  --fdIcon_Tab_Bar_Badge_Color: var(--sapContent_BadgeBackground);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Positive: var(--sapPositiveElementColor);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Negative: var(--sapNegativeElementColor);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Critical: var(--sapCriticalElementColor);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapInformativeElementColor);
-  --fdIcon_Tab_Bar_Overflowing_Padding: 0.188rem;
-  --fdIcon_Tab_Bar_Overflow_Button_Hover_Box_Shadow: var(--sapContent_Interaction_Shadow);
-  --fdIcon_Tab_Bar_Overflow_Button_Focus_Offset: -0.25rem;
-  --fdIcon_Tab_Bar_Overflow_Button_Border_Radius: 1rem;
 
   /* Toolbar */
   --fdToolbar_Auto_Background: var(--sapToolbar_Background);

--- a/src/styles/theming/sap_horizon.scss
+++ b/src/styles/theming/sap_horizon.scss
@@ -338,6 +338,10 @@
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Negative: var(--sapNegativeElementColor);
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Critical: var(--sapCriticalElementColor);
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapInformativeElementColor);
+  --fdIcon_Tab_Bar_Overflowing_Padding: 0.188rem;
+  --fdIcon_Tab_Bar_Overflow_Button_Hover_Box_Shadow: var(--sapContent_Interaction_Shadow);
+  --fdIcon_Tab_Bar_Overflow_Button_Focus_Offset: -0.25rem;
+  --fdIcon_Tab_Bar_Overflow_Button_Border_Radius: 1rem;
 
   /* Toolbar */
   --fdToolbar_Auto_Background: var(--sapToolbar_Background);

--- a/src/styles/theming/sap_horizon.scss
+++ b/src/styles/theming/sap_horizon.scss
@@ -321,9 +321,9 @@
 
   /* Icon Tab Bar */
   --fdIcon_Tab_Bar_Selection_Bar_Height: 0.188rem;
-  --fdIcon_Tab_Bar_Selection_Color: var(--sapSelectedColor);
-  --fdIcon_Tab_Bar_Selection_Bar_Color: var(--sapSelectedColor);
-  --fdIcon_Tab_Bar_Icon_Border_Color: var(--sapSelectedColor);
+  --fdIcon_Tab_Bar_Selection_Color: var(--sapContent_Selected_ForegroundColor);
+  --fdIcon_Tab_Bar_Selection_Bar_Color: var(--sapContent_Selected_ForegroundColor);
+  --fdIcon_Tab_Bar_Icon_Border_Color: var(--sapContent_Selected_ForegroundColor);
   --fdIcon_Tab_Bar_Semantic_Icon_Display: none;
   --fdIcon_Tab_Bar_Semantic_Color_Positive: var(--sapPositiveElementColor);
   --fdIcon_Tab_Bar_Semantic_Color_Negative: var(--sapNegativeElementColor);

--- a/src/styles/theming/sap_horizon_dark.scss
+++ b/src/styles/theming/sap_horizon_dark.scss
@@ -1,5 +1,6 @@
 @import "./common/switch/sap_horizon";
 @import "./common/button/sap_horizon";
+@import "./common/icon-tab-bar/sap_horizon";
 
 :root {
   /* Switch */
@@ -318,30 +319,6 @@
   --fdSlide_Tile_Indicator_Active_Dot_Color: var(--sapTile_TitleTextColor);
   --fdSlide_Tile_Indicator_Dot_Border: none;
   --fdSlide_Tile_Indicator_Active_Dot_Border: none;
-
-  /* Icon Tab Bar */
-  --fdIcon_Tab_Bar_Selection_Bar_Height: 0.188rem;
-  --fdIcon_Tab_Bar_Selection_Color: var(--sapContent_Selected_ForegroundColor);
-  --fdIcon_Tab_Bar_Selection_Bar_Color: var(--sapContent_Selected_ForegroundColor);
-  --fdIcon_Tab_Bar_Icon_Border_Color: var(--sapContent_Selected_ForegroundColor);
-  --fdIcon_Tab_Bar_Semantic_Icon_Display: none;
-  --fdIcon_Tab_Bar_Semantic_Color_Positive: var(--sapPositiveElementColor);
-  --fdIcon_Tab_Bar_Semantic_Color_Negative: var(--sapNegativeElementColor);
-  --fdIcon_Tab_Bar_Semantic_Color_Critical: var(--sapCriticalElementColor);
-  --fdIcon_Tab_Bar_Semantic_Color_Informative: var(--sapInformativeElementColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Positive: var(--sapPositiveElementColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Negative: var(--sapNegativeElementColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Critical: var(--sapCriticalElementColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Informative: var(--sapInformativeElementColor);
-  --fdIcon_Tab_Bar_Badge_Color: var(--sapContent_BadgeBackground);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Positive: var(--sapPositiveElementColor);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Negative: var(--sapNegativeElementColor);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Critical: var(--sapCriticalElementColor);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapInformativeElementColor);
-  --fdIcon_Tab_Bar_Overflowing_Padding: 0.188rem;
-  --fdIcon_Tab_Bar_Overflow_Button_Hover_Box_Shadow: var(--sapContent_Interaction_Shadow);
-  --fdIcon_Tab_Bar_Overflow_Button_Focus_Offset: -0.25rem;
-  --fdIcon_Tab_Bar_Overflow_Button_Border_Radius: 1rem;
 
   /* Toolbar */
   --fdToolbar_Auto_Background: var(--sapToolbar_Background);

--- a/src/styles/theming/sap_horizon_dark.scss
+++ b/src/styles/theming/sap_horizon_dark.scss
@@ -338,6 +338,10 @@
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Negative: var(--sapNegativeElementColor);
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Critical: var(--sapCriticalElementColor);
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapInformativeElementColor);
+  --fdIcon_Tab_Bar_Overflowing_Padding: 0.188rem;
+  --fdIcon_Tab_Bar_Overflow_Button_Hover_Box_Shadow: var(--sapContent_Interaction_Shadow);
+  --fdIcon_Tab_Bar_Overflow_Button_Focus_Offset: -0.25rem;
+  --fdIcon_Tab_Bar_Overflow_Button_Border_Radius: 1rem;
 
   /* Toolbar */
   --fdToolbar_Auto_Background: var(--sapToolbar_Background);

--- a/src/styles/theming/sap_horizon_dark.scss
+++ b/src/styles/theming/sap_horizon_dark.scss
@@ -321,9 +321,9 @@
 
   /* Icon Tab Bar */
   --fdIcon_Tab_Bar_Selection_Bar_Height: 0.188rem;
-  --fdIcon_Tab_Bar_Selection_Color: var(--sapSelectedColor);
-  --fdIcon_Tab_Bar_Selection_Bar_Color: var(--sapSelectedColor);
-  --fdIcon_Tab_Bar_Icon_Border_Color: var(--sapSelectedColor);
+  --fdIcon_Tab_Bar_Selection_Color: var(--sapContent_Selected_ForegroundColor);
+  --fdIcon_Tab_Bar_Selection_Bar_Color: var(--sapContent_Selected_ForegroundColor);
+  --fdIcon_Tab_Bar_Icon_Border_Color: var(--sapContent_Selected_ForegroundColor);
   --fdIcon_Tab_Bar_Semantic_Icon_Display: none;
   --fdIcon_Tab_Bar_Semantic_Color_Positive: var(--sapPositiveElementColor);
   --fdIcon_Tab_Bar_Semantic_Color_Negative: var(--sapNegativeElementColor);

--- a/src/styles/theming/sap_horizon_hcb.scss
+++ b/src/styles/theming/sap_horizon_hcb.scss
@@ -36,7 +36,7 @@
   --fdWizard_Content_Solid_Background: var(--sapShell_Background);
   --fdWizard_Content_List_Background: var(--sapGroup_ContentBackground);
   --fdWizard_Content_Transparent_Background: transparent;
-  --fdWizard_Selection_Bar_Height: 0.188rem;
+  --fdWizard_Selection_Bar_Height: 0.313rem;
   --fdWizard_Selection_Bar_Background: var(--sapSelectedColor);
 
   /* Slider */

--- a/src/styles/theming/sap_horizon_hcb.scss
+++ b/src/styles/theming/sap_horizon_hcb.scss
@@ -291,10 +291,10 @@
 
   /* Icon Tab Bar */
   --fdIcon_Tab_Bar_Selection_Bar_Height: 0.188rem;
-  --fdIcon_Tab_Bar_Selection_Color: var(--sapSelectedColor);
-  --fdIcon_Tab_Bar_Selection_Bar_Color: var(--sapSelectedColor);
-  --fdIcon_Tab_Bar_Icon_Border_Color: var(--sapSelectedColor);
-  --fdIcon_Tab_Bar_Semantic_Icon_Display: none;
+  --fdIcon_Tab_Bar_Selection_Color: var(--sapContent_Selected_ForegroundColor);
+  --fdIcon_Tab_Bar_Selection_Bar_Color: var(--sapContent_Selected_ForegroundColor);
+  --fdIcon_Tab_Bar_Icon_Border_Color: var(--sapContent_Selected_ForegroundColor);
+  --fdIcon_Tab_Bar_Semantic_Icon_Display: inline;
   --fdIcon_Tab_Bar_Semantic_Color_Positive: var(--sapPositiveElementColor);
   --fdIcon_Tab_Bar_Semantic_Color_Negative: var(--sapNegativeElementColor);
   --fdIcon_Tab_Bar_Semantic_Color_Critical: var(--sapCriticalElementColor);

--- a/src/styles/theming/sap_horizon_hcb.scss
+++ b/src/styles/theming/sap_horizon_hcb.scss
@@ -308,6 +308,10 @@
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Negative: var(--sapNegativeElementColor);
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Critical: var(--sapCriticalElementColor);
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapInformativeElementColor);
+  --fdIcon_Tab_Bar_Overflowing_Padding: 0.188rem;
+  --fdIcon_Tab_Bar_Overflow_Button_Hover_Box_Shadow: var(--sapContent_Interaction_Shadow);
+  --fdIcon_Tab_Bar_Overflow_Button_Focus_Offset: -0.25rem;
+  --fdIcon_Tab_Bar_Overflow_Button_Border_Radius: 1rem;
 
   /* Toolbar */
   --fdToolbar_Auto_Background: var(--sapToolbar_Background);

--- a/src/styles/theming/sap_horizon_hcb.scss
+++ b/src/styles/theming/sap_horizon_hcb.scss
@@ -1,5 +1,7 @@
 @import "./common/switch/sap_horizon";
 @import "./common/button/sap_horizon";
+@import "./common/icon-tab-bar/sap_horizon";
+@import "./common/icon-tab-bar/sap_horizon_hc";
 
 :root {
   /* Switch */
@@ -288,30 +290,6 @@
   --fdSlide_Tile_Indicator_Active_Dot_Color: var(--sapTile_TitleTextColor);
   --fdSlide_Tile_Indicator_Dot_Border: none;
   --fdSlide_Tile_Indicator_Active_Dot_Border: none;
-
-  /* Icon Tab Bar */
-  --fdIcon_Tab_Bar_Selection_Bar_Height: 0.188rem;
-  --fdIcon_Tab_Bar_Selection_Color: var(--sapContent_Selected_ForegroundColor);
-  --fdIcon_Tab_Bar_Selection_Bar_Color: var(--sapContent_Selected_ForegroundColor);
-  --fdIcon_Tab_Bar_Icon_Border_Color: var(--sapContent_Selected_ForegroundColor);
-  --fdIcon_Tab_Bar_Semantic_Icon_Display: inline;
-  --fdIcon_Tab_Bar_Semantic_Color_Positive: var(--sapPositiveElementColor);
-  --fdIcon_Tab_Bar_Semantic_Color_Negative: var(--sapNegativeElementColor);
-  --fdIcon_Tab_Bar_Semantic_Color_Critical: var(--sapCriticalElementColor);
-  --fdIcon_Tab_Bar_Semantic_Color_Informative: var(--sapInformativeElementColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Positive: var(--sapPositiveElementColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Negative: var(--sapNegativeElementColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Critical: var(--sapCriticalElementColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Informative: var(--sapInformativeElementColor);
-  --fdIcon_Tab_Bar_Badge_Color: var(--sapContent_BadgeBackground);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Positive: var(--sapPositiveElementColor);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Negative: var(--sapNegativeElementColor);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Critical: var(--sapCriticalElementColor);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapInformativeElementColor);
-  --fdIcon_Tab_Bar_Overflowing_Padding: 0.188rem;
-  --fdIcon_Tab_Bar_Overflow_Button_Hover_Box_Shadow: var(--sapContent_Interaction_Shadow);
-  --fdIcon_Tab_Bar_Overflow_Button_Focus_Offset: -0.25rem;
-  --fdIcon_Tab_Bar_Overflow_Button_Border_Radius: 1rem;
 
   /* Toolbar */
   --fdToolbar_Auto_Background: var(--sapToolbar_Background);

--- a/src/styles/theming/sap_horizon_hcw.scss
+++ b/src/styles/theming/sap_horizon_hcw.scss
@@ -36,7 +36,7 @@
   --fdWizard_Content_Solid_Background: var(--sapShell_Background);
   --fdWizard_Content_List_Background: var(--sapGroup_ContentBackground);
   --fdWizard_Content_Transparent_Background: transparent;
-  --fdWizard_Selection_Bar_Height: 0.188rem;
+  --fdWizard_Selection_Bar_Height: 0.313rem;
   --fdWizard_Selection_Bar_Background: var(--sapSelectedColor);
 
   /* Slider */

--- a/src/styles/theming/sap_horizon_hcw.scss
+++ b/src/styles/theming/sap_horizon_hcw.scss
@@ -290,10 +290,10 @@
 
   /* Icon Tab Bar */
   --fdIcon_Tab_Bar_Selection_Bar_Height: 0.188rem;
-  --fdIcon_Tab_Bar_Selection_Color: var(--sapSelectedColor);
-  --fdIcon_Tab_Bar_Selection_Bar_Color: var(--sapSelectedColor);
-  --fdIcon_Tab_Bar_Icon_Border_Color: var(--sapSelectedColor);
-  --fdIcon_Tab_Bar_Semantic_Icon_Display: none;
+  --fdIcon_Tab_Bar_Selection_Color: var(--sapContent_Selected_ForegroundColor);
+  --fdIcon_Tab_Bar_Selection_Bar_Color: var(--sapContent_Selected_ForegroundColor);
+  --fdIcon_Tab_Bar_Icon_Border_Color: var(--sapContent_Selected_ForegroundColor);
+  --fdIcon_Tab_Bar_Semantic_Icon_Display: inline;
   --fdIcon_Tab_Bar_Semantic_Color_Positive: var(--sapPositiveElementColor);
   --fdIcon_Tab_Bar_Semantic_Color_Negative: var(--sapNegativeElementColor);
   --fdIcon_Tab_Bar_Semantic_Color_Critical: var(--sapCriticalElementColor);

--- a/src/styles/theming/sap_horizon_hcw.scss
+++ b/src/styles/theming/sap_horizon_hcw.scss
@@ -307,6 +307,10 @@
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Negative: var(--sapNegativeElementColor);
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Critical: var(--sapCriticalElementColor);
   --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapInformativeElementColor);
+  --fdIcon_Tab_Bar_Overflowing_Padding: 0.188rem;
+  --fdIcon_Tab_Bar_Overflow_Button_Hover_Box_Shadow: var(--sapContent_Interaction_Shadow);
+  --fdIcon_Tab_Bar_Overflow_Button_Focus_Offset: -0.25rem;
+  --fdIcon_Tab_Bar_Overflow_Button_Border_Radius: 1rem;
 
   /* Toolbar */
   --fdToolbar_Auto_Background: var(--sapToolbar_Background);

--- a/src/styles/theming/sap_horizon_hcw.scss
+++ b/src/styles/theming/sap_horizon_hcw.scss
@@ -1,5 +1,7 @@
 @import "./common/switch/sap_horizon";
 @import "./common/button/sap_horizon";
+@import "./common/icon-tab-bar/sap_horizon";
+@import "./common/icon-tab-bar/sap_horizon_hc";
 
 :root {
   /* Switch */
@@ -287,30 +289,6 @@
   --fdSlide_Tile_Indicator_Active_Dot_Color: var(--sapTile_TitleTextColor);
   --fdSlide_Tile_Indicator_Dot_Border: none;
   --fdSlide_Tile_Indicator_Active_Dot_Border: none;
-
-  /* Icon Tab Bar */
-  --fdIcon_Tab_Bar_Selection_Bar_Height: 0.188rem;
-  --fdIcon_Tab_Bar_Selection_Color: var(--sapContent_Selected_ForegroundColor);
-  --fdIcon_Tab_Bar_Selection_Bar_Color: var(--sapContent_Selected_ForegroundColor);
-  --fdIcon_Tab_Bar_Icon_Border_Color: var(--sapContent_Selected_ForegroundColor);
-  --fdIcon_Tab_Bar_Semantic_Icon_Display: inline;
-  --fdIcon_Tab_Bar_Semantic_Color_Positive: var(--sapPositiveElementColor);
-  --fdIcon_Tab_Bar_Semantic_Color_Negative: var(--sapNegativeElementColor);
-  --fdIcon_Tab_Bar_Semantic_Color_Critical: var(--sapCriticalElementColor);
-  --fdIcon_Tab_Bar_Semantic_Color_Informative: var(--sapInformativeElementColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Positive: var(--sapPositiveElementColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Negative: var(--sapNegativeElementColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Critical: var(--sapCriticalElementColor);
-  --fdIcon_Tab_Bar_Semantic_Background_Color_Informative: var(--sapInformativeElementColor);
-  --fdIcon_Tab_Bar_Badge_Color: var(--sapContent_BadgeBackground);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Positive: var(--sapPositiveElementColor);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Negative: var(--sapNegativeElementColor);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Critical: var(--sapCriticalElementColor);
-  --fdIcon_Tab_Bar_Semantic_Badge_Color_Informative: var(--sapInformativeElementColor);
-  --fdIcon_Tab_Bar_Overflowing_Padding: 0.188rem;
-  --fdIcon_Tab_Bar_Overflow_Button_Hover_Box_Shadow: var(--sapContent_Interaction_Shadow);
-  --fdIcon_Tab_Bar_Overflow_Button_Focus_Offset: -0.25rem;
-  --fdIcon_Tab_Bar_Overflow_Button_Border_Radius: 1rem;
 
   /* Toolbar */
   --fdToolbar_Auto_Background: var(--sapToolbar_Background);

--- a/stories/icon-tab-bar/icon-tab-bar.stories.js
+++ b/stories/icon-tab-bar/icon-tab-bar.stories.js
@@ -929,7 +929,7 @@ Overflow.parameters = {
 
 export const SingleClick = () => `<div class='fddocs-icon-tab-container' style="min-height: 800px;">
     <div class="fd-icon-tab-bar fd-icon-tab-bar--xl">
-        <ul role="tablist" class="fd-icon-tab-bar__header" style="overflow: visible">
+        <ul role="tablist" class="fd-icon-tab-bar__header">
             <li role="presentation" class="fd-icon-tab-bar__item">
                 <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab111">
                     <span class="fd-icon-tab-bar__tag">Section 1</span>
@@ -998,7 +998,7 @@ export const SingleClick = () => `<div class='fddocs-icon-tab-container' style="
     <div style="height: 20rem;"></div>
 
      <div class='fd-icon-tab-bar fd-icon-tab-bar--icon'>
-  <ul role='tablist' class='fd-icon-tab-bar__header' style='overflow: visible'>
+  <ul role='tablist' class='fd-icon-tab-bar__header'>
     <li role='presentation' class='fd-icon-tab-bar__item'>
       <a role='tab' class='fd-icon-tab-bar__tab' href='#' aria-selected='true' id='tab1'>
         <div class='fd-icon-tab-bar__container'>

--- a/stories/icon-tab-bar/icon-tab-bar.stories.js
+++ b/stories/icon-tab-bar/icon-tab-bar.stories.js
@@ -846,13 +846,16 @@ Filter.parameters = {
 };
 
 
-export const Overflow = () => `<div class="fd-icon-tab-bar">
+export const Overflow = () => `<div class="fd-icon-tab-bar fd-icon-tab-bar--process">
     <ul role="tablist" class="fd-icon-tab-bar__header fd-icon-tab-bar__header--left-offset">
-        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--overflow fd-icon-tab-bar__item--overflow-left">
+        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--overflow">
             <button class="fd-icon-tab-bar__overflow">
                 <span class="fd-icon-tab-bar__overflow-text">+2</span>
                 <i class="sap-icon--slim-arrow-down" role="presentation"></i>
             </button>
+        </li>
+        <li tabindex="-1" class="fd-icon-tab-bar__icon-separator">
+            <span class="sap-icon--process"></span>
         </li>
         <li role="presentation" class="fd-icon-tab-bar__item">
             <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab1">
@@ -860,15 +863,24 @@ export const Overflow = () => `<div class="fd-icon-tab-bar">
                 <span class="fd-icon-tab-bar__badge"></span>
             </a>
         </li>
+        <li tabindex="-1" class="fd-icon-tab-bar__icon-separator">
+            <span class="sap-icon--process"></span>
+        </li>
         <li role="presentation" class="fd-icon-tab-bar__item">
             <a role="tab" class="fd-icon-tab-bar__tab" href="#" aria-selected="true" id="tab2">
                 <span class="fd-icon-tab-bar__tag">Section 2</span>
             </a>
         </li>
+        <li tabindex="-1" class="fd-icon-tab-bar__icon-separator">
+            <span class="sap-icon--process"></span>
+        </li>
         <li role="presentation" class="fd-icon-tab-bar__item">
             <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab3">
                 <span class="fd-icon-tab-bar__tag">Section 3</span>
             </a>
+        </li>
+        <li tabindex="-1" class="fd-icon-tab-bar__icon-separator">
+            <span class="sap-icon--process"></span>
         </li>
         <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--overflow" style="left: 20rem;">
             <button class="fd-icon-tab-bar__overflow">
@@ -897,7 +909,7 @@ export const Overflow = () => `<div class="fd-icon-tab-bar">
                 <span class="fd-icon-tab-bar__tag">Section 3</span>
             </a>
         </li>
-        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--overflow" style="left: 17rem;">
+        <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--overflow">
             <button class="fd-icon-tab-bar__overflow">
                 <span class="fd-icon-tab-bar__overflow-text">More</span>
                 <i class="sap-icon--slim-arrow-down" role="presentation"></i>
@@ -917,7 +929,7 @@ Overflow.parameters = {
 
 export const SingleClick = () => `<div class='fddocs-icon-tab-container' style="min-height: 800px;">
     <div class="fd-icon-tab-bar fd-icon-tab-bar--xl">
-        <ul role="tablist" class="fd-icon-tab-bar__header">
+        <ul role="tablist" class="fd-icon-tab-bar__header" style="overflow: visible">
             <li role="presentation" class="fd-icon-tab-bar__item">
                 <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab111">
                     <span class="fd-icon-tab-bar__tag">Section 1</span>
@@ -986,7 +998,7 @@ export const SingleClick = () => `<div class='fddocs-icon-tab-container' style="
     <div style="height: 20rem;"></div>
 
      <div class='fd-icon-tab-bar fd-icon-tab-bar--icon'>
-  <ul role='tablist' class='fd-icon-tab-bar__header'>
+  <ul role='tablist' class='fd-icon-tab-bar__header' style='overflow: visible'>
     <li role='presentation' class='fd-icon-tab-bar__item'>
       <a role='tab' class='fd-icon-tab-bar__tab' href='#' aria-selected='true' id='tab1'>
         <div class='fd-icon-tab-bar__container'>


### PR DESCRIPTION
## Related Issue
part of #3213

## Description
Icon tabs bar update

## Breaking Changes

* Overflow button instead of positioning itself using `position: absolute`, now positions using `margin-left: auto`. It now is always in the end of container
