### PR TITLE
fix(styles): simplify avatar, checkbox and radio built markup

### DIFF
--- a/packages/styles/src/avatar.scss
+++ b/packages/styles/src/avatar.scss
@@ -4,6 +4,8 @@
 $block: #{$fd-namespace}-avatar;
 
 .#{$block} {
+  --fdAvatarZoomIconPosition: 0;
+
   @include fd-reset();
   @include fd-fake-fiori-focus(
     var(--fdAvatar_Focus_Outline_Offset),
@@ -35,6 +37,12 @@ $block: #{$fd-namespace}-avatar;
       border-radius: $fd-avatar-border-radius;
       color: var(--sapButton_Emphasized_TextColor);
       background-color: var(--sapButton_Emphasized_Background);
+
+      @include fd-icon-selector() {
+        @include fd-set-position-right(var(--fdAvatarZoomIconPosition));
+
+        bottom: var(--fdAvatarZoomIconPosition);
+      }
     }
   }
 
@@ -54,14 +62,6 @@ $block: #{$fd-namespace}-avatar;
     );
 
     border-radius: $fd-avatar-border-radius;
-
-    .#{$block}__zoom-icon {
-      @include fd-icon-selector() {
-        @include fd-set-position-right(0);
-
-        bottom: 0;
-      }
-    }
   }
 
   &--transparent {
@@ -91,18 +91,13 @@ $block: #{$fd-namespace}-avatar;
       border: map_get($color-set, "border");
       color: map_get($color-set, "text-color");
       background-color: map_get($color-set, "background-color");
-
-      &.#{$block}--shell {
-        @include fd-set-border(var(--sapShell_InteractiveBorderColor));
-      }
     }
   }
 
-  // sizes
   @each $set-name, $size-set in $fd-avatar-sizes {
     &--#{$set-name} {
-      @include fd-reset-spacing();
-      @include fd-inline-flex-center();
+      --fdAvatarZoomIconOffset: #{map_get($size-set, "offset")};
+
       @include fd-avatar-set-size(map_get($size-set, "ratio"));
 
       font-size: map_get($size-set, "font-size");
@@ -115,17 +110,32 @@ $block: #{$fd-namespace}-avatar;
           font-size: map_get($size-set, "beforeFontSize");
         }
       }
-
-      // Do not modify alignment of the icon if it's circle avatar
-      &:not(.#{$block}--circle) {
-        .#{$block}__zoom-icon {
-          @include fd-icon-selector() {
-            @include fd-set-position-right(map_get($size-set, "offset"));
-
-            bottom: map_get($size-set, "offset");
-          }
-        }
-      }
     }
+  }
+}
+
+$accent-selector: ();
+
+@each $item in map-keys($fd-avatar-accent-colors) {
+  $accent-selector: $accent-selector, '.#{$block}--accent-color-#{$item}';
+}
+
+#{$accent-selector} {
+  &.#{$block}--shell {
+    @include fd-set-border(var(--sapShell_InteractiveBorderColor));
+  }
+}
+
+$selector: ();
+
+@each $item in map-keys($fd-avatar-sizes) {
+  $selector: $selector, '.#{$block}.#{$block}--#{$item}';
+}
+
+#{$selector} {
+  @include fd-reset-spacing();
+  @include fd-inline-flex-center();
+  &:not(.#{$block}--circle) {
+    --fdAvatarZoomIconPosition: var(--fdAvatarZoomIconOffset);
   }
 }

--- a/packages/styles/src/avatar.scss
+++ b/packages/styles/src/avatar.scss
@@ -129,7 +129,7 @@ $accent-selector: ();
 $selector: ();
 
 @each $item in map-keys($fd-avatar-sizes) {
-  $selector: $selector, '.#{$block}.#{$block}--#{$item}';
+  $selector: $selector, '.#{$block}--#{$item}';
 }
 
 #{$selector} {

--- a/packages/styles/src/checkbox.scss
+++ b/packages/styles/src/checkbox.scss
@@ -42,7 +42,7 @@ $block: #{$fd-namespace}-checkbox;
     }
   }
 
-  @include fd-form-base();
+  @include fd-form-base(false, false);
 
   @extend %fd-checkbox-input-hidden;
 

--- a/packages/styles/src/mixins/_forms.scss
+++ b/packages/styles/src/mixins/_forms.scss
@@ -104,7 +104,7 @@ $fd-input-field-height--compact: 1.625rem;
   background-color: var(--sapField_ReadOnly_Background);
 }
 
