### PR TITLE
fix(styles): popover's visibility for vertical nav

### DIFF
--- a/packages/styles/src/popover.scss
+++ b/packages/styles/src/popover.scss
@@ -87,6 +87,8 @@ $fd-popover-arrow-offset-x: calc(var(--fdIcon_Button_Width) * 0.5 - #{$fd-popove
     background: $fd-popover-background-color;
     top: calc(var(--fdPopover_Offset) + #{$fd-popover-arrow-size});
     transition: all $fd-animation-speed;
+    opacity: 1;
+    visibility: visible;
 
     @include fd-both-pseudo-selectors() {
       content: "";


### PR DESCRIPTION
## Related Issue

Closes none

## Description

Popover's visibility for vertical nav issue fix

## Screenshots

### Before:

<img width="100" alt="CleanShot 2022-12-01 at 13 51 58@2x" src="https://user-images.githubusercontent.com/20265336/205057652-04f81c1d-a871-4e9c-abf4-fc94c36c3bea.png">

### After:

<img width="151" alt="CleanShot 2022-12-01 at 13 52 07@2x" src="https://user-images.githubusercontent.com/20265336/205057678-02cdadb6-92ea-43a0-9d48-a256727a84f1.png">
