### PR TITLE
fix(styles): add fix for User Menu search field

### DIFF
--- a/stories/user-menu/__snapshots__/user-menu.stories.storyshot
+++ b/stories/user-menu/__snapshots__/user-menu.stories.storyshot
@@ -2276,7 +2276,7 @@ exports[`Storyshots Components/User Menu Compact 1`] = `
                                 
                   <button
                     aria-label="Search"
-                    class="fd-input-group__button fd-button fd-button--icon fd-button--transparent"
+                    class="fd-input-group__button fd-button fd-button--icon fd-button--transparent fd-button--compact"
                   >
                     
                                     
@@ -3242,7 +3242,7 @@ exports[`Storyshots Components/User Menu In-Place Navigation 1`] = `
                                 
                   <button
                     aria-label="Search"
-                    class="fd-input-group__button fd-button fd-button--icon fd-button--transparent"
+                    class="fd-input-group__button fd-button fd-button--icon fd-button--transparent fd-button--compact"
                   >
                     
                                     

--- a/stories/user-menu/user-menu.stories.js
+++ b/stories/user-menu/user-menu.stories.js
@@ -283,7 +283,7 @@ export const Navigation = () => `<div class="fddocs-container" style="margin-bot
                         <div class="fd-input-group">
                             <input class="fd-input fd-input--compact fd-input-group__input" type="text" id="aqwsde118" name="" aria-label="Search" placeholder="Search">
                             <span class="fd-input-group__addon fd-input-group__addon--button fd-input-group__addon--compact">
-                                <button class="fd-input-group__button fd-button fd-button--icon fd-button--transparent" aria-label="Search">
+                                <button class="fd-input-group__button fd-button fd-button--icon fd-button--transparent fd-button--compact" aria-label="Search">
                                     <i class="sap-icon--search"></i>
                                 </button>
                             </span>
@@ -909,7 +909,7 @@ export const Compact = () => `<div class="fddocs-container" style="margin-bottom
                         <div class="fd-input-group">
                             <input class="fd-input fd-input--compact fd-input-group__input" type="text" id="aqwsde118" name="" aria-label="Search" placeholder="Search">
                             <span class="fd-input-group__addon fd-input-group__addon--button fd-input-group__addon--compact">
-                                <button class="fd-input-group__button fd-button fd-button--icon fd-button--transparent" aria-label="Search">
+                                <button class="fd-input-group__button fd-button fd-button--icon fd-button--transparent fd-button--compact" aria-label="Search">
                                     <i class="sap-icon--search"></i>
                                 </button>
                             </span>


### PR DESCRIPTION
## Related Issue
Part of https://github.com/SAP/fundamental-styles/issues/3327

## Description
add compact modifier class to button in compact input group that is use ass search field in User Menu.

BREAKING CHANGE:
The button from compact input group needs a compact modifier class.
BEFORE:
```
<div class="fd-input-group">
    <input class="fd-input fd-input--compact fd-input-group__input" type="text" id="aqwsde118" name="" aria-label="Search" placeholder="Search">
    <span class="fd-input-group__addon fd-input-group__addon--button fd-input-group__addon--compact">
        <button class="fd-input-group__button fd-button fd-button--icon fd-button--transparent" aria-label="Search">
            <i class="sap-icon--search"></i>
        </button>
    </span>
</div>
```

NOW:
```
<div class="fd-input-group">
    <input class="fd-input fd-input--compact fd-input-group__input" type="text" id="aqwsde118" name="" aria-label="Search" placeholder="Search">
    <span class="fd-input-group__addon fd-input-group__addon--button fd-input-group__addon--compact">
        <button class="fd-input-group__button fd-button fd-button--icon fd-button--transparent fd-button--compact" aria-label="Search">
            <i class="sap-icon--search"></i>
        </button>
    </span>
</div>
```

## Screenshots
### Before:
<img width="385" alt="167512692-8dab6a07-53b0-47ac-8433-433c5c29e152" src="https://user-images.githubusercontent.com/39598672/167723882-62984716-0741-4739-b7f4-e2b4471be3c7.png">


### After:
![Screen Shot 2022-05-10 at 5 20 41 PM](https://user-images.githubusercontent.com/39598672/167723911-91b57573-00b0-4e65-9606-172b5aa012c1.png)

4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