-@mixin fd-input-field-states($hasFocusWithin: false) {
+@mixin fd-input-field-states($hasFocusWithin: false, $supportsText: true) {
   $fd-input-states: (
     'success': (
       'background': var(--sapField_SuccessBackgroundStyle),
@@ -187,14 +187,16 @@ $fd-input-field-height--compact: 1.625rem;
     }
   }
 
-  &.is-error,
-  &.is-warning,
-  &.is-alert {
-    font-style: var(--fdInput_State_Text_Style);
-    font-weight: var(--fdInput_State_Font_Weight);
-
-    &::placeholder {
+  @if ($supportsText) {
+    &.is-error,
+    &.is-warning,
+    &.is-alert {
+      font-style: var(--fdInput_State_Text_Style);
       font-weight: var(--fdInput_State_Font_Weight);
+
+      &::placeholder {
+        font-weight: var(--fdInput_State_Font_Weight);
+      }
     }
   }
 
@@ -207,9 +209,11 @@ $fd-input-field-height--compact: 1.625rem;
     }
   }
 
-  &.is-error {
-    &::placeholder {
-      color: var(--sapField_TextColor);
+  @if ($supportsText) {
+    &.is-error {
+      &::placeholder {
+        color: var(--sapField_TextColor);
+      }
     }
   }
 
@@ -217,16 +221,20 @@ $fd-input-field-height--compact: 1.625rem;
     pointer-events: none;
     opacity: var(--sapContent_DisabledOpacity);
 
-    &::placeholder {
-      color: var(--fdInput_Non_Interactive_State_Placeholder_Color);
+    @if ($supportsText) {
+      &::placeholder {
+        color: var(--fdInput_Non_Interactive_State_Placeholder_Color);
+      }
     }
   }
 
   @include fd-readonly() {
     @include fd-input-readonly();
 
-    &::placeholder {
-      color: var(--fdInput_Non_Interactive_State_Placeholder_Color);
+    @if ($supportsText) {
+      &::placeholder {
+        color: var(--fdInput_Non_Interactive_State_Placeholder_Color);
+      }
     }
 
     @include fd-hover() {
@@ -349,7 +357,7 @@ $fd-input-field-height--compact: 1.625rem;
   background-color: var($background-color, transparent);
 }
 
-@mixin fd-form-base {
+@mixin fd-form-base($hasFocusWithin: false, $supportsText: true) {
   @include fd-reset();
   @include fd-ellipsis();
 
@@ -374,7 +382,7 @@ $fd-input-field-height--compact: 1.625rem;
     background-color: var(--sapSelectedColor);
   }
   // states
-  @include fd-input-field-states();
+  @include fd-input-field-states($hasFocusWithin, $supportsText);
 }
 
 @mixin fd-form-text() {

--- a/packages/styles/src/mixins/_mixins.scss
+++ b/packages/styles/src/mixins/_mixins.scss
@@ -796,10 +796,8 @@
 
 @mixin fd-compact() {
   @at-root {
-    [class*="--compact"] &:not([class*="--cozy"]):not([class*="--condensed"]),
-    .is-compact &:not(.is-cozy):not(.is-condensed),
-    &[class*="--compact"],
-    &.is-compact {
+    [class*="-compact"] &:not([class*="-cozy"]):not([class*="-condensed"]),
+    &[class*="-compact"] {
       @content;
     }
   }
@@ -807,10 +805,8 @@
 
 @mixin fd-compact-and-condensed() {
   @at-root {
-    [class*="--compact"] &:not([class*="--cozy"]),
-    .is-compact &:not(.is-cozy),
-    &[class*="--compact"],
-    &.is-compact {
+    [class*="-compact"] &:not([class*="-cozy"]),
+    &[class*="-compact"] {
       @content;
     }
   }
@@ -818,10 +814,8 @@
 
 @mixin fd-condensed() {
   @at-root {
-    [class*="--condensed"] &:not([class*="--cozy"]):not([class*="--compact"]),
-    .is-condensed &:not(.is-cozy):not(.is-compact),
-    &[class*="--condensed"],
-    .is-condensed {
+    [class*="-condensed"] &:not([class*="-cozy"]):not([class*="-compact"]),
+    &[class*="-condensed"] {
       @content;
     }
   }
@@ -829,14 +823,10 @@
 
 @mixin fd-compact-or-condensed() {
   @at-root {
-    [class*="--condensed"] &:not([class*="--cozy"]),
-    [class*="--compact"] &:not([class*="--cozy"]),
-    .is-compact &:not(.is-cozy),
-    .is-condensed &:not(.is-cozy),
-    &[class*="--condensed"],
-    &[class*="--compact"],
-    &.is-condensed,
-    &.is-compact {
+    [class*="-condensed"] &:not([class*="-cozy"]),
+    [class*="-compact"] &:not([class*="-cozy"]),
+    &[class*="-condensed"],
+    &[class*="-compact"] {
       @content;
     }
   }

--- a/packages/styles/src/pagination.scss
+++ b/packages/styles/src/pagination.scss
@@ -34,6 +34,8 @@ $block: #{$fd-namespace}-pagination;
 }
 
 .#{$block} {
+  --fdPaginationMoreWidth: 2.25rem;
+
   @include fd-reset();
 
   @include fd-flex-vertical-center() {
@@ -61,12 +63,12 @@ $block: #{$fd-namespace}-pagination;
     &::before {
       content: "...";
       display: block;
-      width: 2.25rem;
+      width: var(--fdPaginationMoreWidth);
       text-align: center;
     }
 
-    &--compact::before {
-      width: 2rem;
+    @include fd-compact-or-condensed() {
+      --fdPaginationMoreWidth: 2rem;
     }
   }
 

--- a/packages/styles/src/radio.scss
+++ b/packages/styles/src/radio.scss
@@ -30,7 +30,7 @@ $block: #{$fd-namespace}-radio;
     }
   }
 
-  @include fd-form-base();
+  @include fd-form-base(false, false);
 
   @extend %fd-radio-input-hidden;
 


### PR DESCRIPTION
## Description
- Removed ::placeholder related stuff from checkbox and ratio button styling;
- Simplified cycled markup for avatar;
- combined multiple selectors for avatar size into one with same styling properties;


#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
