### PR TITLE
fix(styles): add fix for multi click Icon Tab Bar [ci visual]

### DIFF
--- a/packages/styles/src/icon-tab-bar.scss
+++ b/packages/styles/src/icon-tab-bar.scss
@@ -346,9 +346,7 @@ $fd-icon-tab-bar-semantic-values: (
       }
 
       .#{$block}__tab {
-        @include fd-selected() {
-          @include fd-set-paddings-x(0.188rem, 2.188rem);
-        }
+        @include fd-set-paddings-x(0.188rem, 2.188rem);
 
         .#{$block}__badge {
           @include fd-set-position-right(1.625rem);

--- a/packages/styles/stories/Components/icon-tab-bar/icon-tab-bar.stories.js
+++ b/packages/styles/stories/Components/icon-tab-bar/icon-tab-bar.stories.js
@@ -1522,12 +1522,12 @@ export const Navigation = () => `<div class="fddocs-icon-tab-container" style="m
     <div class="fd-icon-tab-bar fd-icon-tab-bar--navigation fd-icon-tab-bar--md">
         <ul role="tablist" class="fd-icon-tab-bar__header">
             <li role="presentation" class="fd-icon-tab-bar__item">
-                <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab4">
+                <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tabA1">
                     <span class="fd-icon-tab-bar__tag">Section 1</span>
                 </a>
             </li>
             <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--multi-click">
-                <a role="tab" class="fd-icon-tab-bar__tab" aria-selected="true" id="tab5" tabindex="0">
+                <a role="tab" class="fd-icon-tab-bar__tab" id="tabA2" tabindex="0">
                     <span class="fd-icon-tab-bar__tag">Section 2</span>
                 </a>
 
@@ -1556,8 +1556,48 @@ export const Navigation = () => `<div class="fddocs-icon-tab-container" style="m
                 </div>
             </li>
             <li role="presentation" class="fd-icon-tab-bar__item">
-                <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab6">
+                <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tabA3">
                     <span class="fd-icon-tab-bar__tag">Section 3</span>
