### PR TITLE
fix(styles): notification mobile

### DIFF
--- a/src/styles/notification.scss
+++ b/src/styles/notification.scss
@@ -196,6 +196,7 @@ $block: #{$fd-namespace}-notification;
       @include fd-reset();
 
       margin: 0.5rem 0 0;
+      white-space: break-spaces;
     }
   }
 
@@ -238,6 +239,7 @@ $block: #{$fd-namespace}-notification;
     @include fd-reset();
 
     overflow: hidden;
+    height: 100%;
 
     .#{$block}__body {
       padding: 1rem 0.5rem 1rem 1rem;

--- a/src/styles/notification.scss
+++ b/src/styles/notification.scss
@@ -190,6 +190,7 @@ $block: #{$fd-namespace}-notification;
       @include fd-reset();
 
       font-size: var(--sapFontHeader5Size);
+      white-space: break-spaces;
     }
 
     &--description {


### PR DESCRIPTION
## Related Issue

Refers to https://github.com/SAP/fundamental-ngx/pull/8525

## Description

Notification mobile mode fixes.

## Screenshots

### Before:

<img width="415" alt="image" src="https://user-images.githubusercontent.com/20265336/183846503-26546612-5d8d-482c-932f-e86f1a57465e.png">
<img width="409" alt="image" src="https://user-images.githubusercontent.com/20265336/183846553-6d7c0e89-01ef-4337-903c-520a2848f0e0.png">

### After:

<img width="410" alt="image" src="https://user-images.githubusercontent.com/20265336/183846739-281469ad-ae14-4eb5-a32d-28be7eaa4da6.png">