### PR TITLE
fix(styles): safari border radius

### DIFF
--- a/src/styles/dialog.scss
+++ b/src/styles/dialog.scss
@@ -130,6 +130,14 @@ $menu: #{$fd-namespace}-menu;
 
   &__header.#{$bar} {
     position: relative;
+    border-top-left-radius: $fd-dialog-content-border-radius;
+    border-top-right-radius: $fd-dialog-content-border-radius;
+  }
+
+  &__footer.#{$bar} {
+    position: relative;
+    border-bottom-left-radius: $fd-dialog-content-border-radius;
+    border-bottom-right-radius: $fd-dialog-content-border-radius;
   }
 
   &__body {


### PR DESCRIPTION
## Related Issue
Part of https://github.com/SAP/fundamental-ngx/issues/7984#issuecomment-1146817687

## Description
Added border radius for header and footer elements of the dialog component.