### PR TITLE
fix(styles): micro process flow icon overlay

### DIFF
--- a/src/styles/micro-process-flow.scss
+++ b/src/styles/micro-process-flow.scss
@@ -269,6 +269,7 @@ $fd-micro-process-flow-semantic-colors: (
       display: block;
       position: absolute;
       border-bottom: 0.0625rem solid var(--sapContent_ForegroundBorderColor);
+      z-index: 1;
     }
 
     &--intermediate {
@@ -287,6 +288,8 @@ $fd-micro-process-flow-semantic-colors: (
 
     .#{$block}__intermediary-item {
       line-height: 1;
+      position: relative;
+      z-index: 2;
     }
   }
 


### PR DESCRIPTION
## Related Issue
Part of #3327

## Description
Fixed micro process flow icon overlay
<img width="732" alt="image" src="https://user-images.githubusercontent.com/6586561/168024688-a851bf91-4069-448e-82c9-944df6e85dce.png">

