### PR TITLE
fix(docs): examples container width

### DIFF
--- a/.storybook/custom/custom.scss
+++ b/.storybook/custom/custom.scss
@@ -709,3 +709,12 @@ body.sb-show-main {
 .fddocs-icon-tab-container .fd-icon-tab-bar__header {
   overflow: visible;
 }
+
+@media (max-width: 600px) {
+  .sbdocs-preview {
+    min-width: calc(100% + 20px * 2);
+    margin-left: -20px;
+    margin-right: -20px;
+    border-radius: 0;
+  }
+}


### PR DESCRIPTION
## Related Issue

Closes none.

## Description

Components are meant to look well on screens >320px, not less. Examples container has 40px of horizontal padding, so there is only 280px left for components what's definitely not okay.

## Screenshots

### Before:

<img width="381" alt="image" src="https://user-images.githubusercontent.com/20265336/191995406-17e810f1-3a0e-4e40-96b3-08c40b381d42.png">

### After:

<img width="374" alt="image" src="https://user-images.githubusercontent.com/20265336/191996179-25b9e21b-561a-4745-86d4-c0972e766f65.png">
