### PR TITLE
fix(styles): shellbar logo, product and subtitle display

### DIFF
--- a/src/styles/shellbar.scss
+++ b/src/styles/shellbar.scss
@@ -68,6 +68,13 @@ $block: #{$fd-namespace}-shellbar;
     color: var(--sapShell_TextColor);
   }
 
+  &__logo,
+  &__product,
+  &__subtitle {
+    display: inline-block;
+    vertical-align: middle;
+  }
+
   &__title {
     font-weight: bold;
     vertical-align: middle;


### PR DESCRIPTION
## Description
It was removed previously when horizon deltas were done, but these display properties should exists, otherwise width and height of replaced logo will not have effect and in ngx will cause issues