### PR TITLE
fix: popover wrapper styles overriding custom body class styles

### DIFF
--- a/packages/styles/src/popover.scss
+++ b/packages/styles/src/popover.scss
@@ -66,7 +66,6 @@ $fd-popover-arrow-offset-x: calc(var(--fdIcon_Button_Width) * 0.5 - #{$fd-popove
   }
 
   &__wrapper {
-    @include fd-reset();
     @include fd-popover-border-radius();
     @include fd-scrollbar(var(--fdScrollbar_Border_Radius));
 


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-ngx#9228

## Description
Popover wrapper had a reset styles, which were overriding styles that were assigned to the popover body if the user used custom classes
