### PR TITLE
fix(styles): list dropdown min-width

### DIFF
--- a/src/styles/mixins/list/_list-dropdown.scss
+++ b/src/styles/mixins/list/_list-dropdown.scss
@@ -1,6 +1,5 @@
 @import "./list-definitions";
 
-$fd-list-dropdown-max-width: 40rem !default;
 $fd-list-dropdown-vertical-padding: 0.75rem !default;
 $fd-list-dropdown-vertical-compact-padding: 0.5rem !default;
 $fd-checkbox-dimensions: 1.375rem !default;
@@ -107,7 +106,7 @@ $fd-checkbox-dimensions: 1.375rem !default;
 
   &--dropdown,
   &--multi-input {
-    @mixin list-width-limit($maxWidth: $fd-list-dropdown-max-width) {
+    @mixin list-width-limit($maxWidth) {
       max-width: $maxWidth;
 
       .#{$block}__title {
@@ -129,7 +128,7 @@ $fd-checkbox-dimensions: 1.375rem !default;
     }
 
     display: block;
-    min-width: 7rem;
+    min-width: 5rem;
 
     .#{$block}__item {
       cursor: pointer;
@@ -145,6 +144,7 @@ $fd-checkbox-dimensions: 1.375rem !default;
       font-size: $fd-list-normal-font-size;
       white-space: normal;
       flex: auto;
+      width: auto;
 
       &--no-wrap {
         white-space: nowrap;
@@ -152,15 +152,10 @@ $fd-checkbox-dimensions: 1.375rem !default;
     }
 
     .#{$block}__secondary {
-      width: auto;
       display: block;
     }
 
-    .#{$block}__title {
-      width: auto;
-    }
-
-    @include list-width-limit($fd-list-dropdown-max-width);
+    @include list-width-limit(40rem);
 
     .#{$block}__icon {
       line-height: 1rem;


### PR DESCRIPTION
## Related Issue

dxp.

## Description

Min width of the select and other components that could have dropdown with list is 5rem accordingly to the wiki.

## Screenshots

### Before:
<img width="163" alt="image" src="https://user-images.githubusercontent.com/20265336/178527307-f035391e-051f-4051-a366-2c35d67f15a3.png">


### After:
<img width="162" alt="image" src="https://user-images.githubusercontent.com/20265336/178527170-aa3be272-677d-4298-b67d-13bdd6e8d423.png">
