### PR TITLE
feat(styles): popover wrapper with overflow visible

### DIFF
--- a/packages/styles/src/popover.scss
+++ b/packages/styles/src/popover.scss
@@ -71,6 +71,10 @@ $fd-popover-arrow-offset-x: calc(var(--fdIcon_Button_Width) * 0.5 - #{$fd-popove
     @include fd-scrollbar(var(--fdScrollbar_Border_Radius));
 
     overflow: auto;
+
+    &--visible {
+      overflow: visible !important;
+    }
   }
 
   &__body {


### PR DESCRIPTION
## Related Issue

Refers to https://github.com/SAP/fundamental-ngx/issues/8897#issuecomment-1361911872.

## Description

popover wrapper with `overflow: visible` to don't hide submenus.

## Screenshots

### Before:
<img width="196" alt="CleanShot 2022-12-26 at 23 42 26@2x" src="https://user-images.githubusercontent.com/20265336/209586996-3b9cf32f-d93c-4f70-9202-edd78c8530b1.png">


### After:
<img width="317" alt="CleanShot 2022-12-26 at 23 41 51@2x" src="https://user-images.githubusercontent.com/20265336/209586974-70213419-3ff5-42b1-ab18-33dd27d858c7.png">
