### PR TITLE
[WIP] feat(styles): some vertical nav improvements for horizon

### DIFF
--- a/src/styles/mixins/vertical-nav/_vertical-nav-navigation.scss
+++ b/src/styles/mixins/vertical-nav/_vertical-nav-navigation.scss
@@ -2,9 +2,8 @@
 @import '../mixins';
 
 $fd-list-navigation-item-height: 2.75rem !default;
-$fd-list-navigation-item-indicator-height: 1.625rem !default;
-$fd-list-navigation-item-indicator-spacing: 0.3125rem !default;
-$fd-list-navigation-item-text-spacing: 2.5rem !default;
+$fd-list-navigation-item-indicator-spacing: var(--fdVerticalNavigation_Indicator_Spacing) !default;
+$fd-list-navigation-item-text-spacing: var(--fdVerticalNav_Item_Text_Spacing) !default;
 $fd-list-second-level-popover-position: 3.25rem !default;
 
 @mixin fd-vertical-nav-navigation($blockList: #{$fd-namespace}-list) {
@@ -18,8 +17,8 @@ $fd-list-second-level-popover-position: 3.25rem !default;
         display: inline-block;
         position: absolute;
         right: 0;
-        top: ($fd-list-navigation-item-height - $fd-list-navigation-item-indicator-height) * 0.5;
-        height: $fd-list-navigation-item-indicator-height;
+        top: var(--fdVerticalNav_Item_Indicator_Top);
+        height: var(--fdVerticalNav_Item_Indicator_Height);
         background-color: var(--sapSelectedColor);
         color: var(--sapSelectedColor);
         border-radius: var(--sapField_BorderCornerRadius);
@@ -42,6 +41,10 @@ $fd-list-second-level-popover-position: 3.25rem !default;
       @include fd-set-paddings-x(0.5rem, 1rem);
       @include _fd-vertical-nav-selected-color();
 
+      @include fd-focus() {
+        outline-offset: var(--fdVerticalNav_Item_Focus_Outline_Offset);
+      }
+
       background: transparent;
       height: $fd-list-navigation-item-height;
       position: relative;
@@ -52,27 +55,28 @@ $fd-list-second-level-popover-position: 3.25rem !default;
       }
 
       &--expandable {
-        margin: 0.25rem 0;
+        margin: var(--fdVerticalNav_Item_Expandable_Margin);
       }
 
       &.is-expanded {
-        @include fd-set-margins-x(0.25rem, 0.25rem);
+        @include fd-set-margins-x(var(--fdVerticalNav_Item_Expanded_Margin), var(--fdVerticalNav_Item_Expanded_Margin));
 
-        border-radius: var(--sapElement_BorderCornerRadius);
-        box-shadow: var(--sapContent_Shadow0);
+        @include fd-hover() {
+          .#{$blockList} {
+            background-color: var(--sapList_AlternatingBackground);
+          }
+        }
+
+        border-radius: var(--fdVerticalNav_Item_Expanded_Border_Radius);
+        box-shadow: var(--fdVerticalNav_Item_Expanded_Box_Shadow);
         height: 100%;
         overflow: hidden;
+        padding-left: var(--fdVerticalNav_Item_Expanded_Padding_Left);
 
         .#{$blockList}__navigation-item {
-          @include fd-focus() {
-            &:last-child {
-              border-bottom-left-radius: var(--fdVerticalNav_Border_Corner_Radius);
-              border-bottom-right-radius: var(--fdVerticalNav_Border_Corner_Radius);
-            }
-          }
-
           @include _fd-vertical-nav-selected-color();
 
+          border-bottom: none;
           width: 100%;
 
           .#{$blockList}__navigation-item-indicator {
@@ -91,10 +95,13 @@ $fd-list-second-level-popover-position: 3.25rem !default;
             @include fd-reset();
             @include fd-set-margin-left($fd-list-navigation-item-text-spacing);
 
-            vertical-align: middle;
             line-height: $fd-list-navigation-item-height;
-            color: var(--sapContent_LabelColor);
+            color: var(--fdVerticalNav_Item_Child_Text_Color);
             font-size: var(--sapFontSize);
