### PR TITLE
docs(styles): fix icon broken link

### DIFF
--- a/stories/icon/SAPIcons/icon.stories.js
+++ b/stories/icon/SAPIcons/icon.stories.js
@@ -3,7 +3,7 @@ import data from './data.json';
 export default {
     title: 'Components/Icons/SAP Icons',
     parameters: {
-        description: `Icons are used to provide visual clarity, save screen space, and help guide users as they navigate an application. They are often used as visual elements within other components, although they can be used independently, given that they can be read by screen readers or have a tooltip for accessibility purposes. See [Project Confirguration](https://sap.github.io/fundamental-styles/?path=/docs/introduction-overview--page) for instructions on how to use the SAP icon font on your page.
+        description: `Icons are used to provide visual clarity, save screen space, and help guide users as they navigate an application. They are often used as visual elements within other components, although they can be used independently, given that they can be read by screen readers or have a tooltip for accessibility purposes. See [Project Confirguration](https://sap.github.io/fundamental-styles/?path=/docs/introduction--overview#icons) for instructions on how to use the SAP icon font on your page.
 
 ##Usage
 **Use the icon if:**


### PR DESCRIPTION
Broken link in icon.stories.js :Update to https://sap.github.io/fundamental-styles/?path=/docs/introduction--overview#icons

## Related Issue
Closes SAP/fundamental-styles#

## Description
Updated the broken link in stories

## Screenshots
![image](https://user-images.githubusercontent.com/5914863/183670830-9746e464-c18d-4ba4-943a-68bcb20b7edc.png)

### Before:
![image](https://user-images.githubusercontent.com/5914863/183670986-65d7dd00-30bb-4848-86d1-d49dc9ae65f1.png)

### After:
![image](https://user-images.githubusercontent.com/5914863/183671135-d2e1d128-10ee-403f-adb6-9faa3525f25b.png)


#### Please check whether the PR fulfills the following requirements
4. Documentation
- [x] Storybook documentation has been updated

