### PR TITLE
docs(styles): add tabindex to menu button in shellbar [ci visual]

### DIFF
--- a/packages/styles/stories/Components/shellbar/shellbar.stories.js
+++ b/packages/styles/stories/Components/shellbar/shellbar.stories.js
@@ -50,7 +50,7 @@ export const Primary = () => `<div style="height:150px">
             <div class="fd-shellbar__action">
                 <div class="fd-popover fd-popover--right">
                     <div class="fd-popover__control">
-                        <div class="fd-button fd-button--transparent fd-shellbar__button fd-user-menu__control" aria-controls="WV3AY276" aria-expanded="false" aria-haspopup="true" role="button">
+                        <div class="fd-button fd-button--transparent fd-shellbar__button fd-user-menu__control" aria-controls="WV3AY276" aria-expanded="false" aria-haspopup="true" role="button" tabindex="0">
                             <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-shellbar__avatar--circle">WW</span>
                         </div>
                     </div>
@@ -151,7 +151,7 @@ export const ProductMenuAndSearch = () => `<div style="height:200px">
             <div class="fd-shellbar__action">
                 <div class="fd-popover fd-popover--right">
                     <div class="fd-popover__control">
-                        <div class="fd-button fd-button--transparent fd-shellbar__button fd-user-menu__control" aria-controls="ZY3AY276" onclick="onPopoverClick('ZY3AY276')" aria-expanded="false" aria-haspopup="true" role="button">
+                        <div class="fd-button fd-button--transparent fd-shellbar__button fd-user-menu__control" aria-controls="ZY3AY276" onclick="onPopoverClick('ZY3AY276')" aria-expanded="false" aria-haspopup="true" role="button" tabindex="0">
                             <span
                                 class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail fd-shellbar__avatar--circle"
                                 style="background-image: url('assets/images/avatars/1.svg');"
@@ -279,7 +279,7 @@ export const LinksWithCollapsibleMenuXlSize = () => `<div style="height:300px">
                     <div class="fd-popover__control">
                         <div class="fd-button fd-button--transparent fd-shellbar__button fd-user-menu__control"
                              onclick="onPopoverClick('DD35G276')" aria-controls="DD35G276" aria-expanded="false"
-                             aria-haspopup="true" role="button">
+                             aria-haspopup="true" role="button" tabindex="0">
                             <span
                                 class="fd-avatar fd-avatar--xs fd-avatar--circle fd-shellbar__avatar--circle">WW</span>
                         </div>
@@ -406,7 +406,7 @@ export const LinksWithCollapsibleMenuMSize = () => `<div style="height:300px; ma
                     <div class="fd-popover__control">
                         <div class="fd-button fd-button--transparent fd-shellbar__button fd-user-menu__control"
                              onclick="onPopoverClick('DD35GBK6')" aria-controls="DD35GBK6" aria-expanded="false"
-                             aria-haspopup="true" role="button">
+                             aria-haspopup="true" role="button" tabindex="0">
                             <span
                                 class="fd-avatar fd-avatar--xs fd-avatar--circle fd-shellbar__avatar--circle">WW</span>
                         </div>
@@ -522,7 +522,7 @@ export const LinksWithCollapsibleMenuSSize = () => `<div style="height:300px; ma
                     <div class="fd-popover__control">
                         <div class="fd-button fd-button--transparent fd-shellbar__button fd-user-menu__control"
                              onclick="onPopoverClick('DD35GBK6')" aria-controls="DD35GBK6" aria-expanded="false"
-                             aria-haspopup="true" role="button">
+                             aria-haspopup="true" role="button" tabindex="0">
                             <span
                                 class="fd-avatar fd-avatar--xs fd-avatar--circle fd-shellbar__avatar--circle">WW</span>
                         </div>
@@ -590,7 +590,7 @@ export const ProductSwitch = () => `<div style="height:600px">
                     <div class="fd-popover__control">
                         <div class="fd-button fd-button--transparent fd-shellbar__button fd-user-menu__control"
                              onclick="onPopoverClick('MKFAY276')" aria-controls="MKFAY276" aria-expanded="false"
