### PR TITLE
fix(ci): chromatic threshold [ci visual]

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -84,6 +84,9 @@ export const parameters = {
             return aPackage - bPackage;
         },
         initialActive: 'docs'
+    },
+    chromatic: {
+        diffThreshold: 0.35
     }
 };
 


### PR DESCRIPTION
## Related Issue

Closes https://github.com/SAP/fundamental-styles/issues/4200

## Description

Default threshold is too low and difference in font rendering being caught, although it's [said](https://www.chromatic.com/docs/threshold#anti-aliasing) that it should be skipped. 

## Screenshots

### Before:

Default threshold, 1px border diff being caught as well as icon's "glitches"
https://www.chromatic.com/test?appId=5f85e3904b19d600221872af&id=63c9903f5f28fcf0cc6b372c
<img width="468" alt="image" src="https://user-images.githubusercontent.com/20265336/213553992-4b22b424-f9e1-4a8e-a4db-2b7ee2af4ce2.png">

Initially found diff
<img width="122" alt="image" src="https://user-images.githubusercontent.com/20265336/213554061-040dc35d-be13-40a8-88c7-04522877b093.png">

Icon zoomed
<img width="615" alt="image" src="https://user-images.githubusercontent.com/20265336/213555713-6705456b-28cb-47a9-be17-7d92ce2d34a1.png">


### After:

With updated threshold, 1px border diff still being caught but not icon's "glitches"
<img width="109" alt="image" src="https://user-images.githubusercontent.com/20265336/213554907-04d337ba-f7f2-4662-93c1-79108ee33e6a.png">