### PR TITLE
docs(styles): update Table to use Toolbar Title [ci visual]

### DIFF
--- a/packages/styles/stories/Components/table/table.stories.js
+++ b/packages/styles/stories/Components/table/table.stories.js
@@ -89,8 +89,8 @@ In these cases, use the **Tree** instead.
     }
 };
 
-export const Primary = () => `<div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
-    <h4 style="margin: 0;">Default Table</h4>
+export const Primary = () => `<div class="fd-toolbar fd-toolbar--title fd-toolbar-active">
+    <h4 class="fd-title fd-title--h4 fd-toolbar__title">Default Table</h4>
     <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
 </div>
 <table class="fd-table">
@@ -155,8 +155,8 @@ The primary table contains columns with headers, and rows with links. In the fir
     }
 };
 
-export const Borderless = () => `<div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
-    <h4 style="margin: 0;">Table Without Borders</h4>
+export const Borderless = () => `<div class="fd-toolbar fd-toolbar--title fd-toolbar-active">
+    <h4 class="fd-title fd-title--h4 fd-toolbar__title">Table Without Borders</h4>
     <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
 </div>
 <table class="fd-table fd-table--no-horizontal-borders fd-table--no-vertical-borders">
@@ -198,8 +198,8 @@ Table can be displayed without borders that separate the columns, column headers
     }
 };
 
-export const Borderlessbody = () => `<div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
-    <h4 style="margin: 0;">Table Without Borders On Body</h4>
+export const Borderlessbody = () => `<div class="fd-toolbar fd-toolbar--title fd-toolbar-active">
+    <h4 class="fd-title fd-title--h4 fd-toolbar__title">Table Without Borders On Body</h4>
     <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
 </div>
 <table class="fd-table">
@@ -239,8 +239,8 @@ Table can be displayed without borders that separate the columns and rows only, 
     }
 };
 
-export const NoOuterBorder = () => `<div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
-    <h4 style="margin: 0;">Table Without Outer Borders</h4>
+export const NoOuterBorder = () => `<div class="fd-toolbar fd-toolbar--title fd-toolbar-active">
+    <h4 class="fd-title fd-title--h4 fd-toolbar__title">Table Without Outer Borders</h4>
     <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
 </div>
 <table class="fd-table fd-table--no-outer-border">
@@ -286,8 +286,8 @@ Table can be displayed without outer borders, might be needed when used inside s
     }
 };
 
-export const Footer = () => `<div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
-    <h4 style="margin: 0;">Table With Footer Cozy Mode</h4>
+export const Footer = () => `<div class="fd-toolbar fd-toolbar--title fd-toolbar-active">
+    <h4 class="fd-title fd-title--h4 fd-toolbar__title">Table With Footer Cozy Mode</h4>
     <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
 </div>
 <table class="fd-table">
