### PR TITLE
fix(styles): input group btn in HC themes

### DIFF
--- a/packages/styles/src/mixins/_forms.scss
+++ b/packages/styles/src/mixins/_forms.scss
@@ -253,6 +253,36 @@ $fd-input-field-height--compact: 1.625rem;
     )
   );
 
+  .#{$block}__addon {
+    &:first-child {
+      .#{$block}__button {
+        @include fd-set-border-right(var(--fdInputGroup_ControlButton_SideBorder));
+
+        @include fd-hover() {
+          @include fd-set-border-right(var(--fdInputGroup_ControlButton_SideBorder_Active));
+        }
+
+        @include fd-active() {
+          @include fd-set-border-right(var(--fdInputGroup_ControlButton_SideBorder_Active));
+        }
+      }
+    }
+
+    &:not(:first-child) {
+      .#{$block}__button {
+        @include fd-set-border-left(var(--fdInputGroup_ControlButton_SideBorder));
+
+        @include fd-hover() {
+          @include fd-set-border-left(var(--fdInputGroup_ControlButton_SideBorder_Active));
+        }
+
+        @include fd-active() {
+          @include fd-set-border-left(var(--fdInputGroup_ControlButton_SideBorder_Active));
+        }
+      }
+    }
+  }
+
   .#{$block}__button {
     @include fd-ellipsis();
 
@@ -263,23 +293,17 @@ $fd-input-field-height--compact: 1.625rem;
     background: var(--fdInput_Group_Button_Background);
     color: var(--fdInput_Group_Button_Text_Color);
 