+
+            &--second-level-no-icon {
+              @include fd-set-margin-left(var(--fdVerticalNav_Item_Text_No_Icon_Margin));
+            }
           }
         }
 
@@ -107,7 +114,7 @@ $fd-list-second-level-popover-position: 3.25rem !default;
         }
 
         .#{$blockList} {
-          @include fd-set-margins-x(-0.5rem, -1rem);
+          @include fd-set-margins-x(var(--fdVerticalNav_Expanded_Item_Margin_Left), -1rem);
 
           width: auto;
           display: block;
@@ -185,10 +192,12 @@ $fd-list-second-level-popover-position: 3.25rem !default;
               overflow: hidden;
               display: block;
 
-              .fd-list {
+              .#{$blockList} {
                 width: 100%;
                 display: inline-block;
                 margin: 0 auto;
+                border-top-left-radius: 0;
+                border-top-right-radius: 0;
               }
 
               .#{$blockList}__navigation-item-text {
@@ -218,7 +227,6 @@ $fd-list-second-level-popover-position: 3.25rem !default;
 
               border-top-right-radius: 0;
               border-top-left-radius: 0;
-              top: $fd-list-navigation-item-height;
               width: 11.4rem;
 
               .#{$blockList}__navigation-item {
@@ -255,6 +263,12 @@ $fd-list-second-level-popover-position: 3.25rem !default;
         .#{$blockList}__navigation-item-arrow {
           width: 100%;
 
+          @include fd-focus() {
+            &::after {
+              border-radius: 0;
+            }
+          }
+
           &::before {
             display: inline-block;
             content: '';
@@ -285,7 +299,7 @@ $fd-list-second-level-popover-position: 3.25rem !default;
         height: $fd-list-navigation-item-height;
         line-height: $fd-list-navigation-item-height;
         width: 2.25rem;
-        color: var(--sapContent_NonInteractiveIconColor);
+        color: var(--fdVerticalNav_Icon_Color);
         vertical-align: top;
         text-align: center;
       }
@@ -302,6 +316,7 @@ $fd-list-second-level-popover-position: 3.25rem !default;
         text-overflow: ellipsis;
         display: inline-block;
         line-height: $fd-list-navigation-item-height;
+        vertical-align: middle;
       }
 
       &-arrow {
@@ -310,7 +325,7 @@ $fd-list-second-level-popover-position: 3.25rem !default;
         @include fd-set-position-right(0);
 
         height: $fd-list-navigation-item-height;
-        width: 2.75rem;
+        width: $fd-list-navigation-item-height;
         position: absolute;
         line-height: $fd-list-navigation-item-height;
         font-family: 'SAP-icons';
@@ -362,6 +377,10 @@ $fd-list-second-level-popover-position: 3.25rem !default;
             color: var(--sapContent_ContrastIconColor);
           }
         }
+      }
+
+      &:not(:last-child) {
+        border-bottom: var(--fdVerticalNav_Item_Border_Top_Bottom);
       }
     }
   }

--- a/src/styles/theming/common/vertical-nav/_sap_fiori.scss
+++ b/src/styles/theming/common/vertical-nav/_sap_fiori.scss
@@ -1,4 +1,19 @@
 :root {
-  --fdVerticalNav_Border_Corner_Radius: 0;
   --fdVerticalNav_Text_Shadow: none;
+  --fdVerticalNav_Icon_Color: var(--sapContent_NonInteractiveIconColor);
+  --fdVerticalNav_Item_Expanded_Box_Shadow: var(--sapContent_Shadow0);
+  --fdVerticalNav_Item_Expanded_Border_Radius: var(--sapElement_BorderCornerRadius);
+  --fdVerticalNav_Item_Expanded_Margin: 0.25rem;
+  --fdVerticalNav_Item_Expanded_Padding_Left: 0.5rem;
+  --fdVerticalNavigation_Indicator_Spacing: 0.3125rem;
+  --fdVerticalNav_Item_Expandable_Margin: 0.25rem 0;
+  --fdVerticalNav_Item_Border_Top_Bottom: none;
+  --fdVerticalNav_Expanded_Item_Margin_Left: -0.5rem;
+  --fdVerticalNav_Item_Text_Spacing: 2.5rem;
+  --fdVerticalNav_Item_Focus_Outline_Offset: -0.1875rem;
+  --fdVerticalNav_Indicator_Height: 1.625rem;
+  --fdVerticalNav_Item_Indicator_Top: 0.5625rem;
+  --fdVerticalNav_Item_Indicator_Height: 1.625rem;
+  --fdVerticalNav_Item_Text_No_Icon_Margin: 2.5rem;
+  --fdVerticalNav_Item_Child_Text_Color: var(--sapContent_LabelColor);
 }

