### PR TITLE
fix: checkbox, radio borders in horizon

### DIFF
--- a/src/styles/checkbox.scss
+++ b/src/styles/checkbox.scss
@@ -198,7 +198,7 @@ $fd-checkbox-tristate-compact-offset: 0.25rem;
       var(--sapField_TextColor),
       var(--sapField_WarningColor),
       var(--sapField_WarningBorderWidth),
-      var(--sapField_WarningBorderStyle),
+      var(--fdCheckbox_Warning_Error_Information_Border_Style),
       var(--fdCheckbox_Warning_State_Shadow)
     );
   }
@@ -209,7 +209,7 @@ $fd-checkbox-tristate-compact-offset: 0.25rem;
       var(--sapField_InvalidColor),
       var(--sapField_InvalidColor),
       var(--sapField_InvalidBorderWidth),
-      var(--sapField_InvalidBorderStyle),
+      var(--fdCheckbox_Warning_Error_Information_Border_Style),
       var(--fdCheckbox_Error_State_Shadow)
     );
   }
@@ -220,7 +220,7 @@ $fd-checkbox-tristate-compact-offset: 0.25rem;
       var(--sapField_SuccessColor),
       var(--sapField_SuccessColor),
       var(--sapField_SuccessBorderWidth),
-      var(--sapField_SuccessBorderStyle),
+      solid,
       var(--fdCheckbox_Success_State_Shadow)
     );
   }
@@ -231,7 +231,7 @@ $fd-checkbox-tristate-compact-offset: 0.25rem;
       var(--sapField_InformationColor),
       var(--sapField_InformationColor),
       var(--sapField_InformationBorderWidth),
-      var(--sapField_InformationBorderStyle),
+      var(--fdCheckbox_Warning_Error_Information_Border_Style),
       var(--fdCheckbox_Information_State_Shadow)
     );
   }

--- a/src/styles/radio.scss
+++ b/src/styles/radio.scss
@@ -135,7 +135,7 @@ $block: #{$fd-namespace}-radio;
       var(--sapField_TextColor),
       var(--sapField_WarningColor),
       var(--sapField_WarningBorderWidth),
-      var(--sapField_WarningBorderStyle),
+      var(--fdRadio_Warning_Error_Information_Border_Style),
       var(--fdRadio_Warning_Hover_Shadow)
     );
   }
@@ -146,7 +146,7 @@ $block: #{$fd-namespace}-radio;
       var(--sapField_InvalidColor),
       var(--sapField_InvalidColor),
       var(--sapField_InvalidBorderWidth),
-      var(--sapField_InvalidBorderStyle),
+      var(--fdRadio_Warning_Error_Information_Border_Style),
       var(--fdRadio_Error_Hover_Shadow)
     );
   }
@@ -157,7 +157,7 @@ $block: #{$fd-namespace}-radio;
       var(--sapField_SuccessColor),
       var(--sapField_SuccessColor),
       var(--sapField_BorderWidth),
-      var(--sapField_SuccessBorderStyle),
+      solid,
       var(--fdRadio_Success_Hover_Shadow)
     );
   }
@@ -168,7 +168,7 @@ $block: #{$fd-namespace}-radio;
       var(--sapField_InformationColor),
       var(--sapField_InformationColor),
       var(--sapField_InformationBorderWidth),
-      var(--sapField_InformationBorderStyle),
+      var(--fdRadio_Warning_Error_Information_Border_Style),
       var(--fdRadio_Information_Hover_Shadow)
     );
   }

--- a/src/styles/theming/sap_fiori_3.scss
+++ b/src/styles/theming/sap_fiori_3.scss
@@ -104,6 +104,7 @@
   --fdRadio_Warning_Hover_Shadow: none;
   --fdRadio_Success_Hover_Shadow: none;
   --fdRadio_Information_Hover_Shadow: none;
+  --fdRadio_Warning_Error_Information_Border_Style: solid;
 
   /* Checkbox */
   --fdCheckbox_Hover_Background: var(--sapField_Hover_Background);

--- a/src/styles/theming/sap_fiori_3.scss
+++ b/src/styles/theming/sap_fiori_3.scss
@@ -116,6 +116,7 @@
   --fdCheckbox_State_Hover_Background: inherit;
   --fdCheckbox_Readonly_Border_Width: var(--sapField_BorderWidth);
   --fdCheckbox_Readonly_Border_Type: solid;
+  --fdCheckbox_Warning_Error_Information_Border_Style: solid;
 
   /* Dynamic Page Layout */
   --fdDynamicPage_Hover_Border_Bottom: none;

--- a/src/styles/theming/sap_fiori_3_dark.scss
+++ b/src/styles/theming/sap_fiori_3_dark.scss
@@ -104,6 +104,7 @@
   --fdRadio_Warning_Hover_Shadow: none;
   --fdRadio_Success_Hover_Shadow: none;
   --fdRadio_Information_Hover_Shadow: none;
+  --fdRadio_Warning_Error_Information_Border_Style: solid;
 
   /* Checkbox */
   --fdCheckbox_Hover_Background: var(--sapField_Hover_Background);

