### PR TITLE
fix(docs): removed leading slashes for preview-head.html

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,83 +1,82 @@
-<link rel="shortcut icon" href="/favicon.ico" />
-<link rel="icon" type="image/svg" href="/logo.svg" sizes="192x192" />
-
 <script type="text/javascript" src="preview-head.js"></script>
 <script src="https://unpkg.com/focus-visible@5.1.0/dist/focus-visible.js"></script>
+
+<link rel="shortcut icon" href="favicon.ico" />
+<link rel="icon" type="image/svg" href="logo.svg" sizes="192x192" />
 
 <style type="text/css">
     @font-face {
         font-family: '72';
-        src: url('/theming-base-content/content/Base/baseLib/baseTheme/fonts/72-Regular.woff') format('woff');
+        src: url('theming-base-content/content/Base/baseLib/baseTheme/fonts/72-Regular.woff') format('woff');
         font-weight: normal;
         font-style: normal;
     }
 
     @font-face {
         font-family: '72-Light';
-        src: url('/theming-base-content/content/Base/baseLib/baseTheme/fonts/72-Light.woff') format('woff');
+        src: url('theming-base-content/content/Base/baseLib/baseTheme/fonts/72-Light.woff') format('woff');
         font-weight: 300;
         font-style: normal;
     }
 
     @font-face {
         font-family: '72-Bold';
-        src: url('/theming-base-content/content/Base/baseLib/baseTheme/fonts/72-Bold.woff') format('woff');
+        src: url('theming-base-content/content/Base/baseLib/baseTheme/fonts/72-Bold.woff') format('woff');
         font-weight: 700;
         font-style: normal;
     }
 
     @font-face {
         font-family: '72-Semibold';
-        src: url('/theming-base-content/content/Base/baseLib/baseTheme/fonts/72-Semibold.woff') format('woff');
+        src: url('theming-base-content/content/Base/baseLib/baseTheme/fonts/72-Semibold.woff') format('woff');
         font-style: normal;
     }
 
     @font-face {
         font-family: '72-SemiboldDuplex';
-        src: url('/theming-base-content/content/Base/baseLib/baseTheme/fonts/72-SemiboldDuplex.woff') format('woff');
+        src: url('theming-base-content/content/Base/baseLib/baseTheme/fonts/72-SemiboldDuplex.woff') format('woff');
         font-style: normal;
     }
 
     @font-face {
         font-family: '72Mono-Regular';
-        src: url('/theming-base-content/content/Base/baseLib/baseTheme/fonts/72Mono-Regular.woff') format('woff');
+        src: url('theming-base-content/content/Base/baseLib/baseTheme/fonts/72Mono-Regular.woff') format('woff');
         font-style: normal;
     }
 
     @font-face {
         font-family: '72Mono-Bold';
-        src: url('/theming-base-content/content/Base/baseLib/baseTheme/fonts/72Mono-Bold.woff') format('woff');
+        src: url('theming-base-content/content/Base/baseLib/baseTheme/fonts/72Mono-Bold.woff') format('woff');
         font-style: normal;
     }
 
     @font-face {
         font-family: '72-Black';
-        src: url('/theming-base-content/content/Base/baseLib/baseTheme/fonts/72-Black.woff') format('woff');
+        src: url('theming-base-content/content/Base/baseLib/baseTheme/fonts/72-Black.woff') format('woff');
         font-style: normal;
     }
 
     @font-face {
         font-family: 'SAP-icons';
-        src: url('/theming-base-content/content/Base/baseLib/sap_horizon/fonts/SAP-icons.woff') format('woff');
+        src: url('theming-base-content/content/Base/baseLib/sap_horizon/fonts/SAP-icons.woff') format('woff');
         font-weight: normal;
         font-style: normal;
     }
 
     @font-face {
         font-family: 'BusinessSuiteInAppSymbols';
-        src: url('/theming-base-content/content/Base/baseLib/baseTheme/fonts/BusinessSuiteInAppSymbols.woff') format('woff');
+        src: url('theming-base-content/content/Base/baseLib/baseTheme/fonts/BusinessSuiteInAppSymbols.woff') format('woff');
         font-weight: normal;
         font-style: normal;
     }
 
     @font-face {
         font-family: 'SAP-icons-TNT';
-        src: url('/theming-base-content/content/Base/baseLib/baseTheme/fonts/SAP-icons-TNT.woff') format('woff');
+        src: url('theming-base-content/content/Base/baseLib/baseTheme/fonts/SAP-icons-TNT.woff') format('woff');
         font-weight: normal;
         font-style: normal;
     }
 </style>
-
 <script>
     window.global = typeof global === 'undefined' ? window : global;
 </script>


### PR DESCRIPTION
## Related Issue
Closes None

## Description
Leading slashes are not needed for these assets, because they are leading to incorrect asset URLs when application has baseUrl 
