### PR TITLE
fix(styles): horizon menu border radius bug [ci-visual]

### DIFF
--- a/src/styles/menu.scss
+++ b/src/styles/menu.scss
@@ -5,7 +5,7 @@ $block: #{$fd-namespace}-menu;
 
 .#{$block} {
   // Menu
-  $fd-menu-border-radius: var(--sapElement_BorderCornerRadius) !default;
+  $fd-menu-border-radius: var(--fdButton_Menu_Border_Radius) !default;
 
   // Menu Item
   $fd-menu-item-color-active: var(--sapList_Active_TextColor) !default;

--- a/src/styles/theming/common/button/_sap_fiori.scss
+++ b/src/styles/theming/common/button/_sap_fiori.scss
@@ -26,6 +26,7 @@
   /** Menu */
   --fdButton_Menu_Emphasized_Margin: 0.0625rem;
   --fdButton_Menu_Border_Width: 0;
+  --fdButton_Menu_Border_Radius: var(--sapElement_BorderCornerRadius);
   --fdButton_Menu_Separator_Display: none;
   --fdButton_Menu_Transparent_Border_Width: var(--sapButton_BorderWidth);
   --fdButton_Menu_Transparent_Separator_Display: block;

--- a/src/styles/theming/common/button/_sap_horizon.scss
+++ b/src/styles/theming/common/button/_sap_horizon.scss
@@ -26,6 +26,7 @@
   /** Menu */
   --fdButton_Menu_Emphasized_Margin: 0;
   --fdButton_Menu_Border_Width: var(--sapButton_BorderWidth);
+  --fdButton_Menu_Border_Radius: var(--sapPopover_BorderCornerRadius);
   --fdButton_Menu_Separator_Display: block;
   --fdButton_Menu_Transparent_Border_Width: var(--sapButton_BorderWidth);
   --fdButton_Menu_Transparent_Separator_Display: block;


### PR DESCRIPTION
part of #3213 

fixes a minor issue with menu border radius

**before**
<img width="174" alt="Screen Shot 2022-04-21 at 1 20 02 PM" src="https://user-images.githubusercontent.com/2471874/164539420-8d3f93e7-0678-43a4-af58-1e83df3257d5.png">

**after**
<img width="170" alt="Screen Shot 2022-04-21 at 1 25 54 PM" src="https://user-images.githubusercontent.com/2471874/164539465-56dbdd7f-9c6c-48c3-b765-9af521611384.png">

