### PR TITLE
fix(styles): full height to shellbar select

### DIFF
--- a/src/styles/shellbar.scss
+++ b/src/styles/shellbar.scss
@@ -146,9 +146,9 @@ $block: #{$fd-namespace}-shellbar;
       }
 
       &--select {
+        @include fd-flex-vertical-center();
+
         font-style: normal;
-        display: flex;
-        align-items: center;
         height: 100%;
       }
     }

--- a/src/styles/shellbar.scss
+++ b/src/styles/shellbar.scss
@@ -147,6 +147,9 @@ $block: #{$fd-namespace}-shellbar;
 
       &--select {
         font-style: normal;
+        display: flex;
+        align-items: center;
+        height: 100%;
       }
     }
 


### PR DESCRIPTION
## Related Issue
Part of SAP/fundamental-ngx#7966

## Related NGX PR
SAP/fundamental-ngx#8347

## Description
Changed shellbar-select style to fix mouse hover effect.

## Screenshots

### Before:
<img width="139" alt="Screen Shot 2022-09-01 at 11 54 19 AM" src="https://user-images.githubusercontent.com/65063487/187958777-9f868acb-564b-4a98-bcbe-318aa3433f03.png">

### After:
<img width="131" alt="Screen Shot 2022-09-01 at 2 26 44 PM" src="https://user-images.githubusercontent.com/65063487/187986350-0188a04a-f4e8-40fb-8dde-930a73f60156.png">
