### PR TITLE
fix(styles): link in quick view width bug

### DIFF
--- a/src/styles/quick-view.scss
+++ b/src/styles/quick-view.scss
@@ -77,6 +77,10 @@ $fd-quick-view-group-item-indent: 0.75rem;
 
   .#{$fd-namespace}-form-item {
     padding-top: $fd-quick-view-group-item-indent;
+
+    .#{$fd-namespace}-link {
+      align-self: flex-start;
+    }
   }
 
   .#{$fd-namespace}-title {


### PR DESCRIPTION
Part of ngx defect hunting here: https://github.com/SAP/fundamental-ngx/issues/8557#issuecomment-1215401360

Before: 
![Screen Shot 2022-09-28 at 12 57 42 PM](https://user-images.githubusercontent.com/2471874/192866603-f9349f82-6a2f-4b3b-a7d2-764b98859945.png)

After:
![Screen Shot 2022-09-28 at 12 58 04 PM](https://user-images.githubusercontent.com/2471874/192866655-edbac63b-ce82-4f66-bf1a-7d86dc4aaab8.png)
