### PR TITLE
fix(styles): tabs padding

### DIFF
--- a/src/styles/tabs.scss
+++ b/src/styles/tabs.scss
@@ -188,6 +188,8 @@ $fd-tabs-link-active-line-offset-x: 0.1875rem;
       margin-left: 0;
 
       .#{$block}__link {
+        @include fd-set-margin-left($fd-tabs-link-active-line-offset-x);
+
         padding-left: 0;
       }
     }
@@ -315,6 +317,14 @@ $fd-tabs-link-active-line-offset-x: 0.1875rem;
   &--filter {
     .#{$block}__count {
       font-size: var(--sapFontSmallSize);
+    }
+
+    .#{$block}__item {
+      &:first-child {
+        .#{$block}__link {
+          margin: 0;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Related Issue

Part of https://github.com/SAP/fundamental-ngx/issues/7984#issuecomment-1146819031.

## Description

Tabs paddings fix.

## Screenshots

### Before:
<img width="202" alt="image" src="https://user-images.githubusercontent.com/20265336/172364066-ef7ecf03-915a-4d92-ba3f-b76f1d0c8f00.png">

### After:
<img width="243" alt="image" src="https://user-images.githubusercontent.com/20265336/172393103-006455e2-d782-4016-abf6-59eac8956415.png">