### PR TITLE
fix(styles): form message margin

### DIFF
--- a/src/styles/popover.scss
+++ b/src/styles/popover.scss
@@ -241,6 +241,7 @@ $listBlock: #{$fd-namespace}-list;
     .#{$block}__popper--no-arrow {
       box-shadow: none;
       border: none;
+      margin-top: -0.25rem;
     }
   }
 
@@ -281,6 +282,7 @@ $listBlock: #{$fd-namespace}-list;
     &--input-message-group {
       box-shadow: none;
       border: none;
+      margin-top: -0.25rem !important;
     }
 
     &--compact {


### PR DESCRIPTION
## Related Issue

Closes https://github.com/SAP/fundamental-ngx/issues/8111

## Description

Form Message margin fix.

## Screenshots

### Before:
<img width="438" alt="image" src="https://user-images.githubusercontent.com/20265336/172669927-0fe8a836-f525-468a-a4ab-93c66a9a0fa2.png">

### After:
<img width="444" alt="image" src="https://user-images.githubusercontent.com/20265336/172669862-469b6e72-af5f-47a7-b0da-931263ff8f41.png">