### PR TITLE
fix(styles): add full width to grid-list-item content

### DIFF
--- a/src/styles/grid-list.scss
+++ b/src/styles/grid-list.scss
@@ -206,6 +206,7 @@ $fd-grid-list-highlight: (
       @include fd-reset();
 
       color: var(--sapList_TextColor);
+      width: 100%;
     }
 
     &-counter {


### PR DESCRIPTION
## Related Issue
Part of SAP/fundamental-ngx#8557

## Description
Solves [this](https://github.com/SAP/fundamental-ngx/issues/8557#issuecomment-1215393590): Added full width to grid-list-item content.

## Screenshots

### Before:
![image](https://user-images.githubusercontent.com/65063487/193307931-f87c532a-180e-463b-872c-f99c8acf07ea.png)

### After:
![image](https://user-images.githubusercontent.com/65063487/193307999-133dba5d-8284-44cb-b9ba-1e7c17afc332.png)