--- a/src/styles/theming/common/vertical-nav/_sap_horizon.scss
+++ b/src/styles/theming/common/vertical-nav/_sap_horizon.scss
@@ -1,4 +1,20 @@
 :root {
   --fdVerticalNav_Border_Corner_Radius: var(--sapElement_BorderCornerRadius);
   --fdVerticalNav_Text_Shadow: none;
+  --fdVerticalNav_Icon_Color: var(--sapHighlightColor);
+  --fdVerticalNav_Item_Expanded_Box_Shadow: none;
+  --fdVerticalNav_Item_Expanded_Border_Radius: none;
+  --fdVerticalNav_Item_Expanded_Margin: 0;
+  --fdVerticalNav_Item_Expanded_Padding_Left: 0.75rem;
+  --fdVerticalNavigation_Indicator_Spacing: 0;
+  --fdVerticalNav_Item_Expandable_Margin: 0;
+  --fdVerticalNav_Item_Border_Top_Bottom: var(--sapList_BorderWidth) solid var(--sapList_BorderColor);
+  --fdVerticalNav_Expanded_Item_Margin_Left: -0.75rem;
+  --fdVerticalNav_Item_Text_Spacing: 2.75rem;
+  --fdVerticalNav_Item_Focus_Outline_Offset: -0.3125rem;
+  --fdVerticalNav_Indicator_Height: 2rem;
+  --fdVerticalNav_Item_Indicator_Top: 0;
+  --fdVerticalNav_Item_Indicator_Height: 2.75rem;
+  --fdVerticalNav_Item_Text_No_Icon_Margin: 1rem;
+  --fdVerticalNav_Item_Child_Text_Color: var(--sapList_TextColor);
 }

--- a/src/styles/vertical-nav.scss
+++ b/src/styles/vertical-nav.scss
@@ -22,10 +22,42 @@ $block: #{$fd-namespace}-vertical-nav;
 
   &--condensed {
     width: 3.25rem;
+
+    .#{$block}__utility-section {
+      .#{$fd-namespace}-list__navigation-item-text {
+        display: none;
+      }
+
+      &::before {
+        width: calc(100% - 1rem);
+      }
+    }
   }
 
   &__main-navigation {
+    .#{$fd-namespace}-list__navigation-item, .#{$fd-namespace}-list__navigation-item--condensed {
+      &:first-child {
+        border-top: var(--fdVerticalNav_Item_Border_Top_Bottom);
+      }
+    }
+  }
+
+  &__main-navigation,
+  &__utility-section {
     @include fd-reset();
+  }
+
+  &__utility-section {
+    margin-top: auto;
+
+    &::before {
+      background-color: var(--sapAccentColor6);
+      width: calc(100% - 2rem);
+      height: 0.0625rem;
+      display: block;
+      margin: 0.25rem auto;
+      content: ' ';
+    }
   }
 
   .#{$block}__group-header {

--- a/stories/vertical-navigation/vertical-navigation.stories.js
+++ b/stories/vertical-navigation/vertical-navigation.stories.js
@@ -88,6 +88,95 @@ The default vertical navigation is comprised of several navigation list items.
     }
 };
 
