### PR TITLE
fix(docs): docs container width

### DIFF
--- a/.storybook/custom/DocsPage.scss
+++ b/.storybook/custom/DocsPage.scss
@@ -6,10 +6,6 @@ a[title='Open canvas in new tab'] {
   margin-top: 0;
 }
 
-.sbdocs.sbdocs-content {
-  max-width: 85%;
-}
-
 /* make room for TOCBot */
 @media (min-width: 1024px) {
   .sbdocs.sbdocs-content {


### PR DESCRIPTION
## Related Issue

Closes none.

## Description

Although there is no difference on the large screen, the docs page container is too narrow on mobile.

## Screenshots

### Before:
<img width="394" alt="зображення" src="https://user-images.githubusercontent.com/20265336/189949799-0434a087-34b2-4f75-8111-4bc3b4e35481.png">

### After:

<img width="358" alt="зображення" src="https://user-images.githubusercontent.com/20265336/189950231-a1d3b105-6636-4f02-b040-0fa10818be8a.png">
