### PR TITLE
feat(styles): popover body compact, arrow position fix

### DIFF
--- a/src/styles/popover.scss
+++ b/src/styles/popover.scss
@@ -15,8 +15,8 @@ $block: #{$fd-namespace}-popover;
   $fd-popover-arrow-width: 1rem !default;
   $fd-popover-arrow-height: 0.5rem !default;
   $fd-popover-arrow-width-half: $fd-popover-arrow-width * 0.5 !default;
-  $fd-popover-arrow-offset: 0.625rem;
-  $fd-popover-arrow-offset-compact: 0.5rem;
+  $fd-popover-arrow-offset: 0.575rem;
+  $fd-popover-arrow-offset-compact: 0.44rem;
   $fd-popover-inline-help-arrow-offset: 0.25rem !default;
   $fd-popover-arrow-color: var(--sapContent_ForegroundBorderColor) !default;
 

--- a/src/styles/popover.scss
+++ b/src/styles/popover.scss
@@ -15,7 +15,8 @@ $block: #{$fd-namespace}-popover;
   $fd-popover-arrow-width: 1rem !default;
   $fd-popover-arrow-height: 0.5rem !default;
   $fd-popover-arrow-width-half: $fd-popover-arrow-width * 0.5 !default;
-  $fd-popover-arrow-offset: var(--fdPopover_Arrow_Offset);
+  $fd-popover-arrow-offset: 0.625rem;
+  $fd-popover-arrow-offset-compact: 0.5rem;
   $fd-popover-inline-help-arrow-offset: 0.25rem !default;
   $fd-popover-arrow-color: var(--sapContent_ForegroundBorderColor) !default;
 
@@ -121,6 +122,42 @@ $block: #{$fd-namespace}-popover;
       & > * {
         border-bottom-right-radius: $fd-popover-border-radius;
         border-bottom-left-radius: $fd-popover-border-radius;
+      }
+    }
+
+    &--compact.#{$block}__body {
+      &,
+      &--left {
+        &::before,
+        &::after {
+          left: $fd-popover-arrow-offset-compact;
+        }
+
+        @include fd-rtl() {
+          &::before,
+          &::after {
+            left: auto;
+            right: $fd-popover-arrow-offset-compact;
+          }
+        }
+      }
+
+      &--right {
+        @include fd-right-popover-offset-placement();
+
+        &::before,
+        &::after {
+          left: auto;
+          right: $fd-popover-arrow-offset-compact;
+        }
+
+        @include fd-rtl() {
+          &::before,
+          &::after {
+            left: $fd-popover-arrow-offset-compact;
+            right: auto;
+          }
+        }
       }
     }
 
@@ -250,6 +287,26 @@ $block: #{$fd-namespace}-popover;
       box-shadow: none;
       border: none;
       margin-top: -0.25rem !important;
+    }
+
+    &--compact {
+      .#{$block}__arrow {
+        &-x--start {
+          left: $fd-popover-arrow-offset-compact;
+        }
+
+        &-x--end {
+          right: $fd-popover-arrow-offset-compact;
+        }
+
+        &-y--top {
+          top: $fd-popover-arrow-offset-compact;
+        }
+
+        &-y--bottom {
+          bottom: $fd-popover-arrow-offset-compact;
+        }
+      }
     }
 
     .#{$block}__arrow {

--- a/src/styles/popover.scss
+++ b/src/styles/popover.scss
@@ -74,8 +74,7 @@ $block: #{$fd-namespace}-popover;
     transition: all $fd-popover-transition-params;
     transform: translateY(0);
 
