### PR TITLE
fix: busy indicator colors

### DIFF
--- a/src/styles/theming/sap_horizon.scss
+++ b/src/styles/theming/sap_horizon.scss
@@ -432,7 +432,9 @@
   --fdInfo_Label_Display_Text_Color: var(--btp-Grey8);
 
   /** Busy Indicator */
-  --fdBusy_Indicator_Dot_Color: var(--sapContent_BusyColor);
+  // Currently this variable has incorrect colour value. Use hardcoded until @sap-theming package is fixed.
+  // --fdBusy_Indicator_Dot_Color: var(--sapContent_BusyColor);
+  --fdBusy_Indicator_Dot_Color: #0070f2;
   --fdBusy_Indicator_Dot_Contrast_Color: var(--sapContent_ContrastIconColor);
 
   /** Text */

--- a/src/styles/theming/sap_horizon_dark.scss
+++ b/src/styles/theming/sap_horizon_dark.scss
@@ -432,7 +432,9 @@
   --fdInfo_Label_Display_Text_Color: var(--btp-Grey8);
 
   /** Busy Indicator */
-  --fdBusy_Indicator_Dot_Color: var(--sapContent_BusyColor);
+  // Currently this variable has incorrect colour value. Use hardcoded until @sap-theming package is fixed.
+  // --fdBusy_Indicator_Dot_Color: var(--sapContent_BusyColor);
+  --fdBusy_Indicator_Dot_Color: #4db1ff;
   --fdBusy_Indicator_Dot_Contrast_Color: var(--sapContent_ContrastIconColor);
 
   /** Text */


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#3361

## Description
Temporary hardcode color values for busy indicator until sap-theming adds correct ones.

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
<img width="626" alt="image" src="https://user-images.githubusercontent.com/6586561/168070047-3b974853-06e8-4b68-b1d6-d134a44bd4ac.png">
<img width="674" alt="image" src="https://user-images.githubusercontent.com/6586561/168070149-b0ae5ab8-a2e0-4682-9c96-df9efe205c68.png">


### After:

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
