### PR TITLE
feat: grid list partial items, auto-height, selection labels position fix

### DIFF
--- a/src/styles/grid-list.scss
+++ b/src/styles/grid-list.scss
@@ -55,16 +55,9 @@ $fd-grid-list-highlight: (
     height: 1rem;
     width: 1rem;
 
-    @include fd-focus() {
-      + .#{$block}__#{$type}-label {
-        outline-offset: 0;
-      }
-    }
-
     + .#{$block}__#{$type}-label {
       @include fd-empty() {
         align-self: center;
-        padding: 0;
       }
     }
   }
@@ -341,6 +334,10 @@ $fd-grid-list-highlight: (
           @include fd-flex();
 
           color: var(--sapContent_LabelColor);
+
+          @include fd-empty() {
+            @include fd-set-margin-left(-0.5rem);
+          }
         }
       }
     }
@@ -363,15 +360,17 @@ $fd-grid-list-highlight: (
       }
     }
 
-    &-single-select-right {
+    &-single-select-right .#{$block-item} {
       .#{$block}__radio-input {
         right: 1rem;
       }
 
       .#{$block}__radio-label {
-        @include fd-set-margin-left(0.5rem !important);
-
         order: 1;
+
+        @include fd-empty() {
+          @include fd-set-margins-x(0.5rem, -0.5rem);
+        }
       }
     }
   }

--- a/src/styles/grid-list.scss
+++ b/src/styles/grid-list.scss
@@ -89,6 +89,10 @@ $fd-grid-list-highlight: (
       }
     }
 
+    &--height-auto {
+      height: auto;
+    }
+
     &--unread {
       .#{$block-item}-body * {
         font-weight: bold;
@@ -151,12 +155,21 @@ $fd-grid-list-highlight: (
       @include fd-reset();
       @include fd-flex(column);
 
-      width: calc(100% - 3rem - 0.75rem);
-      flex: 0 0 auto;
+      flex: 0 0 100%;
+
+      + .#{$block-item}-content {
+        padding-top: 1rem;
+      }
     }
 
     &-image {
       @include fd-set-margin-right(0.75rem);
+
+      + .#{$block-item}-header,
+      + .#{$block-item}-content {
+        // 3rem for xs avatar, 0.75rem for margin
+        max-width: calc(100% - 3rem - 0.75rem);
+      }
     }
 
     &-title {
@@ -181,7 +194,6 @@ $fd-grid-list-highlight: (
       @include fd-reset();
 
       color: var(--sapList_TextColor);
-      padding-top: 1rem;
     }
 
     &-counter {

--- a/stories/list-grid/grid-list.stories.js
+++ b/stories/list-grid/grid-list.stories.js
@@ -1170,3 +1170,97 @@ To create a grid list footer, follow the current example.
         }
     }
 };
