### PR TITLE
fix(styles): add fix for margin-bottom of Select [ci visual]

### DIFF
--- a/packages/styles/src/select.scss
+++ b/packages/styles/src/select.scss
@@ -88,8 +88,11 @@ $fd-select-padding-x-compact: 0.5rem;
       pointer-events: none;
     }
 
+    @include fd-expanded() {
+      margin-bottom: 0;
+    }
+
     padding: 0;
-    margin-bottom: 0;
 
     .#{$block}__button {
       @include fd-set-margin-left(0.25rem);

--- a/packages/styles/stories/Components/select/select.stories.js
+++ b/packages/styles/stories/Components/select/select.stories.js
@@ -319,7 +319,7 @@ export const SemanticStates = () => `<div style="height: 200px">
                                 toggleElAttrs('h07j9978H', ['aria-hidden']);
                                 toggleElAttrs('errorFormMessage', ['aria-hidden']);
                             "
-                            aria-expanded="false"
+                            aria-expanded="true"
                             aria-haspopup="listbox">
                             <span id="b4546C40Value" class="fd-select__text-content">Error</span>
                             <span class="fd-button fd-button--transparent fd-select__button">
@@ -447,7 +447,7 @@ export const SemanticStates = () => `<div style="height: 200px">
                                 toggleElAttrs('hkhh998hhH', ['aria-hidden']);
                                 toggleElAttrs('informationFormMessage', ['aria-hidden']);
                             "
-                            aria-expanded="false"
+                            aria-expanded="true"
                             aria-haspopup="listbox">
                             <span id="h45336C4Value" class="fd-select__text-content">Information</span>
                                 <span class="fd-button fd-button--transparent fd-select__button">

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -24126,7 +24126,7 @@ exports[`Check stories > Components/Select > Story SemanticStates > Should match
                                 toggleElAttrs('h07j9978H', ['aria-hidden']);
                                 toggleElAttrs('errorFormMessage', ['aria-hidden']);
                             \\"
-                            aria-expanded=\\"false\\"
+                            aria-expanded=\\"true\\"
                             aria-haspopup=\\"listbox\\">
                             <span id=\\"b4546C40Value\\" class=\\"fd-select__text-content\\">Error</span>
                             <span class=\\"fd-button fd-button--transparent fd-select__button\\">
@@ -24254,7 +24254,7 @@ exports[`Check stories > Components/Select > Story SemanticStates > Should match
                                 toggleElAttrs('hkhh998hhH', ['aria-hidden']);
                                 toggleElAttrs('informationFormMessage', ['aria-hidden']);
                             \\"
-                            aria-expanded=\\"false\\"
+                            aria-expanded=\\"true\\"
                             aria-haspopup=\\"listbox\\">
                             <span id=\\"h45336C4Value\\" class=\\"fd-select__text-content\\">Information</span>
                                 <span class=\\"fd-button fd-button--transparent fd-select__button\\">


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/3589

## Description
The inputs (by design) have margins top and bottom of 0.25rem. When the inputs are controls, aka open/close a menu, which is the case of Select component, the bottom margin should disappear. In recent fix the margin-bottom of the Select control was set to 0, which makes the control not vertically aligned when positioned with other controls. 
The current fix sets the margin-bottom to 0 only when the input has aria-expanded set to true or the class `is-expanded` is added to the element