### PR TITLE
fix(styles): remove additional dimming of controls inside input-group

### DIFF
--- a/src/styles/input-group.scss
+++ b/src/styles/input-group.scss
@@ -103,6 +103,13 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
     resize: vertical;
   }
 
+  * {
+    // since input-group applies disabled styles, inner elements should not be additionally dimmed
+    @include fd-disabled() {
+      opacity: 1;
+    }
+  }
+
   &[readonly],
   &.is-readonly {
     overflow: visible;


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-ngx/issues/4663

## Description
`fd-disabled` mixin is applied to both input-group and inputs/buttons inside of it. Because of this opacity: 0.4 is applied multiple times

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
<img width="925" alt="image" src="https://user-images.githubusercontent.com/33101123/168303841-741a60bd-d53f-43e6-899d-deb252875cd8.png">


### After:
<img width="762" alt="image" src="https://user-images.githubusercontent.com/33101123/168303218-c030116a-d94b-4c96-874a-369c6e4da6fc.png">

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [n/a] Verified all styles in IE11
- [n/a] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [n/a] Storybook documentation has been created/updated
- [n/a] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
