### PR TITLE
fix(styles): there should be no compact object list

### DIFF
--- a/src/styles/mixins/list/_list-base.scss
+++ b/src/styles/mixins/list/_list-base.scss
@@ -240,7 +240,7 @@
     @include fd-set-margin-left(var(--fdList_Button_Spacing));
   }
 
-  &--compact {
+  &--compact:not(.#{$objectListBlock}) {
     .#{$block}__item {
       height: 2rem;
     }

--- a/src/styles/mixins/list/_list-definitions.scss
+++ b/src/styles/mixins/list/_list-definitions.scss
@@ -3,6 +3,8 @@
 
 $block: #{$fd-namespace}-list;
 
+$objectListBlock: #{$fd-namespace}-object-list;
+
 $fd-list-item-padding-x: 1rem !default;
 $fd-list-large-font-size: var(--sapFontLargeSize) !default;
 $fd-list-normal-font-size: var(--sapFontSize) !default;


### PR DESCRIPTION
fixes none. improvement upon this PR: https://github.com/SAP/fundamental-ngx/pull/8628

before:
<img width="1242" alt="Screen Shot 2022-08-31 at 11 59 27 AM" src="https://user-images.githubusercontent.com/2471874/187747448-75192f72-3407-4ec6-a82b-eb9a778d1981.png">

after:
<img width="1220" alt="Screen Shot 2022-08-31 at 12 01 06 PM" src="https://user-images.githubusercontent.com/2471874/187747758-7f097f3d-4b76-44f7-8c64-10c51f498c8f.png">