### PR TITLE
feat(styles): wizard horizon updates [ci-visual]

### DIFF
--- a/src/styles/theming/common/wizard/_sap_fiori.scss
+++ b/src/styles/theming/common/wizard/_sap_fiori.scss
@@ -8,6 +8,7 @@
   --fdWizard_Completed_Step_Icon_Color: var(--sapSelectedColor);
   --fdWizard_Current_Step_Color: var(--sapContent_ContrastTextColor);
   --fdWizard_Current_Step_Icon_Color: var(--sapContent_ContrastIconColor);
+  --fdWizard_Current_Step_Border: 0.0625rem solid var(--sapSelectedColor);
   --fdWizard_Upcoming_Step_Color: var(--sapContent_LabelColor);
   --fdWizard_Upcoming_Step_Text_Color: var(--sapTextColor);
   --fdWizard_Upcoming_Step_Icon_Color: var(--sapContent_LabelColor);
@@ -23,6 +24,6 @@
   --fdWizard_Selection_Bar_Height: 0.188rem;
   --fdWizard_Selection_Bar_Background: var(--sapSelectedColor);
   --fdWizard_Step_Indicator_Margin_Right: 0.1875rem;
-  --fdWizard_Step_Content_Container_Background_Color: var(--sapBackgroundColor);
+  --fdWizard_Step_Content_Container_Background_Color: transparent;
   --fdWizard_Step_Content_Container_Spacing: 0;
 }

--- a/src/styles/theming/common/wizard/_sap_fiori.scss
+++ b/src/styles/theming/common/wizard/_sap_fiori.scss
@@ -1,0 +1,26 @@
+:root {
+  --fdWizard_Current_Step_Background_Color: var(--sapSelectedColor);
+  --fdWizard_Label_Current_Step_Color: var(--sapTextColor);
+  --fdWizard_Optional_Text_Color: var(--sapTextColor);
+  --fdWizard_Label_Font_Family: var(--sapFontFamily);
+  --fdWizard_Completed_Step_Color: var(--sapSelectedColor);
+  --fdWizard_Completed_Step_Border: 0.0625rem solid var(--sapSelectedColor);
+  --fdWizard_Completed_Step_Icon_Color: var(--sapSelectedColor);
+  --fdWizard_Current_Step_Color: var(--sapContent_ContrastTextColor);
+  --fdWizard_Current_Step_Icon_Color: var(--sapContent_ContrastIconColor);
+  --fdWizard_Upcoming_Step_Color: var(--sapContent_LabelColor);
+  --fdWizard_Upcoming_Step_Text_Color: var(--sapTextColor);
+  --fdWizard_Upcoming_Step_Icon_Color: var(--sapContent_LabelColor);
+  --fdWizard_Upcoming_Step_Border: 0.0625rem solid var(--sapList_BorderColor);
+  --fdWizard_Active_Step_Color: var(--sapContent_ContrastTextColor);
+  --fdWizard_Active_Step_Icon_Color: var(--sapContent_ContrastIconColor);
+  --fdWizard_Active_Step_Border_Color: var(--sapActiveColor);
+  --fdWizard_Connector_Active_Border_Color: var(--sapSelectedColor);
+  --fdWizard_Content_Default_Background: var(--sapBackgroundColor);
+  --fdWizard_Content_Solid_Background: var(--sapShell_Background);
+  --fdWizard_Content_List_Background: var(--sapGroup_ContentBackground);
+  --fdWizard_Content_Transparent_Background: transparent;
+  --fdWizard_Selection_Bar_Height: 0.188rem;
+  --fdWizard_Selection_Bar_Background: var(--sapSelectedColor);
+  --fdWizard_Step_Indicator_Margin_Right: 0.1875rem;
+}

--- a/src/styles/theming/common/wizard/_sap_fiori.scss
+++ b/src/styles/theming/common/wizard/_sap_fiori.scss
@@ -23,4 +23,6 @@
   --fdWizard_Selection_Bar_Height: 0.188rem;
   --fdWizard_Selection_Bar_Background: var(--sapSelectedColor);
   --fdWizard_Step_Indicator_Margin_Right: 0.1875rem;
+  --fdWizard_Step_Content_Container_Background_Color: var(--sapBackgroundColor);
+  --fdWizard_Step_Content_Container_Spacing: 0;
 }

--- a/src/styles/theming/common/wizard/_sap_fiori_hc.scss
+++ b/src/styles/theming/common/wizard/_sap_fiori_hc.scss
@@ -1,0 +1,20 @@
+:root {
+  --fdWizard_Completed_Step_Color: var(--sapTextColor);
+  --fdWizard_Completed_Step_Icon_Color: var(--sapTextColor);
+  --fdWizard_Completed_Step_Border: 0.0625rem solid var(--sapObjectHeader_BorderColor);
+  --fdWizard_Current_Step_Color: var(--sapTextColor);
+  --fdWizard_Current_Step_Icon_Color: var(--sapTextColor);
+  --fdWizard_Upcoming_Step_Color: var(--sapTextColor);
+  --fdWizard_Upcoming_Step_Icon_Color: var(--sapTextColor);
+  --fdWizard_Upcoming_Step_Border: 0.0625rem solid var(--sapList_BorderColor);
+  --fdWizard_Active_Step_Color: var(--sapTextColor);
+  --fdWizard_Active_Step_Icon_Color: var(--sapTextColor);
+  --fdWizard_Active_Step_Border_Color: var(--sapObjectHeader_BorderColor);
+  --fdWizard_Connector_Active_Border_Color: var(--sapList_SelectionBorderColor);
+  --fdWizard_Content_Default_Background: var(--sapBackgroundColor);
+  --fdWizard_Content_Solid_Background: var(--sapBackgroundColor);
+  --fdWizard_Content_List_Background: var(--sapBackgroundColor);
+  --fdWizard_Content_Transparent_Background: var(--sapBackgroundColor);
+  --fdWizard_Selection_Bar_Height: 0.313rem;
+  --fdWizard_Selection_Bar_Background: var(--sapList_SelectionBorderColor);
+}

--- a/src/styles/theming/common/wizard/_sap_horizon.scss
+++ b/src/styles/theming/common/wizard/_sap_horizon.scss
@@ -1,5 +1,5 @@
 :root {
-  --fdWizard_Current_Step_Background_Color: var(-sapContent_Selected_ForegroundColor);
+  --fdWizard_Current_Step_Background_Color: var(--sapContent_Selected_ForegroundColor);
   --fdWizard_Label_Current_Step_Color: var(--sapContent_Selected_ForegroundColor);
   --fdWizard_Optional_Text_Color: var(--sapContent_LabelColor);
   --fdWizard_Label_Font_Family: var(--sapFontBoldFamily);
@@ -23,4 +23,6 @@
   --fdWizard_Selection_Bar_Height: 0.188rem;
   --fdWizard_Selection_Bar_Background: var(--sapSelectedColor);
   --fdWizard_Step_Indicator_Margin_Right: 0.5rem;
+  --fdWizard_Step_Content_Container_Background_Color: var(--sapGroup_ContentBackground);
+  --fdWizard_Step_Content_Container_Spacing: 1rem;
 }

