### PR TITLE
fix(styles): layout panel scrollbar

### DIFF
--- a/packages/styles/src/layout-panel.scss
+++ b/packages/styles/src/layout-panel.scss
@@ -105,6 +105,8 @@ $block: #{$fd-namespace}-layout-panel;
   &__body {
     @include fd-reset();
 
+    display: block;
+    height: 100%;
     padding: $fd-layout-panel-padding;
 
     &--full-bleed,


### PR DESCRIPTION
Relates to [#9173](https://github.com/SAP/fundamental-ngx/issues/9173)

## Screenshots

### Before:
<img width="1219" alt="Screenshot 2023-01-03 at 17 14 15" src="https://user-images.githubusercontent.com/28543391/210364256-c3f1788d-f414-4ae7-87d9-12339596b020.png">

### After:

<img width="1215" alt="Screenshot 2023-01-03 at 17 12 46" src="https://user-images.githubusercontent.com/28543391/210364278-3e1d9439-3b76-4cf2-bbd5-676e957537ad.png">
