### PR TITLE
fix: fixed package.json exports default condition order

### DIFF
--- a/packages/workspace-plugins/src/executors/build/executor.ts
+++ b/packages/workspace-plugins/src/executors/build/executor.ts
@@ -62,14 +62,14 @@ export default async function runExecutor(options: BuildExecutorSchema, context:
     projectPackageJson['exports'] = {
         ...projectPackageJson['exports'],
         "./dist/js/*": {
-            "default": "./dist/js/*.mjs",
-            "types": "./dist/js/*.d.ts"
-        },
-        "./dist/*": {
-            "default": "./dist/*"
+            "types": "./dist/js/*.d.ts",
+            "default": "./dist/js/*.mjs"
         },
         "./dist/*.css": {
             "default": "./dist/*.css"
+        },
+        "./dist/*": {
+            "default": "./dist/*"
         }
     }
     projectPackageJsonContent = JSON.stringify(projectPackageJson, null, 4);


### PR DESCRIPTION
## Related Issue
Relates to SAP/fundamental-styles#4274

## Description
Fixing error `Module not found: Error: Default condition should be last one`
