### PR TITLE
fix(styles): quick view styles & examples

### DIFF
--- a/packages/styles/src/quick-view.scss
+++ b/packages/styles/src/quick-view.scss
@@ -83,6 +83,10 @@ $fd-quick-view-group-item-indent: 0.75rem;
     }
   }
 
+  .#{$fd-namespace}-form-group__header + .#{$fd-namespace}-form-item {
+    padding-top: 0;
+  }
+
   .#{$fd-namespace}-title {
     .#{$fd-namespace}-link {
       @include fd-ellipsis();

--- a/packages/styles/stories/Components/quick-view/quick-view.stories.js
+++ b/packages/styles/stories/Components/quick-view/quick-view.stories.js
@@ -12,6 +12,7 @@ import '../../../src/form-group.scss';
 import '../../../src/form-item.scss';
 import '../../../src/form-label.scss';
 import '../../../src/input.scss';
+import '../../../src/text.scss';
 export default {
     title: 'Components/Quick View',
     parameters: {
@@ -59,7 +60,7 @@ export const Popover = () => `<div class="fd-popover">
                     </div>
                     <div class="fd-form-item">
                         <label class="fd-form-label">Address</label>
-                        <span class="fd-input">
+                        <span class="fd-text">
                             781 Main Street <br>
                             Anytown, SD 57401, USA
                         </span>
@@ -72,7 +73,7 @@ export const Popover = () => `<div class="fd-popover">
                     </div>
                     <div class="fd-form-item">
                         <label class="fd-form-label">Name</label>
-                        <span class="fd-input">Michael Adams</span>
+                        <span class="fd-text">Michael Adams</span>
                     </div>
                     <div class="fd-form-item">
                         <label class="fd-form-label">Mobile</label>
@@ -117,9 +118,11 @@ export const Dialog = () => `<section class="fd-dialog-docs-static fd-dialog fd-
                             </span>
 
                             <div class="fd-quick-view__subheader-text">
-                                <h5 class="fd-title fd-title--h5">
-                                    <a class="fd-link" href="#"><span class="fd-link__content">Inventarisation</span></a>
-                                </h5>
+                                <h5 class="fd-title fd-title--h5">Company B</h5>
+    
+                                <div class="fd-quick-view__subtitle">
+                                    Michael Adams
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -127,15 +130,15 @@ export const Dialog = () => `<section class="fd-dialog-docs-static fd-dialog fd-
                     <div class="fd-form-group" role="group">
                         <div class="fd-form-item">
                             <label class="fd-form-label">Start Date:</label>
-                            <span class="fd-input">01/01/2015</span>
+                            <span class="fd-text">01/01/2015</span>
                         </div>
                         <div class="fd-form-item">
                             <label class="fd-form-label">End Date:</label>
-                            <span class="fd-input">31/12/2015</span>
+                            <span class="fd-text">31/12/2015</span>
                         </div>
                         <div class="fd-form-item">
                             <label class="fd-form-label">Occurrence:</label>
-                            <span class="fd-input">Weekly</span>
+                            <span class="fd-text">Weekly</span>
                         </div>
                     </div>
                 </div>
@@ -181,9 +184,11 @@ export const NoHeader = () => `<div class="fd-popover">
                         </span>
 
                         <div class="fd-quick-view__subheader-text">
-                            <h5 class="fd-title fd-title--h5">
-                                <a class="fd-link" href="#"><span class="fd-link__content">Inventarisation</span></a>
-                            </h5>
+                            <h5 class="fd-title fd-title--h5">Company B</h5>
+
+                            <div class="fd-quick-view__subtitle">
+                                Michael Adams
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -191,15 +196,15 @@ export const NoHeader = () => `<div class="fd-popover">
                 <div class="fd-form-group" role="group">
                     <div class="fd-form-item">
                         <label class="fd-form-label">Start Date:</label>
-                        <span class="fd-input">01/01/2015</span>
+                        <span class="fd-text">01/01/2015</span>
                     </div>
                     <div class="fd-form-item">
                         <label class="fd-form-label">End Date:</label>
-                        <span class="fd-input">31/12/2015</span>
+                        <span class="fd-text">31/12/2015</span>
                     </div>
                     <div class="fd-form-item">
                         <label class="fd-form-label">Occurrence:</label>
-                        <span class="fd-input">Weekly</span>
+                        <span class="fd-text">Weekly</span>
                     </div>
                 </div>
             </div>

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -15564,7 +15564,7 @@ style=\\"background-image: url('assets/images/backgrounds/Godafoss_waterfall_in_
 
 exports[`Check stories > Components/List/Byline > Story UnreadNotification > Should match snapshot 1`] = `
 "<h4 id=\\"O09lk9\\">Standard size</h4>
-<ul class=\\"fd-list fd-list--byline\\" role=\\"listbox\\" aria-labelledby=\\"O09lk9\\">
+<ul class=\\"fd-list fd-list--byline fd-list--unread-indicator\\" role=\\"listbox\\" aria-labelledby=\\"O09lk9\\">
 <li role=\\"option\\" tabindex=\\"0\\" class=\\"fd-list__item is-selected\\">
     <span class=\\"sap-icon--circle-task-2 fd-list__notification\\"></span>
     <span class=\\"fd-list__thumbnail\\"><i role=\\"presentation\\" class=\\"sap-icon--activate\\"></i></span>
@@ -15595,7 +15595,7 @@ style=\\"background-image: url('assets/images/backgrounds/Godafoss_waterfall_in_
 </ul>
 
 <h4 id=\\"O09lk8\\">Compact size</h4>
-<ul class=\\"fd-list fd-list--compact fd-list--byline\\" role=\\"listbox\\" aria-labelledby=\\"O09lk8\\">
+<ul class=\\"fd-list fd-list--compact fd-list--byline fd-list--unread-indicator\\" role=\\"listbox\\" aria-labelledby=\\"O09lk8\\">
 <li role=\\"option\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
     <span class=\\"sap-icon--circle-task-2 fd-list__notification\\"></span>
     <span class=\\"fd-list__thumbnail\\"><i role=\\"presentation\\" class=\\"sap-icon--activate\\"></i></span>
@@ -15623,6 +15623,50 @@ style=\\"background-image: url('assets/images/backgrounds/Godafoss_waterfall_in_
       <div class=\\"fd-list__byline\\">Byline (description)</div>
     </div>
 </li>
+</ul>
+
+<h4 id=\\"O09lk9\\">Navigation</h4>
+<ul class=\\"fd-list fd-list--byline fd-list--navigation fd-list--unread-indicator\\" role=\\"list\\">
+  <li role=\\"listitem\\" tabindex=\\"-1\\" class=\\"fd-list__item fd-list__item--link\\">
+    <span class=\\"sap-icon--circle-task-2 fd-list__notification\\"></span>
+    <a tabindex=\\"0\\" class=\\"fd-list__link\\" href=\\"#\\">
+      <span class=\\"fd-list__thumbnail\\"><i role=\\"presentation\\" class=\\"sap-icon--activate\\"></i></span>
+      <div class=\\"fd-list__content\\">
+        <div class=\\"fd-list__title\\">Title</div>
+        <div class=\\"fd-list__byline\\">Byline (description)</div>
+      </div>
+    </a>
+  </li>
+  <li role=\\"listitem\\" tabindex=\\"-1\\" class=\\"fd-list__item fd-list__item--link is-selected\\">
+  <span class=\\"sap-icon--circle-task-2 fd-list__notification\\"></span>
+    <a tabindex=\\"0\\" class=\\"fd-list__link\\" href=\\"#\\">
+      <span class=\\"fd-list__thumbnail\\"><i role=\\"presentation\\" class=\\"sap-icon--employee\\"></i></span>
+      <div class=\\"fd-list__content\\">
+        <div class=\\"fd-list__title\\">List item with no byline</div>
+      </div>
+    </a>
+  </li>
+  <li role=\\"listitem\\" tabindex=\\"-1\\" class=\\"fd-list__item fd-list__item--link\\">
+    <a tabindex=\\"0\\" class=\\"fd-list__link\\" href=\\"#\\">
+        <span class=\\"fd-image--s fd-list__thumbnail\\" aria-label=\\"Godafoss waterfall in northern Iceland\\"
+    style=\\"background-image: url('assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg'); background-size:cover;\\"></span>
+        <div class=\\"fd-list__content\\">
+            <div class=\\"fd-list__title\\">List item with 2-column byline</div>
+            <div class=\\"fd-list__byline fd-list__byline--2-col\\">
+                <div class=\\"fd-list__byline-left\\">First text item in byline (standard text)</div>
+                <div class=\\"fd-list__byline-right\\">Second text item in byline (can be semantic)</div>
+            </div>
+        </div>
+    </a>
+  </li>
+  <li role=\\"listitem\\" tabindex=\\"-1\\" class=\\"fd-list__item fd-list__item--link\\">
+    <a tabindex=\\"0\\" class=\\"fd-list__link\\" href=\\"#\\">
+      <div class=\\"fd-list__content\\">
+        <div class=\\"fd-list__title\\">Text-only list item</div>
+        <div class=\\"fd-list__byline\\">Byline (description)</div>
+      </div>
+    </a>
+  </li>
 </ul>
 "
 `;
@@ -22656,9 +22700,11 @@ exports[`Check stories > Components/Quick View > Story Dialog > Should match sna
                             </span>
 
                             <div class=\\"fd-quick-view__subheader-text\\">
-                                <h5 class=\\"fd-title fd-title--h5\\">
-                                    <a class=\\"fd-link\\" href=\\"#\\"><span class=\\"fd-link__content\\">Inventarisation</span></a>
-                                </h5>
+                                <h5 class=\\"fd-title fd-title--h5\\">Company B</h5>
+    
+                                <div class=\\"fd-quick-view__subtitle\\">
+                                    Michael Adams
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -22666,15 +22712,15 @@ exports[`Check stories > Components/Quick View > Story Dialog > Should match sna
                     <div class=\\"fd-form-group\\" role=\\"group\\">
                         <div class=\\"fd-form-item\\">
                             <label class=\\"fd-form-label\\">Start Date:</label>
-                            <span class=\\"fd-input\\">01/01/2015</span>
+                            <span class=\\"fd-text\\">01/01/2015</span>
                         </div>
                         <div class=\\"fd-form-item\\">
                             <label class=\\"fd-form-label\\">End Date:</label>
-                            <span class=\\"fd-input\\">31/12/2015</span>
+                            <span class=\\"fd-text\\">31/12/2015</span>
                         </div>
                         <div class=\\"fd-form-item\\">
                             <label class=\\"fd-form-label\\">Occurrence:</label>
-                            <span class=\\"fd-input\\">Weekly</span>
+                            <span class=\\"fd-text\\">Weekly</span>
                         </div>
                     </div>
                 </div>
@@ -22712,9 +22758,11 @@ exports[`Check stories > Components/Quick View > Story NoHeader > Should match s
                         </span>
 
                         <div class=\\"fd-quick-view__subheader-text\\">
-                            <h5 class=\\"fd-title fd-title--h5\\">
-                                <a class=\\"fd-link\\" href=\\"#\\"><span class=\\"fd-link__content\\">Inventarisation</span></a>
-                            </h5>
+                            <h5 class=\\"fd-title fd-title--h5\\">Company B</h5>
+
+                            <div class=\\"fd-quick-view__subtitle\\">
+                                Michael Adams
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -22722,15 +22770,15 @@ exports[`Check stories > Components/Quick View > Story NoHeader > Should match s
                 <div class=\\"fd-form-group\\" role=\\"group\\">
                     <div class=\\"fd-form-item\\">
                         <label class=\\"fd-form-label\\">Start Date:</label>
-                        <span class=\\"fd-input\\">01/01/2015</span>
+                        <span class=\\"fd-text\\">01/01/2015</span>
                     </div>
                     <div class=\\"fd-form-item\\">
                         <label class=\\"fd-form-label\\">End Date:</label>
-                        <span class=\\"fd-input\\">31/12/2015</span>
+                        <span class=\\"fd-text\\">31/12/2015</span>
                     </div>
                     <div class=\\"fd-form-item\\">
                         <label class=\\"fd-form-label\\">Occurrence:</label>
-                        <span class=\\"fd-input\\">Weekly</span>
+                        <span class=\\"fd-text\\">Weekly</span>
                     </div>
                 </div>
             </div>
@@ -22778,7 +22826,7 @@ exports[`Check stories > Components/Quick View > Story Popover > Should match sn
                     </div>
                     <div class=\\"fd-form-item\\">
                         <label class=\\"fd-form-label\\">Address</label>
-                        <span class=\\"fd-input\\">
+                        <span class=\\"fd-text\\">
                             781 Main Street <br>
                             Anytown, SD 57401, USA
                         </span>
@@ -22791,7 +22839,7 @@ exports[`Check stories > Components/Quick View > Story Popover > Should match sn
                     </div>
                     <div class=\\"fd-form-item\\">
                         <label class=\\"fd-form-label\\">Name</label>
-                        <span class=\\"fd-input\\">Michael Adams</span>
+                        <span class=\\"fd-text\\">Michael Adams</span>
                     </div>
                     <div class=\\"fd-form-item\\">
                         <label class=\\"fd-form-label\\">Mobile</label>


### PR DESCRIPTION
## Related Issue

Relates to https://github.com/SAP/fundamental-styles/issues/3955#issuecomment-1355378065

## Description

Quick view styles & docs issues fixes.

## Screenshots

### Before:
![CleanShot 2022-12-19 at 13 48 26@2x](https://user-images.githubusercontent.com/20265336/208429938-018c84c9-ee43-45db-a219-b4f5b1a90f7a.png)


### After:
<img width="393" alt="CleanShot 2022-12-19 at 13 47 52@2x" src="https://user-images.githubusercontent.com/20265336/208429673-9576aef8-ca0a-4e35-93a4-349fdeecac8b.png">
