### PR TITLE
fix(styles): fix outline issues in Shellbar

### DIFF
--- a/packages/styles/src/shellbar.scss
+++ b/packages/styles/src/shellbar.scss
@@ -230,6 +230,14 @@ $block: #{$fd-namespace}-shellbar;
         margin: 0;
       }
     }
+
+    &--user-menu {
+      @include fd-focus() {
+        outline-offset: -0.13rem;
+      }
+
+      border-radius: 50%;
+    }
   }
 
   &--s {

--- a/packages/styles/src/shellbar.scss
+++ b/packages/styles/src/shellbar.scss
@@ -154,9 +154,6 @@ $block: #{$fd-namespace}-shellbar;
     @include fd-hover() {
       border-color: var(--fdShellbar_Input_Hover_Border_Color);
       box-shadow: var(--sapContent_Interaction_Shadow);
-    }
-
-    @include fd-focus() {
       outline: none;
     }
 


### PR DESCRIPTION
## Related Issue
Related to (https://github.com/SAP/fundamental-styles/issues/3955#issuecomment-1355381408)

## Description
1. Fixed outline issue for Avatar in Shellbar - added user-menu styles for Shellbar button.
2. Fixed no focus-outline for Shellbar-input-group. 

### Before:
https://fundamental-ngx.netlify.app/#/core/shellbar#overflow-menu

![image](https://user-images.githubusercontent.com/65063487/208763524-e6beb548-243b-4c61-aba6-c1b910e8a768.png)

![chrome_gWo9CxNUeO](https://user-images.githubusercontent.com/65063487/208792540-c041fe14-3187-4dc6-916d-6bb2819c92f8.gif)


### After:
![image](https://user-images.githubusercontent.com/65063487/208763536-49415ba5-bc0d-472e-82b1-c494044a33c1.png)


![chrome_jStzG43ReK](https://user-images.githubusercontent.com/65063487/208792634-c9963c4f-a9ec-4767-8e14-67e25db64593.gif)

