### PR TITLE
fix(styles): focus border radius on list items in popovers [ci visual]

### DIFF
--- a/src/styles/dialog.scss
+++ b/src/styles/dialog.scss
@@ -17,6 +17,7 @@
 $block: #{$fd-namespace}-dialog;
 $bar: #{$fd-namespace}-bar;
 $button: #{$fd-namespace}-button;
+$menu: #{$fd-namespace}-menu;
 
 .#{$block} {
 
@@ -56,6 +57,13 @@ $button: #{$fd-namespace}-button;
     @include fd-reset();
 
     @extend %dialog-content;
+
+    .#{$menu}__item:first-child,
+    .#{$menu}__item:first-child .#{$menu}__link::after,
+    .#{$menu}__item:last-child,
+    .#{$menu}__item:last-child .#{$menu}__link::after {
+      border-radius: 0;
+    }
 
     @each $size-label, $size in $fd-dialog-content-padding-x {
       &--#{$size-label} {

--- a/src/styles/popover.scss
+++ b/src/styles/popover.scss
@@ -62,24 +62,6 @@ $listBlock: #{$fd-namespace}-list;
   &__wrapper {
     border-radius: $fd-popover-border-radius;
     overflow: auto;
-
-    .#{$listBlock}:first-child {
-      li:first-child {
-        &::before {
-          border-top-left-radius: $fd-popover-border-radius;
-          border-top-right-radius: $fd-popover-border-radius;
-        }
-      }
-    }
-
-    .#{$listBlock}:last-child {
-      li:last-child {
-        &::before {
-          border-bottom-left-radius: $fd-popover-border-radius;
-          border-bottom-right-radius: $fd-popover-border-radius;
-        }
-      }
-    }
   }
 
   &__body {
@@ -97,6 +79,26 @@ $listBlock: #{$fd-namespace}-list;
     top: $fd-popover-top-position;
     transition: all $fd-popover-transition-params;
     transform: translateY(0);
+
+    .#{$listBlock}:first-child {
+      li:first-child,
+      li:first-child a {
+        &::before {
+          border-top-left-radius: $fd-popover-border-radius;
+          border-top-right-radius: $fd-popover-border-radius;
+        }
+      }
+    }
+
+    .#{$listBlock}:last-child {
+      li:last-child,
+      li:last-child a {
+        &::before {
+          border-bottom-left-radius: $fd-popover-border-radius;
+          border-bottom-right-radius: $fd-popover-border-radius;
+        }
+      }
+    }
 
     @include both-pseudo-selectors() {
       content: "";

--- a/src/styles/popover.scss
+++ b/src/styles/popover.scss
@@ -2,6 +2,7 @@
 @import "./mixins";
 
 $block: #{$fd-namespace}-popover;
+$listBlock: #{$fd-namespace}-list;
 
 .#{$block} {
   $fd-popover-top-position: calc(100% + 0.5rem) !default;
@@ -61,6 +62,24 @@ $block: #{$fd-namespace}-popover;
   &__wrapper {
     border-radius: $fd-popover-border-radius;
     overflow: auto;
+
+    .#{$listBlock}:first-child {
+      li:first-child {
+        &::before {
+          border-top-left-radius: $fd-popover-border-radius;
+          border-top-right-radius: $fd-popover-border-radius;
+        }
+      }
+    }
+
+    .#{$listBlock}:last-child {
+      li:last-child {
+        &::before {
+          border-bottom-left-radius: $fd-popover-border-radius;
+          border-bottom-right-radius: $fd-popover-border-radius;
+        }
+      }
+    }
   }
 
   &__body {

--- a/stories/menu/menu.stories.js
+++ b/stories/menu/menu.stories.js
@@ -426,7 +426,7 @@ export const DifferentStates = () => `<div style="width: 50%; display: inline-bl
                 </a>
             </li>
             <li class="fd-menu__item" role="presentation">
-                <a class="fd-menu__link is-disabled" href="#" role="menuitem">
+                <a class="fd-menu__link is-disabled" href="#" role="menuitem" tabindex="-1">
                     <span class="fd-menu__title">Option 6 - Disabled</span>
                 </a>
             </li>


### PR DESCRIPTION
part of #3495 

FIxes an issue with the focus outline on list items in a popover. This does unfortunately break our self-contained style rule, but as discussed we will address in a later refactor

before:
![image](https://user-images.githubusercontent.com/2471874/171678243-cd2345cd-3394-44b4-b110-2c3fd86eafd4.png)

after:
![Screen Shot 2022-06-02 at 10 16 44 AM](https://user-images.githubusercontent.com/2471874/171678265-0f4c4948-ec5d-468b-bade-f3cb6ac08d5a.png)

