### PR TITLE
feat(styles): add delta horizon theming for Splitter

### DIFF
--- a/src/styles/fundamental-styles.scss
+++ b/src/styles/fundamental-styles.scss
@@ -26,7 +26,7 @@
 @import "./feed-list";
 @import "./fieldset";
 @import "./file-uploader";
-@import "./fixed-card-layout.scss";
+@import "./fixed-card-layout";
 @import "./flexible-column-layout";
 @import "./form-layout-grid";
 @import "./form-group";
@@ -36,7 +36,7 @@
 @import "./form-message";
 @import "./helpers";
 @import "./horizontal-navigation";
-@import "./icon-tab-bar.scss";
+@import "./icon-tab-bar";
 @import "./illustrated-message";
 @import "./info-label";
 @import "./input";
@@ -55,7 +55,7 @@
 @import "./micro-process-flow";
 @import "./notification";
 @import "./numeric-content";
-@import "./off-screen.scss";
+@import "./off-screen";
 @import "./object-attribute";
 @import "./object-identifier";
 @import "./object-list";
@@ -72,7 +72,7 @@
 @import "./quick-view";
 @import "./radio";
 @import "./rating-indicator";
-@import "./resizable-card-layout.scss";
+@import "./resizable-card-layout";
 @import "./scrollbar";
 @import "./section";
 @import "./segmented-button";
@@ -92,10 +92,11 @@
 @import "./title";
 @import "./token";
 @import "./tokenizer";
-@import "./tool-header.scss";
+@import "./tool-header";
 @import "./toolbar";
 @import "./tree";
 @import "./upload-collection";
 @import "./user-menu";
 @import "./vertical-nav";
-@import "./wizard.scss";
+@import "./wizard";
+@import "./splitter";

--- a/src/styles/splitter.scss
+++ b/src/styles/splitter.scss
@@ -166,7 +166,7 @@ $block: fd-splitter;
     @include fd-flex-center();
     @include fd-fiori-focus(-0.125rem);
 
-    background-color: var(--sapShell_Background);
+    background: var(--sapShell_Background);
     border: var(--fdSplitter_Resizer_Border);
 
     @include fd-splitter-resizer-decoration() {
@@ -178,6 +178,14 @@ $block: fd-splitter;
       .#{$block}__resizer-decoration-after {
         background: var(--sapContent_Selected_ForegroundColor);
       }
+    }
+
+    &--translucent {
+      background: var(--sapGroup_ContentBackground);
+    }
+
+    &--transparent {
+      background: transparent;
     }
 
     .#{$block}__resizer-grip {

--- a/src/styles/splitter.scss
+++ b/src/styles/splitter.scss
@@ -37,13 +37,13 @@ $block: fd-splitter;
 }
 
 .#{$block} {
-  display: block;
+  @include fd-flex();
+
   width: 100%;
   height: 100%;
 
   &,
   &__pane-container,
-  &__pane-container-wrapper,
   &__pane,
   &__resizer,
   &__resizer-grip,
@@ -65,7 +65,6 @@ $block: fd-splitter;
   }
 
   &__pane-container,
-  &__pane-container-wrapper,
   &__pane {
     max-width: 100%;
     max-height: 100%;
@@ -74,25 +73,13 @@ $block: fd-splitter;
   &__pane-container {
     @include fd-flex();
 
-    width: 100%;
-    height: 100%;
+    flex-grow: 1;
     overflow: hidden;
-
-    &-wrapper {
-      @include fd-flex(column);
-
-      flex-grow: 1;
-    }
-
-    &--root {
-      height: calc(100% - 2.7rem);
-    }
 
     &--horizontal {
       flex-direction: column;
 
       > .#{$block}__resizer {
-        // width: 100%;
         height: 1rem;
         cursor: row-resize;
 
@@ -101,7 +88,7 @@ $block: fd-splitter;
         }
 
         @include fd-splitter-resizer-decoration() {
-          width: 4rem;
+          min-width: 4rem;
           height: 0.0625rem;
         }
 
@@ -116,6 +103,10 @@ $block: fd-splitter;
         .#{$block}__resizer-grip {
           width: 2rem;
           height: 1.5rem;
+
+          &-icon {
+            margin-top: 0.125rem;
+          }
         }
       }
     }
@@ -124,7 +115,6 @@ $block: fd-splitter;
       flex-direction: row;
 
       > .#{$block}__resizer {
-        // height: 100%;
         width: 1rem;
         cursor: col-resize;
         flex-direction: column;
@@ -135,7 +125,7 @@ $block: fd-splitter;
 
         @include fd-splitter-resizer-decoration() {
           width: 0.0625rem;
-          height: 4rem;
+          min-height: 4rem;
         }
 
         .#{$block}__resizer-decoration-before {
@@ -155,6 +145,8 @@ $block: fd-splitter;
   }
 
   &__split-pane {
+    @include fd-flex(column);
+
     flex-grow: 1;
     overflow: auto;
     text-overflow: ellipsis;
@@ -198,25 +190,11 @@ $block: fd-splitter;
     border-top: 0.0625rem solid var(--sapPageFooter_BorderColor);
     flex-shrink: 0;
 
-    &-item {
-      @include fd-flex-center();
-      @include fd-fiori-focus();
-
-      width: 2.25rem;
-      height: 2.25rem;
-      cursor: pointer;
-      border-radius: 0.25rem;
-      border: none;
-      background: transparent;
-
-      @include fd-hover() {
-        background: var(--sapButton_Lite_Hover_Background);
-      }
+    .#{$block}__pagination-item {
+      border-width: var(--fdSplitter_Pagination_Item_Border_Width);
 
       @include fd-active() {
         &:not(.#{$block}__pagination-item--active) {
-          background: var(--sapButton_Lite_Active_Background);
-
           .#{$block}__pagination-item-dot {
             background: var(--sapButton_Active_TextColor);
           }
@@ -231,14 +209,14 @@ $block: fd-splitter;
       }
 
       &--active {
-        @include fd-hover() {
-          background: var(--sapButton_Lite_Hover_Background);
-        }
-
         .#{$block}__pagination-item-dot {
           width: 0.5rem;
           height: 0.5rem;
           background: var(--sapSelectedColor);
+        }
+
+        @include fd-active() {
+          background: var(--sapButton_Lite_Hover_Background);
         }
       }
     }

