### PR TITLE
feat(styles): add delta horizon theming for Carousel

### DIFF
--- a/src/styles/carousel.scss
+++ b/src/styles/carousel.scss
@@ -1,31 +1,21 @@
 @import "./new-settings";
 @import "./mixins";
-@import "./mixins/button/button-helper";
 
 $block: #{$fd-namespace}-carousel;
-$button: #{$fd-namespace}-button;
 
-#{$block} {
-  @include fd-focus() {
-    outline: 0.0625rem var(--sapContent_FocusStyle);
-  }
-}
+$fd-carousel-button-size: 2.125rem !default;
+$fd-carousel-touchable-button-size: 2.625rem !default;
+$fd-carousel-button-content-offset: 0.5rem !default;
+$fd-carousel-dot-active-size: 0.5rem !default;
 
 .#{$block} {
-  $fd-carousel-page-indicator-border: 0.0625rem solid var(--sapPageFooter_BorderColor) !default;
-  $fd-carousel-button-size: 2.125rem !default;
-  $fd-carousel-touchable-button-size: 2.625rem !default;
-  $fd-carousel-button-focus-outline-offset: 0.0625rem !default;
-  $fd-carousel-button-content-offset: 0.5rem !default;
-  $fd-carousel-dot-size: var(--fdCarousel_Dot_Size) !default;
-  $fd-carousel-dot-active-size: 0.5rem !default;
-
-  @mixin after-position-overwrite() {
-    outline-offset: $fd-carousel-button-focus-outline-offset;
-  }
-
   @include fd-reset();
   @include fd-flex(column);
+
+  width: 100%;
+  min-width: 15.5rem;
+  height: 100%;
+  max-width: 100%;
 
   @include fd-hover() {
     .#{$block}__content {
@@ -35,20 +25,18 @@ $button: #{$fd-namespace}-button;
     }
   }
 
-  width: 100%;
-  min-width: 11rem;
-  max-width: 100%;
-  height: 100%;
+  @include fd-focus() {
+    outline: 0.0625rem var(--sapContent_FocusStyle);
+  }
 
-  &__content {
+  .#{$block}__content {
     @include fd-reset();
 
-    flex: 1 1 auto;
-    width: 100%;
-    background: var(--sapBackgroundColor);
+    background: var(--fdCarousel_Content_Background);
     position: relative;
+    overflow: hidden;
 
-    .#{$block}__button.#{$button} {
+    .#{$block}__button {
       box-shadow: var(--sapContent_Shadow1);
       position: absolute;
       margin: 0;
@@ -56,31 +44,36 @@ $button: #{$fd-namespace}-button;
       transform: translateY(-50%);
       display: none;
 
-      &.#{$block}__button--left {
-        left: $fd-carousel-button-content-offset;
-
-        @include fd-rtl() {
-          left: initial;
-          right: $fd-carousel-button-content-offset;
-        }
+      &--left {
+        @include fd-set-position-left($fd-carousel-button-content-offset);
       }
 
-      &.#{$block}__button--right {
-        right: $fd-carousel-button-content-offset;
-
-        @include fd-rtl() {
-          right: initial;
-          left: $fd-carousel-button-content-offset;
-        }
+      &--right {
+        @include fd-set-position-right($fd-carousel-button-content-offset);
       }
-    }
-
-    &--display {
-      overflow: hidden;
     }
 
     &--horizontal {
-      @include fd-flex();
+      .#{$block}__slides {
+        @include fd-flex();
+
+        width: 100%;
+        min-width: fit-content;
+        touch-action: pan-y;
+      }
+    }
+  }
+
+  &__slides {
+    min-height: fit-content;
+    touch-action: pan-x;
+    user-select: none;
+    -webkit-user-drag: none;
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+
+    &-wrapper {
+      overflow: hidden;
+      margin: 0 auto;
     }
   }
 
@@ -101,29 +94,25 @@ $button: #{$fd-namespace}-button;
     @include fd-reset();
     @include fd-flex-center();
 
