### PR TITLE
fix(styles): form grid margins & paddings issues

### DIFF
--- a/src/styles/form-group.scss
+++ b/src/styles/form-group.scss
@@ -2,7 +2,7 @@
 @import "./mixins";
 
 /*!
-.fd-form-group
+  .fd-form-group(--inline)
 */
 
 $block: #{$fd-namespace}-form-group;
@@ -11,10 +11,10 @@ $block: #{$fd-namespace}-form-group;
   @include fd-reset();
 
   &--inline {
-    @include fd-flex() {
-      justify-content: flex-start;
-      flex-wrap: wrap;
-    }
+    @include fd-flex();
+
+    justify-content: flex-start;
+    flex-wrap: wrap;
   }
 
   &__header {

--- a/src/styles/form-group.scss
+++ b/src/styles/form-group.scss
@@ -11,10 +11,10 @@ $block: #{$fd-namespace}-form-group;
   @include fd-reset();
 
   &--inline {
-    @include fd-flex();
-
-    justify-content: flex-start;
-    flex-wrap: wrap;
+    @include fd-flex() {
+      justify-content: flex-start;
+      flex-wrap: wrap;
+    }
   }
 
   &__header {

--- a/src/styles/form-group.scss
+++ b/src/styles/form-group.scss
@@ -10,19 +10,11 @@ $block: #{$fd-namespace}-form-group;
 .#{$block} {
   @include fd-reset();
 
-  &:last-child {
-    margin-bottom: 0;
-  }
-
   &--inline {
     @include fd-flex() {
       justify-content: flex-start;
       flex-wrap: wrap;
     }
-  }
-
-  &__item {
-    @include fd-reset();
   }
 
   &__header {

--- a/src/styles/form-item.scss
+++ b/src/styles/form-item.scss
@@ -2,7 +2,7 @@
 @import "./mixins";
 
 /*!
-.fd-form-item+(--inline)
+  .fd-form-item(--horizontal)
 */
 $block: #{$fd-namespace}-form-item;
 

--- a/src/styles/form-layout-grid.scss
+++ b/src/styles/form-layout-grid.scss
@@ -89,10 +89,6 @@ $groupGutter: 1rem;
 
         white-space: initial;
       }
-
-      &__form-group {
-        padding: $groupGutter;
-      }
     }
 
     .#{$gridRow}__form-item {
@@ -121,10 +117,6 @@ $groupGutter: 1rem;
 
       .#{$gridCol} {
         padding: 0 $gutter;
-
-        &__form-group {
-          padding: $groupGutter;
-        }
       }
     }
   }

--- a/src/styles/form-layout-grid.scss
+++ b/src/styles/form-layout-grid.scss
@@ -104,8 +104,10 @@ $groupGutter: 1rem;
 @media (min-width: 0) {
   @include fd-form-col-paddings('fd-col');
 
-  .#{$gridRow} {
-    margin-bottom: 0.625rem;
+  .#{$gridContainer}.#{$blockContainer} {
+    .#{$gridRow} {
+      margin-bottom: 0.625rem;
+    }
   }
 }
 

--- a/src/styles/form-layout-grid.scss
+++ b/src/styles/form-layout-grid.scss
@@ -45,19 +45,16 @@ $groupGutter: 1rem;
       }
     }
   }
-
-  .#{$gridContainer}.#{$blockContainer}--vertical .#{$gridRow}:not(:first-child) {
-    .#{$colSelector},
-    .#{$colSelector}--12 {
-      .#{$fd-namespace}-form-label {
-        margin-top: 0.625rem;
-      }
-    }
-  }
 }
 
 .#{$gridContainer}.#{$blockContainer} {
   padding: $groupGutter;
+
+  &--vertical {
+    .#{$gridRow}:not(:first-child) {
+      margin-top: 0.625rem;
+    }
+  }
 
   .#{$gridRow} {
     align-items: center;
@@ -65,14 +62,6 @@ $groupGutter: 1rem;
 
     &--top {
       align-items: start;
-    }
-
-    &:first-child {
-      margin-top: 0;
-    }
-
-    &:last-child {
-      margin-bottom: 0;
     }
 
     .#{$gridCol} {
@@ -114,6 +103,10 @@ $groupGutter: 1rem;
 
 @media (min-width: 0) {
   @include fd-form-col-paddings('fd-col');
+
+  .#{$gridRow} {
+    margin-bottom: 0.625rem;
+  }
 }
 
 @media (min-width: 600px) {
@@ -121,7 +114,7 @@ $groupGutter: 1rem;
     padding: $groupGutter;
 
     .#{$gridRow} {
-      margin: 0 -#{$gutter} 0.625rem;
+      margin: 0 -#{$gutter};
       min-width: calc(100% + #{$gutter} * 2);
 
       .#{$gridCol} {

--- a/src/styles/form-layout-grid.scss
+++ b/src/styles/form-layout-grid.scss
@@ -1,22 +1,38 @@
 @import "./mixins";
-@import "./layout-grid.scss";
+@import "./layout-grid";
 
 $block: #{$fd-namespace}-form-layout-grid;
-$blockContainer: #{$block}-container;
+
+$formContainer: #{$block}-container;
+$formGroup: #{$fd-namespace}-form-group;
+$formItem: #{$fd-namespace}-form-item;
 
 $gridContainer: #{$fd-namespace}-container;
 $gridRow: #{$fd-namespace}-row;
 $gridCol: #{$fd-namespace}-col;
 
-$cols: 12;
-$gutter: 0.25rem;
-$groupGutter: 1rem;
+@mixin fd-form-vertical($marginTop: 0.625rem) {
+  &.#{$formGroup},
+  .#{$formGroup} {
+    .#{$formItem} {
+      margin-top: $marginTop;
+
+      &:first-of-type {
+        margin-top: 0;
+      }
+    }
+  }
+}
 
 @mixin fd-form-col-paddings($colSelector) {
-  .#{$gridContainer}.#{$blockContainer} .#{$gridRow} {
+  $cols: 12;
+
+  .#{$gridContainer}.#{$formContainer} .#{$gridRow} {
     @for $col from 1 through $cols - 1 {
       .#{$colSelector}--#{$col} {
-        .#{$fd-namespace}-form-label {
+        @include fd-form-vertical();
+
+        > .#{$fd-namespace}-form-label {
           float: right;
           text-align: right;
           padding-bottom: 0;
@@ -32,7 +48,7 @@ $groupGutter: 1rem;
 
     .#{$colSelector},
     .#{$colSelector}--12 {
-      .#{$fd-namespace}-form-label {
+      > .#{$fd-namespace}-form-label {
         float: left;
         text-align: left;
         width: auto;
@@ -47,69 +63,61 @@ $groupGutter: 1rem;
   }
 }
 
-.#{$gridContainer}.#{$blockContainer} {
-  padding: $groupGutter;
-
-  &--vertical {
-    .#{$gridRow}:not(:first-child) {
-      margin-top: 0.625rem;
-    }
+.#{$gridContainer}.#{$formContainer} {
+  &,
+  &.#{$formContainer}--vertical {
+    @include fd-form-vertical();
   }
 
-  .#{$gridRow} {
-    align-items: center;
-    margin-bottom: 0.625rem;
+  &.#{$formGroup},
+  .#{$formGroup} {
+    padding: 1rem !important;
 
-    &--top {
-      align-items: start;
-    }
-
-    .#{$gridCol} {
-      padding-top: 0;
-      padding-bottom: 0;
-
-      @include fd-ellipsis();
+    .#{$formItem} {
+      &--compact {
+        .#{$fd-namespace}-select__control {
+          margin-bottom: 0.1875rem;
+        }
+      }
 
       .#{$fd-namespace}-select__control {
         margin: 0.25rem 0;
       }
 
-      &--compact {
-        .#{$fd-namespace}-select__control {
-          margin: 0.1875rem 0 0.25rem 0;
-        }
-      }
-
       .#{$fd-namespace}-form-label {
         @include fd-set-margin-right(0);
+
+        white-space: initial;
 
         &--required {
           @include fd-set-padding-right(0.5rem);
         }
-
-        white-space: initial;
       }
     }
+  }
 
