### PR TITLE
fix(styles): outline-offset of dynamic page header not visible when page is fullscreen

### DIFF
--- a/packages/styles/src/dynamic-page.scss
+++ b/packages/styles/src/dynamic-page.scss
@@ -10,7 +10,7 @@ $block: #{$fd-namespace}-dynamic-page;
   $fd-dynamic-page-box-shadow: var(--sapContent_HeaderShadow);
   $fd-dynamic-page-button-group-width: 4rem;
   $fd-dynamic-page-button-group-height: 0.0625rem;
-  $fd-dynamic-page-focus-outline-offset: 0.0625rem;
+  $fd-dynamic-page-focus-outline-offset: -0.25rem;
   $fd-dynamic-page-toolbar-space: 1rem;
 
   @mixin fd-background-page($background-color) {


### PR DESCRIPTION
fixes #4170 

Before:
<img width="1471" alt="Screenshot 2023-01-11 at 2 56 12 PM" src="https://user-images.githubusercontent.com/2471874/211927529-b222c580-6ec1-43d4-babf-e773c4a58a73.png">

After:
<img width="1480" alt="Screenshot 2023-01-11 at 2 56 01 PM" src="https://user-images.githubusercontent.com/2471874/211927546-4550d716-1b0e-4643-979d-1a1e47ce373b.png">
