### PR TITLE
fix(styles): remove overflow: hidden from tool header elements [ci visual]

### DIFF
--- a/src/styles/tool-header.scss
+++ b/src/styles/tool-header.scss
@@ -94,7 +94,6 @@ $fd-tool-header-object-status-semantic-values: (
     }
 
     max-width: 100%;
-    overflow: hidden;
     height: $fd-tool-header-height;
 
     &:not(:last-child) {


### PR DESCRIPTION
part of #3495 

Unsure why these elements have overflow: hidden, we don't have the same for shellbar and removing it doesn't seem to cause any problems. Alternatively we could add some padding but that will affect the whole toolbar. 

before:
![Screen Shot 2022-06-03 at 10 55 23 AM](https://user-images.githubusercontent.com/2471874/171910919-896a144e-b54c-4e37-b6aa-56d330c6c32c.png)

after:
![Screen Shot 2022-06-03 at 10 54 52 AM](https://user-images.githubusercontent.com/2471874/171910949-ec3c17a9-aa5d-48e9-acc9-678b1020b6a9.png)

