### PR TITLE
fix(styles): remove search button in inputs in webkit browsers

### DIFF
--- a/src/styles/input.scss
+++ b/src/styles/input.scss
@@ -8,6 +8,7 @@ $block: #{$fd-namespace}-input;
 
 .#{$block} {
   @include fd-form-text();
+  @include fd-reset-webkit-input-buttons();
 
   min-width: 2.75rem;
   width: 100%;

--- a/src/styles/mixins/_mixins.scss
+++ b/src/styles/mixins/_mixins.scss
@@ -30,6 +30,15 @@
   }
 }
 
+@mixin fd-reset-webkit-input-buttons {
+  &[type="search"]::-webkit-search-decoration,
+  &[type="search"]::-webkit-search-cancel-button,
+  &[type="search"]::-webkit-search-results-button,
+  &[type="search"]::-webkit-search-results-decoration {
+    -webkit-appearance: none;
+  }
+}
+
 @mixin fd-children {
   &:nth-child(n + 1) {
     @content;


### PR DESCRIPTION
## Related Issue

Part of https://github.com/SAP/fundamental-ngx/issues/7908

## Description

Removes clear button from input of type search that automatically applied in webkit browsers.

## Screenshots

### Before:
<img width="68" alt="image" src="https://user-images.githubusercontent.com/20265336/165096459-8086e496-3527-4165-922e-947de76f0ad7.png">

### After:
<img width="56" alt="image" src="https://user-images.githubusercontent.com/20265336/165096658-95b8dfa1-e0f9-459f-a3b4-980439ae9a5e.png">
