### PR TITLE
fix(styles): tokenizer not rendering as compact

### DIFF
--- a/src/styles/tokenizer.scss
+++ b/src/styles/tokenizer.scss
@@ -91,6 +91,8 @@ $block: #{$fd-namespace}-tokenizer;
   }
 
   &--compact {
+    @include fd-input-field-base-compact();
+
     .#{$block}__inner {
       padding: 0 $fd-tokenizer-compact-spacing;
     }


### PR DESCRIPTION
fixes #3897 

The tokens themselves are showing as compact but the tokenizer as a whole is not.

Before:
<img width="516" alt="Screen Shot 2022-09-28 at 4 11 42 PM" src="https://user-images.githubusercontent.com/2471874/192898269-cc18491e-13fa-4010-86c6-84ad334cd0ba.png">

After:
<img width="513" alt="Screen Shot 2022-09-28 at 4 11 52 PM" src="https://user-images.githubusercontent.com/2471874/192898287-68206462-e2be-494e-b8d6-f1ce80a71d1d.png">
