### PR TITLE
fix(styles): form message icon in horizon themes

### DIFF
--- a/src/styles/form-message.scss
+++ b/src/styles/form-message.scss
@@ -9,6 +9,7 @@ $block: #{$fd-namespace}-form-message;
 .#{$block} {
   @include fd-reset();
   @include fd-ellipsis();
+  @include fd-flex-vertical-center();
 
   padding: 0.5rem;
   min-width: 6rem;
@@ -25,6 +26,19 @@ $block: #{$fd-namespace}-form-message;
 
   @include fd-rtl() {
     right: 0;
+
+    &::before {
+      margin-right: 0;
+      margin-left: 0.375rem;
+    }
+  }
+
+  &::before {
+    display: var(--fdMessage_Icon_Display);
+    align-self: flex-start;
+    margin-right: 0.375rem;
+    font-family: 'SAP-icons';
+    font-size: 1rem;
   }
 
   &--static {
@@ -35,17 +49,37 @@ $block: #{$fd-namespace}-form-message;
 
   &--error {
     background-color: var(--sapErrorBackground);
+
+    &::before {
+      content: "\e0b1";
+      color: var(--sapNegativeElementColor);
+    }
   }
 
   &--warning {
     background-color: var(--sapWarningBackground);
+
+    &::before {
+      content: "\e201";
+      color: var(--sapCriticalElementColor);
+    }
   }
 
   &--success {
     background-color: var(--sapSuccessBackground);
+
+    &::before {
+      content: "\e203";
+      color: var(--sapPositiveElementColor);
+    }
   }
 
   &--information {
     background-color: var(--sapInformationBackground);
+
+    &::before {
+      content: "\e202";
+      color: var(--sapInformativeElementColor);
+    }
   }
 }

--- a/src/styles/theming/sap_fiori_3.scss
+++ b/src/styles/theming/sap_fiori_3.scss
@@ -175,6 +175,7 @@
   --fdMessage_Box_Shadow: var(--sapContent_Shadow1);
   --fdMessage_Border: none;
   --fdMessage_Border_Radius: 0;
+  --fdMessage_Icon_Display: none;
 
   /* Calendar */
   --fdCalendar_Text_Shadow: none;

--- a/src/styles/theming/sap_fiori_3_dark.scss
+++ b/src/styles/theming/sap_fiori_3_dark.scss
@@ -181,6 +181,7 @@
   --fdMessage_Box_Shadow: var(--sapContent_Shadow1);
   --fdMessage_Border: none;
   --fdMessage_Border_Radius: 0;
+  --fdMessage_Icon_Display: none;
 
   /* Calendar */
   --fdCalendar_Text_Shadow: none;

--- a/src/styles/theming/sap_fiori_3_hcb.scss
+++ b/src/styles/theming/sap_fiori_3_hcb.scss
@@ -188,6 +188,7 @@
   --fdMessage_Box_Shadow: none;
   --fdMessage_Border: calc(2 * var(--sapField_BorderWidth)) solid var(--sapField_BorderColor);
   --fdMessage_Border_Radius: 0;
+  --fdMessage_Icon_Display: none;
 
   /* Calendar */
   --fdCalendar_Text_Shadow: 0 0 0.125rem #000;

--- a/src/styles/theming/sap_fiori_3_hcw.scss
+++ b/src/styles/theming/sap_fiori_3_hcw.scss
@@ -184,6 +184,7 @@
   --fdMessage_Box_Shadow: none;
   --fdMessage_Border: calc(2 * var(--sapField_BorderWidth)) solid var(--sapField_BorderColor);
   --fdMessage_Border_Radius: 0;
+  --fdMessage_Icon_Display: none;
 
   /* Calendar */
   --fdCalendar_Text_Shadow: none;

--- a/src/styles/theming/sap_fiori_3_light_dark.scss
+++ b/src/styles/theming/sap_fiori_3_light_dark.scss
@@ -182,6 +182,7 @@
   --fdMessage_Box_Shadow: var(--sapContent_Shadow1);
   --fdMessage_Border: none;
   --fdMessage_Border_Radius: 0;
+  --fdMessage_Icon_Display: none;
 
   /* Calendar */
   --fdCalendar_Text_Shadow: none;

--- a/src/styles/theming/sap_horizon.scss
+++ b/src/styles/theming/sap_horizon.scss
@@ -183,6 +183,7 @@
   --fdMessage_Box_Shadow: var(--sapContent_Shadow1);
   --fdMessage_Border: none;
   --fdMessage_Border_Radius: var(--sapPopover_BorderCornerRadius);
+  --fdMessage_Icon_Display: block;
 
   /* Calendar */
   --fdCalendar_Text_Shadow: none;

--- a/src/styles/theming/sap_horizon_dark.scss
+++ b/src/styles/theming/sap_horizon_dark.scss
@@ -192,6 +192,7 @@
   --fdMessage_Box_Shadow: var(--sapContent_Shadow1);
   --fdMessage_Border: none;
   --fdMessage_Border_Radius: var(--sapPopover_BorderCornerRadius);
+  --fdMessage_Icon_Display: block;
 
   /* Calendar */
   --fdCalendar_Text_Shadow: none;

--- a/src/styles/theming/sap_horizon_hcb.scss
+++ b/src/styles/theming/sap_horizon_hcb.scss
@@ -179,6 +179,7 @@
   --fdMessage_Box_Shadow: none;
   --fdMessage_Border: calc(2 * var(--sapField_BorderWidth)) solid var(--sapField_BorderColor);
   --fdMessage_Border_Radius: 0;
+  --fdMessage_Icon_Display: block;
 
   /* Calendar */
   --fdCalendar_Text_Shadow: none;

--- a/src/styles/theming/sap_horizon_hcw.scss
+++ b/src/styles/theming/sap_horizon_hcw.scss
@@ -180,6 +180,7 @@
   --fdMessage_Box_Shadow: none;
   --fdMessage_Border: calc(2 * var(--sapField_BorderWidth)) solid var(--sapField_BorderColor);
   --fdMessage_Border_Radius: 0;
+  --fdMessage_Icon_Display: block;
 
   /* Calendar */
   --fdCalendar_Text_Shadow: none;


### PR DESCRIPTION
## Related Issue

Closes https://github.com/SAP/fundamental-styles/issues/3804

## Description

* form message icon in horizon themes

## Screenshots

### Before:

<img width="138" alt="image" src="https://user-images.githubusercontent.com/20265336/188605316-c10e0dbd-f768-46e5-9199-a8d12c89d8bf.png">

### After:

<img width="171" alt="Screenshot 2022-09-06 at 11 51 58" src="https://user-images.githubusercontent.com/20265336/188605199-d6a649fd-46c8-4366-9550-c852d75ab68a.png">