-    width: 100%;
-    height: 100%;
     min-height: 2.75rem;
     max-height: 3.5rem;
-    background: var(--sapPageFooter_Background);
     padding: 0.375rem 0.5rem;
-    border-top: $fd-carousel-page-indicator-border;
+    background: var(--sapPageFooter_Background);
+    border-top: var(--fdCarousel_Pagination_Border);
 
     &:first-child {
       border-top: none;
-      border-bottom: $fd-carousel-page-indicator-border;
+      border-bottom: var(--fdCarousel_Pagination_Border);
     }
   }
 
   &__page-indicators {
     @include fd-reset();
+    @include fd-flex-center();
 
-    @include fd-flex-center() {
-      flex-wrap: wrap;
-    }
-
-    min-width: 7rem;
-    padding: 0.5rem 0;
+    min-width: 9rem;
+    padding: 0.5rem;
+    flex-wrap: wrap;
   }
 
   &__page-indicator {
@@ -131,17 +120,18 @@ $button: #{$fd-namespace}-button;
 
     list-style-type: none;
     margin: var(--fdCarousel_Dot_Margin);
-    width: $fd-carousel-dot-size;
-    height: $fd-carousel-dot-size;
+    width: var(--fdCarousel_Dot_Size);
+    height: var(--fdCarousel_Dot_Size);
     border-radius: 50%;
-    background-color: var(--sapContent_NonInteractiveIconColor);
+    background-color: var(--fdCarousel_Dot_Background);
     border: var(--fdCarousel_Dot_Border);
 
     &--active {
       margin: 0 0.25rem;
       width: $fd-carousel-dot-active-size;
       height: $fd-carousel-dot-active-size;
-      background-color: var(--sapSelectedColor);
+      background-color: var(--fdCarousel_Dot_Selected_Background);
+      border: var(--fdCarousel_Dot_Selected_Border);
     }
   }
 
@@ -153,48 +143,36 @@ $button: #{$fd-namespace}-button;
     text-align: center;
   }
 
-  &__button {
-    &.#{$button} {
-      @include fd-flex-center();
-      @include set-width($fd-carousel-button-size);
-      @include set-height($fd-carousel-button-size);
+  .#{$block}__button {
+    @include fd-flex-center();
+    @include set-width($fd-carousel-button-size);
+    @include set-height($fd-carousel-button-size);
 
-      border-radius: 50%;
-      padding: 0;
-      box-shadow: none;
-      margin: 0.25rem;
+    border-radius: 50%;
+    padding: 0;
+    margin: 0.25rem;
 
-      &::before {
-        left: -0.25rem;
-        right: -0.25rem;
-        height: $fd-carousel-touchable-button-size;
-        width: $fd-carousel-touchable-button-size;
+    &::before {
+      left: -0.25rem;
+      right: -0.25rem;
+      bottom: -0.25rem;
+      top: -0.25rem;
+      width: auto;
+    }
+
+    @include fd-rtl() {
+      & > [class*=sap-icon] {
+        transform: rotate(180deg);
       }
+    }
 
-      @include fd-rtl() {
-        & > [class*=sap-icon] {
-          transform: rotate(180deg);
-        }
-      }
-
-      @include fd-focus() {
-        @include after-position-overwrite();
-      }
-
-      @include fd-hover() {
-        box-shadow: var(--sapContent_Shadow1);
-      }
-
-      @include fd-active() {
-        @include fd-button-focus() {
-          @include after-position-overwrite();
-        }
-      }
+    @include fd-hover() {
+      box-shadow: var(--sapContent_Shadow1);
     }
   }
 
   &--no-navigation {
-    .#{$block}__button.#{$button} {
+    .#{$block}__button {
       display: none;
     }
 

--- a/src/styles/message-page.scss
+++ b/src/styles/message-page.scss
@@ -28,7 +28,6 @@ $block: #{$fd-namespace}-message-page;
     }
 
     padding: 1rem;
