### PR TITLE
fix(styles): fix vertical alignment of icon in alert

### DIFF
--- a/src/styles/alert.scss
+++ b/src/styles/alert.scss
@@ -21,6 +21,7 @@ $block: #{$fd-namespace}-alert;
     width: 2.5rem;
     top: 0.4375rem;
     left: 0;
+    line-height: 1rem;
   }
 
   @mixin fd-alert-close-btn-container {


### PR DESCRIPTION
part of https://github.com/SAP/fundamental-ngx/issues/8342

before:
<img width="248" alt="Screen Shot 2022-07-12 at 11 21 38 AM" src="https://user-images.githubusercontent.com/2471874/178554181-5a044f07-a171-4c85-be3a-d2e90ca32d8a.png">

after:
<img width="279" alt="Screen Shot 2022-07-12 at 11 16 31 AM" src="https://user-images.githubusercontent.com/2471874/178554035-ffcb9cdf-ee91-4303-9304-815d760013b4.png">

