### PR TITLE
fix(styles): popover arrow styles

### DIFF
--- a/packages/styles/src/popover.scss
+++ b/packages/styles/src/popover.scss
@@ -329,7 +329,7 @@ $fd-popover-arrow-offset-x: calc(var(--fdIcon_Button_Width) * 0.5 - #{$fd-popove
     &--static {
       position: relative;
 
-      --fdPopover_Offset: 0;
+      --fdPopover_Offset: 0%;
       --fdPopover_Center_Offset: 0%;
     }
 


### PR DESCRIPTION
## Related Issue

Refers to https://github.com/SAP/fundamental-ngx/pull/8967#pullrequestreview-1198114630

## Description

Arrow position Fix

*Note: When variable value is `0` it's not being properly handled in CSS's `calc()` function, but when it's `0rem` it's fine*

## Screenshots

### Before:

![image](https://user-images.githubusercontent.com/20265336/204618648-669a6c02-6ea1-4729-a48e-bae5a7f68a15.png)

### After:

![image](https://user-images.githubusercontent.com/20265336/204618687-a669b764-2283-4833-8069-d38005f07d95.png)

