### PR TITLE
feat(styles): add focus styles to scrollbar

### DIFF
--- a/src/styles/scrollbar.scss
+++ b/src/styles/scrollbar.scss
@@ -5,6 +5,10 @@ $block: fd-scrollbar;
 .#{$block} {
   @include fd-reset();
 
+  @include fd-focus() {
+    outline: none;
+  }
+
   overflow: auto;
 
   /** Firefox


### PR DESCRIPTION
## Related Issue
Support for SAP/fundamental-ngx#8780

## Description
Added focus mixin with outline none.

## Screenshots

### Before:
**`Note:` This can only be reproducible on the PR branch of NGX.**

![image](https://user-images.githubusercontent.com/65063487/194394891-dd5bce66-c03f-444a-b9f5-b4548916b20d.png)


### After:
![image](https://user-images.githubusercontent.com/65063487/194394907-9d145023-ed89-4e70-8fd9-bb565a12fd96.png)


- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)