### PR TITLE
fix(styles): menu border radius in dialog and disabled outline

### DIFF
--- a/src/styles/menu.scss
+++ b/src/styles/menu.scss
@@ -3,6 +3,10 @@
 
 $block: #{$fd-namespace}-menu;
 
+.#{$fd-namespace}-dialog__body {
+  --fdButton_Menu_Border_Radius: 0;
+}
+
 .#{$block} {
   // Menu
   $fd-menu-border-radius: var(--fdButton_Menu_Border_Radius) !default;
@@ -184,6 +188,12 @@ $block: #{$fd-namespace}-menu;
     @include fd-disabled() {
       pointer-events: none;
       opacity: var(--sapContent_DisabledOpacity);
+
+      @include fd-focus() {
+        &::after {
+          display: none;
+        }
+      }
     }
 
     &.has-child {


### PR DESCRIPTION
## Related Issue
https://github.com/SAP/fundamental-styles/issues/3495#issuecomment-1144101035

## Description
Fixed border radius in dialog context and removed disabled state focus outline