--- a/src/styles/splitter.scss
+++ b/src/styles/splitter.scss
@@ -1,0 +1,246 @@
+@import "mixins/mixins";
+
+$block: fd-splitter;
+
+@mixin fd-splitter-gradient($deg) {
+  background: linear-gradient($deg, transparent, var(--fdSplitter_Decoration_Background));
+}
+
+@mixin fd-splitter-resizer-decoration() {
+  .#{$block}__resizer-decoration-before,
+  .#{$block}__resizer-decoration-after {
+    @content;
+  }
+}
+
+@mixin fd-splitter-resizer-hover-focus-active() {
+  @include fd-hover() {
+    .#{$block}__resizer-decoration-before,
+    .#{$block}__resizer-decoration-after {
+      @content;
+    }
+  }
+
+  @include fd-focus() {
+    .#{$block}__resizer-decoration-before,
+    .#{$block}__resizer-decoration-after {
+      @content;
+    }
+  }
+
+  @include fd-active() {
+    .#{$block}__resizer-decoration-before,
+    .#{$block}__resizer-decoration-after {
+      @content;
+    }
+  }
+}
+
+.#{$block} {
+  display: block;
+  width: 100%;
+  height: 100%;
+
+  &,
+  &__pane-container,
+  &__pane-container-wrapper,
+  &__pane,
+  &__resizer,
+  &__resizer-grip,
+  &__resizer-grip-icon,
+  &__resizer-decoration-before,
+  &__resizer-decoration-after,
+  &__pagination,
+  &__pagination-item,
+  &__pagination-item-dot {
+    @include fd-reset();
+  }
+
+  &__resizer,
+  &__resizer-grip,
+  &__resizer-grip-icon,
+  &__resizer-decoration-before,
+  &__resizer-decoration-after {
+    user-select: none;
+  }
+
+  &__pane-container,
+  &__pane-container-wrapper,
+  &__pane {
+    max-width: 100%;
+    max-height: 100%;
+  }
+
+  &__pane-container {
+    @include fd-flex();
+
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+
+    &-wrapper {
+      @include fd-flex(column);
+
+      flex-grow: 1;
+    }
+
+    &--root {
+      height: calc(100% - 2.7rem);
+    }
+
+    &--horizontal {
+      flex-direction: column;
+
+      > .#{$block}__resizer {
+        // width: 100%;
+        height: 1rem;
+        cursor: row-resize;
+
+        @include fd-splitter-resizer-hover-focus-active() {
+          width: 100%;
+        }
+
+        @include fd-splitter-resizer-decoration() {
+          width: 4rem;
+          height: 0.0625rem;
+        }
+
+        .#{$block}__resizer-decoration-before {
+          @include fd-splitter-gradient(90deg);
+        }
+
+        .#{$block}__resizer-decoration-after {
+          @include fd-splitter-gradient(270deg);
+        }
+
+        .#{$block}__resizer-grip {
+          width: 2rem;
+          height: 1.5rem;
+        }
+      }
+    }
+
+    &--vertical {
+      flex-direction: row;
+
+      > .#{$block}__resizer {
+        // height: 100%;
+        width: 1rem;
+        cursor: col-resize;
+        flex-direction: column;
+
+        @include fd-splitter-resizer-hover-focus-active() {
+          height: 100%;
+        }
+
+        @include fd-splitter-resizer-decoration() {
+          width: 0.0625rem;
+          height: 4rem;
+        }
+
+        .#{$block}__resizer-decoration-before {
+          @include fd-splitter-gradient(180deg);
+        }
+
+        .#{$block}__resizer-decoration-after {
+          @include fd-splitter-gradient(0deg);
+        }
+
+        .#{$block}__resizer-grip {
+          width: 1.5rem;
+          height: 2rem;
+        }
+      }
+    }
+  }
+
+  &__split-pane {
+    flex-grow: 1;
+    overflow: auto;
+    text-overflow: ellipsis;
+  }
+
+  &__resizer {
+    @include fd-flex-center();
+    @include fd-fiori-focus(-0.125rem);
+
+    background-color: var(--sapShell_Background);
+
+    @include fd-splitter-resizer-decoration() {
+      transition: all 0.1s ease-in;
+    }
+
+    @include fd-active() {
+      .#{$block}__resizer-decoration-before,
+      .#{$block}__resizer-decoration-after {
+        background: var(--sapContent_Selected_ForegroundColor);
+      }
+    }
+
+    &-grip {
+      flex-shrink: 0;
+
+      @include fd-flex-center();
+
+      .#{$block}__resizer-grip-icon {
+        color: var(--sapButton_Lite_TextColor);
+        line-height: 1rem;
+      }
+    }
+  }
+
+  &__pagination {
+    @include fd-flex-center();
+
+    width: 100%;
+    height: 2.75rem;
+    background: var(--sapPageFooter_Background);
+    border-top: 0.0625rem solid var(--sapPageFooter_BorderColor);
+    flex-shrink: 0;
+
+    &-item {
+      @include fd-flex-center();
+      @include fd-fiori-focus();
+
+      width: 2.25rem;
+      height: 2.25rem;
+      cursor: pointer;
+      border-radius: 0.25rem;
+      border: none;
+      background: transparent;
+
+      @include fd-hover() {
+        background: var(--sapButton_Lite_Hover_Background);
+      }
+
+      @include fd-active() {
+        &:not(.#{$block}__pagination-item--active) {
+          background: var(--sapButton_Lite_Active_Background);
+
+          .#{$block}__pagination-item-dot {
+            background: var(--sapButton_Active_TextColor);
+          }
+        }
+      }
+
+      &-dot {
+        width: 0.25rem;
+        height: 0.25rem;
+        border-radius: 100%;
+        background: var(--sapContent_NonInteractiveIconColor);
+      }
+
+      &--active {
+        @include fd-hover() {
+          background: var(--sapButton_Lite_Hover_Background);
+        }
+
+        .#{$block}__pagination-item-dot {
+          width: 0.5rem;
+          height: 0.5rem;
+          background: var(--sapSelectedColor);
+        }
+      }
+    }
+  }
+}

--- a/src/styles/splitter.scss
+++ b/src/styles/splitter.scss
@@ -182,6 +182,7 @@ $block: fd-splitter;
   }
 
   &__pagination {
+    @include fd-ellipsis();
     @include fd-flex-center();
 
     width: 100%;

--- a/src/styles/splitter.scss
+++ b/src/styles/splitter.scss
@@ -3,7 +3,7 @@
 $block: fd-splitter;
 
 @mixin fd-splitter-gradient($deg) {
-  background: linear-gradient($deg, transparent, var(--fdSplitter_Decoration_Background));
+  background: linear-gradient($deg, transparent, var(--fdSplitter_Resizer_Decoration_Background));
 }
 
 @mixin fd-splitter-resizer-decoration() {
@@ -46,12 +46,10 @@ $block: fd-splitter;
   &__pane-container,
   &__pane,
   &__resizer,
-  &__resizer-grip,
   &__resizer-grip-icon,
   &__resizer-decoration-before,
   &__resizer-decoration-after,
   &__pagination,
-  &__pagination-item,
   &__pagination-item-dot {
     @include fd-reset();
   }
@@ -82,6 +80,8 @@ $block: fd-splitter;
       > .#{$block}__resizer {
         height: 1rem;
         cursor: row-resize;
+        border-left: none;
+        border-right: none;
 
         @include fd-splitter-resizer-hover-focus-active() {
           width: 100%;
@@ -101,11 +101,13 @@ $block: fd-splitter;
         }
 
         .#{$block}__resizer-grip {
-          width: 2rem;
-          height: 1.5rem;
+          min-width: 2rem;
+          max-width: 2rem;
+          max-height: 1.5rem;
+          cursor: row-resize;
 
           &-icon {
-            margin-top: 0.125rem;
+            margin-top: 0.0625rem;
           }
         }
       }
