### PR TITLE
feat(styles): feed list item horizon theme

### DIFF
--- a/src/styles/feed-list.scss
+++ b/src/styles/feed-list.scss
@@ -15,7 +15,7 @@ $block: #{$fd-namespace}-feed-list;
   @include fd-reset();
   @include fd-flex();
 
-  background-color: var(--sapField_Background);
+  background-color: var(--fdFeed_List_Item_Background);
   max-width: 40rem;
 
   .#{$block}__thumb {
@@ -38,7 +38,11 @@ $block: #{$fd-namespace}-feed-list;
     padding: 1rem;
 
     & + .#{$block}__body {
-      border-top: var(--sapList_BorderWidth) solid var(--sapList_BorderColor);
+      border-top: var(--fdFeed_List_Item_Border_Top);
+
+      &:last-child {
+        border-bottom: var(--fdFeed_List_Item_Border_Bottom);
+      }
     }
   }
 
@@ -54,13 +58,14 @@ $block: #{$fd-namespace}-feed-list;
 
       &:last-child {
         padding-bottom: 1rem;
+        border-bottom: none;
       }
     }
   }
 
   &__link {
     &--more {
-      text-transform: uppercase;
+      text-transform: var(--fdFeed_List_Item_More_Transform);
       cursor: pointer;
     }
   }
