### PR TITLE
fix(styles): textarea focus & scrollbar styles

### DIFF
--- a/packages/styles/src/textarea.scss
+++ b/packages/styles/src/textarea.scss
@@ -7,10 +7,10 @@
 $block: #{$fd-namespace}-textarea;
 
 .#{$block} {
+  @include fd-scrollbar();
   @include fd-input-field-base();
   @include fd-input-field-states();
   @include fd-form-text();
-  @include fd-scrollbar();
 
   min-width: 6rem;
   width: 100%;
@@ -24,19 +24,17 @@ $block: #{$fd-namespace}-textarea;
   display: block;
   cursor: text;
 
+  &::-webkit-scrollbar-track,
+  &::-webkit-scrollbar-corner {
+    border-radius: 0 var(--sapField_BorderCornerRadius) var(--sapField_BorderCornerRadius) 0 !important;
+  }
+
   &[aria-expanded="false"] {
     z-index: 0;
   }
 
   @include fd-expanded() {
     z-index: 4;
-  }
-
-  @include fd-hover() {
-    &::-webkit-scrollbar-track,
-    &::-webkit-scrollbar-corner {
-      border-radius: 0 var(--fdScrollbar_Border_Radius) var(--fdScrollbar_Border_Radius) 0 !important;
-    }
   }
 
   &--compact {


### PR DESCRIPTION
## Related Issue

Relates to https://github.com/SAP/fundamental-styles/issues/3955#issuecomment-1355341272

## Description

Fixes for the textarea focus styles & scrollbar styles.

## Screenshots

### Before:
![image](https://user-images.githubusercontent.com/20265336/208411926-1d20b21a-3f5e-49c7-ac09-c107b186ea0d.png)

*Note: Not rounded*
<img width="145" alt="CleanShot 2022-12-19 at 11 55 10@2x" src="https://user-images.githubusercontent.com/20265336/208411960-a63c147c-a072-480b-bde9-4c996a5ed62b.png">

*Note: way too rounded on hover*
<img width="113" alt="CleanShot 2022-12-19 at 11 55 27@2x" src="https://user-images.githubusercontent.com/20265336/208412004-ff682de4-8eeb-4abd-b85b-e1da2d5efb77.png">

### After:
<img width="215" alt="CleanShot 2022-12-19 at 12 02 51@2x" src="https://user-images.githubusercontent.com/20265336/208412017-c05405b9-19ab-425e-b334-bfc68bc74ae6.png">

*Note: ideally rounded*
<img width="122" alt="CleanShot 2022-12-19 at 11 55 47@2x" src="https://user-images.githubusercontent.com/20265336/208412049-d056b0b4-3327-497b-8acd-8f02fa8e2e0f.png">