@@ -118,6 +120,8 @@ $block: fd-splitter;
         width: 1rem;
         cursor: col-resize;
         flex-direction: column;
+        border-top: none;
+        border-bottom: none;
 
         @include fd-splitter-resizer-hover-focus-active() {
           height: 100%;
@@ -137,8 +141,14 @@ $block: fd-splitter;
         }
 
         .#{$block}__resizer-grip {
-          width: 1.5rem;
-          height: 2rem;
+          min-width: 1.5rem;
+          max-width: 1.5rem;
+          max-height: 2rem;
+          cursor: col-resize;
+
+          &-icon {
+            @include fd-set-margin-left(0.0625rem);
+          }
         }
       }
     }
@@ -152,11 +162,12 @@ $block: fd-splitter;
     text-overflow: ellipsis;
   }
 
-  &__resizer {
+  .#{$block}__resizer {
     @include fd-flex-center();
     @include fd-fiori-focus(-0.125rem);
 
     background-color: var(--sapShell_Background);
+    border: var(--fdSplitter_Resizer_Border);
 
     @include fd-splitter-resizer-decoration() {
       transition: all 0.1s ease-in;
@@ -169,14 +180,19 @@ $block: fd-splitter;
       }
     }
 
-    &-grip {
+    .#{$block}__resizer-grip {
+      outline: none;
+      box-shadow: none;
+      border-width: var(--fdSplitter_Resizer_Grip_Border_Width);
       flex-shrink: 0;
 
-      @include fd-flex-center();
+      @include fd-hover() {
+        background: var(--sapButton_Lite_Background);
+      }
 
-      .#{$block}__resizer-grip-icon {
+      @include fd-active() {
+        background: var(--sapButton_Lite_Background);
         color: var(--sapButton_Lite_TextColor);
-        line-height: 1rem;
       }
     }
   }

--- a/src/styles/splitter.scss
+++ b/src/styles/splitter.scss
@@ -68,7 +68,7 @@ $block: fd-splitter;
     max-height: 100%;
   }
 
-  &__pane-container {
+  .#{$block}__pane-container {
     @include fd-flex();
 
     flex-grow: 1;

--- a/src/styles/theming/common/splitter/_sap_fiori.scss
+++ b/src/styles/theming/common/splitter/_sap_fiori.scss
@@ -1,0 +1,8 @@
+:root {
+  --fdSplitter_Resizer_Border: none;
+  --fdSplitter_Resizer_Grip_Border_Width: 0;
+  --fdSplitter_Resizer_Decoration_Background: var(--sapHighlightColor);
+
+  /** Pagination */
+  --fdSplitter_Pagination_Item_Border_Width: 0;
+}

--- a/src/styles/theming/common/splitter/_sap_fiori_hc.scss
+++ b/src/styles/theming/common/splitter/_sap_fiori_hc.scss
@@ -1,0 +1,5 @@
+:root {
+  --fdSplitter_Resizer_Border: 0.0625rem solid var(--sapGroup_ContentBorderColor);
+  --fdSplitter_Resizer_Grip_Border_Width: var(--sapButton_BorderWidth);
+  --fdSplitter_Resizer_Decoration_Background: var(--sapGroup_ContentBorderColor);
+}

--- a/src/styles/theming/common/splitter/_sap_horizon.scss
+++ b/src/styles/theming/common/splitter/_sap_horizon.scss
@@ -1,0 +1,8 @@
+:root {
+  --fdSplitter_Resizer_Border: none;
+  --fdSplitter_Resizer_Grip_Border_Width: 0;
+  --fdSplitter_Resizer_Decoration_Background: var(--sapGroup_ContentBorderColor);
+
+  /** Pagination */
+  --fdSplitter_Pagination_Item_Border_Width: var(--sapButton_BorderWidth);
+}

--- a/src/styles/theming/common/splitter/_sap_horizon_hc.scss
+++ b/src/styles/theming/common/splitter/_sap_horizon_hc.scss
@@ -1,0 +1,4 @@
+:root {
+  --fdSplitter_Resizer_Border: 0.0625rem solid var(--sapGroup_ContentBorderColor);
+  --fdSplitter_Resizer_Grip_Border_Width: var(--sapButton_BorderWidth);
+}

--- a/src/styles/theming/sap_fiori_3.scss
+++ b/src/styles/theming/sap_fiori_3.scss
@@ -416,4 +416,7 @@
   --fdObject_List_Title_Font_Size: var(--sapFontHeader4Size);
   --fdObject_List_Title_Font_Weight: var(--sapFontHeaderWeight);
   --fdObject_List_Number_Font_Size: 1.375rem;
+
+  /** Splitter */
+  --fdSplitter_Decoration_Background: var(--sapHighlightColor);
 }

--- a/src/styles/theming/sap_fiori_3.scss
+++ b/src/styles/theming/sap_fiori_3.scss
@@ -6,6 +6,7 @@
 @import "./common/dynamic-page-layout/sap_fiori";
 @import "./common/card/sap_fiori";
 @import "./common/scrollbar/sap_fiori";
+@import "./common/splitter/sap_fiori";
 
 :root {
   --fdInverted_Object_Border_Width: 0;
@@ -416,8 +417,4 @@
   --fdObject_List_Title_Font_Size: var(--sapFontHeader4Size);
   --fdObject_List_Title_Font_Weight: var(--sapFontHeaderWeight);
   --fdObject_List_Number_Font_Size: 1.375rem;
-
-  /** Splitter */
-  --fdSplitter_Decoration_Background: var(--sapHighlightColor);
-  --fdSplitter_Pagination_Item_Border_Width: 0;
 }

--- a/src/styles/theming/sap_fiori_3.scss
+++ b/src/styles/theming/sap_fiori_3.scss
@@ -419,4 +419,5 @@
 
   /** Splitter */
   --fdSplitter_Decoration_Background: var(--sapHighlightColor);
+  --fdSplitter_Pagination_Item_Border_Width: 0;
 }

--- a/src/styles/theming/sap_fiori_3_dark.scss
+++ b/src/styles/theming/sap_fiori_3_dark.scss
@@ -6,6 +6,7 @@
 @import "./common/dynamic-page-layout/sap_fiori";
 @import "./common/card/sap_fiori";
 @import "./common/scrollbar/sap_fiori";
