### PR TITLE
feat(styles): card footer implementation

### DIFF
--- a/src/styles/card.scss
+++ b/src/styles/card.scss
@@ -121,12 +121,31 @@ $fd-card-header-outline-offset: 0.0625rem !default;
 
   &__footer {
     @include fd-reset();
-    @include fd-flex();
+    @include fd-flex-vertical-center();
 
-    padding: 1rem;
+    padding: var(--fdCard_Footer_Padding);
     background: $fd-card-default-body-background-color;
     border-bottom: $fd-card-header-border;
     border-radius: 0 0 $fd-card-border-radius $fd-card-border-radius;
+
+    &__actions {
+      @include fd-flex();
+
+      justify-content: flex-end;
+      width: 100%;
+
+      &__item {
+        &:not(:last-child) {
+          @include fd-set-margin-right(var(--fdCard_Footer_Actions_Item_Spacing));
+        }
+      }
+    }
+
+    &__link {
+      @include fd-ellipsis();
+
+      text-overflow: clip;
+    }
   }
 
   &__header-text {

--- a/src/styles/card.scss
+++ b/src/styles/card.scss
@@ -146,8 +146,9 @@ $fd-card-header-outline-offset: 0.0625rem !default;
       }
     }
 
-    &-link {
+    .#{$block}__footer-link {
       @include fd-ellipsis();
+      @include fd-set-margin-right(var(--fdCard_Footer_Actions_Item_Spacing));
 
       text-overflow: clip;
     }

--- a/src/styles/card.scss
+++ b/src/styles/card.scss
@@ -6,7 +6,7 @@ $object-status: #{$fd-namespace}-object-status;
 $numeric-content: #{$fd-namespace}-numeric-content;
 
 $fd-card-header-border: var(--fdCard_Header_Border_Bottom) !default;
-$fd-card-header-border-radius: var(--fdCard_Border_Radius) !default;
+$fd-card-border-radius: var(--fdCard_Border_Radius) !default;
 $fd-card-avatar-text-spacing: 0.75rem !default;
 $fd-card-title-counter-spacing: 1rem !default;
 $fd-card-currency-spacing: 0.25rem !default;
@@ -40,7 +40,7 @@ $fd-card-header-outline-offset: 0.0625rem !default;
       left: $fd-card-header-outline-offset;
       right: $fd-card-header-outline-offset;
       bottom: $fd-card-header-outline-offset * 2;
-      border-radius: $fd-card-header-border-radius $fd-card-header-border-radius 0 0;
+      border-radius: $fd-card-border-radius $fd-card-border-radius 0 0;
       z-index: 3;
     }
   }
@@ -66,10 +66,10 @@ $fd-card-header-outline-offset: 0.0625rem !default;
       @include fake-card-outline();
     }
 
-    padding: 1rem;
+    padding: var(--fdCard_Header_Padding);
     background: $fd-card-default-body-background-color;
     border-bottom: $fd-card-header-border;
-    border-radius: $fd-card-header-border-radius $fd-card-header-border-radius 0 0;
+    border-radius: $fd-card-border-radius $fd-card-border-radius 0 0;
     text-decoration: none;
     cursor: pointer;
     position: relative;
@@ -104,18 +104,29 @@ $fd-card-header-outline-offset: 0.0625rem !default;
     }
 
     &:last-child {
+      padding: var(--fdCard_Bottom_Positioned_Header_Padding);
       border-bottom: none;
       border-top: $fd-card-header-border;
-      border-radius: 0 0 $fd-card-header-border-radius $fd-card-header-border-radius;
+      border-radius: 0 0 $fd-card-border-radius $fd-card-border-radius;
 
       @include fd-focus() {
         &::before {
           top: $fd-card-header-outline-offset * 2;
           bottom: $fd-card-header-outline-offset;
-          border-radius: 0 0 $fd-card-header-border-radius $fd-card-header-border-radius;
+          border-radius: 0 0 $fd-card-border-radius $fd-card-border-radius;
         }
       }
     }
