### PR TITLE
fix(styles): reset input-field hover style in input-group

### DIFF
--- a/src/styles/input-group.scss
+++ b/src/styles/input-group.scss
@@ -34,7 +34,7 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
     text-shadow: var(--fdInputGroup_Text_Shadow);
 
     @include fd-hover() {
-      box-shadow: none;
+      @include fd-input-field-nested-reset();
     }
 
     @include fd-focus() {


### PR DESCRIPTION
## Related Issue
Part of SAP/fundamental-ngx#8557

## Description
Solves one of [these](https://github.com/SAP/fundamental-ngx/issues/8557#issuecomment-1215609973): 
Added mixin  `fd-input-field-nested-reset` for input hover in input-group. 

## Screenshots

### Before:
**Hover over it** :
![image](https://user-images.githubusercontent.com/65063487/193682884-16620d26-7366-40ab-9254-6ad870535708.png)

### After:
**Hover over it** :
![image](https://user-images.githubusercontent.com/65063487/193682923-c773bfd4-d9d6-4858-a3ee-e1f2b79b5083.png)
