### PR TITLE
feat(styles): dynamic page title & subtitle wrapping

### DIFF
--- a/src/styles/dynamic-page.scss
+++ b/src/styles/dynamic-page.scss
@@ -209,6 +209,10 @@ $block: #{$fd-namespace}-dynamic-page;
       max-width: 100%;
       vertical-align: bottom;
     }
+
+    &--wrap {
+      white-space: initial;
+    }
   }
 
   &__subtitle {
@@ -218,6 +222,10 @@ $block: #{$fd-namespace}-dynamic-page;
     color: var(--fdDynamicPage_Subtitle_Color);
     font-size: var(--sapFontSize);
     margin-top: 0.25rem;
+
+    &--wrap {
+      white-space: initial;
+    }
   }
 
   &__title-content {

--- a/stories/dynamic-page/dynamic-page.stories.js
+++ b/stories/dynamic-page/dynamic-page.stories.js
@@ -26,11 +26,13 @@ export default {
                     - \`fd-dynamic-page__breadcrumb\` Breadcrumbs
                 - \`fd-dynamic-page__title-container\` The container for title, KPI content and actions and toolbar container
                     - \`fd-dynamic-page__title\` Dynamic page title
+                        - \`fd-dynamic-page__title--wrap\` Whether the title wraps instead of truncating
                     - \`fd-dynamic-page__title-content\` The KPI content
                 - \`fd-dynamic-page__toolbar-container\` Container that holds toolbar-related actions
                     - \`fd-dynamic-page__toolbar\` Toolbar container for actions
                     - \`fd-dynamic-page__toolbar--actions\` Navigation actions
         - \`fd-dynamic-page__subtitle\` Dynamic page subtitle
+            - \`fd-dynamic-page__subtitle--wrap\` Whether the subtitle wraps instead of truncating
     - \`fd-dynamic-page__collapsible-header-container\` Dynamic page header container
         - \`fd-dynamic-page__collapsible-header\` Dynamic page header
         - \`fd-dynamic-page__collapsible-header-visibility-container\` The container for pin/collapse buttons


### PR DESCRIPTION
## Related Issue

Refers to DXP.

## Description

Wrapping mode for Dynamic Page's Title & Subtitle elements.

## Screenshots

### Before:

<img width="664" alt="image" src="https://user-images.githubusercontent.com/20265336/194891030-26f6a755-5b1d-4ba2-ac6b-7745688eb639.png">

### After:

<img width="926" alt="image" src="https://user-images.githubusercontent.com/20265336/194890887-66c34601-1aad-428c-b3d5-3deda4f6f0f7.png">

