### PR TITLE
fix(styles): dialog mobile lists should be in --dialog class [ci visual]

### DIFF
--- a/src/styles/dialog.scss
+++ b/src/styles/dialog.scss
@@ -58,13 +58,6 @@ $menu: #{$fd-namespace}-menu;
 
     @extend %dialog-content;
 
-    .#{$menu}__item:first-child,
-    .#{$menu}__item:first-child .#{$menu}__link::after,
-    .#{$menu}__item:last-child,
-    .#{$menu}__item:last-child .#{$menu}__link::after {
-      border-radius: 0;
-    }
-
     @each $size-label, $size in $fd-dialog-content-padding-x {
       &--#{$size-label} {
         .#{$block}__header.#{$bar},
@@ -81,6 +74,13 @@ $menu: #{$fd-namespace}-menu;
       @extend %dialog-mobile;
 
       .#{$block}__body {
+        border-radius: 0;
+      }
+
+      .#{$menu}__item:first-child,
+      .#{$menu}__item:first-child .#{$menu}__link::after,
+      .#{$menu}__item:last-child,
+      .#{$menu}__item:last-child .#{$menu}__link::after {
         border-radius: 0;
       }
     }

--- a/src/styles/product-switch.scss
+++ b/src/styles/product-switch.scss
@@ -221,6 +221,7 @@ $block: #{$fd-namespace}-product-switch;
     width: 100%;
     max-width: 100vw;
     overflow-x: hidden;
+    border-radius: 0;
 
     .#{$block}__list {
       @include fd-flex(column);

--- a/stories/calendar/calendar.stories.js
+++ b/stories/calendar/calendar.stories.js
@@ -970,7 +970,7 @@ Compact.parameters = {
 };
 
 export const LandscapeMobile = () => `<div class="fd-dialog-docs-static fd-calendar-mobile-docs-static--landscape fd-dialog fd-dialog--active">
-    <div class="fd-dialog__content fd-dialog__content--s">
+    <div class="fd-dialog__content fd-dialog__content--s fd-dialog__content--mobile">
         <div class="fd-dialog__body fd-dialog__body--no-vertical-padding">
             <div class="fd-calendar fd-calendar--mobile-landscape">
                 <header class="fd-calendar__header">
@@ -1157,7 +1157,7 @@ Note: For landscape mode, no dialog header element should be used. However, a di
 };
 
 export const PortraitMobile = () => `<div class="fd-dialog-docs-static fd-calendar-mobile-docs-static--portrait fd-dialog fd-dialog--active">
-    <section class="fd-dialog__content fd-dialog__content--s" style="width: 375px; height: 600px;">
+    <section class="fd-dialog__content fd-dialog__content--s fd-dialog__content--mobile" style="width: 375px; height: 600px;">
         <header class="fd-dialog__header fd-bar fd-bar--header fd-bar--cozy">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">

--- a/stories/combobox-input/combobox-input.stories.js
+++ b/stories/combobox-input/combobox-input.stories.js
@@ -82,13 +82,7 @@ export const CozyAndCompact = () => `<div style="display:flex;justify-content:sp
                             <span class="fd-list__title">Watermelon</span>
                         </li>
                         <li role="option" tabindex="0" class="fd-list__item">
-                            <span class="fd-list__title">Rockmelon</span>
-                        </li>
-                        <li role="option" tabindex="0" class="fd-list__item">
                             <span class="fd-list__title">Honeydew</span>
-                        </li>
-                        <li role="option" tabindex="0" class="fd-list__item">
-                            <span class="fd-list__title">Apple</span>
                         </li>
                     </ul>
                 </div>
@@ -213,13 +207,7 @@ export const AsFormItem = () => `<div style="height:700px">
                             <span class="fd-list__title">Watermelon</span>
                         </li>
                         <li role="option" tabindex="0" class="fd-list__item">
-                            <span class="fd-list__title">Rockmelon</span>
-                        </li>
-                        <li role="option" tabindex="0" class="fd-list__item">
                             <span class="fd-list__title">Honeydew</span>
-                        </li>
-                        <li role="option" tabindex="0" class="fd-list__item">
-                            <span class="fd-list__title">Apple</span>
                         </li>
                     </ul>
                 </div>

--- a/stories/combobox-input/combobox-input.stories.js
+++ b/stories/combobox-input/combobox-input.stories.js
@@ -537,7 +537,7 @@ To add text in the \`body\` of the component, simply include your text in the \`
 
 export const Mobile = () => `<div class="fd-dialog fd-dialog-docs-static fd-select-docs-max-height fd-dialog--active"
 id="select-dialog-example" style="height:600px">
-    <section role="dialog" aria-labelledby="mobileDialogHeader" class="fd-dialog__content">
+    <section role="dialog" aria-labelledby="mobileDialogHeader" class="fd-dialog__content fd-dialog__content--mobile">
         <header class="fd-dialog__header fd-bar fd-bar--header-with-subheader">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
@@ -588,7 +588,7 @@ id="select-dialog-example" style="height:600px">
             <label id="vegMobileHeader" class="fd-list__group-header">
                 <span class="fd-list__title">Vegetables</span>
             </label>
