### PR TITLE
docs(styles): remove fd-input from links

### DIFF
--- a/stories/avatar-group/avatar-group.stories.js
+++ b/stories/avatar-group/avatar-group.stories.js
@@ -79,15 +79,15 @@ export const IndividualType = () => `<div class="fd-avatar-group fd-avatar-group
                         </div>
                         <div class="fd-form-item">
                             <label class="fd-form-label">Mobile</label>
-                            <a class="fd-link fd-input" href="tel:+89181818181"><span class="fd-link__content">+89181818181</span></a>
+                            <a class="fd-link" href="tel:+89181818181"><span class="fd-link__content">+89181818181</span></a>
                         </div>
                         <div class="fd-form-item">
                             <label class="fd-form-label">Phone</label>
-                            <a class="fd-link fd-input" href="tel:+2828282828"><span class="fd-link__content">+2828282828</span></a>
+                            <a class="fd-link" href="tel:+2828282828"><span class="fd-link__content">+2828282828</span></a>
                         </div>
                         <div class="fd-form-item">
                             <label class="fd-form-label">Email</label>
-                            <a class="fd-link fd-input" href="mailto:blabla@blabla"><span class="fd-link__content">blabla@blabla</span></a>
+                            <a class="fd-link" href="mailto:blabla@blabla"><span class="fd-link__content">blabla@blabla</span></a>
                         </div>
                     </div>
                 </div>
@@ -126,15 +126,15 @@ export const IndividualType = () => `<div class="fd-avatar-group fd-avatar-group
                         </div>
                         <div class="fd-form-item">
                             <label class="fd-form-label">Mobile</label>
-                            <a class="fd-link fd-input" href="tel:+89181818181">+89181818181</a>
+                            <a class="fd-link" href="tel:+89181818181">+89181818181</a>
                         </div>
                         <div class="fd-form-item">
                             <label class="fd-form-label">Phone</label>
-                            <a class="fd-link fd-input" href="tel:+2828282828">+2828282828</a>
+                            <a class="fd-link" href="tel:+2828282828">+2828282828</a>
                         </div>
                         <div class="fd-form-item">
                             <label class="fd-form-label">Email</label>
-                            <a class="fd-link fd-input" href="mailto:blabla@blabla">blabla@blabla</a>
+                            <a class="fd-link" href="mailto:blabla@blabla">blabla@blabla</a>
                         </div>
                     </div>
                 </div>
@@ -170,15 +170,15 @@ export const IndividualType = () => `<div class="fd-avatar-group fd-avatar-group
                         </div>
                         <div class="fd-form-item">
                             <label class="fd-form-label">Mobile</label>
-                            <a class="fd-link fd-input" href="tel:+89181818181">+89181818181</a>
+                            <a class="fd-link" href="tel:+89181818181">+89181818181</a>
                         </div>
                         <div class="fd-form-item">
                             <label class="fd-form-label">Phone</label>
-                            <a class="fd-link fd-input" href="tel:+2828282828">+2828282828</a>
+                            <a class="fd-link" href="tel:+2828282828">+2828282828</a>
                         </div>
                         <div class="fd-form-item">
                             <label class="fd-form-label">Email</label>
-                            <a class="fd-link fd-input" href="mailto:blabla@blabla">blabla@blabla</a>
+                            <a class="fd-link" href="mailto:blabla@blabla">blabla@blabla</a>
                         </div>
                     </div>
                 </div>
@@ -215,15 +215,15 @@ export const IndividualType = () => `<div class="fd-avatar-group fd-avatar-group
                         </div>
                         <div class="fd-form-item">
                             <label class="fd-form-label">Mobile</label>
-                            <a class="fd-link fd-input" href="tel:+89181818181">+89181818181</a>
+                            <a class="fd-link" href="tel:+89181818181">+89181818181</a>
                         </div>
                         <div class="fd-form-item">
                             <label class="fd-form-label">Phone</label>
-                            <a class="fd-link fd-input" href="tel:+2828282828">+2828282828</a>
+                            <a class="fd-link" href="tel:+2828282828">+2828282828</a>
                         </div>
                         <div class="fd-form-item">
                             <label class="fd-form-label">Email</label>
-                            <a class="fd-link fd-input" href="mailto:blabla@blabla">blabla@blabla</a>
+                            <a class="fd-link" href="mailto:blabla@blabla">blabla@blabla</a>
                         </div>
                     </div>
                 </div>

--- a/stories/quick-view/quick-view.stories.js
+++ b/stories/quick-view/quick-view.stories.js
@@ -42,7 +42,7 @@ export const Popover = () => `<div class="fd-popover">
                     </div>
                     <div class="fd-form-item">
                         <label class="fd-form-label">Phone</label>
-                        <a class="fd-link fd-input" href="tel:+1 605 555 5555"><span class="fd-link__content">+1 605 555 5555</span></a>
+                        <a class="fd-link" href="tel:+1 605 555 5555"><span class="fd-link__content">+1 605 555 5555</span></a>
                     </div>
                     <div class="fd-form-item">
                         <label class="fd-form-label">Address</label>
@@ -63,11 +63,11 @@ export const Popover = () => `<div class="fd-popover">
                     </div>
                     <div class="fd-form-item">
                         <label class="fd-form-label">Mobile</label>
-                        <a class="fd-link fd-input" href="tel:+1 605 555 5555"><span class="fd-link__content">+1 605 555 5555</span></a>
+                        <a class="fd-link" href="tel:+1 605 555 5555"><span class="fd-link__content">+1 605 555 5555</span></a>
                     </div>
                     <div class="fd-form-item">
                         <label class="fd-form-label">Mobile</label>
-                        <a class="fd-link fd-input" href="tel:+1 605 555 5555"><span class="fd-link__content">+1 605 555 5555</span></a>
+                        <a class="fd-link" href="tel:+1 605 555 5555"><span class="fd-link__content">+1 605 555 5555</span></a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
part of #3495 

These links also had fd-input classes and those should not be used together. Was looking bad on horizon
before:
![image](https://user-images.githubusercontent.com/2471874/172256806-f4c503c2-395e-481d-bb67-81853063e32b.png)

after:
![Screen Shot 2022-06-06 at 4 03 15 PM](https://user-images.githubusercontent.com/2471874/172256833-d1a6857d-20b2-40d4-9194-439ab1a266d2.png)

