### PR TITLE
fix(styles): compact state for form controls

### DIFF
--- a/src/styles/input-group.scss
+++ b/src/styles/input-group.scss
@@ -12,7 +12,7 @@ $fd-input-padding: 0.625rem;
 $fd-input-border-radius: var(--sapField_BorderCornerRadius);
 
 .#{$block} {
-  @include fd-input-field-base();
+  @include fd-input-field-base(false, false);
   @include fd-input-field-states();
   @include fd-input-group-button-overwrite();
 

--- a/src/styles/mixins/_forms.scss
+++ b/src/styles/mixins/_forms.scss
@@ -5,10 +5,13 @@
 $fd-input-field-height: 2.25rem;
 $fd-input-field-height--compact: 1.625rem;
 
-@mixin fd-input-field-base($hasFocusWithin: false) {
+@mixin fd-input-field-base($hasFocusWithin: false, $withMinHeight: true) {
   @include fd-reset();
   @include fd-ellipsis();
-  @include set-min-height($fd-input-field-height);
+
+  @if $withMinHeight {
+    @include set-min-height($fd-input-field-height);
+  }
 
   z-index: 1;
   width: 100%;

--- a/src/styles/select.scss
+++ b/src/styles/select.scss
@@ -136,6 +136,7 @@ $fd-select-padding-x-compact: 0.5rem;
   &--compact {
     .#{$block}__control {
       height: $fd-form-input-height--compact;
+      min-height: $fd-form-input-height--compact;
 
       .#{$block}__text-content {
         @include fd-set-padding-left($fd-select-padding-x-compact);

--- a/src/styles/step-input.scss
+++ b/src/styles/step-input.scss
@@ -90,6 +90,7 @@ $block: #{$fd-namespace}-step-input;
 
   &--compact {
     height: $fd-step-input-compact-height;
+    min-height: $fd-step-input-compact-height;
 
     /** Width is different due to different border width  */
     &.is-information,


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/3723

## Description
Added correct element size for compact state for:
* Select
* Step Input
* input Group

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
<img width="1032" alt="image" src="https://user-images.githubusercontent.com/6586561/179457274-f9796803-d9ca-4940-9b0a-e920023e178d.png">
<img width="701" alt="image" src="https://user-images.githubusercontent.com/6586561/179457368-2f76f201-5e45-4166-ab77-6136204b73ea.png">
<img width="287" alt="image" src="https://user-images.githubusercontent.com/6586561/179457484-e8dec6ef-1285-4e51-b207-39fbee72d51b.png">


### After:
<img width="1042" alt="image" src="https://user-images.githubusercontent.com/6586561/179457331-b058ea16-2c98-4815-a84b-4e72351d065f.png">
<img width="697" alt="image" src="https://user-images.githubusercontent.com/6586561/179457414-c9d610af-5484-47a4-a497-a7f105c633ec.png">
<img width="314" alt="image" src="https://user-images.githubusercontent.com/6586561/179457506-25100cb3-b07a-48df-81fe-54261690be09.png">

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
