### PR TITLE
fix(styles): load styles once

### DIFF
--- a/.storybook/custom/styleChangers/utils/generateUseFn.js
+++ b/.storybook/custom/styleChangers/utils/generateUseFn.js
@@ -1,5 +1,13 @@
-export default (linkTag) => {
+export default (linkTag, uniqueIdentifier) => {
     return () => {
+        if (uniqueIdentifier) {
+            const uniqueValue = linkTag.getAttribute(uniqueIdentifier);
+            const tagName = linkTag.tagName;
+            // If such element with such unique attribute value already loaded on the page, no need to duplicate it once again.
+            if (document.querySelector(`${tagName}[${uniqueIdentifier}="${uniqueValue}"]`) !== null) {
+                return;
+            }
+        }
         document.head.appendChild(linkTag);
     };
 }

--- a/.storybook/custom/styleChangers/utils/getLazyLoader.js
+++ b/.storybook/custom/styleChangers/utils/getLazyLoader.js
@@ -1,9 +1,9 @@
 import generateUnuseFn from './generateUnuseFn';
 import generateUseFn from './generateUseFn';
 
-export default (linkTagGenerator) => {
+export default (linkTagGenerator, uniqueIdentifier = 'href') => {
     return (pathToStyle) => {
         const linkTag = linkTagGenerator(pathToStyle);
-        return { use: generateUseFn(linkTag), unuse: generateUnuseFn(linkTag) };
+        return { use: generateUseFn(linkTag, uniqueIdentifier), unuse: generateUnuseFn(linkTag) };
     };
 }


### PR DESCRIPTION
## Related Issue
Closes none

## Description
Previously, componentStylesManager loaded styles for every example. This created an overhead of loaded identical style files, which could cause hang of the developer tools of the browser. This behaviour was changed that only unique hrefs will be loaded now.

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
<img width="1060" alt="image" src="https://user-images.githubusercontent.com/6586561/165523875-8fd4b27d-52c0-433b-8e6f-e2712826754d.png">


### After:
<img width="1045" alt="image" src="https://user-images.githubusercontent.com/6586561/165524141-752e7f78-f9c7-4c54-8df4-34006eeb4d80.png">
