### PR TITLE
feat(styles): add delta horizon theming for Object List

### DIFF
--- a/src/styles/object-list.scss
+++ b/src/styles/object-list.scss
@@ -4,9 +4,8 @@
 
 $block: #{$fd-namespace}-object-list;
 
-$fd-object-list-with-padding-value-half: 0.5rem;
-$fd-object-list-with-padding-value-one: 1rem;
-$fd-object-list-with-value-half: 0.75rem;
+$fd-object-list-with-padding-big: 1rem;
+$fd-object-list-with-padding-small: 0.75rem;
 $fd-object-list-font-color: var(--sapContent_LabelColor);
 
 @mixin fd-object-list-text-align($align) {
@@ -19,7 +18,7 @@ $fd-object-list-font-color: var(--sapContent_LabelColor);
 
 .#{$block} {
   &__item {
-    @include padding-top-bottom($fd-object-list-with-padding-value-one);
+    @include padding-top-bottom($fd-object-list-with-padding-big);
 
     height: 100%;
 
@@ -36,6 +35,7 @@ $fd-object-list-font-color: var(--sapContent_LabelColor);
         .#{$fd-namespace}-object-status__text,
         .#{$fd-namespace}-object-status__icon {
           color: var(--sapList_Active_TextColor);
+          text-shadow: none;
         }
       }
     }
@@ -48,7 +48,7 @@ $fd-object-list-font-color: var(--sapContent_LabelColor);
     width: 100%;
     max-width: 100%;
     color: $fd-object-list-font-color;
-    padding-bottom: $fd-object-list-with-value-half;
+    padding-bottom: $fd-object-list-with-padding-small;
   }
 
   &__container {
@@ -65,7 +65,7 @@ $fd-object-list-font-color: var(--sapContent_LabelColor);
     display: flex;
 
     &-left:not(:first-child) {
-      @include fd-set-margin-left($fd-object-list-with-value-half);
+      @include fd-set-margin-left($fd-object-list-with-padding-small);
     }
   }
 
@@ -78,7 +78,7 @@ $fd-object-list-font-color: var(--sapContent_LabelColor);
 
   &__header-right {
     @include fd-reset();
-    @include fd-set-padding-left($fd-object-list-with-padding-value-one);
+    @include fd-set-padding-left($fd-object-list-with-padding-big);
     @include fd-object-list-text-align(right);
 
     width: 40%;
@@ -102,7 +102,7 @@ $fd-object-list-font-color: var(--sapContent_LabelColor);
     @include fd-ellipsis();
 
     width: 50%;
-    padding: $fd-object-list-with-padding-value-half;
+    padding: 0.5rem 0.5rem 0 0.5rem;
   }
 
   &__row-left {
@@ -132,7 +132,7 @@ $fd-object-list-font-color: var(--sapContent_LabelColor);
 
   &__object-number {
     .#{$fd-namespace}-object-number__text {
-      font-size: 1.375rem;
+      font-size: var(--fdObject_List_Number_Font_Size);
       display: block;
 
       &::after {
@@ -145,7 +145,9 @@ $fd-object-list-font-color: var(--sapContent_LabelColor);
     .#{$fd-namespace}-object-identifier__title {
       @include line-clamp($lines: 2);
 
-      font-size: var(--sapFontHeader4Size);
+      font-size: var(--fdObject_List_Title_Font_Size);
+      font-weight: var(--fdObject_List_Title_Font_Weight);
+      color: var(--sapGroup_TitleTextColor);
       line-height: 1.5;
     }
   }

--- a/src/styles/object-list.scss
+++ b/src/styles/object-list.scss
@@ -4,24 +4,27 @@
 
 $block: #{$fd-namespace}-object-list;
 
+$fd-object-list-with-padding-value-half: 0.5rem;
+$fd-object-list-with-padding-value-one: 1rem;
+$fd-object-list-with-value-half: 0.75rem;
+$fd-object-list-font-color: var(--sapContent_LabelColor);
+
+@mixin fd-object-list-text-align($align) {
+  text-align: $align;
+
+  @include fd-rtl() {
+    text-align: if($align == left, right, left);
+  }
+}
+
 .#{$block} {
-
-  $fd-object-list-with-value-zero: 0;
-  $fd-object-list-with-padding-value-half: 0.5rem;
-  $fd-object-list-with-padding-value-one: 1rem;
-  $fd-object-list-with-value-half: 0.75rem;
-  $fd-object-list-align-left: left;
-  $fd-object-list-align-right: right;
-  $fd-object-list-font-color: var(--sapContent_LabelColor);
-
   &__item {
-    @include padding-top-bottom(1rem);
+    @include padding-top-bottom($fd-object-list-with-padding-value-one);
 
     height: 100%;
 
     .#{$fd-namespace}-list__link {
       @include fd-active() {
-
         .#{$block}__intro,
         .#{$block}__object-attribute,
         .#{$fd-namespace}-avatar,
@@ -60,48 +63,25 @@ $block: #{$fd-namespace}-object-list;
     @include fd-reset();
 
     display: flex;
-    vertical-align: top;
 
-    .#{$block}__header-left:not(:first-child) {
-      margin-left: $fd-object-list-with-value-half;
-
-      @include fd-rtl() {
-        margin-left: 0;
-        margin-right: $fd-object-list-with-value-half;
-      }
+    &-left:not(:first-child) {
+      @include fd-set-margin-left($fd-object-list-with-value-half);
     }
   }
 
   &__header-left {
     @include fd-reset();
+    @include fd-object-list-text-align(left);
 
     width: 60%;
-
-    @include fd-rtl() {
-      text-align: $fd-object-list-align-right;
-    }
   }
 
   &__header-right {
     @include fd-reset();
+    @include fd-set-padding-left($fd-object-list-with-padding-value-one);
+    @include fd-object-list-text-align(right);
 
     width: 40%;
-    text-align: $fd-object-list-align-right;
-    padding-left: $fd-object-list-with-padding-value-one;
-
-    .#{$fd-namespace}-object-number {
-      margin-right: $fd-object-list-with-value-zero;
-    }
-
-    @include fd-rtl() {
-      text-align: $fd-object-list-align-left;
-      padding-right: $fd-object-list-with-padding-value-one;
-      padding-left: $fd-object-list-with-value-zero;
-
-      .#{$fd-namespace}-object-number {
-        margin-left: $fd-object-list-with-value-zero;
-      }
-    }
   }
 
   &__row {
@@ -112,44 +92,27 @@ $block: #{$fd-namespace}-object-list;
     justify-content: flex-end;
 
     > *:only-child {
-      padding: $fd-object-list-with-value-zero;
       width: 100%;
     }
   }
 
