### PR TITLE
fix(styles): tree expander button focus outline

### DIFF
--- a/src/styles/tree.scss
+++ b/src/styles/tree.scss
@@ -103,8 +103,16 @@ $fd-tree-item-selected-border-bottom: var(--sapList_BorderWidth) solid var(--sap
 
   &__expander {
     @include fd-reset();
+    @include fd-button-reset();
+
+    @include fd-focus() {
+      outline: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
+      outline-offset: var(--fdButton_Outline_Offset);
+    }
 
     .#{$block}__icon {
+      @include fd-reset();
+
       @include fd-icon-selector() {
         font-size: var(--fdTree_Expander_Icon_Font_Size);
         color: var(--sapButton_IconColor);


### PR DESCRIPTION
part of #3495 

Fixes an outline issue on the tree expander buttons. Previously a `:focus-visible` outline was set by the browser when the buttons were accessed via tab key. This removes that by adding the button reset and adds the correct focus outline 