### PR TITLE
fix(styles): more tokenizer fixes

### DIFF
--- a/src/styles/tokenizer.scss
+++ b/src/styles/tokenizer.scss
@@ -91,7 +91,7 @@ $block: #{$fd-namespace}-tokenizer;
   }
 
   &--compact {
-    @include fd-input-field-base-compact();
+    @include set-min-height($fd-input-field-height--compact);
 
     .#{$block}__inner {
       padding: 0 $fd-tokenizer-compact-spacing;


### PR DESCRIPTION
fixes none

Multi-input, combobox etc. set paddings/margins so standalone tokenizer should not have these

before:
<img width="473" alt="Screen Shot 2022-10-04 at 9 44 35 PM" src="https://user-images.githubusercontent.com/2471874/193977343-94d16013-1b10-4232-87eb-8bf3b29498cf.png">

after:
<img width="448" alt="Screen Shot 2022-10-04 at 9 44 46 PM" src="https://user-images.githubusercontent.com/2471874/193977358-f3f7b19c-1cae-40d6-8201-cb85c9325917.png">