--- a/src/styles/theming/sap_fiori_3_dark.scss
+++ b/src/styles/theming/sap_fiori_3_dark.scss
@@ -116,6 +116,7 @@
   --fdCheckbox_State_Hover_Background: inherit;
   --fdCheckbox_Readonly_Border_Width: var(--sapField_BorderWidth);
   --fdCheckbox_Readonly_Border_Type: solid;
+  --fdCheckbox_Warning_Error_Information_Border_Style: solid;
 
   /* Dynamic Page Layout */
   --fdDynamicPage_Hover_Border_Bottom: none;

--- a/src/styles/theming/sap_fiori_3_hcb.scss
+++ b/src/styles/theming/sap_fiori_3_hcb.scss
@@ -117,6 +117,7 @@
   --fdCheckbox_State_Hover_Background: inherit;
   --fdCheckbox_Readonly_Border_Width: var(--sapField_BorderWidth);
   --fdCheckbox_Readonly_Border_Type: solid;
+  --fdCheckbox_Warning_Error_Information_Border_Style: dashed;
 
   /* Dynamic Page Layout */
   --fdDynamicPage_Hover_Border_Bottom: solid 0.0625rem var(--sapObjectHeader_Hover_Background);

--- a/src/styles/theming/sap_fiori_3_hcb.scss
+++ b/src/styles/theming/sap_fiori_3_hcb.scss
@@ -105,6 +105,7 @@
   --fdRadio_Warning_Hover_Shadow: none;
   --fdRadio_Success_Hover_Shadow: none;
   --fdRadio_Information_Hover_Shadow: none;
+  --fdRadio_Warning_Error_Information_Border_Style: dashed;
 
   /* Checkbox */
   --fdCheckbox_Hover_Background: var(--sapSelectedColor);

--- a/src/styles/theming/sap_fiori_3_hcw.scss
+++ b/src/styles/theming/sap_fiori_3_hcw.scss
@@ -118,6 +118,7 @@
   --fdCheckbox_State_Hover_Background: inherit;
   --fdCheckbox_Readonly_Border_Width: var(--sapField_BorderWidth);
   --fdCheckbox_Readonly_Border_Type: solid;
+  --fdCheckbox_Warning_Error_Information_Border_Style: dashed;
 
   /* Dynamic Page Layout */
   --fdDynamicPage_Hover_Border_Bottom: solid 0.0625rem var(--sapObjectHeader_Hover_Background);

--- a/src/styles/theming/sap_fiori_3_hcw.scss
+++ b/src/styles/theming/sap_fiori_3_hcw.scss
@@ -106,6 +106,7 @@
   --fdRadio_Warning_Hover_Shadow: none;
   --fdRadio_Success_Hover_Shadow: none;
   --fdRadio_Information_Hover_Shadow: none;
+  --fdRadio_Warning_Error_Information_Border_Style: dashed;
 
   /* Checkbox */
   --fdCheckbox_Hover_Background: var(--sapSelectedColor);

--- a/src/styles/theming/sap_fiori_3_light_dark.scss
+++ b/src/styles/theming/sap_fiori_3_light_dark.scss
@@ -104,6 +104,7 @@
   --fdRadio_Warning_Hover_Shadow: none;
   --fdRadio_Success_Hover_Shadow: none;
   --fdRadio_Information_Hover_Shadow: none;
+  --fdRadio_Warning_Error_Information_Border_Style: solid;
 
   /* Checkbox */
   --fdCheckbox_Hover_Background: var(--sapField_Hover_Background);

--- a/src/styles/theming/sap_fiori_3_light_dark.scss
+++ b/src/styles/theming/sap_fiori_3_light_dark.scss
@@ -116,6 +116,7 @@
   --fdCheckbox_State_Hover_Background: inherit;
   --fdCheckbox_Readonly_Border_Width: var(--sapField_BorderWidth);
   --fdCheckbox_Readonly_Border_Type: solid;
+  --fdCheckbox_Warning_Error_Information_Border_Style: solid;
 
   /* Dynamic Page Layout */
   --fdDynamicPage_Hover_Border_Bottom: none;

--- a/src/styles/theming/sap_horizon.scss
+++ b/src/styles/theming/sap_horizon.scss
@@ -155,6 +155,7 @@
   --fdCheckbox_State_Hover_Background: var(--sapField_Hover_Background);
   --fdCheckbox_Readonly_Border_Width: var(--sapElement_BorderWidth);
   --fdCheckbox_Readonly_Border_Type: dashed;
+  --fdCheckbox_Warning_Error_Information_Border_Style: solid;
 
   /* Dynamic Page Layout */
   --fdDynamicPage_Hover_Border_Bottom: none;

--- a/src/styles/theming/sap_horizon.scss
+++ b/src/styles/theming/sap_horizon.scss
@@ -143,6 +143,7 @@
   --fdRadio_Warning_Hover_Shadow: var(--sapContent_Critical_Shadow);
   --fdRadio_Success_Hover_Shadow: var(--sapContent_Positive_Shadow);
   --fdRadio_Information_Hover_Shadow: var(--sapContent_Informative_Shadow);
