### PR TITLE
fix(styles): input field readonly state fixes and adaptations

### DIFF
--- a/src/styles/mixins/_forms.scss
+++ b/src/styles/mixins/_forms.scss
@@ -190,7 +190,7 @@
     opacity: var(--sapContent_DisabledOpacity);
 
     &::placeholder {
-      color: transparent;
+      color: var(--fdInput_Non_Interactive_State_Placeholder_Color);
     }
   }
 
@@ -202,7 +202,7 @@
     pointer-events: none;
 
     &::placeholder {
-      color: transparent;
+      color: var(--fdInput_Non_Interactive_State_Placeholder_Color);
     }
 
     @include fd-hover() {

--- a/src/styles/mixins/_forms.scss
+++ b/src/styles/mixins/_forms.scss
@@ -199,6 +199,7 @@
     border-radius: var(--fdInput_ReadOnly_Border_Radius);
     background: var(--sapField_ReadOnly_BackgroundStyle);
     background-color: var(--sapField_ReadOnly_Background);
+    pointer-events: none;
 
     &::placeholder {
       color: transparent;

--- a/src/styles/theming/common/input/_sap_fiori.scss
+++ b/src/styles/theming/common/input/_sap_fiori.scss
@@ -14,4 +14,5 @@
   --fdInput_Information_Box_Shadow_Hover: none;
   --fdInput_Information_Outline_Color: var(--sapContent_FocusColor);
   --fdInput_ReadOnly_Border_Radius: var(--sapField_BorderCornerRadius);
+  --fdInput_Non_Interactive_State_Placeholder_Color: transparent;
 }

--- a/src/styles/theming/common/input/_sap_horizon.scss
+++ b/src/styles/theming/common/input/_sap_horizon.scss
@@ -14,4 +14,5 @@
   --fdInput_Information_Box_Shadow_Hover: var(--sapContent_Informative_Shadow);
   --fdInput_Information_Outline_Color: var(--sapField_InformationColor);
   --fdInput_ReadOnly_Border_Radius: 0;
+  --fdInput_Non_Interactive_State_Placeholder_Color: var(--sapField_PlaceholderTextColor);
 }


### PR DESCRIPTION
## Related Issue
part of #3327

## Description
Readonly fields became unfocusable and unactionable with cursor and placeholder colors became visible in Horizon