@@ -339,8 +339,8 @@ Table can be displayed with a footer. To display a table footer, add the \`fd-ta
     }
 };
 
-export const CompactFooter = () => `<div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
-    <h4 style="margin: 0;">Table With Footer Compact Mode</h4>
+export const CompactFooter = () => `<div class="fd-toolbar fd-toolbar--title fd-toolbar-active">
+    <h4 class="fd-title fd-title--h4 fd-toolbar__title">Table With Footer Compact Mode</h4>
     <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
 </div>
 <table class="fd-table fd-table--compact">
@@ -388,8 +388,8 @@ Table can be displayed with a footer in compact mode, which is ideal for larger 
     }
 };
 
-export const CondensedFooter = () => `<div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
-    <h4 style="margin: 0;">Table With Footer Condensed Mode</h4>
+export const CondensedFooter = () => `<div class="fd-toolbar fd-toolbar--title fd-toolbar-active">
+    <h4 class="fd-title fd-title--h4 fd-toolbar__title">Table With Footer Condensed Mode</h4>
     <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
 </div>
 <table class="fd-table fd-table--condensed">
@@ -437,8 +437,8 @@ Similar to the previous example, table can be displayed with a footer in condens
     }
 };
 
-export const Interactive = () => `<div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
-    <h4 style="margin: 0;">Interactive Table With Hoverable and Activable Cells and Rows</h4>
+export const Interactive = () => `<div class="fd-toolbar fd-toolbar--title fd-toolbar-active">
+    <h4 class="fd-title fd-title--h4 fd-toolbar__title">Interactive Table With Hoverable and Activable Cells and Rows</h4>
     <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
 </div>
 <table class="fd-table">
@@ -513,8 +513,8 @@ Hover | \`--hoverable\`
     }
 };
 
-export const SemanticRows = () => `<div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
-    <h4 style="margin: 0;">Table with Semantic Rows</h4>
+export const SemanticRows = () => `<div class="fd-toolbar fd-toolbar--title fd-toolbar-active">
+    <h4 class="fd-title fd-title--h4 fd-toolbar__title">Table with Semantic Rows</h4>
     <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
 </div>
 <table class="fd-table">
@@ -655,8 +655,8 @@ Information | \`--information\`
     }
 };
 
-export const FocusableRows = () => `<div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
-    <h4 style="margin: 0;">Table With Focusable Rows</h4>
+export const FocusableRows = () => `<div class="fd-toolbar fd-toolbar--title fd-toolbar-active">
+    <h4 class="fd-title fd-title--h4 fd-toolbar__title">Table With Focusable Rows</h4>
     <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
 </div>
 <table class="fd-table" role="grid">
@@ -699,8 +699,8 @@ Table can display focusable rows by adding the \`fd-table__row--focusable\` modi
     }
 };
 
-export const FocusableCells = () => `<div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
-    <h4 style="margin: 0;">Table With Focusable Cells</h4>
+export const FocusableCells = () => `<div class="fd-toolbar fd-toolbar--title fd-toolbar-active">
+    <h4 class="fd-title fd-title--h4 fd-toolbar__title">Table With Focusable Cells</h4>
     <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
 </div>
 <table class="fd-table" role="grid">
@@ -743,8 +743,8 @@ Table can display focusable cells by adding the \`fd-table__cell--focusable\` mo
     }
 };
 
-export const Checkbox = () => `<div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
-    <h4 style="margin: 0;">Table With Checkbox Cozy Mode</h4>
+export const Checkbox = () => `<div class="fd-toolbar fd-toolbar--title fd-toolbar-active">
+    <h4 class="fd-title fd-title--h4 fd-toolbar__title">Table With Checkbox Cozy Mode</h4>
     <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
 </div>
 <table class="fd-table">
@@ -808,8 +808,8 @@ Also recommended to add class \`fd-table__checkbox\` to the checkbox (input) and
     }
 };
 
-export const CompactCheckbox = () => `<div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
-    <h4 style="margin: 0;">Table With Checkbox Compact Mode</h4>
+export const CompactCheckbox = () => `<div class="fd-toolbar fd-toolbar--title fd-toolbar-active">
+    <h4 class="fd-title fd-title--h4 fd-toolbar__title">Table With Checkbox Compact Mode</h4>
     <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
 </div>
 <table class="fd-table fd-table--compact">
@@ -874,8 +874,8 @@ To display the table in compact mode, add the \`fd-table--compact\` modifier cla
     }
 };
 
-export const CondensedCheckbox = () => `<div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
-    <h4 style="margin: 0;">Table With Checkbox Condensed Mode</h4>
+export const CondensedCheckbox = () => `<div class="fd-toolbar fd-toolbar--title fd-toolbar-active">
+    <h4 class="fd-title fd-title--h4 fd-toolbar__title">Table With Checkbox Condensed Mode</h4>
     <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
 </div>
 <table class="fd-table fd-table--condensed">
@@ -940,8 +940,8 @@ To display the table in condensed mode, add the \`fd-table--condensed\` modifier
     }
 };
 
-export const Pagination = () => `<div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
-    <h4 style="margin: 0;">Table With Pagination at The Bottom</h4>
+export const Pagination = () => `<div class="fd-toolbar fd-toolbar--title fd-toolbar-active">
+    <h4 class="fd-title fd-title--h4 fd-toolbar__title">Table With Pagination at The Bottom</h4>
     <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
 </div>
 <table class="fd-table">
@@ -1161,8 +1161,8 @@ export const AdvancedToolbar = () => `<div class="fd-dialog" id="filter-dialog-e
         </footer>
     </section>
 </div>
-<div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
-    <h4 style="margin: 0;">Table With Advanced Shellbar</h4>
+<div class="fd-toolbar fd-toolbar--title fd-toolbar-active">
+    <h4 class="fd-title fd-title--h4 fd-toolbar__title">Table With Advanced Shellbar</h4>
     <div class="fd-toolbar__spacer"></div>
     <button aria-label="navigation" class="fd-button fd-button--compact fd-button--transparent" onclick="toggleClass('filter-dialog-example', 'fd-dialog--active')">
         <i class="sap-icon--filter"></i>
