### PR TITLE
fix(styles): vertical navigation focus outlines for horizon [ci visual]

### DIFF
--- a/src/styles/mixins/vertical-nav/_vertical-nav-navigation.scss
+++ b/src/styles/mixins/vertical-nav/_vertical-nav-navigation.scss
@@ -64,6 +64,13 @@ $fd-list-second-level-popover-position: 3.25rem !default;
         overflow: hidden;
 
         .#{$blockList}__navigation-item {
+          @include fd-focus() {
+            &:last-child {
+              border-bottom-left-radius: var(--fdVerticalNav_Border_Corner_Radius);
+              border-bottom-right-radius: var(--fdVerticalNav_Border_Corner_Radius);
+            }
+          }
+
           @include _fd-vertical-nav-selected-color();
 
           width: 100%;
@@ -323,6 +330,7 @@ $fd-list-second-level-popover-position: 3.25rem !default;
             position: absolute;
             display: block;
             border: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
+            border-radius: var(--fdVerticalNav_Border_Corner_Radius);
             top: 0.125rem;
             left: 0.125rem;
             right: 0.125rem;

--- a/src/styles/theming/common/vertical-nav/_sap_fiori.scss
+++ b/src/styles/theming/common/vertical-nav/_sap_fiori.scss
@@ -1,0 +1,4 @@
+:root {
+  --fdVerticalNav_Border_Corner_Radius: 0;
+  --fdVerticalNav_Text_Shadow: none;
+}

--- a/src/styles/theming/common/vertical-nav/_sap_horizon.scss
+++ b/src/styles/theming/common/vertical-nav/_sap_horizon.scss
@@ -1,0 +1,4 @@
+:root {
+  --fdVerticalNav_Border_Corner_Radius: var(--sapElement_BorderCornerRadius);
+  --fdVerticalNav_Text_Shadow: none;
+}

--- a/src/styles/theming/sap_fiori_3.scss
+++ b/src/styles/theming/sap_fiori_3.scss
@@ -20,6 +20,7 @@
 @import "./common/checkbox/sap_foiri";
 @import "./common/radio/sap_fiori";
 @import "./common/link/sap_fiori";
+@import "./common/vertical-nav/sap_fiori";
 
 :root {
   --fdInverted_Object_Border_Width: 0;
@@ -126,9 +127,6 @@
 
   /* TODO: DEPRECATED Side-Nav */
   --fdSideNav_Text_Shadow: none;
-
-  /* Vertical-Nav */
-  --fdVerticalNav_Text_Shadow: none;
 
   /* Time */
   --fdTime_Text_Shadow: none;

--- a/src/styles/theming/sap_fiori_3_dark.scss
+++ b/src/styles/theming/sap_fiori_3_dark.scss
@@ -20,6 +20,7 @@
 @import "./common/checkbox/sap_foiri";
 @import "./common/radio/sap_fiori";
 @import "./common/link/sap_fiori";
+@import "./common/vertical-nav/sap_fiori";
 
 :root {
   --fdInverted_Object_Border_Width: 0;

--- a/src/styles/theming/sap_fiori_3_hcb.scss
+++ b/src/styles/theming/sap_fiori_3_hcb.scss
@@ -27,6 +27,7 @@
 @import "./common/checkbox/sap_fiori_hc";
 @import "./common/radio/sap_fiori_hc";
 @import "./common/link/sap_fiori_hc";
+@import "./common/vertical-nav/sap_fiori";
 
 :root {
   --fdInverted_Object_Border_Width: 0.0625rem;

--- a/src/styles/theming/sap_fiori_3_hcw.scss
+++ b/src/styles/theming/sap_fiori_3_hcw.scss
@@ -21,6 +21,7 @@
 @import "./common/checkbox/sap_fiori_hc";
 @import "./common/radio/sap_fiori_hc";
 @import "./common/link/sap_fiori_hc";
+@import "./common/vertical-nav/sap_fiori";
 
 :root {
   --fdInverted_Object_Border_Width: 0.0625rem;

--- a/src/styles/theming/sap_fiori_3_light_dark.scss
+++ b/src/styles/theming/sap_fiori_3_light_dark.scss
@@ -20,6 +20,7 @@
 @import "./common/checkbox/sap_foiri";
 @import "./common/radio/sap_fiori";
 @import "./common/link/sap_fiori";
+@import "./common/vertical-nav/sap_fiori";
 
 :root {
   --fdInverted_Object_Border_Width: 0;

--- a/src/styles/theming/sap_horizon.scss
+++ b/src/styles/theming/sap_horizon.scss
@@ -20,6 +20,7 @@
 @import "./common/checkbox/sap_horizon";
 @import "./common/radio/sap_horizon";
 @import "./common/link/sap_horizon";
+@import "./common/vertical-nav/sap_horizon";
 
 :root {
   /* Switch */
@@ -165,9 +166,6 @@
 
   /* TODO: DEPRECATED Side-Nav */
   --fdSideNav_Text_Shadow: none;
-
-  /* Vertical-Nav */
-  --fdVerticalNav_Text_Shadow: none;
 
   /* Time */
   --fdTime_Text_Shadow: none;

--- a/src/styles/theming/sap_horizon_dark.scss
+++ b/src/styles/theming/sap_horizon_dark.scss
@@ -20,6 +20,7 @@
 @import "./common/checkbox/sap_horizon";
 @import "./common/radio/sap_horizon";
 @import "./common/link/sap_horizon";
+@import "./common/vertical-nav/sap_horizon";
 
 :root {
   /* Busy indicator */

--- a/src/styles/theming/sap_horizon_hcb.scss
+++ b/src/styles/theming/sap_horizon_hcb.scss
@@ -20,6 +20,7 @@
 @import "./common/checkbox/sap_horizon_hc";
 @import "./common/radio/sap_horizon_hc";
 @import "./common/link/sap_horizon_hc";
+@import "./common/vertical-nav/sap_horizon";
 
 :root {
   /* Switch */

--- a/src/styles/theming/sap_horizon_hcw.scss
+++ b/src/styles/theming/sap_horizon_hcw.scss
@@ -21,6 +21,7 @@
 @import "./common/checkbox/sap_horizon_hc";
 @import "./common/radio/sap_horizon_hc";
 @import "./common/link/sap_horizon_hc";
+@import "./common/vertical-nav/sap_horizon";
 
 :root {
   /* Switch */


### PR DESCRIPTION
part of #3327 

fixes incorrect focus outlines for vertical navigation items. I didn't see anything in the specs about this so I am basing this off of Menu styles

before:
<img width="286" alt="Screen Shot 2022-05-19 at 3 00 15 PM" src="https://user-images.githubusercontent.com/2471874/169414140-22d0eeec-dd7b-4af5-ba0c-3ca9f1363c36.png">
<img width="304" alt="Screen Shot 2022-05-19 at 3 00 18 PM" src="https://user-images.githubusercontent.com/2471874/169414142-b52f5bd1-d920-498c-9b41-3b3a7951d1ff.png">

after:
![Screen Shot 2022-05-19 at 4 21 00 PM](https://user-images.githubusercontent.com/2471874/169414155-6a5ad66a-ad32-44ec-86c8-330e5fb41caf.png)
![Screen Shot 2022-05-19 at 4 21 04 PM](https://user-images.githubusercontent.com/2471874/169414157-960dfc1d-ddaf-4e36-b080-3bcc9b11e36c.png)

