### PR TITLE
fix(styles): add text shadow to inverted Object Status [ci visual]

### DIFF
--- a/packages/styles/src/object-status.scss
+++ b/packages/styles/src/object-status.scss
@@ -345,14 +345,15 @@ $inverted-color-accents: (
     min-height: $fd-object-status-inverted-min-height;
     width: auto;
     max-width: 100%;
+    min-width: $fd-object-status-inverted-min-width;
     padding: $fd-object-status-inverted-padding;
     border-radius: $fd-object-status-inverted-border-radius;
     font-size: var(--sapFontSmallSize);
     font-weight: $fd-object-status-inverted-text-font-weight;
     border-width: var(--fdInverted_Object_Border_Width);
     border-style: solid;
-    text-shadow: none;
     line-height: $fd-object-status-height;
+    text-shadow: var(--sapContent_ContrastTextShadow);
 
     .#{$block}__icon,
     .#{$block}__text {

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -30262,7 +30262,7 @@ exports[`Check stories > Components/Time Picker > Story Hours12Cozy > Should mat
                 <div class=\\"fd-bar fd-bar--footer fd-bar--cozy\\">
                     <div class=\\"fd-bar__right\\">
                         <div class=\\"fd-bar__element\\">
-                            <button class=\\"fd-button fd-button--decisive fd-button--emphasized\\">OK</button>
+                            <button class=\\"fd-button fd-button--decisive fd-button--emphasized\\">Ok</button>
                         </div>
                         <div class=\\"fd-bar__element\\">
                             <button class=\\"fd-button fd-button--decisive fd-button--transparent\\">Cancel</button>
@@ -30905,7 +30905,7 @@ exports[`Check stories > Components/Time Picker > Story Hours24Cozy > Should mat
                 <div class=\\"fd-bar fd-bar--footer fd-bar--cozy\\">
                     <div class=\\"fd-bar__right\\">
                         <div class=\\"fd-bar__element\\">
-                            <button class=\\"fd-button fd-button--decisive fd-button--emphasized\\">OK</button>
+                            <button class=\\"fd-button fd-button--decisive fd-button--emphasized\\">Ok</button>
                         </div>
                         <div class=\\"fd-bar__element\\">
                             <button class=\\"fd-button fd-button--decisive fd-button--transparent\\">Cancel</button>
@@ -31546,7 +31546,7 @@ exports[`Check stories > Components/Time Picker > Story MinutesCozy > Should mat
                 <div class=\\"fd-bar fd-bar--footer fd-bar--cozy\\">
                     <div class=\\"fd-bar__right\\">
                         <div class=\\"fd-bar__element\\">
-                            <button class=\\"fd-button fd-button--decisive fd-button--emphasized\\">OK</button>
+                            <button class=\\"fd-button fd-button--decisive fd-button--emphasized\\">Ok</button>
                         </div>
                         <div class=\\"fd-bar__element\\">
                             <button class=\\"fd-button fd-button--decisive fd-button--transparent\\">Cancel</button>
@@ -31597,7 +31597,7 @@ exports[`Check stories > Components/Time Picker > Story Mobile > Should match sn
                 <div class=\\"fd-bar fd-bar--footer fd-bar--cozy\\">
                     <div class=\\"fd-bar__right\\">
                         <div class=\\"fd-bar__element\\">
-                            <button class=\\"fd-button fd-button--decisive fd-button--emphasized\\">OK</button>
+                            <button class=\\"fd-button fd-button--decisive fd-button--emphasized\\">Ok</button>
                         </div>
                         <div class=\\"fd-bar__element\\">
                             <button class=\\"fd-button fd-button--decisive fd-button--transparent\\">Cancel</button>
@@ -31918,7 +31918,7 @@ exports[`Check stories > Components/Time Picker > Story SecondsCozy > Should mat
                 <div class=\\"fd-bar fd-bar--footer fd-bar--cozy\\">
                     <div class=\\"fd-bar__right\\">
                         <div class=\\"fd-bar__element\\">
-                            <button class=\\"fd-button fd-button--decisive fd-button--emphasized\\">OK</button>
+                            <button class=\\"fd-button fd-button--decisive fd-button--emphasized\\">Ok</button>
                         </div>
                         <div class=\\"fd-bar__element\\">
                             <button class=\\"fd-button fd-button--decisive fd-button--transparent\\">Cancel</button>


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/4027

## Description
adds text-shadow to Inverted Object Status, the font-size was recently fixed in another PR