@@ -1227,8 +1227,8 @@ The table component can be displayed with an advanced **Toolbar**, which allows 
 };
 
 export const ContextualMenu = () => `<div style="min-height: 400px">
-<div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
-    <h4 style="margin: 0;">Table with Contextual Menu</h4>
+<div class="fd-toolbar fd-toolbar--title fd-toolbar-active">
+    <h4 class="fd-title fd-title--h4 fd-toolbar__title">Table with Contextual Menu</h4>
     <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
 </div>
 <table class="fd-table" >
@@ -1328,8 +1328,8 @@ Table can display a contextual menu containing actions if there is not enough sp
     }
 };
 
-export const MenuHeader = () => `<div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
-    <h4 style="margin: 0;">Table with Popover in Headers</h4>
+export const MenuHeader = () => `<div class="fd-toolbar fd-toolbar--title fd-toolbar-active">
+    <h4 class="fd-title fd-title--h4 fd-toolbar__title">Table with Popover in Headers</h4>
     <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
 </div>
 <table class="fd-table" >
@@ -1527,8 +1527,8 @@ It’s important to hardcode the width of the columns, otherwise the cells will 
     }
 };
 
-export const NavIcon = () => `<div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
-    <h4>Responsive Table - row navigation</h4>
+export const NavIcon = () => `<div class="fd-toolbar fd-toolbar--title fd-toolbar-active">
+    <h4 class="fd-title fd-title--h4 fd-toolbar__title">Responsive Table - row navigation</h4>
     <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
 </div>
 <table class="fd-table fd-table--responsive fd-table--no-horizontal-borders">
@@ -1583,8 +1583,8 @@ export const NavIcon = () => `<div class="fd-toolbar fd-toolbar--solid fd-toolba
         </tr>
     </tbody>
 </table>
-<div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
-    <h4>Table - icon button for navigation</h4>
+<div class="fd-toolbar fd-toolbar--title fd-toolbar-active">
+    <h4 class="fd-title fd-title--h4 fd-toolbar__title">Table - icon button for navigation</h4>
     <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
 </div>
 <table class="fd-table ">
@@ -1660,8 +1660,8 @@ You have an option to add icon button \`sap-icon--navigation-right-arrow\` as a 
     }
 };
 
-export const NavIndicators = () => `<div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
-    <h4>Table with Navigation Indication State</h4>
+export const NavIndicators = () => `<div class="fd-toolbar fd-toolbar--title fd-toolbar-active">
+    <h4 class="fd-title fd-title--h4 fd-toolbar__title">Table with Navigation Indication State</h4>
     <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
 </div>
 <table class="fd-table fd-table--no-horizontal-borders">
@@ -1734,8 +1734,8 @@ The table component can display navigation indicators. When multi-selection is u
     }
 };
 
-export const ResponsiveTable = () => `<div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
-    <h4 style="margin: 0;">Responsive Table</h4>
+export const ResponsiveTable = () => `<div class="fd-toolbar fd-toolbar--title fd-toolbar-active">
+    <h4 class="fd-title fd-title--h4 fd-toolbar__title">Responsive Table</h4>
     <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
 </div>
 <table class="fd-table fd-table--responsive fd-table--no-horizontal-borders">
@@ -1818,8 +1818,8 @@ The desktop responsive table should contain \`fd-table--responsive\` modifier.
 };
 
 export const ResponsiveTablePopInMode = () => `<div style="max-width: 450px">
-    <div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
-        <h4 style="margin: 0;">Responsive Table - Pop-in mode</h4>
+    <div class="fd-toolbar fd-toolbar--title fd-toolbar-active">
+        <h4 class="fd-title fd-title--h4 fd-toolbar__title">Responsive Table - Pop-in mode</h4>
         <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
     </div>
     <table class="fd-table fd-table--responsive fd-table--no-horizontal-borders fd-table--no-vertical-borders fd-table--pop-in">
