### PR TITLE
fix(styles): dynamic page buttons styling

### DIFF
--- a/packages/styles/src/dynamic-page.scss
+++ b/packages/styles/src/dynamic-page.scss
@@ -4,23 +4,14 @@
 $block: #{$fd-namespace}-dynamic-page;
 
 .#{$block} {
-
   $fd-dynamic-page-background-color: var(--sapObjectHeader_Background);
-  $fd-dynamic-page-content-background-color: var(--sapBackgroundColor);
   $fd-dynamic-page-padding-top-bottom: 0.5rem;
   $fd-dynamic-page-header-padding-top-bottom: 1rem;
   $fd-dynamic-page-box-shadow: var(--sapContent_HeaderShadow);
-  $fd-dynamic-page-button-width: 1.5rem;
-  $fd-dynamic-page-button-padding: 0 0.25rem;
   $fd-dynamic-page-button-group-width: 4rem;
   $fd-dynamic-page-button-group-height: 0.0625rem;
   $fd-dynamic-page-focus-outline-offset: 0.0625rem;
-  $fd-button-height: 1.5rem;
-  $fd-button-clickable-height: 2rem;
-  $fd-button-touchable-area: ($fd-button-clickable-height - $fd-button-height) * 0.5;
   $fd-dynamic-page-toolbar-space: 1rem;
-
-  @include fd-reset();
 
   @mixin fd-background-page($background-color) {
     .#{$block}__content {
@@ -59,47 +50,7 @@ $block: #{$fd-namespace}-dynamic-page;
     box-shadow: none;
   }
 
-  @mixin custom-button() {
-    @include fd-flex-vertical-center() {
-      justify-content: center;
-    }
-
-    margin: $fd-dynamic-page-button-padding;
-    padding: 0;
-    width: $fd-dynamic-page-button-width;
-    height: $fd-button-height;
-    min-width: $fd-dynamic-page-button-width;
-    background: var(--fdDynamicPage_Button_Pin_Background);
-    border: var(--fdDynamicPage_Button_Pin_Border);
-
-    // Extended touchable area
-    &::before {
-      height: $fd-button-clickable-height;
-      width: 100%;
-      top: -$fd-button-touchable-area;
-      bottom: -$fd-button-touchable-area;
-    }
-
-    @include fd-hover() {
-      background: var(--sapButton_Hover_Background);
-      border-color: var(--sapButton_Hover_BorderColor);
-    }
-
-    @include fd-active() {
-      background: var(--sapButton_Active_Background);
-      border-color: var(--sapButton_Active_BorderColor);
-    }
-
-    @include fd-rtl() {
-      > [class*='sap-icon'] {
-        &:last-child {
-          margin-right: 0;
-          margin-left: 0;
-        }
-      }
-    }
-  }
-
+  @include fd-reset();
   @include fd-flex(column);
 
   &__header-fixed {
@@ -379,17 +330,6 @@ $block: #{$fd-namespace}-dynamic-page;
       width: 4.25rem;
       height: $fd-dynamic-page-button-group-height;
       z-index: 1;
-
-      // button styles
-      .#{$block}__pin-button.#{$fd-namespace}-button,
-      .#{$block}__expand-button.#{$fd-namespace}-button,
-      .#{$block}__collapse-button.#{$fd-namespace}-button {
-        @include custom-button();
-
-        &[aria-hidden="true"] {
-          display: none;
-        }
-      }
     }
 
     &[aria-hidden="true"] {
@@ -401,10 +341,39 @@ $block: #{$fd-namespace}-dynamic-page;
     }
   }
 
+  &__pin-button,
+  &__expand-button,
+  &__collapse-button {
+    $fd-dynamic-page-button-width: 1.5rem;
+    $fd-dynamic-page-button-height: 1.5rem;
+    $fd-dynamic-page-button-clickable-height: 2rem;
+    $fd-dynamic-page-button-touchable-area: ($fd-dynamic-page-button-clickable-height - $fd-dynamic-page-button-height) * 0.5;
+
+    --fdButtonBackgroundColor: var(--fdDynamicPage_Button_Pin_Background);
+
+    margin: 0 0.25rem;
+    padding: 0;
+    width: $fd-dynamic-page-button-width;
+    height: $fd-dynamic-page-button-height;
+    min-width: $fd-dynamic-page-button-width;
+
+    // Extended touchable area
+    &::before {
+      height: $fd-dynamic-page-button-clickable-height;
+      width: 100%;
+      top: -$fd-dynamic-page-button-touchable-area;
+      bottom: -$fd-dynamic-page-button-touchable-area;
+    }
+
+    &[aria-hidden="true"] {
+      display: none;
+    }
+  }
+
   &__content {
     @include fd-reset();
 
-    background-color: $fd-dynamic-page-content-background-color;
+    background-color: var(--sapBackgroundColor);
     overflow-y: auto;
   }
 

--- a/packages/styles/src/theming/common/dynamic-page-layout/_sap_fiori.scss
+++ b/packages/styles/src/theming/common/dynamic-page-layout/_sap_fiori.scss
@@ -5,5 +5,4 @@
   --fdDynamicPage_Title_Font_Family: var(--sapFontFamily);
   --fdDynamicPage_Subtitle_Color: var(--sapContent_LabelColor);
   --fdDynamicPage_Button_Pin_Background: var(--sapButton_Background);
-  --fdDynamicPage_Button_Pin_Border: var(--sapButton_BorderWidth) solid var(--sapButton_TextColor);
 }

--- a/packages/styles/src/theming/common/dynamic-page-layout/_sap_horizon.scss
+++ b/packages/styles/src/theming/common/dynamic-page-layout/_sap_horizon.scss
@@ -4,6 +4,5 @@
   --fdDynamicPage_Title_Collapsed_Font_Size: var(--sapObjectHeader_Title_SnappedFontSize);
   --fdDynamicPage_Title_Font_Family: var(--sapObjectHeader_Title_FontFamily);
   --fdDynamicPage_Subtitle_Color: var(--sapObjectHeader_Subtitle_TextColor);
-  --fdDynamicPage_Button_Pin_Background: var(--sapButton_Hover_Background);
-  --fdDynamicPage_Button_Pin_Border: 0.0625rem solid var(--sapButton_BorderColor);
+  --fdDynamicPage_Button_Pin_Background: var(--sapObjectHeader_Background);
 }


### PR DESCRIPTION
## Related Issue

Refers to `dxp/backlog/issues/812`

## Description

Dynamic Page button color fix.

## Screenshots

### Before:

<img width="125" alt="CleanShot 2022-11-28 at 16 00 55@2x" src="https://user-images.githubusercontent.com/20265336/204310097-2b1402b5-5d6e-4cf7-afc3-f47e32815a21.png">

### After:

<img width="116" alt="CleanShot 2022-11-28 at 16 00 02@2x" src="https://user-images.githubusercontent.com/20265336/204309882-c2016486-3737-44cd-a90e-d1b1fd50b074.png">

