### PR TITLE
fix(styles): quick view background [ci visual]

### DIFF
--- a/src/styles/quick-view.scss
+++ b/src/styles/quick-view.scss
@@ -30,6 +30,7 @@ $fd-quick-view-group-item-indent: 0.75rem;
     @include fd-reset();
 
     padding: 1rem;
+    background-color: var(--sapGroup_ContentBackground);
 
     .#{$fd-namespace}-bar {
       padding: 0;


### PR DESCRIPTION
part of https://github.com/SAP/fundamental-ngx/issues/7984

Adds a background-color style to quick view so it works in standalone mode for all themes: https://sap.github.io/fundamental-ngx/#/core/quick-view#basic