+  }
+
+  &__footer {
+    @include fd-reset();
+    @include fd-flex();
+
+    padding: 1rem;
+    background: $fd-card-default-body-background-color;
+    border-bottom: $fd-card-header-border;
+    border-radius: 0 0 $fd-card-border-radius $fd-card-border-radius;
   }
 
   &__header-text {
@@ -399,11 +410,11 @@ $fd-card-header-outline-offset: 0.0625rem !default;
 
           tr:last-child {
             td:first-child {
-              border-bottom-left-radius: $fd-card-header-border-radius;
+              border-bottom-left-radius: $fd-card-border-radius;
             }
 
             td:last-child {
-              border-bottom-right-radius: $fd-card-header-border-radius;
+              border-bottom-right-radius: $fd-card-border-radius;
             }
           }
         }
@@ -415,8 +426,8 @@ $fd-card-header-outline-offset: 0.0625rem !default;
     .#{$block}__content {
       .#{$fd-namespace}-list {
         &__item:last-child {
-          border-bottom-left-radius: $fd-card-header-border-radius;
-          border-bottom-right-radius: $fd-card-header-border-radius;
+          border-bottom-left-radius: $fd-card-border-radius;
+          border-bottom-right-radius: $fd-card-border-radius;
         }
       }
     }

--- a/src/styles/card.scss
+++ b/src/styles/card.scss
@@ -147,7 +147,6 @@ $fd-card-header-outline-offset: 0.0625rem !default;
     }
 
     &-link {
-      @include fd-reset();
       @include fd-ellipsis();
 
       text-overflow: clip;

--- a/src/styles/card.scss
+++ b/src/styles/card.scss
@@ -136,13 +136,13 @@ $fd-card-header-outline-offset: 0.0625rem !default;
       }
 
       width: 100%;
-    }
 
-    &-actions-item {
-      @include fd-reset();
+      &-item {
+        @include fd-reset();
 
-      &:not(:last-child) {
-        @include fd-set-margin-right(var(--fdCard_Footer_Actions_Item_Spacing));
+        &:not(:last-child) {
+          @include fd-set-margin-right(var(--fdCard_Footer_Actions_Item_Spacing));
+        }
       }
     }
 

--- a/src/styles/card.scss
+++ b/src/styles/card.scss
@@ -136,13 +136,13 @@ $fd-card-header-outline-offset: 0.0625rem !default;
       }
 
       width: 100%;
+    }
 
