### PR TITLE
fix(styles): fix shellbar styles for input-group and addon

### DIFF
--- a/packages/styles/src/shellbar.scss
+++ b/packages/styles/src/shellbar.scss
@@ -133,6 +133,10 @@ $block: #{$fd-namespace}-shellbar;
       box-shadow: var(--sapContent_Interaction_Shadow);
     }
 
+    @include fd-focus() {
+      outline: none;
+    }
+
     &-input {
       border: none;
       color: var(--fdShellbar_Input_Color);
@@ -159,11 +163,17 @@ $block: #{$fd-namespace}-shellbar;
       }
     }
 
-    &-addon .#{$block}__button {
-      height: var(--fdShellbar_Input_Addon_Dimension);
-      min-width: var(--fdShellbar_Input_Addon_Dimension);
-      border-radius: var(--fdShellbar_Input_Border_Radius);
-      border-width: var(--fdShellbar_Input_Addon_Border_Width);
+    &-addon {
+      @include fd-flex-vertical-center() {
+        height: 100%;
+      }
+
+      .#{$block}__button {
+        height: var(--fdShellbar_Input_Addon_Dimension);
+        min-width: var(--fdShellbar_Input_Addon_Dimension);
+        border-radius: var(--fdShellbar_Input_Border_Radius);
+        border-width: var(--fdShellbar_Input_Addon_Border_Width);
+      }
     }
   }
 


### PR DESCRIPTION
## Related Issue
Part of https://github.com/SAP/fundamental-ngx/pull/8347#pullrequestreview-1168875862

## Description
fix: input-group focus outline and select hover issues.

## Screenshots

### Before:
`:hover`

![msedge_p32iJtPQJH](https://user-images.githubusercontent.com/65063487/200943221-449317b9-dc68-425a-b211-18cafcc08adb.gif)

![msedge_msdKVcKXff](https://user-images.githubusercontent.com/65063487/200943657-6d7dec6c-0775-4f59-88ef-e0baca978c4d.gif)
### After:
![msedge_CD6TfON3hq](https://user-images.githubusercontent.com/65063487/200943941-5e9bec15-848b-409e-ab48-2b241a10400b.gif)

![msedge_gEUTjqs66U](https://user-images.githubusercontent.com/65063487/200943806-bd24ea4c-7d2b-4423-b7cc-8ab9a013cf9c.gif)