### PR TITLE
fix(styles): dialog body corner radius in mobile mode

### DIFF
--- a/src/styles/dialog.scss
+++ b/src/styles/dialog.scss
@@ -71,6 +71,10 @@ $button: #{$fd-namespace}-button;
 
     &--mobile {
       @extend %dialog-mobile;
+
+      .#{$block}__body {
+        border-radius: 0;
+      }
     }
 
     &--no-mobile-stretch {


### PR DESCRIPTION
part of https://github.com/SAP/fundamental-ngx/issues/7984

Fixes an issue that became apparent with Horizon when a dialog would have the `--mobile` modifier class which removes border radius but the dialog body's top corners would still have a border radius.

before:
![Screen Shot 2022-05-18 at 3 52 37 PM](https://user-images.githubusercontent.com/2471874/169162397-28dfa1c3-4b9a-4abb-a720-79c528d27a7a.png)

after:
![Screen Shot 2022-05-18 at 3 52 30 PM](https://user-images.githubusercontent.com/2471874/169162409-52242bcb-4d46-44b1-9542-ba76833f352b.png)

