### PR TITLE
fix(styles): remove full width from carousel-item [ci visual]

### DIFF
--- a/packages/styles/src/carousel.scss
+++ b/packages/styles/src/carousel.scss
@@ -88,7 +88,6 @@ $fd-carousel-dot-active-size: 0.5rem !default;
     @include fd-reset();
     @include fd-flex-center();
 
-    width: 100%;
     height: 100%;
     line-height: 0;
     display: none;


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-ngx#8596

## Related NGX-PR
Closes SAP/fundamental-ngx#9059

## Description
Removed full width from carousel-item.

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/65063487/206596958-d591fadb-5d59-43c5-b1a4-040ccbce11a9.png)


### After:
![image](https://user-images.githubusercontent.com/65063487/206596968-5725cf70-dce5-4262-8956-829dda84ae84.png)