### PR TITLE
fix(styles): add fix for no horizontal and vertical borders in Table

### DIFF
--- a/packages/styles/src/table.scss
+++ b/packages/styles/src/table.scss
@@ -342,11 +342,11 @@ $block: #{$fd-namespace}-table;
       border-bottom: $fd-table-border;
 
       &--no-vertical-border {
-        border-bottom-color: transparent;
+        border-right-color: transparent;
       }
 
       &--no-horizontal-border {
-        border-right-color: transparent;
+        border-bottom-color: transparent;
       }
     }
 
@@ -607,7 +607,7 @@ $block: #{$fd-namespace}-table;
     &--no-vertical-borders {
       .#{$block}__row {
         .#{$block}__cell {
-          border-bottom: none;
+          border-right: none;
         }
       }
     }
@@ -615,7 +615,7 @@ $block: #{$fd-namespace}-table;
     &--no-horizontal-borders {
       .#{$block}__row {
         .#{$block}__cell {
-          border-right: none;
+          border-bottom: none;
         }
       }
     }


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/4029

## Description
the modifier classes for removing horizontal and vertical borders were flipped. `--no-horizontal-borders` were removing the vertical borders and vice-versa. The current issue provides a fix for this.
