### PR TITLE
chore(deps-dev): removed postcss-custom-properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "postcss": "^8.2.13",
     "postcss-banner": "^4.0.0",
     "postcss-cli": "^9.0.1",
-    "postcss-custom-properties": "^11.0.0",
     "postcss-import": "^14.0.1",
     "postcss-normalize-charset": "^4.0.1",
     "postcss-scss": "^4.0.5",

--- a/packages/workspace-plugins/src/executors/shared/postcss.plugins.ts
+++ b/packages/workspace-plugins/src/executors/shared/postcss.plugins.ts
@@ -4,7 +4,6 @@ import postcssRemoveFonts from './postcss-remove-fonts';
 const autoprefixer = require('autoprefixer');
 const postcssBanner = require('postcss-banner');
 const postcssNormalizeCharset = require('postcss-normalize-charset');
-const postcssCustomProperties = require('postcss-custom-properties'); //ie11 fallbacks
 const postcssImport = require('postcss-import');
 const packageVersion = require('../../../../../package.json').version;
 const year = new Date().getFullYear();
@@ -14,9 +13,6 @@ export default (minify?: boolean) => [
     postcssImport(),
     autoprefixer({
         cascade: true
-    }),
-    postcssCustomProperties({
-        preserve: true
     }),
     postcssRemoveFonts(), // remove fonts from @sap-theming/theming-base-content
     postcssBanner({

--- a/yarn.lock
+++ b/yarn.lock
@@ -7059,7 +7059,7 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
-color-name@^1.0.0, color-name@^1.1.4, color-name@~1.1.4:
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
@@ -11981,11 +11981,6 @@ is-unicode-supported@^0.1.0:
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
 
-is-url-superb@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/is-url-superb/-/is-url-superb-4.0.0.tgz#b54d1d2499bb16792748ac967aa3ecb41a33a8c2"
-  integrity sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==
-
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
@@ -15490,13 +15485,6 @@ postcss-custom-media@^7.0.8:
   dependencies:
     postcss "^7.0.14"
 
-postcss-custom-properties@^11.0.0:
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-custom-properties/-/postcss-custom-properties-11.0.0.tgz#f98cd192cd8dfcd8afa3baa1ad5b5d91d01292f3"
-  integrity sha512-Fhnx/QLt+CTt23A/KKVx1anZD9nmVpOxKCKv5owWacMoOsBXFhMAD6SZYbmPMH4nHdIeMUnWOvLZnlY4niS0sA==
-  dependencies:
-    postcss-values-parser "^4.0.0"
-
 postcss-custom-properties@^8.0.11:
   version "8.0.11"
   resolved "https://registry.yarnpkg.com/postcss-custom-properties/-/postcss-custom-properties-8.0.11.tgz#2d61772d6e92f22f5e0d52602df8fae46fa30d97"
@@ -16358,15 +16346,6 @@ postcss-values-parser@^2.0.0, postcss-values-parser@^2.0.1:
     flatten "^1.0.2"
     indexes-of "^1.0.1"
     uniq "^1.0.1"
-
-postcss-values-parser@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-values-parser/-/postcss-values-parser-4.0.0.tgz#3b4625e649279613f52842f1c81f2064321beec7"
-  integrity sha512-R9x2D87FcbhwXUmoCXJR85M1BLII5suXRuXibGYyBJ7lVDEpRIdKZh4+8q5S+/+A4m0IoG1U5tFw39asyhX/Hw==
-  dependencies:
-    color-name "^1.1.4"
-    is-url-superb "^4.0.0"
-    postcss "^7.0.5"
 
 postcss@7.0.36:
   version "7.0.36"


### PR DESCRIPTION
## Description
postcss-custom-properties is not needed anymore, since we do not support IE11 and even if we did, that configuration did not have any meaningful effect on output files, because it was missing the source of the variables