### PR TITLE
fix(styles): new time line height [ci visual]

### DIFF
--- a/src/styles/time.scss
+++ b/src/styles/time.scss
@@ -147,7 +147,7 @@ $block: #{$fd-namespace}-time;
     width: 100%;
     height: 100%;
     z-index: 2;
-    line-height: $fd-time-item-height;
+    line-height: 2.75rem;
   }
 
   &__list {
@@ -225,7 +225,7 @@ $block: #{$fd-namespace}-time;
     }
 
     .#{$block}__unit {
-      line-height: $fd-time-item-compact-height;
+      line-height: 1.875rem;
     }
   }
 


### PR DESCRIPTION
part of #3495 

The distance between the time text and the top/bottom borders looked slightly off to me and I think this better centers them. Here they are zoomed in 500%, Measure the distance from the top of the digit to the top of the digit to the border and bottom of the digit to the border.
![Screen Shot 2022-06-03 at 10 41 44 AM](https://user-images.githubusercontent.com/2471874/171909293-9a726c0c-2c3e-4111-984e-900fc4b1ab83.png)
![Screen Shot 2022-06-03 at 10 42 02 AM](https://user-images.githubusercontent.com/2471874/171909304-71d5c772-c06c-4b8a-8c8a-253b78066c60.png)

