### PR TITLE
fix(styles): shellbar various issues

### DIFF
--- a/src/styles/shellbar.scss
+++ b/src/styles/shellbar.scss
@@ -121,8 +121,8 @@ $block: #{$fd-namespace}-shellbar;
       cursor: text;
 
       @include fd-hover() {
-        border-color: var(--sapField_BorderColor);
-        box-shadow: var(--fdShellbar_Button_Hover_Shadow);
+        border-color: var(--fdShellbar_Input_Hover_Border_Color);
+        box-shadow: var(--sapContent_Interaction_Shadow);
       }
 
       &-input {
@@ -134,7 +134,7 @@ $block: #{$fd-namespace}-shellbar;
           &,
           & + .#{$block}__input-group-addon {
             background: transparent;
-            background-color: $fd-shellbar-hover-background !important;
+            background-color: var(--fdShellbar_Input_Hover_Background) !important;
           }
         }
 
@@ -152,22 +152,22 @@ $block: #{$fd-namespace}-shellbar;
         height: var(--fdShellbar_Input_Addon_Dimension);
         min-width: var(--fdShellbar_Input_Addon_Dimension);
         border-radius: var(--fdShellbar_Input_Border_Radius);
+        border-width: var(--fdShellbar_Input_Addon_Border_Width);
       }
     }
   }
 
   .#{$block}__button {
-    background: $fd-shellbar-background;
-    border: var(--fdShellbar_Button_Border);
+    outline-color: var(--fdShellbar_Button_Outline_Color);
     color: var(--sapShell_InteractiveTextColor);
 