-  &__row-left {
-    @include fd-reset();
-    @include fd-ellipsis();
-
-    width: 50%;
-    text-align: $fd-object-list-align-left;
-    padding:
-      $fd-object-list-with-padding-value-half
-      $fd-object-list-with-padding-value-half
-      $fd-object-list-with-padding-value-half
-      $fd-object-list-with-value-zero;
-
-    @include fd-rtl() {
-      text-align: $fd-object-list-align-right;
-      padding:
-        $fd-object-list-with-padding-value-half
-        $fd-object-list-with-value-zero
-        $fd-object-list-with-padding-value-half
-        $fd-object-list-with-padding-value-half;
-    }
-  }
-
+  &__row-left,
   &__row-right {
     @include fd-reset();
     @include fd-ellipsis();
 
     width: 50%;
-    text-align: $fd-object-list-align-right;
-    padding:
-      $fd-object-list-with-padding-value-half
-      $fd-object-list-with-value-zero
-      $fd-object-list-with-padding-value-half
-      $fd-object-list-with-padding-value-half;
+    padding: $fd-object-list-with-padding-value-half;
+  }
+
+  &__row-left {
+    @include fd-object-list-text-align(left);
+    @include fd-set-padding-left(0);
+  }
+
+  &__row-right {
+    @include fd-object-list-text-align(right);
+    @include fd-set-padding-right(0);
 
     .#{$fd-namespace}-object-status {
       &__text,
@@ -157,21 +120,6 @@ $block: #{$fd-namespace}-object-list;
         @include fd-ellipsis();
 
         line-height: 1.4;
-      }
-
-      margin-right: $fd-object-list-with-value-zero;
-    }
-
-    @include fd-rtl() {
-      text-align: $fd-object-list-align-left;
-      padding:
-        $fd-object-list-with-padding-value-half
-        $fd-object-list-with-padding-value-half
-        $fd-object-list-with-padding-value-half
-        $fd-object-list-with-value-zero;
-
-      .#{$fd-namespace}-object-status {
-        margin-left: $fd-object-list-with-value-zero;
       }
     }
   }
