### PR TITLE
feat(styles): add border to the Card Footer in Quartz [ci visual]

### DIFF
--- a/packages/styles/src/card.scss
+++ b/packages/styles/src/card.scss
@@ -7,6 +7,7 @@ $numeric-content: #{$fd-namespace}-numeric-content;
 $list: #{$fd-namespace}-list;
 
 $fd-card-header-border: var(--fdCard_Header_Border_Bottom) !default;
+$fd-card-footer-border: var(--fdCard_Footer_Border_Top) !default;
 $fd-card-border-radius: var(--fdCard_Border_Radius) !default;
 $fd-card-avatar-text-spacing: 0.75rem !default;
 $fd-card-title-counter-spacing: 1rem !default;
@@ -126,8 +127,8 @@ $fd-card-header-outline-offset: 0.0625rem !default;
 
     padding: var(--fdCard_Footer_Padding);
     background: $fd-card-default-body-background-color;
-    border-bottom: $fd-card-header-border;
     border-radius: 0 0 $fd-card-border-radius $fd-card-border-radius;
+    border-top: $fd-card-footer-border;
 
     &-actions {
       @include fd-reset();
@@ -153,6 +154,10 @@ $fd-card-header-outline-offset: 0.0625rem !default;
 
       text-overflow: clip;
     }
+  }
+
+  &__bar-footer {
+    border-radius: 0 0 $fd-card-border-radius $fd-card-border-radius;
   }
 
   &__header-text {

--- a/packages/styles/src/theming/common/card/_sap_fiori.scss
+++ b/packages/styles/src/theming/common/card/_sap_fiori.scss
@@ -3,6 +3,7 @@
   --fdCard_Box_Shadow: var(--sapContent_Shadow0);
   --fdCard_Border_Radius: var(--sapElement_BorderCornerRadius);
   --fdCard_Header_Border_Bottom: 0.0625rem solid var(--sapTile_SeparatorColor);
+  --fdCard_Footer_Border_Top: 0.0625rem solid var(--sapTile_SeparatorColor);
   --fdCard_Border: none;
   --fdCard_Counter_Margin: 0.188rem 0 0 1rem;
   --fdCard_Counter_Margin_RTL: 0.188rem 1rem 0 0;

--- a/packages/styles/src/theming/common/card/_sap_horizon.scss
+++ b/packages/styles/src/theming/common/card/_sap_horizon.scss
@@ -2,7 +2,8 @@
   --fdCard_Background_Color: var(--sapTile_Background);
   --fdCard_Box_Shadow: var(--sapContent_Shadow0);
   --fdCard_Border_Radius: var(--sapTile_BorderCornerRadius);
-  --fdCard_Header_Border_Bottom: none;
+  --fdCard_Header_Border_Bottom: 0.0625rem solid transparent;
+  --fdCard_Footer_Border_Top: 0.0625rem solid transparent;
   --fdCard_Border: none;
   --fdCard_Counter_Margin: 0.125rem 0 0 1rem;
   --fdCard_Counter_Margin_RTL: 0.125rem 1rem 0 0;

--- a/packages/styles/stories/Components/card/card.stories.js
+++ b/packages/styles/stories/Components/card/card.stories.js
@@ -264,6 +264,53 @@ CardAnatomy.parameters = {
     }
 };
 
+export const CardFooterBar = () => `<div style="display:flex; justify-content:space-around; flex-wrap: wrap">
+    <div style="width: 300px; height: 400px; margin: 1rem;">
+        <div class="fd-card" role="region" aria-label="Card Anatomy Example 1">
+            <a class="fd-card__header" tabindex="0">
+                <span
+                    class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--thumbnail fd-card__avatar"
+                    style="background-image: url('/assets/images/backgrounds/city.jpg')"
+                    role="img"
+                    aria-label="John Doe"></span>
+                <div class="fd-card__header-text">
+                    <div class="fd-card__title-area">
+                        <div class="fd-card__title">Card Title</div>
+                        <span class="fd-object-status fd-card__counter">Counter</span>
+                    </div>
+                    <div class="fd-card__subtitle-area">
+                        <div class="fd-card__subtitle">Card Subtitle</div>
+                    </div>
+                </div>
+            </a>
+            <div class="fd-card__content" role="group" aria-label="Card Content"></div>
+            <div class="fd-bar fd-bar--footer fd-card__bar-footer">
+                <div class="fd-bar__right">
+                    <div class="fd-bar__element">
+                        <button aria-label="button" class="fd-button fd-button--emphasized fd-button--compact">Save</button>
+                    </div>
+                    <div class="fd-bar__element">
+                        <button aria-label="button" class="fd-button fd-button--transparent fd-button--compact">Cancel</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    
+</div>
+`;
+
+CardFooterBar.storyName = 'Card Footer with Bar';
+CardFooterBar.parameters = {
+    docs: {
+        iframeHeight: 900,
+        description: {
+            story: `Alternatively, the Card Footer can be built using the Bar component with an additional <code>fd-card__bar-footer</code> modifier class.
+`
+        }
+    }
+};
+
 export const AnalyticalCard = () => `<div style="display:flex; justify-content:space-around; flex-wrap: wrap">
     <div style="width: 300px; height: 400px; margin: 1rem;">
         <div class="fd-card fd-card--analytical" role="region" aria-label="Analytical Card Example 1">


### PR DESCRIPTION
## Related Issue
Closes [SAP/fundamental-styles#](https://github.com/SAP/fundamental-styles/issues/3960)

## Description
- adds border-top to the Card Footer in Quartz theme (uses the same values as the header)
- changes the border-bottom for Card header to transparent instead of none to keep the Card dimensions
- adds an example of how to build a Card footer using Bar component