-                             aria-haspopup="true" role="button">
+                             aria-haspopup="true" role="button" tabindex="0">
                             <span
                                 class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail fd-shellbar__avatar--circle"
                                 style="background-image: url('assets/images/avatars/1.svg');"

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -24621,7 +24621,7 @@ exports[`Check stories > Components/Shellbar > Story LinksWithCollapsibleMenuMSi
                     <div class=\\"fd-popover__control\\">
                         <div class=\\"fd-button fd-button--transparent fd-shellbar__button fd-user-menu__control\\"
                              onclick=\\"onPopoverClick('DD35GBK6')\\" aria-controls=\\"DD35GBK6\\" aria-expanded=\\"false\\"
-                             aria-haspopup=\\"true\\" role=\\"button\\">
+                             aria-haspopup=\\"true\\" role=\\"button\\" tabindex=\\"0\\">
                             <span
                                 class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-shellbar__avatar--circle\\">WW</span>
                         </div>
@@ -24727,7 +24727,7 @@ exports[`Check stories > Components/Shellbar > Story LinksWithCollapsibleMenuSSi
                     <div class=\\"fd-popover__control\\">
                         <div class=\\"fd-button fd-button--transparent fd-shellbar__button fd-user-menu__control\\"
                              onclick=\\"onPopoverClick('DD35GBK6')\\" aria-controls=\\"DD35GBK6\\" aria-expanded=\\"false\\"
-                             aria-haspopup=\\"true\\" role=\\"button\\">
+                             aria-haspopup=\\"true\\" role=\\"button\\" tabindex=\\"0\\">
                             <span
                                 class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-shellbar__avatar--circle\\">WW</span>
                         </div>
@@ -24843,7 +24843,7 @@ exports[`Check stories > Components/Shellbar > Story LinksWithCollapsibleMenuXlS
                     <div class=\\"fd-popover__control\\">
                         <div class=\\"fd-button fd-button--transparent fd-shellbar__button fd-user-menu__control\\"
                              onclick=\\"onPopoverClick('DD35G276')\\" aria-controls=\\"DD35G276\\" aria-expanded=\\"false\\"
-                             aria-haspopup=\\"true\\" role=\\"button\\">
+                             aria-haspopup=\\"true\\" role=\\"button\\" tabindex=\\"0\\">
                             <span
                                 class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-shellbar__avatar--circle\\">WW</span>
                         </div>
@@ -24884,7 +24884,7 @@ exports[`Check stories > Components/Shellbar > Story Primary > Should match snap
             <div class=\\"fd-shellbar__action\\">
                 <div class=\\"fd-popover fd-popover--right\\">
                     <div class=\\"fd-popover__control\\">
-                        <div class=\\"fd-button fd-button--transparent fd-shellbar__button fd-user-menu__control\\" aria-controls=\\"WV3AY276\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\" role=\\"button\\">
+                        <div class=\\"fd-button fd-button--transparent fd-shellbar__button fd-user-menu__control\\" aria-controls=\\"WV3AY276\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\" role=\\"button\\" tabindex=\\"0\\">
                             <span class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-shellbar__avatar--circle\\">WW</span>
                         </div>
                     </div>
@@ -24978,7 +24978,7 @@ exports[`Check stories > Components/Shellbar > Story ProductMenuAndSearch > Shou
             <div class=\\"fd-shellbar__action\\">
                 <div class=\\"fd-popover fd-popover--right\\">
                     <div class=\\"fd-popover__control\\">
-                        <div class=\\"fd-button fd-button--transparent fd-shellbar__button fd-user-menu__control\\" aria-controls=\\"ZY3AY276\\" onclick=\\"onPopoverClick('ZY3AY276')\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\" role=\\"button\\">
+                        <div class=\\"fd-button fd-button--transparent fd-shellbar__button fd-user-menu__control\\" aria-controls=\\"ZY3AY276\\" onclick=\\"onPopoverClick('ZY3AY276')\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\" role=\\"button\\" tabindex=\\"0\\">
                             <span
                                 class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail fd-shellbar__avatar--circle\\"
                                 style=\\"background-image: url('assets/images/avatars/1.svg');\\"
@@ -25038,7 +25038,7 @@ exports[`Check stories > Components/Shellbar > Story ProductSwitch > Should matc
                     <div class=\\"fd-popover__control\\">
                         <div class=\\"fd-button fd-button--transparent fd-shellbar__button fd-user-menu__control\\"
                              onclick=\\"onPopoverClick('MKFAY276')\\" aria-controls=\\"MKFAY276\\" aria-expanded=\\"false\\"
-                             aria-haspopup=\\"true\\" role=\\"button\\">
+                             aria-haspopup=\\"true\\" role=\\"button\\" tabindex=\\"0\\">
                             <span
                                 class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail fd-shellbar__avatar--circle\\"
                                 style=\\"background-image: url('assets/images/avatars/1.svg');\\"


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/3780

## Description
the Menu button in Shellbar is a `<div>` with role=button but was missing tabindex, which is now added and the element gets a focus.