@@ -1881,8 +1881,8 @@ export const ResponsiveTablePopInMode = () => `<div style="max-width: 450px">
 </div>
 <br>
 <div style="max-width: 450px">
-    <div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
-        <h4 style="margin: 0;">Responsive Table - Pop-in Mode with Checkboxes and Navigation Indicator</h4>
+    <div class="fd-toolbar fd-toolbar--title fd-toolbar-active">
+        <h4 class="fd-title fd-title--h4 fd-toolbar__title">Responsive Table - Pop-in Mode with Checkboxes and Navigation Indicator</h4>
         <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
     </div>
     <table class="fd-table fd-table--responsive fd-table--no-horizontal-borders fd-table--no-vertical-borders fd-table--pop-in">

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -14848,6 +14848,31 @@ exports[`Check stories > Components/Illustrated Message > Story Dialog > Should 
 "
 `;
 
+exports[`Check stories > Components/Illustrated Message > Story Dot > Should match snapshot 1`] = `
+"
+    <figure class=\\"fd-illustrated-message fd-illustrated-message--dot\\">
+        <svg class=\\"fd-illustrated-message__illustration\\" xmlns=\\"http://www.w3.org/2000/svg\\" xmlns:xlink=\\"http://www.w3.org/1999/xlink\\" width=\\"128\\" height=\\"128\\" viewBox=\\"0 0 128 128\\" id=\\"sapIllus-Spot-NoMail\\">
+            <path class=\\"sapIllus_ObjectFillColor\\" style=\\"fill:var(--sapIllus_ObjectFillColor)\\" d=\\"M97.2067,60.8347v40.18a3,3,0,0,1-3,3H33.9947a3,3,0,0,1-3-3V60.8765a3,3,0,0,1,1.254-2.44L62.321,36.9154a3,3,0,0,1,3.487-.0035l30.14,21.48A3,3,0,0,1,97.2067,60.8347Z\\"/>
+            <polygon class=\\"sapIllus_Layering2\\" style=\\"fill:var(--sapIllus_Layering2)\\" points=\\"92.761 103.489 35.468 103.489 64.096 82.677 92.761 103.489\\"/>
+            <path class=\\"sapIllus_BrandColorSecondary\\" style=\\"fill:var(--sapIllus_BrandColorSecondary)\\" d=\\"M90.367,64.3134,65.917,82.8827a3.0257,3.0257,0,0,1-3.6308.0171L37.626,64.5377l24.716-17.487a3.0264,3.0264,0,0,1,3.4838-.0046Z\\"/>
+            <path class=\\"sapIllus_PatternShadow\\" style=\\"fill:var(--sapIllus_PatternShadow)\\" d=\\"M90.5326,64.1056,74.8393,53.3121l-26.5862,19.16L61.852,82.481a4,4,0,0,0,4.8068-.0486Z\\"/>
+            <path class=\\"sapIllus_Layering1\\" style=\\"fill:var(--sapIllus_Layering1)\\" d=\\"M63.7051,23.52a1.0169,1.0169,0,0,1-1-1.0334V9.5356a1.0005,1.0005,0,1,1,2,0V22.4867A1.0169,1.0169,0,0,1,63.7051,23.52Z\\"/>
+            <path class=\\"sapIllus_Layering1\\" style=\\"fill:var(--sapIllus_Layering1)\\" d=\\"M93.7146,41.4936a1.0127,1.0127,0,0,1-.7165-1.7286l8.9808-8.9742a1.0129,1.0129,0,1,1,1.433,1.4319l-8.9808,8.9742A1.0105,1.0105,0,0,1,93.7146,41.4936Z\\"/>
+            <path class=\\"sapIllus_Layering1\\" style=\\"fill:var(--sapIllus_Layering1)\\" d=\\"M33.6873,41.5044a1.01,1.01,0,0,1-.7162-.2968l-8.9771-8.98a1.013,1.013,0,1,1,1.4324-1.4329l8.9771,8.98a1.0132,1.0132,0,0,1-.7162,1.73Z\\"/>
+            <path class=\\"sapIllus_StrokeDetailColor\\" style=\\"fill:var(--sapIllus_StrokeDetailColor)\\" d=\\"M96.2422,57.7315,66.1948,36.142a3.4676,3.4676,0,0,0-4.0559.0039l-29.98,21.6317A3.5346,3.5346,0,0,0,30.7,60.6384v40.3442a3.5,3.5,0,0,0,3.2612,3.4947l-.0321.0232.2469-.0013.0133.0013H94.2172a3.5079,3.5079,0,0,0,3.4892-3.5179V60.5966A3.5329,3.5329,0,0,0,96.2422,57.7315Zm-63.506.866,29.98-21.6337a2.4774,2.4774,0,0,1,2.8973-.003L95.6608,58.5523a2.49,2.49,0,0,1,.6548.7262l-4.9722,3.6834q-.5681.38-1.1359.7607L65.6853,46.9533l23.918,17.1739L65.8584,80.0282a3.33,3.33,0,0,1-3.2087.13L38.61,64.0228,62.5492,46.9171,38.2518,63.7824l-1.96-1.3153-4.22-3.1264A2.4893,2.4893,0,0,1,32.7362,58.5975Zm63.97,42.3914a2.5054,2.5054,0,0,1-2.4923,2.513H92.8174l-27.74-20.09,26.6776,20.09H36.3728L63.0443,83.4555,35.3109,103.5019H34.1868a2.5054,2.5054,0,0,1-2.4923-2.513V60.6408a2.4906,2.4906,0,0,1,.0367-.3075L62.0678,82.8075a3.4809,3.4809,0,0,0,4.167,0L96.6663,60.2637a2.49,2.49,0,0,1,.04.3354Z\\"/>
+        </svg>
+        <figcaption class=\\"fd-illustrated-message__figcaption\\">
+            <h5 class=\\"fd-illustrated-message__title\\">Headline text goes here</h5>
+            <p class=\\"fd-illustrated-message__text\\">Description provides user with clarity and possible next steps.</p>
+        </figcaption>
+
+        <div class=\\"fd-illustrated-message__actions\\">
+            <button class=\\"fd-button\\">Action</button>
+        </div>
+    </figure>
+"
+`;
+
 exports[`Check stories > Components/Illustrated Message > Story Scene > Should match snapshot 1`] = `
 "<div style=\\"width: 100%; display: flex; justify-content: center\\">
     <figure class=\\"fd-illustrated-message\\">
