### PR TITLE
feat(styles): added interactive upload collection item

### DIFF
--- a/packages/styles/src/mixins/list/_list-base.scss
+++ b/packages/styles/src/mixins/list/_list-base.scss
@@ -38,7 +38,8 @@
       }
     }
 
-    &--interractive {
+    &--interractive, // This is a typo, but we can't remove it yet
+    &--interactive {
       @include fd-list-item-states();
     }
 

--- a/packages/styles/src/upload-collection.scss
+++ b/packages/styles/src/upload-collection.scss
@@ -12,6 +12,12 @@ $fd-upload-collection-button-group-small-margin: 0.5rem !default;
 .#{$block} {
   .#{$block}__item {
     flex-wrap: nowrap;
+
+    &--interactive {
+      .#{$block}__thumbnail {
+        color: var(--sapContent_IconColor);
+      }
+    }
   }
 
   &__thumbnail {

--- a/packages/styles/stories/Components/upload-collection/upload-collection.stories.js
+++ b/packages/styles/stories/Components/upload-collection/upload-collection.stories.js
@@ -76,7 +76,7 @@ export const Standard = () => `<h4>Default mode</h4>
             <button aria-label="Delete" class="fd-button fd-button--transparent"><i class="sap-icon--decline"></i></button>
         </div>
     </li>
-    <li role="listitem" tabindex="0" class="fd-list__item fd-upload-collection__item">
+    <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interactive fd-upload-collection__item--interactive fd-upload-collection__item">
         <span class="fd-list__thumbnail fd-upload-collection__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
         <div class="fd-list__content">
             <div class="fd-upload-collection__title-container">

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -31353,7 +31353,7 @@ exports[`Check stories > Components/Upload Collection > Story Standard > Should 
             <button aria-label=\\"Delete\\" class=\\"fd-button fd-button--transparent\\"><i class=\\"sap-icon--decline\\"></i></button>
         </div>
     </li>
-    <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-upload-collection__item\\">
+    <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-list__item--interactive fd-upload-collection__item--interactive fd-upload-collection__item\\">
         <span class=\\"fd-list__thumbnail fd-upload-collection__thumbnail\\"><i role=\\"presentation\\" class=\\"sap-icon--activate\\"></i></span>
         <div class=\\"fd-list__content\\">
             <div class=\\"fd-upload-collection__title-container\\">


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#3895

## Description
The only thing, that was different from the specs was the interactive item's thumbnail color, everything else aligns with the specs. In wiki UploadCollection and UploadSet are the same, so no need to move "collection" into the deprecation just to replace it with exact same contents with a different names.

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/28543391/201047030-d2af421e-80c4-4b74-b550-f52f864aec22.png)

### After:
![image](https://user-images.githubusercontent.com/28543391/201047112-cfc7726a-5326-4db6-b010-0020b7eb09e6.png)

