### PR TITLE
fix(styles): popover arrow styles

### DIFF
--- a/src/styles/popover.scss
+++ b/src/styles/popover.scss
@@ -10,7 +10,7 @@ $block: #{$fd-namespace}-popover;
   $fd-popover-box-shadow: var(--sapContent_Shadow2) !default;
 
   $fd-popover-arrow-top-back: -0.5rem !default;
-  $fd-popover-arrow-top-front: calc(-0.5rem + 0.0625rem) !default;
+  $fd-popover-arrow-top-front: calc(-0.5rem + var(--fdPopover_Border_Width)) !default;
 
   $fd-popover-arrow-width: 1rem !default;
   $fd-popover-arrow-height: 0.5rem !default;
@@ -18,7 +18,7 @@ $block: #{$fd-namespace}-popover;
   $fd-popover-arrow-offset: 0.575rem;
   $fd-popover-arrow-offset-compact: 0.44rem;
   $fd-popover-inline-help-arrow-offset: 0.25rem !default;
-  $fd-popover-arrow-color: var(--sapContent_ForegroundBorderColor) !default;
+  $fd-popover-arrow-color: var(--fdPopover_Border_Color) !default;
 
   $fd-popover-transition-params: $fd-animation-speed !default;
 

--- a/src/styles/theming/sap_fiori_3.scss
+++ b/src/styles/theming/sap_fiori_3.scss
@@ -161,6 +161,8 @@
   /* Popover */
   --fdPopover_Text_Shadow: none;
   --fdPopover_Border_Radius: var(--sapElement_BorderCornerRadius);
+  --fdPopover_Border_Width: 0.0625rem;
+  --fdPopover_Border_Color: #878787;
 
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: none;

--- a/src/styles/theming/sap_fiori_3_dark.scss
+++ b/src/styles/theming/sap_fiori_3_dark.scss
@@ -161,6 +161,8 @@
   /* Popover */
   --fdPopover_Text_Shadow: none;
   --fdPopover_Border_Radius: var(--sapElement_BorderCornerRadius);
+  --fdPopover_Border_Width: 0.0625rem;
+  --fdPopover_Border_Color: #8c8f91;
 
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: none;

--- a/src/styles/theming/sap_fiori_3_hcb.scss
+++ b/src/styles/theming/sap_fiori_3_hcb.scss
@@ -168,6 +168,8 @@
   /* Popover */
   --fdPopover_Text_Shadow: 0 0 0.125rem #000;
   --fdPopover_Border_Radius: var(--sapElement_BorderCornerRadius);
+  --fdPopover_Border_Width: 0.1875rem;
+  --fdPopover_Border_Color: #ffffff;
 
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: 0 0 0.125rem #000;

--- a/src/styles/theming/sap_fiori_3_hcw.scss
+++ b/src/styles/theming/sap_fiori_3_hcw.scss
@@ -169,6 +169,8 @@
   /* Popover */
   --fdPopover_Text_Shadow: none;
   --fdPopover_Border_Radius: var(--sapElement_BorderCornerRadius);
+  --fdPopover_Border_Width: 0.1875rem;
+  --fdPopover_Border_Color: #000000;
 
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: none;

--- a/src/styles/theming/sap_fiori_3_light_dark.scss
+++ b/src/styles/theming/sap_fiori_3_light_dark.scss
@@ -161,6 +161,8 @@
   /* Popover */
   --fdPopover_Text_Shadow: none;
   --fdPopover_Border_Radius: var(--sapElement_BorderCornerRadius);
+  --fdPopover_Border_Width: 0.0625rem;
+  --fdPopover_Border_Color: #878787;
 
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: none;

--- a/src/styles/theming/sap_horizon.scss
+++ b/src/styles/theming/sap_horizon.scss
@@ -200,6 +200,8 @@
   /* Popover */
   --fdPopover_Text_Shadow: none;
   --fdPopover_Border_Radius: var(--sapPopover_BorderCornerRadius);
+  --fdPopover_Border_Width: 0.0625rem;
+  --fdPopover_Border_Color: #acb8c1;
 
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: none;

--- a/src/styles/theming/sap_horizon_dark.scss
+++ b/src/styles/theming/sap_horizon_dark.scss
@@ -200,6 +200,8 @@
   /* Popover */
   --fdPopover_Text_Shadow: none;
   --fdPopover_Border_Radius: var(--sapPopover_BorderCornerRadius);
+  --fdPopover_Border_Width: 0.0625rem;
+  --fdPopover_Border_Color: #636669;
 
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: none;

--- a/src/styles/theming/sap_horizon_hcb.scss
+++ b/src/styles/theming/sap_horizon_hcb.scss
@@ -174,6 +174,8 @@
   /* Popover */
   --fdPopover_Text_Shadow: none;
   --fdPopover_Border_Radius: var(--sapPopover_BorderCornerRadius);
+  --fdPopover_Border_Width: 0.1875rem;
+  --fdPopover_Border_Color: #ffffff;
 
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: none;

--- a/src/styles/theming/sap_horizon_hcw.scss
+++ b/src/styles/theming/sap_horizon_hcw.scss
@@ -174,6 +174,8 @@
   /* Popover */
   --fdPopover_Text_Shadow: none;
   --fdPopover_Border_Radius: var(--sapPopover_BorderCornerRadius);
+  --fdPopover_Border_Width: 0.1875rem;
+  --fdPopover_Border_Color: #000000;
 
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: none;


### PR DESCRIPTION
## Related Issue

Part of https://github.com/SAP/fundamental-styles/issues/3327

## Description

Popover arrow styles.

## Screenshots

### Before:
<img width="161" alt="image" src="https://user-images.githubusercontent.com/20265336/167889421-d0910ca4-c92a-49a0-a7e4-7ab3711efa67.png">
<img width="103" alt="image" src="https://user-images.githubusercontent.com/20265336/167889505-e4c60a8e-053d-41b8-aa5e-0ad0466ae788.png">

### After:

<img width="195" alt="image" src="https://user-images.githubusercontent.com/20265336/167889449-f17209a1-aa4a-416e-aefc-8ae1b1e532d2.png">
<img width="193" alt="image" src="https://user-images.githubusercontent.com/20265336/167889547-c647ad22-c844-433f-91b3-6492e425c110.png">
