### PR TITLE
fix(styles): remove product switch control class [ci visual]

### DIFF
--- a/src/styles/product-switch.scss
+++ b/src/styles/product-switch.scss
@@ -20,50 +20,6 @@ $block: #{$fd-namespace}-product-switch;
 
   @include fd-reset();
 
-  .#{$fd-namespace}-button.#{$block}__control {
-    @include fd-reset();
-
-    color: var(--sapShell_InteractiveTextColor);
-    justify-content: center;
-
-    &::before {
-      margin-right: 0;
-    }
-
-    > [class*='sap-icon'] {
-      color: inherit;
-
-      &::before {
-        color: inherit;
-      }
-    }
-
-    @include fd-hover() {
-      color: var(--sapShell_InteractiveTextColor);
-      background-color: var(--sapShell_Hover_Background);
-
-      @include fd-disabled() {
-        color: var(--sapShell_InteractiveTextColor);
-        opacity: 0.4%;
-      }
-    }
-
-    @include fd-disabled() {
-      opacity: 0.4%;
-    }
-
-    @include fd-active-pressed-selected() {
-      color: var(--sapShell_Active_TextColor);
-      background-color: var(--sapShell_Active_Background);
-    }
-
-    @include fd-focus() {
-      @include fd-button-focus() {
-        outline-color: var(--sapContent_ContrastFocusColor);
-      }
-    }
-  }
-
   &__list {
     @include fd-reset();
 

--- a/stories/product-switch/product-switch.stories.js
+++ b/stories/product-switch/product-switch.stories.js
@@ -14,7 +14,7 @@ export default {
 -	You want your users to navigate within the current product. In this case, use a product menu (see **Shellbar**).
         `,
         tags: ['f3', 'a11y', 'theme'],
-        components: ['product-switch', 'popover', 'button', 'icon']
+        components: ['product-switch', 'popover', 'button', 'icon', 'shellbar']
     }
 };
 
@@ -30,112 +30,116 @@ const localStyles = `
 `;
 
 export const Shellbar = () => `${localStyles}
-<div class="docs-product-switch-shellbar">
-    <div class="fd-product-switch">
-        <div class="fd-popover fd-popover--right">
-            <button class="fd-button fd-button--transparent fd-popover__control"
-                aria-label="Image label"
-                aria-controls="product-switch-body"
-                aria-expanded="true"
-                aria-haspopup="true">
-                <i class="sap-icon--grid"></i>
-            </button>
-            <div class="fd-popover__body fd-popover__body--right" aria-hidden="false" id="product-switch-body">
-                <div class="fd-product-switch__body">
-                    <ul class="fd-product-switch__list">
-                        <li class="fd-product-switch__item selected" tabindex="0">
-                            <i role="presentation" class="fd-product-switch__icon sap-icon--home"></i>
-                            <div class="fd-product-switch__text">
-                                <div class="fd-product-switch__title">Home</div>
-                                <div class="fd-product-switch__subtitle">Central Home</div>
-                            </div>
-                        </li>
-                        <li class="fd-product-switch__item" tabindex="0" selected>
-                            <i role="presentation" class="fd-product-switch__icon sap-icon--business-objects-experience"></i>
-                            <div class="fd-product-switch__text">
-                                <div class="fd-product-switch__title">Analytics Cloud</div>
-                                <div class="fd-product-switch__subtitle">Analytics Cloud</div>
-                            </div>
-                        </li>
-                        <li class="fd-product-switch__item" tabindex="0">
-                            <i role="presentation" class="fd-product-switch__icon sap-icon--contacts"></i>
-                            <div class="fd-product-switch__text">
-                                <div class="fd-product-switch__title">Catalog</div>
-                                <div class="fd-product-switch__subtitle">Ariba</div>
-                            </div>
-                        </li>
-                        <li class="fd-product-switch__item" tabindex="0">
-                            <i role="presentation" class="fd-product-switch__icon sap-icon--credit-card"></i>
-                            <div class="fd-product-switch__text">
-                                <div class="fd-product-switch__title">Guided Buying</div>
-                            </div>
-                        </li>
-                        <li class="fd-product-switch__item" tabindex="0">
-                            <i role="presentation" class="fd-product-switch__icon sap-icon--cart-3"></i>
-                            <div class="fd-product-switch__text">
-                                <div class="fd-product-switch__title">Strategic Procurement</div>
-                            </div>
-                        </li>
-                        <li class="fd-product-switch__item" tabindex="0">
-                            <i role="presentation" class="fd-product-switch__icon sap-icon--flight"></i>
-                            <div class="fd-product-switch__text">
-                                <div class="fd-product-switch__title">Travel & Expense</div>
-                                <div class="fd-product-switch__subtitle">Concur</div>
-                            </div>
-                        </li>
-                        <li class="fd-product-switch__item" tabindex="0">
-                            <i role="presentation" class="fd-product-switch__icon sap-icon--shipping-status"></i>
-                            <div class="fd-product-switch__text">
-                                <div class="fd-product-switch__title">Vendor Management</div>
-                                <div class="fd-product-switch__subtitle">Fieldglass</div>
-                            </div>
-                        </li>
-                        <li class="fd-product-switch__item" tabindex="0">
-                            <i role="presentation" class="fd-product-switch__icon sap-icon--customer"></i>
-                            <div class="fd-product-switch__text">
-                                <div class="fd-product-switch__title">Human Capital Management</div>
-                            </div>
-                        </li>
-                        <li class="fd-product-switch__item" tabindex="0">
-                            <i role="presentation" class="fd-product-switch__icon sap-icon--sales-notification"></i>
-                            <div class="fd-product-switch__text">
-                                <div class="fd-product-switch__title">Sales Cloud</div>
-                                <div class="fd-product-switch__subtitle">Sales Cloud</div>
-                            </div>
-                        </li>
-                        <li class="fd-product-switch__item" tabindex="0">
-                            <i role="presentation" class="fd-product-switch__icon sap-icon--retail-store"></i>
-                            <div class="fd-product-switch__text">
-                                <div class="fd-product-switch__title">Commerce Cloud</div>
-                                <div class="fd-product-switch__subtitle">Commerce Cloud</div>
-                            </div>
-                        </li>
-                        <li class="fd-product-switch__item" tabindex="0">
-                            <i role="presentation" class="fd-product-switch__icon sap-icon--marketing-campaign"></i>
-                            <div class="fd-product-switch__text">
-                                <div class="fd-product-switch__title">Marketing Cloud</div>
-                                <div class="fd-product-switch__subtitle">Marketing Cloud</div>
-                            </div>
-                        </li>
-                        <li class="fd-product-switch__item" tabindex="0">
-                            <i role="presentation" class="fd-product-switch__icon sap-icon--family-care"></i>
-                            <div class="fd-product-switch__text">
-                                <div class="fd-product-switch__title">Service Cloud</div>
-                            </div>
-                        </li>
-                        <li class="fd-product-switch__item" tabindex="0">
-                            <i role="presentation" class="fd-product-switch__icon sap-icon--customer-briefing"></i>
-                            <div class="fd-product-switch__text">
-                                <div class="fd-product-switch__title">Customer Data Cloud</div>
-                            </div>
-                        </li>
-                        <li class="fd-product-switch__item" tabindex="0">
-                            <i role="presentation" class="fd-product-switch__icon sap-icon--batch-payments"></i>
-                            <div class="fd-product-switch__text">
-                                <div class="fd-product-switch__title">S/4HANA</div>
-                            </div>
-                        </li>
-                    </ul>
+<div class="fd-shellbar">
+    <div class="fd-shellbar__group fd-shellbar__group--actions">
+        <div class="fd-shellbar__action">
+            <div class="fd-product-switch">
+                <div class="fd-popover fd-popover--right">
+                    <button class="fd-button fd-button--transparent fd-popover__control fd-shellbar__button"
+                        aria-label="Image label"
+                        aria-controls="product-switch-body"
+                        aria-expanded="true"
+                        aria-haspopup="true">
+                        <i class="sap-icon--grid"></i>
+                    </button>
+                    <div class="fd-popover__body fd-popover__body--right" aria-hidden="false" id="product-switch-body">
+                        <div class="fd-product-switch__body">
+                            <ul class="fd-product-switch__list">
+                                <li class="fd-product-switch__item selected" tabindex="0">
+                                    <i role="presentation" class="fd-product-switch__icon sap-icon--home"></i>
+                                    <div class="fd-product-switch__text">
+                                        <div class="fd-product-switch__title">Home</div>
+                                        <div class="fd-product-switch__subtitle">Central Home</div>
+                                    </div>
+                                </li>
+                                <li class="fd-product-switch__item" tabindex="0" selected>
+                                    <i role="presentation" class="fd-product-switch__icon sap-icon--business-objects-experience"></i>
+                                    <div class="fd-product-switch__text">
+                                        <div class="fd-product-switch__title">Analytics Cloud</div>
+                                        <div class="fd-product-switch__subtitle">Analytics Cloud</div>
+                                    </div>
+                                </li>
+                                <li class="fd-product-switch__item" tabindex="0">
+                                    <i role="presentation" class="fd-product-switch__icon sap-icon--contacts"></i>
+                                    <div class="fd-product-switch__text">
+                                        <div class="fd-product-switch__title">Catalog</div>
+                                        <div class="fd-product-switch__subtitle">Ariba</div>
+                                    </div>
+                                </li>
+                                <li class="fd-product-switch__item" tabindex="0">
+                                    <i role="presentation" class="fd-product-switch__icon sap-icon--credit-card"></i>
+                                    <div class="fd-product-switch__text">
+                                        <div class="fd-product-switch__title">Guided Buying</div>
+                                    </div>
+                                </li>
+                                <li class="fd-product-switch__item" tabindex="0">
+                                    <i role="presentation" class="fd-product-switch__icon sap-icon--cart-3"></i>
+                                    <div class="fd-product-switch__text">
+                                        <div class="fd-product-switch__title">Strategic Procurement</div>
+                                    </div>
+                                </li>
+                                <li class="fd-product-switch__item" tabindex="0">
+                                    <i role="presentation" class="fd-product-switch__icon sap-icon--flight"></i>
+                                    <div class="fd-product-switch__text">
+                                        <div class="fd-product-switch__title">Travel & Expense</div>
+                                        <div class="fd-product-switch__subtitle">Concur</div>
+                                    </div>
+                                </li>
+                                <li class="fd-product-switch__item" tabindex="0">
+                                    <i role="presentation" class="fd-product-switch__icon sap-icon--shipping-status"></i>
+                                    <div class="fd-product-switch__text">
+                                        <div class="fd-product-switch__title">Vendor Management</div>
+                                        <div class="fd-product-switch__subtitle">Fieldglass</div>
+                                    </div>
+                                </li>
+                                <li class="fd-product-switch__item" tabindex="0">
+                                    <i role="presentation" class="fd-product-switch__icon sap-icon--customer"></i>
+                                    <div class="fd-product-switch__text">
+                                        <div class="fd-product-switch__title">Human Capital Management</div>
+                                    </div>
+                                </li>
+                                <li class="fd-product-switch__item" tabindex="0">
+                                    <i role="presentation" class="fd-product-switch__icon sap-icon--sales-notification"></i>
+                                    <div class="fd-product-switch__text">
+                                        <div class="fd-product-switch__title">Sales Cloud</div>
+                                        <div class="fd-product-switch__subtitle">Sales Cloud</div>
+                                    </div>
+                                </li>
+                                <li class="fd-product-switch__item" tabindex="0">
+                                    <i role="presentation" class="fd-product-switch__icon sap-icon--retail-store"></i>
+                                    <div class="fd-product-switch__text">
+                                        <div class="fd-product-switch__title">Commerce Cloud</div>
+                                        <div class="fd-product-switch__subtitle">Commerce Cloud</div>
+                                    </div>
+                                </li>
+                                <li class="fd-product-switch__item" tabindex="0">
+                                    <i role="presentation" class="fd-product-switch__icon sap-icon--marketing-campaign"></i>
+                                    <div class="fd-product-switch__text">
+                                        <div class="fd-product-switch__title">Marketing Cloud</div>
+                                        <div class="fd-product-switch__subtitle">Marketing Cloud</div>
+                                    </div>
+                                </li>
+                                <li class="fd-product-switch__item" tabindex="0">
+                                    <i role="presentation" class="fd-product-switch__icon sap-icon--family-care"></i>
+                                    <div class="fd-product-switch__text">
+                                        <div class="fd-product-switch__title">Service Cloud</div>
+                                    </div>
+                                </li>
+                                <li class="fd-product-switch__item" tabindex="0">
+                                    <i role="presentation" class="fd-product-switch__icon sap-icon--customer-briefing"></i>
+                                    <div class="fd-product-switch__text">
+                                        <div class="fd-product-switch__title">Customer Data Cloud</div>
+                                    </div>
+                                </li>
+                                <li class="fd-product-switch__item" tabindex="0">
+                                    <i role="presentation" class="fd-product-switch__icon sap-icon--batch-payments"></i>
+                                    <div class="fd-product-switch__text">
+                                        <div class="fd-product-switch__title">S/4HANA</div>
+                                    </div>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/stories/product-switch/product-switch.stories.js
+++ b/stories/product-switch/product-switch.stories.js
@@ -33,15 +33,13 @@ export const Shellbar = () => `${localStyles}
 <div class="docs-product-switch-shellbar">
     <div class="fd-product-switch">
         <div class="fd-popover fd-popover--right">
-            <div class="fd-popover__control">
-                <button class="fd-button fd-button--transparent fd-popover__control"
-                    aria-label="Image label"
-                    aria-controls="product-switch-body"
-                    aria-expanded="true"
-                    aria-haspopup="true">
-                    <i class="sap-icon--grid"></i>
-                </button>
-            </div>
+            <button class="fd-button fd-button--transparent fd-popover__control"
+                aria-label="Image label"
+                aria-controls="product-switch-body"
+                aria-expanded="true"
+                aria-haspopup="true">
+                <i class="sap-icon--grid"></i>
+            </button>
             <div class="fd-popover__body fd-popover__body--right" aria-hidden="false" id="product-switch-body">
                 <div class="fd-product-switch__body">
                     <ul class="fd-product-switch__list">

--- a/stories/product-switch/product-switch.stories.js
+++ b/stories/product-switch/product-switch.stories.js
@@ -34,7 +34,7 @@ export const Shellbar = () => `${localStyles}
     <div class="fd-product-switch">
         <div class="fd-popover fd-popover--right">
             <div class="fd-popover__control">
-                <button class="fd-button fd-button--transparent fd-popover__control fd-product-switch__control"
+                <button class="fd-button fd-button--transparent fd-popover__control"
                     aria-label="Image label"
                     aria-controls="product-switch-body"
                     aria-expanded="true"

--- a/stories/shellbar/shellbar.stories.js
+++ b/stories/shellbar/shellbar.stories.js
@@ -614,7 +614,7 @@ export const ProductSwitch = () => `<div style="height:600px">
                     <div class="fd-popover fd-popover--right">
                         <div class="fd-popover__control">
                             <button
-                                class="fd-button fd-button--transparent fd-shellbar__button fd-popover__control fd-product-switch__control"
+                                class="fd-button fd-button--transparent fd-shellbar__button fd-popover__control"
                                 aria-label="Image label"
                                 aria-controls="product-switch-body"
                                 aria-expanded="true"

--- a/stories/shellbar/shellbar.stories.js
+++ b/stories/shellbar/shellbar.stories.js
@@ -612,17 +612,15 @@ export const ProductSwitch = () => `<div style="height:600px">
             <div class="fd-shellbar__action fd-shellbar__action--desktop">
                 <div class="fd-product-switch">
                     <div class="fd-popover fd-popover--right">
-                        <div class="fd-popover__control">
-                            <button
-                                class="fd-button fd-button--transparent fd-shellbar__button fd-popover__control"
-                                aria-label="Image label"
-                                aria-controls="product-switch-body"
-                                aria-expanded="true"
-                                aria-haspopup="true"
-                                onclick="onPopoverClick('product-switch-body')">
-                                <i class="sap-icon--grid"></i>
-                            </button>
-                        </div>
+                        <button
+                            class="fd-button fd-button--transparent fd-shellbar__button fd-popover__control"
+                            aria-label="Image label"
+                            aria-controls="product-switch-body"
+                            aria-expanded="true"
+                            aria-haspopup="true"
+                            onclick="onPopoverClick('product-switch-body')">
+                            <i class="sap-icon--grid"></i>
+                        </button>
                         <div class="fd-popover__body fd-popover__body--right" aria-hidden="false"
                              id="product-switch-body">
                             <div class="fd-product-switch__body">


### PR DESCRIPTION
Part of https://github.com/SAP/fundamental-ngx/issues/7984

**Breaking change** removes an old class that is no longer required because the styles are covered by `fd-button--transparent` class.