### PR TITLE
fix(styles): toolbar info mode styling, grid list toolbar

### DIFF
--- a/src/styles/grid-list.scss
+++ b/src/styles/grid-list.scss
@@ -79,6 +79,7 @@ $fd-grid-list-highlight: (
     height: 100%;
     position: relative;
     overflow: hidden;
+    outline: none;
 
     @include fd-focus() {
       &::before {
@@ -89,7 +90,7 @@ $fd-grid-list-highlight: (
         inset: var(--fdGrid_List_Item_Focus_Outline_Offset);
         box-shadow: var(--fdGrid_List_Item_Focus_Box_Shadow);
         border: var(--fdGrid_List_Item_Focus_Border);
-        border-radius: var(--fdGrid_List_Item_Focus_Border_Radius);
+        border-radius: $fd-grid-list-border-radius;
         z-index: 1;
       }
     }

--- a/src/styles/grid-list.scss
+++ b/src/styles/grid-list.scss
@@ -244,36 +244,6 @@ $fd-grid-list-highlight: (
     }
   }
 
-  &__filter {
-    &,
-    * {
-      color: var(--sapList_TextColor) !important;
-    }
-
-    &[class*="active"] {
-      @include fd-fiori-focus();
-
-      &,
-      * {
-        color: var(--sapInfobar_TextColor) !important;
-      }
-    }
-
-    .#{$block}__filter-button {
-      @include fd-hover() {
-        background: transparent;
-        box-shadow: none;
-        border: none;
-      }
-
-      @include fd-active() {
-        background: transparent;
-        box-shadow: none;
-        border: none;
-      }
-    }
-  }
-
   &__more {
     @include fd-reset();
     @include fd-fiori-focus();

--- a/src/styles/theming/common/grid-list/_sap_fiori.scss
+++ b/src/styles/theming/common/grid-list/_sap_fiori.scss
@@ -2,9 +2,7 @@
   --fdGrid_List_Item_Hover_Border_Color: var(--sapTile_Interactive_BorderColor);
   --fdGrid_List_Item_Border_Radius: var(--sapElement_BorderCornerRadius);
   --fdGrid_List_Item_Toolbar_Shadow: var(--sapContent_HeaderShadow);
-  --fdGrid_List_Highlight_Offset: 0.1875rem;
   --fdGrid_List_Item_Focus_Box_Shadow: none;
   --fdGrid_List_Item_Focus_Border: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
-  --fdGrid_List_Item_Focus_Border_Radius: 0;
   --fdGrid_List_Item_Focus_Outline_Offset: 0.0625rem;
 }

--- a/src/styles/theming/common/grid-list/_sap_horizon.scss
+++ b/src/styles/theming/common/grid-list/_sap_horizon.scss
@@ -2,9 +2,7 @@
   --fdGrid_List_Item_Hover_Border_Color: var(--sapTile_Interactive_BorderColor);
   --fdGrid_List_Item_Border_Radius: var(--sapTile_BorderCornerRadius);
   --fdGrid_List_Item_Toolbar_Shadow: none;
-  --fdGrid_List_Highlight_Offset: 0.5rem;
   --fdGrid_List_Item_Focus_Box_Shadow: inset 0 0 0 var(--sapContent_FocusWidth) var(--sapContent_FocusColor);
   --fdGrid_List_Item_Focus_Border: 0.1775rem solid var(--sapList_Background);
-  --fdGrid_List_Item_Focus_Border_Radius: var(--sapTile_BorderCornerRadius);
   --fdGrid_List_Item_Focus_Outline_Offset: 0;
 }

