### PR TITLE
fix(styles): added missing style imports

### DIFF
--- a/src/styles/fundamental-styles.scss
+++ b/src/styles/fundamental-styles.scss
@@ -2,6 +2,7 @@
 @import "./icon";
 @import "./layout";
 @import "./action-bar";
+@import "./action-sheet";
 @import "./alert";
 @import "./avatar";
 @import "./avatar-group";
@@ -36,6 +37,7 @@
 @import "./helpers";
 @import "./horizontal-navigation";
 @import "./icon-tab-bar.scss";
+@import "./illustrated-message";
 @import "./info-label";
 @import "./input";
 @import "./input-group";
@@ -71,6 +73,7 @@
 @import "./radio";
 @import "./rating-indicator";
 @import "./resizable-card-layout.scss";
+@import "./scrollbar";
 @import "./section";
 @import "./segmented-button";
 @import "./select";


### PR DESCRIPTION
Signed-off-by: StanZGenchev <stanislav.genchev@sap.com>

## Related Issue
Closes SAP/fundamental-styles#

fix for #3321 

## Description

Added `action-sheet`, `illustrated-message` and `scrollbar` imports in the "src/styles/fundamental-styles.scss" file.