### PR TITLE
fix(styles): last item in menu list border radius issue

### DIFF
--- a/packages/styles/src/menu.scss
+++ b/packages/styles/src/menu.scss
@@ -135,8 +135,8 @@ $block: #{$fd-namespace}-menu;
       border-top-left-radius: $fd-menu-border-radius;
     }
 
-    &:last-child,
-    &:last-child .#{$block}__link::after {
+    &:last-of-type,
+    &:last-of-type .#{$block}__link::after {
       border-bottom-right-radius: $fd-menu-border-radius;
       border-bottom-left-radius: $fd-menu-border-radius;
     }
@@ -297,7 +297,7 @@ $block: #{$fd-namespace}-menu;
       }
     }
 
-    .#{$block}__item:last-child {
+    .#{$block}__item:last-of-type {
       border-bottom-right-radius: 0;
 
       @include fd-rtl() {


### PR DESCRIPTION
## Related Issue

Part of https://github.com/SAP/fundamental-ngx/pull/8930

## Description

Fix for the last item border radius.

### Before:

<img width="172" alt="image" src="https://user-images.githubusercontent.com/20265336/200293375-a9aac945-f64f-4950-95da-8bb3bdcdb910.png">

### After:

<img width="193" alt="image" src="https://user-images.githubusercontent.com/20265336/200293232-879b7e59-daa2-4be2-9d3a-d85126a64f6d.png">