### PR TITLE
fix: split button separator in horizon

### DIFF
--- a/src/styles/button-split.scss
+++ b/src/styles/button-split.scss
@@ -73,6 +73,12 @@ $split-button-states: (
         display: none;
       }
     }
+
+    @include fd-active() {
+      &::after {
+        display: none;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Related Issue

Closes none.

## Description

Split button separator fix in Horizon themes.

## Screenshots

### Before:

<img width="130" alt="image" src="https://user-images.githubusercontent.com/20265336/166643326-d64fefcb-8f32-431b-9e93-05c969adb367.png">

### After:

<img width="142" alt="image" src="https://user-images.githubusercontent.com/20265336/166643015-72b1de3b-4d10-403e-afd8-1ae1b745ad7b.png">