### PR TITLE
feat(styles): adopt Fiori Scrollbar for all components with scrollable area

### DIFF
--- a/packages/styles/src/menu.scss
+++ b/packages/styles/src/menu.scss
@@ -110,6 +110,8 @@ $block: #{$fd-namespace}-menu;
   &__list--overflow {
     overflow-y: scroll;
     flex-wrap: nowrap;
+
+    @include fd-scrollbar(var(--fdScrollbar_Border_Radius));
   }
 
   &__separator {
@@ -276,6 +278,8 @@ $block: #{$fd-namespace}-menu;
   }
 
   &--overflow {
+    @include fd-scrollbar(var(--fdScrollbar_Border_Radius));
+
     overflow-y: scroll;
     box-shadow: var(--sapContent_Shadow1);
     border-radius: $fd-menu-border-radius;

--- a/packages/styles/src/mixins/_mixins.scss
+++ b/packages/styles/src/mixins/_mixins.scss
@@ -798,3 +798,49 @@
   width: $size;
   min-width: $size;
 }
+
+@mixin fd-scrollbar($borderRadius: '') {
+  @include fd-focus() {
+    outline: none;
+  }
+
+  scrollbar-color: var(--fdScrollbar_Thumb_Color) var(--fdScrollbar_Track_Color);
+
+  /** Chrome, WebKit */
+  &::-webkit-scrollbar {
+    width: var(--fdScrollbar_Dimension);
+    height: var(--fdScrollbar_Dimension);
+  }
+
+  &::-webkit-scrollbar-track,
+  &::-webkit-scrollbar-corner {
+    background-color: var(--fdScrollbar_Track_Color);
+  }
+
+  &::-webkit-scrollbar-thumb {
+    // In order to achieve space between scrollbar and scrollbar thumb, we need to use box shadow instead of background.
+    background-color: transparent;
+    box-shadow: inset 0 0 0 var(--fdScrollbar_Dimension) var(--fdScrollbar_Thumb_Color);
+    border: var(--fdScrollbar_Thumb_Offset) solid transparent;
+    border-radius: calc(var(--fdScrollbar_Thumb_Border_Radius) - var(--fdScrollbar_Thumb_Offset));
+
+    &:hover,
+    &:active {
+      box-shadow: inset 0 0 0 var(--fdScrollbar_Dimension) var(--fdScrollbar_Thumb_Hover_Color);
+    }
+  }
+
+  @if $borderRadius != '' {
+    &::-webkit-scrollbar-track,
+    &::-webkit-scrollbar-corner {
+      border-radius: 0 $borderRadius $borderRadius 0;
+    }
+
+    @include fd-rtl() {
+      &::-webkit-scrollbar-track,
+      &::-webkit-scrollbar-corner {
+        border-radius: $borderRadius 0 0 $borderRadius;
+      }
+    }
+  }
+}

--- a/packages/styles/src/panel.scss
+++ b/packages/styles/src/panel.scss
@@ -43,6 +43,8 @@ $block: #{$fd-namespace}-panel;
   }
 
   &__content {
+    @include fd-scrollbar(var(--fdScrollbar_Border_Radius));
+
     padding: 0.625rem 1rem 1.375rem 1rem;
     overflow: auto;
     border-bottom: solid 0.0625rem var(--fdPanel_Content_Border_Bottom_Color);

--- a/packages/styles/src/popover.scss
+++ b/packages/styles/src/popover.scss
@@ -60,6 +60,8 @@ $listBlock: #{$fd-namespace}-list;
   }
 
   &__wrapper {
+    @include fd-scrollbar(var(--fdScrollbar_Border_Radius));
+
     border-radius: $fd-popover-border-radius;
     overflow: auto;
   }