+export const Utility = () => `<div class="fd-vertical-nav" style="height: 450px;">
+    <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu">
+        <ul class="fd-list" aria-label="Main Menu List">
+            <li class="fd-list__navigation-item" tabindex="0">
+                <i role="presentation" class="fd-list__navigation-item-icon sap-icon--home"></i>
+                <span class="fd-list__navigation-item-text">Overview</span>
+            </li>
+            <li class="fd-list__navigation-item fd-list__navigation-item--expandable is-expanded" onclick="toggleVerticalNavSubmenu(event)">
+                <i role="presentation" class="fd-list__navigation-item-icon sap-icon--customer"></i>
+                <span class="fd-list__navigation-item-text">Customers</span>
+                <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded" aria-label="Expand second submenu"></button>
+                <ul class="fd-list">
+                    <li class="fd-list__navigation-item" tabindex="0">
+                        <span class="fd-list__navigation-item-text">Second level item 1</span>
+                    </li>
+                    <li class="fd-list__navigation-item" tabindex="0">
+                        <span class="fd-list__navigation-item-text">Second level item 2</span>
+                    </li>
+                </ul>
+            </li>
+            <li class="fd-list__navigation-item" tabindex="0">
+                <i role="presentation" class="fd-list__navigation-item-icon sap-icon--shipping-status"></i>
+                <span class="fd-list__navigation-item-text">Deliveries</span>
+            </li>
+        </ul>
+    </nav>
+    <nav class="fd-vertical-nav__utility-section" aria-label="Main Menu">
+        <ul class="fd-list" aria-label="Main Menu List">
+            <li class="fd-list__navigation-item" tabindex="0">
+                <i role="presentation" class="fd-list__navigation-item-icon sap-icon--legend"></i>
+                <span class="fd-list__navigation-item-text">Legal Information</span>
+            </li>
+            <li class="fd-list__navigation-item" tabindex="0">
+                <i role="presentation" class="fd-list__navigation-item-icon sap-icon--chain-link"></i>
+                <span class="fd-list__navigation-item-text">Useful Links</span>
+            </li>
+        </ul>
+    </nav>
+</div>
+<br/><br/>
+<div class="fd-vertical-nav fd-vertical-nav--condensed">
+  <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu 2">
+    <ul class="fd-list" aria-label="Main Menu List 2">
+      <li class="fd-list__navigation-item fd-list__navigation-item--condensed" tabindex="0">
+        <i role="presentation" class="fd-list__navigation-item-icon sap-icon--home"></i>
+        <span class="fd-list__navigation-item-text">Overview</span>
+      </li>
+      <li class="fd-list__navigation-item fd-list__navigation-item--condensed" tabindex="0">
+        <i role="presentation" class="fd-list__navigation-item-icon sap-icon--calendar"></i>
+        <span class="fd-list__navigation-item-text">Calendar</span>
+      </li>
+      <li class="fd-list__navigation-item fd-list__navigation-item--condensed" tabindex="0">
+        <i role="presentation" class="fd-list__navigation-item-icon sap-icon--customer"></i>
+        <span class="fd-list__navigation-item-text">Customers</span>
+      </li>
+      <li class="fd-list__navigation-item fd-list__navigation-item--condensed" tabindex="0">
+        <i role="presentation" class="fd-list__navigation-item-icon sap-icon--shipping-status"></i>
+        <span class="fd-list__navigation-item-text">Deliveries</span>
+      </li>
+    </ul>
+  </nav>
+  <nav class="fd-vertical-nav__utility-section" aria-label="Main Menu">
+    <ul class="fd-list" aria-label="Main Menu List">
+        <li class="fd-list__navigation-item" tabindex="0">
+            <i role="presentation" class="fd-list__navigation-item-icon sap-icon--legend"></i>
+            <span class="fd-list__navigation-item-text">Legal Information</span>
+        </li>
+        <li class="fd-list__navigation-item" tabindex="0">
+            <i role="presentation" class="fd-list__navigation-item-icon sap-icon--chain-link"></i>
+            <span class="fd-list__navigation-item-text">Useful Links</span>
+        </li>
+    </ul>
+  </nav>
+</div>
+`;
+
+Utility.storyName = 'Utility Section';
+
+Utility.parameters = {
+    docs: {
+        iframeHeight: 700,
+        description: {
+            story: `
+The vertical navigation can also have a bottom-aligned "Utility" section.
+        `
+        }
+    }
+};
+
 export const Condensed = () => `<div class="fd-vertical-nav fd-vertical-nav--condensed">
     <nav class="fd-vertical-nav__main-navigation" aria-label="Main Menu 2">
         <ul class="fd-list" aria-label="Main Menu List 2">
@@ -134,10 +223,10 @@ export const Text = () => `<div class="fd-vertical-nav">
                 <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded" aria-label="Expand second submenu 3"></button>
                 <ul class="fd-list">
                     <li class="fd-list__navigation-item" tabindex="0">