-    transform: translateY(-1rem);
     background: var(--fdMessage_Page_Container_Background);
     border-radius: var(--fdMessage_Page_Container_Corner_Radius);
   }

--- a/src/styles/theming/common/carousel/_sap_fiori.scss
+++ b/src/styles/theming/common/carousel/_sap_fiori.scss
@@ -1,0 +1,14 @@
+:root {
+  --fdCarousel_Content_Background: var(sapBackgroundColor);
+
+  /* Pagination */
+  --fdCarousel_Pagination_Border: 0.0625rem solid var(--sapPageFooter_BorderColor);
+
+  /* Pagination Dots */
+  --fdCarousel_Dot_Size: 0.25rem;
+  --fdCarousel_Dot_Margin: 0 0.375rem;
+  --fdCarousel_Dot_Background: var(--sapContent_NonInteractiveIconColor);
+  --fdCarousel_Dot_Selected_Background: var(--sapSelectedColor);
+  --fdCarousel_Dot_Border: none;
+  --fdCarousel_Dot_Selected_Border: none;
+}

--- a/src/styles/theming/common/carousel/_sap_fiori_hc.scss
+++ b/src/styles/theming/common/carousel/_sap_fiori_hc.scss
@@ -1,0 +1,7 @@
+:root {
+  --fdCarousel_Dot_Size: 0.5rem;
+  --fdCarousel_Dot_Margin: 0 0.25rem;
+  --fdCarousel_Dot_Background: transparent;
+  --fdCarousel_Dot_Border: 0.0625rem solid var(--sapContent_ForegroundBorderColor);
+  --fdCarousel_Dot_Selected_Border: 0.0625rem solid var(--sapContent_ForegroundBorderColor);
+}

--- a/src/styles/theming/common/carousel/_sap_horizon.scss
+++ b/src/styles/theming/common/carousel/_sap_horizon.scss
@@ -1,0 +1,14 @@
+:root {
+  --fdCarousel_Content_Background: var(--sapGroup_ContentBackground);
+
+  /* Pagination */
+  --fdCarousel_Pagination_Border: 0.0625rem solid var(--sapList_BorderColor);
+
+  /* Pagination Dots */
+  --fdCarousel_Dot_Size: 0.25rem;
+  --fdCarousel_Dot_Margin: 0 0.375rem;
+  --fdCarousel_Dot_Background: var(--sapContent_ForegroundBorderColor);
+  --fdCarousel_Dot_Selected_Background: var(--sapContent_Selected_ForegroundColor);
+  --fdCarousel_Dot_Border: 0.0625rem solid var(--sapContent_ForegroundBorderColor);
+  --fdCarousel_Dot_Selected_Border: 0.0625rem solid var(--sapContent_Selected_ForegroundColor);
+}

--- a/src/styles/theming/common/carousel/_sap_horizon_hc.scss
+++ b/src/styles/theming/common/carousel/_sap_horizon_hc.scss
@@ -1,0 +1,6 @@
+:root {
+  --fdCarousel_Dot_Size: 0.5rem;
+  --fdCarousel_Dot_Margin: 0 0.25rem;
+  --fdCarousel_Dot_Background: transparent;
+  --fdCarousel_Dot_Border: 0.0625rem solid var(--sapContent_ForegroundBorderColor);
+}

--- a/src/styles/theming/sap_fiori_3.scss
+++ b/src/styles/theming/sap_fiori_3.scss
@@ -12,6 +12,7 @@
 @import "./common/input-group/sap_fiori";
 @import "./common/wizard/sap_fiori";
 @import "./common/panel/sap_fiori";