--- a/src/styles/theming/common/grid-list/_sap_horizon_hc.scss
+++ b/src/styles/theming/common/grid-list/_sap_horizon_hc.scss
@@ -1,10 +1,8 @@
 @import "./sap_horizon";
 
 :root {
-  --fdGrid_List_Highlight_Offset: 0.1875rem;
   --fdGrid_List_Item_Border_Radius: 1rem; // Should be --sapTile_BorderCornerRadius, but in themes, it is incorrect value
   --fdGrid_List_Item_Focus_Box_Shadow: none;
   --fdGrid_List_Item_Focus_Border: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
-  --fdGrid_List_Item_Focus_Border_Radius: var(--sapTile_BorderCornerRadius);
   --fdGrid_List_Item_Focus_Outline_Offset: 0.1875rem;
 }

--- a/src/styles/theming/sap_fiori_3.scss
+++ b/src/styles/theming/sap_fiori_3.scss
@@ -247,6 +247,7 @@
   /* Toolbar */
   --fdToolbar_Auto_Background: inherit;
   --fdToolbar_Solid_Background: var(--sapBackgroundColor);
+  --fdToolbar_Info_Outline_Color: var(--sapContent_ContrastFocusColor);
 
   /* Tool Header */
   --fdTool_Header_Icon_Color_Default: var(--sapShell_TextColor);

--- a/src/styles/theming/sap_fiori_3_dark.scss
+++ b/src/styles/theming/sap_fiori_3_dark.scss
@@ -256,6 +256,7 @@
   /* Toolbar */
   --fdToolbar_Auto_Background: inherit;
   --fdToolbar_Solid_Background: var(--sapBackgroundColor);
+  --fdToolbar_Info_Outline_Color: var(--sapContent_ContrastFocusColor);
 
   /* Tool Header */
   --fdTool_Header_Icon_Color_Default: var(--sapShell_TextColor);

--- a/src/styles/theming/sap_fiori_3_hcb.scss
+++ b/src/styles/theming/sap_fiori_3_hcb.scss
@@ -260,6 +260,7 @@
   /* Toolbar */
   --fdToolbar_Auto_Background: var(--sapToolbar_Background);
   --fdToolbar_Solid_Background: var(--sapBackgroundColor);
+  --fdToolbar_Info_Outline_Color: var(--sapContent_ContrastFocusColor);
 
   /* Tool Header */
   --fdTool_Header_Icon_Color_Default: var(--sapContent_IconColor);

--- a/src/styles/theming/sap_fiori_3_hcw.scss
+++ b/src/styles/theming/sap_fiori_3_hcw.scss
@@ -256,6 +256,7 @@
   /* Toolbar */
   --fdToolbar_Auto_Background: var(--sapToolbar_Background);
   --fdToolbar_Solid_Background: var(--sapBackgroundColor);
+  --fdToolbar_Info_Outline_Color: var(--sapContent_ContrastFocusColor);
 
   /* Tool Header */
   --fdTool_Header_Icon_Color_Default: var(--sapContent_IconColor);

--- a/src/styles/theming/sap_fiori_3_light_dark.scss
+++ b/src/styles/theming/sap_fiori_3_light_dark.scss
@@ -257,6 +257,7 @@
   /* Toolbar */
   --fdToolbar_Auto_Background: inherit;
   --fdToolbar_Solid_Background: var(--sapBackgroundColor);
+  --fdToolbar_Info_Outline_Color: var(--sapContent_ContrastFocusColor);
 
   /* Tool Header */
   --fdTool_Header_Icon_Color_Default: var(--sapShell_TextColor);

--- a/src/styles/theming/sap_horizon.scss
+++ b/src/styles/theming/sap_horizon.scss
@@ -289,6 +289,7 @@
   /* Toolbar */
   --fdToolbar_Auto_Background: var(--sapToolbar_Background);
   --fdToolbar_Solid_Background: var(--sapToolbar_Background);
+  --fdToolbar_Info_Outline_Color: var(--sapContent_FocusColor);
 
   /* Tool Header */
   --fdTool_Header_Icon_Color_Default: var(--sapShell_TextColor);

