### PR TITLE
fix(styles): tabs & dynamic page horizontal paddings

### DIFF
--- a/packages/styles/src/dynamic-page.scss
+++ b/packages/styles/src/dynamic-page.scss
@@ -42,7 +42,7 @@ $block: #{$fd-namespace}-dynamic-page;
     }
   }
 
-  @mixin responsive-page($padding-y: 0,$padding-x: 1rem) {
+  @mixin responsive-page($padding-y: 0, $padding-x: 1rem) {
     padding: $padding-y $padding-x;
   }
 
@@ -386,7 +386,7 @@ $block: #{$fd-namespace}-dynamic-page;
   }
 
   &--sm {
-    @include fd-responsive-page($fd-dynamic-page-header-padding-top-bottom, 0.5rem);
+    @include fd-responsive-page($fd-dynamic-page-header-padding-top-bottom);
 
     .#{$block}__breadcrumb {
       padding: 0;


### PR DESCRIPTION
## Related Issue

Refers to `dxp/organization/issues/87`

## Description

Tabs & dynamic page horizontal paddings issue fix.

## Screenshots

### Before:

![CleanShot 2022-11-30 at 11 28 50@2x](https://user-images.githubusercontent.com/20265336/204772586-1eec3f61-4536-4449-9686-06d918ce64d8.png)

### After:

![CleanShot 2022-11-30 at 11 27 58@2x](https://user-images.githubusercontent.com/20265336/204772394-9e93f998-5a53-4c85-ad5a-c6630e8cc61e.png)

