### PR TITLE
fix(styles): menu focus outline [ci visual]

### DIFF
--- a/src/styles/menu.scss
+++ b/src/styles/menu.scss
@@ -148,6 +148,7 @@ $block: #{$fd-namespace}-menu;
     border-radius: inherit;
     height: 2.75rem;
     padding: 0.75rem 1rem 0.75rem 0.75rem;
+    outline: none;
 
     @include fd-hover() {
       background-color: var(--sapList_Hover_Background);

--- a/src/styles/menu.scss
+++ b/src/styles/menu.scss
@@ -47,6 +47,12 @@ $block: #{$fd-namespace}-menu;
         background-color: var(--sapList_Hover_SelectionBackground);
       }
     }
+
+    @include fd-focus() {
+      &::after {
+        bottom: 0.125rem;
+      }
+    }
   }
 
   // BLOCK BASE *******************************************
@@ -117,12 +123,14 @@ $block: #{$fd-namespace}-menu;
     border-radius: 0;
     background-color: var(--sapList_Background);
 
-    &:first-child {
+    &:first-child,
+    &:first-child .#{$block}__link::after {
       border-top-right-radius: $fd-menu-border-radius;
       border-top-left-radius: $fd-menu-border-radius;
     }
 
-    &:last-child {
+    &:last-child,
+    &:last-child .#{$block}__link::after {
       border-bottom-right-radius: $fd-menu-border-radius;
       border-bottom-left-radius: $fd-menu-border-radius;
     }
@@ -131,7 +139,7 @@ $block: #{$fd-namespace}-menu;
   &__link {
     @include fd-reset();
     @include action-cursor();
-    @include fd-fiori-focus();
+    @include fd-fiori-pseudo-focus();
 
     text-decoration: none;
     display: flex;
@@ -152,6 +160,10 @@ $block: #{$fd-namespace}-menu;
     @include fd-active() {
       color: $fd-menu-item-color-active;
       background-color: var(--sapList_Active_Background);
+
+      &::after {
+        display: none;
+      }
 
       .#{$block}__title {
         color: $fd-menu-item-color-active;


### PR DESCRIPTION
## Related Issue

Part of https://github.com/SAP/fundamental-styles/issues/3327#issuecomment-1133854430

## Description

Menu component link outline fix.

## Screenshots

### Before:
![image](https://user-images.githubusercontent.com/28543391/169688510-8cadf2e6-8782-4e2d-8bd8-5a20ee620479.png)

### After:
<img width="417" alt="image" src="https://user-images.githubusercontent.com/20265336/170003086-b90cbb53-46bd-450d-a532-73bfbd96288e.png">

