### PR TITLE
fix(styles): add fix for double focus in single click area for IconTabBar

### DIFF
--- a/src/styles/icon-tab-bar.scss
+++ b/src/styles/icon-tab-bar.scss
@@ -157,6 +157,16 @@ $fd-icon-tab-bar-semantic-values: (
   }
 }
 
+@mixin fd-tabs-remove-focus-from-tag() {
+  .#{$block}__tag {
+    outline: none;
+
+    &::after {
+      border: none;
+    }
+  }
+}
+
 @mixin fd-set-navigation-tab-colors($color: var(--sapShell_Navigation_Selected_TextColor)) {
   [class*='sap-icon'] {
     color: $color;
@@ -298,13 +308,19 @@ $fd-icon-tab-bar-semantic-values: (
 
         @include fd-focus() {
           .#{$block}__tab-container {
-            position: relative;
+            @include fd-tabs-remove-focus-from-tag();
 
-            @include fd-tabs-focus();
+            @include fd-tabs-focus(var(--sapContent_FocusColor), true) {
+              border-radius: var(--fdIcon_Tab_Bar_Text_Focus_Radius);
+            }
+
+            position: relative;
           }
 
-          .#{$block}__tag {
-            outline: none;
+          .#{$block}__badge {
+            @include fd-set-position-right(-0.4375rem);
+
+            top: -0.125rem;
           }
         }
       }
@@ -752,6 +768,7 @@ $fd-icon-tab-bar-semantic-values: (
     @include fd-icon-tab-bar-set-circle-size(0.375rem);
     @include fd-set-position-right(-1 * ($fd-icon-tab-bar-border-thickness + $fd-icon-tab-bar-icon-spacing));
 
+    z-index: 5;
     top: 0.75rem;
     position: absolute;
     box-sizing: content-box;
@@ -1249,18 +1266,15 @@ $fd-icon-tab-bar-semantic-values: (
       }
 
       @include fd-focus() {
-        .#{$block}__tab-container {
-          position: relative;
-
-          @include fd-tabs-focus(var(--sapShell_Navigation_TextColor), true);
-
-          .#{$block}__tag {
-            outline: none;
-          }
-        }
-
         .#{$block}__tag {
           @include fd-tabs-focus(var(--sapShell_Navigation_TextColor), true);
+        }
+
+        .#{$block}__tab-container {
+          @include fd-tabs-remove-focus-from-tag();
+          @include fd-tabs-focus(var(--sapShell_Navigation_TextColor), true);
+
+          position: relative;
         }
       }
 


### PR DESCRIPTION
## Related Issue
Part of https://github.com/SAP/fundamental-styles/issues/3495

## Description
fixes the issue with the double focus for Universal Icon Tab Bar Single Click Area and the wrong position of the badge on focus

## Screenshots
### Before:

<img width="560" alt="171494104-98f24575-12ac-4fbe-be7e-d98a6058916f" src="https://user-images.githubusercontent.com/39598672/171926067-b5ffa1b5-b463-4d0d-911e-73e9954db3d5.png">
<img width="672" alt="171494099-c062dfa0-5054-41bd-bc9e-b68ac7fc4085" src="https://user-images.githubusercontent.com/39598672/171926069-5b18db94-53ab-49ee-ae7b-df855585fe7b.png">

### After:

<img width="445" alt="Screen Shot 2022-06-03 at 1 40 54 PM" src="https://user-images.githubusercontent.com/39598672/171926117-72ea6011-6e8a-4e42-88f0-f0533878b09e.png">
<img width="745" alt="Screen Shot 2022-06-03 at 2 12 07 PM" src="https://user-images.githubusercontent.com/39598672/171926120-125c7b03-4a70-49ab-9cef-fa08caa9a8c6.png">
<img width="375" alt="Screen Shot 2022-06-03 at 1 40 28 PM" src="https://user-images.githubusercontent.com/39598672/171926123-4e713a72-683d-48d9-99ee-dd160d53238e.png">