--- a/src/styles/theming/sap_horizon_dark.scss
+++ b/src/styles/theming/sap_horizon_dark.scss
@@ -298,6 +298,7 @@
   /* Toolbar */
   --fdToolbar_Auto_Background: var(--sapToolbar_Background);
   --fdToolbar_Solid_Background: var(--sapToolbar_Background);
+  --fdToolbar_Info_Outline_Color: var(--sapContent_FocusColor);
 
   /* Tool Header */
   --fdTool_Header_Icon_Color_Default: var(--sapShell_TextColor);

--- a/src/styles/theming/sap_horizon_hcb.scss
+++ b/src/styles/theming/sap_horizon_hcb.scss
@@ -256,6 +256,7 @@
   /* Toolbar */
   --fdToolbar_Auto_Background: var(--sapToolbar_Background);
   --fdToolbar_Solid_Background: var(--sapToolbar_Background);
+  --fdToolbar_Info_Outline_Color: var(--sapContent_FocusColor);
 
   /* Tool Header */
   --fdTool_Header_Icon_Color_Default: var(--sapShell_TextColor);

--- a/src/styles/theming/sap_horizon_hcw.scss
+++ b/src/styles/theming/sap_horizon_hcw.scss
@@ -256,6 +256,7 @@
   /* Toolbar */
   --fdToolbar_Auto_Background: var(--sapToolbar_Background);
   --fdToolbar_Solid_Background: var(--sapToolbar_Background);
+  --fdToolbar_Info_Outline_Color: var(--sapContent_FocusColor);
 
   /* Tool Header */
   --fdTool_Header_Icon_Color_Default: var(--sapShell_TextColor);

--- a/src/styles/toolbar.scss
+++ b/src/styles/toolbar.scss
@@ -134,6 +134,7 @@ $title-toolbar-height: 2.75rem;
     @include fd-fiori-pseudo-focus();
 
     position: relative;
+    outline: none;
 
     @include fd-focus() {
       &::after {

--- a/src/styles/toolbar.scss
+++ b/src/styles/toolbar.scss
@@ -130,6 +130,23 @@ $title-toolbar-height: 2.75rem;
 
   &--info {
     @include toolbarInfo();
+    @include fd-set-paddings-x(0.5rem, 1rem);
+    @include fd-fiori-pseudo-focus();
+
+    position: relative;
+
+    @include fd-focus() {
+      &::after {
+        border-color: var(--fdToolbar_Info_Outline_Color);
+      }
+    }
+
+    [class*='sap-icon'] {
+      font-size: 1rem;
+      height: 1rem;
+      line-height: 1rem;
+      color: var(--sapInfobar_TextColor);
+    }
   }
 
   &__spacer {

--- a/stories/list-grid/grid-list.stories.js
+++ b/stories/list-grid/grid-list.stories.js
@@ -738,9 +738,8 @@ export const FilterInfobar = () => `<div style="min-height: 350px;">
                 <div class="fd-toolbar fd-toolbar--info fd-toolbar--active fd-grid-list__filter" tabindex="0">
                     Filtered by: Company (Company A, Company B)
                     <span class="fd-toolbar__spacer"></span>
-                    <button class="fd-button fd-button--compact fd-button--transparent fd-grid-list__filter-button" aria-label="Cancel">
-                        <i class="sap-icon--decline"></i>
-                    </button>
+
+                    <i class="sap-icon--decline"></i>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Related Issue

Part of https://github.com/SAP/fundamental-styles/issues/3327#issuecomment-1122190654

## Description

Toolbar Infobar mode styling change.
Grid List Toolbar Infobar usage adoption.

## Screenshots

### Before:

<img width="1339" alt="image" src="https://user-images.githubusercontent.com/20265336/168571752-99da7d0f-238f-4294-bc9a-064cb4a16f1e.png">

### After:
<img width="1331" alt="image" src="https://user-images.githubusercontent.com/20265336/168571794-9cdc9273-dc14-480b-a5ed-7ccbbe7c175c.png">

## BREAKING CHANGE:

* Grid list info bar markup change