### PR TITLE
fix(styles): object marker focus state & styles refactoring

### DIFF
--- a/src/styles/object-marker.scss
+++ b/src/styles/object-marker.scss
@@ -6,14 +6,13 @@
 */
 $block: #{$fd-namespace}-object-marker;
 
-.#{$block} {
-  // ICON VARIABLES
-  $fd-object-marker-color: var(--sapContent_MarkerIconColor) !default;
-  $fd-object-marker-text-color: var(--sapContent_LabelColor) !default;
-  $fd-object-marker-color-hover: var(--sapContent_IconColor) !default;
-  $fd-object-marker-padding-left: 0.5rem !default;
-  $fd-object-marker-padding-right: 0.25rem !default;
+$fd-object-marker-color: var(--sapContent_MarkerIconColor) !default;
+$fd-object-marker-text-color: var(--sapContent_LabelColor) !default;
+$fd-object-marker-color-hover: var(--sapContent_IconColor) !default;
+$fd-object-marker-padding-left: 0.5rem !default;
+$fd-object-marker-padding-right: 0.25rem !default;
 
+.#{$block} {
   @include fd-reset();
 
   max-width: 100%;
@@ -22,29 +21,37 @@ $block: #{$fd-namespace}-object-marker;
   display: inline-flex;
   align-items: center;
 
-  // CLICKABLE OBJECT STATUS
   &--link {
-    @include fd-fiori-focus(0.0625rem);
+    @include fd-link();
 
-    cursor: pointer;
     text-decoration: none;
-    color: $fd-object-marker-color;
 
+    &,
     .#{$block}__text {
       color: $fd-object-marker-color;
     }
 
-    &:focus,
-    &:hover,
-    &:visited {
+    @include fd-focus() {
+      .#{$block}__icon,
+      .#{$block}__text {
+        color: var(--fdLink_Text_Focus_Color);
+      }
+
       .#{$block}__text {
         text-decoration: underline;
       }
     }
 
-    &:hover {
+    @include fd-hover() {
       .#{$block}__text {
         color: $fd-object-marker-color-hover;
+        text-decoration: underline;
+      }
+    }
+
+    &:visited {
+      .#{$block}__text {
+        text-decoration: underline;
       }
     }
   }
@@ -52,30 +59,19 @@ $block: #{$fd-namespace}-object-marker;
   &__icon {
     @include fd-icon-element-base() {
       @include fd-flex-center();
+      @include fd-set-padding-right($fd-object-marker-padding-right);
 
       font-size: 1rem;
       line-height: normal;
       color: $fd-object-marker-color;
-      padding-right: $fd-object-marker-padding-right;
 
       @include fd-only-child() {
         padding-right: 0;
         padding-left: 0;
       }
-
-      @include fd-rtl() {
-        padding-left: $fd-object-marker-padding-right;
-        padding-right: 0;
-
-        @include fd-only-child() {
-          padding-right: 0;
-          padding-left: 0;
-        }
-      }
     }
   }
 
-  // OBJECT MARKER TEXT
   &__text {
     @include fd-reset();
     @include fd-ellipsis();
@@ -87,13 +83,7 @@ $block: #{$fd-namespace}-object-marker;
     color: $fd-object-marker-text-color;
   }
 
-  & + .#{$block} {
-    margin-left: $fd-object-marker-padding-left;
-    margin-right: 0;
-
-    @include fd-rtl() {
-      margin-right: $fd-object-marker-padding-left;
-      margin-left: 0;
-    }
+  & + & {
+    @include fd-set-margin-left($fd-object-marker-padding-left);
   }
 }


### PR DESCRIPTION
## Related Issue

Part of https://github.com/SAP/fundamental-styles/issues/3495#issuecomment-1153915782

## Description

Link focus state applied to the Object Marker component. Styles refactored.

## Screenshots

### Before:
<img width="139" alt="image" src="https://user-images.githubusercontent.com/20265336/173586818-303be50e-33a4-4a6b-ba45-d1dd3d39f8c5.png">
<img width="151" alt="image" src="https://user-images.githubusercontent.com/20265336/173586860-58eb2978-e7c6-4a62-8657-807f5ab9accf.png">


### After:
<img width="123" alt="image" src="https://user-images.githubusercontent.com/20265336/173586666-1b703e2e-ba35-4583-ad75-0da77be6884d.png">
<img width="151" alt="image" src="https://user-images.githubusercontent.com/20265336/173586733-01cc3a41-bd19-4f23-a164-05ed9252c48e.png">

