### PR TITLE
fix(styles): fd-emty was used instead fd-only-child

### DIFF
--- a/src/styles/object-status.scss
+++ b/src/styles/object-status.scss
@@ -382,7 +382,7 @@ $inverted-color-accents: (
         font-size: $fd-object-status-icon-text-font-size-large-inverted;
 
         // ICON ONLY MODE
-        @include fd-empty() {
+        @include fd-only-child() {
           height: $fd-object-status-min-height-large-inverted-empty;
           min-width: $fd-object-status-min-width-large-inverted-empty;
           padding: $fd-object-status-padding-large-inverted-empty;


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#3724 
Closes SAP/fundamental-ngx#8431

## Description
For object status large size, `fd-only-child` should be used instead `fd-empty`.