### PR TITLE
fix(styles): carousel outline

### DIFF
--- a/src/styles/carousel.scss
+++ b/src/styles/carousel.scss
@@ -11,6 +11,7 @@ $fd-carousel-dot-active-size: 0.5rem !default;
 .#{$block} {
   @include fd-reset();
   @include fd-flex(column);
+  @include fd-fiori-focus(0);
 
   width: 100%;
   min-width: 15.5rem;
@@ -23,10 +24,6 @@ $fd-carousel-dot-active-size: 0.5rem !default;
         display: block;
       }
     }
-  }
-
-  @include fd-focus() {
-    outline: 0.0625rem var(--sapContent_FocusStyle);
   }
 
   .#{$block}__content {


### PR DESCRIPTION
## Related Issue

Part of https://github.com/SAP/fundamental-ngx/issues/7984#issuecomment-1145286641

## Description

Carousel outline fix.

## Screenshots

### Before:

![image](https://user-images.githubusercontent.com/20265336/172055042-2f6b0651-75e6-4c47-adbf-63cfa3ae73d1.png)

### After:

<img width="349" alt="image" src="https://user-images.githubusercontent.com/20265336/172055021-259a597d-513c-4305-931c-b95ffb62347d.png">