-    &::before,
-    &::after {
+    @include both-pseudo-selectors() {
       content: "";
       position: absolute;
     }
@@ -128,14 +127,12 @@ $block: #{$fd-namespace}-popover;
     &--compact.#{$block}__body {
       &,
       &--left {
-        &::before,
-        &::after {
+        @include both-pseudo-selectors() {
           left: $fd-popover-arrow-offset-compact;
         }
 
         @include fd-rtl() {
-          &::before,
-          &::after {
+          @include both-pseudo-selectors() {
             left: auto;
             right: $fd-popover-arrow-offset-compact;
           }
@@ -145,15 +142,13 @@ $block: #{$fd-namespace}-popover;
       &--right {
         @include fd-right-popover-offset-placement();
 
-        &::before,
-        &::after {
+        @include both-pseudo-selectors() {
           left: auto;
           right: $fd-popover-arrow-offset-compact;
         }
 
         @include fd-rtl() {
-          &::before,
-          &::after {
+          @include both-pseudo-selectors() {
             left: $fd-popover-arrow-offset-compact;
             right: auto;
           }
@@ -165,14 +160,12 @@ $block: #{$fd-namespace}-popover;
     &--left {
       @include fd-left-popover-offset-placement();
 
-      &::before,
-      &::after {
+      @include both-pseudo-selectors() {
         left: $fd-popover-arrow-offset;
       }
 
       @include fd-rtl() {
-        &::before,
-        &::after {
+        @include both-pseudo-selectors() {
           left: auto;
           right: $fd-popover-arrow-offset;
         }
@@ -182,15 +175,13 @@ $block: #{$fd-namespace}-popover;
     &--right {
       @include fd-right-popover-offset-placement();
 
-      &::before,
-      &::after {
+      @include both-pseudo-selectors() {
         left: auto;
         right: $fd-popover-arrow-offset;
       }
 
       @include fd-rtl() {
-        &::before,
-        &::after {
+        @include both-pseudo-selectors() {
           left: $fd-popover-arrow-offset;
           right: auto;
         }
@@ -202,8 +193,7 @@ $block: #{$fd-namespace}-popover;
       top: $fd-popover-top-position-noarrow;
       z-index: 2;
 
-      &::before,
-      &::after {
+      @include both-pseudo-selectors() {
         display: none;
       }
     }

--- a/src/styles/theming/sap_fiori_3.scss
+++ b/src/styles/theming/sap_fiori_3.scss
@@ -156,7 +156,6 @@
   /* Popover */
   --fdPopover_Text_Shadow: none;
   --fdPopover_Border_Radius: var(--sapElement_BorderCornerRadius);
-  --fdPopover_Arrow_Offset: 0.5rem;
 
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: none;

--- a/src/styles/theming/sap_fiori_3_dark.scss
+++ b/src/styles/theming/sap_fiori_3_dark.scss
@@ -156,7 +156,6 @@
   /* Popover */
   --fdPopover_Text_Shadow: none;
   --fdPopover_Border_Radius: var(--sapElement_BorderCornerRadius);
-  --fdPopover_Arrow_Offset: 0.5rem;
 
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: none;

--- a/src/styles/theming/sap_fiori_3_hcb.scss
+++ b/src/styles/theming/sap_fiori_3_hcb.scss
@@ -157,7 +157,6 @@
   /* Popover */
   --fdPopover_Text_Shadow: 0 0 0.125rem #000;
   --fdPopover_Border_Radius: var(--sapElement_BorderCornerRadius);
-  --fdPopover_Arrow_Offset: 0.5rem;
 
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: 0 0 0.125rem #000;

--- a/src/styles/theming/sap_fiori_3_hcw.scss
+++ b/src/styles/theming/sap_fiori_3_hcw.scss
@@ -158,7 +158,6 @@
   /* Popover */
   --fdPopover_Text_Shadow: none;
   --fdPopover_Border_Radius: var(--sapElement_BorderCornerRadius);
-  --fdPopover_Arrow_Offset: 0.5rem;
 
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: none;

--- a/src/styles/theming/sap_fiori_3_light_dark.scss
+++ b/src/styles/theming/sap_fiori_3_light_dark.scss
@@ -156,7 +156,6 @@
   /* Popover */
   --fdPopover_Text_Shadow: none;
   --fdPopover_Border_Radius: var(--sapElement_BorderCornerRadius);
-  --fdPopover_Arrow_Offset: 0.5rem;
 
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: none;

--- a/src/styles/theming/sap_horizon.scss
+++ b/src/styles/theming/sap_horizon.scss
@@ -195,7 +195,6 @@
   /* Popover */
   --fdPopover_Text_Shadow: none;
   --fdPopover_Border_Radius: var(--sapPopover_BorderCornerRadius);
-  --fdPopover_Arrow_Offset: 1rem;
 
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: none;

--- a/src/styles/theming/sap_horizon_dark.scss
+++ b/src/styles/theming/sap_horizon_dark.scss
@@ -195,7 +195,6 @@
   /* Popover */
   --fdPopover_Text_Shadow: none;
   --fdPopover_Border_Radius: var(--sapPopover_BorderCornerRadius);
-  --fdPopover_Arrow_Offset: 1rem;
 
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: none;

--- a/src/styles/theming/sap_horizon_hcb.scss
+++ b/src/styles/theming/sap_horizon_hcb.scss
@@ -162,7 +162,6 @@
   /* Popover */
   --fdPopover_Text_Shadow: none;
   --fdPopover_Border_Radius: var(--sapPopover_BorderCornerRadius);
-  --fdPopover_Arrow_Offset: 1rem;
 
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: none;

--- a/src/styles/theming/sap_horizon_hcw.scss
+++ b/src/styles/theming/sap_horizon_hcw.scss
@@ -162,7 +162,6 @@
   /* Popover */
   --fdPopover_Text_Shadow: none;
   --fdPopover_Border_Radius: var(--sapPopover_BorderCornerRadius);
-  --fdPopover_Arrow_Offset: 1rem;
 
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: none;

--- a/stories/action-bar/action-bar.stories.js
+++ b/stories/action-bar/action-bar.stories.js
@@ -144,7 +144,7 @@ export const Actions = () => `<div class="fd-action-bar">
                         <i class="sap-icon--overflow"></i>
                     </button>
                 </div>
-                <div class="fd-popover__body fd-popover__body--right" aria-hidden="false" id="wgxzK859">
+                <div class="fd-popover__body fd-popover__body--compact fd-popover__body--right" aria-hidden="false" id="wgxzK859">
                     <nav class="fd-menu" id="">
                         <ul class="fd-menu__list fd-menu__list--no-shadow">
                             <li class="fd-menu__item">

--- a/stories/action-sheet/action-sheet.stories.js
+++ b/stories/action-sheet/action-sheet.stories.js
@@ -33,7 +33,7 @@ export const ActionSheetDesktop = () => `
             <i class="sap-icon--settings"></i>
         </button>
     </div>
-    <div class="fd-popover__body" aria-hidden="false" id="actionSheetDesktop">
+    <div class="fd-popover__body fd-popover__body--compact" aria-hidden="false" id="actionSheetDesktop">
         <ul class="fd-action-sheet fd-action-sheet--compact" role="list" aria-label="List of contextual options">
             <li class="fd-action-sheet__item" role="listitem">
                 <button class="fd-button fd-button--full-width fd-button--compact fd-button--transparent fd-button--text-alignment-left">

--- a/stories/feed-list/feed-list.stories.js
+++ b/stories/feed-list/feed-list.stories.js
@@ -240,7 +240,7 @@ export const WithActions = () => `<ul class="fd-feed-list" aria-label="Feed List
                             <i class="sap-icon--overflow"></i>
                         </button>
                     </div>
-                    <div class="fd-popover__body fd-popover__body--right" aria-hidden="true" id="actionSheetDesktop">
+                    <div class="fd-popover__body fd-popover__body--compact fd-popover__body--right" aria-hidden="true" id="actionSheetDesktop">
                         <ul class="fd-action-sheet fd-action-sheet--compact" role="list" aria-label="List of contextual options">
                             <li class="fd-action-sheet__item" role="listitem">
                                 <button class="fd-button fd-button--full-width fd-button--compact fd-button--transparent fd-button--text-alignment-left">

--- a/stories/popover/popover.stories.js
+++ b/stories/popover/popover.stories.js
@@ -289,160 +289,210 @@ export const Variants = () => `<div class="fddocs-container">
             </div>
         </div>
     </div>
-    </div>
-    <div class="fddocs-container" style="margin-top:300px; margin-bottom: 300px">
-        <div class="fd-popover">
-            <div class="fd-popover__control">
-                <button
-                    aria-controls="popoverHSF3"
-                    aria-expanded="true"
-                    aria-haspopup="dialog"
-                    class="fd-button"
-                    onclick="onPopoverClick('popoverHSF3');"
-                    role="button">
-                        <!- role is needed to override the combobox role due to aria-haspopup -->
-                        Header, subheader and footer
-                </button>
-            </div>
-            <section
-                aria-hidden="false"
-                class="fd-popover__body fd-popover__body--no-arrow"
-                id="popoverHSF3"
-                aria-label="Dialog Data 1"
-                role="dialog">
-                <header class="fd-popover__body-header">
-                    <div class="fd-bar fd-bar--header-with-subheader">
-                        <div class="fd-bar__left">
-                            <div class="fd-bar__element">
-                                <button
-                                    aria-label="back button"
-                                    class="fd-button fd-button--transparent">
-                                    <i class="sap-icon--navigation-left-arrow"></i>
-                                </button>
-                            </div>
-                            <div id="popoverHeader" class="fd-bar__element">
-                                Header
-                            </div>
-                        </div>
-                    </div>
-                    <div class="fd-bar fd-bar--subheader">
-                        <div class="fd-bar__middle">
-                            <div class="fd-bar__element">
-                                <div class="fd-form-item">
-                                    <div class="fd-segmented-button" role="group" aria-label="Group label">
-                                        <button aria-label="email" class="fd-button fd-button--compact" aria-pressed="true">
-                                            <i class="sap-icon--email"></i>
-                                        </button>
-                                        <button  aria-label="phone" class="fd-button fd-button--compact">
-                                            <i class="sap-icon--iphone"></i>
-                                        </button>
-                                        <button  aria-label="notification" class="fd-button fd-button--compact">
-                                            <i class="sap-icon--notification-2"></i>
-                                        </button>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </header>
-                <div style="margin: 20px 80px;">
-                    <span
-                        class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--thumbnail"
-                        style="background-image: url('assets/images/avatars/2.svg');"
-                        role="img"
-                        aria-label="Avatar"></span>
-                </div>
-                <footer class="fd-popover__body-footer">
-                    <div class="fd-bar fd-bar--footer">
-                        <div class="fd-bar__right">
-                            <div class="fd-bar__element">
-                                <button class="fd-button fd-button--compact fd-button--emphasized">Save</button>
-                            </div>
-                            <div class="fd-bar__element">
-                                <button class="fd-button fd-button--compact fd-button--transparent">Cancel</button>
-                            </div>
-                        </div>
-                    </div>
-                </footer>
-            </section>
-        </div>
+</div>
 
-        <div class="fd-popover">
-            <div class="fd-popover__control">
-                <button
-                    aria-controls="popoverHSF345"
-                    aria-expanded="true"
-                    aria-haspopup="dialog"
-                    class="fd-button"
-                    onclick="onPopoverClick('popoverHSF345');"
-                    role="button">
-                        <!- role is needed to override the combobox role due to aria-haspopup -->
-                        Cozy mode
-                </button>
-            </div>
-            <section
-                aria-hidden="false"
-                class="fd-popover__body fd-popover__body--no-arrow"
-                id="popoverHSF345"
-                aria-label="Dialog data"
-                role="dialog">
-                <header class="fd-popover__body-header">
-                    <div class="fd-bar fd-bar--cozy fd-bar--header-with-subheader">
-                        <div class="fd-bar__left">
-                            <div class="fd-bar__element">
-                                <button
-                                    aria-label="go back"
-                                    class="fd-button fd-button--transparent">
-                                    <i class="sap-icon--navigation-left-arrow"></i>
-                                </button>
-                            </div>
-                            <div class="fd-bar__element">
-                                Header
-                            </div>
+<div class="fddocs-container" style="margin-top:300px; margin-bottom: 300px">
+    <div class="fd-popover">
+        <div class="fd-popover__control">
+            <button
+                aria-controls="popoverHSF3"
+                aria-expanded="true"
+                aria-haspopup="dialog"
+                class="fd-button"
+                onclick="onPopoverClick('popoverHSF3');"
+                role="button">
+                    <!- role is needed to override the combobox role due to aria-haspopup -->
+                    Header, subheader and footer
+            </button>
+        </div>
+        <section
+            aria-hidden="false"
+            class="fd-popover__body fd-popover__body--no-arrow"
+            id="popoverHSF3"
+            aria-label="Dialog Data 1"
+            role="dialog">
+            <header class="fd-popover__body-header">
+                <div class="fd-bar fd-bar--header-with-subheader">
+                    <div class="fd-bar__left">
+                        <div class="fd-bar__element">
+                            <button
+                                aria-label="back button"
+                                class="fd-button fd-button--transparent">
+                                <i class="sap-icon--navigation-left-arrow"></i>
+                            </button>
+                        </div>
+                        <div id="popoverHeader" class="fd-bar__element">
+                            Header
                         </div>
                     </div>
-                    <div class="fd-bar fd-bar--cozy fd-bar--subheader">
-                        <div class="fd-bar__middle">
-                            <div class="fd-bar__element">
-                                <div class="fd-form-item">
-                                    <div class="fd-segmented-button" role="group" aria-label="Group label">
-                                        <button aria-label="email" class="fd-button fd-button--compact" aria-pressed="true">
-                                            <i class="sap-icon--email"></i>
-                                        </button>
-                                        <button aria-label="phone" class="fd-button fd-button--compact">
-                                            <i class="sap-icon--iphone"></i>
-                                        </button>
-                                        <button aria-label="notifications" class="fd-button fd-button--compact">
-                                            <i class="sap-icon--notification-2"></i>
-                                        </button>
-                                    </div>
+                </div>
+                <div class="fd-bar fd-bar--subheader">
+                    <div class="fd-bar__middle">
+                        <div class="fd-bar__element">
+                            <div class="fd-form-item">
+                                <div class="fd-segmented-button" role="group" aria-label="Group label">
+                                    <button aria-label="email" class="fd-button fd-button--compact" aria-pressed="true">
+                                        <i class="sap-icon--email"></i>
+                                    </button>
+                                    <button  aria-label="phone" class="fd-button fd-button--compact">
+                                        <i class="sap-icon--iphone"></i>
+                                    </button>
+                                    <button  aria-label="notification" class="fd-button fd-button--compact">
+                                        <i class="sap-icon--notification-2"></i>
+                                    </button>
                                 </div>
                             </div>
                         </div>
                     </div>
-                </header>
-                <div style="margin: 20px 80px;">
-                    <span
-                        class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--thumbnail"
-                        style="background-image: url('assets/images/avatars/1.svg');"
-                        role="img"
-                        aria-label="Avatar">
-                    </span>
                 </div>
-                <footer class="fd-popover__body-footer">
-                    <div class="fd-bar fd-bar--cozy fd-bar--footer">
-                        <div class="fd-bar__right">
-                            <div class="fd-bar__element">
-                                <button class="fd-button fd-button--compact fd-button--emphasized">Save</button>
-                            </div>
-                            <div class="fd-bar__element">
-                                <button class="fd-button fd-button--compact fd-button--transparent">Cancel</button>
+            </header>
+            <div style="margin: 20px 80px;">
+                <span
+                    class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--thumbnail"
+                    style="background-image: url('assets/images/avatars/2.svg');"
+                    role="img"
+                    aria-label="Avatar"></span>
+            </div>
+            <footer class="fd-popover__body-footer">
+                <div class="fd-bar fd-bar--footer">
+                    <div class="fd-bar__right">
+                        <div class="fd-bar__element">
+                            <button class="fd-button fd-button--compact fd-button--emphasized">Save</button>
+                        </div>
+                        <div class="fd-bar__element">
+                            <button class="fd-button fd-button--compact fd-button--transparent">Cancel</button>
+                        </div>
+                    </div>
+                </div>
+            </footer>
+        </section>
+    </div>
+
+    <div class="fd-popover">
+        <div class="fd-popover__control">
+            <button
+                aria-controls="popoverHSF345"
+                aria-expanded="true"
+                aria-haspopup="dialog"
+                class="fd-button"
+                onclick="onPopoverClick('popoverHSF345');"
+                role="button">
+                    <!- role is needed to override the combobox role due to aria-haspopup -->
+                    Cozy mode
+            </button>
+        </div>
+        <section
+            aria-hidden="false"
+            class="fd-popover__body fd-popover__body--no-arrow"
+            id="popoverHSF345"
+            aria-label="Dialog data"
+            role="dialog">
+            <header class="fd-popover__body-header">
+                <div class="fd-bar fd-bar--cozy fd-bar--header-with-subheader">
+                    <div class="fd-bar__left">
+                        <div class="fd-bar__element">
+                            <button
+                                aria-label="go back"
+                                class="fd-button fd-button--transparent">
+                                <i class="sap-icon--navigation-left-arrow"></i>
+                            </button>
+                        </div>
+                        <div class="fd-bar__element">
+                            Header
+                        </div>
+                    </div>
+                </div>
+                <div class="fd-bar fd-bar--cozy fd-bar--subheader">
+                    <div class="fd-bar__middle">
+                        <div class="fd-bar__element">
+                            <div class="fd-form-item">
+                                <div class="fd-segmented-button" role="group" aria-label="Group label">
+                                    <button aria-label="email" class="fd-button fd-button--compact" aria-pressed="true">
+                                        <i class="sap-icon--email"></i>
+                                    </button>
+                                    <button aria-label="phone" class="fd-button fd-button--compact">
+                                        <i class="sap-icon--iphone"></i>
+                                    </button>
+                                    <button aria-label="notifications" class="fd-button fd-button--compact">
+                                        <i class="sap-icon--notification-2"></i>
+                                    </button>
+                                </div>
                             </div>
                         </div>
                     </div>
-                </footer>
-            </section>
+                </div>
+            </header>
+            <div style="margin: 20px 80px;">
+                <span
+                    class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--thumbnail"
+                    style="background-image: url('assets/images/avatars/1.svg');"
+                    role="img"
+                    aria-label="Avatar">
+                </span>
+            </div>
+            <footer class="fd-popover__body-footer">
+                <div class="fd-bar fd-bar--cozy fd-bar--footer">
+                    <div class="fd-bar__right">
+                        <div class="fd-bar__element">
+                            <button class="fd-button fd-button--compact fd-button--emphasized">Save</button>
+                        </div>
+                        <div class="fd-bar__element">
+                            <button class="fd-button fd-button--compact fd-button--transparent">Cancel</button>
+                        </div>
+                    </div>
+                </div>
+            </footer>
+        </section>
+    </div>
+</div>
+
+<div class="fddocs-container" style="margin-top:300px; margin-bottom: 300px;">
+    <div class="fd-popover">
+        <div class="fd-popover__control">
+            <button
+                aria-controls="popoverHSF3"
+                aria-expanded="true"
+                aria-haspopup="dialog"
+                class="fd-button fd-button--compact"
+                onclick="onPopoverClick('popoverHSF3');"
+                role="button">
+                    <!- role is needed to override the combobox role due to aria-haspopup -->
+                    <i role="presentation" class="sap-icon--navigation-down-arrow"></i>
+            </button>
+            Compact body
         </div>
+        <section
+            aria-hidden="false"
+            class="fd-popover__body fd-popover__body--compact"
+            id="popoverHSF3"
+            aria-label="Dialog Data 1"
+            role="dialog">
+            <nav class="fd-menu" aria-label="options with header">
+                <ul class="fd-menu__list fd-menu__list--no-shadow">
+                    <li class="fd-menu__item">
+                        <a class="fd-menu__link" href="#">
+                            <span class="fd-menu__title">Option 1</span>
+                        </a>
+                    </li>
+                    <li class="fd-menu__item">
+                        <a class="fd-menu__link" href="#">
+                            <span class="fd-menu__title">Option 2</span>
+                        </a>
+                    </li>
+                    <li class="fd-menu__item">
+                        <a class="fd-menu__link" href="#">
+                            <span class="fd-menu__title">Option 3</span>
+                        </a>
+                    </li>
+                    <li class="fd-menu__item">
+                        <a class="fd-menu__link" href="#">
+                            <span class="fd-menu__title">Option 4</span>
+                        </a>
+                    </li>
+                </ul>
+            </nav>
+        </section>
+    </div>
 </div>
 `;
 
@@ -458,8 +508,9 @@ Variant | Modifier class | Description
 :------ | :------------- | :---------------
 Header | \`fd-popover__body-header\` | To display a header with text.
 Footer | \`fd-popover__body-footer\` | To display a footer with actions.
-Header, subheader and footer | \`fd-popover__body-header\` containing \`fd-bar fd-bar--header-with-subheader\` and \`fd-bar fd-bar--subheader\` | This variant uses the **Bar** component.
+Header, subheader | \`fd-popover__body-header\` containing \`fd-bar fd-bar--header-with-subheader\` and \`fd-bar fd-bar--subheader\` | This variant uses the **Bar** component.
 Cozy mode | \`fd-bar--cozy\` | Add this modifier class to the header area where \`fd-bar\` is used.
+Compact mode | \`fd-popover__body--compact\` | Add this modifier class the popover body component to display the popover in compact mode.
 
         ` }
     }

--- a/stories/popover/popover.stories.js
+++ b/stories/popover/popover.stories.js
@@ -36,10 +36,13 @@ export const Alignment = () => `<div class="fddocs-container" style="margin-bott
                     aria-haspopup="true"
                     class="fd-button"
                     onclick="onPopoverClick('popoverA1');"
-                    role="button">
+                    role="button"
+                >
                     <!- role is needed to override the combobox role due to aria-haspopup -->
-                        Left-aligned (default)
+                    <i class="sap-icon--navigation-down-arrow"></i>
                 </button>
+
+                Left-aligned (default)
             </div>
             <div class="fd-popover__body" aria-hidden="false" id="popoverA1">
                 <nav class="fd-menu" aria-label="options">
@@ -71,16 +74,19 @@ export const Alignment = () => `<div class="fddocs-container" style="margin-bott
 
         <div class="fd-popover fd-popover--right">
             <div class="fd-popover__control">
+                Right-aligned
+
                 <button
                     aria-controls="popoverA2"
                     aria-expanded="true"
                     aria-haspopup="true"
                     class="fd-button"
                     onclick="onPopoverClick('popoverA2');"
-                    role="button">
+                    role="button"
+                >
                         <!- role is needed to override the combobox role due to aria-haspopup -->
-                        Right-aligned
-                    </button>
+                    <i class="sap-icon--navigation-down-arrow"></i>
+                </button>
             </div>
             <div class="fd-popover__body fd-popover__body--right" aria-hidden="false" id="popoverA2">
                 <div style="margin: 20px;">


### PR DESCRIPTION
## Related Issue

Closes none.

## Description

Popover's arrow placement fix.

## Screenshots

### Before:

<img width="56" alt="image" src="https://user-images.githubusercontent.com/20265336/165084478-0d776017-d501-4200-b253-c6d335c50150.png">

### After:

<img width="45" alt="image" src="https://user-images.githubusercontent.com/20265336/165084533-2ded7f75-d0cd-438d-a709-df2384d3c622.png">