-            <ul aria-labelledby="vegMobileHeader" class="fd-list fd-list--dropdown" role="listbox">
+            <ul aria-labelledby="vegMobileHeader" class="fd-list fd-list--dropdown fd-list--mobile" role="listbox">
                 <li role="option" tabindex="0" class="fd-list__item">
                     <span class="fd-list__title">Tomato</span>
                 </li>

--- a/stories/multi-combo-box/multi-combo-box.stories.js
+++ b/stories/multi-combo-box/multi-combo-box.stories.js
@@ -747,7 +747,7 @@ To add text in the \`body\` of the component, simply include your text in the \`
 };
 
 export const MobileMode = () => `<div class="fd-dialog fd-dialog-docs-static fd-select-docs-max-height fd-dialog--active" id="select-dialog-example">
-    <div class="fd-dialog__content">
+    <div class="fd-dialog__content fd-dialog__content--mobile">
         <header class="fd-dialog__header fd-bar fd-bar--header-with-subheader">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">

--- a/stories/multi-input/multi-input.stories.js
+++ b/stories/multi-input/multi-input.stories.js
@@ -834,7 +834,7 @@ To add text in the \`body\` of the component, simply include your text in the \`
 
 export const MobileMode = () => `<section role="dialog" aria-labelledby="mobileModeMultiInputHeader"
          class="fd-dialog fd-dialog-docs-static fd-select-docs-max-height fd-dialog--active" id="select-dialog-example">
-    <div class="fd-dialog__content">
+    <div class="fd-dialog__content fd-dialog__content--mobile">
         <header class="fd-dialog__header fd-bar fd-bar--header-with-subheader">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">

--- a/stories/select/select.stories.js
+++ b/stories/select/select.stories.js
@@ -161,7 +161,7 @@ When in compact mode, select displays a dropdown menu that can contain long list
 };
 
 export const MobileMode = () => `<div class="fd-dialog fd-dialog-docs-static fd-select-docs-max-height fd-dialog--active" id="select-dialog-example">
-    <div class="fd-dialog__content">
+    <div class="fd-dialog__content fd-dialog__content--mobile">
         <header class="fd-dialog__header fd-bar fd-bar--header-with-subheader">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">

--- a/stories/table/table.stories.js
+++ b/stories/table/table.stories.js
@@ -1098,31 +1098,31 @@ export const AdvancedToolbar = () => `<div class="fd-dialog" id="filter-dialog-e
                     <input aria-label="checkbox" type="checkbox" checked
                         class="fd-checkbox fd-checkbox--compact fd-list__input" id="GGi4ezFD1">
                     <label class="fd-checkbox__label fd-checkbox__label--compact fd-list__label" for="GGi4ezFD1">
-                        <span class="fd-list__title">All</span>
+                        <div class="fd-checkbox__label-container"><span class="fd-checkbox__text">All</span></div>
                     </label>
                 </li>
                 <li class="fd-list__item is-selected" role="option">
                     <input aria-label="checkbox" type="checkbox" checked class="fd-checkbox fd-checkbox--compact fd-list__input" id="GGi4ez641">
                     <label class="fd-checkbox__label fd-checkbox__label--compact fd-list__label" for="GGi4ez641">
-                        <span class="fd-list__title">Name</span>
+                        <div class="fd-checkbox__label-container"><span class="fd-checkbox__text">Name</span></div>
                     </label>
                 </li>
                 <li class="fd-list__item is-selected" role="option">
                     <input aria-label="checkbox" type="checkbox" checked class="fd-checkbox fd-checkbox--compact fd-list__input" id="Ai4FGFG612">
                     <label class="fd-checkbox__label fd-checkbox__label--compact fd-list__label" for="Ai4FGFG612">
-                        <span class="fd-list__title">Status</span>
+                        <div class="fd-checkbox__label-container"><span class="fd-checkbox__text">Status</span></div>
                     </label>
                 </li>
                 <li class="fd-list__item is-selected" role="option">
                     <input aria-label="checkbox" type="checkbox" checked class="fd-checkbox fd-checkbox--compact fd-list__input" id="Ai4e88614">
                     <label class="fd-checkbox__label fd-checkbox__label--compact fd-list__label" for="Ai4e88614">
-                        <span class="fd-list__title">Price</span>
+                        <div class="fd-checkbox__label-container"><span class="fd-checkbox__text">Price</span></div>
                     </label>
                 </li>
                 <li class="fd-list__item is-selected" role="option">
                     <input aria-label="checkbox" type="checkbox" checked class="fd-checkbox fd-checkbox--compact fd-list__input" id="Ai4egh6024">
                     <label class="fd-checkbox__label fd-checkbox__label--compact fd-list__label" for="Ai4egh6024">
-                        <span class="fd-list__title">Country</span>
+                        <div class="fd-checkbox__label-container"><span class="fd-checkbox__text">Country</span></div>
                     </label>
                 </li>
             </ul>


### PR DESCRIPTION
part of #3495 

- Dialog mobile list modifiers were in the wrong place
- Product switch mobile should have 0 border radius
- Also fixes up some docs that should have been using `fd-dialog__content--mobile` modifier
- Issue with checkboxes i found in a dialog on the table docs