### PR TITLE
docs(styles): align theme names with the other technologies

### DIFF
--- a/.storybook/custom/components/Header.js
+++ b/.storybook/custom/components/Header.js
@@ -7,7 +7,7 @@ import { IfBlock } from './IfBlock';
 import { ThemeSelect } from './ThemeSelect';
 
 const Header = ({ showSelectors, theme, directionality, onThemeChange, onDirectionalityChange, fioriVersion, setFioriVersion }) => {
-    const selectedTheme = theme || 'sap_fiori_3';
+    const selectedTheme = theme || 'sap_horizon';
     const selectedDirectionality = directionality || 'ltr';
     const handlersPassed = onThemeChange && onDirectionalityChange;
     const hasThemeSupport = fioriVersion !== 'fioriNext';

--- a/.storybook/custom/constants/availableThemes.js
+++ b/.storybook/custom/constants/availableThemes.js
@@ -1,11 +1,11 @@
 export default [
-    { value: 'sap_fiori_3', title: 'Quartz Light' },
-    { value: 'sap_fiori_3_dark', title: 'Quartz Dark' },
-    { value: 'sap_fiori_3_light_dark', title: 'Quartz Light Dark' },
-    { value: 'sap_fiori_3_hcw', title: 'Quartz High Contrast White' },
-    { value: 'sap_fiori_3_hcb', title: 'Quartz High Contrast Black' },
     { value: 'sap_horizon', title: 'Morning Horizon (Light)' },
+    { value: 'sap_horizon_dark', title: 'Evening Horizon (Dark)' },
     { value: 'sap_horizon_hcb', title: 'Horizon High Contrast Black' },
     { value: 'sap_horizon_hcw', title: 'Horizon High Contrast White' },
-    { value: 'sap_horizon_dark', title: 'Evening Horizon (Dark)' }
+    { value: 'sap_fiori_3', title: 'Quartz Light' },
+    { value: 'sap_fiori_3_dark', title: 'Quartz Dark' },
+    { value: 'sap_fiori_3_light_dark', title: 'Quartz Auto (Depending on the OS Settings)' },
+    { value: 'sap_fiori_3_hcw', title: 'Quartz High Contrast White' },
+    { value: 'sap_fiori_3_hcb', title: 'Quartz High Contrast Black' }
 ];

--- a/.storybook/custom/constants/availableThemes.js
+++ b/.storybook/custom/constants/availableThemes.js
@@ -1,11 +1,11 @@
 export default [
     { value: 'sap_fiori_3', title: 'Quartz Light' },
     { value: 'sap_fiori_3_dark', title: 'Quartz Dark' },
-    { value: 'sap_fiori_3_light_dark', title: 'Light Dark' },
-    { value: 'sap_fiori_3_hcw', title: 'High Contrast White' },
-    { value: 'sap_fiori_3_hcb', title: 'High Contrast Black' },
-    { value: 'sap_horizon', title: 'Morning Horizon' },
-    { value: 'sap_horizon_hcb', title: 'High Contrast Black Horizon' },
-    { value: 'sap_horizon_hcw', title: 'High Contrast White Horizon' },
-    { value: 'sap_horizon_dark', title: 'Evening Horizon' }
+    { value: 'sap_fiori_3_light_dark', title: 'Quartz Light Dark' },
+    { value: 'sap_fiori_3_hcw', title: 'Quartz High Contrast White' },
+    { value: 'sap_fiori_3_hcb', title: 'Quartz High Contrast Black' },
+    { value: 'sap_horizon', title: 'Morning Horizon (Light)' },
+    { value: 'sap_horizon_hcb', title: 'Horizon High Contrast Black' },
+    { value: 'sap_horizon_hcw', title: 'Horizon High Contrast White' },
+    { value: 'sap_horizon_dark', title: 'Evening Horizon (Dark)' }
 ];

--- a/.storybook/custom/decorators/themeProvider.js
+++ b/.storybook/custom/decorators/themeProvider.js
@@ -21,7 +21,7 @@ export const withThemeProvider = makeDecorator({
     name: 'withThemeProvider',
     parameterName: 'themes',
     wrapper: (storyFn, context) => {
-        const newTheme = context?.parameters?.theme || context?.globals?.theme || 'sap_fiori_3';
+        const newTheme = context?.parameters?.theme || context?.globals?.theme || 'sap_horizon';
         getThemeManager(context.id).use(newTheme);
         return storyFn(context);
     }

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -77,7 +77,7 @@ export const globalTypes = {
     theme: {
         name: 'Theme',
         description: 'Global theme for components',
-        defaultValue: 'sap_fiori_3',
+        defaultValue: 'sap_horizon',
         toolbar: {
             icon: 'paintbrush',
             items: availableThemes

--- a/README.md
+++ b/README.md
@@ -61,15 +61,15 @@ To use particular theme you need to include two CSS variables files:
 <link href='https://unpkg.com/fundamental-styles@{versionNumber}/dist/theming/{themeName}.css' rel='stylesheet'>
 ```
 Available values for `themeName` are
+`sap_horizon`,
+`sap_horizon_dark`,
+`sap_horizon_hcb`,
+`sap_horizon_hcw`,
 `sap_fiori_3`,
 `sap_fiori_3_dark`,
 `sap_fiori_3_hcb`,
 `sap_fiori_3_hcw`,
-`sap_fiori_3_light_dark`,
-`sap_horizon`,
-`sap_horizon_dark`,
-`sap_horizon_hcb`,
-`sap_horizon_hcw`
+`sap_fiori_3_light_dark`
 
 ### NPM Package
 

--- a/config/constants.js
+++ b/config/constants.js
@@ -1,13 +1,13 @@
 const supportedThemes = [
+    'sap_horizon',
+    'sap_horizon_dark',
+    'sap_horizon_hcb',
+    'sap_horizon_hcw',
     'sap_fiori_3',
     'sap_fiori_3_dark',
     'sap_fiori_3_hcb',
     'sap_fiori_3_hcw',
-    'sap_fiori_3_light_dark',
-    'sap_horizon',
-    'sap_horizon_hcb',
-    'sap_horizon_hcw',
-    'sap_horizon_dark'
+    'sap_fiori_3_light_dark'
 ];
 
 module.exports = supportedThemes;

--- a/scripts/build-visual-stories.js
+++ b/scripts/build-visual-stories.js
@@ -13,8 +13,8 @@ const themes = [
     { value: 'sap_fiori_3', title: 'Quartz Light' },
     // { value: 'sap_fiori_3_dark', title: 'Quartz Dark' },
     // { value: 'sap_fiori_3_hcw', title: 'High Contrast White' },
-    { value: 'sap_fiori_3_hcb', title: 'High Contrast Black' },
-    { value: 'sap_horizon', title: 'Morning Horizon' }
+    { value: 'sap_fiori_3_hcb', title: 'Quartz High Contrast Black' },
+    { value: 'sap_horizon', title: 'Morning Horizon (Light)' }
 ];
 rimraf('**/*.visual.js', (rimRafError) => {
     if (rimRafError) {

--- a/stories/BTP Experimental Design/fn-icons/IconsDocsPage.js
+++ b/stories/BTP Experimental Design/fn-icons/IconsDocsPage.js
@@ -27,7 +27,7 @@ export default () => {
 
     useStyles(customStyles, fnSearch, section, layoutPanel, layoutGrid, link, nestedButton);
     useEffect(() => {
-        themeManager.use('sap_fiori_3');
+        themeManager.use('sap_horizon');
     }, []);
     useThemedStoryContainers();
 

--- a/theming-preview/testsuite.json
+++ b/theming-preview/testsuite.json
@@ -83,14 +83,14 @@
     {
       "library":"baseLib",
       "theme": [
-        "sap_fiori_3",
-        "sap_fiori_3_dark",
-        "sap_fiori_3_hcb",
-        "sap_fiori_3_hcw",
         "sap_horizon",
         "sap_horizon_hcb",
         "sap_horizon_hcw",
-        "sap_horizon_dark"
+        "sap_horizon_dark",
+        "sap_fiori_3",
+        "sap_fiori_3_dark",
+        "sap_fiori_3_hcb",
+        "sap_fiori_3_hcw"
       ]
     }
   ]

--- a/theming-preview/theme-manager.js
+++ b/theming-preview/theme-manager.js
@@ -16,7 +16,7 @@ class ThemeManager {
 
     determineThemeId(sapThemeUrlParameter) {
         let values = sapThemeUrlParameter.split('@');
-        let themeId = values.length > 0 ? values[0] : 'sap_fiori_3';
+        let themeId = values.length > 0 ? values[0] : 'sap_horizon';
         return themeId;
     }
 


### PR DESCRIPTION
align Theme's Names with the other technologies
- Replace `Fiori 3` with `Quartz`
- Add `Quarts` to `fiori 3` HC Themes
- Add `Horizon` to horizon themes 