+                </a>
+            </li>
+            <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--multi-click">
+                <a role="tab" class="fd-icon-tab-bar__tab" id="tabA4" tabindex="0">
+                    <span class="fd-icon-tab-bar__tag">Section 4</span>
+                </a>
+
+                <div class="fd-popover fd-icon-tab-bar__popover">
+                    <div class="fd-popover__control">
+                        <div class="fd-icon-tab-bar__button-container">
+                            <button class="fd-button fd-button--transparent fd-button--compact  fd-icon-tab-bar__button" aria-controls="popoverAaC" aria-expanded="false" aria-haspopup="true" onclick="onPopoverClick('popoverAaC');" aria-label="open menu button">
+                                <i class="sap-icon--slim-arrow-down"></i>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </li>
+            <li role="presentation" class="fd-icon-tab-bar__item">
+                <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tabA5">
+                    <span class="fd-icon-tab-bar__tag">Section 5</span>
+                </a>
+            </li>
+            <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--multi-click">
+                <a role="tab" class="fd-icon-tab-bar__tab" aria-selected="true" id="tabA6" tabindex="0">
+                    <span class="fd-icon-tab-bar__tag">Section 6</span>
+                </a>
+
+                <div class="fd-popover fd-icon-tab-bar__popover">
+                    <div class="fd-popover__control">
+                        <div class="fd-icon-tab-bar__button-container">
+                            <button class="fd-button fd-button--transparent fd-button--compact  fd-icon-tab-bar__button" aria-controls="popoverAa1" aria-expanded="false" aria-haspopup="true" onclick="onPopoverClick('popoverAa1');" aria-label="open menu button">
+                                <i class="sap-icon--slim-arrow-down"></i>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </li>
+            <li role="presentation" class="fd-icon-tab-bar__item">
+                <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab6">
+                    <span class="fd-icon-tab-bar__tag">Section 7</span>
                 </a>
             </li>
         </ul>

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -13968,12 +13968,12 @@ exports[`Check stories > Components/Icon Tab Bar > Story Navigation > Should mat
     <div class=\\"fd-icon-tab-bar fd-icon-tab-bar--navigation fd-icon-tab-bar--md\\">
         <ul role=\\"tablist\\" class=\\"fd-icon-tab-bar__header\\">
             <li role=\\"presentation\\" class=\\"fd-icon-tab-bar__item\\">
-                <a role=\\"tab\\" class=\\"fd-icon-tab-bar__tab\\" href=\\"#\\" id=\\"tab4\\">
+                <a role=\\"tab\\" class=\\"fd-icon-tab-bar__tab\\" href=\\"#\\" id=\\"tabA1\\">
                     <span class=\\"fd-icon-tab-bar__tag\\">Section 1</span>
                 </a>
             </li>
             <li role=\\"presentation\\" class=\\"fd-icon-tab-bar__item fd-icon-tab-bar__item--multi-click\\">
-                <a role=\\"tab\\" class=\\"fd-icon-tab-bar__tab\\" aria-selected=\\"true\\" id=\\"tab5\\" tabindex=\\"0\\">
+                <a role=\\"tab\\" class=\\"fd-icon-tab-bar__tab\\" id=\\"tabA2\\" tabindex=\\"0\\">
                     <span class=\\"fd-icon-tab-bar__tag\\">Section 2</span>
                 </a>
 
@@ -14002,8 +14002,48 @@ exports[`Check stories > Components/Icon Tab Bar > Story Navigation > Should mat
                 </div>
             </li>
             <li role=\\"presentation\\" class=\\"fd-icon-tab-bar__item\\">
-                <a role=\\"tab\\" class=\\"fd-icon-tab-bar__tab\\" href=\\"#\\" id=\\"tab6\\">
+                <a role=\\"tab\\" class=\\"fd-icon-tab-bar__tab\\" href=\\"#\\" id=\\"tabA3\\">
                     <span class=\\"fd-icon-tab-bar__tag\\">Section 3</span>
+                </a>
+            </li>
+            <li role=\\"presentation\\" class=\\"fd-icon-tab-bar__item fd-icon-tab-bar__item--multi-click\\">
+                <a role=\\"tab\\" class=\\"fd-icon-tab-bar__tab\\" id=\\"tabA4\\" tabindex=\\"0\\">
+                    <span class=\\"fd-icon-tab-bar__tag\\">Section 4</span>
+                </a>
+
+                <div class=\\"fd-popover fd-icon-tab-bar__popover\\">
+                    <div class=\\"fd-popover__control\\">
+                        <div class=\\"fd-icon-tab-bar__button-container\\">
+                            <button class=\\"fd-button fd-button--transparent fd-button--compact  fd-icon-tab-bar__button\\" aria-controls=\\"popoverAaC\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\" onclick=\\"onPopoverClick('popoverAaC');\\" aria-label=\\"open menu button\\">
+                                <i class=\\"sap-icon--slim-arrow-down\\"></i>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </li>
+            <li role=\\"presentation\\" class=\\"fd-icon-tab-bar__item\\">
+                <a role=\\"tab\\" class=\\"fd-icon-tab-bar__tab\\" href=\\"#\\" id=\\"tabA5\\">
+                    <span class=\\"fd-icon-tab-bar__tag\\">Section 5</span>
+                </a>
+            </li>
+            <li role=\\"presentation\\" class=\\"fd-icon-tab-bar__item fd-icon-tab-bar__item--multi-click\\">
+                <a role=\\"tab\\" class=\\"fd-icon-tab-bar__tab\\" aria-selected=\\"true\\" id=\\"tabA6\\" tabindex=\\"0\\">
+                    <span class=\\"fd-icon-tab-bar__tag\\">Section 6</span>
+                </a>
+
+                <div class=\\"fd-popover fd-icon-tab-bar__popover\\">
+                    <div class=\\"fd-popover__control\\">
+                        <div class=\\"fd-icon-tab-bar__button-container\\">
+                            <button class=\\"fd-button fd-button--transparent fd-button--compact  fd-icon-tab-bar__button\\" aria-controls=\\"popoverAa1\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\" onclick=\\"onPopoverClick('popoverAa1');\\" aria-label=\\"open menu button\\">
+                                <i class=\\"sap-icon--slim-arrow-down\\"></i>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </li>
+            <li role=\\"presentation\\" class=\\"fd-icon-tab-bar__item\\">
+                <a role=\\"tab\\" class=\\"fd-icon-tab-bar__tab\\" href=\\"#\\" id=\\"tab6\\">
+                    <span class=\\"fd-icon-tab-bar__tag\\">Section 7</span>
                 </a>
             </li>
         </ul>


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/4336

## Description
When the Icon Tab Bar had more than 1 tab with multi click option and one is selected, the other multi click tabs had visual issues. This was due to paddings not being applied properly. 

## Screenshots
### Before:
![224811965-a2454ce0-e160-4867-83f2-aae54cd0f8d7](https://user-images.githubusercontent.com/39598672/226439158-4aad64de-b79a-468a-b5d8-b24471944fef.png)


### After:
<img width="906" alt="Screenshot 2023-03-20 at 2 56 19 PM" src="https://user-images.githubusercontent.com/39598672/226439180-df94ab3a-9254-4b5a-91d7-c3986de3aa7b.png">
