### PR TITLE
fix(styles): fix padding of nested list in rtl

### DIFF
--- a/src/styles/nested-list.scss
+++ b/src/styles/nested-list.scss
@@ -335,7 +335,6 @@ $button: #{$fd-namespace}-button;
       .#{$block}__link,
       .#{$block}__content {
         padding-right: 1rem;
-        padding-left: 0;
 
         &.has-child {
           padding-right: 0;


### PR DESCRIPTION
## Related Issue
part of SAP/fundamental-ngx#8557

## Description
Solve one of [these](https://github.com/SAP/fundamental-ngx/issues/8557#issuecomment-1215609973) : Removed zero left padding of nested list in RTL

## Screenshots

### Before:
![image](https://user-images.githubusercontent.com/65063487/193723584-8aae6626-70c9-47d2-a65b-cfe7b720c5aa.png)

### After:
![image](https://user-images.githubusercontent.com/65063487/193723620-c55906f5-158e-4d9f-9e75-058847abedd4.png)