@@ -27050,8 +27075,8 @@ exports[`Check stories > Components/Table > Story AdvancedToolbar > Should match
         </footer>
     </section>
 </div>
-<div class=\\"fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active\\">
-    <h4 style=\\"margin: 0;\\">Table With Advanced Shellbar</h4>
+<div class=\\"fd-toolbar fd-toolbar--title fd-toolbar-active\\">
+    <h4 class=\\"fd-title fd-title--h4 fd-toolbar__title\\">Table With Advanced Shellbar</h4>
     <div class=\\"fd-toolbar__spacer\\"></div>
     <button aria-label=\\"navigation\\" class=\\"fd-button fd-button--compact fd-button--transparent\\" onclick=\\"toggleClass('filter-dialog-example', 'fd-dialog--active')\\">
         <i class=\\"sap-icon--filter\\"></i>
@@ -27106,8 +27131,8 @@ exports[`Check stories > Components/Table > Story AdvancedToolbar > Should match
 `;
 
 exports[`Check stories > Components/Table > Story Borderless > Should match snapshot 1`] = `
-"<div class=\\"fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active\\">
-    <h4 style=\\"margin: 0;\\">Table Without Borders</h4>
+"<div class=\\"fd-toolbar fd-toolbar--title fd-toolbar-active\\">
+    <h4 class=\\"fd-title fd-title--h4 fd-toolbar__title\\">Table Without Borders</h4>
     <span class=\\"fd-toolbar__spacer fd-toolbar__spacer--auto\\"></span>
 </div>
 <table class=\\"fd-table fd-table--no-horizontal-borders fd-table--no-vertical-borders\\">
@@ -27138,8 +27163,8 @@ exports[`Check stories > Components/Table > Story Borderless > Should match snap
 `;
 
 exports[`Check stories > Components/Table > Story Borderlessbody > Should match snapshot 1`] = `
-"<div class=\\"fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active\\">
-    <h4 style=\\"margin: 0;\\">Table Without Borders On Body</h4>
+"<div class=\\"fd-toolbar fd-toolbar--title fd-toolbar-active\\">
+    <h4 class=\\"fd-title fd-title--h4 fd-toolbar__title\\">Table Without Borders On Body</h4>
     <span class=\\"fd-toolbar__spacer fd-toolbar__spacer--auto\\"></span>
 </div>
 <table class=\\"fd-table\\">
@@ -27170,8 +27195,8 @@ exports[`Check stories > Components/Table > Story Borderlessbody > Should match 
 `;
 
 exports[`Check stories > Components/Table > Story Checkbox > Should match snapshot 1`] = `
-"<div class=\\"fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active\\">
-    <h4 style=\\"margin: 0;\\">Table With Checkbox Cozy Mode</h4>
+"<div class=\\"fd-toolbar fd-toolbar--title fd-toolbar-active\\">
+    <h4 class=\\"fd-title fd-title--h4 fd-toolbar__title\\">Table With Checkbox Cozy Mode</h4>
     <span class=\\"fd-toolbar__spacer fd-toolbar__spacer--auto\\"></span>
 </div>
 <table class=\\"fd-table\\">
@@ -27224,8 +27249,8 @@ exports[`Check stories > Components/Table > Story Checkbox > Should match snapsh
 `;
 
 exports[`Check stories > Components/Table > Story CompactCheckbox > Should match snapshot 1`] = `
-"<div class=\\"fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active\\">
-    <h4 style=\\"margin: 0;\\">Table With Checkbox Compact Mode</h4>
+"<div class=\\"fd-toolbar fd-toolbar--title fd-toolbar-active\\">
+    <h4 class=\\"fd-title fd-title--h4 fd-toolbar__title\\">Table With Checkbox Compact Mode</h4>
     <span class=\\"fd-toolbar__spacer fd-toolbar__spacer--auto\\"></span>
 </div>
 <table class=\\"fd-table fd-table--compact\\">
@@ -27278,8 +27303,8 @@ exports[`Check stories > Components/Table > Story CompactCheckbox > Should match
 `;
 
 exports[`Check stories > Components/Table > Story CompactFooter > Should match snapshot 1`] = `
-"<div class=\\"fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active\\">
-    <h4 style=\\"margin: 0;\\">Table With Footer Compact Mode</h4>
+"<div class=\\"fd-toolbar fd-toolbar--title fd-toolbar-active\\">
+    <h4 class=\\"fd-title fd-title--h4 fd-toolbar__title\\">Table With Footer Compact Mode</h4>
     <span class=\\"fd-toolbar__spacer fd-toolbar__spacer--auto\\"></span>
 </div>
 <table class=\\"fd-table fd-table--compact\\">
@@ -27318,8 +27343,8 @@ exports[`Check stories > Components/Table > Story CompactFooter > Should match s
 `;
 
 exports[`Check stories > Components/Table > Story CondensedCheckbox > Should match snapshot 1`] = `
-"<div class=\\"fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active\\">
-    <h4 style=\\"margin: 0;\\">Table With Checkbox Condensed Mode</h4>
+"<div class=\\"fd-toolbar fd-toolbar--title fd-toolbar-active\\">
+    <h4 class=\\"fd-title fd-title--h4 fd-toolbar__title\\">Table With Checkbox Condensed Mode</h4>
     <span class=\\"fd-toolbar__spacer fd-toolbar__spacer--auto\\"></span>
 </div>
 <table class=\\"fd-table fd-table--condensed\\">
@@ -27372,8 +27397,8 @@ exports[`Check stories > Components/Table > Story CondensedCheckbox > Should mat
 `;
 
 exports[`Check stories > Components/Table > Story CondensedFooter > Should match snapshot 1`] = `
-"<div class=\\"fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active\\">
-    <h4 style=\\"margin: 0;\\">Table With Footer Condensed Mode</h4>
+"<div class=\\"fd-toolbar fd-toolbar--title fd-toolbar-active\\">
+    <h4 class=\\"fd-title fd-title--h4 fd-toolbar__title\\">Table With Footer Condensed Mode</h4>
     <span class=\\"fd-toolbar__spacer fd-toolbar__spacer--auto\\"></span>
 </div>
 <table class=\\"fd-table fd-table--condensed\\">
@@ -27413,8 +27438,8 @@ exports[`Check stories > Components/Table > Story CondensedFooter > Should match
 
 exports[`Check stories > Components/Table > Story ContextualMenu > Should match snapshot 1`] = `
 "<div style=\\"min-height: 400px\\">
-<div class=\\"fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active\\">
-    <h4 style=\\"margin: 0;\\">Table with Contextual Menu</h4>
+<div class=\\"fd-toolbar fd-toolbar--title fd-toolbar-active\\">
+    <h4 class=\\"fd-title fd-title--h4 fd-toolbar__title\\">Table with Contextual Menu</h4>
     <span class=\\"fd-toolbar__spacer fd-toolbar__spacer--auto\\"></span>
 </div>
 <table class=\\"fd-table\\" >
@@ -27591,8 +27616,8 @@ exports[`Check stories > Components/Table > Story FixColumnHeader > Should match
 `;
 
 exports[`Check stories > Components/Table > Story FocusableCells > Should match snapshot 1`] = `
-"<div class=\\"fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active\\">
-    <h4 style=\\"margin: 0;\\">Table With Focusable Cells</h4>
+"<div class=\\"fd-toolbar fd-toolbar--title fd-toolbar-active\\">
+    <h4 class=\\"fd-title fd-title--h4 fd-toolbar__title\\">Table With Focusable Cells</h4>
     <span class=\\"fd-toolbar__spacer fd-toolbar__spacer--auto\\"></span>
 </div>
 <table class=\\"fd-table\\" role=\\"grid\\">
@@ -27626,8 +27651,8 @@ exports[`Check stories > Components/Table > Story FocusableCells > Should match 
 `;
 
 exports[`Check stories > Components/Table > Story FocusableRows > Should match snapshot 1`] = `
-"<div class=\\"fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active\\">
-    <h4 style=\\"margin: 0;\\">Table With Focusable Rows</h4>
+"<div class=\\"fd-toolbar fd-toolbar--title fd-toolbar-active\\">
+    <h4 class=\\"fd-title fd-title--h4 fd-toolbar__title\\">Table With Focusable Rows</h4>
     <span class=\\"fd-toolbar__spacer fd-toolbar__spacer--auto\\"></span>
 </div>
 <table class=\\"fd-table\\" role=\\"grid\\">
@@ -27661,8 +27686,8 @@ exports[`Check stories > Components/Table > Story FocusableRows > Should match s
 `;
 
 exports[`Check stories > Components/Table > Story Footer > Should match snapshot 1`] = `
-"<div class=\\"fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active\\">
-    <h4 style=\\"margin: 0;\\">Table With Footer Cozy Mode</h4>
+"<div class=\\"fd-toolbar fd-toolbar--title fd-toolbar-active\\">
+    <h4 class=\\"fd-title fd-title--h4 fd-toolbar__title\\">Table With Footer Cozy Mode</h4>
     <span class=\\"fd-toolbar__spacer fd-toolbar__spacer--auto\\"></span>
 </div>
 <table class=\\"fd-table\\">
@@ -27982,8 +28007,8 @@ exports[`Check stories > Components/Table > Story GroupRowsInTable > Should matc
 `;
 
 exports[`Check stories > Components/Table > Story Interactive > Should match snapshot 1`] = `
-"<div class=\\"fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active\\">
-    <h4 style=\\"margin: 0;\\">Interactive Table With Hoverable and Activable Cells and Rows</h4>
+"<div class=\\"fd-toolbar fd-toolbar--title fd-toolbar-active\\">
+    <h4 class=\\"fd-title fd-title--h4 fd-toolbar__title\\">Interactive Table With Hoverable and Activable Cells and Rows</h4>
     <span class=\\"fd-toolbar__spacer fd-toolbar__spacer--auto\\"></span>
 </div>
 <table class=\\"fd-table\\">
@@ -28045,8 +28070,8 @@ exports[`Check stories > Components/Table > Story Interactive > Should match sna
 `;
 
 exports[`Check stories > Components/Table > Story MenuHeader > Should match snapshot 1`] = `
-"<div class=\\"fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active\\">
-    <h4 style=\\"margin: 0;\\">Table with Popover in Headers</h4>
+"<div class=\\"fd-toolbar fd-toolbar--title fd-toolbar-active\\">
+    <h4 class=\\"fd-title fd-title--h4 fd-toolbar__title\\">Table with Popover in Headers</h4>
     <span class=\\"fd-toolbar__spacer fd-toolbar__spacer--auto\\"></span>
 </div>
 <table class=\\"fd-table\\" >
@@ -28135,8 +28160,8 @@ exports[`Check stories > Components/Table > Story MenuHeader > Should match snap
 `;
 
 exports[`Check stories > Components/Table > Story NavIcon > Should match snapshot 1`] = `
-"<div class=\\"fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active\\">
-    <h4>Responsive Table - row navigation</h4>
+"<div class=\\"fd-toolbar fd-toolbar--title fd-toolbar-active\\">
+    <h4 class=\\"fd-title fd-title--h4 fd-toolbar__title\\">Responsive Table - row navigation</h4>
     <span class=\\"fd-toolbar__spacer fd-toolbar__spacer--auto\\"></span>
 </div>
 <table class=\\"fd-table fd-table--responsive fd-table--no-horizontal-borders\\">
@@ -28191,8 +28216,8 @@ exports[`Check stories > Components/Table > Story NavIcon > Should match snapsho
         </tr>
     </tbody>
 </table>
-<div class=\\"fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active\\">
-    <h4>Table - icon button for navigation</h4>
+<div class=\\"fd-toolbar fd-toolbar--title fd-toolbar-active\\">
+    <h4 class=\\"fd-title fd-title--h4 fd-toolbar__title\\">Table - icon button for navigation</h4>
     <span class=\\"fd-toolbar__spacer fd-toolbar__spacer--auto\\"></span>
 </div>
 <table class=\\"fd-table \\">
@@ -28257,8 +28282,8 @@ exports[`Check stories > Components/Table > Story NavIcon > Should match snapsho
 `;
 
 exports[`Check stories > Components/Table > Story NavIndicators > Should match snapshot 1`] = `
-"<div class=\\"fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active\\">
-    <h4>Table with Navigation Indication State</h4>
+"<div class=\\"fd-toolbar fd-toolbar--title fd-toolbar-active\\">
+    <h4 class=\\"fd-title fd-title--h4 fd-toolbar__title\\">Table with Navigation Indication State</h4>
     <span class=\\"fd-toolbar__spacer fd-toolbar__spacer--auto\\"></span>
 </div>
 <table class=\\"fd-table fd-table--no-horizontal-borders\\">
@@ -28354,8 +28379,8 @@ exports[`Check stories > Components/Table > Story NoDataTable > Should match sna
 `;
 
 exports[`Check stories > Components/Table > Story NoOuterBorder > Should match snapshot 1`] = `
-"<div class=\\"fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active\\">
-    <h4 style=\\"margin: 0;\\">Table Without Outer Borders</h4>
+"<div class=\\"fd-toolbar fd-toolbar--title fd-toolbar-active\\">
+    <h4 class=\\"fd-title fd-title--h4 fd-toolbar__title\\">Table Without Outer Borders</h4>
     <span class=\\"fd-toolbar__spacer fd-toolbar__spacer--auto\\"></span>
 </div>
 <table class=\\"fd-table fd-table--no-outer-border\\">
@@ -28392,8 +28417,8 @@ exports[`Check stories > Components/Table > Story NoOuterBorder > Should match s
 `;
 
 exports[`Check stories > Components/Table > Story Pagination > Should match snapshot 1`] = `
-"<div class=\\"fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active\\">
-    <h4 style=\\"margin: 0;\\">Table With Pagination at The Bottom</h4>
+"<div class=\\"fd-toolbar fd-toolbar--title fd-toolbar-active\\">
+    <h4 class=\\"fd-title fd-title--h4 fd-toolbar__title\\">Table With Pagination at The Bottom</h4>
     <span class=\\"fd-toolbar__spacer fd-toolbar__spacer--auto\\"></span>
 </div>
 <table class=\\"fd-table\\">
@@ -28478,8 +28503,8 @@ exports[`Check stories > Components/Table > Story Pagination > Should match snap
 `;
 
 exports[`Check stories > Components/Table > Story Primary > Should match snapshot 1`] = `
-"<div class=\\"fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active\\">
-    <h4 style=\\"margin: 0;\\">Default Table</h4>
+"<div class=\\"fd-toolbar fd-toolbar--title fd-toolbar-active\\">
+    <h4 class=\\"fd-title fd-title--h4 fd-toolbar__title\\">Default Table</h4>
     <span class=\\"fd-toolbar__spacer fd-toolbar__spacer--auto\\"></span>
 </div>
 <table class=\\"fd-table\\">
@@ -28536,8 +28561,8 @@ exports[`Check stories > Components/Table > Story Primary > Should match snapsho
 `;
 
 exports[`Check stories > Components/Table > Story ResponsiveTable > Should match snapshot 1`] = `
-"<div class=\\"fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active\\">
-    <h4 style=\\"margin: 0;\\">Responsive Table</h4>
+"<div class=\\"fd-toolbar fd-toolbar--title fd-toolbar-active\\">
+    <h4 class=\\"fd-title fd-title--h4 fd-toolbar__title\\">Responsive Table</h4>
     <span class=\\"fd-toolbar__spacer fd-toolbar__spacer--auto\\"></span>
 </div>
 <table class=\\"fd-table fd-table--responsive fd-table--no-horizontal-borders\\">
@@ -28612,8 +28637,8 @@ exports[`Check stories > Components/Table > Story ResponsiveTable > Should match
 
 exports[`Check stories > Components/Table > Story ResponsiveTablePopInMode > Should match snapshot 1`] = `
 "<div style=\\"max-width: 450px\\">
-    <div class=\\"fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active\\">
-        <h4 style=\\"margin: 0;\\">Responsive Table - Pop-in mode</h4>
+    <div class=\\"fd-toolbar fd-toolbar--title fd-toolbar-active\\">
+        <h4 class=\\"fd-title fd-title--h4 fd-toolbar__title\\">Responsive Table - Pop-in mode</h4>
         <span class=\\"fd-toolbar__spacer fd-toolbar__spacer--auto\\"></span>
     </div>
     <table class=\\"fd-table fd-table--responsive fd-table--no-horizontal-borders fd-table--no-vertical-borders fd-table--pop-in\\">
@@ -28675,8 +28700,8 @@ exports[`Check stories > Components/Table > Story ResponsiveTablePopInMode > Sho
 </div>
 <br>
 <div style=\\"max-width: 450px\\">
-    <div class=\\"fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active\\">
-        <h4 style=\\"margin: 0;\\">Responsive Table - Pop-in Mode with Checkboxes and Navigation Indicator</h4>
+    <div class=\\"fd-toolbar fd-toolbar--title fd-toolbar-active\\">
+        <h4 class=\\"fd-title fd-title--h4 fd-toolbar__title\\">Responsive Table - Pop-in Mode with Checkboxes and Navigation Indicator</h4>
         <span class=\\"fd-toolbar__spacer fd-toolbar__spacer--auto\\"></span>
     </div>
     <table class=\\"fd-table fd-table--responsive fd-table--no-horizontal-borders fd-table--no-vertical-borders fd-table--pop-in\\">
@@ -28750,8 +28775,8 @@ exports[`Check stories > Components/Table > Story ResponsiveTablePopInMode > Sho
 `;
 
 exports[`Check stories > Components/Table > Story SemanticRows > Should match snapshot 1`] = `
-"<div class=\\"fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active\\">
-    <h4 style=\\"margin: 0;\\">Table with Semantic Rows</h4>
+"<div class=\\"fd-toolbar fd-toolbar--title fd-toolbar-active\\">
+    <h4 class=\\"fd-title fd-title--h4 fd-toolbar__title\\">Table with Semantic Rows</h4>
     <span class=\\"fd-toolbar__spacer fd-toolbar__spacer--auto\\"></span>
 </div>
 <table class=\\"fd-table\\">


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/4088

## Description
Update the Toolbar used in tables to Title Toolbar and the <h4> with the appropriate classes.

BREAKING CHANGE:
- `fd-toolbar--solid` class is removed
- the h4 element in the Toolbar has classes `fd-title fd-title--h4 fd-toolbar__title`

Before:
```
<div class="fd-toolbar fd-toolbar--solid fd-toolbar--title fd-toolbar-active">
    <h4>Default Table</h4>
    <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
</div>
```

Now:
```
<div class="fd-toolbar fd-toolbar--title fd-toolbar-active">
    <h4 class="fd-title fd-title--h4 fd-toolbar__title">Default Table</h4>
    <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
</div>```