### PR TITLE
fix(styles): form message in popover

### DIFF
--- a/src/styles/popover.scss
+++ b/src/styles/popover.scss
@@ -229,7 +229,7 @@ $listBlock: #{$fd-namespace}-list;
       visibility: hidden;
     }
 
-    &--hidden {
+    .#{$body}--hidden {
       display: none;
     }
   }

--- a/src/styles/popover.scss
+++ b/src/styles/popover.scss
@@ -229,7 +229,7 @@ $listBlock: #{$fd-namespace}-list;
       visibility: hidden;
     }
 
-    .#{$body}--hidden {
+    .#{$block}__body--hidden {
       display: none;
     }
   }


### PR DESCRIPTION
## Related Issue

Follows up https://github.com/SAP/fundamental-styles/pull/3858

## Description

Popover's styles specificity.

## Screenshots

### Before:

<img width="248" alt="зображення" src="https://user-images.githubusercontent.com/20265336/189905510-20476186-c26c-4a74-93bb-4c00ba944242.png">

### After:

<img width="240" alt="зображення" src="https://user-images.githubusercontent.com/20265336/189905789-ae058a8d-e2e5-42c1-a167-826e414b5bd8.png">