-    .#{$gridRow}__form-item {
-      flex-direction: row;
+  .#{$gridRow} {
+    .#{$gridCol} {
+      @include fd-ellipsis();
+
+      padding-top: 0;
+      padding-bottom: 0;
+      align-self: center;
     }
   }
 }
 
 @media (min-width: 0) {
   @include fd-form-col-paddings('fd-col');
-
-  .#{$gridContainer}.#{$blockContainer} {
-    .#{$gridRow} {
-      margin-bottom: 0.625rem;
-    }
-  }
 }
 
 @media (min-width: 600px) {
-  .#{$gridContainer}.#{$blockContainer} {
-    padding: $groupGutter;
+  .#{$gridContainer}.#{$formContainer} {
+    $gutter: 0.25rem;
+
+    padding: 0 $gutter;
+
+    @include fd-form-vertical(0);
 
     .#{$gridRow} {
       margin: 0 -#{$gutter};

--- a/stories/checkbox/__snapshots__/checkbox.stories.storyshot
+++ b/stories/checkbox/__snapshots__/checkbox.stories.storyshot
@@ -304,7 +304,7 @@ exports[`Storyshots Components/Forms/Checkbox Inline 1`] = `
       
         
       <div
-        class="fd-form-group__item fd-form-item"
+        class="fd-form-item"
       >
         
             
@@ -343,7 +343,7 @@ exports[`Storyshots Components/Forms/Checkbox Inline 1`] = `
       
         
       <div
-        class="fd-form-group__item fd-form-item"
+        class="fd-form-item"
       >
         
             
@@ -383,7 +383,7 @@ exports[`Storyshots Components/Forms/Checkbox Inline 1`] = `
       
         
       <div
-        class="fd-form-group__item fd-form-item"
+        class="fd-form-item"
       >
         
             

--- a/stories/checkbox/checkbox.stories.js
+++ b/stories/checkbox/checkbox.stories.js
@@ -201,7 +201,7 @@ Mobile.parameters = {
 export const Inline = () => `<fieldset class="fd-fieldset">
     <legend class="fd-fieldset__legend">Inline checkboxes</legend>
     <div class="fd-form-group fd-form-group--inline">
-        <div class="fd-form-group__item fd-form-item">
+        <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez617">
             <label class="fd-checkbox__label" for="Ai4ez617">
                 <div class="fd-checkbox__label-container">
@@ -209,7 +209,7 @@ export const Inline = () => `<fieldset class="fd-fieldset">
                 </div>
             </label>
         </div>
-        <div class="fd-form-group__item fd-form-item">
+        <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez618" checked>
             <label class="fd-checkbox__label" for="Ai4ez618">
                 <div class="fd-checkbox__label-container">
@@ -217,7 +217,7 @@ export const Inline = () => `<fieldset class="fd-fieldset">
                 </div>
             </label>
         </div>
-        <div class="fd-form-group__item fd-form-item">
+        <div class="fd-form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez619" disabled checked>
             <label class="fd-checkbox__label" for="Ai4ez619">
                 <div class="fd-checkbox__label-container">

--- a/stories/dialog/__snapshots__/dialog.stories.storyshot
+++ b/stories/dialog/__snapshots__/dialog.stories.storyshot
@@ -354,12 +354,12 @@ exports[`Storyshots Components/Dialog Horizontal Form 1`] = `
         
             
         <div
-          class="fd-container fd-form-layout-grid-container"
+          class="fd-container fd-form-layout-grid-container fd-form-group"
         >
           
                 
           <div
-            class="fd-row"
+            class="fd-row fd-form-item"
           >
             
                     
@@ -400,7 +400,7 @@ exports[`Storyshots Components/Dialog Horizontal Form 1`] = `
           
                 
           <div
-            class="fd-row"
+            class="fd-row fd-form-item"
           >
             
                     
@@ -476,7 +476,7 @@ exports[`Storyshots Components/Dialog Horizontal Form 1`] = `
 
                 
           <div
-            class="fd-row"
+            class="fd-row fd-form-item"
           >
             
                     
@@ -552,7 +552,7 @@ exports[`Storyshots Components/Dialog Horizontal Form 1`] = `
 
                 
           <div
-            class="fd-row"
+            class="fd-row fd-form-item"
           >
             
                     
@@ -593,7 +593,7 @@ exports[`Storyshots Components/Dialog Horizontal Form 1`] = `
 
                 
           <div
-            class="fd-row"
+            class="fd-row fd-form-item"
           >
             
                     
@@ -1910,8 +1910,6 @@ exports[`Storyshots Components/Dialog Vertical Form 1`] = `
 <div
   dir="ltr"
 >
-  
-
   <section
     class="fd-dialog-docs-static fd-dialog fd-dialog--active"
   >
@@ -1965,12 +1963,12 @@ exports[`Storyshots Components/Dialog Vertical Form 1`] = `
         
             
         <div
-          class="fd-container fd-form-layout-grid-container fd-form-layout-grid-container--vertical"
+          class="fd-container fd-form-layout-grid-container fd-form-layout-grid-container--vertical fd-form-group"
         >
           
                 
           <div
-            class="fd-row"
+            class="fd-row fd-form-item"
           >
             
                     
@@ -2011,7 +2009,7 @@ exports[`Storyshots Components/Dialog Vertical Form 1`] = `
           
                 
           <div
-            class="fd-row"
+            class="fd-row fd-form-item"
           >
             
                     
@@ -2087,7 +2085,7 @@ exports[`Storyshots Components/Dialog Vertical Form 1`] = `
 
                 
           <div
-            class="fd-row"
+            class="fd-row fd-form-item"
           >
             
                     
@@ -2163,7 +2161,7 @@ exports[`Storyshots Components/Dialog Vertical Form 1`] = `
 
                 
           <div
-            class="fd-row"
+            class="fd-row fd-form-item"
           >
             
                     
@@ -2204,7 +2202,7 @@ exports[`Storyshots Components/Dialog Vertical Form 1`] = `
 
                 
           <div
-            class="fd-row"
+            class="fd-row fd-form-item"
           >
             
                     

--- a/stories/dialog/dialog.stories.js
+++ b/stories/dialog/dialog.stories.js
@@ -497,8 +497,8 @@ export const HorizontalFormInDialog = () => `
             </div>
         </header>
         <div class="fd-dialog__body">
-            <div class="fd-container fd-form-layout-grid-container">
-                <div class="fd-row">
+            <div class="fd-container fd-form-layout-grid-container fd-form-group">
+                <div class="fd-row fd-form-item">
                     <div class="fd-col fd-col-md--2 fd-col-lg--4">
                         <label class="fd-form-label" for="input-222-name">Name:</label>
                     </div>
@@ -506,7 +506,7 @@ export const HorizontalFormInDialog = () => `
                         <input class="fd-input" type="text" id="input-222-name" placeholder="Enter First and Last Name" value="Amelia Perry">
                     </div>
                 </div>
-                <div class="fd-row">
+                <div class="fd-row fd-form-item">
                     <div class="fd-col fd-col-md--2 fd-col-lg--4">
                         <label class="fd-form-label fd-form-label--required" for="input-233-street">Street/No.: </label>
                     </div>
@@ -522,7 +522,7 @@ export const HorizontalFormInDialog = () => `
                     </div>
                 </div>
 
-                <div class="fd-row">
+                <div class="fd-row fd-form-item">
                     <div class="fd-col fd-col-md--2  fd-col-lg--4">
                         <label class="fd-form-label fd-form-label--required" for="input-233-zip">ZIP Code/City: </label>
                     </div>
@@ -538,7 +538,7 @@ export const HorizontalFormInDialog = () => `
                     </div>
                 </div>
 
-                <div class="fd-row">
+                <div class="fd-row fd-form-item">
                     <div class="fd-col fd-col-md--2 fd-col-lg--4">
                         <label class="fd-form-label for="text-243-name">Bio: </label>
                     </div>
@@ -547,7 +547,7 @@ export const HorizontalFormInDialog = () => `
                     </div>
                 </div>
 
-                <div class="fd-row">
+                <div class="fd-row fd-form-item">
                     <div class="fd-col fd-col-md--2  fd-col-lg--4">
                         <label class="fd-form-label" for="input-2-country">Country:</label>
                     </div>
@@ -592,8 +592,7 @@ HorizontalFormInDialog.parameters = {
 };
 
 
-export const VerticalFormInDialog = () => `
-<section class="fd-dialog-docs-static fd-dialog fd-dialog--active">
+export const VerticalFormInDialog = () => `<section class="fd-dialog-docs-static fd-dialog fd-dialog--active">
     <div class="fd-dialog__content fd-dialog__content--s" role="dialog" aria-modal="true" aria-labelledby="dialog-title-2">
         <header class="fd-dialog__header fd-bar fd-bar--header">
             <div class="fd-bar__left">
@@ -605,8 +604,8 @@ export const VerticalFormInDialog = () => `
             </div>
         </header>
         <div class="fd-dialog__body">
-            <div class="fd-container fd-form-layout-grid-container fd-form-layout-grid-container--vertical">
-                <div class="fd-row">
+            <div class="fd-container fd-form-layout-grid-container fd-form-layout-grid-container--vertical fd-form-group">
+                <div class="fd-row fd-form-item">
                     <div class="fd-col">
                         <label class="fd-form-label" for="input-2224-name">Name:</label>
                     </div>
@@ -614,7 +613,7 @@ export const VerticalFormInDialog = () => `
                         <input class="fd-input" type="text" id="input-2224-name" placeholder="Enter First and Last Name" value="Amelia Perry">
                     </div>
                 </div>
-                <div class="fd-row">
+                <div class="fd-row fd-form-item">
                     <div class="fd-col">
                         <label class="fd-form-label fd-form-label--required" for="input-2334-street">Street/No.: </label>
                     </div>
@@ -630,7 +629,7 @@ export const VerticalFormInDialog = () => `
                     </div>
                 </div>
 
-                <div class="fd-row">
+                <div class="fd-row fd-form-item">
                     <div class="fd-col">
                         <label class="fd-form-label fd-form-label--required" for="input-2334-zip">ZIP Code/City: </label>
                     </div>
@@ -646,7 +645,7 @@ export const VerticalFormInDialog = () => `
                     </div>
                 </div>
 
-                <div class="fd-row">
+                <div class="fd-row fd-form-item">
                     <div class="fd-col">
                         <label class="fd-form-label for="text-2434-name">Bio: </label>
                     </div>
@@ -655,7 +654,7 @@ export const VerticalFormInDialog = () => `
                     </div>
                 </div>
 
-                <div class="fd-row">
+                <div class="fd-row fd-form-item">
                     <div class="fd-col">
                         <label class="fd-form-label" for="input-2-country">Country:</label>
                     </div>

--- a/stories/form-fieldset/__snapshots__/form-fieldset.stories.storyshot
+++ b/stories/form-fieldset/__snapshots__/form-fieldset.stories.storyshot
@@ -274,7 +274,7 @@ exports[`Storyshots Components/Forms/Field Set Checkbox Groups 1`] = `
       
             
       <div
-        class="fd-form-group__item fd-form-item"
+        class="fd-form-item"
       >
         
                 
@@ -307,7 +307,7 @@ exports[`Storyshots Components/Forms/Field Set Checkbox Groups 1`] = `
       
             
       <div
-        class="fd-form-group__item fd-form-item"
+        class="fd-form-item"
       >
         
                 
@@ -340,7 +340,7 @@ exports[`Storyshots Components/Forms/Field Set Checkbox Groups 1`] = `
       
             
       <div
-        class="fd-form-group__item fd-form-item"
+        class="fd-form-item"
       >
         
                 

--- a/stories/form-fieldset/form-fieldset.stories.js
+++ b/stories/form-fieldset/form-fieldset.stories.js
@@ -72,7 +72,7 @@ export const CheckboxGroups = () => `
     <fieldset class="fd-fieldset">
         <legend class="fd-fieldset__legend">Checkboxes inline</legend>
         <div class="fd-form-group fd-form-group--inline">
-            <div class="fd-form-group__item fd-form-item">
+            <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox" id="Ai4ez617">
                 <label class="fd-checkbox__label" for="Ai4ez617">
                     <span class="fd-checkbox__text">
@@ -80,7 +80,7 @@ export const CheckboxGroups = () => `
                     </span>
                 </label>
             </div>
-            <div class="fd-form-group__item fd-form-item">
+            <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox" id="Ai4ez618">
                 <label class="fd-checkbox__label" for="Ai4ez618">
                     <span class="fd-checkbox__text">
@@ -88,7 +88,7 @@ export const CheckboxGroups = () => `
                     </span>
                 </label>
             </div>
-            <div class="fd-form-group__item fd-form-item">
+            <div class="fd-form-item">
                 <input type="checkbox" class="fd-checkbox" id="Ai4ez619">
                 <label class="fd-checkbox__label" for="Ai4ez619">
                     <span class="fd-checkbox__text">

--- a/stories/form-grid/__snapshots__/form-grid.stories.storyshot
+++ b/stories/form-grid/__snapshots__/form-grid.stories.storyshot
@@ -10,7 +10,7 @@ exports[`Storyshots Components/Forms/Form Grid Column Not Recommended 1`] = `
   
 
   <div
-    class="fd-container fd-form-layout-grid-container"
+    class="fd-container fd-form-layout-grid-container fd-form-group"
   >
     
   
@@ -20,7 +20,7 @@ exports[`Storyshots Components/Forms/Form Grid Column Not Recommended 1`] = `
       
     
       <div
-        class="fd-col fd-col-lg--6 fd-col-xl--4 fd-col--wrap"
+        class="fd-col fd-col-lg--6 fd-col-xl--4 fd-col--wrap fd-form-item"
       >
         
       
@@ -70,7 +70,7 @@ exports[`Storyshots Components/Forms/Form Grid Column Not Recommended 1`] = `
 
     
       <div
-        class="fd-col fd-col-lg--6 fd-col-xl--4 fd-col--wrap"
+        class="fd-col fd-col-lg--6 fd-col-xl--4 fd-col--wrap fd-form-item"
       >
         
       
@@ -120,7 +120,7 @@ exports[`Storyshots Components/Forms/Form Grid Column Not Recommended 1`] = `
 
     
       <div
-        class="fd-col fd-col-lg--6 fd-col-xl--4 fd-col--wrap"
+        class="fd-col fd-col-lg--6 fd-col-xl--4 fd-col--wrap fd-form-item"
       >
         
       
@@ -182,12 +182,12 @@ exports[`Storyshots Components/Forms/Form Grid Compact form 1`] = `
   dir="ltr"
 >
   <div
-    class="fd-container fd-form-layout-grid-container"
+    class="fd-container fd-form-layout-grid-container fd-form-group"
   >
     
     
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
         
@@ -227,7 +227,7 @@ exports[`Storyshots Components/Forms/Form Grid Compact form 1`] = `
     
     
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
         
@@ -268,7 +268,7 @@ exports[`Storyshots Components/Forms/Form Grid Compact form 1`] = `
     
     <div
       aria-labelledby="groupLabel-compact"
-      class="fd-row"
+      class="fd-row fd-form-item"
       role="group"
     >
       
@@ -353,13 +353,13 @@ exports[`Storyshots Components/Forms/Form Grid Default [L] 1`] = `
   dir="ltr"
 >
   <div
-    class="fd-container fd-form-layout-grid-container"
+    class="fd-container fd-form-layout-grid-container fd-form-group"
     style="max-width:1440px"
   >
     
   
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
     
@@ -401,7 +401,7 @@ exports[`Storyshots Components/Forms/Form Grid Default [L] 1`] = `
 
   
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
     
@@ -477,7 +477,7 @@ exports[`Storyshots Components/Forms/Form Grid Default [L] 1`] = `
 
   
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
     
@@ -553,7 +553,7 @@ exports[`Storyshots Components/Forms/Form Grid Default [L] 1`] = `
 
   
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
     
@@ -654,13 +654,13 @@ exports[`Storyshots Components/Forms/Form Grid Default [M] 1`] = `
   dir="ltr"
 >
   <div
-    class="fd-container fd-form-layout-grid-container"
+    class="fd-container fd-form-layout-grid-container fd-form-group"
     style="max-width:1024px"
   >
     
   
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
     
@@ -702,7 +702,7 @@ exports[`Storyshots Components/Forms/Form Grid Default [M] 1`] = `
 
   
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
     
@@ -778,7 +778,7 @@ exports[`Storyshots Components/Forms/Form Grid Default [M] 1`] = `
 
   
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
     
@@ -854,7 +854,7 @@ exports[`Storyshots Components/Forms/Form Grid Default [M] 1`] = `
 
   
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
     
@@ -955,12 +955,12 @@ exports[`Storyshots Components/Forms/Form Grid Default [XL] 1`] = `
   dir="ltr"
 >
   <div
-    class="fd-container fd-form-layout-grid-container"
+    class="fd-container fd-form-layout-grid-container fd-form-group"
   >
     
   
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
     
@@ -1002,7 +1002,7 @@ exports[`Storyshots Components/Forms/Form Grid Default [XL] 1`] = `
 
   
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
     
@@ -1078,7 +1078,7 @@ exports[`Storyshots Components/Forms/Form Grid Default [XL] 1`] = `
 
   
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
     
@@ -1154,7 +1154,7 @@ exports[`Storyshots Components/Forms/Form Grid Default [XL] 1`] = `
 
   
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
     
@@ -1265,12 +1265,12 @@ exports[`Storyshots Components/Forms/Form Grid Double form [XL] 1`] = `
       
     
       <div
-        class="fd-col fd-col-xl--6 fd-col--wrap"
+        class="fd-col fd-col-xl--6 fd-col--wrap fd-form-group"
       >
         
       
         <div
-          class="fd-row"
+          class="fd-row fd-form-item"
         >
           
         
@@ -1312,7 +1312,7 @@ exports[`Storyshots Components/Forms/Form Grid Double form [XL] 1`] = `
 
       
         <div
-          class="fd-row"
+          class="fd-row fd-form-item"
         >
           
         
@@ -1388,7 +1388,7 @@ exports[`Storyshots Components/Forms/Form Grid Double form [XL] 1`] = `
 
       
         <div
-          class="fd-row"
+          class="fd-row fd-form-item"
         >
           
         
@@ -1464,7 +1464,7 @@ exports[`Storyshots Components/Forms/Form Grid Double form [XL] 1`] = `
 
       
         <div
-          class="fd-row"
+          class="fd-row fd-form-item"
         >
           
         
@@ -1557,12 +1557,12 @@ exports[`Storyshots Components/Forms/Form Grid Double form [XL] 1`] = `
       
     
       <div
-        class="fd-col fd-col-xl--6 fd-col--wrap"
+        class="fd-col fd-col-xl--6 fd-col--wrap fd-form-group"
       >
         
       
         <div
-          class="fd-row"
+          class="fd-row fd-form-item"
         >
           
         
@@ -1604,7 +1604,7 @@ exports[`Storyshots Components/Forms/Form Grid Double form [XL] 1`] = `
 
       
         <div
-          class="fd-row"
+          class="fd-row fd-form-item"
         >
           
         
@@ -1680,7 +1680,7 @@ exports[`Storyshots Components/Forms/Form Grid Double form [XL] 1`] = `
 
       
         <div
-          class="fd-row"
+          class="fd-row fd-form-item"
         >
           
         
@@ -1756,7 +1756,7 @@ exports[`Storyshots Components/Forms/Form Grid Double form [XL] 1`] = `
 
       
         <div
-          class="fd-row"
+          class="fd-row fd-form-item"
         >
           
         
@@ -1862,13 +1862,13 @@ exports[`Storyshots Components/Forms/Form Grid Full screen [M] 1`] = `
   dir="ltr"
 >
   <div
-    class="fd-container fd-form-layout-grid-container"
+    class="fd-container fd-form-layout-grid-container fd-form-group"
     style="max-width:1024px"
   >
     
   
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
     
@@ -1910,7 +1910,7 @@ exports[`Storyshots Components/Forms/Form Grid Full screen [M] 1`] = `
 
   
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
     
@@ -1986,7 +1986,7 @@ exports[`Storyshots Components/Forms/Form Grid Full screen [M] 1`] = `
 
   
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
     
@@ -2062,7 +2062,7 @@ exports[`Storyshots Components/Forms/Form Grid Full screen [M] 1`] = `
 
   
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
     
@@ -2168,7 +2168,7 @@ exports[`Storyshots Components/Forms/Form Grid Layout variations 1`] = `
   
 
   <div
-    class="fd-container fd-form-layout-grid-container"
+    class="fd-container fd-form-layout-grid-container fd-form-group"
   >
     
   
@@ -2178,7 +2178,7 @@ exports[`Storyshots Components/Forms/Form Grid Layout variations 1`] = `
       
     
       <div
-        class="fd-col fd-col-xl--4 fd-col--wrap"
+        class="fd-col fd-col-xl--4 fd-col--wrap fd-form-item"
       >
         
       
@@ -2228,7 +2228,7 @@ exports[`Storyshots Components/Forms/Form Grid Layout variations 1`] = `
 
     
       <div
-        class="fd-col fd-col-xl--4 fd-col--wrap"
+        class="fd-col fd-col-xl--4 fd-col--wrap fd-form-item"
       >
         
       
@@ -2278,7 +2278,7 @@ exports[`Storyshots Components/Forms/Form Grid Layout variations 1`] = `
 
     
       <div
-        class="fd-col fd-col-xl--4 fd-col--wrap"
+        class="fd-col fd-col-xl--4 fd-col--wrap fd-form-item"
       >
         
       
@@ -2339,7 +2339,7 @@ exports[`Storyshots Components/Forms/Form Grid Layout variations 1`] = `
   
 
   <div
-    class="fd-container fd-form-layout-grid-container"
+    class="fd-container fd-form-layout-grid-container fd-form-group"
   >
     
   
@@ -2349,7 +2349,7 @@ exports[`Storyshots Components/Forms/Form Grid Layout variations 1`] = `
       
     
       <div
-        class="fd-col fd-col--wrap"
+        class="fd-col fd-col--wrap fd-form-item"
       >
         
       
@@ -2399,7 +2399,7 @@ exports[`Storyshots Components/Forms/Form Grid Layout variations 1`] = `
 
     
       <div
-        class="fd-col fd-col--wrap"
+        class="fd-col fd-col--wrap fd-form-item"
       >
         
       
@@ -2461,13 +2461,13 @@ exports[`Storyshots Components/Forms/Form Grid Long label [M] 1`] = `
   dir="ltr"
 >
   <div
-    class="fd-container fd-form-layout-grid-container"
+    class="fd-container fd-form-layout-grid-container fd-form-group"
     style="max-width:1024px"
   >
     
   
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
     
@@ -2509,7 +2509,7 @@ exports[`Storyshots Components/Forms/Form Grid Long label [M] 1`] = `
 
   
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
     
@@ -2585,7 +2585,7 @@ exports[`Storyshots Components/Forms/Form Grid Long label [M] 1`] = `
 
   
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
     
@@ -2661,7 +2661,7 @@ exports[`Storyshots Components/Forms/Form Grid Long label [M] 1`] = `
 
   
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
     
@@ -2773,12 +2773,12 @@ exports[`Storyshots Components/Forms/Form Grid Multiple form [L] 1`] = `
       
     
       <div
-        class="fd-col fd-col-lg--6 fd-col--wrap"
+        class="fd-col fd-col-lg--6 fd-col--wrap fd-form-group"
       >
         
       
         <div
-          class="fd-row"
+          class="fd-row fd-form-item"
         >
           
         
@@ -2819,7 +2819,7 @@ exports[`Storyshots Components/Forms/Form Grid Multiple form [L] 1`] = `
         
       
         <div
-          class="fd-row"
+          class="fd-row fd-form-item"
         >
           
         
@@ -2895,7 +2895,7 @@ exports[`Storyshots Components/Forms/Form Grid Multiple form [L] 1`] = `
 
       
         <div
-          class="fd-row"
+          class="fd-row fd-form-item"
         >
           
         
@@ -2971,7 +2971,7 @@ exports[`Storyshots Components/Forms/Form Grid Multiple form [L] 1`] = `
 
       
         <div
-          class="fd-row"
+          class="fd-row fd-form-item"
         >
           
         
@@ -3065,12 +3065,12 @@ exports[`Storyshots Components/Forms/Form Grid Multiple form [L] 1`] = `
 
     
       <div
-        class="fd-col fd-col-lg--6 fd-col--wrap"
+        class="fd-col fd-col-lg--6 fd-col--wrap fd-form-group"
       >
         
       
         <div
-          class="fd-row"
+          class="fd-row fd-form-item"
         >
           
         
@@ -3111,7 +3111,7 @@ exports[`Storyshots Components/Forms/Form Grid Multiple form [L] 1`] = `
         
       
         <div
-          class="fd-row"
+          class="fd-row fd-form-item"
         >
           
         
@@ -3187,7 +3187,7 @@ exports[`Storyshots Components/Forms/Form Grid Multiple form [L] 1`] = `
 
       
         <div
-          class="fd-row"
+          class="fd-row fd-form-item"
         >
           
         
@@ -3263,7 +3263,7 @@ exports[`Storyshots Components/Forms/Form Grid Multiple form [L] 1`] = `
 
       
         <div
-          class="fd-row"
+          class="fd-row fd-form-item"
         >
           
         
@@ -3374,19 +3374,19 @@ exports[`Storyshots Components/Forms/Form Grid Multiple form [XL] 1`] = `
     
   
     <div
-      class="fd-row fd-row--top"
+      class="fd-row"
     >
       
     
       <div
-        class="fd-col fd-col-xl--4 fd-col--wrap"
+        class="fd-col fd-col-xl--4 fd-col--wrap fd-form-group"
       >
         
 
 
       
         <div
-          class="fd-row"
+          class="fd-row fd-form-item"
         >
           
         
@@ -3462,7 +3462,7 @@ exports[`Storyshots Components/Forms/Form Grid Multiple form [XL] 1`] = `
 
       
         <div
-          class="fd-row"
+          class="fd-row fd-form-item"
         >
           
         
@@ -3538,7 +3538,7 @@ exports[`Storyshots Components/Forms/Form Grid Multiple form [XL] 1`] = `
 
       
         <div
-          class="fd-row"
+          class="fd-row fd-form-item"
         >
           
         
@@ -3631,12 +3631,12 @@ exports[`Storyshots Components/Forms/Form Grid Multiple form [XL] 1`] = `
       
     
       <div
-        class="fd-col fd-col-xl--4 fd-col--wrap"
+        class="fd-col fd-col-xl--4 fd-col--wrap fd-form-group"
       >
         
       
         <div
-          class="fd-row"
+          class="fd-row fd-form-item"
         >
           
         
@@ -3678,7 +3678,7 @@ exports[`Storyshots Components/Forms/Form Grid Multiple form [XL] 1`] = `
 
       
         <div
-          class="fd-row"
+          class="fd-row fd-form-item"
         >
           
         
@@ -3754,7 +3754,7 @@ exports[`Storyshots Components/Forms/Form Grid Multiple form [XL] 1`] = `
 
       
         <div
-          class="fd-row"
+          class="fd-row fd-form-item"
         >
           
         
@@ -3830,7 +3830,7 @@ exports[`Storyshots Components/Forms/Form Grid Multiple form [XL] 1`] = `
 
       
         <div
-          class="fd-row"
+          class="fd-row fd-form-item"
         >
           
         
@@ -3925,12 +3925,12 @@ exports[`Storyshots Components/Forms/Form Grid Multiple form [XL] 1`] = `
 
     
       <div
-        class="fd-col fd-col-xl--4 fd-col--wrap"
+        class="fd-col fd-col-xl--4 fd-col--wrap fd-form-group"
       >
         
     
         <div
-          class="fd-row"
+          class="fd-row fd-form-item"
         >
           
       
@@ -3972,7 +3972,7 @@ exports[`Storyshots Components/Forms/Form Grid Multiple form [XL] 1`] = `
 
     
         <div
-          class="fd-row"
+          class="fd-row fd-form-item"
         >
           
       
@@ -4048,7 +4048,7 @@ exports[`Storyshots Components/Forms/Form Grid Multiple form [XL] 1`] = `
 
     
         <div
-          class="fd-row"
+          class="fd-row fd-form-item"
         >
           
       
@@ -4124,7 +4124,7 @@ exports[`Storyshots Components/Forms/Form Grid Multiple form [XL] 1`] = `
 
     
         <div
-          class="fd-row"
+          class="fd-row fd-form-item"
         >
           
       
@@ -4237,7 +4237,7 @@ exports[`Storyshots Components/Forms/Form Grid Recommended layouts 1`] = `
   
 
   <div
-    class="fd-container fd-form-layout-grid-container"
+    class="fd-container fd-form-layout-grid-container fd-form-group"
   >
     
   
@@ -4247,7 +4247,7 @@ exports[`Storyshots Components/Forms/Form Grid Recommended layouts 1`] = `
       
     
       <div
-        class="fd-col fd-col-md--6  fd-col-lg--6 fd-col-xl--6 fd-col--wrap"
+        class="fd-col fd-col-md--6 fd-col-lg--6 fd-col-xl--6 fd-col--wrap fd-form-item"
       >
         
       
@@ -4297,7 +4297,7 @@ exports[`Storyshots Components/Forms/Form Grid Recommended layouts 1`] = `
 
     
       <div
-        class="fd-col fd-col-md--6 fd-col-lg--6 fd-col-xl--6 fd-col--wrap"
+        class="fd-col fd-col-md--6 fd-col-lg--6 fd-col-xl--6 fd-col--wrap fd-form-item"
       >
         
       
@@ -4358,7 +4358,7 @@ exports[`Storyshots Components/Forms/Form Grid Recommended layouts 1`] = `
   
 
   <div
-    class="fd-container fd-form-layout-grid-container"
+    class="fd-container fd-form-layout-grid-container fd-form-group"
   >
     
   
@@ -4368,7 +4368,7 @@ exports[`Storyshots Components/Forms/Form Grid Recommended layouts 1`] = `
       
     
       <div
-        class="fd-col fd-col-md--12 fd-col-lg--6 fd-col-xl--6 fd-col--wrap"
+        class="fd-col fd-col-md--12 fd-col-lg--6 fd-col-xl--6 fd-col--wrap fd-form-item"
       >
         
       
@@ -4418,7 +4418,7 @@ exports[`Storyshots Components/Forms/Form Grid Recommended layouts 1`] = `
 
     
       <div
-        class="fd-col fd-col-md--12 fd-col-lg--6 fd-col-xl--6 fd-col--wrap"
+        class="fd-col fd-col-md--12 fd-col-lg--6 fd-col-xl--6 fd-col--wrap  fd-form-item"
       >
         
       
@@ -4479,7 +4479,7 @@ exports[`Storyshots Components/Forms/Form Grid Recommended layouts 1`] = `
   
 
   <div
-    class="fd-container fd-form-layout-grid-container"
+    class="fd-container fd-form-layout-grid-container fd-form-group"
   >
     
   
@@ -4489,7 +4489,7 @@ exports[`Storyshots Components/Forms/Form Grid Recommended layouts 1`] = `
       
     
       <div
-        class="fd-col fd-col-md--12 fd-col-xl--6 fd-col--wrap"
+        class="fd-col fd-col-md--12 fd-col-xl--6 fd-col--wrap fd-form-item"
       >
         
       
@@ -4539,7 +4539,7 @@ exports[`Storyshots Components/Forms/Form Grid Recommended layouts 1`] = `
 
     
       <div
-        class="fd-col fd-col-md--12 fd-col-xl--6 fd-col--wrap"
+        class="fd-col fd-col-md--12 fd-col-xl--6 fd-col--wrap fd-form-item"
       >
         
       
@@ -4601,13 +4601,13 @@ exports[`Storyshots Components/Forms/Form Grid Single form [L] 1`] = `
   dir="ltr"
 >
   <div
-    class="fd-container fd-form-layout-grid-container"
+    class="fd-container fd-form-layout-grid-container fd-form-group"
     style="max-width:1440px"
   >
     
   
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
     
@@ -4649,7 +4649,7 @@ exports[`Storyshots Components/Forms/Form Grid Single form [L] 1`] = `
 
   
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
     
@@ -4725,7 +4725,7 @@ exports[`Storyshots Components/Forms/Form Grid Single form [L] 1`] = `
 
   
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
     
@@ -4801,7 +4801,7 @@ exports[`Storyshots Components/Forms/Form Grid Single form [L] 1`] = `
 
   
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
     
@@ -4901,12 +4901,12 @@ exports[`Storyshots Components/Forms/Form Grid Single form [XL] 1`] = `
   dir="ltr"
 >
   <div
-    class="fd-container fd-form-layout-grid-container"
+    class="fd-container fd-form-layout-grid-container fd-form-group"
   >
     
   
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
     
@@ -4948,7 +4948,7 @@ exports[`Storyshots Components/Forms/Form Grid Single form [XL] 1`] = `
 
   
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
     
@@ -5024,7 +5024,7 @@ exports[`Storyshots Components/Forms/Form Grid Single form [XL] 1`] = `
 
   
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
     
@@ -5100,7 +5100,7 @@ exports[`Storyshots Components/Forms/Form Grid Single form [XL] 1`] = `
 
   
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
     
@@ -5201,13 +5201,13 @@ exports[`Storyshots Components/Forms/Form Grid Small 1`] = `
   dir="ltr"
 >
   <div
-    class="fd-container fd-form-layout-grid-container fd-form-layout-grid-container--vertical"
+    class="fd-container fd-form-layout-grid-container fd-form-layout-grid-container--vertical fd-form-group"
     style="max-width:600px"
   >
     
     
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
         
@@ -5248,7 +5248,7 @@ exports[`Storyshots Components/Forms/Form Grid Small 1`] = `
     
     
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
         
@@ -5307,7 +5307,7 @@ exports[`Storyshots Components/Forms/Form Grid Small 1`] = `
     
     
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
         
@@ -5366,7 +5366,7 @@ exports[`Storyshots Components/Forms/Form Grid Small 1`] = `
     
     
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
         
@@ -5466,13 +5466,13 @@ exports[`Storyshots Components/Forms/Form Grid Split screen [M] 1`] = `
   dir="ltr"
 >
   <div
-    class="fd-container fd-form-layout-grid-container"
+    class="fd-container fd-form-layout-grid-container fd-form-group"
     style="max-width:1024px"
   >
     
   
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
     
@@ -5514,7 +5514,7 @@ exports[`Storyshots Components/Forms/Form Grid Split screen [M] 1`] = `
 
   
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
     
@@ -5590,7 +5590,7 @@ exports[`Storyshots Components/Forms/Form Grid Split screen [M] 1`] = `
 
   
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
     
@@ -5666,7 +5666,7 @@ exports[`Storyshots Components/Forms/Form Grid Split screen [M] 1`] = `
 
   
     <div
-      class="fd-row"
+      class="fd-row fd-form-item"
     >
       
     

--- a/stories/form-grid/form-grid.stories.js
+++ b/stories/form-grid/form-grid.stories.js
@@ -28,8 +28,8 @@ When working with form groups, it's always best to use the recommended number of
     }
 };
 
-export const SSize = () => `<div class="fd-container fd-form-layout-grid-container fd-form-layout-grid-container--vertical" style="max-width:600px">
-    <div class="fd-row">
+export const SSize = () => `<div class="fd-container fd-form-layout-grid-container fd-form-layout-grid-container--vertical fd-form-group" style="max-width:600px">
+    <div class="fd-row fd-form-item">
         <div class="fd-col">
                 <label class="fd-form-label" for="input-1-name">Name:</label>
         </div>
@@ -37,7 +37,7 @@ export const SSize = () => `<div class="fd-container fd-form-layout-grid-contain
             <input class="fd-input" type="text" id="input-1-name" placeholder="Enter First and Last Name" value="Amelia Perry">
         </div>
     </div>
-    <div class="fd-row">
+    <div class="fd-row fd-form-item">
         <div class="fd-col">
                 <label class="fd-form-label fd-form-label--required" for="input-1-street">Street/No.: </label>
         </div>
@@ -48,7 +48,7 @@ export const SSize = () => `<div class="fd-container fd-form-layout-grid-contain
             <input class="fd-input" type="text" id="input-1-number" aria-label="Street Number" placeholder="Enter Street Number" value="495">
         </div>
     </div>
-    <div class="fd-row">
+    <div class="fd-row fd-form-item">
         <div class="fd-col">
                 <label class="fd-form-label fd-form-label--required" for="input-1-zip">ZIP Code/City: </label>
         </div>
@@ -59,7 +59,7 @@ export const SSize = () => `<div class="fd-container fd-form-layout-grid-contain
             <input class="fd-input" type="text" id="input-1-city" placeholder="Enter City" aria-label="City" value="Downtown">
         </div>
     </div>
-    <div class="fd-row">
+    <div class="fd-row fd-form-item">
         <div class="fd-col">
                 <label class="fd-form-label" for="input-1-country">Country:</label>
         </div>
@@ -108,8 +108,8 @@ Empty grid columns | 0 | There are no empty spaces on the right of the fields.
     }
 };
 
