### PR TITLE
fix(styles): add flex-center to list-title-text

### DIFF
--- a/packages/styles/src/mixins/list/_list-base.scss
+++ b/packages/styles/src/mixins/list/_list-base.scss
@@ -127,6 +127,10 @@
       flex-basis: auto;
     }
 
+    .#{$block }__title-text {
+      @include fd-flex-center();
+    }
+
     ~ .#{$block}__icon {
       @include fd-set-margin-right(-1rem);
     }


### PR DESCRIPTION
## Related Issue
Support for SAP/fundamental-ngx#8805

## Description
Added class `fd-list__title-text` with flex-center

## Screenshots

### Before:
![image](https://user-images.githubusercontent.com/65063487/197676771-aa749ad5-f7b6-40f2-87d7-420445723c31.png)

![image](https://user-images.githubusercontent.com/65063487/197676799-b316054a-d0c2-4d4d-99bb-7d0fc4b5d421.png)

### After:
![image](https://user-images.githubusercontent.com/65063487/197676833-0398093f-a25f-4c73-92c9-3c5870ac3c8d.png)

![image](https://user-images.githubusercontent.com/65063487/197676844-05f428d9-b2d7-4391-a1b2-b23a256c2c57.png)


#### Please check whether the PR fulfills the following requirements

- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)