### PR TITLE
fix(styles): apply custom scrollbar to vertical nav

### DIFF
--- a/packages/styles/src/vertical-nav.scss
+++ b/packages/styles/src/vertical-nav.scss
@@ -17,6 +17,8 @@ $block: #{$fd-namespace}-vertical-nav;
   height: 100%;
 
   &--overflow {
+    @include fd-scrollbar();
+
     overflow-y: scroll;
   }
 


### PR DESCRIPTION
## Related Issue

Relates to https://github.com/SAP/fundamental-styles/issues/3955#issuecomment-1355402445

## Description

Custom scrollbar applied to Vertical Nav component.

## Screenshots

### Before:
![image](https://user-images.githubusercontent.com/20265336/208448686-41a48ade-561b-481e-9b19-fa1b8f30ec98.png)



### After:
<img width="268" alt="CleanShot 2022-12-19 at 15 29 36@2x" src="https://user-images.githubusercontent.com/20265336/208448524-3b3a2a3f-ac37-40c7-a528-28a0ba829eee.png">