### PR TITLE
fix(styles): link styles & breadcrumbs overflow item

### DIFF
--- a/packages/styles/src/mixins/_mixins.scss
+++ b/packages/styles/src/mixins/_mixins.scss
@@ -195,6 +195,7 @@
   align-items: center;
   transition: all $fd-animation-speed ease-in;
   line-height: inherit;
+  padding: 0 0.0625rem;
 
   @include fd-link-underline();
 

--- a/packages/styles/stories/Components/breadcrumb/breadcrumb.stories.js
+++ b/packages/styles/stories/Components/breadcrumb/breadcrumb.stories.js
@@ -55,46 +55,44 @@ Standard.parameters = {
 export const Overflow = () => `
 <nav aria-label="overflowing product breadcrumbs">
     <ul class="fd-breadcrumb">
-        <li class="fd-breadcrumb__item">
-            <div class="fd-popover">
-                <div class="fd-popover__control">
-                    <div
-                        aria-controls="breadcrumb1"
-                        aria-expanded="true"
-                        aria-haspopup="true"
-                        aria-label="Show collapsed breadcrumbs"
-                        class="fd-link"
-                        onclick="onPopoverClick('breadcrumb1');"
-                        onkeypress="isSpaceOrEnter(event, onPopoverClick('breadcrumb1'));"
-                        role="button"
-                        tabindex="0">
-                        <span class="fd-link__content">...</span>
-                        <i role="presentation" class="sap-icon sap-icon--slim-arrow-down"></i>
-                    </div>
-                </div>
-                <div class="fd-popover__body fd-popover__body--no-arrow" aria-hidden="false" id="breadcrumb1">
-                    <div class="fd-popover__wrapper">
-                        <ul class="fd-list fd-list--navigation" role="menu">
-                            <li tabindex="-1" role="menuitem" class="fd-list__item fd-list__item--link">
-                                <a tabindex="0" class="fd-list__link" href="#">
-                                    <span class="fd-list__title">Products</span>
-                                </a>
-                            </li>
-                            <li tabindex="-1" role="menuitem" class="fd-list__item fd-list__item--link">
-                                <a tabindex="0" class="fd-list__link" href="#">
-                                    <span class="fd-list__title">Suppliers</span>
-                                </a>
-                            </li>
-                            <li tabindex="-1" role="menuitem" class="fd-list__item fd-list__item--link">
-                                <a tabindex="0" class="fd-list__link" href="#">
-                                    <span class="fd-list__title">Titanium</span>
-                                </a>
-                            </li>
-                        </ul>
-                    </div>
+        <li class="fd-breadcrumb__item"><div class="fd-popover">
+            <div class="fd-popover__control">
+                <div
+                    aria-controls="breadcrumb1"
+                    aria-expanded="true"
+                    aria-haspopup="true"
+                    aria-label="Show collapsed breadcrumbs"
+                    class="fd-link"
+                    onclick="onPopoverClick('breadcrumb1');"
+                    onkeypress="isSpaceOrEnter(event, onPopoverClick('breadcrumb1'));"
+                    role="button"
+                    tabindex="0">
+                    <span class="fd-link__content"><i role="presentation" class="sap-icon sap-icon--overflow"></i></span>
+                    <i role="presentation" class="sap-icon sap-icon--slim-arrow-down"></i>
                 </div>
             </div>
-        </li>
+            <div class="fd-popover__body fd-popover__body--no-arrow" aria-hidden="false" id="breadcrumb1">
+                <div class="fd-popover__wrapper">
+                    <ul class="fd-list fd-list--navigation" role="menu">
+                        <li tabindex="-1" role="menuitem" class="fd-list__item fd-list__item--link">
+                            <a tabindex="0" class="fd-list__link" href="#">
+                                <span class="fd-list__title">Products</span>
+                            </a>
+                        </li>
+                        <li tabindex="-1" role="menuitem" class="fd-list__item fd-list__item--link">
+                            <a tabindex="0" class="fd-list__link" href="#">
+                                <span class="fd-list__title">Suppliers</span>
+                            </a>
+                        </li>
+                        <li tabindex="-1" role="menuitem" class="fd-list__item fd-list__item--link">
+                            <a tabindex="0" class="fd-list__link" href="#">
+                                <span class="fd-list__title">Titanium</span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div></li>
         <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Ultra Portable</span></a></li>
         <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">12 inch</span></a></li>
         <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Super portable deluxe</span></a></li>

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -1434,46 +1434,44 @@ exports[`Check stories > Components/Breadcrumb > Story Overflow > Should match s
 "
 <nav aria-label=\\"overflowing product breadcrumbs\\">
     <ul class=\\"fd-breadcrumb\\">
-        <li class=\\"fd-breadcrumb__item\\">
-            <div class=\\"fd-popover\\">
-                <div class=\\"fd-popover__control\\">
-                    <div
-                        aria-controls=\\"breadcrumb1\\"
-                        aria-expanded=\\"true\\"
-                        aria-haspopup=\\"true\\"
-                        aria-label=\\"Show collapsed breadcrumbs\\"
-                        class=\\"fd-link\\"
-                        onclick=\\"onPopoverClick('breadcrumb1');\\"
-                        onkeypress=\\"isSpaceOrEnter(event, onPopoverClick('breadcrumb1'));\\"
-                        role=\\"button\\"
-                        tabindex=\\"0\\">
-                        <span class=\\"fd-link__content\\">...</span>
-                        <i role=\\"presentation\\" class=\\"sap-icon sap-icon--slim-arrow-down\\"></i>
-                    </div>
-                </div>
-                <div class=\\"fd-popover__body fd-popover__body--no-arrow\\" aria-hidden=\\"false\\" id=\\"breadcrumb1\\">
-                    <div class=\\"fd-popover__wrapper\\">
-                        <ul class=\\"fd-list fd-list--navigation\\" role=\\"menu\\">
-                            <li tabindex=\\"-1\\" role=\\"menuitem\\" class=\\"fd-list__item fd-list__item--link\\">
-                                <a tabindex=\\"0\\" class=\\"fd-list__link\\" href=\\"#\\">
-                                    <span class=\\"fd-list__title\\">Products</span>
-                                </a>
-                            </li>
-                            <li tabindex=\\"-1\\" role=\\"menuitem\\" class=\\"fd-list__item fd-list__item--link\\">
-                                <a tabindex=\\"0\\" class=\\"fd-list__link\\" href=\\"#\\">
-                                    <span class=\\"fd-list__title\\">Suppliers</span>
-                                </a>
-                            </li>
-                            <li tabindex=\\"-1\\" role=\\"menuitem\\" class=\\"fd-list__item fd-list__item--link\\">
-                                <a tabindex=\\"0\\" class=\\"fd-list__link\\" href=\\"#\\">
-                                    <span class=\\"fd-list__title\\">Titanium</span>
-                                </a>
-                            </li>
-                        </ul>
-                    </div>
+        <li class=\\"fd-breadcrumb__item\\"><div class=\\"fd-popover\\">
+            <div class=\\"fd-popover__control\\">
+                <div
+                    aria-controls=\\"breadcrumb1\\"
+                    aria-expanded=\\"true\\"
+                    aria-haspopup=\\"true\\"
+                    aria-label=\\"Show collapsed breadcrumbs\\"
+                    class=\\"fd-link\\"
+                    onclick=\\"onPopoverClick('breadcrumb1');\\"
+                    onkeypress=\\"isSpaceOrEnter(event, onPopoverClick('breadcrumb1'));\\"
+                    role=\\"button\\"
+                    tabindex=\\"0\\">
+                    <span class=\\"fd-link__content\\"><i role=\\"presentation\\" class=\\"sap-icon sap-icon--overflow\\"></i></span>
+                    <i role=\\"presentation\\" class=\\"sap-icon sap-icon--slim-arrow-down\\"></i>
                 </div>
             </div>
-        </li>
+            <div class=\\"fd-popover__body fd-popover__body--no-arrow\\" aria-hidden=\\"false\\" id=\\"breadcrumb1\\">
+                <div class=\\"fd-popover__wrapper\\">
+                    <ul class=\\"fd-list fd-list--navigation\\" role=\\"menu\\">
+                        <li tabindex=\\"-1\\" role=\\"menuitem\\" class=\\"fd-list__item fd-list__item--link\\">
+                            <a tabindex=\\"0\\" class=\\"fd-list__link\\" href=\\"#\\">
+                                <span class=\\"fd-list__title\\">Products</span>
+                            </a>
+                        </li>
+                        <li tabindex=\\"-1\\" role=\\"menuitem\\" class=\\"fd-list__item fd-list__item--link\\">
+                            <a tabindex=\\"0\\" class=\\"fd-list__link\\" href=\\"#\\">
+                                <span class=\\"fd-list__title\\">Suppliers</span>
+                            </a>
+                        </li>
+                        <li tabindex=\\"-1\\" role=\\"menuitem\\" class=\\"fd-list__item fd-list__item--link\\">
+                            <a tabindex=\\"0\\" class=\\"fd-list__link\\" href=\\"#\\">
+                                <span class=\\"fd-list__title\\">Titanium</span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div></li>
         <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Ultra Portable</span></a></li>
         <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">12 inch</span></a></li>
         <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Super portable deluxe</span></a></li>
@@ -15564,7 +15562,7 @@ style=\\"background-image: url('assets/images/backgrounds/Godafoss_waterfall_in_
 
 exports[`Check stories > Components/List/Byline > Story UnreadNotification > Should match snapshot 1`] = `
 "<h4 id=\\"O09lk9\\">Standard size</h4>
-<ul class=\\"fd-list fd-list--byline\\" role=\\"listbox\\" aria-labelledby=\\"O09lk9\\">
+<ul class=\\"fd-list fd-list--byline fd-list--unread-indicator\\" role=\\"listbox\\" aria-labelledby=\\"O09lk9\\">
 <li role=\\"option\\" tabindex=\\"0\\" class=\\"fd-list__item is-selected\\">
     <span class=\\"sap-icon--circle-task-2 fd-list__notification\\"></span>
     <span class=\\"fd-list__thumbnail\\"><i role=\\"presentation\\" class=\\"sap-icon--activate\\"></i></span>
@@ -15595,7 +15593,7 @@ style=\\"background-image: url('assets/images/backgrounds/Godafoss_waterfall_in_
 </ul>
 
 <h4 id=\\"O09lk8\\">Compact size</h4>
-<ul class=\\"fd-list fd-list--compact fd-list--byline\\" role=\\"listbox\\" aria-labelledby=\\"O09lk8\\">
+<ul class=\\"fd-list fd-list--compact fd-list--byline fd-list--unread-indicator\\" role=\\"listbox\\" aria-labelledby=\\"O09lk8\\">
 <li role=\\"option\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
     <span class=\\"sap-icon--circle-task-2 fd-list__notification\\"></span>
     <span class=\\"fd-list__thumbnail\\"><i role=\\"presentation\\" class=\\"sap-icon--activate\\"></i></span>
@@ -15623,6 +15621,50 @@ style=\\"background-image: url('assets/images/backgrounds/Godafoss_waterfall_in_
       <div class=\\"fd-list__byline\\">Byline (description)</div>
     </div>
 </li>
+</ul>
+
+<h4 id=\\"O09lk9\\">Navigation</h4>
+<ul class=\\"fd-list fd-list--byline fd-list--navigation fd-list--unread-indicator\\" role=\\"list\\">
+  <li role=\\"listitem\\" tabindex=\\"-1\\" class=\\"fd-list__item fd-list__item--link\\">
+    <span class=\\"sap-icon--circle-task-2 fd-list__notification\\"></span>
+    <a tabindex=\\"0\\" class=\\"fd-list__link\\" href=\\"#\\">
+      <span class=\\"fd-list__thumbnail\\"><i role=\\"presentation\\" class=\\"sap-icon--activate\\"></i></span>
+      <div class=\\"fd-list__content\\">
+        <div class=\\"fd-list__title\\">Title</div>
+        <div class=\\"fd-list__byline\\">Byline (description)</div>
+      </div>
+    </a>
+  </li>
+  <li role=\\"listitem\\" tabindex=\\"-1\\" class=\\"fd-list__item fd-list__item--link is-selected\\">
+  <span class=\\"sap-icon--circle-task-2 fd-list__notification\\"></span>
+    <a tabindex=\\"0\\" class=\\"fd-list__link\\" href=\\"#\\">
+      <span class=\\"fd-list__thumbnail\\"><i role=\\"presentation\\" class=\\"sap-icon--employee\\"></i></span>
+      <div class=\\"fd-list__content\\">
+        <div class=\\"fd-list__title\\">List item with no byline</div>
+      </div>
+    </a>
+  </li>
+  <li role=\\"listitem\\" tabindex=\\"-1\\" class=\\"fd-list__item fd-list__item--link\\">
+    <a tabindex=\\"0\\" class=\\"fd-list__link\\" href=\\"#\\">
+        <span class=\\"fd-image--s fd-list__thumbnail\\" aria-label=\\"Godafoss waterfall in northern Iceland\\"
+    style=\\"background-image: url('assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg'); background-size:cover;\\"></span>
+        <div class=\\"fd-list__content\\">
+            <div class=\\"fd-list__title\\">List item with 2-column byline</div>
+            <div class=\\"fd-list__byline fd-list__byline--2-col\\">
+                <div class=\\"fd-list__byline-left\\">First text item in byline (standard text)</div>
+                <div class=\\"fd-list__byline-right\\">Second text item in byline (can be semantic)</div>
+            </div>
+        </div>
+    </a>
+  </li>
+  <li role=\\"listitem\\" tabindex=\\"-1\\" class=\\"fd-list__item fd-list__item--link\\">
+    <a tabindex=\\"0\\" class=\\"fd-list__link\\" href=\\"#\\">
+      <div class=\\"fd-list__content\\">
+        <div class=\\"fd-list__title\\">Text-only list item</div>
+        <div class=\\"fd-list__byline\\">Byline (description)</div>
+      </div>
+    </a>
+  </li>
 </ul>
 "
 `;


### PR DESCRIPTION
## Related Issue

Relates to https://github.com/SAP/fundamental-styles/issues/3955#issuecomment-1355348853

## Description

Added `0.0625rem`(`1px`) horizontal padding in link to better align with design specs.
Overflow icon used in breadcrumb overflow item to better align with the specs.

## Screenshots

### Before:
<img width="467" alt="CleanShot 2022-12-19 at 12 38 02@2x" src="https://user-images.githubusercontent.com/20265336/208419031-56ef6cce-d9ed-407b-8beb-35bb87450b47.png">

### After:
<img width="485" alt="CleanShot 2022-12-19 at 12 37 21@2x" src="https://user-images.githubusercontent.com/20265336/208419040-8bc34a23-4151-4196-91a6-edfa5f7aed9d.png">
