### PR TITLE
chore: allowed usage of any case in value keywords

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -35,6 +35,7 @@
     "scss/dollar-variable-colon-space-before": "never",
     "scss/dollar-variable-no-missing-interpolation": true,
     "scss/double-slash-comment-whitespace-inside": "always",
-    "scss/operator-no-newline-before": true
+    "scss/operator-no-newline-before": true,
+    "value-keyword-case": null
   }
 }


### PR DESCRIPTION
Without this rule, stylelint is not allowing the usage of camel case in arrays, and such. Problem is that we need them