### PR TITLE
fix(styles): popper border radius fix for ngx

### DIFF
--- a/src/styles/popover.scss
+++ b/src/styles/popover.scss
@@ -80,26 +80,6 @@ $listBlock: #{$fd-namespace}-list;
     transition: all $fd-popover-transition-params;
     transform: translateY(0);
 
-    .#{$listBlock}:first-child {
-      li:first-child,
-      li:first-child a {
-        &::before {
-          border-top-left-radius: $fd-popover-border-radius;
-          border-top-right-radius: $fd-popover-border-radius;
-        }
-      }
-    }
-
-    .#{$listBlock}:last-child {
-      li:last-child,
-      li:last-child a {
-        &::before {
-          border-bottom-left-radius: $fd-popover-border-radius;
-          border-bottom-right-radius: $fd-popover-border-radius;
-        }
-      }
-    }
-
     @include both-pseudo-selectors() {
       content: "";
       position: absolute;
@@ -427,6 +407,29 @@ $listBlock: #{$fd-namespace}-list;
 
       &-y--bottom {
         bottom: $fd-popover-arrow-offset;
+      }
+    }
+  }
+
+  &__popper,
+  &__body {
+    .#{$listBlock}:first-child {
+      li:first-child,
+      li:first-child a {
+        &::before {
+          border-top-left-radius: $fd-popover-border-radius;
+          border-top-right-radius: $fd-popover-border-radius;
+        }
+      }
+    }
+
+    .#{$listBlock}:last-child {
+      li:last-child,
+      li:last-child a {
+        &::before {
+          border-bottom-left-radius: $fd-popover-border-radius;
+          border-bottom-right-radius: $fd-popover-border-radius;
+        }
       }
     }
   }


### PR DESCRIPTION
part of #3495 

Because ngx uses the "__popper" modifier instead of "__body", need this border corner radius styles in popper class as well