### PR TITLE
fix(styles): pagination button focus styles

### DIFF
--- a/packages/styles/src/pagination.scss
+++ b/packages/styles/src/pagination.scss
@@ -1,5 +1,6 @@
 @import "./new-settings";
 @import "./mixins";
+@import './mixins/button/button-helper';
 
 /*!
 .fd-pagination
@@ -110,6 +111,11 @@ $block: #{$fd-namespace}-pagination;
   }
 
   .#{$block}__link {
+    @include fd-focus() {
+      /** Better would be to reuse button focus styles & fd-button--toggled instead of is-active class but it leads to breaking changes. */
+      @include fd-button-focus(var(--fdButton_Outline_Offset));
+    }
+
     /** :active links still should be displayed */
     &.is-active {
       display: none;


### PR DESCRIPTION
## Related Issue

Refers to https://github.com/SAP/fundamental-ngx/issues/8897#issuecomment-1366587987

## Description

Pagination active item button focus styles issue fix.

## Screenshots

### Before:
<img width="72" alt="CleanShot 2022-12-30 at 15 43 03@2x" src="https://user-images.githubusercontent.com/20265336/210082369-cba0275f-6cc1-4da6-b557-210af8fd89da.png">


### After:
<img width="67" alt="CleanShot 2022-12-30 at 15 43 15@2x" src="https://user-images.githubusercontent.com/20265336/210082397-926c33b4-fe4e-49f6-ada2-21c225a7ef54.png">