+@import "./common/splitter/sap_fiori";
 
 :root {
   --fdInverted_Object_Border_Width: 0;

--- a/src/styles/theming/sap_fiori_3_hcb.scss
+++ b/src/styles/theming/sap_fiori_3_hcb.scss
@@ -9,6 +9,8 @@
 @import "./common/scrollbar/sap_fiori";
 @import "./common/card/sap_fiori";
 @import "./common/card/sap_fiori_hc";
+@import "./common/splitter/sap_fiori";
+@import "./common/splitter/sap_fiori_hc";
 
 :root {
   --fdInverted_Object_Border_Width: 0.0625rem;

--- a/src/styles/theming/sap_fiori_3_hcw.scss
+++ b/src/styles/theming/sap_fiori_3_hcw.scss
@@ -10,6 +10,7 @@
 @import "./common/scrollbar/sap_fiori";
 @import "./common/card/sap_fiori";
 @import "./common/card/sap_fiori_hc";
+@import "./common/splitter/sap_fiori";
 @import "./common/splitter/sap_fiori_hc";
 
 :root {

--- a/src/styles/theming/sap_fiori_3_hcw.scss
+++ b/src/styles/theming/sap_fiori_3_hcw.scss
@@ -10,6 +10,7 @@
 @import "./common/scrollbar/sap_fiori";
 @import "./common/card/sap_fiori";
 @import "./common/card/sap_fiori_hc";
+@import "./common/splitter/sap_fiori_hc";
 
 :root {
   --fdInverted_Object_Border_Width: 0.0625rem;

--- a/src/styles/theming/sap_fiori_3_light_dark.scss
+++ b/src/styles/theming/sap_fiori_3_light_dark.scss
@@ -6,6 +6,7 @@
 @import "./common/dynamic-page-layout/sap_fiori";
 @import "./common/scrollbar/sap_fiori";
 @import "./common/card/sap_fiori";
+@import "./common/splitter/sap_fiori";
 
 :root {
   --fdInverted_Object_Border_Width: 0;

--- a/src/styles/theming/sap_horizon.scss
+++ b/src/styles/theming/sap_horizon.scss
@@ -6,6 +6,7 @@
 @import "./common/dynamic-page-layout/sap_horizon";
 @import "./common/scrollbar/sap_horizon";
 @import "./common/card/sap_horizon";
+@import "./common/splitter/sap_horizon";
 
 :root {
   /* Switch */
@@ -578,8 +579,4 @@
   --btp-Hazelnut9: #714700;
   --btp-Hazelnut10: #523100;
   --btp-Hazelnut11: #3d1f00;
-
-  /** Splitter */
-  --fdSplitter_Decoration_Background: var(--sapGroup_ContentBorderColor);
-  --fdSplitter_Pagination_Item_Border_Width: var(--sapButton_BorderWidth);
 }

--- a/src/styles/theming/sap_horizon.scss
+++ b/src/styles/theming/sap_horizon.scss
@@ -578,4 +578,7 @@
   --btp-Hazelnut9: #714700;
   --btp-Hazelnut10: #523100;
   --btp-Hazelnut11: #3d1f00;
+
+  /** Splitter */
+  --fdSplitter_Decoration_Background: var(--sapGroup_ContentBorderColor);
 }

--- a/src/styles/theming/sap_horizon.scss
+++ b/src/styles/theming/sap_horizon.scss
@@ -581,4 +581,5 @@
 
   /** Splitter */
   --fdSplitter_Decoration_Background: var(--sapGroup_ContentBorderColor);
+  --fdSplitter_Pagination_Item_Border_Width: var(--sapButton_BorderWidth);
 }

--- a/src/styles/theming/sap_horizon_dark.scss
+++ b/src/styles/theming/sap_horizon_dark.scss
@@ -6,6 +6,7 @@
 @import "./common/dynamic-page-layout/sap_horizon";
 @import "./common/scrollbar/sap_horizon";
 @import "./common/card/sap_horizon";
+@import "./common/splitter/sap_horizon";
 
 :root {
   /* Switch */

--- a/src/styles/theming/sap_horizon_hcb.scss
+++ b/src/styles/theming/sap_horizon_hcb.scss
@@ -11,6 +11,8 @@
 @import "./common/scrollbar/sap_horizon";
 @import "./common/card/sap_horizon";
 @import "./common/card/sap_horizon_hc";
+@import "./common/splitter/sap_horizon";
+@import "./common/splitter/sap_horizon_hc";
 
 :root {
   /* Switch */

--- a/src/styles/theming/sap_horizon_hcw.scss
+++ b/src/styles/theming/sap_horizon_hcw.scss
@@ -11,6 +11,8 @@
 @import "./common/scrollbar/sap_horizon";
 @import "./common/card/sap_horizon";
 @import "./common/card/sap_horizon_hc";
+@import "./common/splitter/sap_horizon";
+@import "./common/splitter/sap_horizon_hc";
 
 :root {
   /* Switch */

--- a/stories/splitter/__snapshots__/splitter.stories.storyshot
+++ b/stories/splitter/__snapshots__/splitter.stories.storyshot
@@ -1,0 +1,213 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Components/Title Semantic Level 1`] = `
+<div
+  dir="ltr"
+>
+  <h1
+    class="fd-title fd-title--h1"
+  >
+    Title Level 1
+  </h1>
+  
+
+  <h2
+    class="fd-title fd-title--h2"
+  >
+    Title Level 2
+  </h2>
+  
+
+  <h3
+    class="fd-title fd-title--h3"
+  >
+    Title Level 3
+  </h3>
+  
+
+  <h4
+    class="fd-title fd-title--h4"
+  >
+    Title Level 4
+  </h4>
+  
+
+  <h5
+    class="fd-title fd-title--h5"
+  >
+    Title Level 5
+  </h5>
+  
+
+  <h6
+    class="fd-title fd-title--h6"
+  >
+    Title Level 6
+  </h6>
+  
+
+</div>
+`;
+
+exports[`Storyshots Components/Title Text Elision 1`] = `
+<div
+  dir="ltr"
+>
+  <div
+    style="width: 300px"
+  >
+    
+    
+    <h1
+      class="fd-title fd-title--h1"
+    >
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit
+    </h1>
+    
+    
+    <h2
+      class="fd-title fd-title--h2"
+    >
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit
+    </h2>
+    
+    
+    <h3
+      class="fd-title fd-title--h3"
+    >
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit
+    </h3>
+    
+    
+    <h4
+      class="fd-title fd-title--h4"
+    >
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit
+    </h4>
+    
+    
+    <h5
+      class="fd-title fd-title--h5"
+    >
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit
+    </h5>
+    
+    
+    <h6
+      class="fd-title fd-title--h6"
+    >
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit
+    </h6>
+    
+
+  </div>
+  
+
+</div>
+`;
+
+exports[`Storyshots Components/Title Text Wrapping 1`] = `
+<div
+  dir="ltr"
+>
+  <div
+    style="width: 300px"
+  >
+    
+    
+    <h1
+      class="fd-title fd-title--h1 fd-title--wrap"
+    >
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit
+    </h1>
+    
+    
+    <h2
+      class="fd-title fd-title--h2 fd-title--wrap"
+    >
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit
+    </h2>
+    
+    
+    <h3
+      class="fd-title fd-title--h3 fd-title--wrap"
+    >
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit
+    </h3>
+    
+    
+    <h4
+      class="fd-title fd-title--h4 fd-title--wrap"
+    >
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit
+    </h4>
+    
+    
+    <h5
+      class="fd-title fd-title--h5 fd-title--wrap"
+    >
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit
+    </h5>
+    
+    
+    <h6
+      class="fd-title fd-title--h6 fd-title--wrap"
+    >
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit
+    </h6>
+    
+
+  </div>
+  
+
+</div>
+`;
+
+exports[`Storyshots Components/Title Visual Level 1`] = `
+<div
+  dir="ltr"
+>
+  <h1
+    class="fd-title fd-title--h6"
+  >
+    Title Level 1
+  </h1>
+  
+
+  <h2
+    class="fd-title fd-title--h5"
+  >
+    Title Level 2
+  </h2>
+  
+
+  <h3
+    class="fd-title fd-title--h4"
+  >
+    Title Level 3
+  </h3>
+  
+
+  <h4
+    class="fd-title fd-title--h3"
+  >
+    Title Level 4
+  </h4>
+  
+
+  <h5
+    class="fd-title fd-title--h2"
+  >
+    Title Level 5
+  </h5>
+  
+
+  <h6
+    class="fd-title fd-title--h1"
+  >
+    Title Level 6
+  </h6>
+  
+
+</div>
+`;

--- a/stories/splitter/splitter.stories.js
+++ b/stories/splitter/splitter.stories.js
@@ -13,6 +13,8 @@ Elements structure:
   * \`fd-splitter__pane-container--horizontal\` Modifier class for the container to set panes orientation to horizontal (align in rows).
     * \`fd-splitter__split-pane\` Pane that can be resized.
     * \`fd-splitter__resizer\` Resizer element.
+    * \`fd-splitter__resizer--translucent\` Modifier class for the resizer to change its look.
+    * \`fd-splitter__resizer--transparent\` Modifier class for the resizer to change its look.
       * \`fd-splitter__resizer-decoration-before\` Resizer decoration element.
       * \`fd-splitter__resizer-grip\` Resizer grip element.
       * \`fd-splitter__resizer-decoration-after\` Resizer decoration element.
@@ -247,6 +249,70 @@ There should be only one or two root panes. In case there is only one on-canvas 
 Otherwise navigation will be shown below the right root pane.
 
 **Note:** Navigation logic you should implement yourself.
+`
+        }
+    }
+};
+
+export const ResizerAppearance = () => `
+<div class="fd-splitter" style="height: 160px; background: #cccccc;">
+    <div class='fd-splitter__pane-container fd-splitter__pane-container--vertical'>
+        <div class='fd-splitter__split-pane'>
+            Next resizer has default appearance.
+        </div>
+
+        <div tabindex='0' class="fd-splitter__resizer" role="separator" aria-orienration="vertical">
+            <span class='fd-splitter__resizer-decoration-before'></span>
+
+            <button class='fd-button fd-button--transparent fd-splitter__resizer-grip' tabindex="-1">
+                <i class="sap-icon--vertical-grip fd-splitter__resizer-grip-icon"></i>
+            </button>
+
+            <span class='fd-splitter__resizer-decoration-after'></span>
+        </div>
+        
+        <div class='fd-splitter__split-pane'>
+            Next resizer has translucent appearance.
+        </div>
+
+        <div tabindex='0' class="fd-splitter__resizer fd-splitter__resizer--translucent" role="separator" aria-orienration="vertical">
+            <span class='fd-splitter__resizer-decoration-before'></span>
+
+            <button class='fd-button fd-button--transparent fd-splitter__resizer-grip' tabindex="-1">
+                <i class="sap-icon--vertical-grip fd-splitter__resizer-grip-icon"></i>
+            </button>
+
+            <span class='fd-splitter__resizer-decoration-after'></span>
+        </div>
+        
+        <div class='fd-splitter__split-pane'>
+            Next resizer has transparent appearance.
+        </div>
+        
+        <div tabindex='0' class="fd-splitter__resizer fd-splitter__resizer--transparent" role="separator" aria-orienration="vertical">
+            <span class='fd-splitter__resizer-decoration-before'></span>
+
+            <button class='fd-button fd-button--transparent fd-splitter__resizer-grip' tabindex="-1">
+                <i class="sap-icon--vertical-grip fd-splitter__resizer-grip-icon"></i>
+            </button>
+
+            <span class='fd-splitter__resizer-decoration-after'></span>
+        </div>
+        
+        <div class='fd-splitter__split-pane'>
+            Content
+        </div>
+    </div>
+</div>`;
+
+ResizerAppearance.parameters = {
+    docs: {
+        description: {
+            story: `
+While panes have transparent background resizer has its own by default
+but it's possible to pick one from several options. To do that apply modifier class to the resizer element:
+* \`fd-splitter__resizer--translucent\` Translucent appearance
+* \`fd-splitter__resizer--transparent\` Transparent appearance
 `
         }
     }

--- a/stories/splitter/splitter.stories.js
+++ b/stories/splitter/splitter.stories.js
@@ -102,7 +102,7 @@ Horizontal.parameters = {
     }
 };
 
-export const MixedAndNested = () => `<div class="fd-splitter">
+export const MixedAndNested = () => `<div class="fd-splitter" style="min-height: 400px">
     <div class='fd-splitter__pane-container fd-splitter__pane-container--vertical'>
         <div class='fd-splitter__split-pane'>
             Content, Level 0
@@ -119,8 +119,6 @@ export const MixedAndNested = () => `<div class="fd-splitter">
         </button>
 
         <div class='fd-splitter__split-pane'>
-            Content, Level 0
-            
             <div class='fd-splitter__pane-container fd-splitter__pane-container--horizontal'>
                 <div class='fd-splitter__split-pane'>
                     Content, Level 1
@@ -137,8 +135,6 @@ export const MixedAndNested = () => `<div class="fd-splitter">
                 </button>
 
                 <div class='fd-splitter__split-pane'>
-                    Content, Level 1
-                    
                     <div class='fd-splitter__pane-container fd-splitter__pane-container--vertical'>
                         <div class='fd-splitter__split-pane'>
                             Content, Level 2
@@ -168,7 +164,41 @@ MixedAndNested.parameters = {
     docs: {
         iframeHeight: 250,
         description: {
-            story: 'Splitter containers may be nested.'
+            story: 'Splitter may contain mixed (vertical + horizontal) and nested split panes (areas).'
         }
     }
 };
+
+export const Pagination = () => `<div class="fd-splitter">
+    <div class='fd-splitter__pane-container fd-splitter__pane-container--vertical'>
+        <div class='fd-splitter__split-pane'>
+            Content
+        </div>
+
+        <button class="fd-splitter__resizer" role="separator" aria-orienration="vertical">
+            <span class='fd-splitter__resizer-decoration-before'></span>
+
+            <span class='fd-splitter__resizer-grip'>
+                <i class="sap-icon--vertical-grip fd-splitter__resizer-grip-icon"></i>
+            </span>
+
+            <span class='fd-splitter__resizer-decoration-after'></span>
+        </button>
+
+        <div class='fd-splitter__pane-container fd-splitter__pane-container--horizontal'>
+            <div class='fd-splitter__split-pane'>
+                Content
+            </div>
+
+            <div class='fd-splitter__pagination'>
+                <button class="fd-button fd-button--transparent fd-splitter__pagination-item fd-splitter__pagination-item--active">
+                    <span class="fd-splitter__pagination-item-dot"></span>
+                </button>
+
+                <button class="fd-button fd-button--transparent fd-splitter__pagination-item">
+                    <span class="fd-splitter__pagination-item-dot"></span>
+                </button>
+            </div>
+        </div>
+    </div>
+</div>`;

--- a/stories/splitter/splitter.stories.js
+++ b/stories/splitter/splitter.stories.js
@@ -1,0 +1,174 @@
+export default {
+    title: 'Components/Splitter',
+    parameters: {
+        description: `
+The responsive splitter layout structures complex applications into defined areas. These areas may be resizable and are either distributed on one screen or across different areas, which may also be off-canvas. This depends on the device class and the requirements and settings of the application.
+
+**Note**: Resizing logic you should implement by yourself.`,
+        tags: ['f3'],
+        components: ['splitter', 'icon', 'button']
+    }
+};
+
+export const Vertical = () => `<div class="fd-splitter">
+    <div class='fd-splitter__pane-container fd-splitter__pane-container--vertical'>
+        <div class='fd-splitter__split-pane'>
+            Content
+        </div>
+
+        <button class="fd-splitter__resizer" role="separator" aria-orienration="vertical">
+            <span class='fd-splitter__resizer-decoration-before'></span>
+
+            <span class='fd-splitter__resizer-grip'>
+                <i class="sap-icon--vertical-grip fd-splitter__resizer-grip-icon"></i>
+            </span>
+
+            <span class='fd-splitter__resizer-decoration-after'></span>
+        </button>
+
+        <div class='fd-splitter__split-pane'>
+            Content
+        </div>
+
+        <button class="fd-splitter__resizer" role="separator" aria-orienration="vertical">
+            <span class='fd-splitter__resizer-decoration-before'></span>
+
+            <span class='fd-splitter__resizer-grip'>
+                <i class="sap-icon--vertical-grip fd-splitter__resizer-grip-icon"></i>
+            </span>
+
+            <span class='fd-splitter__resizer-decoration-after'></span>
+        </button>
+
+        <div class='fd-splitter__split-pane'>
+            Content
+        </div>
+    </div>
+</div>
+`;
+
+Vertical.parameters = {
+    docs: {
+        iframeHeight: 250,
+        description: {
+            story: 'Content split by the vertical areas (columns).'
+        }
+    }
+};
+
+export const Horizontal = () => `<div class="fd-splitter">
+    <div class='fd-splitter__pane-container fd-splitter__pane-container--horizontal'>
+        <div class='fd-splitter__split-pane'>
+            Content
+        </div>
+
+        <button class="fd-splitter__resizer" role="separator" aria-orienration="vertical">
+            <span class='fd-splitter__resizer-decoration-before'></span>
+
+            <span class='fd-splitter__resizer-grip'>
+                <i class="sap-icon--horizontal-grip fd-splitter__resizer-grip-icon"></i>
+            </span>
+
+            <span class='fd-splitter__resizer-decoration-after'></span>
+        </button>
+
+        <div class='fd-splitter__split-pane'>
+            Content
+        </div>
+
+        <button class="fd-splitter__resizer" role="separator" aria-orienration="vertical">
+            <span class='fd-splitter__resizer-decoration-before'></span>
+
+            <span class='fd-splitter__resizer-grip'>
+                <i class="sap-icon--horizontal-grip fd-splitter__resizer-grip-icon"></i>
+            </span>
+
+            <span class='fd-splitter__resizer-decoration-after'></span>
+        </button>
+
+        <div class='fd-splitter__split-pane'>
+            Content
+        </div>
+    </div>
+</div>
+`;
+
+Horizontal.parameters = {
+    docs: {
+        iframeHeight: 250,
+        description: {
+            story: 'Content split by the horizontal areas (rows).'
+        }
+    }
+};
+
+export const MixedAndNested = () => `<div class="fd-splitter">
+    <div class='fd-splitter__pane-container fd-splitter__pane-container--vertical'>
+        <div class='fd-splitter__split-pane'>
+            Content, Level 0
+        </div>
+
+        <button class="fd-splitter__resizer" role="separator" aria-orienration="vertical">
+            <span class='fd-splitter__resizer-decoration-before'></span>
+
+            <span class='fd-splitter__resizer-grip'>
+                <i class="sap-icon--vertical-grip fd-splitter__resizer-grip-icon"></i>
+            </span>
+
+            <span class='fd-splitter__resizer-decoration-after'></span>
+        </button>
+
+        <div class='fd-splitter__split-pane'>
+            Content, Level 0
+            
+            <div class='fd-splitter__pane-container fd-splitter__pane-container--horizontal'>
+                <div class='fd-splitter__split-pane'>
+                    Content, Level 1
+                </div>
+
+                <button class="fd-splitter__resizer" role="separator" aria-orienration="vertical">
+                    <span class='fd-splitter__resizer-decoration-before'></span>
+
+                    <span class='fd-splitter__resizer-grip'>
+                        <i class="sap-icon--horizontal-grip fd-splitter__resizer-grip-icon"></i>
+                    </span>
+
+                    <span class='fd-splitter__resizer-decoration-after'></span>
+                </button>
+
+                <div class='fd-splitter__split-pane'>
+                    Content, Level 1
+                    
+                    <div class='fd-splitter__pane-container fd-splitter__pane-container--vertical'>
+                        <div class='fd-splitter__split-pane'>
+                            Content, Level 2
+                        </div>
+        
+                        <button class="fd-splitter__resizer" role="separator" aria-orienration="vertical">
+                            <span class='fd-splitter__resizer-decoration-before'></span>
+        
+                            <span class='fd-splitter__resizer-grip'>
+                                <i class="sap-icon--vertical-grip fd-splitter__resizer-grip-icon"></i>
+                            </span>
+        
+                            <span class='fd-splitter__resizer-decoration-after'></span>
+                        </button>
+        
+                        <div class='fd-splitter__split-pane'>
+                            Content, Level 2
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>`;
+
+MixedAndNested.parameters = {
+    docs: {
+        iframeHeight: 250,
+        description: {
+            story: 'Splitter containers may be nested.'
+        }
+    }
+};

--- a/stories/splitter/splitter.stories.js
+++ b/stories/splitter/splitter.stories.js
@@ -33,29 +33,29 @@ export const Default = () => `<h2>Vertical</h2>
             Content
         </div>
 
-        <button class="fd-splitter__resizer" role="separator" aria-orienration="vertical">
+        <div tabindex='0' class="fd-splitter__resizer" role="separator" aria-orienration="vertical">
             <span class='fd-splitter__resizer-decoration-before'></span>
 
-            <span class='fd-splitter__resizer-grip'>
+            <button class='fd-button fd-button--transparent fd-splitter__resizer-grip' tabindex="-1">
                 <i class="sap-icon--vertical-grip fd-splitter__resizer-grip-icon"></i>
-            </span>
+            </button>
 
             <span class='fd-splitter__resizer-decoration-after'></span>
-        </button>
+        </div>
 
         <div class='fd-splitter__split-pane'>
             Content
         </div>
 
-        <button class="fd-splitter__resizer" role="separator" aria-orienration="vertical">
+        <div tabindex='0' class="fd-splitter__resizer" role="separator" aria-orienration="vertical">
             <span class='fd-splitter__resizer-decoration-before'></span>
 
-            <span class='fd-splitter__resizer-grip'>
+            <button class='fd-button fd-button--transparent fd-splitter__resizer-grip' tabindex="-1">
                 <i class="sap-icon--vertical-grip fd-splitter__resizer-grip-icon"></i>
-            </span>
+            </button>
 
             <span class='fd-splitter__resizer-decoration-after'></span>
-        </button>
+        </div>
 
         <div class='fd-splitter__split-pane'>
             Content
@@ -70,29 +70,29 @@ export const Default = () => `<h2>Vertical</h2>
             Content
         </div>
 
-        <button class="fd-splitter__resizer" role="separator" aria-orienration="vertical">
+        <div tabindex='0' class="fd-splitter__resizer" role="separator" aria-orienration="vertical">
             <span class='fd-splitter__resizer-decoration-before'></span>
 
-            <span class='fd-splitter__resizer-grip'>
+            <button class='fd-button fd-button--transparent fd-splitter__resizer-grip' tabindex="-1">
                 <i class="sap-icon--horizontal-grip fd-splitter__resizer-grip-icon"></i>
-            </span>
+            </button>
 
             <span class='fd-splitter__resizer-decoration-after'></span>
-        </button>
+        </div>
 
         <div class='fd-splitter__split-pane'>
             Content
         </div>
 
-        <button class="fd-splitter__resizer" role="separator" aria-orienration="vertical">
+        <div tabindex='0' class="fd-splitter__resizer" role="separator" aria-orienration="vertical">
             <span class='fd-splitter__resizer-decoration-before'></span>
 
-            <span class='fd-splitter__resizer-grip'>
+            <button class='fd-button fd-button--transparent fd-splitter__resizer-grip' tabindex="-1">
                 <i class="sap-icon--horizontal-grip fd-splitter__resizer-grip-icon"></i>
-            </span>
+            </button>
 
             <span class='fd-splitter__resizer-decoration-after'></span>
-        </button>
+        </div>
 
         <div class='fd-splitter__split-pane'>
             Content
@@ -120,15 +120,15 @@ export const MixedAndNested = () => `
             Content, Level 0
         </div>
 
-        <button class="fd-splitter__resizer" role="separator" aria-orienration="vertical">
+        <div tabindex='0' class="fd-splitter__resizer" role="separator" aria-orienration="vertical">
             <span class='fd-splitter__resizer-decoration-before'></span>
 
-            <span class='fd-splitter__resizer-grip'>
+            <button class='fd-button fd-button--transparent fd-splitter__resizer-grip' tabindex="-1">
                 <i class="sap-icon--vertical-grip fd-splitter__resizer-grip-icon"></i>
-            </span>
+            </button>
 
             <span class='fd-splitter__resizer-decoration-after'></span>
-        </button>
+        </div>
 
         <div class='fd-splitter__split-pane'>
             <div class='fd-splitter__pane-container fd-splitter__pane-container--horizontal'>
@@ -136,15 +136,15 @@ export const MixedAndNested = () => `
                     Content, Level 1
                 </div>
 
-                <button class="fd-splitter__resizer" role="separator" aria-orienration="vertical">
+                <div tabindex='0' class="fd-splitter__resizer" role="separator" aria-orienration="vertical">
                     <span class='fd-splitter__resizer-decoration-before'></span>
 
-                    <span class='fd-splitter__resizer-grip'>
+                    <button class='fd-button fd-button--transparent fd-splitter__resizer-grip' tabindex='-1'>
                         <i class="sap-icon--horizontal-grip fd-splitter__resizer-grip-icon"></i>
-                    </span>
+                    </button>
 
                     <span class='fd-splitter__resizer-decoration-after'></span>
-                </button>
+                </div>
 
                 <div class='fd-splitter__split-pane'>
                     <div class='fd-splitter__pane-container fd-splitter__pane-container--vertical'>
@@ -152,15 +152,15 @@ export const MixedAndNested = () => `
                             Content, Level 2
                         </div>
         
-                        <button class="fd-splitter__resizer" role="separator" aria-orienration="vertical">
+                        <div tabindex='0' class="fd-splitter__resizer" role="separator" aria-orienration="vertical">
                             <span class='fd-splitter__resizer-decoration-before'></span>
         
-                            <span class='fd-splitter__resizer-grip'>
+                            <button class='fd-button fd-button--transparent fd-splitter__resizer-grip' tabindex='-1'>
                                 <i class="sap-icon--vertical-grip fd-splitter__resizer-grip-icon"></i>
-                            </span>
+                            </button>
         
                             <span class='fd-splitter__resizer-decoration-after'></span>
-                        </button>
+                        </div>
         
                         <div class='fd-splitter__split-pane'>
                             Content, Level 2
@@ -209,15 +209,15 @@ export const Pagination = () => `<h2>One root pane</h2>
             Content
         </div>
 
-        <button class="fd-splitter__resizer" role="separator" aria-orienration="vertical">
+        <div tabindex='0' class="fd-splitter__resizer" role="separator" aria-orienration="vertical">
             <span class='fd-splitter__resizer-decoration-before'></span>
 
-            <span class='fd-splitter__resizer-grip'>
+            <button class='fd-button fd-button--transparent fd-splitter__resizer-grip' tabindex="-1">
                 <i class="sap-icon--vertical-grip fd-splitter__resizer-grip-icon"></i>
-            </span>
+            </button>
 
             <span class='fd-splitter__resizer-decoration-after'></span>
-        </button>
+        </div>
 
         <div class='fd-splitter__pane-container fd-splitter__pane-container--horizontal'>
             <div class='fd-splitter__split-pane'>

--- a/stories/splitter/splitter.stories.js
+++ b/stories/splitter/splitter.stories.js
@@ -4,13 +4,30 @@ export default {
         description: `
 The responsive splitter layout structures complex applications into defined areas. These areas may be resizable and are either distributed on one screen or across different areas, which may also be off-canvas. This depends on the device class and the requirements and settings of the application.
 
-**Note**: Resizing logic you should implement by yourself.`,
-        tags: ['f3'],
+**Note**: Resizing logic you should implement yourself.
+
+Elements structure:
+* \`fd-splitter\` Component
+  * \`fd-splitter__pane-container\` Container for panes that has the same orientation.
+  * \`fd-splitter__pane-container--vertical\` Modifier class for the container to set panes orientation to vertical (align in columns).
+  * \`fd-splitter__pane-container--horizontal\` Modifier class for the container to set panes orientation to horizontal (align in rows).
+    * \`fd-splitter__split-pane\` Pane that can be resized.
+    * \`fd-splitter__resizer\` Resizer element.
+      * \`fd-splitter__resizer-decoration-before\` Resizer decoration element.
+      * \`fd-splitter__resizer-grip\` Resizer grip element.
+      * \`fd-splitter__resizer-decoration-after\` Resizer decoration element.
+    * \`fd-splitter__pagination\` Pagination element.
+      * \`fd-splitter__pagination-item\` Pagination item element.
+      * \`fd-splitter__pagination-item--active\` Modifier class for the active pagination item.
+        * \`fd-splitter__pagination-item-dot\` Pagination item dot element.
+`,
+        tags: ['non-f3'],
         components: ['splitter', 'icon', 'button']
     }
 };
 
-export const Vertical = () => `<div class="fd-splitter">
+export const Default = () => `<h2>Vertical</h2>
+<div class="fd-splitter" style="height: 160px">
     <div class='fd-splitter__pane-container fd-splitter__pane-container--vertical'>
         <div class='fd-splitter__split-pane'>
             Content
@@ -45,18 +62,9 @@ export const Vertical = () => `<div class="fd-splitter">
         </div>
     </div>
 </div>
-`;
 
-Vertical.parameters = {
-    docs: {
-        iframeHeight: 250,
-        description: {
-            story: 'Content split by the vertical areas (columns).'
-        }
-    }
-};
-
-export const Horizontal = () => `<div class="fd-splitter">
+<h2>Horizontal</h2>
+<div class="fd-splitter" style="height: 160px">
     <div class='fd-splitter__pane-container fd-splitter__pane-container--horizontal'>
         <div class='fd-splitter__split-pane'>
             Content
@@ -93,16 +101,20 @@ export const Horizontal = () => `<div class="fd-splitter">
 </div>
 `;
 
-Horizontal.parameters = {
+Default.parameters = {
     docs: {
-        iframeHeight: 250,
         description: {
-            story: 'Content split by the horizontal areas (rows).'
+            story: `
+Content can be split by the vertical areas (columns) or by the horizontal areas (rows).
+
+**Note:** You should explicitly set the dimensions of the splitter component and of the every area otherwise it will be set to the size of the content.
+`
         }
     }
 };
 
-export const MixedAndNested = () => `<div class="fd-splitter" style="min-height: 400px">
+export const MixedAndNested = () => `
+<div class="fd-splitter" style="height: 160px">
     <div class='fd-splitter__pane-container fd-splitter__pane-container--vertical'>
         <div class='fd-splitter__split-pane'>
             Content, Level 0
@@ -162,14 +174,36 @@ export const MixedAndNested = () => `<div class="fd-splitter" style="min-height:
 
 MixedAndNested.parameters = {
     docs: {
-        iframeHeight: 250,
         description: {
-            story: 'Splitter may contain mixed (vertical + horizontal) and nested split panes (areas).'
+            story: `
+Splitter may contain nested containers with different orientations.
+`
         }
     }
 };
 
-export const Pagination = () => `<div class="fd-splitter">
+export const Pagination = () => `<h2>One root pane</h2>
+<div class="fd-splitter" style="height: 160px">
+    <div class='fd-splitter__pane-container fd-splitter__pane-container--horizontal'>
+        <div class='fd-splitter__split-pane'>
+            Content
+        </div>
+
+        <div class='fd-splitter__pagination'>
+            <button class="fd-button fd-button--transparent fd-splitter__pagination-item fd-splitter__pagination-item--active">
+                <span class="fd-splitter__pagination-item-dot"></span>
+            </button>
+
+            <button class="fd-button fd-button--transparent fd-splitter__pagination-item">
+                <span class="fd-splitter__pagination-item-dot"></span>
+            </button>
+        </div>
+    </div>
+</div>
+
+<h2>Two root panes</h2>
+
+<div class="fd-splitter" style="height: 160px">
     <div class='fd-splitter__pane-container fd-splitter__pane-container--vertical'>
         <div class='fd-splitter__split-pane'>
             Content
@@ -202,3 +236,18 @@ export const Pagination = () => `<div class="fd-splitter">
         </div>
     </div>
 </div>`;
+
+Pagination.parameters = {
+    docs: {
+        description: {
+            story: `
+Not all the panes should be visible at the same time. Some of them might be just hidden or goes off-canvas at certain breakpoint.
+Navigate into off-canvas panes possible via the navigation. Navigation should be placed in root container.
+There should be only one or two root panes. In case there is only one on-canvas root pane navigation will be shown just below, having the full width.
+Otherwise navigation will be shown below the right root pane.
+
+**Note:** Navigation logic you should implement yourself.
+`
+        }
+    }
+};


### PR DESCRIPTION
## Related Issue

Part of #3354

## Description

Splitter styles moved to this lib, hcw/hcb themes support implemented, horizon themes support implemented.

_Icon might look wrong but it just comes from the iconfont, nothing is done on the component level._

## Screenshots

### Before:

HC
<img width="184" alt="image" src="https://user-images.githubusercontent.com/20265336/166629929-66e6bf0d-e6df-43a3-947b-1d8bc9594e1d.png">

Horizon
<img width="152" alt="image" src="https://user-images.githubusercontent.com/20265336/166629963-083a9905-2f91-4f6c-bc61-218a74990b86.png">


### After:

HC
<img width="254" alt="image" src="https://user-images.githubusercontent.com/20265336/166629863-884b9efb-695d-4c77-baca-bb941321b2ae.png">

Horizon
<img width="167" alt="image" src="https://user-images.githubusercontent.com/20265336/166629997-54427ddf-9263-4ca7-8091-06063b1053e2.png">