### PR TITLE
fix(styles): remove pop-in border right [ci visual]

### DIFF
--- a/src/styles/table.scss
+++ b/src/styles/table.scss
@@ -541,19 +541,6 @@ $block: #{$fd-namespace}-table;
       }
     }
 
-    .#{$block}__row {
-      .#{$block}__cell {
-        @include fd-last-child() {
-          border-right: $fd-table-border;
-
-          @include fd-rtl() {
-            border-left: $fd-table-border;
-            border-right: none;
-          }
-        }
-      }
-    }
-
     .#{$block}__row--main {
       border: none;
 


### PR DESCRIPTION
part of https://github.com/SAP/fundamental-ngx/issues/7984

removes an unnecessary border on pop-in table cells