### PR TITLE
fix(styles): fixed checkbox spacing when label is empty

### DIFF
--- a/src/styles/checkbox.scss
+++ b/src/styles/checkbox.scss
@@ -106,6 +106,10 @@ $fd-checkbox-tristate-compact-offset: 0.25rem;
       position: relative;
     }
 
+    @include fd-empty() {
+      margin: 0;
+    }
+
     @include fd-rtl() {
       &::after {
         padding-left: 0;


### PR DESCRIPTION
## Related Issue
Part of https://github.com/SAP/fundamental-styles/issues/3327#issuecomment-1100225638

## Description
Checkboxes had margin despite empty labels

## Screenshots

### Before:
![image](https://user-images.githubusercontent.com/28543391/167689851-fc2c9294-4b45-4b69-bb04-f438ceea515f.png)

### After:
![image](https://user-images.githubusercontent.com/28543391/167689938-1d925542-1792-4974-b4fe-71f388046aa6.png)