-                        <span class="fd-list__navigation-item-text">Second level item 1</span>
+                        <span class="fd-list__navigation-item-text fd-list__navigation-item-text--second-level-no-icon">Second level item 1</span>
                     </li>
                     <li class="fd-list__navigation-item" tabindex="0">
-                        <span class="fd-list__navigation-item-text">Second level item 2</span>
+                        <span class="fd-list__navigation-item-text fd-list__navigation-item-text--second-level-no-icon">Second level item 2</span>
                     </li>
                 </ul>
             </li>
@@ -146,10 +235,10 @@ export const Text = () => `<div class="fd-vertical-nav">
                 <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded" aria-label="Expand third submenu 2"></button>
                 <ul class="fd-list">
                     <li class="fd-list__navigation-item" tabindex="0">
-                        <span class="fd-list__navigation-item-text">Second level item 1</span>
+                        <span class="fd-list__navigation-item-text fd-list__navigation-item-text--second-level-no-icon">Second level item 1</span>
                     </li>
                     <li class="fd-list__navigation-item" tabindex="0">
-                        <span class="fd-list__navigation-item-text">Second level item 2</span>
+                        <span class="fd-list__navigation-item-text fd-list__navigation-item-text--second-level-no-icon">Second level item 2</span>
                     </li>
                 </ul>
             </li>
@@ -186,7 +275,7 @@ export const Indication = () => `<div class="fd-vertical-nav">
                 <span class="fd-list__navigation-item-text">Calendar</span>
                 <button class="fd-list__navigation-item-arrow sap-icon--navigation-down-arrow is-expanded" aria-label="Expand second submenu 3"></button>
                 <ul class="fd-list">
-                    <li class="fd-list__navigation-item fd-list__navigation-item--indicated">
+                    <li class="fd-list__navigation-item fd-list__navigation-item--indicated" tabindex="0">
                         <span class="fd-list__navigation-item-text">Second level item 1</span>
                         <span class="fd-list__navigation-item-indicator"></span>
                     </li>
@@ -270,7 +359,7 @@ export const Grouping = () => `<div class="fd-vertical-nav">
                 <span class="fd-list__navigation-item-text">Calendar</span>
                 <button class="fd-list__navigation-item-arrow sap-icon--navigation-right-arrow" aria-label="Expand second submenu 3"></button>
                 <ul class="fd-list">
-                    <li class="fd-list__navigation-item fd-list__navigation-item--indicated">
+                    <li class="fd-list__navigation-item fd-list__navigation-item--indicated" tabindex="0">
                         <span class="fd-list__navigation-item-text">Second level item 1</span>
                         <span class="fd-list__navigation-item-indicator"></span>
                     </li>
@@ -340,7 +429,7 @@ export const GroupingOverflow = () => `<div class="fd-vertical-nav fd-vertical-n
                 <span class="fd-list__navigation-item-text">Calendar</span>
                 <button class="fd-list__navigation-item-arrow sap-icon--navigation-right-arrow" aria-label="Expand second submenu 3"></button>
                 <ul class="fd-list">
-                    <li class="fd-list__navigation-item fd-list__navigation-item--indicated">
+                    <li class="fd-list__navigation-item fd-list__navigation-item--indicated" tabindex="0">
                         <span class="fd-list__navigation-item-text">Second level item 1</span>
                         <span class="fd-list__navigation-item-indicator"></span>
                     </li>


### PR DESCRIPTION
part of #3247 

adds a new class `fd-list__navigation-item-text--second-level-no-icon` which must be used for correct spacing on the "second level" items in the screenshot below
![Screen Shot 2022-05-27 at 4 34 47 PM](https://user-images.githubusercontent.com/2471874/170796862-d1988159-faf9-4bcf-bd74-ef64eb6481e3.png)