-export const MSizeDefault = () => `<div class="fd-container fd-form-layout-grid-container" style="max-width:1024px">
-  <div class="fd-row">
+export const MSizeDefault = () => `<div class="fd-container fd-form-layout-grid-container fd-form-group" style="max-width:1024px">
+  <div class="fd-row fd-form-item">
     <div class="fd-col fd-col-md--2 fd-col-lg--4">
       <label class="fd-form-label" for="input-2-name">Name:</label>
     </div>
@@ -118,7 +118,7 @@ export const MSizeDefault = () => `<div class="fd-container fd-form-layout-grid-
     </div>
   </div>
 
-  <div class="fd-row">
+  <div class="fd-row fd-form-item">
     <div class="fd-col fd-col-md--2 fd-col-lg--4">
       <label class="fd-form-label fd-form-label--required" for="input-2-street">Street/No.: </label>
     </div>
@@ -134,7 +134,7 @@ export const MSizeDefault = () => `<div class="fd-container fd-form-layout-grid-
     </div>
   </div>
 
-  <div class="fd-row">
+  <div class="fd-row fd-form-item">
     <div class="fd-col fd-col-md--2  fd-col-lg--4">
       <label class="fd-form-label fd-form-label--required" for="input-2-zip">ZIP Code/City: </label>
     </div>
