### PR TITLE
fix(styles): select's, step-input's button border styles in hc [ci visual]

### DIFF
--- a/packages/styles/src/mixins/_forms.scss
+++ b/packages/styles/src/mixins/_forms.scss
@@ -233,6 +233,34 @@ $fd-input-field-height--compact: 1.625rem;
   }
 }
 
+@mixin _fd-input-group-button-first-child($selector) {
+  #{$selector} {
+    @include fd-set-border-right(var(--fdInputGroup_ControlButton_SideBorder));
+
+    @include fd-hover() {
+      @include fd-set-border-right(var(--fdInputGroup_ControlButton_SideBorder_Active));
+    }
+
+    @include fd-active() {
+      @include fd-set-border-right(var(--fdInputGroup_ControlButton_SideBorder_Active));
+    }
+  }
+}
+
+@mixin _fd-input-group-button-last-child($selector) {
+  #{$selector} {
+    @include fd-set-border-left(var(--fdInputGroup_ControlButton_SideBorder));
+
+    @include fd-hover() {
+      @include fd-set-border-left(var(--fdInputGroup_ControlButton_SideBorder_Active));
+    }
+
+    @include fd-active() {
+      @include fd-set-border-left(var(--fdInputGroup_ControlButton_SideBorder_Active));
+    }
+  }
+}
+
 @mixin fd-input-group-button-overwrite() {
   $fd-input-group-button-states: (
     'success': (
@@ -257,37 +285,14 @@ $fd-input-field-height--compact: 1.625rem;
     )
   );
 
-  .#{$block}__addon {
-    &:first-child {
-      .#{$block}__button {
-        @include fd-set-border-right(var(--fdInputGroup_ControlButton_SideBorder));
+  @include _fd-input-group-button-first-child(".#{$fd-namespace}-button:first-child:not(.#{$fd-namespace}-input-group__button)");
+  @include _fd-input-group-button-last-child(".#{$fd-namespace}-button:not(:first-child, .#{$fd-namespace}-input-group__button)");
 
-        @include fd-hover() {
-          @include fd-set-border-right(var(--fdInputGroup_ControlButton_SideBorder_Active));
-        }
+  // To support `fd-input-group__addon` and avoid breaking changes
+  @include _fd-input-group-button-first-child(".#{$block}__addon:first-child .#{$fd-namespace}-button");
+  @include _fd-input-group-button-last-child(".#{$block}__addon:not(:first-child) .#{$fd-namespace}-button");
 
-        @include fd-active() {
-          @include fd-set-border-right(var(--fdInputGroup_ControlButton_SideBorder_Active));
-        }
-      }
-    }
-
-    &:not(:first-child) {
-      .#{$block}__button {
-        @include fd-set-border-left(var(--fdInputGroup_ControlButton_SideBorder));
-
-        @include fd-hover() {
-          @include fd-set-border-left(var(--fdInputGroup_ControlButton_SideBorder_Active));
-        }
-
-        @include fd-active() {
-          @include fd-set-border-left(var(--fdInputGroup_ControlButton_SideBorder_Active));
-        }
-      }
-    }
-  }
-
-  .#{$block}__button {
+  .#{$fd-namespace}-button {
     @include fd-ellipsis();
 
     border: none;
@@ -317,7 +322,7 @@ $fd-input-field-height--compact: 1.625rem;
   @each $set-name, $set-props in $fd-input-group-button-states {
     &.is-#{$set-name} {
 
-      .#{$block}__button {
+      .#{$fd-namespace}-button {
         @include fd-hover() {
           box-shadow: map_get($set-props, "boxShadow");
         }

--- a/packages/styles/src/mixins/_forms.scss
+++ b/packages/styles/src/mixins/_forms.scss
@@ -233,30 +233,28 @@ $fd-input-field-height--compact: 1.625rem;
   }
 }
 