+
+export const PartialItems = () => `<div style="min-height: 300px;">
+<div class="fd-grid-list fd-grid-list--mode-delete">
+    <div class="fd-container">
+        <div class="fd-row">
+            <div class="fd-col fd-col--12">
+                <div class="fd-toolbar fd-toolbar--solid">
+                    <span>For every item class <code>fd-grid-list__item--height-auto</code> is applied.</span>
+                </div>
+            </div>
+          </div>
+      
+        <div class="fd-row">
+            <div  class="fd-col fd-col--12 fd-col-md--6 fd-col-lg--4 fd-col-xl--3">
+                <div tabindex="0" class="fd-grid-list__item fd-grid-list__item--height-auto fd-grid-list__item--link">
+                    <div class="fd-grid-list__item-body">
+                        <div class="fd-grid-list__item-header">
+                            <h4 class="fd-title fd-title--h4 fd-grid-list__item-title">No image</h4>
+                            <span class="fd-grid-list__item-subtitle">Product Owner, Company B</span>
+                        </div>
+
+                        <div class="fd-grid-list__item-content">
+                            <p>781 Main Street</p>
+                            <p>Anytown, SD 57401</p>
+                            <p>USA</p>
+
+                            <a href="#" class="fd-link" tabindex="0">john_li@example.com</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div  class="fd-col fd-col--12 fd-col-md--6 fd-col-lg--4 fd-col-xl--3">
+                <div tabindex="0" class="fd-grid-list__item fd-grid-list__item--height-auto">
+                    <div class="fd-grid-list__item-body">
+                        <span class="fd-avatar fd-avatar--s fd-grid-list__item-image" role="presentation"></span>
+
+                        <div class="fd-grid-list__item-content">
+                            <p>No title & description</p>
+                            <p>Anytown, SD 57401</p>
+                            <p>USA</p>
+
+                            <a href="#" class="fd-link" tabindex="0">john_li@example.com</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div  class="fd-col fd-col--12 fd-col-md--6 fd-col-lg--4 fd-col-xl--3">
+                <div tabindex="0" class="fd-grid-list__item fd-grid-list__item--height-auto">
+                    <div class="fd-grid-list__item-body">
+                        <span class="fd-avatar fd-avatar--s fd-grid-list__item-image" role="presentation"></span>
+
+                        <div class="fd-grid-list__item-header">
+                            <h4 class="fd-title fd-title--h4 fd-grid-list__item-title">No body</h4>
+                            <span class="fd-grid-list__item-subtitle">Product Owner, Company B</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div  class="fd-col fd-col--12 fd-col-md--6 fd-col-lg--4 fd-col-xl--3">
+                <div tabindex="0" class="fd-grid-list__item fd-grid-list__item--height-auto">
+                    <div class="fd-grid-list__item-body">
+                        <div class="fd-grid-list__item-content">
+                            <p>No image, title & description</p>
+                            <p>Anytown, SD 57401</p>
+                            <p>USA</p>
+
+                            <a href="#" class="fd-link" tabindex="0">john_li@example.com</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</div>
+`;
+
+PartialItems.storyName = 'No height / Partial Items';
+
+PartialItems.parameters = {
+    docs: {
+        description: {
+            story: `
+It's possible to have items without some parts like image, title & description or body.
+
+But please note that by default items have equal height set by the tallest item, you can overwrite it by yourself or use
+class \`fd-grid-list__item--height-auto\` to set item's height to auto.
+`
+        }
+    }
+};


### PR DESCRIPTION
## Related Issue

Part of #3213.

## Description

Grid List Item
* Auto height feature for the item
* Partial items (no image, no title & subtitle, no body)
* Selection radio label position fix

## Screenshots

### Before:

Selection
<img width="67" alt="image" src="https://user-images.githubusercontent.com/20265336/166220107-9d020db3-4130-4c90-80a3-2d10895ecd15.png">

No title, subtitle
<img width="336" alt="image" src="https://user-images.githubusercontent.com/20265336/166225440-7ed3122f-bf98-46f2-943b-3db4a8594875.png">

No image
<img width="334" alt="image" src="https://user-images.githubusercontent.com/20265336/166225571-6027284c-83ce-4ddf-9e92-a13a348c0548.png">

No title, subtitle, image
<img width="190" alt="image" src="https://user-images.githubusercontent.com/20265336/166225696-4afa0c11-46b8-4e21-8329-c1e838ac625d.png">


### After:

Selection
<img width="58" alt="image" src="https://user-images.githubusercontent.com/20265336/166220146-9c5059f5-fdc6-4c5b-ae71-5b4034ebf30a.png">

No title, subtitle
<img width="334" alt="image" src="https://user-images.githubusercontent.com/20265336/166225459-aaf89815-ba27-4128-a7b7-fe9a3fcd57ff.png">

No image
<img width="334" alt="image" src="https://user-images.githubusercontent.com/20265336/166225599-33ada02d-5ff6-4388-8ddc-90d481e4aedc.png">

No title, subtitle, image
<img width="179" alt="image" src="https://user-images.githubusercontent.com/20265336/166225756-b79cac30-3919-4e45-9b3d-2249ed543ad4.png">
