### PR TITLE
fix(styles): combobox row height

### DIFF
--- a/src/styles/mixins/list/_list-dropdown.scss
+++ b/src/styles/mixins/list/_list-dropdown.scss
@@ -10,17 +10,20 @@ $fd-checkbox-dimensions: 1.375rem !default;
       outline: none;
     }
 
-    .#{$block}__item {
+    .#{$block}__item:not(.#{$block}__group-header) {
+      @include fd-flex-vertical-center();
       @include fd-list-item-states();
 
       height: auto;
-      padding: $fd-list-dropdown-vertical-padding $fd-list-item-padding-x;
+      min-height: 2.5rem;
+      padding: 0 $fd-list-item-padding-x;
     }
 
     &.#{$block}--compact {
-      .#{$block}__item {
+      .#{$block}__item:not(.#{$block}__group-header) {
         height: auto;
-        padding: $fd-list-dropdown-vertical-compact-padding $fd-list-item-padding-x;
+        min-height: 2rem;
+        padding: 0 $fd-list-item-padding-x;
       }
     }
   }


### PR DESCRIPTION
## Related Issue

Closes https://github.com/SAP/fundamental-styles/issues/3802

## Description

Combobox row height fix.

## Screenshots

### Before:
<img width="723" alt="зображення" src="https://user-images.githubusercontent.com/20265336/187923256-354ce7c4-9830-41f7-9ac5-0d8102fac330.png">

### After:
<img width="696" alt="зображення" src="https://user-images.githubusercontent.com/20265336/187923372-05b52da9-e47b-4ac6-a2e1-cb9f74522cb2.png">