@@ -108,7 +113,7 @@ $block: #{$fd-namespace}-feed-list;
     padding-top: 0.375rem;
 
     &--byline {
-      color: var(--sapNeutralTextColor);
+      color: var(--fdFeed_List_Item_Byline_Text_Color);
 
       &:not(:last-child)::after {
         content: '\2022';
@@ -142,6 +147,14 @@ $block: #{$fd-namespace}-feed-list;
 
       padding-left: $fd-feed-list-padding-action-small;
       padding-bottom: 0.25rem;
+
+      > .fd-button {
+        padding-left: var(--fdFeed_List_Mobile_Actions_Button_Padding_X);
+        padding-right: var(--fdFeed_List_Mobile_Actions_Button_Padding_X);
+        height: var(--fdFeed_List_Mobile_Actions_Button_Padding_Height);
+        max-height: var(--fdFeed_List_Mobile_Actions_Button_Padding_Height);
+        min-width: var(--fdFeed_List_Mobile_Actions_Button_Padding_Width);
+      }
 
       @include fd-rtl() {
         padding-right: $fd-feed-list-padding-action-small;

--- a/src/styles/theming/common/feed-list-item/_sap_fiori.scss
+++ b/src/styles/theming/common/feed-list-item/_sap_fiori.scss
@@ -1,0 +1,11 @@
+:root {
+  --fdFeed_List_Item_Background: var(--sapField_Background);
+  --fdFeed_List_Item_Padding: 1rem;
+  --fdFeed_List_Item_Byline_Text_Color: var(--sapNeutralTextColor);
+  --fdFeed_List_Item_More_Transform: uppercase;
+  --fdFeed_List_Mobile_Actions_Button_Padding_X: calc(0.625rem - var(--sapButton_BorderWidth));
+  --fdFeed_List_Mobile_Actions_Button_Padding_Height: 2.25rem;
+  --fdFeed_List_Mobile_Actions_Button_Padding_Width: 2.25rem;
+  --fdFeed_List_Item_Border_Top: var(--sapList_BorderWidth) solid var(--sapList_BorderColor);
+  --fdFeed_List_Item_Border_Bottom: var(--sapList_BorderWidth) solid var(--sapList_BorderColor);
+}

--- a/src/styles/theming/common/feed-list-item/_sap_horizon.scss
+++ b/src/styles/theming/common/feed-list-item/_sap_horizon.scss
@@ -1,0 +1,11 @@
+:root {
+  --fdFeed_List_Item_Background: var(--sapList_Background);
+  --fdFeed_List_Item_Padding: 1rem 1rem 0.5rem;
+  --fdFeed_List_Item_Byline_Text_Color: var(--sapContent_LabelColor);
+  --fdFeed_List_Item_More_Transform: capitalize;
+  --fdFeed_List_Mobile_Actions_Button_Padding_X: calc(0.5rem - var(--sapButton_BorderWidth));
+  --fdFeed_List_Mobile_Actions_Button_Padding_Height: 1.625rem;
+  --fdFeed_List_Mobile_Actions_Button_Padding_Width: 2rem;
+  --fdFeed_List_Item_Border_Top: var(--sapList_BorderWidth) solid var(--sapList_BorderColor);
+  --fdFeed_List_Item_Border_Bottom: var(--sapList_BorderWidth) solid var(--sapList_BorderColor);
+}

--- a/src/styles/theming/sap_fiori_3.scss
+++ b/src/styles/theming/sap_fiori_3.scss
@@ -13,6 +13,7 @@
 @import "./common/wizard/sap_fiori";
 @import "./common/panel/sap_fiori";
 @import "./common/carousel/sap_fiori";
+@import "./common/feed-list-item/sap_fiori";
 
 :root {
   --fdInverted_Object_Border_Width: 0;

--- a/src/styles/theming/sap_fiori_3_dark.scss
+++ b/src/styles/theming/sap_fiori_3_dark.scss
@@ -13,6 +13,7 @@
 @import "./common/wizard/sap_fiori";
 @import "./common/panel/sap_fiori";
 @import "./common/carousel/sap_fiori";
+@import "./common/feed-list-item/sap_fiori";
 
 :root {
   --fdInverted_Object_Border_Width: 0;

--- a/src/styles/theming/sap_fiori_3_hcb.scss
+++ b/src/styles/theming/sap_fiori_3_hcb.scss
@@ -20,6 +20,7 @@
 @import "./common/panel/sap_fiori";
 @import "./common/carousel/sap_fiori";
 @import "./common/carousel/sap_fiori_hc";
+@import "./common/feed-list-item/sap_fiori";
 
 :root {
   --fdInverted_Object_Border_Width: 0.0625rem;

--- a/src/styles/theming/sap_fiori_3_hcw.scss
+++ b/src/styles/theming/sap_fiori_3_hcw.scss
@@ -21,6 +21,7 @@
 @import "./common/panel/sap_fiori";
 @import "./common/carousel/sap_fiori";
 @import "./common/carousel/sap_fiori_hc";
+@import "./common/feed-list-item/sap_fiori";
 
 :root {
   --fdInverted_Object_Border_Width: 0.0625rem;

--- a/src/styles/theming/sap_fiori_3_light_dark.scss
+++ b/src/styles/theming/sap_fiori_3_light_dark.scss
@@ -13,6 +13,7 @@
 @import "./common/wizard/sap_fiori";
 @import "./common/panel/sap_fiori";
 @import "./common/carousel/sap_fiori";
+@import "./common/feed-list-item/sap_fiori";
 
 :root {
   --fdInverted_Object_Border_Width: 0;

--- a/src/styles/theming/sap_horizon.scss
+++ b/src/styles/theming/sap_horizon.scss
@@ -13,6 +13,7 @@
 @import "./common/wizard/sap_horizon";
 @import "./common/panel/sap_horizon";
 @import "./common/carousel/sap_horizon";
+@import "./common/feed-list-item/sap_horizon";
 
 :root {
   /* Switch */

--- a/src/styles/theming/sap_horizon_dark.scss
+++ b/src/styles/theming/sap_horizon_dark.scss
@@ -13,6 +13,7 @@
 @import "./common/wizard/sap_horizon";
 @import "./common/panel/sap_horizon";
 @import "./common/carousel/sap_horizon";
+@import "./common/feed-list-item/sap_horizon";
 
 :root {
   /* Switch */

--- a/src/styles/theming/sap_horizon_hcb.scss
+++ b/src/styles/theming/sap_horizon_hcb.scss
@@ -22,6 +22,7 @@
 @import "./common/panel/sap_horizon";
 @import "./common/carousel/sap_horizon";
 @import "./common/carousel/sap_horizon_hc";
+@import "./common/feed-list-item/sap_horizon";
 
 :root {
   /* Switch */

--- a/src/styles/theming/sap_horizon_hcw.scss
+++ b/src/styles/theming/sap_horizon_hcw.scss
@@ -22,6 +22,7 @@
 @import "./common/panel/sap_horizon";
 @import "./common/carousel/sap_horizon";
 @import "./common/carousel/sap_horizon_hc";
+@import "./common/feed-list-item/sap_horizon";
 
 :root {
   /* Switch */


### PR DESCRIPTION
## Related Issue
Relates https://github.com/SAP/fundamental-styles/issues/3354

## Description
Added delta theming for feed list item component. No breaking changes.

## Screenshots
<img width="682" alt="image" src="https://user-images.githubusercontent.com/6586561/167113465-aae039ff-25f9-4f46-a455-ffc8d374743e.png">
<img width="681" alt="image" src="https://user-images.githubusercontent.com/6586561/167113484-b0faf1d5-76ca-420d-8736-e8cbb0976394.png">
<img width="380" alt="image" src="https://user-images.githubusercontent.com/6586561/167113519-78913dda-a46d-4df6-ba84-25cc915f7e9d.png">


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- n/a Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