@@ -150,7 +150,7 @@ export const MSizeDefault = () => `<div class="fd-container fd-form-layout-grid-
     </div>
   </div>
 
-  <div class="fd-row">
+  <div class="fd-row fd-form-item">
     <div class="fd-col fd-col-md--2  fd-col-lg--4">
       <label class="fd-form-label" for="input-2-country">Country:</label>
     </div>
@@ -201,8 +201,8 @@ Empty grid columns | 0 | There are no empty spaces on the right of the fields.
     }
 };
 
-export const MSizeSplitScreen = () => `<div class="fd-container fd-form-layout-grid-container" style="max-width:1024px">
-  <div class="fd-row">
+export const MSizeSplitScreen = () => `<div class="fd-container fd-form-layout-grid-container fd-form-group" style="max-width:1024px">
+  <div class="fd-row fd-form-item">
     <div class="fd-col fd-col-md--4  fd-col-lg--4">
       <label class="fd-form-label" for="input-3-name">Name:</label>
     </div>
@@ -211,7 +211,7 @@ export const MSizeSplitScreen = () => `<div class="fd-container fd-form-layout-g
     </div>
   </div>
 
-  <div class="fd-row">
+  <div class="fd-row fd-form-item">
     <div class="fd-col fd-col-md--4  fd-col-lg--4">
       <label class="fd-form-label fd-form-label--required" for="input-3-street">Street/No.: </label>
     </div>
@@ -227,7 +227,7 @@ export const MSizeSplitScreen = () => `<div class="fd-container fd-form-layout-g
     </div>
   </div>
 
-  <div class="fd-row">
+  <div class="fd-row fd-form-item">
     <div class="fd-col fd-col-md--4  fd-col-lg--4">
       <label class="fd-form-label fd-form-label--required" for="input-3-zip">ZIP Code/City: </label>
     </div>
@@ -243,7 +243,7 @@ export const MSizeSplitScreen = () => `<div class="fd-container fd-form-layout-g
     </div>
   </div>
 
-  <div class="fd-row">
+  <div class="fd-row fd-form-item">
     <div class="fd-col fd-col-md--4  fd-col-lg--4">
       <label class="fd-form-label" for="input-3-country">Country:</label>
     </div>
@@ -295,8 +295,8 @@ Empty grid columns | 1 | There is one empty space on the right of the field.
 };
 
 
-export const MSizeFullScreenApp = () => `<div class="fd-container fd-form-layout-grid-container" style="max-width:1024px">
-  <div class="fd-row">
+export const MSizeFullScreenApp = () => `<div class="fd-container fd-form-layout-grid-container fd-form-group" style="max-width:1024px">
+  <div class="fd-row fd-form-item">
     <div class="fd-col fd-col-md--3  fd-col-lg--4">
       <label class="fd-form-label" for="input-4-name">Name:</label>
     </div>
@@ -305,7 +305,7 @@ export const MSizeFullScreenApp = () => `<div class="fd-container fd-form-layout
     </div>
   </div>
 
-  <div class="fd-row">
+  <div class="fd-row fd-form-item">
     <div class="fd-col fd-col-md--3  fd-col-lg--4">
       <label class="fd-form-label fd-form-label--required" for="input-4-street">Street/No.: </label>
     </div>
@@ -321,7 +321,7 @@ export const MSizeFullScreenApp = () => `<div class="fd-container fd-form-layout
     </div>
   </div>
 
