### PR TITLE
fix(styles): add min-height for input fields

### DIFF
--- a/src/styles/mixins/_forms.scss
+++ b/src/styles/mixins/_forms.scss
@@ -2,9 +2,13 @@
 @import "./mixins";
 @import "./states";
 
+$fd-input-field-height: 2.25rem;
+$fd-input-field-height--compact: 1.625rem;
+
 @mixin fd-input-field-base($hasFocusWithin: false) {
   @include fd-reset();
   @include fd-ellipsis();
+  @include set-min-height($fd-input-field-height);
 
   z-index: 1;
   width: 100%;
@@ -12,7 +16,6 @@
   border-radius: var(--sapField_BorderCornerRadius);
   padding: 0 0.625rem;
   margin: 0.25rem 0;
-  height: 2.25rem;
   box-shadow: none;
   color: var(--sapField_TextColor);
   text-shadow: var(--fdInput_Text_Shadow);
@@ -69,8 +72,9 @@
 }
 
 @mixin fd-input-field-base-compact {
+  @include set-min-height($fd-input-field-height--compact);
+
   min-width: 2rem;
-  height: 1.625rem;
   margin: 0.1875rem 0;
   padding: 0 0.5rem;
   box-sizing: border-box;

--- a/src/styles/mixins/_mixins.scss
+++ b/src/styles/mixins/_mixins.scss
@@ -517,6 +517,11 @@
   max-height: $height;
 }
 
+@mixin set-min-height($height) {
+  height: $height;
+  min-height: $height;
+}
+
 @mixin fd-icon-selector() {
   [class*="sap-icon"],
   &[class*="sap-icon"] {


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#3688

## Description
Created mixin that set both height and min-height for an element and used it in `fd-input-field-base`

- [x] All values are in `rem`