### PR TITLE
fix(styles): add fix for button outline in Safari [ci visual]

### DIFF
--- a/packages/styles/src/button-split.scss
+++ b/packages/styles/src/button-split.scss
@@ -41,31 +41,22 @@ $split-button-states: (
   )
 );
 
-@mixin fd-split-button-separator($display, $background) {
-  &:first-of-type:hover + button::after {
-    display: none;
-  }
+.#{$block} {
+  --fdButtonSplit_Separator_Offset: 2.125rem;
 
-  &:nth-of-type(2) {
-    position: relative;
-
+  @mixin fd-split-button-separator($display, $background) {
     &::after {
       content: "";
       display: $display;
       position: absolute;
       top: 50%;
-      left: -0.0625rem;
+      right: var(--fdButtonSplit_Separator_Offset);
       width: var(--sapButton_BorderWidth);
       height: var(--fdButton_Menu_Transparent_Separator_Height);
       background: $background;
       transform: translate(0, -50%);
-    }
-
-    @include fd-rtl() {
-      &::after {
-        left: auto;
-        right: -0.0625rem;
-      }
+      margin: 0 0.125rem;
+      z-index: 10;
     }
 
     @include fd-hover() {
@@ -74,15 +65,14 @@ $split-button-states: (
       }
     }
 
-    @include fd-active() {
+    @include fd-rtl() {
       &::after {
-        display: none;
+        right: auto;
+        left: var(--fdButtonSplit_Separator_Offset);
       }
     }
   }
-}
 
-.#{$block} {
   @include fd-reset();
   @include fd-button-pad();
 
@@ -90,9 +80,9 @@ $split-button-states: (
   vertical-align: middle;
   position: relative;
 
-  > button {
-    @include fd-split-button-separator(var(--fdButton_Menu_Separator_Display), var(--sapButton_TextColor));
+  @include fd-split-button-separator(var(--fdButton_Menu_Separator_Display), var(--sapButton_TextColor));
 
+  > button {
     margin: 0;
 
     &:first-of-type {
@@ -102,16 +92,40 @@ $split-button-states: (
       justify-content: flex-start;
       border-radius: var(--fdButton_Border_Radius_Left);
 
+      @include fd-focus() {
+        &::after {
+          border-radius: var(--fdButton_Border_Radius_Outline_Left);
+        }
+      }
+
       @include fd-rtl() {
         border-radius: var(--fdButton_Border_Radius_Left_RTL);
+
+        @include fd-focus() {
+          &::after {
+            border-radius: var(--fdButton_Border_Radius_Outline_Left_RTL);
+          }
+        }
       }
     }
 
     &:nth-of-type(2) {
       border-radius: var(--fdButton_Border_Radius_Right);
 
+      @include fd-focus() {
+        &::after {
+          border-radius: var(--fdButton_Border_Radius_Outline_Right);
+        }
+      }
+
       @include fd-rtl() {
         border-radius: var(--fdButton_Border_Radius_Right_RTL);
+
+        @include fd-focus() {
+          &::after {
+            border-radius: var(--fdButton_Border_Radius_Outline_Right_RTL);
+          }
+        }
       }
     }
 
@@ -123,10 +137,7 @@ $split-button-states: (
   @each $set-name, $props-set in $split-button-states {
     &--#{$set-name} {
       @include fd-button-pad(map_get($props-set, "padBackground"));
-
-      > button {
-        @include fd-split-button-separator(map_get($props-set, "separatorDisplay"), map_get($props-set, "separatorBackground"));
-      }
+      @include fd-split-button-separator(map_get($props-set, "separatorDisplay"), map_get($props-set, "separatorBackground"));
     }
   }
 
@@ -149,5 +160,6 @@ $split-button-states: (
 
   @include fd-compact-or-condensed() {
     --fdButtonSplit_Text_Max_Width: 9rem;
+    --fdButtonSplit_Separator_Offset: 1.875rem;
   }
 }

--- a/packages/styles/src/button.scss
+++ b/packages/styles/src/button.scss
@@ -80,6 +80,7 @@ $fd-button-badge-spacing: 0.25rem;
     @include fd-inline-flex-center();
     @include fd-set-position-right(-$fd-button-badge-spacing);
 
+    z-index: 1;
     height: 1rem;
     position: var(--fdButton_Badge_Position, absolute);
     padding: 0 0.3125rem;

--- a/packages/styles/src/mixins/button/_button-helper.scss
+++ b/packages/styles/src/mixins/button/_button-helper.scss
@@ -4,15 +4,26 @@
 $block-button: #{$fd-namespace}-button;
 $block-button-toggled: #{$block-button}--toggled;
 
-@mixin fd-button-focus($fd-button-outline-offset: -0.1875rem) {
-  outline: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
-  outline-offset: $fd-button-outline-offset;
+@mixin fd-button-focus($fd-button-fake-outline-offset: 0.0625rem) {
+  outline: none;
 
-  @content;
+  &::after {
+    content: '';
+    position: absolute;
+    display: block;
+    border: var(--sapContent_FocusWidth) var(--sapContent_FocusStyle) var(--sapContent_FocusColor);
+    top: $fd-button-fake-outline-offset;
+    left: $fd-button-fake-outline-offset;
+    right: $fd-button-fake-outline-offset;
+    bottom: $fd-button-fake-outline-offset;
+    border-radius: calc(var(--sapButton_BorderCornerRadius) - var(--sapContent_FocusWidth));
+  }
 
   &.#{$block-button-toggled},
   &.is-selected {
-    outline-color: var(--fdButton_Outline_Contrast);
+    &::after {
+      border-color: var(--fdButton_Outline_Contrast);
+    }
   }
 }
 

--- a/packages/styles/src/mixins/button/_button-types.scss
+++ b/packages/styles/src/mixins/button/_button-types.scss
@@ -42,7 +42,9 @@
     );
 
     @include fd-focus() {
-      outline-color: var(--sapContent_ContrastFocusColor);
+      &::after {
+        border-color: var(--sapContent_ContrastFocusColor);
+      }
     }
 
     // @deprecated selected state

--- a/packages/styles/src/theming/common/button/_sap_fiori.scss
+++ b/packages/styles/src/theming/common/button/_sap_fiori.scss
@@ -3,7 +3,7 @@
   --fdButton_Emphasized_Active_Outline: var(--sapContent_ContrastFocusColor);
   --fdButton_Ghost_Background: var(--sapButton_Lite_Background);
   --fdButton_Outline_Contrast: var(--sapContent_ContrastFocusColor);
-  --fdButton_Outline_Offset: -0.1875rem;
+  --fdButton_Outline_Offset: var(--sapButton_BorderWidth);
   --fdButton_Font_Family: var(--sapFontFamily);
 
   /** Shadows */
@@ -21,6 +21,10 @@
   --fdButton_Border_Radius_Left_RTL: 0 var(--sapButton_BorderCornerRadius) var(--sapButton_BorderCornerRadius) 0;
   --fdButton_Border_Radius_Right: 0 var(--sapButton_BorderCornerRadius) var(--sapButton_BorderCornerRadius) 0;
   --fdButton_Border_Radius_Right_RTL: var(--sapButton_BorderCornerRadius) 0 0 var(--sapButton_BorderCornerRadius);
+  --fdButton_Border_Radius_Outline_Left: var(--sapButton_BorderCornerRadius) 0 0 var(--sapButton_BorderCornerRadius);
+  --fdButton_Border_Radius_Outline_Left_RTL: 0 var(--sapButton_BorderCornerRadius) var(--sapButton_BorderCornerRadius) 0;
+  --fdButton_Border_Radius_Outline_Right: 0 var(--sapButton_BorderCornerRadius) var(--sapButton_BorderCornerRadius) 0;
+  --fdButton_Border_Radius_Outline_Right_RTL: var(--sapButton_BorderCornerRadius) 0 0 var(--sapButton_BorderCornerRadius);
 
   /** Segmented */
   --fdButton_Segmented_Pad_Display: none;

--- a/packages/styles/src/theming/common/button/_sap_fiori_hc.scss
+++ b/packages/styles/src/theming/common/button/_sap_fiori_hc.scss
@@ -1,7 +1,7 @@
 @import "./sap_fiori";
 
 :root {
-  --fdButton_Outline_Offset: calc(-0.1875rem - var(--sapButton_BorderWidth));
+  --fdButton_Outline_Offset: var(--sapButton_BorderWidth);
   --fdButton_Emphasized_Border_Width: 0.125rem;
 
   /** Badge */

--- a/packages/styles/src/theming/common/button/_sap_horizon.scss
+++ b/packages/styles/src/theming/common/button/_sap_horizon.scss
@@ -3,7 +3,7 @@
   --fdButton_Emphasized_Active_Outline: var(--sapContent_FocusColor);
   --fdButton_Ghost_Background: var(--sapButton_Background);
   --fdButton_Outline_Contrast: var(--sapContent_FocusColor);
-  --fdButton_Outline_Offset: calc(-0.1875rem - var(--sapButton_BorderWidth));
+  --fdButton_Outline_Offset: var(--sapButton_BorderWidth);
   --fdButton_Font_Family: var(--sapFontSemiboldDuplexFamily);
 
   /** Shadows */
@@ -21,6 +21,10 @@
   --fdButton_Border_Radius_Left_RTL: var(--sapButton_BorderCornerRadius);
   --fdButton_Border_Radius_Right: var(--sapButton_BorderCornerRadius);
   --fdButton_Border_Radius_Right_RTL: var(--sapButton_BorderCornerRadius);
+  --fdButton_Border_Radius_Outline_Left: calc(var(--sapButton_BorderCornerRadius) - var(--sapContent_FocusWidth));
+  --fdButton_Border_Radius_Outline_Left_RTL: calc(var(--sapButton_BorderCornerRadius) - var(--sapContent_FocusWidth));
+  --fdButton_Border_Radius_Outline_Right: calc(var(--sapButton_BorderCornerRadius) - var(--sapContent_FocusWidth));
+  --fdButton_Border_Radius_Outline_Right_RTL: calc(var(--sapButton_BorderCornerRadius) - var(--sapContent_FocusWidth));
 
   /** Segmented */
   --fdButton_Segmented_Pad_Display: block;

--- a/packages/styles/src/theming/common/button/_sap_horizon_hc.scss
+++ b/packages/styles/src/theming/common/button/_sap_horizon_hc.scss
@@ -11,13 +11,18 @@
   --fdButton_Menu_Separator_Display: none;
   --fdButton_Menu_Offset: calc(var(--sapButton_BorderWidth) * -1);
   --fdButton_Menu_Emphasized_Margin: calc(var(--fdButton_Emphasized_Border_Width) * -1);
+  --fdButton_Menu_Transparent_Separator_Display: none;
 
   /** Segmented */
   --fdButton_Segmented_Pad_Display: none;
   --fdButton_Segmented_Border_Offset: calc(var(--sapButton_BorderWidth) * -1);
   --fdButton_Border_Radius_Left: var(--sapButton_BorderCornerRadius) 0 0 var(--sapButton_BorderCornerRadius);
   --fdButton_Border_Radius_Left_RTL: 0 var(--sapButton_BorderCornerRadius) var(--sapButton_BorderCornerRadius) 0;
-  --fdButton_Segmented_Middle_Border_Radius: 0 0 0 0;
   --fdButton_Border_Radius_Right: 0 var(--sapButton_BorderCornerRadius) var(--sapButton_BorderCornerRadius) 0;
   --fdButton_Border_Radius_Right_RTL: var(--sapButton_BorderCornerRadius) 0 0 var(--sapButton_BorderCornerRadius);
+  --fdButton_Border_Radius_Outline_Left: var(--sapButton_BorderCornerRadius) 0 0 var(--sapButton_BorderCornerRadius);
+  --fdButton_Border_Radius_Outline_Left_RTL: 0 var(--sapButton_BorderCornerRadius) var(--sapButton_BorderCornerRadius) 0;
+  --fdButton_Segmented_Middle_Border_Radius: 0 0 0 0;
+  --fdButton_Border_Radius_Outline_Right: 0 var(--sapButton_BorderCornerRadius) var(--sapButton_BorderCornerRadius) 0;
+  --fdButton_Border_Radius_Outline_Right_RTL: var(--sapButton_BorderCornerRadius) 0 0 var(--sapButton_BorderCornerRadius);
 }


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/4252

## Description
Button focus outline in Safari is not rendered properly. It's a known issue of Safari https://medium.com/@jeandesravines/use-border-radius-and-outline-simultaneously-on-safari-14ce92889e1f

To fix the issue we abandon the normal way of applying outline and use a normal border which is added with `::after` to the element. This solution requires some refactoring for the Split button as the second button (with the arrow) uses\ `::after` to apply the separator and `::before` is also taken. 

No breaking changes are introduced.