-  <div class="fd-row">
+  <div class="fd-row fd-form-item">
     <div class="fd-col fd-col-md--3  fd-col-lg--4">
       <label class="fd-form-label fd-form-label--required" for="input-4-zip">ZIP Code/City: </label>
     </div>
@@ -337,7 +337,7 @@ export const MSizeFullScreenApp = () => `<div class="fd-container fd-form-layout
     </div>
   </div>
 
-  <div class="fd-row">
+  <div class="fd-row fd-form-item">
     <div class="fd-col fd-col-md--3  fd-col-lg--4">
       <label class="fd-form-label" for="input-4-country">Country:</label>
     </div>
@@ -387,8 +387,8 @@ Empty grid columns | 4 | There are four empty spaces on the right of the field.
     }
 };
 
-export const MSizeFullScreenAppLongLabel = () => `<div class="fd-container fd-form-layout-grid-container" style="max-width:1024px">
-  <div class="fd-row">
+export const MSizeFullScreenAppLongLabel = () => `<div class="fd-container fd-form-layout-grid-container fd-form-group" style="max-width:1024px">
+  <div class="fd-row fd-form-item">
     <div class="fd-col fd-col-md--4 fd-col-lg--3">
       <label class="fd-form-label" for="input-5-name">Name:</label>
     </div>
@@ -397,7 +397,7 @@ export const MSizeFullScreenAppLongLabel = () => `<div class="fd-container fd-fo
     </div>
   </div>
 
-  <div class="fd-row">
+  <div class="fd-row fd-form-item">
     <div class="fd-col fd-col-md--4 fd-col-lg--3">
       <label class="fd-form-label fd-form-label--required" for="input-5-street">Street/No.: </label>
     </div>
@@ -413,7 +413,7 @@ export const MSizeFullScreenAppLongLabel = () => `<div class="fd-container fd-fo
     </div>
   </div>
 
-  <div class="fd-row">
+  <div class="fd-row fd-form-item">
     <div class="fd-col fd-col-md--4 fd-col-lg--3">
       <label class="fd-form-label fd-form-label--required" for="input-5-zip">ZIP Code/City: </label>
     </div>
@@ -429,7 +429,7 @@ export const MSizeFullScreenAppLongLabel = () => `<div class="fd-container fd-fo
     </div>
   </div>
 
-  <div class="fd-row">
+  <div class="fd-row fd-form-item">
     <div class="fd-col fd-col-md--4 fd-col-lg--3">
       <label class="fd-form-label" for="input-5-country">Country:</label>
     </div>
@@ -480,8 +480,8 @@ Empty grid columns | 0 | There is no empty space on the right of the field.
     }
 };
 
-export const LSizeDefault = () => `<div class="fd-container fd-form-layout-grid-container" style="max-width:1440px">
-  <div class="fd-row">
+export const LSizeDefault = () => `<div class="fd-container fd-form-layout-grid-container fd-form-group" style="max-width:1440px">
+  <div class="fd-row fd-form-item">
     <div class="fd-col fd-col-md--2 fd-col-lg--4">
       <label class="fd-form-label" for="input-6-name">Name:</label>
     </div>
@@ -490,7 +490,7 @@ export const LSizeDefault = () => `<div class="fd-container fd-form-layout-grid-
     </div>
   </div>
 
-  <div class="fd-row">
+  <div class="fd-row fd-form-item">
     <div class="fd-col fd-col-md--2 fd-col-lg--4">
       <label class="fd-form-label fd-form-label--required" for="input-6-street">Street/No.: </label>
     </div>
@@ -506,7 +506,7 @@ export const LSizeDefault = () => `<div class="fd-container fd-form-layout-grid-
     </div>
   </div>
 
-  <div class="fd-row">
+  <div class="fd-row fd-form-item">
     <div class="fd-col fd-col-md--2 fd-col-lg--4">
       <label class="fd-form-label fd-form-label--required" for="input-6-zip">ZIP Code/City: </label>
     </div>
@@ -522,7 +522,7 @@ export const LSizeDefault = () => `<div class="fd-container fd-form-layout-grid-
     </div>
   </div>
 
-  <div class="fd-row">
+  <div class="fd-row fd-form-item">
     <div class="fd-col fd-col-md--2 fd-col-lg--4">
       <label class="fd-form-label" for="input-6-country">Country:</label>
     </div>
@@ -573,8 +573,8 @@ Empty grid columns | 0 | There is no empty space on the right of the field.
     }
 };
 
-export const LSizeSingleFormGroup = () => `<div class="fd-container fd-form-layout-grid-container" style="max-width:1440px">
-  <div class="fd-row">
+export const LSizeSingleFormGroup = () => `<div class="fd-container fd-form-layout-grid-container fd-form-group" style="max-width:1440px">
+  <div class="fd-row fd-form-item">
     <div class="fd-col fd-col-md--2 fd-col-lg--3">
       <label class="fd-form-label" for="input-7-name">Name:</label>
     </div>
@@ -583,7 +583,7 @@ export const LSizeSingleFormGroup = () => `<div class="fd-container fd-form-layo
     </div>
   </div>
 
-  <div class="fd-row">
+  <div class="fd-row fd-form-item">
     <div class="fd-col fd-col-md--2 fd-col-lg--3">
       <label class="fd-form-label fd-form-label--required" for="input-7-street">Street/No.: </label>
     </div>
@@ -599,7 +599,7 @@ export const LSizeSingleFormGroup = () => `<div class="fd-container fd-form-layo
     </div>
   </div>
 
-  <div class="fd-row">
+  <div class="fd-row fd-form-item">
     <div class="fd-col fd-col-md--2 fd-col-lg--3">
       <label class="fd-form-label fd-form-label--required" for="input-7-zip">ZIP Code/City: </label>
     </div>
@@ -615,7 +615,7 @@ export const LSizeSingleFormGroup = () => `<div class="fd-container fd-form-layo
     </div>
   </div>
 
-  <div class="fd-row">
+  <div class="fd-row fd-form-item">
     <div class="fd-col fd-col-md--2 fd-col-lg--3">
       <label class="fd-form-label" for="input-7-country">Country:</label>
     </div>
@@ -667,8 +667,8 @@ Empty grid columns | 4 | There are four empty spaces on the right of the field.
 
 export const LSizeMultipleFormGroup = () => `<div class="fd-container fd-form-layout-grid-container" style="max-width:1440px">
   <div class="fd-row">
-    <div class="fd-col fd-col-lg--6 fd-col--wrap">
-      <div class="fd-row">
+    <div class="fd-col fd-col-lg--6 fd-col--wrap fd-form-group">
+      <div class="fd-row fd-form-item">
         <div class="fd-col fd-col-md--2 fd-col-lg--12">
           <label class="fd-form-label" for="input-7-name">Name:</label>
         </div>
@@ -676,7 +676,7 @@ export const LSizeMultipleFormGroup = () => `<div class="fd-container fd-form-la
           <input class="fd-input" type="text" id="input-7-name" placeholder="Enter First and Last Name" value="Amelia Perry">
         </div>
       </div>
-      <div class="fd-row">
+      <div class="fd-row fd-form-item">
         <div class="fd-col fd-col-md--2 fd-col-lg--12">
           <label class="fd-form-label fd-form-label--required" for="input-7-street">Street/No.: </label>
         </div>
@@ -692,7 +692,7 @@ export const LSizeMultipleFormGroup = () => `<div class="fd-container fd-form-la
         </div>
       </div>
 
-      <div class="fd-row">
+      <div class="fd-row fd-form-item">
         <div class="fd-col fd-col-md--2 fd-col-lg--12">
           <label class="fd-form-label fd-form-label--required" for="input-7-zip">ZIP Code/City: </label>
         </div>
@@ -708,7 +708,7 @@ export const LSizeMultipleFormGroup = () => `<div class="fd-container fd-form-la
         </div>
       </div>
 
-      <div class="fd-row">
+      <div class="fd-row fd-form-item">
         <div class="fd-col fd-col-md--2 fd-col-lg--12">
           <label class="fd-form-label" for="input-7-country">Country:</label>
         </div>
@@ -735,8 +735,8 @@ export const LSizeMultipleFormGroup = () => `<div class="fd-container fd-form-la
       </div>
     </div>
 
-    <div class="fd-col fd-col-lg--6 fd-col--wrap">
-      <div class="fd-row">
+    <div class="fd-col fd-col-lg--6 fd-col--wrap fd-form-group">
+      <div class="fd-row fd-form-item">
         <div class="fd-col fd-col-md--2 fd-col-lg--12">
           <label class="fd-form-label" for="input-8-name">Name:</label>
         </div>
@@ -744,7 +744,7 @@ export const LSizeMultipleFormGroup = () => `<div class="fd-container fd-form-la
           <input class="fd-input" type="text" id="input-8-name" placeholder="Enter First and Last Name" value="Amelia Perry">
         </div>
       </div>
-      <div class="fd-row">
+      <div class="fd-row fd-form-item">
         <div class="fd-col fd-col-md--2 fd-col-lg--12">
           <label class="fd-form-label fd-form-label--required" for="input-8-street">Street/No.: </label>
         </div>
@@ -760,7 +760,7 @@ export const LSizeMultipleFormGroup = () => `<div class="fd-container fd-form-la
         </div>
       </div>
 
-      <div class="fd-row">
+      <div class="fd-row fd-form-item">
         <div class="fd-col fd-col-md--2 fd-col-lg--12">
           <label class="fd-form-label fd-form-label--required" for="input-8-zip">ZIP Code/City: </label>
         </div>
@@ -776,7 +776,7 @@ export const LSizeMultipleFormGroup = () => `<div class="fd-container fd-form-la
         </div>
       </div>
 
-      <div class="fd-row">
+      <div class="fd-row fd-form-item">
         <div class="fd-col fd-col-md--2 fd-col-lg--12">
           <label class="fd-form-label" for="input-8-country">Country:</label>
         </div>
@@ -830,8 +830,8 @@ Empty grid columns | 0 | There are no empty spaces on the right of the fields.
     }
 };
 
-export const XlDefault = () => `<div class="fd-container fd-form-layout-grid-container">
-  <div class="fd-row">
+export const XlDefault = () => `<div class="fd-container fd-form-layout-grid-container fd-form-group">
+  <div class="fd-row fd-form-item">
     <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
       <label class="fd-form-label" for="input-9-name">Name:</label>
     </div>
@@ -840,7 +840,7 @@ export const XlDefault = () => `<div class="fd-container fd-form-layout-grid-con
     </div>
   </div>
 
-  <div class="fd-row">
+  <div class="fd-row fd-form-item">
     <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
       <label class="fd-form-label fd-form-label--required" for="input-9-street">Street/No.: </label>
     </div>
@@ -856,7 +856,7 @@ export const XlDefault = () => `<div class="fd-container fd-form-layout-grid-con
     </div>
   </div>
 
-  <div class="fd-row">
+  <div class="fd-row fd-form-item">
     <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
       <label class="fd-form-label fd-form-label--required" for="input-9-zip">ZIP Code/City: </label>
     </div>
@@ -872,7 +872,7 @@ export const XlDefault = () => `<div class="fd-container fd-form-layout-grid-con
     </div>
   </div>
 
-  <div class="fd-row">
+  <div class="fd-row fd-form-item">
     <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
       <label class="fd-form-label" for="input-9-country">Country:</label>
     </div>
@@ -924,8 +924,8 @@ Empty grid columns | 0 | There are no empty spaces on the right of the fields.
 };
 
 
-export const XlSingleFormGroup = () => `<div class="fd-container fd-form-layout-grid-container">
-  <div class="fd-row">
+export const XlSingleFormGroup = () => `<div class="fd-container fd-form-layout-grid-container fd-form-group">
+  <div class="fd-row fd-form-item">
     <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--3">
       <label class="fd-form-label" for="input-10-name">Name:</label>
     </div>
@@ -934,7 +934,7 @@ export const XlSingleFormGroup = () => `<div class="fd-container fd-form-layout-
     </div>
   </div>
 
-  <div class="fd-row">
+  <div class="fd-row fd-form-item">
     <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--3">
       <label class="fd-form-label fd-form-label--required" for="input-10-street">Street/No.: </label>
     </div>
