### PR TITLE
fix(styles): micro process flow horizon hc

### DIFF
--- a/src/styles/theming/sap_horizon_hcb.scss
+++ b/src/styles/theming/sap_horizon_hcb.scss
@@ -339,7 +339,7 @@
   --fdTool_Header_Object_Status_Background_Color_Inverted_Informative: var(--sapShell_InformativeColor);
 
   /* Micro Process Flow */
-  --fdMicro_Process_Flow_Icon_Color: var(--sapContent_ContrastIconColor);
+  --fdMicro_Process_Flow_Icon_Color: var(--sapContent_ForegroundColor);
 
   /* Progress Indicator */
   --fdProgress_Indicator_Background_Color_Neutral: var(--sapNeutralElementColor);

--- a/src/styles/theming/sap_horizon_hcw.scss
+++ b/src/styles/theming/sap_horizon_hcw.scss
@@ -338,7 +338,7 @@
   --fdTool_Header_Object_Status_Background_Color_Inverted_Informative: var(--sapShell_InformativeColor);
 
   /* Micro Process Flow */
-  --fdMicro_Process_Flow_Icon_Color: var(--sapContent_ContrastIconColor);
+  --fdMicro_Process_Flow_Icon_Color: var(--sapContent_ForegroundColor);
 
   /* Progress Indicator */
   --fdProgress_Indicator_Background_Color_Neutral: var(--sapNeutralElementColor);


### PR DESCRIPTION
## Related Issue

Part of https://github.com/SAP/fundamental-styles/issues/3327#issuecomment-1128598823

## Description

Micro Process Flow icon colors in Horizon HC themes.

### Before:
<img width="266" alt="image" src="https://user-images.githubusercontent.com/20265336/169298393-1489be51-e962-4536-babe-df60ee84aa5b.png">
<img width="302" alt="image" src="https://user-images.githubusercontent.com/20265336/169298419-40ace919-a179-4430-8205-230f19c86238.png">

### After:

<img width="278" alt="Screenshot 2022-05-19 at 15 54 07" src="https://user-images.githubusercontent.com/20265336/169298120-8a72a7b7-acce-4afe-b0f5-699c26d49c2d.png">
<img width="274" alt="image" src="https://user-images.githubusercontent.com/20265336/169298456-91145e3f-6501-4b75-80e3-f4e242db7d59.png">
