### PR TITLE
fix(styles): provide option for ShellBar logo to be used as a link 

### DIFF
--- a/packages/styles/src/shellbar.scss
+++ b/packages/styles/src/shellbar.scss
@@ -4,6 +4,29 @@
 
 $block: #{$fd-namespace}-shellbar;
 
+@mixin fd-logo-outline() {
+  &:focus,
+  &.is-focus {
+    outline: none;
+    pointer-events: all;
+
+    &::before {
+      content: '';
+      position: absolute;
+      display: block;
+      border: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--fdShellbar_Button_Outline_Color);
+      top: -0.25rem;
+      left: -0.25rem;
+      right: -0.25rem;
+      bottom: -0.25rem;
+      pointer-events: none;
+      border-radius: calc(var(--sapButton_BorderCornerRadius) - 0.125rem);
+
+      @content;
+    }
+  }
+}
+
 .#{$block} {
   // Brand
   $fd-shellbar-logo-background-image-url: "data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0MTIuMzggMjA0Ij48ZGVmcz48c3R5bGU+LmNscy0xLC5jbHMtMntmaWxsLXJ1bGU6ZXZlbm9kZH0uY2xzLTF7ZmlsbDp1cmwoI2xpbmVhci1ncmFkaWVudCl9LmNscy0ye2ZpbGw6I2ZmZn08L3N0eWxlPjxsaW5lYXJHcmFkaWVudCBpZD0ibGluZWFyLWdyYWRpZW50IiB4MT0iMjA2LjE5IiB4Mj0iMjA2LjE5IiB5Mj0iMjA0IiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSI+PHN0b3Agb2Zmc2V0PSIwIiBzdG9wLWNvbG9yPSIjMDBiOGYxIi8+PHN0b3Agb2Zmc2V0PSIuMDIiIHN0b3AtY29sb3I9IiMwMWI2ZjAiLz48c3RvcCBvZmZzZXQ9Ii4zMSIgc3RvcC1jb2xvcj0iIzBkOTBkOSIvPjxzdG9wIG9mZnNldD0iLjU4IiBzdG9wLWNvbG9yPSIjMTc3NWM4Ii8+PHN0b3Agb2Zmc2V0PSIuODIiIHN0b3AtY29sb3I9IiMxYzY1YmYiLz48c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiMxZTVmYmIiLz48L2xpbmVhckdyYWRpZW50PjwvZGVmcz48dGl0bGU+U0FQX2dyYWRfUl9zY3JuX1plaWNoZW5mbMOkY2hlIDE8L3RpdGxlPjxwYXRoIGNsYXNzPSJjbHMtMSIgZD0iTTAgMjA0aDIwOC40MUw0MTIuMzggMEgwdjIwNCIvPjxwYXRoIGNsYXNzPSJjbHMtMiIgZD0iTTI0NC43MyAzOC4zNmgtNDAuNnY5Ni41MmwtMzUuNDYtOTYuNTVoLTM1LjE2bC0zMC4yNyA4MC43MkMxMDAgOTguNyA3OSA5MS42NyA2Mi40IDg2LjQgNTEuNDYgODIuODkgMzkuODUgNzcuNzIgNDAgNzJjLjA5LTQuNjggNi4yMy05IDE4LjM4LTguMzggOC4xNy40MyAxNS4zNyAxLjA5IDI5LjcxIDhsMTQuMS0yNC41NUM4OS4wNiA0MC40MiA3MSAzNi4yMSA1Ni4xNyAzNi4xOWgtLjA5Yy0xNy4yOCAwLTMxLjY4IDUuNi00MC42IDE0LjgzQTM0LjIzIDM0LjIzIDAgMCAwIDUuNzcgNzQuN0M1LjU0IDg3LjE1IDEwLjExIDk2IDE5LjcxIDEwM2M4LjEgNS45NCAxOC40NiA5Ljc5IDI3LjYgMTIuNjIgMTEuMjcgMy40OSAyMC40NyA2LjUzIDIwLjM2IDEzQTkuNTcgOS41NyAwIDAgMSA2NSAxMzVjLTIuODEgMi45LTcuMTMgNC0xMy4wOSA0LjEtMTEuNDkuMjQtMjAtMS41Ni0zMy42MS05LjU5TDUuNzcgMTU0LjQyYTkzLjc3IDkzLjc3IDAgMCAwIDQ2IDEyLjIyaDIuMTFjMTQuMjQtLjI1IDI1Ljc0LTQuMzEgMzQuOTItMTEuNzEuNTMtLjQxIDEtLjg0IDEuNDktMS4yOGwtNC4xMiAxMC44NUgxMjNsNi4xOS0xOC44MmE2Ny40NiA2Ny40NiAwIDAgMCAyMS42OCAzLjQzIDY4LjMzIDY4LjMzIDAgMCAwIDIxLjE2LTMuMjVsNiAxOC42NGg2MC4xNHYtMzloMTMuMTFjMzEuNzEgMCA1MC40Ni0xNi4xNSA1MC40Ni00My4yIDAtMzAuMTEtMTguMjItNDMuOTQtNTcuMDEtNDMuOTR6TTE1MC45MSAxMjFhMzYuOTMgMzYuOTMgMCAwIDEtMTMtMi4yOGwxMi44Ny00MC41OWguMjJsMTIuNjUgNDAuNzFhMzguNSAzOC41IDAgMCAxLTEyLjc0IDIuMTZ6bTk2LjItMjMuMzNoLTguOTRWNjQuOTFoOC45NGMxMS45MyAwIDIxLjQ0IDQgMjEuNDQgMTYuMTQgMCAxMi42LTkuNTEgMTYuNTctMjEuNDQgMTYuNTciLz48L3N2Zz4=" !default;