+@import "./common/carousel/sap_fiori";
 
 :root {
   --fdInverted_Object_Border_Width: 0;
@@ -211,11 +212,6 @@
 
   /* Badge */
   --fdBadge_Border_Color: transparent;
-
-  /* Carousel */
-  --fdCarousel_Dot_Size: 0.25rem;
-  --fdCarousel_Dot_Margin: 0 0.375rem;
-  --fdCarousel_Dot_Border: none;
 
   /** Flexible Column Layout */
   --fdFlexibleColumnLayout_Toggle_Image_Color: var(--sapHighlightColor);

--- a/src/styles/theming/sap_fiori_3_dark.scss
+++ b/src/styles/theming/sap_fiori_3_dark.scss
@@ -12,6 +12,7 @@
 @import "./common/input-group/sap_fiori";
 @import "./common/wizard/sap_fiori";
 @import "./common/panel/sap_fiori";
+@import "./common/carousel/sap_fiori";
 
 :root {
   --fdInverted_Object_Border_Width: 0;
@@ -214,11 +215,6 @@
 
   /* Badge */
   --fdBadge_Border_Color: transparent;
-
-  /* Carousel */
-  --fdCarousel_Dot_Size: 0.25rem;
-  --fdCarousel_Dot_Margin: 0 0.375rem;
-  --fdCarousel_Dot_Border: none;
 
   /** Flexible Column Layout */
   --fdFlexibleColumnLayout_Toggle_Image_Color: var(--sapHighlightColor);

--- a/src/styles/theming/sap_fiori_3_hcb.scss
+++ b/src/styles/theming/sap_fiori_3_hcb.scss
@@ -18,6 +18,8 @@
 @import "./common/wizard/sap_fiori";
 @import "./common/wizard/sap_fiori_hc";
 @import "./common/panel/sap_fiori";
+@import "./common/carousel/sap_fiori";
+@import "./common/carousel/sap_fiori_hc";
 
 :root {
   --fdInverted_Object_Border_Width: 0.0625rem;
@@ -220,11 +222,6 @@
 
   /* Badge */
   --fdBadge_Border_Color: var(--sapContent_ForegroundBorderColor);
-
-  /* Carousel */
-  --fdCarousel_Dot_Size: 0.5rem;
-  --fdCarousel_Dot_Margin: 0 0.25rem;
-  --fdCarousel_Dot_Border: 1px solid var(--sapContent_ForegroundBorderColor);
 
   /** Flexible Column Layout */
   --fdFlexibleColumnLayout_Toggle_Image_Color: var(--sapObjectHeader_BorderColor);

--- a/src/styles/theming/sap_fiori_3_hcw.scss
+++ b/src/styles/theming/sap_fiori_3_hcw.scss
@@ -19,6 +19,8 @@
 @import "./common/wizard/sap_fiori";
 @import "./common/wizard/sap_fiori_hc";
 @import "./common/panel/sap_fiori";
+@import "./common/carousel/sap_fiori";
+@import "./common/carousel/sap_fiori_hc";
 
 :root {
   --fdInverted_Object_Border_Width: 0.0625rem;
@@ -218,11 +220,6 @@
 
   /* Badge */
   --fdBadge_Border_Color: var(--sapContent_ForegroundBorderColor);
-
-  /* Carousel */
-  --fdCarousel_Dot_Size: 0.5rem;
-  --fdCarousel_Dot_Margin: 0 0.25rem;
-  --fdCarousel_Dot_Border: 1px solid var(--sapContent_ForegroundBorderColor);
 
   /** Flexible Column Layout */
   --fdFlexibleColumnLayout_Toggle_Image_Color: var(--sapObjectHeader_BorderColor);

--- a/src/styles/theming/sap_fiori_3_light_dark.scss
+++ b/src/styles/theming/sap_fiori_3_light_dark.scss
@@ -12,6 +12,7 @@
 @import "./common/input-group/sap_fiori";
 @import "./common/wizard/sap_fiori";
 @import "./common/panel/sap_fiori";
+@import "./common/carousel/sap_fiori";
 
 :root {
   --fdInverted_Object_Border_Width: 0;
@@ -214,11 +215,6 @@
 
   /* Badge */
   --fdBadge_Border_Color: transparent;
-
-  /* Carousel */
-  --fdCarousel_Dot_Size: 0.25rem;
-  --fdCarousel_Dot_Margin: 0 0.375rem;
-  --fdCarousel_Dot_Border: none;
 
   /** Flexible Column Layout */
   --fdFlexibleColumnLayout_Toggle_Image_Color: var(--sapHighlightColor);

--- a/src/styles/theming/sap_horizon.scss
+++ b/src/styles/theming/sap_horizon.scss
@@ -12,6 +12,7 @@
 @import "./common/input-group/sap_horizon";
 @import "./common/wizard/sap_horizon";
 @import "./common/panel/sap_horizon";
+@import "./common/carousel/sap_horizon";
 
 :root {
   /* Switch */
@@ -251,11 +252,6 @@
 
   /* Badge */
   --fdBadge_Border_Color: transparent;
-
-  /* Carousel */
-  --fdCarousel_Dot_Size: 0.25rem;
-  --fdCarousel_Dot_Margin: 0 0.375rem;
-  --fdCarousel_Dot_Border: none;
 
   /** Flexible Column Layout */
   --fdFlexibleColumnLayout_Toggle_Image_Color: var(--sapHighlightColor);

--- a/src/styles/theming/sap_horizon_dark.scss
+++ b/src/styles/theming/sap_horizon_dark.scss
@@ -12,6 +12,7 @@
 @import "./common/input-group/sap_horizon";
 @import "./common/wizard/sap_horizon";
 @import "./common/panel/sap_horizon";
+@import "./common/carousel/sap_horizon";
 
 :root {
   /* Switch */
@@ -251,11 +252,6 @@
 
   /* Badge */
   --fdBadge_Border_Color: transparent;
-
-  /* Carousel */
-  --fdCarousel_Dot_Size: 0.25rem;
-  --fdCarousel_Dot_Margin: 0 0.375rem;
-  --fdCarousel_Dot_Border: none;
 
   /** Flexible Column Layout */
   --fdFlexibleColumnLayout_Toggle_Image_Color: var(--sapHighlightColor);

--- a/src/styles/theming/sap_horizon_hcb.scss
+++ b/src/styles/theming/sap_horizon_hcb.scss
@@ -20,6 +20,8 @@
 @import "./common/wizard/sap_horizon";
 @import "./common/wizard/sap_horizon_hc";
 @import "./common/panel/sap_horizon";
+@import "./common/carousel/sap_horizon";
+@import "./common/carousel/sap_horizon_hc";
 
 :root {
   /* Switch */
@@ -224,11 +226,6 @@
 
   /* Badge */
   --fdBadge_Border_Color: transparent;
-
-  /* Carousel */
-  --fdCarousel_Dot_Size: 0.25rem;
-  --fdCarousel_Dot_Margin: 0 0.375rem;
-  --fdCarousel_Dot_Border: none;
 
   /** Flexible Column Layout */
   --fdFlexibleColumnLayout_Toggle_Image_Color: var(--sapHighlightColor);

--- a/src/styles/theming/sap_horizon_hcw.scss
+++ b/src/styles/theming/sap_horizon_hcw.scss
@@ -20,6 +20,8 @@
 @import "./common/wizard/sap_horizon";
 @import "./common/wizard/sap_horizon_hc";
 @import "./common/panel/sap_horizon";
+@import "./common/carousel/sap_horizon";
+@import "./common/carousel/sap_horizon_hc";
 
 :root {
   /* Switch */
@@ -224,11 +226,6 @@
 
   /* Badge */
   --fdBadge_Border_Color: transparent;
-
-  /* Carousel */
-  --fdCarousel_Dot_Size: 0.25rem;
-  --fdCarousel_Dot_Margin: 0 0.375rem;
-  --fdCarousel_Dot_Border: none;
 
   /** Flexible Column Layout */
   --fdFlexibleColumnLayout_Toggle_Image_Color: var(--sapHighlightColor);

--- a/stories/carousel/carousel.stories.js
+++ b/stories/carousel/carousel.stories.js
@@ -576,7 +576,7 @@ export const Error = () => `<div style="display: flex; flex-direction: column; a
         class="fd-carousel fd-carousel--no-navigation"
         style="max-width: 30rem"
         data-ride="carousel">
-        <div class="fd-carousel__content">
+        <div class="fd-carousel__content" style="height: 20rem;">
             <div class="fd-message-page">
                 <div class="fd-message-page__container">
                 <div class="fd-message-page__icon-container">

--- a/stories/carousel/carousel.stories.js
+++ b/stories/carousel/carousel.stories.js
@@ -30,7 +30,7 @@ To ensure that the carousel is accessible, a div element with class \`fd-carouse
     }
 };
 
-export const CarouselBottom = () => `<div style="display: flex; flex-direction: column; align-items: center; background: #CCD1D1;">
+export const CarouselBottom = () => `<div style="display: flex; flex-direction: column; align-items: center;">
     <h4>Navigation buttons in page indicator</h4>
     <div
         class="fd-carousel"
@@ -194,7 +194,7 @@ CarouselBottom.parameters = {
     }
 };
 
-export const CarouselTop = () => `<div style="display: flex; flex-direction: column; align-items: center; background: #CCD1D1;">
+export const CarouselTop = () => `<div style="display: flex; flex-direction: column; align-items: center;">
     <h4>Navigation buttons in page indicator</h4>
     <div
         class="fd-carousel"
@@ -371,7 +371,7 @@ CarouselTop.parameters = {
     }
 };
 
-export const CarouselNoNavigation = () => `<div style="display: flex; flex-direction: column; align-items: center; background: #CCD1D1;">
+export const CarouselNoNavigation = () => `<div style="display: flex; flex-direction: column; align-items: center;">
     <h4>Hiding navigation buttons in page indicator</h4>
     <div
         class="fd-carousel fd-carousel--no-navigation"
@@ -483,7 +483,7 @@ CarouselNoNavigation.parameters = {
     }
 };
 
-export const HorizontalCarousel = () => `<div style="display: flex; flex-direction: column; align-items: center; background: #CCD1D1; height: 25rem;">
+export const HorizontalCarousel = () => `<div style="display: flex; flex-direction: column; align-items: center; height: 25rem;">
     <h4>Items in horizontal direction</h4>
     <div
         class="fd-carousel"
@@ -570,11 +570,11 @@ HorizontalCarousel.parameters = {
     }
 };
 
-export const Error = () => `<div style="display: flex; flex-direction: column; align-items: center; background: #CCD1D1; height: 25rem;">
+export const Error = () => `<div style="display: flex; flex-direction: column; align-items: center; height: 25rem;">
     <h4>Error in loading items</h4>
     <div
         class="fd-carousel fd-carousel--no-navigation"
-        style="max-width: 30rem; max-height: 15.5rem;"
+        style="max-width: 30rem"
         data-ride="carousel">
         <div class="fd-carousel__content">
             <div class="fd-message-page">


### PR DESCRIPTION
## Related Issue

Part of #3354.

## Description

Horizon support implemented for the Carousel component.

## Screenshots

### Before:

<img width="504" alt="image" src="https://user-images.githubusercontent.com/20265336/166880126-57a17107-3035-42b5-ac86-98a0dc54110f.png">

<img width="502" alt="image" src="https://user-images.githubusercontent.com/20265336/166880182-0f2ac24d-63e7-44fc-92be-c39533beda70.png">

### After:

<img width="504" alt="image" src="https://user-images.githubusercontent.com/20265336/166880087-ccac62b0-728b-4c37-957e-911ec5f76f67.png">

<img width="488" alt="image" src="https://user-images.githubusercontent.com/20265336/166880234-b3d8143f-bd3f-43bc-bb2d-0569a46339bf.png">

