### PR TITLE
fix(styles): safari switch outline visibility

### DIFF
--- a/src/styles/switch.scss
+++ b/src/styles/switch.scss
@@ -196,23 +196,18 @@ $block: #{$fd-namespace}-switch;
   }
 
   &__input:focus + .#{$block}__slider {
-    outline-offset: 0.125rem;
-    outline-width: 0.125rem;
-    outline-style: solid;
-    outline-color: var(--fdSwitch_Focus_Outline_Color);
-
     &::before {
       position: absolute;
-      display: var(--fdSwitch_Focus_Border_Display);
-      outline-offset: -0.0625rem;
+      display: block;
       border-width: var(--sapContent_FocusWidth);
       border-color: var(--sapContent_FocusColor);
       border-style: var(--sapContent_FocusStyle);
       content: '';
       top: var(--fdSwitch_Focus_Outline_Vertical_Offset);
       bottom: var(--fdSwitch_Focus_Outline_Vertical_Offset);
-      left: 0;
-      right: 0;
+      left: var(--fdSwitch_Focus_Outline_Horizontal_Offset);
+      right: var(--fdSwitch_Focus_Outline_Horizontal_Offset);
+      border-radius: var(--fdSwitch_Focus_Outline_Border_Radius);
     }
   }
 

--- a/src/styles/theming/common/switch/_sap_fiori.scss
+++ b/src/styles/theming/common/switch/_sap_fiori.scss
@@ -19,10 +19,10 @@
   --fdSwitch_Active_Shadow: none;
   --fdSwitch_Border: var(--fdSwitch_Border_Width) solid var(--fdSwitch_Handle_Border_Color);
   --fdSwitch_Slider_Box_Sizing: content-box;
-  --fdSwitch_Focus_Border_Display: block;
-  --fdSwitch_Focus_Outline_Color: transparent;
   --fdSwitch_Padding: 0.625rem 0;
   --fdSwitch_Focus_Outline_Vertical_Offset: -0.375rem;
+  --fdSwitch_Focus_Outline_Horizontal_Offset: 0;
+  --fdSwitch_Focus_Outline_Border_Radius: 0;
 
   // Compact mode
   --fdSwitch_Compact_Width: 2.375rem;

--- a/src/styles/theming/common/switch/_sap_horizon.scss
+++ b/src/styles/theming/common/switch/_sap_horizon.scss
@@ -25,10 +25,10 @@
   --fdSwitch_Active_Shadow: inset 0 0 0 0.0625rem var(--sapButton_Selected_BorderColor);
   --fdSwitch_Border: none;
   --fdSwitch_Slider_Box_Sizing: content-box;
-  --fdSwitch_Focus_Border_Display: none;
-  --fdSwitch_Focus_Outline_Color: var(--sapContent_FocusColor);
   --fdSwitch_Padding: 0.625rem 0;
-  --fdSwitch_Focus_Outline_Vertical_Offset: 0;
+  --fdSwitch_Focus_Outline_Vertical_Offset: calc(var(--sapContent_FocusWidth) * -2);
+  --fdSwitch_Focus_Outline_Horizontal_Offset: calc(var(--sapContent_FocusWidth) * -2);
+  --fdSwitch_Focus_Outline_Border_Radius: calc(var(--fdSwitch_Border_Radius) + (var(--sapContent_FocusWidth) * 2));
 
   // Switch borders
   --fdSwitch_Handle_Border_Color: var(--sapButton_Track_BorderColor);


### PR DESCRIPTION
## Related Issue
Relates [SAP/fundamental-styles#](https://github.com/SAP/fundamental-styles/issues/3327)

## Description
Changed horizon switch outline to border in order for it to work in Safari browser.