--- a/src/styles/theming/common/wizard/_sap_horizon.scss
+++ b/src/styles/theming/common/wizard/_sap_horizon.scss
@@ -1,0 +1,26 @@
+:root {
+  --fdWizard_Current_Step_Background_Color: var(-sapContent_Selected_ForegroundColor);
+  --fdWizard_Label_Current_Step_Color: var(--sapContent_Selected_ForegroundColor);
+  --fdWizard_Optional_Text_Color: var(--sapContent_LabelColor);
+  --fdWizard_Label_Font_Family: var(--sapFontBoldFamily);
+  --fdWizard_Completed_Step_Color: var(--sapContent_Selected_ForegroundColor);
+  --fdWizard_Completed_Step_Border: 0.0625rem solid var(--sapContent_Selected_ForegroundColor);
+  --fdWizard_Completed_Step_Icon_Color: var(--sapContent_Selected_ForegroundColor);
+  --fdWizard_Current_Step_Color: var(--sapContent_ContrastTextColor);
+  --fdWizard_Current_Step_Icon_Color: var(--sapContent_ContrastIconColor);
+  --fdWizard_Upcoming_Step_Color: var(--sapContent_LabelColor);
+  --fdWizard_Upcoming_Step_Text_Color: var(--sapContent_LabelColor);
+  --fdWizard_Upcoming_Step_Icon_Color: var(--sapContent_LabelColor);
+  --fdWizard_Upcoming_Step_Border: 0.0625rem solid var(--sapList_BorderColor);
+  --fdWizard_Active_Step_Color: var(--sapContent_ContrastTextColor);
+  --fdWizard_Active_Step_Icon_Color: var(--sapContent_ContrastIconColor);
+  --fdWizard_Active_Step_Border_Color: var(--sapActiveColor);
+  --fdWizard_Connector_Active_Border_Color: var(--sapContent_Selected_ForegroundColor);
+  --fdWizard_Content_Default_Background: var(--sapBackgroundColor);
+  --fdWizard_Content_Solid_Background: var(--sapShell_Background);
+  --fdWizard_Content_List_Background: var(--sapGroup_ContentBackground);
+  --fdWizard_Content_Transparent_Background: transparent;
+  --fdWizard_Selection_Bar_Height: 0.188rem;
+  --fdWizard_Selection_Bar_Background: var(--sapSelectedColor);
+  --fdWizard_Step_Indicator_Margin_Right: 0.5rem;
+}

--- a/src/styles/theming/common/wizard/_sap_horizon.scss
+++ b/src/styles/theming/common/wizard/_sap_horizon.scss
@@ -8,6 +8,7 @@
   --fdWizard_Completed_Step_Icon_Color: var(--sapContent_Selected_ForegroundColor);
   --fdWizard_Current_Step_Color: var(--sapContent_ContrastTextColor);
   --fdWizard_Current_Step_Icon_Color: var(--sapContent_ContrastIconColor);
+  --fdWizard_Current_Step_Border: 0.0625rem solid var(--sapContent_Selected_ForegroundColor);
   --fdWizard_Upcoming_Step_Color: var(--sapContent_LabelColor);
   --fdWizard_Upcoming_Step_Text_Color: var(--sapContent_LabelColor);
   --fdWizard_Upcoming_Step_Icon_Color: var(--sapContent_LabelColor);

--- a/src/styles/theming/common/wizard/_sap_horizon_hc.scss
+++ b/src/styles/theming/common/wizard/_sap_horizon_hc.scss
@@ -1,0 +1,8 @@
+:root {
+  --fdWizard_Current_Step_Background_Color: var(-sapContent_Selected_BackgroundColor);
+  --fdWizard_Label_Font_Family: var(--sapFontFamily);
+  --fdWizard_Selection_Bar_Height: 0.313rem;
+  --fdWizard_Content_Solid_Background: var(--sapBackgroundColor);
+  --fdWizard_Content_List_Background: var(--sapBackgroundColor);
+  --fdWizard_Content_Transparent_Background: var(--sapBackgroundColor);
+}

