### PR TITLE
feat(docs): move deprecated components to the separate list

### DIFF
--- a/stories/side-navigation/side-navigation.stories.js
+++ b/stories/side-navigation/side-navigation.stories.js
@@ -1,8 +1,13 @@
 export default {
-    title: 'Components/Side Navigation',
+    title: 'Deprecated/Components/Side Navigation',
     parameters: {
         description: `
-**DEPRECATED**. This component will be deprecated in favor of the vertical navigation component. The side navigation area can be used to display navigation structures with up to two levels and contains links that change the content area. The side navigation consists of two container sections: the **main navigation section** (top-aligned) with links used to navigate within the user’s current work context, and the **utility section** (bottom-aligned) that contains links to additional information. Both of these sections use a nested list to display navigation items.
+## DEPRECATED
+
+This component is deprecated in favor of the vertical navigation component.
+The side navigation area can be used to display navigation structures with up to two levels and contains links that change the content area.
+The side navigation consists of two container sections: the **main navigation section** (top-aligned) with links used to navigate within the user’s current work context,
+and the **utility section** (bottom-aligned) that contains links to additional information. Both of these sections use a nested list to display navigation items.
 
 ##Usage
 **Use the side navigation if:**

--- a/stories/tabs/tabs.stories.js
+++ b/stories/tabs/tabs.stories.js
@@ -1,12 +1,11 @@
 export default {
-    title: 'Components/Tabs',
+    title: 'Deprecated/Components/Tabs',
     parameters: {
         tags: ['f3', 'a11y', 'theme'],
         description: `Tabs are based on the folder metaphor and used to separate content into different sections. Tabs should be ordered based on priority to create visual hierarchy.
+## DEPRECATED
 
-## Deprecated
-
-**This component is deprecated. Please use the *Icon Tab Bar* component instead.**
+This component is deprecated. Please use the *Icon Tab Bar* component instead.
 
 ## Usage
 **Use tabs if:**


### PR DESCRIPTION
## Related Issue
 
Closes none.

## Description

Move deprecated components in the separate list in the sidebar.

## Screenshots

### After:

<img width="283" alt="image" src="https://user-images.githubusercontent.com/20265336/173600857-b9b7af39-add8-4d06-b793-00a9965e8a4c.png">