--- a/packages/styles/src/product-switch.scss
+++ b/packages/styles/src/product-switch.scss
@@ -201,6 +201,7 @@ $block: #{$fd-namespace}-product-switch;
 
   &__body {
     @include fd-reset();
+    @include fd-scrollbar();
 
     width: fit-content;
     max-height: calc(100vh - 76px);

--- a/packages/styles/src/scrollbar.scss
+++ b/packages/styles/src/scrollbar.scss
@@ -4,41 +4,22 @@ $block: fd-scrollbar;
 
 .#{$block} {
   @include fd-reset();
-
-  @include fd-focus() {
-    outline: none;
-  }
+  @include fd-scrollbar();
 
   overflow: auto;
 
-  /** Firefox
-    * Currently Firefox doesn't support changing scrollbar color on hover & width but it's allowed by Fiori.
-    */
-  scrollbar-color: var(--fdScrollbar_Thumb_Color) var(--fdScrollbar_Track_Color);
+  &--container {
+    &::-webkit-scrollbar-track,
+    &::-webkit-scrollbar-corner {
+      background-color: var(--fdScrollbar_Track_Color);
+      border-radius: 0 var(--fdScrollbar_Border_Radius) var(--fdScrollbar_Border_Radius) 0;
+    }
 
-  /** Chrome, WebKit */
-  &::-webkit-scrollbar {
-    width: var(--fdScrollbar_Dimension);
-    height: var(--fdScrollbar_Dimension);
-  }
-
-  &::-webkit-scrollbar-track,
-  &::-webkit-scrollbar-corner {
-    background-color: var(--fdScrollbar_Track_Color);
-  }
-
-  &::-webkit-scrollbar-thumb {
-    // In order to achieve space between scrollbar and scrollbar thumb, we need to use box shadow instead of background.
-    background-color: transparent;
-    box-shadow: inset 0 0 0 var(--fdScrollbar_Dimension) var(--fdScrollbar_Thumb_Color);
-    border: var(--fdScrollbar_Thumb_Offset) solid transparent;
-    border-radius: calc(var(--fdScrollbar_Thumb_Border_Radius) - var(--fdScrollbar_Thumb_Offset));
-
-    &:hover,
-    &:active {
-      box-shadow: inset 0 0 0 var(--fdScrollbar_Dimension) var(--fdScrollbar_Thumb_Hover_Color);
+    @include fd-rtl() {
+      &::-webkit-scrollbar-track,
+      &::-webkit-scrollbar-corner {
+        border-radius: var(--fdScrollbar_Border_Radius) 0 0 var(--fdScrollbar_Border_Radius);
+      }
     }
   }
-
-  /** For any other browser native scrollbar is used. */
 }

--- a/packages/styles/src/table.scss
+++ b/packages/styles/src/table.scss
@@ -495,6 +495,8 @@ $block: #{$fd-namespace}-table;
   /****** Modifiers ******/
 
   &--fixed {
+    @include fd-scrollbar();
+
     overflow-x: scroll;
 
     .#{$block}__header,

--- a/packages/styles/src/textarea.scss
+++ b/packages/styles/src/textarea.scss
@@ -10,6 +10,7 @@ $block: #{$fd-namespace}-textarea;
   @include fd-input-field-base();
   @include fd-input-field-states();
   @include fd-form-text();
+  @include fd-scrollbar();
 
   min-width: 6rem;
   width: 100%;
@@ -29,6 +30,13 @@ $block: #{$fd-namespace}-textarea;
 
   @include fd-expanded() {
     z-index: 4;
+  }
+
+  @include fd-hover() {
+    &::-webkit-scrollbar-track,
+    &::-webkit-scrollbar-corner {
+      border-radius: 0 var(--fdScrollbar_Border_Radius) var(--fdScrollbar_Border_Radius) 0 !important;
+    }
   }
 
   &--compact {

--- a/packages/styles/src/theming/common/scrollbar/_sap_fiori.scss
+++ b/packages/styles/src/theming/common/scrollbar/_sap_fiori.scss
@@ -5,4 +5,5 @@
   --fdScrollbar_Dimension: var(--sapScrollBar_Dimension);
   --fdScrollbar_Thumb_Border_Radius: 0;
   --fdScrollbar_Thumb_Offset: 0;
+  --fdScrollbar_Border_Radius: var(--sapElement_BorderCornerRadius);
 }

--- a/packages/styles/src/theming/common/scrollbar/_sap_horizon.scss
+++ b/packages/styles/src/theming/common/scrollbar/_sap_horizon.scss
@@ -5,4 +5,5 @@
   --fdScrollbar_Dimension: var(--sapScrollBar_Dimension);
   --fdScrollbar_Thumb_Border_Radius: var(--sapScrollBar_Dimension);
   --fdScrollbar_Thumb_Offset: 0.125rem;
+  --fdScrollbar_Border_Radius: var(--sapPopover_BorderCornerRadius);
 }


### PR DESCRIPTION
## Related Issue
Closes [SAP/fundamental-styles#](https://github.com/SAP/fundamental-styles/issues/3959)

## Description
- moved the code for Scrollbar into a mixin so it can be reused in components with overflow area
- added a modifier class `fd-scrollbar--container` to `fd-scrollbar` for when the scrollbar is used inside a container with border radius.
- added scrollbar css (mixin reuse) to the components that have scrollable area: Popover, Menu, Textarea, Feed Input, Panel, Product Switch, Table


## Screenshots

### After:
![Screenshot 2022-11-01 at 4 42 21 PM](https://user-images.githubusercontent.com/39598672/199344589-0a4459d3-d1c3-4a75-80d2-97545f661866.png)
![Screenshot 2022-11-01 at 4 41 59 PM](https://user-images.githubusercontent.com/39598672/199344591-5ccddef2-a98e-4703-9876-7ab2f83cb7ad.png)
![Screenshot 2022-11-01 at 4 38 48 PM](https://user-images.githubusercontent.com/39598672/199344594-1ffcb5d7-d214-4bf2-bbd4-7731409121f0.png)
![Screenshot 2022-11-01 at 4 38 30 PM](https://user-images.githubusercontent.com/39598672/199344596-135f5c23-6db4-4fc0-a25e-38c202154b2c.png)
![Screenshot 2022-11-01 at 4 45 43 PM](https://user-images.githubusercontent.com/39598672/199344598-16a0b3e3-0b9c-4274-bdfa-622882453bdc.png)
![Screenshot 2022-11-01 at 4 44 05 PM](https://user-images.githubusercontent.com/39598672/199344600-711cd86b-e4b9-456d-a9cf-bf1d9cccf318.png)