-      &-item {
-        @include fd-reset();
+    &-actions-item {
+      @include fd-reset();
 
-        &:not(:last-child) {
-          @include fd-set-margin-right(var(--fdCard_Footer_Actions_Item_Spacing));
-        }
+      &:not(:last-child) {
+        @include fd-set-margin-right(var(--fdCard_Footer_Actions_Item_Spacing));
       }
     }
 

--- a/src/styles/card.scss
+++ b/src/styles/card.scss
@@ -128,20 +128,26 @@ $fd-card-header-outline-offset: 0.0625rem !default;
     border-bottom: $fd-card-header-border;
     border-radius: 0 0 $fd-card-border-radius $fd-card-border-radius;
 
-    &__actions {
-      @include fd-flex();
+    &-actions {
+      @include fd-reset();
 
-      justify-content: flex-end;
+      @include fd-flex() {
+        justify-content: flex-end;
+      }
+
       width: 100%;
 
-      &__item {
+      &-item {
+        @include fd-reset();
+
         &:not(:last-child) {
           @include fd-set-margin-right(var(--fdCard_Footer_Actions_Item_Spacing));
         }
       }
     }
 
-    &__link {
+    &-link {
+      @include fd-reset();
       @include fd-ellipsis();
 
       text-overflow: clip;

--- a/src/styles/theming/common/card/_sap_fiori.scss
+++ b/src/styles/theming/common/card/_sap_fiori.scss
@@ -1,0 +1,11 @@
+:root {
+  --fdCard_Background_Color: var(--sapTile_Background);
+  --fdCard_Box_Shadow: var(--sapContent_Shadow0);
+  --fdCard_Border_Radius: var(--sapElement_BorderCornerRadius);
+  --fdCard_Header_Border_Bottom: 0.0625rem solid var(--sapTile_SeparatorColor);
+  --fdCard_Border: none;
+  --fdCard_Counter_Margin: 0.188rem 0 0 1rem;
+  --fdCard_Counter_Margin_RTL: 0.188rem 1rem 0 0;
+  --fdCard_Header_Padding: 1rem;
+  --fdCard_Bottom_Positioned_Header_Padding: 1rem;
+}

--- a/src/styles/theming/common/card/_sap_fiori.scss
+++ b/src/styles/theming/common/card/_sap_fiori.scss
@@ -8,4 +8,6 @@
   --fdCard_Counter_Margin_RTL: 0.188rem 1rem 0 0;
   --fdCard_Header_Padding: 1rem;
   --fdCard_Bottom_Positioned_Header_Padding: 1rem;
+  --fdCard_Footer_Padding: 1rem;
+  --fdCard_Footer_Actions_Item_Spacing: 0.5rem;
 }

--- a/src/styles/theming/common/card/_sap_fiori_hc.scss
+++ b/src/styles/theming/common/card/_sap_fiori_hc.scss
@@ -1,0 +1,4 @@
+:root {
+  --fdCard_Background_Color: transparent;
+  --fdCard_Box_Shadow: none;
+}

--- a/src/styles/theming/common/card/_sap_horizon.scss
+++ b/src/styles/theming/common/card/_sap_horizon.scss
@@ -1,0 +1,11 @@
+:root {
+  --fdCard_Background_Color: var(--sapTile_Background);
+  --fdCard_Box_Shadow: var(--sapContent_Shadow0);
+  --fdCard_Border_Radius: var(--sapTile_BorderCornerRadius);
+  --fdCard_Header_Border_Bottom: none;
+  --fdCard_Border: none;
+  --fdCard_Counter_Margin: 0.125rem 0 0 1rem;
+  --fdCard_Counter_Margin_RTL: 0.125rem 1rem 0 0;
+  --fdCard_Header_Padding: 1rem 1rem 0.75rem;
+  --fdCard_Bottom_Positioned_Header_Padding: 0.75rem 1rem 1rem;
+}

--- a/src/styles/theming/common/card/_sap_horizon.scss
+++ b/src/styles/theming/common/card/_sap_horizon.scss
@@ -8,4 +8,6 @@
   --fdCard_Counter_Margin_RTL: 0.125rem 1rem 0 0;
   --fdCard_Header_Padding: 1rem 1rem 0.75rem;
   --fdCard_Bottom_Positioned_Header_Padding: 0.75rem 1rem 1rem;
+  --fdCard_Footer_Padding: 0.75rem 1rem 1rem;
+  --fdCard_Footer_Actions_Item_Spacing: 0.5rem;
 }

--- a/src/styles/theming/common/card/_sap_horizon_hc.scss
+++ b/src/styles/theming/common/card/_sap_horizon_hc.scss
@@ -1,0 +1,4 @@
+:root {
+  --fdCard_Background_Color: transparent;
+  --fdCard_Box_Shadow: none;
+}

--- a/src/styles/theming/sap_fiori_3.scss
+++ b/src/styles/theming/sap_fiori_3.scss
@@ -4,6 +4,7 @@
 @import "./common/icon-tab-bar/sap_fiori";
 @import "./common/table/sap_fiori";
 @import "./common/dynamic-page-layout/sap_fiori";
+@import "./common/card/sap_fiori";
 @import "./common/scrollbar/sap_fiori";
 
 :root {
@@ -390,15 +391,6 @@
 
   /** Text */
   --fdText_Selected_Background_Color: var(--sapSelectedColor);
-
-  /** Card */
-  --fdCard_Background_Color: var(--sapTile_Background);
-  --fdCard_Box_Shadow: var(--sapContent_Shadow0);
-  --fdCard_Border_Radius: var(--sapElement_BorderCornerRadius);
-  --fdCard_Header_Border_Bottom: 0.0625rem solid var(--sapTile_SeparatorColor);
-  --fdCard_Border: none;
-  --fdCard_Counter_Margin: 0.188rem 0 0 1rem;
-  --fdCard_Counter_Margin_RTL: 0.188rem 1rem 0 0;
 
   /** Shellbar */
   --fdShellbar_Height: 2.75rem;

--- a/src/styles/theming/sap_fiori_3_dark.scss
+++ b/src/styles/theming/sap_fiori_3_dark.scss
@@ -4,6 +4,7 @@
 @import "./common/icon-tab-bar/sap_fiori";
 @import "./common/table/sap_fiori";
 @import "./common/dynamic-page-layout/sap_fiori";
+@import "./common/card/sap_fiori";
 @import "./common/scrollbar/sap_fiori";
 
 :root {
@@ -392,15 +393,6 @@
 
   /** Text */
   --fdText_Selected_Background_Color: var(--sapSelectedColor);
-
-  /** Card */
-  --fdCard_Background_Color: var(--sapTile_Background);
-  --fdCard_Box_Shadow: var(--sapContent_Shadow0);
-  --fdCard_Border_Radius: var(--sapElement_BorderCornerRadius);
-  --fdCard_Header_Border_Bottom: 0.0625rem solid var(--sapTile_SeparatorColor);
-  --fdCard_Border: none;
-  --fdCard_Counter_Margin: 0.188rem 0 0 1rem;
-  --fdCard_Counter_Margin_RTL: 0.188rem 1rem 0 0;
 
   /** Shellbar */
   --fdShellbar_Height: 2.75rem;

--- a/src/styles/theming/sap_fiori_3_hcb.scss
+++ b/src/styles/theming/sap_fiori_3_hcb.scss
@@ -6,6 +6,8 @@
 @import "./common/table/sap_fiori";
 @import "./common/dynamic-page-layout/sap_fiori";
 @import "./common/scrollbar/sap_fiori";
+@import "./common/card/sap_fiori";
+@import "./common/card/sap_fiori_hc";
 
 :root {
   --fdInverted_Object_Border_Width: 0.0625rem;
@@ -393,15 +395,6 @@
 
   /** Text */
   --fdText_Selected_Background_Color: var(--sapSelectedColor);
-
-  /** Card */
-  --fdCard_Background_Color: transparent;
-  --fdCard_Box_Shadow: none;
-  --fdCard_Border_Radius: var(--sapElement_BorderCornerRadius);
-  --fdCard_Header_Border_Bottom: 0.0625rem solid var(--sapTile_SeparatorColor);
-  --fdCard_Border: 0.0625rem solid var(--sapTile_BorderColor);
-  --fdCard_Counter_Margin: 0.188rem 0 0 1rem;
-  --fdCard_Counter_Margin_RTL: 0.188rem 1rem 0 0;
 
   /** Shellbar */
   --fdShellbar_Height: 2.75rem;

--- a/src/styles/theming/sap_fiori_3_hcw.scss
+++ b/src/styles/theming/sap_fiori_3_hcw.scss
@@ -7,6 +7,8 @@
 @import "./common/table/sap_fiori";
 @import "./common/dynamic-page-layout/sap_fiori";
 @import "./common/scrollbar/sap_fiori";
+@import "./common/card/sap_fiori";
+@import "./common/card/sap_fiori_hc";
 
 :root {
   --fdInverted_Object_Border_Width: 0.0625rem;
@@ -394,15 +396,6 @@
 
   /** Text */
   --fdText_Selected_Background_Color: var(--sapSelectedColor);
-
-  /** Card */
-  --fdCard_Background_Color: transparent;
-  --fdCard_Box_Shadow: none;
-  --fdCard_Border_Radius: var(--sapElement_BorderCornerRadius);
-  --fdCard_Header_Border_Bottom: 0.0625rem solid var(--sapTile_SeparatorColor);
-  --fdCard_Border: 0.0625rem solid var(--sapTile_BorderColor);
-  --fdCard_Counter_Margin: 0.188rem 0 0 1rem;
-  --fdCard_Counter_Margin_RTL: 0.188rem 1rem 0 0;
 
   /** Shellbar */
   --fdShellbar_Height: 2.75rem;

--- a/src/styles/theming/sap_fiori_3_light_dark.scss
+++ b/src/styles/theming/sap_fiori_3_light_dark.scss
@@ -5,6 +5,7 @@
 @import "./common/table/sap_fiori";
 @import "./common/dynamic-page-layout/sap_fiori";
 @import "./common/scrollbar/sap_fiori";
+@import "./common/card/sap_fiori";
 
 :root {
   --fdInverted_Object_Border_Width: 0;

--- a/src/styles/theming/sap_horizon.scss
+++ b/src/styles/theming/sap_horizon.scss
@@ -5,6 +5,7 @@
 @import "./common/table/sap_horizon";
 @import "./common/dynamic-page-layout/sap_horizon";
 @import "./common/scrollbar/sap_horizon";
+@import "./common/card/sap_horizon";
 
 :root {
   /* Switch */
@@ -429,15 +430,6 @@
 
   /** Text */
   --fdText_Selected_Background_Color: var(--sapSelectedColor);
-
-  /** Card */
-  --fdCard_Background_Color: var(--sapTile_Background);
-  --fdCard_Box_Shadow: var(--sapContent_Shadow0);
-  --fdCard_Border_Radius: var(--sapTile_BorderCornerRadius);
-  --fdCard_Header_Border_Bottom: none;
-  --fdCard_Border: none;
-  --fdCard_Counter_Margin: 0.125rem 0 0 1rem;
-  --fdCard_Counter_Margin_RTL: 0.125rem 1rem 0 0;
 
   /** Shellbar */
   --fdShellbar_Height: 3.25rem;

--- a/src/styles/theming/sap_horizon_dark.scss
+++ b/src/styles/theming/sap_horizon_dark.scss
@@ -5,6 +5,7 @@
 @import "./common/table/sap_horizon";
 @import "./common/dynamic-page-layout/sap_horizon";
 @import "./common/scrollbar/sap_horizon";
+@import "./common/card/sap_horizon";
 
 :root {
   /* Switch */
@@ -429,15 +430,6 @@
 
   /** Text */
   --fdText_Selected_Background_Color: var(--sapSelectedColor);
-
-  /** Card */
-  --fdCard_Background_Color: var(--sapTile_Background);
-  --fdCard_Box_Shadow: var(--sapContent_Shadow0);
-  --fdCard_Border_Radius: var(--sapTile_BorderCornerRadius);
-  --fdCard_Header_Border_Bottom: none;
-  --fdCard_Border: none;
-  --fdCard_Counter_Margin: 0.125rem 0 0 1rem;
-  --fdCard_Counter_Margin_RTL: 0.125rem 1rem 0 0;
 
   /** Shellbar */
   --fdShellbar_Height: 3.25rem;

--- a/src/styles/theming/sap_horizon_hcb.scss
+++ b/src/styles/theming/sap_horizon_hcb.scss
@@ -8,6 +8,8 @@
 @import "./common/table/sap_horizon_hc";
 @import "./common/dynamic-page-layout/sap_horizon";
 @import "./common/scrollbar/sap_horizon";
+@import "./common/card/sap_horizon";
+@import "./common/card/sap_horizon_hc";
 
 :root {
   /* Switch */
@@ -408,15 +410,6 @@
 
   /** Text */
   --fdText_Selected_Background_Color: var(--sapContent_Selected_Background);
-
-  /** Card */
-  --fdCard_Background_Color: transparent;
-  --fdCard_Box_Shadow: none;
-  --fdCard_Border_Radius: var(--sapTile_BorderCornerRadius);
-  --fdCard_Header_Border_Bottom: none;
-  --fdCard_Border: 0.0625rem solid var(--sapTile_BorderColor);
-  --fdCard_Counter_Margin: 0.125rem 0 0 1rem;
-  --fdCard_Counter_Margin_RTL: 0.125rem 1rem 0 0;
 
   /** Shellbar */
   --fdShellbar_Height: 3.25rem;

--- a/src/styles/theming/sap_horizon_hcw.scss
+++ b/src/styles/theming/sap_horizon_hcw.scss
@@ -8,6 +8,8 @@
 @import "./common/table/sap_horizon_hc";
 @import "./common/dynamic-page-layout/sap_horizon";
 @import "./common/scrollbar/sap_horizon";
+@import "./common/card/sap_horizon";
+@import "./common/card/sap_horizon_hc";
 
 :root {
   /* Switch */
@@ -401,15 +403,6 @@
 
   /** Text */
   --fdText_Selected_Background_Color: var(--sapContent_Selected_Background);
-
-  /** Card */
-  --fdCard_Background_Color: transparent;
-  --fdCard_Box_Shadow: none;
-  --fdCard_Border_Radius: var(--sapTile_BorderCornerRadius);
-  --fdCard_Header_Border_Bottom: none;
-  --fdCard_Border: 0.0625rem solid var(--sapTile_BorderColor);
-  --fdCard_Counter_Margin: 0.125rem 0 0 1rem;
-  --fdCard_Counter_Margin_RTL: 0.125rem 1rem 0 0;
 
   /** Shellbar */
   --fdShellbar_Height: 3.25rem;

--- a/stories/card/card.stories.js
+++ b/stories/card/card.stories.js
@@ -56,12 +56,16 @@ export const CardAnatomy = () => `<div style="display:flex; justify-content:spac
             <div class="fd-card__content" role="group" aria-label="Card Content"></div>
             <div class="fd-card__footer">
                 <div class="fd-card__footer-actions">
-                    <button class="fd-button fd-button--positive fd-card__footer-actions-item">
-                        Button
-                    </button>
-                    <button class="fd-button fd-button--negative fd-card__footer-actions-item">
-                        Button
-                    </button>
+                    <div class="fd-card__footer-actions-item">
+                        <button class="fd-button fd-button--positive">
+                            Button
+                        </button>
+                    </div>
+                    <div class="fd-card__footer-actions-item">
+                        <button class="fd-button fd-button--negative">
+                            Button
+                        </button>
+                    </div>
                 </div>
             </div>
         </div>

--- a/stories/card/card.stories.js
+++ b/stories/card/card.stories.js
@@ -55,11 +55,11 @@ export const CardAnatomy = () => `<div style="display:flex; justify-content:spac
             </a>
             <div class="fd-card__content" role="group" aria-label="Card Content"></div>
             <div class="fd-card__footer">
-                <div class="fd-card__footer__actions">
-                    <button class="fd-button fd-button--positive fd-card__footer__actions__item">
+                <div class="fd-card__footer-actions">
+                    <button class="fd-button fd-button--positive fd-card__footer-actions-item">
                         Button
                     </button>
-                    <button class="fd-button fd-button--negative fd-card__footer__actions__item">
+                    <button class="fd-button fd-button--negative fd-card__footer-actions-item">
                         Button
                     </button>
                 </div>
@@ -83,7 +83,7 @@ export const CardAnatomy = () => `<div style="display:flex; justify-content:spac
             </a>
             <div class="fd-card__content" role="group" aria-label="Card Content"></div>
             <div class="fd-card__footer">
-                <a class="fd-link fd-card__footer__link" href="#">Footer with a link</a>
+                <a class="fd-link fd-card__footer-link" href="#">Footer with a link</a>
             </div>
         </div>
     </div>
@@ -104,7 +104,7 @@ export const CardAnatomy = () => `<div style="display:flex; justify-content:spac
             </a>
             <div class="fd-card__content" role="group" aria-label="Card Content"></div>
             <div class="fd-card__footer">
-                <a class="fd-link fd-card__footer__link" href="#">Footer with a long link Lorem ipsum dolor sit amet, consectetur adipisicing elit. Accusantium</a>
+                <a class="fd-link fd-card__footer-link" href="#">Footer with a long link Lorem ipsum dolor sit amet, consectetur adipisicing elit. Accusantium</a>
                 <button class="fd-button fd-button--transparent">
                     <i class="sap-icon sap-icon--overflow"></i>
                 </button>

--- a/stories/card/card.stories.js
+++ b/stories/card/card.stories.js
@@ -26,6 +26,7 @@ Title | A title is mandatory to explain what content is being displayed to the u
 Avatar (optional) | An avatar can be displayed in a size S (3rem).
 Subtitle (optional) | The subtitle provides additional context to the title or displays a status. Its usage depends on the card type. Subtitles that exceed one line are truncated with an ellipsis.
 Counter (optional) | The counter indicates how many items are showing on the card in relation to the total number of relevant items. If all the relevant items are visible on the card, no counter is shown. There is also no counter if there is an issue loading a card, or if no items are found in the filter criteria. The counter is right-aligned and is never truncated.
+Footer (optional) | The footer displays a list of actions that can be performed on the card.
 `,
         tags: ['f3', 'a11y', 'theme', 'development'],
         components: ['button', 'avatar', 'badge', 'card', 'object-status', 'numeric-content', 'table', 'checkbox', 'list', 'link', 'icon']
@@ -53,6 +54,9 @@ export const CardAnatomy = () => `<div style="display:flex; justify-content:spac
                 </div>
             </a>
             <div class="fd-card__content" role="group" aria-label="Card Content"></div>
+            <div class="fd-card__footer">
+                
+            </div>
         </div>
     </div>
     <div style="width: 300px; height: 400px; margin: 1rem;">

--- a/stories/card/card.stories.js
+++ b/stories/card/card.stories.js
@@ -26,7 +26,7 @@ Title | A title is mandatory to explain what content is being displayed to the u
 Avatar (optional) | An avatar can be displayed in a size S (3rem).
 Subtitle (optional) | The subtitle provides additional context to the title or displays a status. Its usage depends on the card type. Subtitles that exceed one line are truncated with an ellipsis.
 Counter (optional) | The counter indicates how many items are showing on the card in relation to the total number of relevant items. If all the relevant items are visible on the card, no counter is shown. There is also no counter if there is an issue loading a card, or if no items are found in the filter criteria. The counter is right-aligned and is never truncated.
-Footer (optional) | The footer displays a list of actions that can be performed on the card.
+Footer (optional) | The footer displays a list of actions that can be performed on the card. When link is too long, or there is no more place for actions, overflow button should appear.
 `,
         tags: ['f3', 'a11y', 'theme', 'development'],
         components: ['button', 'avatar', 'badge', 'card', 'object-status', 'numeric-content', 'table', 'checkbox', 'list', 'link', 'icon']
@@ -55,7 +55,59 @@ export const CardAnatomy = () => `<div style="display:flex; justify-content:spac
             </a>
             <div class="fd-card__content" role="group" aria-label="Card Content"></div>
             <div class="fd-card__footer">
-                
+                <div class="fd-card__footer__actions">
+                    <button class="fd-button fd-button--positive fd-card__footer__actions__item">
+                        Button
+                    </button>
+                    <button class="fd-button fd-button--negative fd-card__footer__actions__item">
+                        Button
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div style="width: 300px; height: 400px; margin: 1rem;">
+        <div class="fd-card" role="region" aria-label="Card Anatomy Example 2">
+            <a class="fd-card__header" tabindex="0">
+                <span
+                    class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--thumbnail fd-card__avatar"
+                    style="background-image: url('/assets/images/backgrounds/city.jpg')"
+                    role="img"
+                    aria-label="John Doe">
+                </span>
+                <div class="fd-card__header-text">
+                    <div class="fd-card__title-area">
+                        <div class="fd-card__title">Card Title</div>
+                    </div>
+                </div>
+            </a>
+            <div class="fd-card__content" role="group" aria-label="Card Content"></div>
+            <div class="fd-card__footer">
+                <a class="fd-link fd-card__footer__link" href="#">Footer with a link</a>
+            </div>
+        </div>
+    </div>
+    <div style="width: 300px; height: 400px; margin: 1rem;">
+        <div class="fd-card" role="region" aria-label="Card Anatomy Example 2">
+            <a class="fd-card__header" tabindex="0">
+                <span
+                    class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--thumbnail fd-card__avatar"
+                    style="background-image: url('/assets/images/backgrounds/city.jpg')"
+                    role="img"
+                    aria-label="John Doe">
+                </span>
+                <div class="fd-card__header-text">
+                    <div class="fd-card__title-area">
+                        <div class="fd-card__title">Card Title</div>
+                    </div>
+                </div>
+            </a>
+            <div class="fd-card__content" role="group" aria-label="Card Content"></div>
+            <div class="fd-card__footer">
+                <a class="fd-link fd-card__footer__link" href="#">Footer with a long link Lorem ipsum dolor sit amet, consectetur adipisicing elit. Accusantium</a>
+                <button class="fd-button fd-button--transparent">
+                    <i class="sap-icon sap-icon--overflow"></i>
+                </button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Related Issue
part of #3213

## Description
Card footer was missing from the styles. Some of the functionalities should be done with javascript. When action items overflow footer, there should be overflow button which will(probably, not clear from specs) open up dropdown for additional actions
