### PR TITLE
fix: menu sub-items should expand the menu width

### DIFF
--- a/src/styles/menu.scss
+++ b/src/styles/menu.scss
@@ -79,7 +79,7 @@ $block: #{$fd-namespace}-menu;
     left: 100%;
     z-index: 2;
     margin: $fd-menu-link-padding-top 0 0 $fd-menu-link-padding-left;
-    width: 100%; // to fix IE issue
+    min-width: 100%;
 
     @include fd-rtl() {
       right: 100%;

--- a/stories/menu/menu.stories.js
+++ b/stories/menu/menu.stories.js
@@ -322,6 +322,11 @@ export const MobileCozyMode = () => `<div style="width: 50%; display: inline-blo
                             <span class="fd-menu__title">Sub-option 4</span>
                         </a>
                     </li>
+                    <li class="fd-menu__item" role="presentation">
+                        <a class="fd-menu__link" href="#" role="menuitem">
+                            <span class="fd-menu__title">Sub-option 5 with very very very very long text</span>
+                        </a>
+                    </li>
                 </ul>
             </nav>
         </div>
@@ -574,6 +579,11 @@ export const WithSubmenu = () => `<nav class="fd-menu">
                 <li class="fd-menu__item" role="presentation">
                     <a class="fd-menu__link" href="#" role="menuitem">
                         <span class="fd-menu__title">Sub-option 4</span>
+                    </a>
+                </li>
+                <li class="fd-menu__item" role="presentation">
+                    <a class="fd-menu__link" href="#" role="menuitem">
+                        <span class="fd-menu__title">Sub-option 5 with very very very very long text</span>
                     </a>
                 </li>
             </ul>


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-ngx/issues/7986

## Description
The submenu width now is only as wide as the parent menu item. It should expand to the whole width of it's text instead


## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
<img width="944" alt="image" src="https://user-images.githubusercontent.com/33101123/163826831-030c820b-6fbf-4069-9764-b0939b642c87.png">



### After:
<img width="943" alt="image" src="https://user-images.githubusercontent.com/33101123/163826650-a4c179f5-047d-4431-821a-a1371ff692b5.png">


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [n/a] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [n/a] Storybook documentation has been created/updated
- [n/a] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
