### PR TITLE
fix(styles): add fix for focus in active state

### DIFF
--- a/src/styles/product-switch.scss
+++ b/src/styles/product-switch.scss
@@ -107,6 +107,10 @@ $block: #{$fd-namespace}-product-switch;
     }
 
     @include fd-active() {
+      @include fd-fiori-focus() {
+        outline-color: var(--sapContent_ContrastFocusColor);
+      }
+
       background-color: var(--sapList_Active_Background);
       border: var(--fdProductSwitch_Border);
 
@@ -290,6 +294,10 @@ $block: #{$fd-namespace}-product-switch;
 
       @include fd-active() {
         @include fd-product-pseudo-element-background(var(--sapList_SelectionBorderColor));
+
+        @include fd-fiori-focus() {
+          outline-color: var(--sapContent_ContrastFocusColor);
+        }
       }
 
       &.selected {


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-styles/issues/3327

## Description
change the focus outline color on active state

## Screenshots

### Before:
<img width="775" alt="Screen Shot 2022-05-10 at 5 01 08 PM" src="https://user-images.githubusercontent.com/39598672/167721190-07e0263a-d2f8-4b9f-92a4-d1a793c1b1ca.png">


### After:
<img width="582" alt="Screen Shot 2022-05-10 at 5 01 32 PM" src="https://user-images.githubusercontent.com/39598672/167721211-383b144f-f055-479d-a3cc-8d37b5fecdaa.png">

