### PR TITLE
fix(styles): add fix for focus color on active state for Horizon

### DIFF
--- a/src/styles/menu.scss
+++ b/src/styles/menu.scss
@@ -164,7 +164,7 @@ $block: #{$fd-namespace}-menu;
       }
 
       @include fd-focus() {
-        outline-color: var(--sapContent_ContrastFocusColor);
+        outline-color: var(--fdMenu_Active_State_Focus);
       }
     }
 

--- a/src/styles/theming/common/menu/_sap_fiori.scss
+++ b/src/styles/theming/common/menu/_sap_fiori.scss
@@ -1,0 +1,3 @@
+:root {
+  --fdMenu_Active_State_Focus: var(--sapContent_ContrastFocusColor);
+}

--- a/src/styles/theming/common/menu/_sap_horizon.scss
+++ b/src/styles/theming/common/menu/_sap_horizon.scss
@@ -1,0 +1,3 @@
+:root {
+  --fdMenu_Active_State_Focus: var(--sapContent_FocusColor);
+}

--- a/src/styles/theming/sap_fiori_3.scss
+++ b/src/styles/theming/sap_fiori_3.scss
@@ -16,6 +16,7 @@
 @import "./common/feed-list-item/sap_fiori";
 @import "common/message-box/sap_fiori";
 @import "./common/busy-indicator/sap_fiori";
+@import "./common/menu/sap_fiori";
 
 :root {
   --fdInverted_Object_Border_Width: 0;

--- a/src/styles/theming/sap_fiori_3_dark.scss
+++ b/src/styles/theming/sap_fiori_3_dark.scss
@@ -16,6 +16,7 @@
 @import "./common/feed-list-item/sap_fiori";
 @import "common/message-box/sap_fiori";
 @import "./common/busy-indicator/sap_fiori";
+@import "./common/menu/sap_fiori";
 
 :root {
   --fdInverted_Object_Border_Width: 0;

--- a/src/styles/theming/sap_fiori_3_hcb.scss
+++ b/src/styles/theming/sap_fiori_3_hcb.scss
@@ -23,6 +23,7 @@
 @import "./common/feed-list-item/sap_fiori";
 @import "./common/message-box/sap_fiori_hc";
 @import "./common/busy-indicator/sap_fiori_hc";
+@import "./common/menu/sap_fiori";
 
 :root {
   --fdInverted_Object_Border_Width: 0.0625rem;

--- a/src/styles/theming/sap_fiori_3_hcw.scss
+++ b/src/styles/theming/sap_fiori_3_hcw.scss
@@ -24,6 +24,7 @@
 @import "./common/feed-list-item/sap_fiori";
 @import "./common/message-box/sap_fiori_hc";
 @import "./common/busy-indicator/sap_fiori_hc";
+@import "./common/menu/sap_fiori";
 
 :root {
   --fdInverted_Object_Border_Width: 0.0625rem;

--- a/src/styles/theming/sap_fiori_3_light_dark.scss
+++ b/src/styles/theming/sap_fiori_3_light_dark.scss
@@ -16,6 +16,7 @@
 @import "./common/feed-list-item/sap_fiori";
 @import "common/message-box/sap_fiori";
 @import "./common/busy-indicator/sap_fiori";
+@import "./common/menu/sap_fiori";
 
 :root {
   --fdInverted_Object_Border_Width: 0;

--- a/src/styles/theming/sap_horizon.scss
+++ b/src/styles/theming/sap_horizon.scss
@@ -16,6 +16,7 @@
 @import "./common/feed-list-item/sap_horizon";
 @import "./common/message-box/sap_horizon";
 @import "./common/busy-indicator/sap_horizon";
+@import "./common/menu/sap_horizon";
 
 :root {
   /* Switch */

--- a/src/styles/theming/sap_horizon_dark.scss
+++ b/src/styles/theming/sap_horizon_dark.scss
@@ -16,6 +16,7 @@
 @import "./common/feed-list-item/sap_horizon";
 @import "./common/message-box/sap_horizon";
 @import "./common/busy-indicator/sap_horizon";
+@import "./common/menu/sap_horizon";
 
 :root {
   /* Busy indicator */

--- a/src/styles/theming/sap_horizon_hcb.scss
+++ b/src/styles/theming/sap_horizon_hcb.scss
@@ -25,6 +25,7 @@
 @import "./common/feed-list-item/sap_horizon";
 @import "./common/message-box/sap_horizon_hc";
 @import "./common/busy-indicator/sap_horizon_hc";
+@import "./common/menu/sap_horizon";
 
 :root {
   /* Switch */

--- a/src/styles/theming/sap_horizon_hcw.scss
+++ b/src/styles/theming/sap_horizon_hcw.scss
@@ -25,6 +25,7 @@
 @import "./common/feed-list-item/sap_horizon";
 @import "./common/message-box/sap_horizon_hc";
 @import "./common/busy-indicator/sap_horizon_hc";
+@import "./common/menu/sap_horizon";
 
 :root {
   /* Switch */


### PR DESCRIPTION
## Related Issue
Part of https://github.com/SAP/fundamental-styles/issues/3327

## Description
fix the focus color of menu item on active state  for Horizon

## Screenshots

### Before:
<img width="576" alt="horiz" src="https://user-images.githubusercontent.com/39598672/167942049-cc8cb91e-db61-48f9-a98c-22a1a3a3eb8a.png">


### After:
<img width="691" alt="Screen Shot 2022-05-11 at 4 28 29 PM" src="https://user-images.githubusercontent.com/39598672/167942067-b21bb2d5-a668-453a-a655-b311ef3849dc.png">

