### PR TITLE
fix(styles): byline list thumbnail issue in safari

### DIFF
--- a/src/styles/mixins/list/_list-byline.scss
+++ b/src/styles/mixins/list/_list-byline.scss
@@ -44,6 +44,10 @@ $fd-list-byline-section-text-color: var(--sapContent_LabelColor) !default;
       border-radius: 0.25rem;
       font-size: 2.5rem;
       color: var(--sapContent_NonInteractiveIconColor);
+
+      > svg {
+        height: 100%;
+      }
     }
 
     .#{$block}__content {


### PR DESCRIPTION
## Related Issue

Refers to dxp/backlog/643

## Description

Displaying SVG in byline list thumbnail fixed (Safari).

## Screenshots

### Before:
<img width="114" alt="Screenshot 2022-08-02 at 15 59 55" src="https://user-images.githubusercontent.com/20265336/182396959-12b62966-afe3-454d-8d12-bf926ddbacb8.png">

### After:
<img width="122" alt="Screenshot 2022-08-02 at 15 59 46" src="https://user-images.githubusercontent.com/20265336/182396945-8a4f8da2-c65d-4a0d-b670-6d8b55a83569.png">