### PR TITLE
fix(styles): icon tab bar separator in horizon

### DIFF
--- a/src/styles/icon-tab-bar.scss
+++ b/src/styles/icon-tab-bar.scss
@@ -375,7 +375,7 @@ $fd-icon-tab-bar-semantic-values: (
         top: 0;
         width: 0.125rem;
         height: 100%;
-        background: var(--sapButton_Hover_BorderColor);
+        background: var(--fdIcon_Tab_Bar_Separator_Color);
 
         @if $is-end {
           @include fd-set-position-right-pseudo($fd-icon-tab-bar-dnd-separator-bar-horizontal-offset);
@@ -392,7 +392,7 @@ $fd-icon-tab-bar-semantic-values: (
         width: $fd-icon-tab-bar-dnd-separator-circle-size;
         height: $fd-icon-tab-bar-dnd-separator-circle-size;
         border-radius: 50%;
-        border: 0.125rem solid var(--sapButton_Hover_BorderColor);
+        border: 0.125rem solid var(--fdIcon_Tab_Bar_Separator_Color);
         background: var(--sapObjectHeader_Background);
 
         @if $is-end {

--- a/src/styles/theming/common/icon-tab-bar/_sap_fiori.scss
+++ b/src/styles/theming/common/icon-tab-bar/_sap_fiori.scss
@@ -30,4 +30,5 @@
   --fdIcon_Tab_Bar_Focus_Offset: -0.0625rem;
   --fdIcon_Tab_Bar_Icon_Border_Weight: 0.0625rem;
   --fdIcon_Tab_Bar_Icon_Focus_Offset: -0.125rem;
+  --fdIcon_Tab_Bar_Separator_Color: var(--sapButton_Hover_BorderColor);
 }

--- a/src/styles/theming/common/icon-tab-bar/_sap_horizon.scss
+++ b/src/styles/theming/common/icon-tab-bar/_sap_horizon.scss
@@ -30,4 +30,5 @@
   --fdIcon_Tab_Bar_Focus_Offset: -0.25rem;
   --fdIcon_Tab_Bar_Icon_Border_Weight: 0.125rem;
   --fdIcon_Tab_Bar_Icon_Focus_Offset: -0.3125rem;
+  --fdIcon_Tab_Bar_Separator_Color: var(--sapContent_Selected_ForegroundColor);
 }


### PR DESCRIPTION
part of #3495 

Assuming a color here as it is not specifically mentioned in the Horizon specs
![Screen Shot 2022-06-03 at 12 55 11 PM](https://user-images.githubusercontent.com/2471874/171930306-b095179a-efed-4547-9ff9-ad17d9f0178f.png)