@@ -183,7 +131,6 @@ $block: #{$fd-namespace}-object-list;
   }
 
   &__object-number {
-
     .#{$fd-namespace}-object-number__text {
       font-size: 1.375rem;
       display: block;
@@ -198,8 +145,8 @@ $block: #{$fd-namespace}-object-list;
     .#{$fd-namespace}-object-identifier__title {
       @include line-clamp($lines: 2);
 
-      line-height: 1.5;
       font-size: var(--sapFontHeader4Size);
+      line-height: 1.5;
     }
   }
 

--- a/src/styles/theming/sap_fiori_3.scss
+++ b/src/styles/theming/sap_fiori_3.scss
@@ -417,4 +417,9 @@
   --fdBar_Left_Area_Padding_Right: 0;
   --fdBar_Middle_Area_Padding_X: 0.5rem;
   --fdBar_Right_Area_Padding_Left: 0;
+
+  /** Object List */
+  --fdObject_List_Title_Font_Size: var(--sapFontHeader4Size);
+  --fdObject_List_Title_Font_Weight: var(--sapFontHeaderWeight);
+  --fdObject_List_Number_Font_Size: 1.375rem;
 }

--- a/src/styles/theming/sap_fiori_3_dark.scss
+++ b/src/styles/theming/sap_fiori_3_dark.scss
@@ -419,4 +419,9 @@
   --fdBar_Left_Area_Padding_Right: 0;
   --fdBar_Middle_Area_Padding_X: 0.5rem;
   --fdBar_Right_Area_Padding_Left: 0;
+
+  /** Object List */
+  --fdObject_List_Title_Font_Size: var(--sapFontHeader4Size);
+  --fdObject_List_Title_Font_Weight: var(--sapFontHeaderWeight);
+  --fdObject_List_Number_Font_Size: 1.375rem;
 }

--- a/src/styles/theming/sap_fiori_3_hcb.scss
+++ b/src/styles/theming/sap_fiori_3_hcb.scss
@@ -427,4 +427,9 @@
   --fdButton_Menu_Separator_Display: none;
   --fdButton_Menu_Transparent_Border_Width: 0;
   --fdButton_Menu_Transparent_Separator_Display: none;
+
+  /** Object List */
+  --fdObject_List_Title_Font_Size: var(--sapFontHeader4Size);
+  --fdObject_List_Title_Font_Weight: var(--sapFontHeaderWeight);
+  --fdObject_List_Number_Font_Size: 1.375rem;
 }

--- a/src/styles/theming/sap_fiori_3_hcw.scss
+++ b/src/styles/theming/sap_fiori_3_hcw.scss
@@ -428,4 +428,9 @@
   --fdButton_Menu_Separator_Display: none;
   --fdButton_Menu_Transparent_Border_Width: 0;
   --fdButton_Menu_Transparent_Separator_Display: none;
+
+  /** Object List */
+  --fdObject_List_Title_Font_Size: var(--sapFontHeader4Size);
+  --fdObject_List_Title_Font_Weight: var(--sapFontHeaderWeight);
+  --fdObject_List_Number_Font_Size: 1.375rem;
 }

--- a/src/styles/theming/sap_fiori_3_light_dark.scss
+++ b/src/styles/theming/sap_fiori_3_light_dark.scss
@@ -410,4 +410,9 @@
   --fdBar_Left_Area_Padding_Right: 0;
   --fdBar_Middle_Area_Padding_X: 0.5rem;
   --fdBar_Right_Area_Padding_Left: 0;
+
+  /** Object List */
+  --fdObject_List_Title_Font_Size: var(--sapFontHeader4Size);
+  --fdObject_List_Title_Font_Weight: var(--sapFontHeaderWeight);
+  --fdObject_List_Number_Font_Size: 1.375rem;
 }

--- a/src/styles/theming/sap_horizon.scss
+++ b/src/styles/theming/sap_horizon.scss
@@ -459,6 +459,6 @@
 
   /** Object List */
   --fdObject_List_Title_Font_Size: var(--sapFontHeader5Size);
-  --fdObject_List_Title_Font_Weight: semibold;
+  --fdObject_List_Title_Font_Weight: bolder;
   --fdObject_List_Number_Font_Size: 1.25rem;
 }

--- a/src/styles/theming/sap_horizon.scss
+++ b/src/styles/theming/sap_horizon.scss
@@ -456,4 +456,9 @@
   --fdBar_Left_Area_Padding_Right: 0.25rem;
   --fdBar_Middle_Area_Padding_X: 0.25rem;
   --fdBar_Right_Area_Padding_Left: 0.25rem;
