### PR TITLE
fix(styles): update values for Toolbar with Title [ci visual]

### DIFF
--- a/packages/styles/src/toolbar.scss
+++ b/packages/styles/src/toolbar.scss
@@ -59,6 +59,7 @@ $title-toolbar-height: 2.75rem;
 @mixin titleToolbar() {
   padding: $title-toolbar-padding;
   height: $title-toolbar-height;
+  background-color: var(--sapGroup_TitleBackground) !important;
 }
 
 @mixin toolbarClear() {
@@ -221,6 +222,7 @@ $title-toolbar-height: 2.75rem;
 
   &__title {
     color: var(--sapGroup_TitleTextColor);
+    font-size: var(--sapGroup_Title_FontSize);
   }
 
   &--cozy {

--- a/packages/styles/stories/Components/toolbar/toolbar.stories.js
+++ b/packages/styles/stories/Components/toolbar/toolbar.stories.js
@@ -209,7 +209,7 @@ export const Types = () => `<div style="padding: 1rem">
     <br>
     <div class="fd-toolbar fd-toolbar--info fd-toolbar--active">3 item selected</div>
     <h3>Title</h3>
-    <div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
+    <div class="fd-toolbar fd-toolbar--title">
         <h4 class="fd-title fd-title--h4 fd-toolbar__title">Products (104)</h4>
         <span class="fd-toolbar__spacer"></span>
         <button class="fd-button fd-button--compact fd-button--transparent">Save</button>
@@ -260,7 +260,7 @@ Types | Modifier class | Description
 :-------- | :------------- | :---------------
 Solid | \`fd-toolbar--solid\` | Displays a solid background color.
 Transparent | \`fd-toolbar--transparent\` | Displays a transparent background.
-Auto | \` d-toolbar--auto\` | Can inherit the design from the parent component it’s being used with.
+Auto | \` fd-toolbar--auto\` | Can inherit the design from the parent component it’s being used with.
 Info | \` fd-toolbar--info\` | Commonly used to display information (text or icons) and is slightly smaller than the regular toolbar.
 Title | \` fd-toolbar--title\` | Should be used whenever a title is required.
 No border-bottom | \`fd-toolbar—clear\` | This is not a type, but it removes the bottom border of each toolbar type.

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -32948,7 +32948,7 @@ exports[`Check stories > Components/Toolbar > Story Types > Should match snapsho
     <br>
     <div class=\\"fd-toolbar fd-toolbar--info fd-toolbar--active\\">3 item selected</div>
     <h3>Title</h3>
-    <div class=\\"fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active\\">
+    <div class=\\"fd-toolbar fd-toolbar--title\\">
         <h4 class=\\"fd-title fd-title--h4 fd-toolbar__title\\">Products (104)</h4>
         <span class=\\"fd-toolbar__spacer\\"></span>
         <button class=\\"fd-button fd-button--compact fd-button--transparent\\">Save</button>


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/4087

## Description
- update the font-size of the title in Toolbar
- update the background color of the Toolbar

BREAKING CHANGE:
- `fd-toolbar--solid` modifier class is no longer needed when `fd-toolbar--title` is applied

**Before**
```
 <div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">...</div>
```

**After**
```
 <div class="fd-toolbar fd-toolbar--title fd-toolbar-active">...</div>
```