@@ -950,7 +950,7 @@ export const XlSingleFormGroup = () => `<div class="fd-container fd-form-layout-
     </div>
   </div>
 
-  <div class="fd-row">
+  <div class="fd-row fd-form-item">
     <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--3">
       <label class="fd-form-label fd-form-label--required" for="input-10-zip">ZIP Code/City: </label>
     </div>
@@ -966,7 +966,7 @@ export const XlSingleFormGroup = () => `<div class="fd-container fd-form-layout-
     </div>
   </div>
 
-  <div class="fd-row">
+  <div class="fd-row fd-form-item">
     <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--3">
       <label class="fd-form-label" for="input-10-country">Country:</label>
     </div>
@@ -1021,8 +1021,8 @@ Empty grid columns | 4 | There are four empty spaces on the right of the fields.
 
 export const XlDoubleFormGroup = () => `<div class="fd-container fd-form-layout-grid-container">
   <div class="fd-row">
-    <div class="fd-col fd-col-xl--6 fd-col--wrap">
-      <div class="fd-row">
+    <div class="fd-col fd-col-xl--6 fd-col--wrap fd-form-group">
+      <div class="fd-row fd-form-item">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
           <label class="fd-form-label" for="input-11-name">Name:</label>
         </div>
@@ -1031,7 +1031,7 @@ export const XlDoubleFormGroup = () => `<div class="fd-container fd-form-layout-
         </div>
       </div>
 
-      <div class="fd-row">
+      <div class="fd-row fd-form-item">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
           <label class="fd-form-label fd-form-label--required" for="input-11-street">Street/No.: </label>
         </div>
@@ -1047,7 +1047,7 @@ export const XlDoubleFormGroup = () => `<div class="fd-container fd-form-layout-
         </div>
       </div>
 
-      <div class="fd-row">
+      <div class="fd-row fd-form-item">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
           <label class="fd-form-label fd-form-label--required" for="input-11-zip">ZIP Code/City: </label>
         </div>
@@ -1063,7 +1063,7 @@ export const XlDoubleFormGroup = () => `<div class="fd-container fd-form-layout-
         </div>
       </div>
 
-      <div class="fd-row">
+      <div class="fd-row fd-form-item">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
           <label class="fd-form-label" for="input-11-country">Country:</label>
         </div>
@@ -1089,8 +1089,8 @@ export const XlDoubleFormGroup = () => `<div class="fd-container fd-form-layout-
         </div>
       </div>
     </div>
-    <div class="fd-col fd-col-xl--6 fd-col--wrap">
-      <div class="fd-row">
+    <div class="fd-col fd-col-xl--6 fd-col--wrap fd-form-group">
+      <div class="fd-row fd-form-item">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
           <label class="fd-form-label" for="input-11a-name">Name:</label>
         </div>
@@ -1099,7 +1099,7 @@ export const XlDoubleFormGroup = () => `<div class="fd-container fd-form-layout-
         </div>
       </div>
 
-      <div class="fd-row">
+      <div class="fd-row fd-form-item">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
           <label class="fd-form-label fd-form-label--required" for="input-11a-street">Street/No.: </label>
         </div>
@@ -1115,7 +1115,7 @@ export const XlDoubleFormGroup = () => `<div class="fd-container fd-form-layout-
         </div>
       </div>
 
-      <div class="fd-row">
+      <div class="fd-row fd-form-item">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
           <label class="fd-form-label fd-form-label--required" for="input-11a-zip">ZIP Code/City: </label>
         </div>
@@ -1131,7 +1131,7 @@ export const XlDoubleFormGroup = () => `<div class="fd-container fd-form-layout-
         </div>
       </div>
 
-      <div class="fd-row">
+      <div class="fd-row fd-form-item">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--4">
           <label class="fd-form-label" for="input-11a-country">Country:</label>
         </div>
@@ -1184,11 +1184,11 @@ Empty grid columns | 0 | There are no empty spaces on the right of the fields.
 };
 
 export const XlMultipleFormGroup = () => `<div class="fd-container fd-form-layout-grid-container">
-  <div class="fd-row fd-row--top">
-    <div class="fd-col fd-col-xl--4 fd-col--wrap">
+  <div class="fd-row">
+    <div class="fd-col fd-col-xl--4 fd-col--wrap fd-form-group">
 
 
-      <div class="fd-row">
+      <div class="fd-row fd-form-item">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
           <label class="fd-form-label fd-form-label--required" for="input-12-street">Street/No.: </label>
         </div>
@@ -1204,7 +1204,7 @@ export const XlMultipleFormGroup = () => `<div class="fd-container fd-form-layou
         </div>
       </div>
 
-      <div class="fd-row">
+      <div class="fd-row fd-form-item">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
           <label class="fd-form-label fd-form-label--required" for="input-12-zip">ZIP Code/City: </label>
         </div>
@@ -1220,7 +1220,7 @@ export const XlMultipleFormGroup = () => `<div class="fd-container fd-form-layou
         </div>
       </div>
 
-      <div class="fd-row">
+      <div class="fd-row fd-form-item">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
           <label class="fd-form-label" for="input-12-country">Country:</label>
         </div>
@@ -1246,8 +1246,8 @@ export const XlMultipleFormGroup = () => `<div class="fd-container fd-form-layou
         </div>
       </div>
     </div>
-    <div class="fd-col fd-col-xl--4 fd-col--wrap">
-      <div class="fd-row">
+    <div class="fd-col fd-col-xl--4 fd-col--wrap fd-form-group">
+      <div class="fd-row fd-form-item">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
           <label class="fd-form-label" for="input-12a-name">Name:</label>
         </div>
@@ -1256,7 +1256,7 @@ export const XlMultipleFormGroup = () => `<div class="fd-container fd-form-layou
         </div>
       </div>
 
-      <div class="fd-row">
+      <div class="fd-row fd-form-item">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
           <label class="fd-form-label fd-form-label--required" for="input-12a-street">Street/No.: </label>
         </div>
@@ -1272,7 +1272,7 @@ export const XlMultipleFormGroup = () => `<div class="fd-container fd-form-layou
         </div>
       </div>
 
-      <div class="fd-row">
+      <div class="fd-row fd-form-item">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
           <label class="fd-form-label fd-form-label--required" for="input-12a-zip">ZIP Code/City: </label>
         </div>
@@ -1288,7 +1288,7 @@ export const XlMultipleFormGroup = () => `<div class="fd-container fd-form-layou
         </div>
       </div>
 
-      <div class="fd-row">
+      <div class="fd-row fd-form-item">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
           <label class="fd-form-label" for="input-12a-country">Country:</label>
         </div>
@@ -1316,8 +1316,8 @@ export const XlMultipleFormGroup = () => `<div class="fd-container fd-form-layou
     </div>
 
 
-    <div class="fd-col fd-col-xl--4 fd-col--wrap">
-    <div class="fd-row">
+    <div class="fd-col fd-col-xl--4 fd-col--wrap fd-form-group">
+    <div class="fd-row fd-form-item">
       <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
         <label class="fd-form-label" for="input-12b-name">Name:</label>
       </div>
@@ -1326,7 +1326,7 @@ export const XlMultipleFormGroup = () => `<div class="fd-container fd-form-layou
       </div>
     </div>
 
-    <div class="fd-row">
+    <div class="fd-row fd-form-item">
       <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
         <label class="fd-form-label fd-form-label--required" for="input-12b-street">Street/No.: </label>
       </div>
@@ -1342,7 +1342,7 @@ export const XlMultipleFormGroup = () => `<div class="fd-container fd-form-layou
       </div>
     </div>
 
-    <div class="fd-row">
+    <div class="fd-row fd-form-item">
       <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
         <label class="fd-form-label fd-form-label--required" for="input-12b-zip">ZIP Code/City: </label>
       </div>
@@ -1358,7 +1358,7 @@ export const XlMultipleFormGroup = () => `<div class="fd-container fd-form-layou
       </div>
     </div>
 
-    <div class="fd-row">
+    <div class="fd-row fd-form-item">
       <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
         <label class="fd-form-label" for="input-12b-country">Country:</label>
       </div>
@@ -1396,8 +1396,6 @@ XlMultipleFormGroup.parameters = {
         iframeHeight: 850,
         description: {
             story: `
-If the form contains multiple form groups, you can use a three-column layout.fd-row--top class will organize all the elements evenly on screen.
-
 ####Label-field ratio
 The extra-large form grid is organized into a **12:12:0** label-field ratio for multiple form groups.
 
@@ -1412,8 +1410,8 @@ Empty grid columns | 0 | There is no empty space on the right of the field.
     }
 };
 
-export const CompactLayout = () => `<div class="fd-container fd-form-layout-grid-container">
-    <div class="fd-row">
+export const CompactLayout = () => `<div class="fd-container fd-form-layout-grid-container fd-form-group">
+    <div class="fd-row fd-form-item">
         <div class="fd-col fd-col--4">
           <label class="fd-form-label" for="input-13-compact">Default Input:</label>
         </div>
@@ -1421,7 +1419,7 @@ export const CompactLayout = () => `<div class="fd-container fd-form-layout-grid
             <input class="fd-input fd-input--compact" type="text" id="input-13-compact" placeholder="Field placeholder text">
         </div>
     </div>
-    <div class="fd-row">
+    <div class="fd-row fd-form-item">
         <div class="fd-col fd-col--4">
           <label class="fd-form-label fd-form-label--required" for="input-13b-compact">Required Input: </label>
         </div>
@@ -1429,7 +1427,7 @@ export const CompactLayout = () => `<div class="fd-container fd-form-layout-grid
             <input class="fd-input fd-input--compact" type="text" id="input-13b-compact" placeholder="Field placeholder text">
         </div>
     </div>
-    <div class="fd-row" role="group" aria-labelledby="groupLabel-compact">
+    <div class="fd-row fd-form-item" role="group" aria-labelledby="groupLabel-compact">
         <div class="fd-col fd-col--4">
           <label class="fd-form-label"  id="groupLabel-compact">2 Inputs: </label>
         </div>
@@ -1459,9 +1457,9 @@ To display the form using a compact layout, add the \`--compact\` modifier on th
 };
 
 export const ColumnRecommended = () => `<h2>Layout 1</h2>
-<div class="fd-container fd-form-layout-grid-container">
+<div class="fd-container fd-form-layout-grid-container fd-form-group">
   <div class="fd-row">
-    <div class="fd-col fd-col-md--6  fd-col-lg--6 fd-col-xl--6 fd-col--wrap">
+    <div class="fd-col fd-col-md--6 fd-col-lg--6 fd-col-xl--6 fd-col--wrap fd-form-item">
       <div class="fd-row">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
           <label class="fd-form-label" for="input-14-name">Name:</label>
@@ -1472,7 +1470,7 @@ export const ColumnRecommended = () => `<h2>Layout 1</h2>
       </div>
     </div>
 
-    <div class="fd-col fd-col-md--6 fd-col-lg--6 fd-col-xl--6 fd-col--wrap">
+    <div class="fd-col fd-col-md--6 fd-col-lg--6 fd-col-xl--6 fd-col--wrap fd-form-item">
       <div class="fd-row">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
           <label class="fd-form-label" for="input-14a-name">Name:</label>
@@ -1486,9 +1484,9 @@ export const ColumnRecommended = () => `<h2>Layout 1</h2>
 </div>
 
 <h2>Layout 2</h2>
-<div class="fd-container fd-form-layout-grid-container">
+<div class="fd-container fd-form-layout-grid-container fd-form-group">
   <div class="fd-row">
-    <div class="fd-col fd-col-md--12 fd-col-lg--6 fd-col-xl--6 fd-col--wrap">
+    <div class="fd-col fd-col-md--12 fd-col-lg--6 fd-col-xl--6 fd-col--wrap fd-form-item">
       <div class="fd-row">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
           <label class="fd-form-label" for="input-15-name">Name:</label>
@@ -1499,7 +1497,7 @@ export const ColumnRecommended = () => `<h2>Layout 1</h2>
       </div>
     </div>
 
-    <div class="fd-col fd-col-md--12 fd-col-lg--6 fd-col-xl--6 fd-col--wrap">
+    <div class="fd-col fd-col-md--12 fd-col-lg--6 fd-col-xl--6 fd-col--wrap  fd-form-item">
       <div class="fd-row">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
           <label class="fd-form-label" for="input-15a-name">Name:</label>
@@ -1513,9 +1511,9 @@ export const ColumnRecommended = () => `<h2>Layout 1</h2>
 </div>
 
 <h2>Layout 3</h2>
-<div class="fd-container fd-form-layout-grid-container">
+<div class="fd-container fd-form-layout-grid-container fd-form-group">
   <div class="fd-row">
