### PR TITLE
fix(styles): dynamic page subtitle color

### DIFF
--- a/src/styles/dynamic-page.scss
+++ b/src/styles/dynamic-page.scss
@@ -215,7 +215,7 @@ $block: #{$fd-namespace}-dynamic-page;
     @include fd-reset();
     @include fd-ellipsis();
 
-    color: var(--fdDynamicPage_Title_Collapsed_Font_Size);
+    color: var(--fdDynamicPage_Subtitle_Color);
     font-size: var(--sapFontSize);
     margin-top: 0.25rem;
   }


### PR DESCRIPTION
## Related Issue

Closes https://github.com/SAP/fundamental-styles/issues/3327

## Description

Dynamic page subtitle color

## Screenshots

### Before:

<img width="422" alt="image" src="https://user-images.githubusercontent.com/20265336/167632469-0220a2dc-549c-4f97-9750-d433bf1f39a3.png">

### After:

<img width="656" alt="image" src="https://user-images.githubusercontent.com/20265336/167632348-e59e3941-0fab-40d0-8a21-6b845d0c0ede.png">