-    @include fd-set-border-left(var(--sapButton_BorderWidth) solid transparent);
-
     &::before {
       display: none !important;
     }
 
     @include fd-hover() {
-      @include fd-set-border-left(var(--fdInputGroup_ControlButton_SideBorder));
-
       background: var(--fdInput_Group_Button_Hover_Background);
       color: var(--fdInput_Group_Button_Hover_Text_Color);
       box-shadow: var(--fdInput_Group_Button_Box_Shadow);
     }
 
     @include fd-active() {
-      @include fd-set-border-left(var(--fdInputGroup_ControlButton_SideBorder));
-
       background: var(--fdInput_Group_Button_Active_Background);
       color: var(--fdInput_Group_Button_Active_Text_Color);
       box-shadow: var(--fdInput_Group_Button_Box_Shadow);

--- a/packages/styles/src/theming/common/input-group/_sap_horizon_hc.scss
+++ b/packages/styles/src/theming/common/input-group/_sap_horizon_hc.scss
@@ -1,3 +1,4 @@
 :root {
   --fdInput_Group_Button_Hover_Background: var(--sapButton_Lite_Hover_Background);
+  --fdInput_Group_Button_Active_Background: var(--sapButton_Lite_Hover_Background);
 }

--- a/packages/styles/src/theming/sap_fiori_3.scss
+++ b/packages/styles/src/theming/sap_fiori_3.scss
@@ -164,7 +164,8 @@
 
   /* Input Group */
   --fdInputGroup_Text_Shadow: none;
-  --fdInputGroup_ControlButton_SideBorder: solid var(--sapButton_BorderWidth) transparent;
+  --fdInputGroup_ControlButton_SideBorder: var(--sapButton_BorderWidth) solid transparent;
+  --fdInputGroup_ControlButton_SideBorder_Active: solid var(--sapButton_BorderWidth) transparent;
 
   /* Input */
   --fdInput_Text_Shadow: none;

--- a/packages/styles/src/theming/sap_fiori_3_dark.scss
+++ b/packages/styles/src/theming/sap_fiori_3_dark.scss
@@ -170,7 +170,8 @@
 
   /* Input Group */
   --fdInputGroup_Text_Shadow: none;
-  --fdInputGroup_ControlButton_SideBorder: solid var(--sapButton_BorderWidth) transparent;
+  --fdInputGroup_ControlButton_SideBorder: var(--sapButton_BorderWidth) solid transparent;
+  --fdInputGroup_ControlButton_SideBorder_Active: solid var(--sapButton_BorderWidth) transparent;
 
   /* Input */
   --fdInput_Text_Shadow: none;

--- a/packages/styles/src/theming/sap_fiori_3_hcb.scss
+++ b/packages/styles/src/theming/sap_fiori_3_hcb.scss
@@ -177,7 +177,8 @@
 
   /* Input Group */
   --fdInputGroup_Text_Shadow: 0 0 0.125rem #000;
-  --fdInputGroup_ControlButton_SideBorder: solid var(--sapButton_BorderWidth) var(--sapList_SelectionBorderColor);
+  --fdInputGroup_ControlButton_SideBorder: var(--sapField_BorderWidth) solid transparent;
+  --fdInputGroup_ControlButton_SideBorder_Active: solid var(--sapField_BorderWidth) var(--sapList_SelectionBorderColor);
 
   /* Input */
   --fdInput_Text_Shadow: 0 0 0.125rem #000;

--- a/packages/styles/src/theming/sap_fiori_3_hcw.scss
+++ b/packages/styles/src/theming/sap_fiori_3_hcw.scss
@@ -173,7 +173,8 @@
 
   /* Input Group */
   --fdInputGroup_Text_Shadow: none;
-  --fdInputGroup_ControlButton_SideBorder: solid var(--sapButton_BorderWidth) var(--sapList_SelectionBorderColor);
+  --fdInputGroup_ControlButton_SideBorder: var(--sapField_BorderWidth) solid transparent;
+  --fdInputGroup_ControlButton_SideBorder_Active: solid var(--sapField_BorderWidth) var(--sapList_SelectionBorderColor);
 
   /* Input */
   --fdInput_Text_Shadow: none;

--- a/packages/styles/src/theming/sap_fiori_3_light_dark.scss
+++ b/packages/styles/src/theming/sap_fiori_3_light_dark.scss
@@ -171,7 +171,8 @@
 
   /* Input Group */
   --fdInputGroup_Text_Shadow: none;
-  --fdInputGroup_ControlButton_SideBorder: solid var(--sapButton_BorderWidth) transparent;
+  --fdInputGroup_ControlButton_SideBorder: var(--sapButton_BorderWidth) solid transparent;
+  --fdInputGroup_ControlButton_SideBorder_Active: solid var(--sapButton_BorderWidth) transparent;
 
   /* Input */
   --fdInput_Text_Shadow: none;

--- a/packages/styles/src/theming/sap_horizon.scss
+++ b/packages/styles/src/theming/sap_horizon.scss
@@ -172,7 +172,8 @@
 
   /* Input Group */
   --fdInputGroup_Text_Shadow: none;
-  --fdInputGroup_ControlButton_SideBorder: solid var(--sapButton_BorderWidth) transparent;
+  --fdInputGroup_ControlButton_SideBorder: var(--sapButton_BorderWidth) solid transparent;
+  --fdInputGroup_ControlButton_SideBorder_Active: solid var(--sapButton_BorderWidth) transparent;
 
   /* Input */
   --fdInput_Text_Shadow: none;

--- a/packages/styles/src/theming/sap_horizon_dark.scss
+++ b/packages/styles/src/theming/sap_horizon_dark.scss
@@ -181,7 +181,8 @@
 
   /* Input Group */
   --fdInputGroup_Text_Shadow: none;
-  --fdInputGroup_ControlButton_SideBorder: solid var(--sapButton_BorderWidth) transparent;
+  --fdInputGroup_ControlButton_SideBorder: var(--sapButton_BorderWidth) solid transparent;
+  --fdInputGroup_ControlButton_SideBorder_Active: solid var(--sapButton_BorderWidth) transparent;
 
   /* Input */
   --fdInput_Text_Shadow: none;

--- a/packages/styles/src/theming/sap_horizon_hcb.scss
+++ b/packages/styles/src/theming/sap_horizon_hcb.scss
@@ -168,7 +168,8 @@
 
   /* Input Group */
   --fdInputGroup_Text_Shadow: none;
-  --fdInputGroup_ControlButton_SideBorder: solid var(--sapButton_BorderWidth) var(--sapList_SelectionBorderColor);
+  --fdInputGroup_ControlButton_SideBorder: var(--sapField_BorderWidth) solid transparent;
+  --fdInputGroup_ControlButton_SideBorder_Active: solid var(--sapField_BorderWidth) var(--sapList_SelectionBorderColor);
 
   /* Input */
   --fdInput_Text_Shadow: none;

--- a/packages/styles/src/theming/sap_horizon_hcw.scss
+++ b/packages/styles/src/theming/sap_horizon_hcw.scss
@@ -169,7 +169,8 @@
 
   /* Input Group */
   --fdInputGroup_Text_Shadow: none;
-  --fdInputGroup_ControlButton_SideBorder: solid var(--sapButton_BorderWidth) var(--sapList_SelectionBorderColor);
+  --fdInputGroup_ControlButton_SideBorder: var(--sapField_BorderWidth) solid transparent;
+  --fdInputGroup_ControlButton_SideBorder_Active: solid var(--sapField_BorderWidth) var(--sapList_SelectionBorderColor);
 
   /* Input */
   --fdInput_Text_Shadow: none;


### PR DESCRIPTION
## Related Issue

Refers to https://github.com/SAP/fundamental-ngx/issues/8897#issuecomment-1366555025

## Description

Input group button styling in HC themes.

## Screenshots

### Before:

Hover State
![image](https://user-images.githubusercontent.com/20265336/209854591-97d38e2a-7831-43a4-af5b-08f91b91543b.png)

Active state
![image](https://user-images.githubusercontent.com/20265336/209854609-35f34068-7207-49f6-a22a-6d93dfa651a3.png)

### After:

Hover State
<img width="109" alt="CleanShot 2022-12-28 at 19 10 06@2x" src="https://user-images.githubusercontent.com/20265336/209854663-0fce5e4a-4f82-43b3-92df-e0801808c830.png">

Active State
<img width="93" alt="CleanShot 2022-12-28 at 19 10 28@2x" src="https://user-images.githubusercontent.com/20265336/209854704-91dd801f-bff9-4305-a5e2-f667399f5d0a.png">

*Note: I suppose that blue background on button in active state is the mistake in the wiki because it's said*

> __The Input Button inherit all styles__ from [Button (Horizon)](https://wiki.one.int.sap/wiki/pages/viewpage.action?pageId=2698912599) with the following deltas:
> 
> border-radius: --sapField_BorderCornerRadius;
> border-color: --sapButton_Hover_BorderColor;
> 
> The Field's underline must appear on top of the Button in all states.
> __The Down state of the input button preserves the hover visual.__

And button in active state has orange background in HC themes.
