### PR TITLE
fix: remove outdated slider variables [ci visual]

### DIFF
--- a/src/styles/slider.scss
+++ b/src/styles/slider.scss
@@ -27,39 +27,6 @@ $handle-outline-width: 0.0625rem;
   padding: 1rem calc((var(--fdSlider_Handle_Width) * 0.5) + #{$handle-outline-offset} + #{$handle-outline-width});
   position: relative;
 
-  &::before,
-  &::after {
-    @include fd-reset();
-
-    content: "";
-    width: var(--fdSlider_Endpoint_Size);
-    height: var(--fdSlider_Endpoint_Size);
-    position: absolute;
-    top: 50%;
-    left: 0.125rem;
-    transform: translateY(-50%);
-    border-radius: 50%;
-
-    @include fd-slider-active-dot();
-  }
-
-  &::after {
-    left: auto;
-    right: 0.125rem;
-
-    @include fd-slider-dot();
-  }
-
-  @include fd-rtl() {
-    &::before {
-      @include fd-slider-dot();
-    }
-
-    &::after {
-      @include fd-slider-active-dot();
-    }
-  }
-
   &--lg {
     @include fd-set-paddings-x-equal(calc((var(--fdSlider_Mobile_Handle_Width) * 0.5) + #{$handle-outline-offset} + #{$handle-outline-width}));
   }
@@ -68,6 +35,39 @@ $handle-outline-width: 0.0625rem;
     @include fd-reset();
 
     position: relative;
+
+    &::before,
+    &::after {
+      @include fd-reset();
+
+      content: "";
+      width: var(--fdSlider_Endpoint_Size);
+      height: var(--fdSlider_Endpoint_Size);
+      position: absolute;
+      top: 50%;
+      left: -0.7rem;
+      transform: translateY(-50%);
+      border-radius: 50%;
+
+      @include fd-slider-active-dot();
+    }
+
+    &::after {
+      left: auto;
+      right: -0.7rem;
+
+      @include fd-slider-dot();
+    }
+
+    @include fd-rtl() {
+      &::before {
+        @include fd-slider-dot();
+      }
+
+      &::after {
+        @include fd-slider-active-dot();
+      }
+    }
   }
 
   &__track {
@@ -202,21 +202,23 @@ $handle-outline-width: 0.0625rem;
   }
 
   &--range {
-    &::before,
-    &::after {
-      @include fd-slider-dot();
-    }
-
-    @include fd-rtl() {
+    .#{$block}__inner {
       &::before,
       &::after {
         @include fd-slider-dot();
       }
-    }
 
-    .#{$block}__handle {
-      @include fd-active() {
-        background-color: var(--fdSlider_Active_Range_Handle_Background);
+      @include fd-rtl() {
+        &::before,
+        &::after {
+          @include fd-slider-dot();
+        }
+      }
+
+      .#{$block}__handle {
+        @include fd-active() {
+          background-color: var(--fdSlider_Active_Range_Handle_Background);
+        }
       }
     }
   }

--- a/src/styles/theming/sap_fiori_3.scss
+++ b/src/styles/theming/sap_fiori_3.scss
@@ -27,13 +27,6 @@
   --fdRating_Indicator_Disabled_Unselected_Color: var(--sapContent_UnratedColor);
   --fdRating_Indicator_Disabled_Control_Opacity: 0.4;
 
-  /* Slider */
-  --fdSlider_Track_Height: 0.25rem;
-  --fdSlider_Track_BorderRadius: 0.25rem;
-  --fdSlider_Tick_Height: 1rem;
-  --fdSlider_Track_Active_Background: var(--sapActiveColor);
-  --fdSlider_Track_Active_Border: var(--sapActiveColor);
-
   /* Wizard */
   --fdWizard_Completed_Step_Color: var(--sapSelectedColor);
   --fdWizard_Completed_Step_Border: 0.0625rem solid var(--sapSelectedColor);

--- a/src/styles/theming/sap_fiori_3_dark.scss
+++ b/src/styles/theming/sap_fiori_3_dark.scss
@@ -27,13 +27,6 @@
   --fdRating_Indicator_Disabled_Unselected_Color: var(--sapContent_UnratedColor);
   --fdRating_Indicator_Disabled_Control_Opacity: 0.4;
 
-  /* Slider */
-  --fdSlider_Track_Height: 0.25rem;
-  --fdSlider_Track_BorderRadius: 0.25rem;
-  --fdSlider_Tick_Height: 1rem;
-  --fdSlider_Track_Active_Background: var(--sapActiveColor);
-  --fdSlider_Track_Active_Border: var(--sapActiveColor);
-
   /* Wizard */
   --fdWizard_Completed_Step_Color: var(--sapSelectedColor);
   --fdWizard_Completed_Step_Border: 0.0625rem solid var(--sapSelectedColor);

--- a/src/styles/theming/sap_fiori_3_hcb.scss
+++ b/src/styles/theming/sap_fiori_3_hcb.scss
@@ -33,13 +33,6 @@
   --fdRating_Indicator_Disabled_Unselected_Color: var(--sapContent_DisabledTextColor);
   --fdRating_Indicator_Disabled_Control_Opacity: 1;
 
-  /* Slider */
-  --fdSlider_Track_Height: 0.375rem;
-  --fdSlider_Track_BorderRadius: 0.375rem;
-  --fdSlider_Tick_Height: 1.125rem;
-  --fdSlider_Track_Active_Background: var(--sapSelectedColor);
-  --fdSlider_Track_Active_Border: var(--sapField_BorderColor);
-
   /* Wizard */
   --fdWizard_Completed_Step_Color: var(--sapTextColor);
   --fdWizard_Completed_Step_Icon_Color: var(--sapTextColor);

--- a/src/styles/theming/sap_fiori_3_hcw.scss
+++ b/src/styles/theming/sap_fiori_3_hcw.scss
@@ -34,13 +34,6 @@
   --fdRating_Indicator_Disabled_Unselected_Color: var(--sapContent_UnratedColor);
   --fdRating_Indicator_Disabled_Control_Opacity: 0.4;
 
-  /* Slider */
-  --fdSlider_Track_Height: 0.375rem;
-  --fdSlider_Track_BorderRadius: 0.375rem;
-  --fdSlider_Tick_Height: 1.125rem;
-  --fdSlider_Track_Active_Background: var(--sapSelectedColor);
-  --fdSlider_Track_Active_Border: var(--sapField_BorderColor);
-
   /* Wizard */
   --fdWizard_Completed_Step_Color: var(--sapTextColor);
   --fdWizard_Completed_Step_Icon_Color: var(--sapTextColor);

--- a/src/styles/theming/sap_fiori_3_light_dark.scss
+++ b/src/styles/theming/sap_fiori_3_light_dark.scss
@@ -27,13 +27,6 @@
   --fdRating_Indicator_Disabled_Unselected_Color: var(--sapContent_UnratedColor);
   --fdRating_Indicator_Disabled_Control_Opacity: 0.4;
 
-  /* Slider */
-  --fdSlider_Track_Height: 0.25rem;
-  --fdSlider_Track_BorderRadius: 0.25rem;
-  --fdSlider_Tick_Height: 1rem;
-  --fdSlider_Track_Active_Background: var(--sapSelectedColor);
-  --fdSlider_Track_Active_Border: var(--sapField_BorderColor);
-
   /* Wizard */
   --fdWizard_Completed_Step_Color: var(--sapSelectedColor);
   --fdWizard_Completed_Step_Border: 0.0625rem solid var(--sapSelectedColor);

--- a/src/styles/theming/sap_horizon.scss
+++ b/src/styles/theming/sap_horizon.scss
@@ -32,13 +32,6 @@
   --fdRating_Indicator_Disabled_Unselected_Color: var(--sapContent_UnratedColor);
   --fdRating_Indicator_Disabled_Control_Opacity: 0.4;
 
-  /* Slider */
-  --fdSlider_Track_Height: 0.25rem;
-  --fdSlider_Track_BorderRadius: 0.25rem;
-  --fdSlider_Tick_Height: 1rem;
-  --fdSlider_Track_Active_Background: var(--sapActiveColor);
-  --fdSlider_Track_Active_Border: var(--sapActiveColor);
-
   /* Wizard */
   --fdWizard_Completed_Step_Color: var(--sapSelectedColor);
   --fdWizard_Completed_Step_Border: 0.0625rem solid var(--sapSelectedColor);

--- a/src/styles/theming/sap_horizon_dark.scss
+++ b/src/styles/theming/sap_horizon_dark.scss
@@ -32,13 +32,6 @@
   --fdRating_Indicator_Disabled_Unselected_Color: var(--sapContent_UnratedColor);
   --fdRating_Indicator_Disabled_Control_Opacity: 0.4;
 
-  /* Slider */
-  --fdSlider_Track_Height: 0.25rem;
-  --fdSlider_Track_BorderRadius: 0.25rem;
-  --fdSlider_Tick_Height: 1rem;
-  --fdSlider_Track_Active_Background: var(--sapActiveColor);
-  --fdSlider_Track_Active_Border: var(--sapActiveColor);
-
   /* Wizard */
   --fdWizard_Completed_Step_Color: var(--sapSelectedColor);
   --fdWizard_Completed_Step_Border: 0.0625rem solid var(--sapSelectedColor);

--- a/src/styles/theming/sap_horizon_hcb.scss
+++ b/src/styles/theming/sap_horizon_hcb.scss
@@ -39,13 +39,6 @@
   --fdRating_Indicator_Disabled_Unselected_Color: var(--sapContent_UnratedColor);
   --fdRating_Indicator_Disabled_Control_Opacity: 0.4;
 
-  /* Slider */
-  --fdSlider_Track_Height: 0.25rem;
-  --fdSlider_Track_BorderRadius: 0.25rem;
-  --fdSlider_Tick_Height: 1rem;
-  --fdSlider_Track_Active_Background: var(--sapActiveColor);
-  --fdSlider_Track_Active_Border: var(--sapActiveColor);
-
   /* Wizard */
   --fdWizard_Completed_Step_Color: var(--sapSelectedColor);
   --fdWizard_Completed_Step_Border: 0.0625rem solid var(--sapSelectedColor);

--- a/src/styles/theming/sap_horizon_hcw.scss
+++ b/src/styles/theming/sap_horizon_hcw.scss
@@ -39,13 +39,6 @@
   --fdRating_Indicator_Disabled_Unselected_Color: var(--sapContent_UnratedColor);
   --fdRating_Indicator_Disabled_Control_Opacity: 0.4;
 
-  /* Slider */
-  --fdSlider_Track_Height: 0.25rem;
-  --fdSlider_Track_BorderRadius: 0.25rem;
-  --fdSlider_Tick_Height: 1rem;
-  --fdSlider_Track_Active_Background: var(--sapActiveColor);
-  --fdSlider_Track_Active_Border: var(--sapActiveColor);
-
   /* Wizard */
   --fdWizard_Completed_Step_Color: var(--sapSelectedColor);
   --fdWizard_Completed_Step_Border: 0.0625rem solid var(--sapSelectedColor);


### PR DESCRIPTION
## Related Issue
none

## Description
Fixes previously incorrect merge. Removes outdated css variables. Moves slider dots from root element to the track to keep vertical centering if vertical padding is not equal.
