### PR TITLE
fix(styles): input readonly state

### DIFF
--- a/packages/styles/src/mixins/_forms.scss
+++ b/packages/styles/src/mixins/_forms.scss
@@ -89,6 +89,13 @@ $fd-input-field-height--compact: 1.625rem;
   box-sizing: border-box;
 }
 
+@mixin fd-input-readonly() {
+  border-color: var(--sapField_ReadOnly_BorderColor);
+  border-radius: var(--fdInput_ReadOnly_Border_Radius);
+  background: var(--sapField_ReadOnly_BackgroundStyle);
+  background-color: var(--sapField_ReadOnly_Background);
+}
+
 @mixin fd-input-field-states($hasFocusWithin: false) {
   $fd-input-states: (
     'success': (
@@ -208,23 +215,20 @@ $fd-input-field-height--compact: 1.625rem;
   }
 
   @include fd-readonly() {
-    border-color: var(--sapField_ReadOnly_BorderColor);
-    border-radius: var(--fdInput_ReadOnly_Border_Radius);
-    background: var(--sapField_ReadOnly_BackgroundStyle);
-    background-color: var(--sapField_ReadOnly_Background);
-    pointer-events: none;
+    @include fd-input-readonly();
 
     &::placeholder {
       color: var(--fdInput_Non_Interactive_State_Placeholder_Color);
     }
 
     @include fd-hover() {
+      @include fd-input-readonly();
+
       box-shadow: none;
     }
 
     @include fd-focus() {
-      background: var(--sapField_Focus_Background);
-      border-radius: var(--sapField_BorderCornerRadius);
+      @include fd-input-readonly();
     }
   }
 }


### PR DESCRIPTION
## Related Issue

Refers to https://github.com/SAP/fundamental-ngx/issues/7246

## Description

Inputs read-only state issue when it's unable to scroll.

## Screenshots

### Before:

![CleanShot 2022-12-27 at 19 03 33@2x](https://user-images.githubusercontent.com/20265336/209705277-0d90fd27-a487-48af-bc62-f124d506f710.png)

### After:

![CleanShot 2022-12-27 at 18 59 16@2x](https://user-images.githubusercontent.com/20265336/209705036-4638628b-10eb-497a-a6f7-bdd75923da72.png)