-@mixin _fd-input-group-button-first-child($selector) {
+@mixin fd-input-group-button($selector, $first: true) {
   #{$selector} {
-    @include fd-set-border-right(var(--fdInputGroup_ControlButton_SideBorder));
+    @if $first {
+      @include fd-set-border-right(var(--fdInputGroup_ControlButton_SideBorder));
 
-    @include fd-hover() {
-      @include fd-set-border-right(var(--fdInputGroup_ControlButton_SideBorder_Active));
-    }
+      @include fd-hover() {
+        @include fd-set-border-right(var(--fdInputGroup_ControlButton_SideBorder_Active));
+      }
 
-    @include fd-active() {
-      @include fd-set-border-right(var(--fdInputGroup_ControlButton_SideBorder_Active));
-    }
-  }
-}
+      @include fd-active() {
+        @include fd-set-border-right(var(--fdInputGroup_ControlButton_SideBorder_Active));
+      }
+    } @else {
+      @include fd-set-border-left(var(--fdInputGroup_ControlButton_SideBorder));
 
-@mixin _fd-input-group-button-last-child($selector) {
-  #{$selector} {
-    @include fd-set-border-left(var(--fdInputGroup_ControlButton_SideBorder));
+      @include fd-hover() {
+        @include fd-set-border-left(var(--fdInputGroup_ControlButton_SideBorder_Active));
+      }
 
-    @include fd-hover() {
-      @include fd-set-border-left(var(--fdInputGroup_ControlButton_SideBorder_Active));
-    }
-
-    @include fd-active() {
-      @include fd-set-border-left(var(--fdInputGroup_ControlButton_SideBorder_Active));
+      @include fd-active() {
+        @include fd-set-border-left(var(--fdInputGroup_ControlButton_SideBorder_Active));
+      }
     }
   }
 }
@@ -285,14 +283,14 @@ $fd-input-field-height--compact: 1.625rem;
     )
   );
 
-  @include _fd-input-group-button-first-child(".#{$fd-namespace}-button:first-child:not(.#{$fd-namespace}-input-group__button)");
-  @include _fd-input-group-button-last-child(".#{$fd-namespace}-button:not(:first-child, .#{$fd-namespace}-input-group__button)");
+  @include fd-input-group-button(".#{$block}__button:first-child");
+  @include fd-input-group-button(".#{$block}__button:not(:first-child)", false);
 
   // To support `fd-input-group__addon` and avoid breaking changes
-  @include _fd-input-group-button-first-child(".#{$block}__addon:first-child .#{$fd-namespace}-button");
-  @include _fd-input-group-button-last-child(".#{$block}__addon:not(:first-child) .#{$fd-namespace}-button");
+  @include fd-input-group-button(".#{$block}__addon:first-child .#{$block}__button");
+  @include fd-input-group-button(".#{$block}__addon:not(:first-child) .#{$block}__button", false);
 
-  .#{$fd-namespace}-button {
+  .#{$block}__button {
     @include fd-ellipsis();
 
     border: none;
@@ -322,7 +320,7 @@ $fd-input-field-height--compact: 1.625rem;
   @each $set-name, $set-props in $fd-input-group-button-states {
     &.is-#{$set-name} {
 
-      .#{$fd-namespace}-button {
+      .#{$block}__button {
         @include fd-hover() {
           box-shadow: map_get($set-props, "boxShadow");
         }

--- a/packages/styles/src/select.scss
+++ b/packages/styles/src/select.scss
@@ -18,6 +18,13 @@ $fd-select-padding-x-compact: 0.5rem;
     box-shadow: var(--fdInput_Group_Button_Box_Shadow);
     @content;
   }
+
+  @include fd-rtl() {
+    .#{$block}__button {
+      border-left-color: transparent;
+      border-right-color: $borderLeft;
+    }
+  }
 }
 
 @mixin fd-select-states-overwrite() {
@@ -62,6 +69,13 @@ $fd-select-padding-x-compact: 0.5rem;
           box-shadow: map_get($set-props, "hoverBoxShadow");
         }
 
+        @include fd-rtl() {
+          .#{$block}__button {
+            border-left-color: transparent;
+            border-right-color: var(--fdSelect_Expanded_Button_Border_Left_Color);
+          }
+        }
+
         @include fd-focus() {
           box-shadow: none;
         }
@@ -97,7 +111,6 @@ $fd-select-padding-x-compact: 0.5rem;
 
     .#{$block}__button {
       @include fd-set-margin-left(0.25rem);
-      @include fd-input-group-button-overwrite();
     }
 
     @include fd-readonly() {


### PR DESCRIPTION
## Related Issue

Closes https://github.com/SAP/fundamental-styles/issues/4197

## Description

Fixes Select's and StepInput's button border styles in HC themes.

## Screenshots

### Before:
<img width="173" alt="image" src="https://user-images.githubusercontent.com/20265336/213522204-3a8e6591-5492-4295-9013-59713a095f57.png">
<img width="285" alt="image" src="https://user-images.githubusercontent.com/20265336/213522356-1bc2387f-e80a-4236-84fc-6312fbce3435.png">


### After:
<img width="156" alt="image" src="https://user-images.githubusercontent.com/20265336/213522268-45dbc4ca-5f96-44d2-be84-8b14a84af852.png">
<img width="297" alt="image" src="https://user-images.githubusercontent.com/20265336/213522309-b77c9228-0f56-4137-a264-d0cdbd3dd8af.png">