-    &:not(.#{$block}__button--menu) {
+    &:not(&--menu) {
       padding: 0;
     }
 
     @include fd-hover() {
-      background: $fd-shellbar-hover-background;
-      box-shadow: var(--fdShellbar_Button_Hover_Shadow);
+      border-color: var(--fdShellbar_Button_Hover_Border_Color);
+      background-color: $fd-shellbar-hover-background;
 
       @include fd-disabled() {
         background: $fd-shellbar-background;
@@ -175,8 +175,8 @@ $block: #{$fd-namespace}-shellbar;
     }
 
     @include fd-active() {
+      border-color: var(--fdShellbar_Button_Active_Border_Color);
       background: var(--sapShell_Active_Background);
-      box-shadow: var(--fdShellbar_Button_Active_Shadow);
       color: var(--sapShell_Active_TextColor);
     }
 

--- a/src/styles/theming/sap_fiori_3.scss
+++ b/src/styles/theming/sap_fiori_3.scss
@@ -397,15 +397,18 @@
   /** Shellbar */
   --fdShellbar_Height: 2.75rem;
   --fdShellbar_Shadow: inset 0 -0.0625rem 0 0 var(--sapShell_BorderColor);
-  --fdShellbar_Button_Border: none;
-  --fdShellbar_Button_Hover_Shadow: none;
-  --fdShellbar_Button_Active_Shadow: none;
+  --fdShellbar_Button_Hover_Border_Color: transparent;
+  --fdShellbar_Button_Active_Border_Color: transparent;
+  --fdShellbar_Button_Outline_Color: var(--sapContent_ContrastFocusColor);
   --fdShellbar_Input_Border: solid 0.0625rem var(--sapShell_InteractiveBorderColor);
   --fdShellbar_Input_Background: var(--sapShellColor);
+  --fdShellbar_Input_Hover_Background: var(--sapShell_Hover_Background);
   --fdShellbar_Input_Color: var(--sapShell_TextColor);
   --fdShellbar_Input_Placeholder_Color: var(--sapShell_InteractiveTextColor);
   --fdShellbar_Input_Border_Radius: var(--sapField_BorderCornerRadius);
+  --fdShellbar_Input_Hover_Border_Color: var(--sapShell_InteractiveBorderColor);
   --fdShellbar_Input_Addon_Dimension: 2.25rem;
+  --fdShellbar_Input_Addon_Border_Width: 0;
 
   /** Message Page */
   --fdMessage_Page_Container_Background: transparent;

--- a/src/styles/theming/sap_fiori_3_dark.scss
+++ b/src/styles/theming/sap_fiori_3_dark.scss
@@ -400,15 +400,18 @@
   /** Shellbar */
   --fdShellbar_Height: 2.75rem;
   --fdShellbar_Shadow: inset 0 -0.0625rem 0 0 var(--sapShell_BorderColor);
-  --fdShellbar_Button_Border: none;
-  --fdShellbar_Button_Hover_Shadow: none;
-  --fdShellbar_Button_Active_Shadow: none;
+  --fdShellbar_Button_Hover_Border_Color: transparent;
+  --fdShellbar_Button_Active_Border_Color: transparent;
+  --fdShellbar_Button_Outline_Color: var(--sapContent_ContrastFocusColor);
   --fdShellbar_Input_Border: solid 0.0625rem var(--sapShell_InteractiveBorderColor);
   --fdShellbar_Input_Background: var(--sapShellColor);
+  --fdShellbar_Input_Hover_Background: var(--sapShell_Hover_Background);
   --fdShellbar_Input_Color: var(--sapShell_TextColor);
   --fdShellbar_Input_Placeholder_Color: var(--sapShell_InteractiveTextColor);
   --fdShellbar_Input_Border_Radius: var(--sapField_BorderCornerRadius);
+  --fdShellbar_Input_Hover_Border_Color: var(--sapShell_InteractiveBorderColor);
   --fdShellbar_Input_Addon_Dimension: 2.25rem;
+  --fdShellbar_Input_Addon_Border_Width: 0;
 
   /** Message Page */
   --fdMessage_Page_Container_Background: transparent;

--- a/src/styles/theming/sap_fiori_3_hcb.scss
+++ b/src/styles/theming/sap_fiori_3_hcb.scss
@@ -407,15 +407,18 @@
   /** Shellbar */
   --fdShellbar_Height: 2.75rem;
   --fdShellbar_Shadow: inset 0 -0.0625rem 0 0 var(--sapShell_BorderColor);
-  --fdShellbar_Button_Border: none;
-  --fdShellbar_Button_Hover_Shadow: none;
-  --fdShellbar_Button_Active_Shadow: none;
+  --fdShellbar_Button_Hover_Border_Color: var(--sapButton_Lite_BorderColor);
+  --fdShellbar_Button_Active_Border_Color: var(--sapButton_Lite_Active_BorderColor);
+  --fdShellbar_Button_Outline_Color: var(--sapContent_FocusColor);
   --fdShellbar_Input_Border: solid 0.0625rem var(--sapShell_InteractiveBorderColor);
   --fdShellbar_Input_Background: var(--sapShellColor);
+  --fdShellbar_Input_Hover_Background: var(--sapShell_Hover_Background);
   --fdShellbar_Input_Color: var(--sapShell_TextColor);
   --fdShellbar_Input_Placeholder_Color: var(--sapShell_InteractiveTextColor);
   --fdShellbar_Input_Border_Radius: var(--sapField_BorderCornerRadius);
+  --fdShellbar_Input_Hover_Border_Color: var(--sapShell_InteractiveBorderColor);
   --fdShellbar_Input_Addon_Dimension: 2.25rem;
+  --fdShellbar_Input_Addon_Border_Width: 0;
 
   /** Message Page */
   --fdMessage_Page_Container_Background: transparent;

--- a/src/styles/theming/sap_fiori_3_hcw.scss
+++ b/src/styles/theming/sap_fiori_3_hcw.scss
@@ -405,15 +405,18 @@
   /** Shellbar */
   --fdShellbar_Height: 2.75rem;
   --fdShellbar_Shadow: inset 0 -0.0625rem 0 0 var(--sapShell_BorderColor);
-  --fdShellbar_Button_Border: none;
-  --fdShellbar_Button_Hover_Shadow: none;
-  --fdShellbar_Button_Active_Shadow: none;
+  --fdShellbar_Button_Hover_Border_Color: var(--sapButton_Lite_BorderColor);
+  --fdShellbar_Button_Active_Border_Color: var(--sapButton_Lite_Active_BorderColor);
+  --fdShellbar_Button_Outline_Color: var(--sapContent_FocusColor);
   --fdShellbar_Input_Border: solid 0.0625rem var(--sapShell_InteractiveBorderColor);
   --fdShellbar_Input_Background: var(--sapShellColor);
+  --fdShellbar_Input_Hover_Background: var(--sapShell_Hover_Background);
   --fdShellbar_Input_Color: var(--sapShell_TextColor);
   --fdShellbar_Input_Placeholder_Color: var(--sapShell_InteractiveTextColor);
   --fdShellbar_Input_Border_Radius: var(--sapField_BorderCornerRadius);
+  --fdShellbar_Input_Hover_Border_Color: var(--sapShell_InteractiveBorderColor);
   --fdShellbar_Input_Addon_Dimension: 2.25rem;
+  --fdShellbar_Input_Addon_Border_Width: 0;
 
   /** Message Page */
   --fdMessage_Page_Container_Background: transparent;

--- a/src/styles/theming/sap_fiori_3_light_dark.scss
+++ b/src/styles/theming/sap_fiori_3_light_dark.scss
@@ -400,15 +400,18 @@
   /** Shellbar */
   --fdShellbar_Height: 2.75rem;
   --fdShellbar_Shadow: inset 0 -0.0625rem 0 0 var(--sapShell_BorderColor);
-  --fdShellbar_Button_Border: none;
-  --fdShellbar_Button_Hover_Shadow: none;
-  --fdShellbar_Button_Active_Shadow: none;
+  --fdShellbar_Button_Hover_Border_Color: transparent;
+  --fdShellbar_Button_Active_Border_Color: transparent;
+  --fdShellbar_Button_Outline_Color: var(--sapContent_ContrastFocusColor);
   --fdShellbar_Input_Border: solid 0.0625rem var(--sapShell_InteractiveBorderColor);
   --fdShellbar_Input_Background: var(--sapShellColor);
+  --fdShellbar_Input_Hover_Background: var(--sapShell_Hover_Background);
   --fdShellbar_Input_Color: var(--sapShell_TextColor);
   --fdShellbar_Input_Placeholder_Color: var(--sapShell_InteractiveTextColor);
   --fdShellbar_Input_Border_Radius: var(--sapField_BorderCornerRadius);
+  --fdShellbar_Input_Hover_Border_Color: var(--sapShell_InteractiveBorderColor);
   --fdShellbar_Input_Addon_Dimension: 2.25rem;
+  --fdShellbar_Input_Addon_Border_Width: 0;
 
   /** Message Page */
   --fdMessage_Page_Container_Background: transparent;

--- a/src/styles/theming/sap_horizon.scss
+++ b/src/styles/theming/sap_horizon.scss
@@ -437,15 +437,18 @@
   /** Shellbar */
   --fdShellbar_Height: 3.25rem;
   --fdShellbar_Shadow: none;
-  --fdShellbar_Button_Border: var(--sapButton_Lite_BorderColor);
-  --fdShellbar_Button_Hover_Shadow: var(--sapContent_Interaction_Shadow);
-  --fdShellbar_Button_Active_Shadow: var(--sapContent_Selected_Shadow);
+  --fdShellbar_Button_Hover_Border_Color: var(--sapButton_Lite_BorderColor);
+  --fdShellbar_Button_Active_Border_Color: var(--sapButton_Lite_Active_BorderColor);
+  --fdShellbar_Button_Outline_Color: var(--sapContent_FocusColor);
   --fdShellbar_Input_Border: none;
   --fdShellbar_Input_Background: var(--sapShell_InteractiveBackground);
+  --fdShellbar_Input_Hover_Background: var(--sapShell_Hover_Background);
   --fdShellbar_Input_Color: var(--sapShell_InteractiveTextColor);
   --fdShellbar_Input_Placeholder_Color: var(--sapField_PlaceholderTextColor);
   --fdShellbar_Input_Border_Radius: 1.125rem;
+  --fdShellbar_Input_Hover_Border_Color: var(--sapField_BorderColor);
   --fdShellbar_Input_Addon_Dimension: 1.75rem;
+  --fdShellbar_Input_Addon_Border_Width: var(--sapButton_BorderWidth);
 
   /** Message Page */
   --fdMessage_Page_Container_Background: var(--sapGroup_ContentBackground);

--- a/src/styles/theming/sap_horizon_dark.scss
+++ b/src/styles/theming/sap_horizon_dark.scss
@@ -437,14 +437,16 @@
   /** Shellbar */
   --fdShellbar_Height: 3.25rem;
   --fdShellbar_Shadow: none;
-  --fdShellbar_Button_Border: var(--sapButton_Lite_BorderColor);
-  --fdShellbar_Button_Hover_Shadow: var(--sapContent_Interaction_Shadow);
-  --fdShellbar_Button_Active_Shadow: var(--sapContent_Selected_Shadow);
+  --fdShellbar_Button_Hover_Border_Color: var(--sapButton_Lite_BorderColor);
+  --fdShellbar_Button_Active_Border_Color: var(--sapButton_Lite_Active_BorderColor);
+  --fdShellbar_Button_Outline_Color: var(--sapContent_FocusColor);
   --fdShellbar_Input_Border: none;
   --fdShellbar_Input_Background: var(--sapShell_InteractiveBackground);
+  --fdShellbar_Input_Addon_Border_Width: var(--sapButton_BorderWidth);
   --fdShellbar_Input_Color: var(--sapShell_InteractiveTextColor);
   --fdShellbar_Input_Placeholder_Color: var(--sapField_PlaceholderTextColor);
   --fdShellbar_Input_Border_Radius: 1.125rem;
+  --fdShellbar_Input_Hover_Border_Color: var(--sapField_BorderColor);
   --fdShellbar_Input_Addon_Dimension: 1.75rem;
 
   /** Message Page */

--- a/src/styles/theming/sap_horizon_hcb.scss
+++ b/src/styles/theming/sap_horizon_hcb.scss
@@ -418,15 +418,18 @@
   /** Shellbar */
   --fdShellbar_Height: 3.25rem;
   --fdShellbar_Shadow: none;
-  --fdShellbar_Button_Border: var(--sapButton_Lite_BorderColor);
-  --fdShellbar_Button_Hover_Shadow: var(--sapContent_Interaction_Shadow);
-  --fdShellbar_Button_Active_Shadow: var(--sapContent_Selected_Shadow);
-  --fdShellbar_Input_Border: none;
+  --fdShellbar_Button_Hover_Border_Color: var(--sapButton_Lite_BorderColor);
+  --fdShellbar_Button_Active_Border_Color: var(--sapButton_Lite_Active_BorderColor);
+  --fdShellbar_Button_Outline_Color: var(--sapContent_FocusColor);
+  --fdShellbar_Input_Border: solid 0.0625rem var(--sapShell_InteractiveBorderColor);
   --fdShellbar_Input_Background: var(--sapShell_InteractiveBackground);
+  --fdShellbar_Input_Hover_Background: var(--sapShellColor);
   --fdShellbar_Input_Color: var(--sapShell_InteractiveTextColor);
   --fdShellbar_Input_Placeholder_Color: var(--sapField_PlaceholderTextColor);
-  --fdShellbar_Input_Border_Radius: 1.125rem;
-  --fdShellbar_Input_Addon_Dimension: 1.75rem;
+  --fdShellbar_Input_Border_Radius: 0;
+  --fdShellbar_Input_Hover_Border_Color: var(--sapField_BorderColor);
+  --fdShellbar_Input_Addon_Dimension: 2.25rem;
+  --fdShellbar_Input_Addon_Border_Width: 0;
 
   /** Message Page */
   --fdMessage_Page_Container_Background: var(--sapGroup_ContentBackground);

--- a/src/styles/theming/sap_horizon_hcw.scss
+++ b/src/styles/theming/sap_horizon_hcw.scss
@@ -411,15 +411,18 @@
   /** Shellbar */
   --fdShellbar_Height: 3.25rem;
   --fdShellbar_Shadow: none;
-  --fdShellbar_Button_Border: var(--sapButton_Lite_BorderColor);
-  --fdShellbar_Button_Hover_Shadow: var(--sapContent_Interaction_Shadow);
-  --fdShellbar_Button_Active_Shadow: var(--sapContent_Selected_Shadow);
-  --fdShellbar_Input_Border: none;
+  --fdShellbar_Button_Hover_Border_Color: var(--sapButton_Lite_BorderColor);
+  --fdShellbar_Button_Active_Border_Color: var(--sapButton_Lite_Active_BorderColor);
+  --fdShellbar_Button_Outline_Color: var(--sapContent_FocusColor);
+  --fdShellbar_Input_Border: solid 0.0625rem var(--sapShell_InteractiveBorderColor);
   --fdShellbar_Input_Background: var(--sapShell_InteractiveBackground);
+  --fdShellbar_Input_Hover_Background: var(--sapShellColor);
   --fdShellbar_Input_Color: var(--sapShell_InteractiveTextColor);
   --fdShellbar_Input_Placeholder_Color: var(--sapField_PlaceholderTextColor);
-  --fdShellbar_Input_Border_Radius: 1.125rem;
-  --fdShellbar_Input_Addon_Dimension: 1.75rem;
+  --fdShellbar_Input_Border_Radius: 0;
+  --fdShellbar_Input_Hover_Border_Color: var(--sapField_BorderColor);
+  --fdShellbar_Input_Addon_Dimension: 2.25rem;
+  --fdShellbar_Input_Addon_Border_Width: 0;
 
   /** Message Page */
   --fdMessage_Page_Container_Background: var(--sapGroup_ContentBackground);

--- a/stories/shellbar/shellbar.stories.js
+++ b/stories/shellbar/shellbar.stories.js
@@ -42,7 +42,7 @@ export const Primary = () => `<div style="height:150px">
             <div class="fd-shellbar__action">
                 <div class="fd-popover fd-popover--right">
                     <div class="fd-popover__control">
-                        <div class="fd-button fd-shellbar__button fd-user-menu__control" aria-controls="WV3AY276" aria-expanded="false" aria-haspopup="true" role="button">
+                        <div class="fd-button fd-button--transparent fd-shellbar__button fd-user-menu__control" aria-controls="WV3AY276" aria-expanded="false" aria-haspopup="true" role="button">
                             <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-shellbar__avatar--circle">WW</span>
                         </div>
                     </div>
@@ -86,7 +86,7 @@ export const ProductMenuAndSearch = () => `<div style="height:200px">
             </span>
             <div class="fd-popover">
                 <div class="fd-popover__control">
-                    <button class="fd-button fd-shellbar__button fd-shellbar__button--menu fd-button--menu" onclick="onPopoverClick('9GLB26941');" aria-controls="9GLB26941" aria-haspopup="true" aria-expanded="false">
+                    <button class="fd-button fd-button--transparent fd-shellbar__button fd-shellbar__button--menu fd-button--menu" onclick="onPopoverClick('9GLB26941');" aria-controls="9GLB26941" aria-haspopup="true" aria-expanded="false">
                         <span class="fd-shellbar__title">Corporate Portal</span>
                         <i class="sap-icon--megamenu"></i>
                     </button>
@@ -127,7 +127,7 @@ export const ProductMenuAndSearch = () => `<div style="height:200px">
                         <div class="fd-input-group fd-shellbar__input-group">
                             <input aria-label="search-input" type="text" class="fd-input fd-input-group__input fd-shellbar__input-group-input" id="F4GcX348b1" placeholder="Search">
                             <span class="fd-input-group__addon fd-shellbar__input-group-addon fd-input-group__addon--button">
-                                <button aria-label="button-decline" class="fd-shellbar__button fd-button">
+                                <button aria-label="button-decline" class="fd-shellbar__button fd-button fd-button--transparent">
                                         <i class="sap-icon--decline"></i>
                                 </button>
                             </span>
@@ -136,14 +136,14 @@ export const ProductMenuAndSearch = () => `<div style="height:200px">
                 </div>
             </div>
             <div class="fd-shellbar__action fd-shellbar__action--desktop">
-                <button class="fd-button fd-shellbar__button" aria-label="Search">
+                <button class="fd-button fd-button--transparent fd-shellbar__button" aria-label="Search">
                         <i class="sap-icon--search"></i>
                 </button>
             </div>
             <div class="fd-shellbar__action">
                 <div class="fd-popover fd-popover--right">
                     <div class="fd-popover__control">
-                        <div class="fd-button fd-shellbar__button fd-user-menu__control" aria-controls="ZY3AY276" onclick="onPopoverClick('ZY3AY276')" aria-expanded="false" aria-haspopup="true" role="button">
+                        <div class="fd-button fd-button--transparent fd-shellbar__button fd-user-menu__control" aria-controls="ZY3AY276" onclick="onPopoverClick('ZY3AY276')" aria-expanded="false" aria-haspopup="true" role="button">
                             <span
                                 class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail fd-shellbar__avatar--circle"
                                 style="background-image: url('assets/images/avatars/1.svg');"
@@ -204,7 +204,7 @@ export const LinksWithCollapsibleMenuXlSize = () => `<div style="height:300px">
                                    placeholder="Search">
                             <span
                                 class="fd-input-group__addon fd-shellbar__input-group-addon fd-input-group__addon--button">
-                                <button aria-label="navigation-down-arrow-button" class="fd-shellbar__button fd-button">
+                                <button aria-label="navigation-down-arrow-button" class="fd-shellbar__button fd-button fd-button--transparent">
                                     <i class="sap-icon--decline"></i>
                                 </button>
                             </span>
@@ -213,18 +213,18 @@ export const LinksWithCollapsibleMenuXlSize = () => `<div style="height:300px">
                 </div>
             </div>
             <div class="fd-shellbar__action fd-shellbar__action--desktop">
-                <button class="fd-button fd-shellbar__button" aria-label="Search">
+                <button class="fd-button fd-button--transparent fd-shellbar__button" aria-label="Search">
                     <i class="sap-icon--search"></i>
                 </button>
             </div>
             <div class="fd-shellbar__action fd-shellbar__action--desktop">
-                <button class="fd-button fd-shellbar__button" aria-label="Notifications">
+                <button class="fd-button fd-button--transparent fd-shellbar__button" aria-label="Notifications">
                     <i class="sap-icon--bell"></i>
                     <span class="fd-button__badge">251K</span>
                 </button>
             </div>
             <div class="fd-shellbar__action fd-shellbar__action--desktop">
-                <button class="fd-button fd-shellbar__button" aria-label="Pool">
+                <button class="fd-button fd-button--transparent fd-shellbar__button" aria-label="Pool">
                     <i class="sap-icon--pool"></i>
                 </button>
             </div>
@@ -234,7 +234,7 @@ export const LinksWithCollapsibleMenuXlSize = () => `<div style="height:300px">
                         <div class="fd-popover__control">
                             <div class="fd-shellbar-collapse--control" onclick="onPopoverClick('CWaGGD78')"
                                  aria-controls="CWaGGD78" aria-expanded="false" aria-haspopup="true" role="button">
-                                <button class="fd-button fd-shellbar__button" aria-controls="undefined"
+                                <button class="fd-button fd-button--transparentfd-shellbar__button" aria-controls="undefined"
                                         aria-haspopup="true" aria-expanded="false">
                                     <i class="sap-icon--overflow"></i>
                                     <span class="fd-buton__badge">251K</span>
@@ -269,7 +269,7 @@ export const LinksWithCollapsibleMenuXlSize = () => `<div style="height:300px">
             <div class="fd-shellbar__action">
                 <div class="fd-popover fd-popover--right">
                     <div class="fd-popover__control">
-                        <div class="fd-button fd-shellbar__button fd-user-menu__control"
+                        <div class="fd-button fd-button--transparent fd-shellbar__button fd-user-menu__control"
                              onclick="onPopoverClick('DD35G276')" aria-controls="DD35G276" aria-expanded="false"
                              aria-haspopup="true" role="button">
                             <span
@@ -331,7 +331,7 @@ export const LinksWithCollapsibleMenuMSize = () => `<div style="height:300px; ma
                                    placeholder="Search">
                             <span
                                 class="fd-input-group__addon fd-shellbar__input-group-addon fd-input-group__addon--button">
-                                <button aria-label="navigation-down-arrow-button" class="fd-shellbar__button fd-button">
+                                <button aria-label="navigation-down-arrow-button" class="fd-shellbar__button fd-button fd-button--transparent">
                                     <i class="sap-icon--decline"></i>
                                 </button>
                             </span>
@@ -340,18 +340,18 @@ export const LinksWithCollapsibleMenuMSize = () => `<div style="height:300px; ma
                 </div>
             </div>
             <div class="fd-shellbar__action fd-shellbar__action--desktop">
-                <button class="fd-button fd-shellbar__button" aria-label="Search">
+                <button class="fd-button fd-button--transparent fd-shellbar__button" aria-label="Search">
                     <i class="sap-icon--search"></i>
                 </button>
             </div>
             <div class="fd-shellbar__action fd-shellbar__action--desktop">
-                <button class="fd-button fd-shellbar__button" aria-label="Notifications">
+                <button class="fd-button fd-button--transparent fd-shellbar__button" aria-label="Notifications">
                     <i class="sap-icon--bell"></i>
                     <span class="fd-button__badge">251K</span>
                 </button>
             </div>
             <div class="fd-shellbar__action fd-shellbar__action--desktop">
-                <button class="fd-button fd-shellbar__button" aria-label="Pool">
+                <button class="fd-button fd-button--transparent fd-shellbar__button" aria-label="Pool">
                     <i class="sap-icon--pool"></i>
                 </button>
             </div>
@@ -361,7 +361,7 @@ export const LinksWithCollapsibleMenuMSize = () => `<div style="height:300px; ma
                         <div class="fd-popover__control">
                             <div class="fd-shellbar-collapse--control" onclick="onPopoverClick('CWaGNGD78')"
                                  aria-controls="CWaGNGD78" aria-expanded="false" aria-haspopup="true" role="button">
-                                <button class="fd-button fd-shellbar__button" aria-controls="undefined"
+                                <button class="fd-button fd-button--transparent fd-shellbar__button" aria-controls="undefined"
                                         aria-haspopup="true" aria-expanded="false">
                                     <i class="sap-icon--overflow"></i>
                                     <span class="fd-button__badge">251K</span>
@@ -396,7 +396,7 @@ export const LinksWithCollapsibleMenuMSize = () => `<div style="height:300px; ma
             <div class="fd-shellbar__action">
                 <div class="fd-popover fd-popover--right">
                     <div class="fd-popover__control">
-                        <div class="fd-button fd-shellbar__button fd-user-menu__control"
+                        <div class="fd-button fd-button--transparent fd-shellbar__button fd-user-menu__control"
                              onclick="onPopoverClick('DD35GBK6')" aria-controls="DD35GBK6" aria-expanded="false"
                              aria-haspopup="true" role="button">
                             <span
@@ -457,7 +457,7 @@ export const LinksWithCollapsibleMenuSSize = () => `<div style="height:300px; ma
                                    placeholder="Search">
                             <span
                                 class="fd-input-group__addon fd-shellbar__input-group-addon fd-input-group__addon--button">
-                                <button aria-label="navigation-down-arrow-button" class="fd-shellbar__button fd-button">
+                                <button aria-label="navigation-down-arrow-button" class="fd-shellbar__button fd-button fd-button--transparent">
                                     <i class="sap-icon--decline"></i>
                                 </button>
                             </span>
@@ -466,18 +466,18 @@ export const LinksWithCollapsibleMenuSSize = () => `<div style="height:300px; ma
                 </div>
             </div>
             <div class="fd-shellbar__action fd-shellbar__action--desktop">
-                <button class="fd-button fd-shellbar__button" aria-label="Search">
+                <button class="fd-button fd-button--transparent fd-shellbar__button" aria-label="Search">
                     <i class="sap-icon--search"></i>
                 </button>
             </div>
             <div class="fd-shellbar__action fd-shellbar__action--desktop">
-                <button class="fd-button fd-shellbar__button" aria-label="Notifications">
+                <button class="fd-button fd-button--transparent fd-shellbar__button" aria-label="Notifications">
                     <i class="sap-icon--bell"></i>
                     <span class="fd-button__badge">251K</span>
                 </button>
             </div>
             <div class="fd-shellbar__action fd-shellbar__action--desktop">
-                <button class="fd-button fd-shellbar__button" aria-label="Pool">
+                <button class="fd-button fd-button--transparent fd-shellbar__button" aria-label="Pool">
                     <i class="sap-icon--pool"></i>
                 </button>
             </div>
@@ -487,7 +487,7 @@ export const LinksWithCollapsibleMenuSSize = () => `<div style="height:300px; ma
                         <div class="fd-popover__control">
                             <div class="fd-shellbar-collapse--control" onclick="onPopoverClick('CWaGNGD78')"
                                  aria-controls="CWaGNGD78" aria-expanded="false" aria-haspopup="true" role="button">
-                                <button class="fd-button fd-shellbar__button" aria-controls="undefined"
+                                <button class="fd-button fd-button--transparent fd-shellbar__button" aria-controls="undefined"
                                         aria-haspopup="true" aria-expanded="false">
                                     <i class="sap-icon--overflow"></i>
                                     <span class="fd-button__badge">251K</span>
@@ -512,7 +512,7 @@ export const LinksWithCollapsibleMenuSSize = () => `<div style="height:300px; ma
             <div class="fd-shellbar__action">
                 <div class="fd-popover fd-popover--right">
                     <div class="fd-popover__control">
-                        <div class="fd-button fd-shellbar__button fd-user-menu__control"
+                        <div class="fd-button fd-button--transparent fd-shellbar__button fd-user-menu__control"
                              onclick="onPopoverClick('DD35GBK6')" aria-controls="DD35GBK6" aria-expanded="false"
                              aria-haspopup="true" role="button">
                             <span
@@ -572,7 +572,7 @@ export const ProductSwitch = () => `<div style="height:600px">
             <span class="fd-shellbar__title">Corporate Portal</span>
         </div>
         <div class="fd-shellbar__group fd-shellbar__group--copilot">
-            <button class="fd-button fd-shellbar__button"><img
+            <button class="fd-button fd-button--transparent fd-shellbar__button"><img
                 src="//unpkg.com/fundamental-styles/dist/images/copilot.png" alt="CoPilot" height="30" width="30"/>
             </button>
         </div>
@@ -580,7 +580,7 @@ export const ProductSwitch = () => `<div style="height:600px">
             <div class="fd-shellbar__action">
                 <div class="fd-popover fd-popover--right">
                     <div class="fd-popover__control">
-                        <div class="fd-button fd-shellbar__button fd-user-menu__control"
+                        <div class="fd-button fd-button--transparent fd-shellbar__button fd-user-menu__control"
                              onclick="onPopoverClick('MKFAY276')" aria-controls="MKFAY276" aria-expanded="false"
                              aria-haspopup="true" role="button">
                             <span
@@ -614,7 +614,7 @@ export const ProductSwitch = () => `<div style="height:600px">
                     <div class="fd-popover fd-popover--right">
                         <div class="fd-popover__control">
                             <button
-                                class="fd-button fd-shellbar__button fd-popover__control fd-product-switch__control"
+                                class="fd-button fd-button--transparent fd-shellbar__button fd-popover__control fd-product-switch__control"
                                 aria-label="Image label"
                                 aria-controls="product-switch-body"
                                 aria-expanded="true"


### PR DESCRIPTION

## Related Issue

Part of https://github.com/SAP/fundamental-styles/issues/3327

## Description

* Horizon, shellbar action active state
* Fiori, shellbar action outline color
* Fiori, Fiori HC, Horizon HC, shellbar search field look

## Screenshots

### Before:
Fiori
<img width="102" alt="image" src="https://user-images.githubusercontent.com/20265336/167877776-aa169400-8e0e-4d0b-803c-9da9d139ae9e.png">

Horizon
<img width="274" alt="image" src="https://user-images.githubusercontent.com/20265336/167877184-cc079a39-442b-40ed-9938-1bde03e4c24c.png">
<img width="140" alt="image" src="https://user-images.githubusercontent.com/20265336/167877274-aa2334ea-47e9-4bf3-bd3c-8816d3f828ba.png">


### After:
Fiori
<img width="91" alt="image" src="https://user-images.githubusercontent.com/20265336/167877696-ff64bc32-1cf2-4aa3-950f-762f7633289c.png">
Horizon
<img width="311" alt="image" src="https://user-images.githubusercontent.com/20265336/167877094-df87df5f-2836-4448-a4ed-f8309212a370.png">
<img width="105" alt="image" src="https://user-images.githubusercontent.com/20265336/167877631-fa7badd2-7d48-4f43-87d5-42e1fdabe5ba.png">



BREAKING CHANGE:
* shellbar actions should have `fd-button--transparent` class from now

* [X] [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes#shellbar-3406)