### PR TITLE
fix(styles): fixed card HC theme borders

### DIFF
--- a/src/styles/theming/common/card/_sap_fiori_hc.scss
+++ b/src/styles/theming/common/card/_sap_fiori_hc.scss
@@ -1,4 +1,5 @@
 :root {
   --fdCard_Background_Color: transparent;
   --fdCard_Box_Shadow: none;
+  --fdCard_Border: 0.0625rem solid var(--sapTile_BorderColor);
 }

--- a/src/styles/theming/common/card/_sap_horizon_hc.scss
+++ b/src/styles/theming/common/card/_sap_horizon_hc.scss
@@ -1,4 +1,5 @@
 :root {
   --fdCard_Background_Color: transparent;
   --fdCard_Box_Shadow: none;
+  --fdCard_Border: 0.0625rem solid var(--sapTile_BorderColor);
 }


### PR DESCRIPTION
## Related Issue
Part of https://github.com/SAP/fundamental-styles/issues/3327#issuecomment-1108540654

## Description
Card had missing borders in high contrast themes

## Screenshots

### Before:
![image](https://user-images.githubusercontent.com/20265336/167416732-67f58cc7-1cd5-4e9b-9e80-3674eb9f828a.png)

### After:
![image](https://user-images.githubusercontent.com/28543391/167692440-1591678f-dc09-4d48-8ea3-6882dc33c6c2.png)
