### PR TITLE
fix(fn): fix missing box-shadow for macOS inputs [ci visual]

### DIFF
--- a/src/fn/fn-input.scss
+++ b/src/fn/fn-input.scss
@@ -3,6 +3,8 @@
 $block: #{$fn-namespace}-input;
 
 @mixin fn-input-base($background, $border, $shadow, $focusShadow: false) {
+  -webkit-appearance: none;
+
   @if $focusShadow {
     @if $shadow != "none" {
       box-shadow: $shadow, $focusShadow;


### PR DESCRIPTION
## Related Issue
none

## Description
fixing the missing box-shadow for Inputs in MacOS Safari and Chrome

**BEFORE:**
![IMG_5787](https://user-images.githubusercontent.com/39598672/168662168-1dfc905c-39ef-4462-a856-c61ef8a7b8d9.PNG)

**NOW:**
![Image from iOS (2)](https://user-images.githubusercontent.com/39598672/168664788-d5092555-708b-46cd-9862-95331c941321.png)
![Image from iOS (3)](https://user-images.githubusercontent.com/39598672/168664796-ee2cf035-96d9-4e7b-81ae-a42b7812e372.png)