-    <div class="fd-col fd-col-md--12 fd-col-xl--6 fd-col--wrap">
+    <div class="fd-col fd-col-md--12 fd-col-xl--6 fd-col--wrap fd-form-item">
       <div class="fd-row">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
           <label class="fd-form-label" for="input-16-name">Name:</label>
@@ -1526,7 +1524,7 @@ export const ColumnRecommended = () => `<h2>Layout 1</h2>
       </div>
     </div>
 
-    <div class="fd-col fd-col-md--12 fd-col-xl--6 fd-col--wrap">
+    <div class="fd-col fd-col-md--12 fd-col-xl--6 fd-col--wrap fd-form-item">
       <div class="fd-row">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
           <label class="fd-form-label" for="input-16a-name">Name:</label>
@@ -1582,9 +1580,9 @@ S | 1
 };
 
 export const ColumnPossible = () => `<h2>Layout 4</h2>
-<div class="fd-container fd-form-layout-grid-container">
+<div class="fd-container fd-form-layout-grid-container fd-form-group">
   <div class="fd-row">
-    <div class="fd-col fd-col-xl--4 fd-col--wrap">
+    <div class="fd-col fd-col-xl--4 fd-col--wrap fd-form-item">
       <div class="fd-row">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
           <label class="fd-form-label" for="input-17-name">Name:</label>
@@ -1595,7 +1593,7 @@ export const ColumnPossible = () => `<h2>Layout 4</h2>
       </div>
     </div>
 
-    <div class="fd-col fd-col-xl--4 fd-col--wrap">
+    <div class="fd-col fd-col-xl--4 fd-col--wrap fd-form-item">
       <div class="fd-row">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
           <label class="fd-form-label" for="input-17a-name">Name:</label>
@@ -1606,7 +1604,7 @@ export const ColumnPossible = () => `<h2>Layout 4</h2>
       </div>
     </div>
 
-    <div class="fd-col fd-col-xl--4 fd-col--wrap">
+    <div class="fd-col fd-col-xl--4 fd-col--wrap fd-form-item">
       <div class="fd-row">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
           <label class="fd-form-label" for="input-17b-name">Name:</label>
@@ -1620,9 +1618,9 @@ export const ColumnPossible = () => `<h2>Layout 4</h2>
 </div>
 
 <h2>Layout 5</h2>
-<div class="fd-container fd-form-layout-grid-container">
+<div class="fd-container fd-form-layout-grid-container fd-form-group">
   <div class="fd-row">
-    <div class="fd-col fd-col--wrap">
+    <div class="fd-col fd-col--wrap fd-form-item">
       <div class="fd-row">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
           <label class="fd-form-label" for="input-18-name">Name:</label>
@@ -1633,7 +1631,7 @@ export const ColumnPossible = () => `<h2>Layout 4</h2>
       </div>
     </div>
 
-    <div class="fd-col fd-col--wrap">
+    <div class="fd-col fd-col--wrap fd-form-item">
       <div class="fd-row">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
           <label class="fd-form-label" for="input-18a-name">Name:</label>
@@ -1680,9 +1678,9 @@ S | 1
 };
 
 export const ColumnNotRecommended = () => `<h1>XL3-L2-M2-S1</h1>
-<div class="fd-container fd-form-layout-grid-container">
+<div class="fd-container fd-form-layout-grid-container fd-form-group">
   <div class="fd-row">
-    <div class="fd-col fd-col-lg--6 fd-col-xl--4 fd-col--wrap">
+    <div class="fd-col fd-col-lg--6 fd-col-xl--4 fd-col--wrap fd-form-item">
       <div class="fd-row">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
           <label class="fd-form-label" for="input-19-name">Name:</label>
@@ -1693,7 +1691,7 @@ export const ColumnNotRecommended = () => `<h1>XL3-L2-M2-S1</h1>
       </div>
     </div>
 
-    <div class="fd-col fd-col-lg--6 fd-col-xl--4 fd-col--wrap">
+    <div class="fd-col fd-col-lg--6 fd-col-xl--4 fd-col--wrap fd-form-item">
       <div class="fd-row">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
           <label class="fd-form-label" for="input-19a-name">Name:</label>
@@ -1704,7 +1702,7 @@ export const ColumnNotRecommended = () => `<h1>XL3-L2-M2-S1</h1>
       </div>
     </div>
 
-    <div class="fd-col fd-col-lg--6 fd-col-xl--4 fd-col--wrap">
+    <div class="fd-col fd-col-lg--6 fd-col-xl--4 fd-col--wrap fd-form-item">
       <div class="fd-row">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
           <label class="fd-form-label" for="input-19b-name">Name:</label>

--- a/stories/form-group/__snapshots__/form-group.stories.storyshot
+++ b/stories/form-group/__snapshots__/form-group.stories.storyshot
@@ -151,7 +151,7 @@ exports[`Storyshots Components/Forms/Form Group Group header (form grid) 1`] = `
             
       <div
         aria-labelledby="grid1GroupHeader"
-        class="fd-form-group fd-col__form-group fd-col fd-col-md--6  fd-col-lg--6 fd-col-xl--6 fd-col--wrap"
+        class="fd-form-group fd-col fd-col-md--6  fd-col-lg--6 fd-col-xl--6 fd-col--wrap"
         role="group"
       >
         
@@ -173,7 +173,7 @@ exports[`Storyshots Components/Forms/Form Group Group header (form grid) 1`] = `
         
                 
         <div
-          class="fd-form-item fd-row__form-item fd-row"
+          class="fd-form-item fd-row"
         >
           
                     
@@ -214,7 +214,7 @@ exports[`Storyshots Components/Forms/Form Group Group header (form grid) 1`] = `
         
                 
         <div
-          class="fd-form-item fd-row__form-item fd-row"
+          class="fd-form-item fd-row"
         >
           
                     
@@ -255,7 +255,7 @@ exports[`Storyshots Components/Forms/Form Group Group header (form grid) 1`] = `
         
                 
         <div
-          class="fd-form-item fd-row__form-item fd-row"
+          class="fd-form-item fd-row"
         >
           
                     
@@ -300,7 +300,7 @@ exports[`Storyshots Components/Forms/Form Group Group header (form grid) 1`] = `
             
       <div
         aria-labelledby="grid2GroupHeader"
-        class="fd-form-group fd-col__form-group fd-col fd-col-md--6 fd-col-lg--6 fd-col-xl--6 fd-col--wrap"
+        class="fd-form-group fd-col fd-col-md--6 fd-col-lg--6 fd-col-xl--6 fd-col--wrap"
         role="group"
       >
         
@@ -322,7 +322,7 @@ exports[`Storyshots Components/Forms/Form Group Group header (form grid) 1`] = `
         
                 
         <div
-          class="fd-form-item fd-row__form-item fd-row"
+          class="fd-form-item fd-row"
         >
           
                     
@@ -363,7 +363,7 @@ exports[`Storyshots Components/Forms/Form Group Group header (form grid) 1`] = `
         
                 
         <div
-          class="fd-form-item fd-row__form-item fd-row"
+          class="fd-form-item fd-row"
         >
           
                     
@@ -404,7 +404,7 @@ exports[`Storyshots Components/Forms/Form Group Group header (form grid) 1`] = `
         
                 
         <div
-          class="fd-form-item fd-row__form-item fd-row"
+          class="fd-form-item fd-row"
         >
           
                     
@@ -449,7 +449,7 @@ exports[`Storyshots Components/Forms/Form Group Group header (form grid) 1`] = `
             
       <div
         aria-labelledby="grid3GroupHeader"
-        class="fd-form-group fd-col__form-group fd-col fd-col-md--6 fd-col-lg--6 fd-col-xl--6 fd-col--wrap"
+        class="fd-form-group fd-col fd-col-md--6 fd-col-lg--6 fd-col-xl--6 fd-col--wrap"
         role="group"
       >
         
@@ -471,7 +471,7 @@ exports[`Storyshots Components/Forms/Form Group Group header (form grid) 1`] = `
         
                 
         <div
-          class="fd-form-item fd-row__form-item fd-row"
+          class="fd-form-item fd-row"
         >
           
                     
@@ -512,7 +512,7 @@ exports[`Storyshots Components/Forms/Form Group Group header (form grid) 1`] = `
         
                 
         <div
-          class="fd-form-item fd-row__form-item fd-row"
+          class="fd-form-item fd-row"
         >
           
                     
@@ -553,7 +553,7 @@ exports[`Storyshots Components/Forms/Form Group Group header (form grid) 1`] = `
         
                 
         <div
-          class="fd-form-item fd-row__form-item fd-row"
+          class="fd-form-item fd-row"
         >
           
                     

--- a/stories/form-group/form-group.stories.js
+++ b/stories/form-group/form-group.stories.js
@@ -119,7 +119,7 @@ export const GroupHeaderInFormGrid = () =>
                 <div class="fd-form-group__header"  id="grid1GroupHeader">
                     <h1 class="fd-form-group__header-text">Group Header 1</h1>
                 </div>
-                <div class="fd-form-item fd-row__form-item fd-row">
+                <div class="fd-form-item fd-row">
                     <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
                         <label class="fd-form-label" for="input-14-name">Name:</label>
                     </div>
@@ -127,7 +127,7 @@ export const GroupHeaderInFormGrid = () =>
                         <input class="fd-input" type="text" id="input-14-name" placeholder="Enter First and Last Name" value="Amelia Perry">
                     </div>
                 </div>
-                <div class="fd-form-item fd-row__form-item fd-row">
+                <div class="fd-form-item fd-row">
                     <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
                         <label class="fd-form-label" for="input-14x-name">Name:</label>
                     </div>
@@ -135,7 +135,7 @@ export const GroupHeaderInFormGrid = () =>
                         <input class="fd-input" type="text" id="input-14x-name" placeholder="Enter First and Last Name" value="Amelia Perry">
                     </div>
                 </div>
-                <div class="fd-form-item fd-row__form-item fd-row">
+                <div class="fd-form-item fd-row">
                     <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
                         <label class="fd-form-label" for="input-14y-name">Name:</label>
                     </div>
@@ -148,7 +148,7 @@ export const GroupHeaderInFormGrid = () =>
                 <div class="fd-form-group__header">
                     <h1 class="fd-form-group__header-text" id="grid2GroupHeader">Group Header 2</h1>
                 </div>
-                <div class="fd-form-item fd-row__form-item fd-row">
+                <div class="fd-form-item fd-row">
                     <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
                         <label class="fd-form-label" for="input-14a-name">Name:</label>
                     </div>
@@ -156,7 +156,7 @@ export const GroupHeaderInFormGrid = () =>
                         <input class="fd-input" type="text" id="input-14a-name" placeholder="Enter First and Last Name" value="Amelia Perry">
                     </div>
                 </div>
-                <div class="fd-form-item fd-row__form-item fd-row">
+                <div class="fd-form-item fd-row">
                     <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
                         <label class="fd-form-label" for="input-14b-name">Name:</label>
                     </div>
@@ -164,7 +164,7 @@ export const GroupHeaderInFormGrid = () =>
                         <input class="fd-input" type="text" id="input-14b-name" placeholder="Enter First and Last Name" value="Amelia Perry">
                     </div>
                 </div>
-                <div class="fd-form-item fd-row__form-item fd-row">
+                <div class="fd-form-item fd-row">
                     <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
                         <label class="fd-form-label" for="input-14c-name">Name:</label>
                     </div>
@@ -177,7 +177,7 @@ export const GroupHeaderInFormGrid = () =>
                 <div class="fd-form-group__header">
                     <h1 class="fd-form-group__header-text" id="grid3GroupHeader">Group Header 3</h1>
                 </div>
-                <div class="fd-form-item fd-row__form-item fd-row">
+                <div class="fd-form-item fd-row">
                     <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
                         <label class="fd-form-label" for="input-14j-name">Name:</label>
                     </div>
@@ -185,7 +185,7 @@ export const GroupHeaderInFormGrid = () =>
                         <input class="fd-input" type="text" id="input-14j-name" placeholder="Enter First and Last Name" value="Amelia Perry">
                     </div>
                 </div>
-                <div class="fd-form-item fd-row__form-item fd-row">
+                <div class="fd-form-item fd-row">
                     <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
                         <label class="fd-form-label" for="input-14h-name">Name:</label>
                     </div>
@@ -193,7 +193,7 @@ export const GroupHeaderInFormGrid = () =>
                         <input class="fd-input" type="text" id="input-14h-name" placeholder="Enter First and Last Name" value="Amelia Perry">
                     </div>
                 </div>
-                <div class="fd-form-item fd-row__form-item fd-row">
+                <div class="fd-form-item fd-row">
                     <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
                         <label class="fd-form-label" for="input-14k-name">Name:</label>
                     </div>

--- a/stories/form-group/form-group.stories.js
+++ b/stories/form-group/form-group.stories.js
@@ -115,7 +115,7 @@ Form group headers can be displayed in compact mode. To display compact group he
 export const GroupHeaderInFormGrid = () =>
     `<div class="fd-container fd-form-layout-grid-container">
         <div class="fd-row">
