### PR TITLE
fix(styles): list in card focus outline

### DIFF
--- a/src/styles/card.scss
+++ b/src/styles/card.scss
@@ -4,6 +4,7 @@
 $block: #{$fd-namespace}-card;
 $object-status: #{$fd-namespace}-object-status;
 $numeric-content: #{$fd-namespace}-numeric-content;
+$list: #{$fd-namespace}-list;
 
 $fd-card-header-border: var(--fdCard_Header_Border_Bottom) !default;
 $fd-card-border-radius: var(--fdCard_Border_Radius) !default;
@@ -326,6 +327,15 @@ $fd-card-header-outline-offset: 0.0625rem !default;
     &:last-child {
       border-bottom-left-radius: $fd-card-border-radius;
       border-bottom-right-radius: $fd-card-border-radius;
+
+      .#{$list}__item:last-of-type {
+        @include fd-focus() {
+          &::before {
+            border-bottom-left-radius: $fd-card-border-radius;
+            border-bottom-right-radius: $fd-card-border-radius;
+          }
+        }
+      }
     }
 
     &:first-child {


### PR DESCRIPTION
part of #3495 

before:
![Screen Shot 2022-06-06 at 3 20 17 PM](https://user-images.githubusercontent.com/2471874/172252348-5ca43e19-bd8d-4194-8c88-3e8a9715b78e.png)

after:
![Screen Shot 2022-06-06 at 3 23 05 PM](https://user-images.githubusercontent.com/2471874/172252364-33df3b0c-2abe-4b6f-abf1-725fc911d4c0.png)