@@ -77,9 +100,9 @@ $block: #{$fd-namespace}-shellbar;
 
   &__logo,
   &__title {
-    @include fd-focus() {
-      outline: var(--fdShellbar_Button_Outline_Color) var(--sapContent_FocusStyle) var(--sapContent_FocusWidth);
-    }
+    @include fd-logo-outline();
+
+    position: relative;
   }
 
   &__title {

--- a/packages/styles/stories/Components/shellbar/shellbar.stories.js
+++ b/packages/styles/stories/Components/shellbar/shellbar.stories.js
@@ -26,7 +26,7 @@ The shellbar supports layout functionality and has some built-in elements, but r
 
 Elements | Class | Description
 :------------ | :------- | :------------
-Logo (mandatory) | \`fd-shellbar__logo\` | For company branding, add the \`--image-replaced\` modifier class when using CSS to display the logo.
+Logo (mandatory) | \`fd-shellbar__logo\` | For company branding, add the \`--image-replaced\` modifier class when using CSS to display the logo. The logo can become a link by replacing the "span" tag with an "a" tag.
 Title (mandatory) | \`fd-shellbar__title\` | Displays the current application.
 Subtitle | \`fd-shellbar__subtitle\` | Displays an application context. Subtitles should seldom be used.
 Action button (mandatory) | \`fd-shellbar__action\` | A container for each product action and link.
@@ -89,9 +89,9 @@ The primary shellbar displays a logo, title, and an avatar where the user settin
 export const ProductMenuAndSearch = () => `<div style="height:200px">
     <div class="fd-shellbar">
         <div class="fd-shellbar__group fd-shellbar__group--product">
-            <span class="fd-shellbar__logo">
+            <a class="fd-shellbar__logo" href="https://www.sap.com/index.html" target="_blank">
                 <img src="//unpkg.com/fundamental-styles/dist/images/sap-logo.png" srcset="//unpkg.com/fundamental-styles/dist/images/sap-logo@2x.png 1x, //unpkg.com/fundamental-styles/dist/images/sap-logo@3x.png 2x, //unpkg.com/fundamental-styles/dist/images/sap-logo@4x.png 3x" width="48" height="24" alt="SAP">
-            </span>
+            </a>
             <div class="fd-popover">
                 <div class="fd-popover__control">
                     <button class="fd-button fd-button--transparent fd-shellbar__button fd-shellbar__button--menu fd-button--menu" onclick="onPopoverClick('9GLB26941');" aria-controls="9GLB26941" aria-haspopup="true" aria-expanded="false">
@@ -188,7 +188,7 @@ ProductMenuAndSearch.parameters = {
     docs: {
         description: {
             story: `
-Shellbar can be displayed with a product menu and search box. The product menu is used for navigating to other applications within the product. To display a product menu, add the \`fd-popover\` class after the \`fd-shellbar__logo\` class.
+Shellbar can be displayed with a product menu and search box. The product menu is used for navigating to other applications within the product. To display a product menu, add the \`fd-popover\` class after the \`fd-shellbar__logo\` class. The logo can become a link by replacing the "span" tag with an "a" tag.
     `
         }
     }

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -24916,9 +24916,9 @@ exports[`Check stories > Components/Shellbar > Story ProductMenuAndSearch > Shou
 "<div style=\\"height:200px\\">
     <div class=\\"fd-shellbar\\">
         <div class=\\"fd-shellbar__group fd-shellbar__group--product\\">
-            <span class=\\"fd-shellbar__logo\\">
+            <a class=\\"fd-shellbar__logo\\" href=\\"https://www.sap.com/index.html\\" target=\\"_blank\\">
                 <img src=\\"//unpkg.com/fundamental-styles/dist/images/sap-logo.png\\" srcset=\\"//unpkg.com/fundamental-styles/dist/images/sap-logo@2x.png 1x, //unpkg.com/fundamental-styles/dist/images/sap-logo@3x.png 2x, //unpkg.com/fundamental-styles/dist/images/sap-logo@4x.png 3x\\" width=\\"48\\" height=\\"24\\" alt=\\"SAP\\">
-            </span>
+            </a>
             <div class=\\"fd-popover\\">
                 <div class=\\"fd-popover__control\\">
                     <button class=\\"fd-button fd-button--transparent fd-shellbar__button fd-shellbar__button--menu fd-button--menu\\" onclick=\\"onPopoverClick('9GLB26941');\\" aria-controls=\\"9GLB26941\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\">


### PR DESCRIPTION

## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/3779

## Description
The ShellBar logo should be used as an image and as a clickable element.
- updated the documentation to show an example with clickable logo
- added css for the focus outline