+
+  /** Object List */
+  --fdObject_List_Title_Font_Size: var(--sapFontHeader5Size);
+  --fdObject_List_Title_Font_Weight: semibold;
+  --fdObject_List_Number_Font_Size: 1.25rem;
 }

--- a/src/styles/theming/sap_horizon_dark.scss
+++ b/src/styles/theming/sap_horizon_dark.scss
@@ -459,6 +459,6 @@
 
   /** Object List */
   --fdObject_List_Title_Font_Size: var(--sapFontHeader5Size);
-  --fdObject_List_Title_Font_Weight: semibold;
+  --fdObject_List_Title_Font_Weight: bolder;
   --fdObject_List_Number_Font_Size: 1.25rem;
 }

--- a/src/styles/theming/sap_horizon_dark.scss
+++ b/src/styles/theming/sap_horizon_dark.scss
@@ -456,4 +456,9 @@
   --fdBar_Left_Area_Padding_Right: 0.25rem;
   --fdBar_Middle_Area_Padding_X: 0.25rem;
   --fdBar_Right_Area_Padding_Left: 0.25rem;
+
+  /** Object List */
+  --fdObject_List_Title_Font_Size: var(--sapFontHeader5Size);
+  --fdObject_List_Title_Font_Weight: semibold;
+  --fdObject_List_Number_Font_Size: 1.25rem;
 }

--- a/src/styles/theming/sap_horizon_hcb.scss
+++ b/src/styles/theming/sap_horizon_hcb.scss
@@ -442,4 +442,9 @@
   --fdButton_Menu_Separator_Display: none;
   --fdButton_Menu_Transparent_Border_Width: 0;
   --fdButton_Menu_Transparent_Separator_Display: none;
+
+  /** Object List */
+  --fdObject_List_Title_Font_Size: var(--sapFontHeader5Size);
+  --fdObject_List_Title_Font_Weight: semibold;
+  --fdObject_List_Number_Font_Size: 1.25rem;
 }

--- a/src/styles/theming/sap_horizon_hcb.scss
+++ b/src/styles/theming/sap_horizon_hcb.scss
@@ -445,6 +445,6 @@
 
   /** Object List */
   --fdObject_List_Title_Font_Size: var(--sapFontHeader5Size);
-  --fdObject_List_Title_Font_Weight: semibold;
+  --fdObject_List_Title_Font_Weight: bolder;
   --fdObject_List_Number_Font_Size: 1.25rem;
 }

--- a/src/styles/theming/sap_horizon_hcw.scss
+++ b/src/styles/theming/sap_horizon_hcw.scss
@@ -441,4 +441,9 @@
   --fdButton_Menu_Separator_Display: none;
   --fdButton_Menu_Transparent_Border_Width: 0;
   --fdButton_Menu_Transparent_Separator_Display: none;
+
+  /** Object List */
+  --fdObject_List_Title_Font_Size: var(--sapFontHeader5Size);
+  --fdObject_List_Title_Font_Weight: semibold;
+  --fdObject_List_Number_Font_Size: 1.25rem;
 }

--- a/src/styles/theming/sap_horizon_hcw.scss
+++ b/src/styles/theming/sap_horizon_hcw.scss
@@ -444,6 +444,6 @@
 
   /** Object List */
   --fdObject_List_Title_Font_Size: var(--sapFontHeader5Size);
-  --fdObject_List_Title_Font_Weight: semibold;
+  --fdObject_List_Title_Font_Weight: bolder;
   --fdObject_List_Number_Font_Size: 1.25rem;
 }


### PR DESCRIPTION
## Related Issue

Part of #3213.

## Description

Object list styles refactoring, horizon support implementation.

_Note: In Horizon specs colors of the Object Statuses in active state are remain the same and in Horizon they're made be one color. Unfortunately, we cannot make them one color in Fiori and don't change in Horizon, there are no any options to conditionally apply the styling._

Current:
<img width="478" alt="image" src="https://user-images.githubusercontent.com/20265336/164204942-8dcedd0e-1aff-45eb-93b5-975a1e9aa3c4.png">

Specs:
<img width="334" alt="image" src="https://user-images.githubusercontent.com/20265336/164205003-5895fc09-ccbf-4ebb-bb0b-38c269a47826.png">

## Screenshots

### Before:

<img width="1364" alt="image" src="https://user-images.githubusercontent.com/20265336/163980027-f0d45dd9-81c6-4710-937c-258211232c25.png">

### After:

<img width="1350" alt="image" src="https://user-images.githubusercontent.com/20265336/163980120-2291b6ab-5cb0-45bd-87e9-11e61825be32.png">