### PR TITLE
fix(styles): button fonts

### DIFF
--- a/src/fonts/sap_fonts.scss
+++ b/src/fonts/sap_fonts.scss
@@ -22,6 +22,13 @@
 }
 
 @font-face {
+  font-family: '72-SemiboldDuplex';
+  src:
+    url('~@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/72-SemiboldDuplex.woff')
+    format('woff');
+}
+
+@font-face {
   font-family: 'BusinessSuiteInAppSymbols';
   src:
     url('~@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/BusinessSuiteInAppSymbols.woff')

--- a/src/styles/button.scss
+++ b/src/styles/button.scss
@@ -55,6 +55,11 @@ $fd-button-compact-padding-x: calc(0.5rem - #{$fd-button-border-width});
     color: inherit;
   }
 
+  &,
+  &__text {
+    font-family: var(--fdButton_Font_Family);
+  }
+
   *:not(:first-child) {
     // Mixin cannot be used because of !important
     margin-left: 0.375rem !important;

--- a/src/styles/theming/common/button/_sap_fiori.scss
+++ b/src/styles/theming/common/button/_sap_fiori.scss
@@ -4,6 +4,7 @@
   --fdButton_Ghost_Background: var(--sapButton_Lite_Background);
   --fdButton_Outline_Contrast: var(--sapContent_ContrastFocusColor);
   --fdButton_Outline_Offset: -0.1875rem;
+  --fdButton_Font_Family: var(--sapFontFamily);
 
   /** Shadows */
   --fdButton_Text_Shadow: none;

--- a/src/styles/theming/common/button/_sap_horizon.scss
+++ b/src/styles/theming/common/button/_sap_horizon.scss
@@ -4,6 +4,7 @@
   --fdButton_Ghost_Background: var(--sapButton_Background);
   --fdButton_Outline_Contrast: var(--sapContent_FocusColor);
   --fdButton_Outline_Offset: calc(-0.1875rem - var(--sapButton_BorderWidth));
+  --fdButton_Font_Family: var(--sapFontSemiboldDuplexFamily);
 
   /** Shadows */
   --fdButton_Text_Shadow: none;

--- a/src/styles/theming/common/button/_sap_horizon_hc.scss
+++ b/src/styles/theming/common/button/_sap_horizon_hc.scss
@@ -2,6 +2,7 @@
 
 :root {
   --fdButton_Emphasized_Border_Width: 0.125rem;
+  --fdButton_Font_Family: var(--sapFontFamily);
 
   /** Badge */
   --fdButton_Badge_Border_Color: var(--sapGroup_ContentBorderColor);


### PR DESCRIPTION
## Related Issue

Closes https://github.com/SAP/fundamental-styles/issues/3798 
Closes https://github.com/SAP/fundamental-styles/issues/3797

## Description

* fix button fonts
* `72-SemiboldDuplex` added to shared fonts.

## Screenshots

### Before:

![image](https://user-images.githubusercontent.com/20265336/188481079-18718ed4-d364-4744-9111-f20b2f584302.png)

### After:

![image](https://user-images.githubusercontent.com/20265336/188481137-94c9d920-d878-42fe-84da-15dc328b5ee3.png)
