### PR TITLE
fix(styles): remove the width limitation from the label of time column

### DIFF
--- a/src/styles/time.scss
+++ b/src/styles/time.scss
@@ -163,7 +163,6 @@ $block: #{$fd-namespace}-time;
     line-height: $fd-time-item-compact-height;
     height: $fd-time-item-compact-height;
     font-size: var(--sapFontSmallSize);
-    max-width: $fd-time-item-width;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: clip;


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-ngx/issues/4669

## Description
removing width limitation from the label of time column in order to be able to use longer text in labels

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
<img width="141" alt="image" src="https://user-images.githubusercontent.com/33101123/168116502-cfad8323-8e48-4cbd-b457-249fab7fbddf.png">


### After:
<img width="175" alt="image" src="https://user-images.githubusercontent.com/33101123/168116596-8084b6b0-cd93-4cdf-bf89-7eecff8bd869.png">

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [n/a] Verified all styles in IE11
- [n/a] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