-            <div class="fd-form-group fd-col__form-group fd-col fd-col-md--6  fd-col-lg--6 fd-col-xl--6 fd-col--wrap" role="group" aria-labelledby="grid1GroupHeader">
+            <div class="fd-form-group fd-col fd-col-md--6  fd-col-lg--6 fd-col-xl--6 fd-col--wrap" role="group" aria-labelledby="grid1GroupHeader">
                 <div class="fd-form-group__header"  id="grid1GroupHeader">
                     <h1 class="fd-form-group__header-text">Group Header 1</h1>
                 </div>
@@ -144,7 +144,7 @@ export const GroupHeaderInFormGrid = () =>
                     </div>
                 </div>
             </div>
-            <div class="fd-form-group fd-col__form-group fd-col fd-col-md--6 fd-col-lg--6 fd-col-xl--6 fd-col--wrap" role="group" aria-labelledby="grid2GroupHeader">
+            <div class="fd-form-group fd-col fd-col-md--6 fd-col-lg--6 fd-col-xl--6 fd-col--wrap" role="group" aria-labelledby="grid2GroupHeader">
                 <div class="fd-form-group__header">
                     <h1 class="fd-form-group__header-text" id="grid2GroupHeader">Group Header 2</h1>
                 </div>
@@ -173,7 +173,7 @@ export const GroupHeaderInFormGrid = () =>
                     </div>
                 </div>
             </div>
-            <div class="fd-form-group fd-col__form-group fd-col fd-col-md--6 fd-col-lg--6 fd-col-xl--6 fd-col--wrap" role="group" aria-labelledby="grid3GroupHeader">
+            <div class="fd-form-group fd-col fd-col-md--6 fd-col-lg--6 fd-col-xl--6 fd-col--wrap" role="group" aria-labelledby="grid3GroupHeader">
                 <div class="fd-form-group__header">
                     <h1 class="fd-form-group__header-text" id="grid3GroupHeader">Group Header 3</h1>
                 </div>
@@ -211,8 +211,6 @@ GroupHeaderInFormGrid.parameters = {
         description: {
             story: `
 When group headers are displayed in a **Form Grid**, paddings are added to the groups.
-
-To display group headers in a form grid, add the \`fd-col__form-group\` class at the same level as \`fd-form-group\` for the styles to reflect properly. Similarly, when using \`fd-form-item\`, add the \`fd-row__form-item\` element at the same level.
         `
         }
     }

--- a/stories/input-group/__snapshots__/input-group.stories.storyshot
+++ b/stories/input-group/__snapshots__/input-group.stories.storyshot
@@ -35,6 +35,7 @@ exports[`Storyshots Components/Forms/Input Group Focus 1`] = `
         class="fd-input fd-input-group__input"
         id="aqwsde133"
         name=""
+        placeholder="Placeholder"
         type="text"
         value="1234568910"
       />
@@ -71,6 +72,7 @@ exports[`Storyshots Components/Forms/Input Group Focus 1`] = `
         class="fd-input fd-input-group__input"
         id="aqwsde134"
         name=""
+        placeholder="Placeholder"
         type="text"
         value="1000000"
       />
@@ -121,6 +123,7 @@ exports[`Storyshots Components/Forms/Input Group Focus 1`] = `
         class="fd-input fd-input-group__input"
         id="aqwsde134ff"
         name=""
+        placeholder="Placeholder"
         type="text"
         value="1000000"
       />
@@ -171,6 +174,7 @@ exports[`Storyshots Components/Forms/Input Group Focus 1`] = `
         class="fd-input fd-input-group__input"
         id="aqwsde134ss"
         name=""
+        placeholder="Placeholder"
         type="text"
         value="1000000"
       />
@@ -227,6 +231,7 @@ exports[`Storyshots Components/Forms/Input Group Input With Actions 1`] = `
         class="fd-input fd-input-group__input"
         id="aqwsde120"
         name=""
+        placeholder="Placeholder"
         type="text"
         value="1000000"
       />
@@ -280,6 +285,7 @@ exports[`Storyshots Components/Forms/Input Group Input With Actions 1`] = `
         class="fd-input fd-input-group__input"
         id="aqwsde121"
         name=""
+        placeholder="Placeholder"
         type="text"
         value="1000000"
       />
@@ -338,6 +344,7 @@ exports[`Storyshots Components/Forms/Input Group Input With Actions 1`] = `
         class="fd-input fd-input--compact fd-input-group__input"
         id="aqwsde122"
         name=""
+        placeholder="Placeholder"
         type="text"
         value="1000000"
       />
@@ -413,6 +420,7 @@ exports[`Storyshots Components/Forms/Input Group Input With Actions 1`] = `
         class="fd-input fd-input-group__input"
         id="aqwsde123"
         name=""
+        placeholder="Placeholder"
         type="text"
         value="1000000"
       />
@@ -469,6 +477,7 @@ exports[`Storyshots Components/Forms/Input Group Input With Icons 1`] = `
         class="fd-input fd-input-group__input"
         id="aqwsde117"
         name=""
+        placeholder="Placeholder"
         type="text"
         value="1000000"
       />
@@ -505,6 +514,7 @@ exports[`Storyshots Components/Forms/Input Group Input With Icons 1`] = `
         class="fd-input fd-input-group__input"
         id="aqwsde118"
         name=""
+        placeholder="Placeholder"
         type="text"
         value="1000000"
       />
@@ -618,6 +628,7 @@ exports[`Storyshots Components/Forms/Input Group Sizes 1`] = `
         class="fd-input fd-input-group__input"
         id="aqwsde111"
         name=""
+        placeholder="Placeholder"
         type="text"
         value="1234568910 "
       />
@@ -661,6 +672,7 @@ exports[`Storyshots Components/Forms/Input Group Sizes 1`] = `
         class="fd-input fd-input--compact fd-input-group__input"
         id="aqwsde112"
         name=""
+        placeholder="Placeholder"
         type="text"
         value="1234568910 "
       />
@@ -710,6 +722,7 @@ exports[`Storyshots Components/Forms/Input Group States 1`] = `
         class="fd-input fd-input-group__input"
         id="aqwsde124"
         name=""
+        placeholder="Placeholder"
         type="text"
         value="1234568910"
       />
@@ -746,6 +759,7 @@ exports[`Storyshots Components/Forms/Input Group States 1`] = `
         class="fd-input fd-input-group__input"
         id="aqwsde125"
         name=""
+        placeholder="Placeholder"
         type="text"
         value="1000000"
       />
@@ -803,6 +817,7 @@ exports[`Storyshots Components/Forms/Input Group States 1`] = `
         class="fd-input fd-input-group__input"
         id="aqwsde126"
         name=""
+        placeholder="Placeholder"
         type="text"
         value="1234568910"
       />
@@ -839,6 +854,7 @@ exports[`Storyshots Components/Forms/Input Group States 1`] = `
         class="fd-input fd-input--compact fd-input-group__input"
         id="aqwsde127"
         name=""
+        placeholder="Placeholder"
         type="text"
         value="1000000"
       />
@@ -893,6 +909,7 @@ exports[`Storyshots Components/Forms/Input Group States 1`] = `
         class="fd-input fd-input--compact fd-input-group__input"
         id="aqwsde127"
         name=""
+        placeholder="Placeholder"
         type="text"
         value="1000000"
       />
@@ -947,6 +964,7 @@ exports[`Storyshots Components/Forms/Input Group States 1`] = `
         class="fd-input fd-input--compact fd-input-group__input"
         id="aqwsde127"
         name=""
+        placeholder="Placeholder"
         type="text"
         value="1000000"
       />
@@ -1001,6 +1019,7 @@ exports[`Storyshots Components/Forms/Input Group States 1`] = `
         class="fd-input fd-input--compact fd-input-group__input"
         id="aqwsde127"
         name=""
+        placeholder="Placeholder"
         type="text"
         value="1000000"
       />
@@ -3255,6 +3274,7 @@ exports[`Storyshots Components/Forms/Input Group Text Add On 1`] = `
         class="fd-input fd-input-group__input"
         id="aqwsde113"
         name=""
+        placeholder="Placeholder"
         type="text"
         value="1234568910 "
       />
@@ -3291,6 +3311,7 @@ exports[`Storyshots Components/Forms/Input Group Text Add On 1`] = `
         class="fd-input fd-input-group__input"
         id="aqwsde114"
         name=""
+        placeholder="Placeholder"
         type="text"
         value="1234568910 "
       />
@@ -3384,6 +3405,7 @@ exports[`Storyshots Components/Forms/Input Group Text Add On 1`] = `
         class="fd-input fd-input-group__input"
         id="aqwsde116"
         name=""
+        placeholder="Placeholder"
         type="text"
         value="This is a test"
       />

--- a/stories/radio/__snapshots__/radio.stories.storyshot
+++ b/stories/radio/__snapshots__/radio.stories.storyshot
@@ -23,7 +23,7 @@ exports[`Storyshots Components/Forms/Radio Inline 1`] = `
       
             
       <div
-        class="fd-form-group__item fd-form-item"
+        class="fd-form-item"
       >
         
                 
@@ -50,7 +50,7 @@ exports[`Storyshots Components/Forms/Radio Inline 1`] = `
       
             
       <div
-        class="fd-form-group__item fd-form-item"
+        class="fd-form-item"
       >
         
                 
@@ -76,7 +76,7 @@ exports[`Storyshots Components/Forms/Radio Inline 1`] = `
       
             
       <div
-        class="fd-form-group__item fd-form-item"
+        class="fd-form-item"
       >
         
                 

--- a/stories/radio/radio.stories.js
+++ b/stories/radio/radio.stories.js
@@ -83,19 +83,19 @@ Primary.parameters = {
 export const Inline = () => `<fieldset class="fd-fieldset" id="radio4">
     <legend class="fd-fieldset__legend">Inline Radio buttons</legend>
         <div class="fd-form-group fd-form-group--inline">
-            <div class="fd-form-group__item fd-form-item">
+            <div class="fd-form-item">
                 <input type="radio" class="fd-radio" id="pDidh767" name="radio4" checked>
                 <label class="fd-radio__label" for="pDidh767">
                     Field label
                 </label>
             </div>
-            <div class="fd-form-group__item fd-form-item">
+            <div class="fd-form-item">
                 <input type="radio" class="fd-radio" id="pDidh7618" name="radio4" >
                 <label class="fd-radio__label" for="pDidh7618">
                     Field label
                 </label>
             </div>
-            <div class="fd-form-group__item fd-form-item">
+            <div class="fd-form-item">
                 <input type="radio" class="fd-radio" id="pDidh7619" name="radio4">
                 <label class="fd-radio__label" for="pDidh7619">
                     Field label


### PR DESCRIPTION
## Related Issue

Closes https://github.com/SAP/fundamental-styles/issues/3574
Refers to https://github.com/SAP/fundamental-ngx/issues/7854

## Description

Form container margins fixed.

## Screenshots

_Form Grid_

### Before:
_Note: Redundant gaps in horizontal mode._
<img width="826" alt="image" src="https://user-images.githubusercontent.com/20265336/182604472-a790892d-0e7c-4ea3-a399-d66dece6fc5d.png">

_Note: No margins between groups._
<img width="174" alt="image" src="https://user-images.githubusercontent.com/20265336/182845448-5dad16c8-6264-4707-b309-f6df90e2bf65.png">

<img width="442" alt="image" src="https://user-images.githubusercontent.com/20265336/182846391-6a19ea01-0a3e-4443-9803-3eb59d61d352.png">

### After:
<img width="827" alt="image" src="https://user-images.githubusercontent.com/20265336/182604439-21f5c629-8bb2-4603-ba87-bd25fb23cfb8.png">

<img width="180" alt="image" src="https://user-images.githubusercontent.com/20265336/182846109-0fc32306-2fce-4cb5-95d3-5ee328f75e31.png">

<img width="441" alt="image" src="https://user-images.githubusercontent.com/20265336/182846343-af4559b3-a466-4993-bbd0-490de2e992a0.png">