### PR TITLE
fix(styles): overflow menu radius

### DIFF
--- a/src/styles/menu.scss
+++ b/src/styles/menu.scss
@@ -256,6 +256,28 @@ $block: #{$fd-namespace}-menu;
     overflow-y: scroll;
     box-shadow: var(--sapContent_Shadow1);
     border-radius: $fd-menu-border-radius;
+
+    .#{$block}__list {
+      box-shadow: none;
+    }
+
+    .#{$block}__item:first-child {
+      border-top-right-radius: 0;
+
+      @include fd-rtl() {
+        border-top-right-radius: $fd-menu-border-radius;
+        border-top-left-radius: 0;
+      }
+    }
+
+    .#{$block}__item:last-child {
+      border-bottom-right-radius: 0;
+
+      @include fd-rtl() {
+        border-bottom-right-radius: $fd-menu-border-radius;
+        border-bottom-left-radius: 0;
+      }
+    }
   }
 
   &--full-width {


### PR DESCRIPTION
## Related Issue

Part of https://github.com/SAP/fundamental-styles/issues/3327#issuecomment-1108540654.

## Description

Overflow menu radius.

## Screenshots

### Before:
<img width="123" alt="Screenshot 2022-05-16 at 18 57 01" src="https://user-images.githubusercontent.com/20265336/168637456-28b601b5-8a09-43c5-85e5-c173b56eec6e.png">

### After:
<img width="133" alt="Screenshot 2022-05-16 at 18 56 31" src="https://user-images.githubusercontent.com/20265336/168637472-42864a3f-f00f-42d0-9c23-e11aca3fdfb3.png">