--- a/src/styles/theming/common/wizard/_sap_horizon_hc.scss
+++ b/src/styles/theming/common/wizard/_sap_horizon_hc.scss
@@ -1,5 +1,7 @@
 :root {
-  --fdWizard_Current_Step_Background_Color: var(-sapContent_Selected_BackgroundColor);
+  --fdWizard_Current_Step_Background_Color: var(--sapContent_Selected_Background);
+  --fdWizard_Current_Step_Border: 0.0625rem solid var(--sapContent_Selected_ForegroundColor);
+  --fdWizard_Selection_Bar_Background: var(--sapContent_Selected_ForegroundColor);
   --fdWizard_Label_Font_Family: var(--sapFontFamily);
   --fdWizard_Selection_Bar_Height: 0.313rem;
   --fdWizard_Content_Solid_Background: var(--sapBackgroundColor);

--- a/src/styles/theming/sap_fiori_3.scss
+++ b/src/styles/theming/sap_fiori_3.scss
@@ -9,6 +9,7 @@
 @import "./common/splitter/sap_fiori";
 @import "./common/input/sap_fiori";
 @import "./common/input-group/sap_fiori";
+@import "./common/wizard/sap_fiori";
 
 :root {
   --fdInverted_Object_Border_Width: 0;
@@ -23,26 +24,6 @@
   --fdRating_Indicator_Disabled_Selected_Color: var(--sapContent_RatedColor);
   --fdRating_Indicator_Disabled_Unselected_Color: var(--sapContent_UnratedColor);
   --fdRating_Indicator_Disabled_Control_Opacity: 0.4;
-
-  /* Wizard */
-  --fdWizard_Completed_Step_Color: var(--sapSelectedColor);
-  --fdWizard_Completed_Step_Border: 0.0625rem solid var(--sapSelectedColor);
-  --fdWizard_Completed_Step_Icon_Color: var(--sapSelectedColor);
-  --fdWizard_Current_Step_Color: var(--sapContent_ContrastTextColor);
-  --fdWizard_Current_Step_Icon_Color: var(--sapContent_ContrastIconColor);
-  --fdWizard_Upcoming_Step_Color: var(--sapContent_LabelColor);
-  --fdWizard_Upcoming_Step_Icon_Color: var(--sapContent_LabelColor);
-  --fdWizard_Upcoming_Step_Border: 0.0625rem solid var(--sapList_BorderColor);
-  --fdWizard_Active_Step_Color: var(--sapContent_ContrastTextColor);
-  --fdWizard_Active_Step_Icon_Color: var(--sapContent_ContrastIconColor);
-  --fdWizard_Active_Step_Border_Color: var(--sapActiveColor);
-  --fdWizard_Connector_Active_Border_Color: var(--sapSelectedColor);
-  --fdWizard_Content_Default_Background: var(--sapBackgroundColor);
-  --fdWizard_Content_Solid_Background: var(--sapShell_Background);
-  --fdWizard_Content_List_Background: var(--sapGroup_ContentBackground);
-  --fdWizard_Content_Transparent_Background: transparent;
-  --fdWizard_Selection_Bar_Height: 0.188rem;
-  --fdWizard_Selection_Bar_Background: var(--sapSelectedColor);
 
   /* Slider */
 

--- a/src/styles/theming/sap_fiori_3_dark.scss
+++ b/src/styles/theming/sap_fiori_3_dark.scss
@@ -9,6 +9,7 @@
 @import "./common/splitter/sap_fiori";
 @import "./common/input/sap_fiori";
 @import "./common/input-group/sap_fiori";
+@import "./common/wizard/sap_fiori";
 
 :root {
   --fdInverted_Object_Border_Width: 0;
@@ -23,26 +24,6 @@
   --fdRating_Indicator_Disabled_Selected_Color: var(--sapContent_RatedColor);
   --fdRating_Indicator_Disabled_Unselected_Color: var(--sapContent_UnratedColor);
   --fdRating_Indicator_Disabled_Control_Opacity: 0.4;
-
-  /* Wizard */
-  --fdWizard_Completed_Step_Color: var(--sapSelectedColor);
-  --fdWizard_Completed_Step_Border: 0.0625rem solid var(--sapSelectedColor);
-  --fdWizard_Completed_Step_Icon_Color: var(--sapSelectedColor);
-  --fdWizard_Current_Step_Color: var(--sapContent_ContrastTextColor);
-  --fdWizard_Current_Step_Icon_Color: var(--sapContent_ContrastIconColor);
-  --fdWizard_Upcoming_Step_Color: var(--sapContent_LabelColor);
-  --fdWizard_Upcoming_Step_Icon_Color: var(--sapContent_LabelColor);
-  --fdWizard_Upcoming_Step_Border: 0.0625rem solid var(--sapList_BorderColor);
-  --fdWizard_Active_Step_Color: var(--sapContent_ContrastTextColor);
-  --fdWizard_Active_Step_Icon_Color: var(--sapContent_ContrastIconColor);
-  --fdWizard_Active_Step_Border_Color: var(--sapActiveColor);
-  --fdWizard_Connector_Active_Border_Color: var(--sapSelectedColor);
-  --fdWizard_Content_Default_Background: var(--sapBackgroundColor);
-  --fdWizard_Content_Solid_Background: var(--sapShell_Background);
-  --fdWizard_Content_List_Background: var(--sapGroup_ContentBackground);
-  --fdWizard_Content_Transparent_Background: transparent;
-  --fdWizard_Selection_Bar_Height: 0.188rem;
-  --fdWizard_Selection_Bar_Background: var(--sapSelectedColor);
 
   /* Slider */
 

--- a/src/styles/theming/sap_fiori_3_hcb.scss
+++ b/src/styles/theming/sap_fiori_3_hcb.scss
@@ -13,6 +13,8 @@
 @import "./common/splitter/sap_fiori_hc";
 @import "./common/input/sap_fiori";
 @import "./common/input-group/sap_fiori";
+@import "./common/wizard/sap_fiori";
+@import "./common/wizard/sap_fiori_hc";
 
 :root {
   --fdInverted_Object_Border_Width: 0.0625rem;
@@ -27,26 +29,6 @@
   --fdRating_Indicator_Disabled_Selected_Color: var(--sapContent_DisabledTextColor);
   --fdRating_Indicator_Disabled_Unselected_Color: var(--sapContent_DisabledTextColor);
   --fdRating_Indicator_Disabled_Control_Opacity: 1;
-
-  /* Wizard */
-  --fdWizard_Completed_Step_Color: var(--sapTextColor);
-  --fdWizard_Completed_Step_Icon_Color: var(--sapTextColor);
-  --fdWizard_Completed_Step_Border: 0.0625rem solid var(--sapObjectHeader_BorderColor);
-  --fdWizard_Current_Step_Color: var(--sapTextColor);
-  --fdWizard_Current_Step_Icon_Color: var(--sapTextColor);
-  --fdWizard_Upcoming_Step_Color: var(--sapTextColor);
-  --fdWizard_Upcoming_Step_Icon_Color: var(--sapTextColor);
-  --fdWizard_Upcoming_Step_Border: 0.0625rem solid var(--sapList_BorderColor);
-  --fdWizard_Active_Step_Color: var(--sapTextColor);
-  --fdWizard_Active_Step_Icon_Color: var(--sapTextColor);
-  --fdWizard_Active_Step_Border_Color: var(--sapObjectHeader_BorderColor);
-  --fdWizard_Connector_Active_Border_Color: var(--sapList_SelectionBorderColor);
-  --fdWizard_Content_Default_Background: var(--sapBackgroundColor);
-  --fdWizard_Content_Solid_Background: var(--sapBackgroundColor);
-  --fdWizard_Content_List_Background: var(--sapBackgroundColor);
-  --fdWizard_Content_Transparent_Background: var(--sapBackgroundColor);
-  --fdWizard_Selection_Bar_Height: 0.313rem;
-  --fdWizard_Selection_Bar_Background: var(--sapList_SelectionBorderColor);
 
   /* Slider */
 

--- a/src/styles/theming/sap_fiori_3_hcw.scss
+++ b/src/styles/theming/sap_fiori_3_hcw.scss
@@ -14,6 +14,8 @@
 @import "./common/splitter/sap_fiori_hc";
 @import "./common/input/sap_fiori";
 @import "./common/input-group/sap_fiori";
+@import "./common/wizard/sap_fiori";
+@import "./common/wizard/sap_fiori_hc";
 
 :root {
   --fdInverted_Object_Border_Width: 0.0625rem;
@@ -28,26 +30,6 @@
   --fdRating_Indicator_Disabled_Selected_Color: var(--sapContent_RatedColor);
   --fdRating_Indicator_Disabled_Unselected_Color: var(--sapContent_UnratedColor);
   --fdRating_Indicator_Disabled_Control_Opacity: 0.4;
-
-  /* Wizard */
-  --fdWizard_Completed_Step_Color: var(--sapTextColor);
-  --fdWizard_Completed_Step_Icon_Color: var(--sapTextColor);
-  --fdWizard_Completed_Step_Border: 0.0625rem solid var(--sapObjectHeader_BorderColor);
-  --fdWizard_Current_Step_Color: var(--sapTextColor);
-  --fdWizard_Current_Step_Icon_Color: var(--sapTextColor);
-  --fdWizard_Upcoming_Step_Color: var(--sapTextColor);
-  --fdWizard_Upcoming_Step_Icon_Color: var(--sapTextColor);
-  --fdWizard_Upcoming_Step_Border: 0.0625rem solid var(--sapList_BorderColor);
-  --fdWizard_Active_Step_Color: var(--sapTextColor);
-  --fdWizard_Active_Step_Icon_Color: var(--sapTextColor);
-  --fdWizard_Active_Step_Border_Color: var(--sapObjectHeader_BorderColor);
-  --fdWizard_Connector_Active_Border_Color: var(--sapList_SelectionBorderColor);
-  --fdWizard_Content_Default_Background: var(--sapBackgroundColor);
-  --fdWizard_Content_Solid_Background: var(--sapBackgroundColor);
-  --fdWizard_Content_List_Background: var(--sapBackgroundColor);
-  --fdWizard_Content_Transparent_Background: var(--sapBackgroundColor);
-  --fdWizard_Selection_Bar_Height: 0.313rem;
-  --fdWizard_Selection_Bar_Background: var(--sapList_SelectionBorderColor);
 
   /* Slider */
 

--- a/src/styles/theming/sap_fiori_3_light_dark.scss
+++ b/src/styles/theming/sap_fiori_3_light_dark.scss
@@ -9,6 +9,7 @@
 @import "./common/splitter/sap_fiori";
 @import "./common/input/sap_fiori";
 @import "./common/input-group/sap_fiori";
+@import "./common/wizard/sap_fiori";
 
 :root {
   --fdInverted_Object_Border_Width: 0;
@@ -23,26 +24,6 @@
   --fdRating_Indicator_Disabled_Selected_Color: var(--sapContent_RatedColor);
   --fdRating_Indicator_Disabled_Unselected_Color: var(--sapContent_UnratedColor);
   --fdRating_Indicator_Disabled_Control_Opacity: 0.4;
-
-  /* Wizard */
-  --fdWizard_Completed_Step_Color: var(--sapSelectedColor);
-  --fdWizard_Completed_Step_Border: 0.0625rem solid var(--sapSelectedColor);
-  --fdWizard_Completed_Step_Icon_Color: var(--sapSelectedColor);
-  --fdWizard_Current_Step_Color: var(--sapContent_ContrastTextColor);
-  --fdWizard_Current_Step_Icon_Color: var(--sapContent_ContrastIconColor);
-  --fdWizard_Upcoming_Step_Color: var(--sapContent_LabelColor);
-  --fdWizard_Upcoming_Step_Icon_Color: var(--sapContent_LabelColor);
-  --fdWizard_Upcoming_Step_Border: 0.0625rem solid var(--sapList_BorderColor);
-  --fdWizard_Active_Step_Color: var(--sapContent_ContrastTextColor);
-  --fdWizard_Active_Step_Icon_Color: var(--sapContent_ContrastIconColor);
-  --fdWizard_Active_Step_Border_Color: var(--sapActiveColor);
-  --fdWizard_Connector_Active_Border_Color: var(--sapSelectedColor);
-  --fdWizard_Content_Default_Background: var(--sapBackgroundColor);
-  --fdWizard_Content_Solid_Background: var(--sapShell_Background);
-  --fdWizard_Content_List_Background: var(--sapGroup_ContentBackground);
-  --fdWizard_Content_Transparent_Background: transparent;
-  --fdWizard_Selection_Bar_Height: 0.188rem;
-  --fdWizard_Selection_Bar_Background: var(--sapSelectedColor);
 
   /* Slider */
 

--- a/src/styles/theming/sap_horizon.scss
+++ b/src/styles/theming/sap_horizon.scss
@@ -9,6 +9,7 @@
 @import "./common/splitter/sap_horizon";
 @import "./common/input/sap_horizon";
 @import "./common/input-group/sap_horizon";
+@import "./common/wizard/sap_horizon";
 
 :root {
   /* Switch */
@@ -29,28 +30,7 @@
   --fdRating_Indicator_Disabled_Unselected_Color: var(--sapContent_UnratedColor);
   --fdRating_Indicator_Disabled_Control_Opacity: 0.4;
 
-  /* Wizard */
-  --fdWizard_Completed_Step_Color: var(--sapSelectedColor);
-  --fdWizard_Completed_Step_Border: 0.0625rem solid var(--sapSelectedColor);
-  --fdWizard_Completed_Step_Icon_Color: var(--sapSelectedColor);
-  --fdWizard_Current_Step_Color: var(--sapContent_ContrastTextColor);
-  --fdWizard_Current_Step_Icon_Color: var(--sapContent_ContrastIconColor);
-  --fdWizard_Upcoming_Step_Color: var(--sapContent_LabelColor);
-  --fdWizard_Upcoming_Step_Icon_Color: var(--sapContent_LabelColor);
-  --fdWizard_Upcoming_Step_Border: 0.0625rem solid var(--sapList_BorderColor);
-  --fdWizard_Active_Step_Color: var(--sapContent_ContrastTextColor);
-  --fdWizard_Active_Step_Icon_Color: var(--sapContent_ContrastIconColor);
-  --fdWizard_Active_Step_Border_Color: var(--sapActiveColor);
-  --fdWizard_Connector_Active_Border_Color: var(--sapSelectedColor);
-  --fdWizard_Content_Default_Background: var(--sapBackgroundColor);
-  --fdWizard_Content_Solid_Background: var(--sapShell_Background);
-  --fdWizard_Content_List_Background: var(--sapGroup_ContentBackground);
-  --fdWizard_Content_Transparent_Background: transparent;
-  --fdWizard_Selection_Bar_Height: 0.188rem;
-  --fdWizard_Selection_Bar_Background: var(--sapSelectedColor);
-
   /* Slider */
-
   --fdSlider_Track_Height: 0.25rem;
   --fdSlider_Track_BorderRadius: 0.25rem;
   --fdSlider_Tick_Height: 1rem;

--- a/src/styles/theming/sap_horizon_dark.scss
+++ b/src/styles/theming/sap_horizon_dark.scss
@@ -9,6 +9,7 @@
 @import "./common/splitter/sap_horizon";
 @import "./common/input/sap_horizon";
 @import "./common/input-group/sap_horizon";
+@import "./common/wizard/sap_horizon";
 
 :root {
   /* Switch */
@@ -28,26 +29,6 @@
   --fdRating_Indicator_Disabled_Selected_Color: var(--sapContent_RatedColor);
   --fdRating_Indicator_Disabled_Unselected_Color: var(--sapContent_UnratedColor);
   --fdRating_Indicator_Disabled_Control_Opacity: 0.4;
-
-  /* Wizard */
-  --fdWizard_Completed_Step_Color: var(--sapSelectedColor);
-  --fdWizard_Completed_Step_Border: 0.0625rem solid var(--sapSelectedColor);
-  --fdWizard_Completed_Step_Icon_Color: var(--sapSelectedColor);
-  --fdWizard_Current_Step_Color: var(--sapContent_ContrastTextColor);
-  --fdWizard_Current_Step_Icon_Color: var(--sapContent_ContrastIconColor);
-  --fdWizard_Upcoming_Step_Color: var(--sapContent_LabelColor);
-  --fdWizard_Upcoming_Step_Icon_Color: var(--sapContent_LabelColor);
-  --fdWizard_Upcoming_Step_Border: 0.0625rem solid var(--sapList_BorderColor);
-  --fdWizard_Active_Step_Color: var(--sapContent_ContrastTextColor);
-  --fdWizard_Active_Step_Icon_Color: var(--sapContent_ContrastIconColor);
-  --fdWizard_Active_Step_Border_Color: var(--sapActiveColor);
-  --fdWizard_Connector_Active_Border_Color: var(--sapSelectedColor);
-  --fdWizard_Content_Default_Background: var(--sapBackgroundColor);
-  --fdWizard_Content_Solid_Background: var(--sapShell_Background);
-  --fdWizard_Content_List_Background: var(--sapGroup_ContentBackground);
-  --fdWizard_Content_Transparent_Background: transparent;
-  --fdWizard_Selection_Bar_Height: 0.188rem;
-  --fdWizard_Selection_Bar_Background: var(--sapSelectedColor);
 
   /* Slider */
 

--- a/src/styles/theming/sap_horizon_hcb.scss
+++ b/src/styles/theming/sap_horizon_hcb.scss
@@ -15,6 +15,8 @@
 @import "./common/splitter/sap_horizon_hc";
 @import "./common/input/sap_horizon";
 @import "./common/input-group/sap_horizon";
+@import "./common/wizard/sap_horizon";
+@import "./common/wizard/sap_horizon_hc";
 
 :root {
   /* Switch */
@@ -33,26 +35,6 @@
   --fdRating_Indicator_Disabled_Selected_Color: var(--sapContent_RatedColor);
   --fdRating_Indicator_Disabled_Unselected_Color: var(--sapContent_UnratedColor);
   --fdRating_Indicator_Disabled_Control_Opacity: 0.4;
-
-  /* Wizard */
-  --fdWizard_Completed_Step_Color: var(--sapSelectedColor);
-  --fdWizard_Completed_Step_Border: 0.0625rem solid var(--sapSelectedColor);
-  --fdWizard_Completed_Step_Icon_Color: var(--sapSelectedColor);
-  --fdWizard_Current_Step_Color: var(--sapContent_ContrastTextColor);
-  --fdWizard_Current_Step_Icon_Color: var(--sapContent_ContrastIconColor);
-  --fdWizard_Upcoming_Step_Color: var(--sapContent_LabelColor);
-  --fdWizard_Upcoming_Step_Icon_Color: var(--sapContent_LabelColor);
-  --fdWizard_Upcoming_Step_Border: 0.0625rem solid var(--sapList_BorderColor);
-  --fdWizard_Active_Step_Color: var(--sapContent_ContrastTextColor);
-  --fdWizard_Active_Step_Icon_Color: var(--sapContent_ContrastIconColor);
-  --fdWizard_Active_Step_Border_Color: var(--sapActiveColor);
-  --fdWizard_Connector_Active_Border_Color: var(--sapSelectedColor);
-  --fdWizard_Content_Default_Background: var(--sapBackgroundColor);
-  --fdWizard_Content_Solid_Background: var(--sapShell_Background);
-  --fdWizard_Content_List_Background: var(--sapGroup_ContentBackground);
-  --fdWizard_Content_Transparent_Background: transparent;
-  --fdWizard_Selection_Bar_Height: 0.313rem;
-  --fdWizard_Selection_Bar_Background: var(--sapSelectedColor);
 
   /* Slider */
 

--- a/src/styles/theming/sap_horizon_hcw.scss
+++ b/src/styles/theming/sap_horizon_hcw.scss
@@ -15,6 +15,8 @@
 @import "./common/splitter/sap_horizon_hc";
 @import "./common/input/sap_horizon";
 @import "./common/input-group/sap_horizon";
+@import "./common/wizard/sap_horizon";
+@import "./common/wizard/sap_horizon_hc";
 
 :root {
   /* Switch */
@@ -33,26 +35,6 @@
   --fdRating_Indicator_Disabled_Selected_Color: var(--sapContent_RatedColor);
   --fdRating_Indicator_Disabled_Unselected_Color: var(--sapContent_UnratedColor);
   --fdRating_Indicator_Disabled_Control_Opacity: 0.4;
-
-  /* Wizard */
-  --fdWizard_Completed_Step_Color: var(--sapSelectedColor);
-  --fdWizard_Completed_Step_Border: 0.0625rem solid var(--sapSelectedColor);
-  --fdWizard_Completed_Step_Icon_Color: var(--sapSelectedColor);
-  --fdWizard_Current_Step_Color: var(--sapContent_ContrastTextColor);
-  --fdWizard_Current_Step_Icon_Color: var(--sapContent_ContrastIconColor);
-  --fdWizard_Upcoming_Step_Color: var(--sapContent_LabelColor);
-  --fdWizard_Upcoming_Step_Icon_Color: var(--sapContent_LabelColor);
-  --fdWizard_Upcoming_Step_Border: 0.0625rem solid var(--sapList_BorderColor);
-  --fdWizard_Active_Step_Color: var(--sapContent_ContrastTextColor);
-  --fdWizard_Active_Step_Icon_Color: var(--sapContent_ContrastIconColor);
-  --fdWizard_Active_Step_Border_Color: var(--sapActiveColor);
-  --fdWizard_Connector_Active_Border_Color: var(--sapSelectedColor);
-  --fdWizard_Content_Default_Background: var(--sapBackgroundColor);
-  --fdWizard_Content_Solid_Background: var(--sapShell_Background);
-  --fdWizard_Content_List_Background: var(--sapGroup_ContentBackground);
-  --fdWizard_Content_Transparent_Background: transparent;
-  --fdWizard_Selection_Bar_Height: 0.313rem;
-  --fdWizard_Selection_Bar_Background: var(--sapSelectedColor);
 
   /* Slider */
 

--- a/src/styles/wizard.scss
+++ b/src/styles/wizard.scss
@@ -94,6 +94,7 @@ $fd-wizard-stacked-upcoming-step-offset: 2.375rem !default;
       }
 
       .#{$block}__step-indicator {
+        border: var(--fdWizard_Current_Step_Border);
         position: relative;
         background: var(--fdWizard_Current_Step_Background_Color);
         color: var(--fdWizard_Current_Step_Color);

--- a/src/styles/wizard.scss
+++ b/src/styles/wizard.scss
@@ -304,9 +304,9 @@ $fd-wizard-stacked-upcoming-step-offset: 2.375rem !default;
     @include fd-reset();
     @include fd-wizard-responsive-paddings();
 
+    padding-top: 1rem;
     width: 100%;
     height: 100%;
-    padding-top: 1rem;
     background: var(--fdWizard_Content_Default_Background);
 
     &--solid {
@@ -320,6 +320,15 @@ $fd-wizard-stacked-upcoming-step-offset: 2.375rem !default;
     &--transparent {
       background: var(--fdWizard_Content_Transparent_Background);
     }
+  }
+
+  &__step-content-container {
+    @include fd-reset();
+    @include fd-wizard-responsive-paddings();
+
+    padding: var(--fdWizard_Step_Content_Container_Spacing);
+    background-color: var(--fdWizard_Step_Content_Container_Background_Color);
+    border-radius: var(--sapElement_BorderCornerRadius);
   }
 
   &__next-step {

--- a/src/styles/wizard.scss
+++ b/src/styles/wizard.scss
@@ -89,9 +89,13 @@ $fd-wizard-stacked-upcoming-step-offset: 2.375rem !default;
     }
 
     &--current {
+      .#{$block}__label {
+        color: var(--fdWizard_Label_Current_Step_Color);
+      }
+
       .#{$block}__step-indicator {
         position: relative;
-        background: var(--sapSelectedColor);
+        background: var(--fdWizard_Current_Step_Background_Color);
         color: var(--fdWizard_Current_Step_Color);
 
         .#{$block}__icon {
@@ -117,6 +121,10 @@ $fd-wizard-stacked-upcoming-step-offset: 2.375rem !default;
     }
 
     &--upcoming {
+      .#{$block}__label, .#{$block}__optional-text {
+        color: var(--fdWizard_Upcoming_Step_Text_Color);
+      }
+
       .#{$block}__step-indicator {
         background: var(--sapObjectHeader_Background);
         border: var(--fdWizard_Upcoming_Step_Border);
@@ -225,7 +233,9 @@ $fd-wizard-stacked-upcoming-step-offset: 2.375rem !default;
     min-height: $fd-wizard-step-indicator-size;
     width: $fd-wizard-step-indicator-size;
     height: $fd-wizard-step-indicator-size;
-    margin: 0 $fd-wizard-step-indicator-spacing;
+    margin: 0;
+
+    @include fd-set-margins-x($fd-wizard-step-indicator-spacing, var(--fdWizard_Step_Indicator_Margin_Right));
   }
 
   &__icon {
@@ -259,6 +269,7 @@ $fd-wizard-stacked-upcoming-step-offset: 2.375rem !default;
     @include fd-reset();
     @include line-clamp();
 
+    font-family: var(--fdWizard_Label_Font_Family);
     line-height: 1rem;
     max-width: 100%;
   }

--- a/stories/wizard/__snapshots__/wizard.stories.storyshot
+++ b/stories/wizard/__snapshots__/wizard.stories.storyshot
@@ -203,23 +203,31 @@ exports[`Storyshots Components/Wizard Customized 1`] = `
     >
       
         
-      <div>
-        
-            Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
-        
-      </div>
-      
-        
       <div
-        class="fd-wizard__next-step"
+        class="fd-wizard__step-content-container"
       >
         
             
-        <button
-          class="fd-button fd-button--compact fd-button--emphasized"
+        <div>
+          
+                Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
+            
+        </div>
+        
+            
+        <div
+          class="fd-wizard__next-step"
         >
-          Step 3
-        </button>
+          
+                
+          <button
+            class="fd-button fd-button--compact fd-button--emphasized"
+          >
+            Step 3
+          </button>
+          
+            
+        </div>
         
         
       </div>
@@ -530,23 +538,31 @@ exports[`Storyshots Components/Wizard Default 1`] = `
     >
       
         
-      <div>
-        
-            Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
-        
-      </div>
-      
-        
       <div
-        class="fd-wizard__next-step"
+        class="fd-wizard__step-content-container"
       >
         
             
-        <button
-          class="fd-button fd-button--compact fd-button--emphasized"
+        <div>
+          
+                Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
+            
+        </div>
+        
+            
+        <div
+          class="fd-wizard__next-step"
         >
-          Step 3
-        </button>
+          
+                
+          <button
+            class="fd-button fd-button--compact fd-button--emphasized"
+          >
+            Step 3
+          </button>
+          
+            
+        </div>
         
         
       </div>
@@ -1214,23 +1230,31 @@ exports[`Storyshots Components/Wizard Mobile 1`] = `
         >
           
                 
-          <div>
-            
-                    Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
-                
-          </div>
-          
-                
           <div
-            class="fd-wizard__next-step"
+            class="fd-wizard__step-content-container"
           >
             
                     
-            <button
-              class="fd-button fd-button--emphasized"
+            <div>
+              
+                        Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis.
+                    
+            </div>
+            
+                    
+            <div
+              class="fd-wizard__next-step"
             >
-              Next Step
-            </button>
+              
+                        
+              <button
+                class="fd-button fd-button--emphasized"
+              >
+                Next Step
+              </button>
+              
+                    
+            </div>
             
                 
           </div>
@@ -1891,26 +1915,34 @@ exports[`Storyshots Components/Wizard Mobile 1`] = `
           
                 
           <div
-            aria-label="Image 4"
-            role="img"
-            style="
-                    width:100%;
-                    background-image: url(assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg);
-                    height: 300px;
-                    background-size:cover;"
+            class="fd-wizard__step-content-container"
           >
             
-                
+                    
             <div
-              class="fd-wizard__next-step fd-wizard__next-step--floating"
+              aria-label="Image 4"
+              role="img"
+              style="
+                        width:100%;
+                        background-image: url(assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg);
+                        height: 300px;
+                        background-size:cover;"
             >
               
                     
-              <button
-                class="fd-button fd-button--emphasized"
+              <div
+                class="fd-wizard__next-step fd-wizard__next-step--floating"
               >
-                Next Step
-              </button>
+                
+                        
+                <button
+                  class="fd-button fd-button--emphasized"
+                >
+                  Next Step
+                </button>
+                
+                    
+              </div>
               
                 
             </div>
@@ -2305,23 +2337,31 @@ exports[`Storyshots Components/Wizard Responsive 1`] = `
     >
       
         
-      <div>
-        
-            Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
-        
-      </div>
-      
-        
       <div
-        class="fd-wizard__next-step"
+        class="fd-wizard__step-content-container"
       >
         
             
-        <button
-          class="fd-button fd-button--compact fd-button--emphasized"
+        <div>
+          
+                Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
+            
+        </div>
+        
+            
+        <div
+          class="fd-wizard__next-step"
         >
-          Next Step
-        </button>
+          
+                
+          <button
+            class="fd-button fd-button--compact fd-button--emphasized"
+          >
+            Next Step
+          </button>
+          
+            
+        </div>
         
         
       </div>
@@ -2837,23 +2877,31 @@ exports[`Storyshots Components/Wizard Responsive 1`] = `
     >
       
         
-      <div>
-        
-            Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
-        
-      </div>
-      
-        
       <div
-        class="fd-wizard__next-step"
+        class="fd-wizard__step-content-container"
       >
         
             
-        <button
-          class="fd-button fd-button--compact fd-button--emphasized"
+        <div>
+          
+                Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
+            
+        </div>
+        
+            
+        <div
+          class="fd-wizard__next-step"
         >
-          Next Step
-        </button>
+          
+                
+          <button
+            class="fd-button fd-button--compact fd-button--emphasized"
+          >
+            Next Step
+          </button>
+          
+            
+        </div>
         
         
       </div>
@@ -3504,23 +3552,31 @@ exports[`Storyshots Components/Wizard Responsive 1`] = `
     >
       
         
-      <div>
-        
-            Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
-        
-      </div>
-      
-        
       <div
-        class="fd-wizard__next-step"
+        class="fd-wizard__step-content-container"
       >
         
             
-        <button
-          class="fd-button fd-button--compact fd-button--emphasized"
+        <div>
+          
+                Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
+            
+        </div>
+        
+            
+        <div
+          class="fd-wizard__next-step"
         >
-          Next Step
-        </button>
+          
+                
+          <button
+            class="fd-button fd-button--compact fd-button--emphasized"
+          >
+            Next Step
+          </button>
+          
+            
+        </div>
         
         
       </div>
@@ -3908,23 +3964,31 @@ exports[`Storyshots Components/Wizard Reverted Steps 1`] = `
     >
       
         
-      <div>
-        
-            Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
-        
-      </div>
-      
-        
       <div
-        class="fd-wizard__next-step"
+        class="fd-wizard__step-content-container"
       >
         
             
-        <button
-          class="fd-button fd-button--compact fd-button--emphasized"
+        <div>
+          
+                Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
+            
+        </div>
+        
+            
+        <div
+          class="fd-wizard__next-step"
         >
-          Next Step
-        </button>
+          
+                
+          <button
+            class="fd-button fd-button--compact fd-button--emphasized"
+          >
+            Next Step
+          </button>
+          
+            
+        </div>
         
         
       </div>
@@ -4440,23 +4504,31 @@ exports[`Storyshots Components/Wizard Reverted Steps 1`] = `
     >
       
         
-      <div>
-        
-            Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
-        
-      </div>
-      
-        
       <div
-        class="fd-wizard__next-step"
+        class="fd-wizard__step-content-container"
       >
         
             
-        <button
-          class="fd-button fd-button--compact fd-button--emphasized"
+        <div>
+          
+                Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
+            
+        </div>
+        
+            
+        <div
+          class="fd-wizard__next-step"
         >
-          Next Step
-        </button>
+          
+                
+          <button
+            class="fd-button fd-button--compact fd-button--emphasized"
+          >
+            Next Step
+          </button>
+          
+            
+        </div>
         
         
       </div>
@@ -5107,23 +5179,31 @@ exports[`Storyshots Components/Wizard Reverted Steps 1`] = `
     >
       
         
-      <div>
-        
-            Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
-        
-      </div>
-      
-        
       <div
-        class="fd-wizard__next-step"
+        class="fd-wizard__step-content-container"
       >
         
             
-        <button
-          class="fd-button fd-button--compact fd-button--emphasized"
+        <div>
+          
+                Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
+            
+        </div>
+        
+            
+        <div
+          class="fd-wizard__next-step"
         >
-          Next Step
-        </button>
+          
+                
+          <button
+            class="fd-button fd-button--compact fd-button--emphasized"
+          >
+            Next Step
+          </button>
+          
+            
+        </div>
         
         
       </div>

--- a/stories/wizard/wizard.stories.js
+++ b/stories/wizard/wizard.stories.js
@@ -85,7 +85,7 @@ There are multiple connector types that can be displayed depending on the steps 
 
 | **Type** | <span style="margin-left: 2rem;">**Modifier class**</span> |
 | :--- | :-------------- |
-| Solid |  <code style="margin-left: 2rem;"> fd-wizard__content--smolid</code> |
+| Solid |  <code style="margin-left: 2rem;"> fd-wizard__content--solid</code> |
 | List | <code style="margin-left: 2rem;"> fd-wizard__content--list</code> |
 | Transparent | <code style="margin-left: 2rem;"> fd-wizard__content--transparent</code> |
 

--- a/stories/wizard/wizard.stories.js
+++ b/stories/wizard/wizard.stories.js
@@ -41,15 +41,15 @@ The wizard can be used both in a full-screen layout and in the flexible column l
 
 ## Responsive paddings
 
-These modifier classes will add horizontal paddings to the content and can be applied on the \`fd-wizard__progress-bar\` level and/or on the \`fd-wizard__content\` level.
+These modifier classes will add horizontal paddings to the content and can be applied on the \`fd-wizard__progress-bar\` level, the \`fd-wizard__content\`, and/or the \`fd-wizard__step-content-container\` level.
 
 
 |  **rem** |  <div style="margin-left: 2rem;"> **Min-width** </div> |  <div style="margin-left: 2rem;">**Max-width** </div> |  <div style="margin-left: 2rem;"> **Modifier class** </div> |
 | :---- | :---------- | :---------- | :---------------------------------- |
-| 1rem | <span style="margin-left: 2rem;">_n/a_</span> | <span style="margin-left: 2rem;">599px</span> | <code style="margin-left: 2rem;">fd-wizard__progress-bar--sm</code> / <code>fd-wizard__content--sm</code> |
-| 2rem | <span style="margin-left: 2rem;">600px</span> | <span style="margin-left: 2rem;">1023px</span> | <code style="margin-left: 2rem;">fd-wizard__progress-bar--md</code> / <code>fd-wizard__content--md</code> |
-| 2rem | <span style="margin-left: 2rem;">1024px</span> | <span style="margin-left: 2rem;">1439px</span> | <code style="margin-left: 2rem;">fd-wizard__progress-bar--lg</code> / <code>fd-wizard__content--lg</code> |
-| 3rem | <span style="margin-left: 2rem;">1440px</span> | <span style="margin-left: 2rem;">_n/a_</span> | <code style="margin-left: 2rem;">fd-wizard__progress-bar--xl</code> / <code>fd-wizard__content--xl</code> |
+| 1rem | <span style="margin-left: 2rem;">_n/a_</span> | <span style="margin-left: 2rem;">599px</span> | <code style="margin-left: 2rem;">fd-wizard__progress-bar--sm</code> / <code>fd-wizard__content--sm</code> / <code>fd-wizard__step-content-container--sm</code> |
+| 2rem | <span style="margin-left: 2rem;">600px</span> | <span style="margin-left: 2rem;">1023px</span> | <code style="margin-left: 2rem;">fd-wizard__progress-bar--md</code> / <code>fd-wizard__content--md</code> / <code>fd-wizard__step-content-container--md</code> |
+| 2rem | <span style="margin-left: 2rem;">1024px</span> | <span style="margin-left: 2rem;">1439px</span> | <code style="margin-left: 2rem;">fd-wizard__progress-bar--lg</code> / <code>fd-wizard__content--lg</code> / <code>fd-wizard__step-content-container--lg</code> |
+| 3rem | <span style="margin-left: 2rem;">1440px</span> | <span style="margin-left: 2rem;">_n/a_</span> | <code style="margin-left: 2rem;">fd-wizard__progress-bar--xl</code> / <code>fd-wizard__content--xl</code> / <code>fd-wizard__step-content-container--xl</code> |
 
 ## Modifiers
 
@@ -150,11 +150,13 @@ export const DefaultExample = () => `<section class="fd-wizard">
         </ul>
     </nav>
     <section class="fd-wizard__content" id="wizard-section-1" style="min-height: 300px;">
-        <div>
-            Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
-        </div>
-        <div class="fd-wizard__next-step">
-            <button class="fd-button fd-button--compact fd-button--emphasized">Step 3</button>
+        <div class="fd-wizard__step-content-container">
+            <div>
+                Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
+            </div>
+            <div class="fd-wizard__next-step">
+                <button class="fd-button fd-button--compact fd-button--emphasized">Step 3</button>
+            </div>
         </div>
     </section>
     <footer>
@@ -223,11 +225,13 @@ export const Customized = () => `<section class="fd-wizard">
         </ul>
     </nav>
     <section class="fd-wizard__content fd-wizard__content--list fd-wizard__content--md" id="wizard-section-2" style="min-height: 300px;">
-        <div>
-            Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
-        </div>
-        <div class="fd-wizard__next-step">
-            <button class="fd-button fd-button--compact fd-button--emphasized">Step 3</button>
+        <div class="fd-wizard__step-content-container">
+            <div>
+                Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
+            </div>
+            <div class="fd-wizard__next-step">
+                <button class="fd-button fd-button--compact fd-button--emphasized">Step 3</button>
+            </div>
         </div>
     </section>
     <footer>
@@ -252,6 +256,7 @@ Customized.parameters = {
 | :---- | :---- | :-------------- |
 | \`fd-wizard__progress-bar\` | \`fd-wizard__progress-bar--md\` | <span style="margin-left: 2rem;"> Added responsive padding </span> |
 | \`fd-wizard__content\` | \`fd-wizard__content--md\` | <span style="margin-left: 2rem;"> Added responsive padding </span> |
+| \`fd-wizard__step-content-container\` | \`fd-wizard__step-content-container--md\` | <span style="margin-left: 2rem;"> Added responsive padding </span> |
 | \`fd-bar--page\` | \`fd-bar--page-m_l\` | <span style="margin-left: 2rem;"> Added responsive padding </span> |
 | \`fd-wizard__content\` | \`fd-wizard__content--list\` | <span style="margin-left: 2rem;"> The background of the wizard content is set to list </span> |
 | \`fd-wizard__connector\` | \`fd-wizard__connector--branching\` | <span style="margin-left: 2rem;"> Adds a branching step connector </span> |
@@ -331,11 +336,13 @@ export const Responsive = () => `<section class="fd-wizard">
         </ul>
     </nav>
     <section class="fd-wizard__content fd-wizard__content--xl" id="wizard-section-3" style="min-height: 300px;">
-        <div>
-            Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
-        </div>
-        <div class="fd-wizard__next-step">
-            <button class="fd-button fd-button--compact fd-button--emphasized">Next Step</button>
+        <div class="fd-wizard__step-content-container">
+            <div>
+                Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
+            </div>
+            <div class="fd-wizard__next-step">
+                <button class="fd-button fd-button--compact fd-button--emphasized">Next Step</button>
+            </div>
         </div>
     </section>
     <footer>
@@ -449,11 +456,13 @@ export const Responsive = () => `<section class="fd-wizard">
         </ul>
     </nav>
     <section class="fd-wizard__content fd-wizard__content--xl" id="wizard-section-4" style="min-height: 300px;">
-        <div>
-            Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
-        </div>
-        <div class="fd-wizard__next-step">
-            <button class="fd-button fd-button--compact fd-button--emphasized">Next Step</button>
+        <div class="fd-wizard__step-content-container">
+            <div>
+                Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
+            </div>
+            <div class="fd-wizard__next-step">
+                <button class="fd-button fd-button--compact fd-button--emphasized">Next Step</button>
+            </div>
         </div>
     </section>
     <footer>
@@ -604,11 +613,13 @@ export const Responsive = () => `<section class="fd-wizard">
         </ul>
     </nav>
     <section class="fd-wizard__content fd-wizard__content--xl" id="wizard-section-5" style="min-height: 300px;">
-        <div>
-            Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
-        </div>
-        <div class="fd-wizard__next-step">
-            <button class="fd-button fd-button--compact fd-button--emphasized">Next Step</button>
+        <div class="fd-wizard__step-content-container">
+            <div>
+                Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
+            </div>
+            <div class="fd-wizard__next-step">
+                <button class="fd-button fd-button--compact fd-button--emphasized">Next Step</button>
+            </div>
         </div>
     </section>
     <footer>
@@ -706,11 +717,13 @@ export const RevertedSteps = () => `<section class="fd-wizard">
         </ul>
     </nav>
     <section class="fd-wizard__content fd-wizard__content--xl" id="wizard-section-3" style="min-height: 300px;">
-        <div>
-            Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
-        </div>
-        <div class="fd-wizard__next-step">
-            <button class="fd-button fd-button--compact fd-button--emphasized">Next Step</button>
+        <div class="fd-wizard__step-content-container">
+            <div>
+                Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
+            </div>
+            <div class="fd-wizard__next-step">
+                <button class="fd-button fd-button--compact fd-button--emphasized">Next Step</button>
+            </div>
         </div>
     </section>
     <footer>
@@ -824,11 +837,13 @@ export const RevertedSteps = () => `<section class="fd-wizard">
         </ul>
     </nav>
     <section class="fd-wizard__content fd-wizard__content--xl" id="wizard-section-4" style="min-height: 300px;">
-        <div>
-            Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
-        </div>
-        <div class="fd-wizard__next-step">
-            <button class="fd-button fd-button--compact fd-button--emphasized">Next Step</button>
+        <div class="fd-wizard__step-content-container">
+            <div>
+                Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
+            </div>
+            <div class="fd-wizard__next-step">
+                <button class="fd-button fd-button--compact fd-button--emphasized">Next Step</button>
+            </div>
         </div>
     </section>
     <footer>
@@ -979,11 +994,13 @@ export const RevertedSteps = () => `<section class="fd-wizard">
         </ul>
     </nav>
     <section class="fd-wizard__content fd-wizard__content--xl" id="wizard-section-5" style="min-height: 300px;">
-        <div>
-            Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
-        </div>
-        <div class="fd-wizard__next-step">
-            <button class="fd-button fd-button--compact fd-button--emphasized">Next Step</button>
+        <div class="fd-wizard__step-content-container">
+            <div>
+                Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
+            </div>
+            <div class="fd-wizard__next-step">
+                <button class="fd-button fd-button--compact fd-button--emphasized">Next Step</button>
+            </div>
         </div>
     </section>
     <footer>
@@ -1145,11 +1162,13 @@ export const Mobile = () => `<div style="display: flex; justify-content: space-a
                 </ul>
             </nav>
             <section class="fd-wizard__content fd-wizard__content--sm" id="wizard-section-6" style="min-height: 500px;">
-                <div>
-                    Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat
-                </div>
-                <div class="fd-wizard__next-step">
-                    <button class="fd-button fd-button--emphasized">Next Step</button>
+                <div class="fd-wizard__step-content-container">
+                    <div>
+                        Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis.
+                    </div>
+                    <div class="fd-wizard__next-step">
+                        <button class="fd-button fd-button--emphasized">Next Step</button>
+                    </div>
                 </div>
             </section>
             <footer>
@@ -1301,16 +1320,18 @@ export const Mobile = () => `<div style="display: flex; justify-content: space-a
                 </ul>
             </nav>
             <section class="fd-wizard__content fd-wizard__content--sm" id="wizard-section-7" style="min-height: 300px;">
-                <div
-                style="
-                    width:100%;
-                    background-image: url(assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg);
-                    height: 300px;
-                    background-size:cover;"
-                role="img"
-                aria-label="Image 4" />
-                <div class="fd-wizard__next-step fd-wizard__next-step--floating">
-                    <button class="fd-button fd-button--emphasized">Next Step</button>
+                <div class="fd-wizard__step-content-container">
+                    <div
+                    style="
+                        width:100%;
+                        background-image: url(assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg);
+                        height: 300px;
+                        background-size:cover;"
+                    role="img"
+                    aria-label="Image 4" />
+                    <div class="fd-wizard__next-step fd-wizard__next-step--floating">
+                        <button class="fd-button fd-button--emphasized">Next Step</button>
+                    </div>
                 </div>
             </section>
             <footer>


### PR DESCRIPTION
part of #3354 

Introduces a breaking change, a new class `fd-wizard__step-content-container`, which is needed because the Horizon wizard has another styled div within each step with a white background and rounded borders as pictured below.

![Screen Shot 2022-05-05 at 11 49 24 AM](https://user-images.githubusercontent.com/2471874/166983223-930de824-88db-4778-838b-59e918a4dd2d.png)