+  --fdRadio_Warning_Error_Information_Border_Style: solid;
 
   /* Checkbox */
   --fdCheckbox_Hover_Background: var(--sapField_Hover_Background);

--- a/src/styles/theming/sap_horizon_dark.scss
+++ b/src/styles/theming/sap_horizon_dark.scss
@@ -155,6 +155,7 @@
   --fdCheckbox_State_Hover_Background: var(--sapField_Hover_Background);
   --fdCheckbox_Readonly_Border_Width: var(--sapElement_BorderWidth);
   --fdCheckbox_Readonly_Border_Type: dashed;
+  --fdCheckbox_Warning_Error_Information_Border_Style: solid;
 
   /* Dynamic Page Layout */
   --fdDynamicPage_Hover_Border_Bottom: none;

--- a/src/styles/theming/sap_horizon_dark.scss
+++ b/src/styles/theming/sap_horizon_dark.scss
@@ -143,6 +143,7 @@
   --fdRadio_Warning_Hover_Shadow: var(--sapContent_Critical_Shadow);
   --fdRadio_Success_Hover_Shadow: var(--sapContent_Positive_Shadow);
   --fdRadio_Information_Hover_Shadow: var(--sapContent_Informative_Shadow);
+  --fdRadio_Warning_Error_Information_Border_Style: solid;
 
   /* Checkbox */
   --fdCheckbox_Hover_Background: var(--sapField_Hover_Background);

--- a/src/styles/theming/sap_horizon_hcb.scss
+++ b/src/styles/theming/sap_horizon_hcb.scss
@@ -123,6 +123,7 @@
   --fdCheckbox_State_Hover_Background: var(--sapField_Hover_Background);
   --fdCheckbox_Readonly_Border_Width: var(--sapElement_BorderWidth);
   --fdCheckbox_Readonly_Border_Type: solid;
+  --fdCheckbox_Warning_Error_Information_Border_Style: dashed;
 
   /* Dynamic Page Layout */
   --fdDynamicPage_Hover_Border_Bottom: solid 0.0625rem var(--sapObjectHeader_Hover_Background);

--- a/src/styles/theming/sap_horizon_hcb.scss
+++ b/src/styles/theming/sap_horizon_hcb.scss
@@ -111,6 +111,7 @@
   --fdRadio_Warning_Hover_Shadow: var(--sapContent_Critical_Shadow);
   --fdRadio_Success_Hover_Shadow: var(--sapContent_Positive_Shadow);
   --fdRadio_Information_Hover_Shadow: var(--sapContent_Informative_Shadow);
+  --fdRadio_Warning_Error_Information_Border_Style: dashed;
 
   /* Checkbox */
   --fdCheckbox_Hover_Background: var(--sapSelectedColor);

--- a/src/styles/theming/sap_horizon_hcw.scss
+++ b/src/styles/theming/sap_horizon_hcw.scss
@@ -123,6 +123,7 @@
   --fdCheckbox_State_Hover_Background: var(--sapField_Hover_Background);
   --fdCheckbox_Readonly_Border_Width: var(--sapElement_BorderWidth);
   --fdCheckbox_Readonly_Border_Type: solid;
+  --fdCheckbox_Warning_Error_Information_Border_Style: dashed;
 
   /* Dynamic Page Layout */
   --fdDynamicPage_Hover_Border_Bottom: solid 0.0625rem var(--sapObjectHeader_Hover_Background);

--- a/src/styles/theming/sap_horizon_hcw.scss
+++ b/src/styles/theming/sap_horizon_hcw.scss
@@ -111,6 +111,7 @@
   --fdRadio_Warning_Hover_Shadow: var(--sapContent_Critical_Shadow);
   --fdRadio_Success_Hover_Shadow: var(--sapContent_Positive_Shadow);
   --fdRadio_Information_Hover_Shadow: var(--sapContent_Informative_Shadow);
+  --fdRadio_Warning_Error_Information_Border_Style: dashed;
 
   /* Checkbox */
   --fdCheckbox_Hover_Background: var(--sapSelectedColor);


### PR DESCRIPTION
## Related Issue

Part of https://github.com/SAP/fundamental-styles/issues/3327

## Description

Checkbox, Radio border style fix in Horizon themes.

## Screenshots

### Before:

<img width="168" alt="image" src="https://user-images.githubusercontent.com/20265336/165535862-30660130-ac00-4350-8358-c68a171edb1d.png">

<img width="191" alt="image" src="https://user-images.githubusercontent.com/20265336/165536211-72c0a7ef-96a8-4bd4-8dff-5ead642c26e3.png">

### After:

<img width="162" alt="image" src="https://user-images.githubusercontent.com/20265336/165536131-fbfb1895-080d-4c30-80a1-252bf1baa2f7.png">

<img width="144" alt="image" src="https://user-images.githubusercontent.com/20265336/165536274-d2e4af0a-1242-4856-8bc4-30ef9ee3cf00.png">