### PR TITLE
fix(styles): fix button outline

### DIFF
--- a/packages/styles/src/mixins/_forms.scss
+++ b/packages/styles/src/mixins/_forms.scss
@@ -311,7 +311,7 @@ $fd-input-field-height--compact: 1.625rem;
 
     border: none;
     z-index: auto !important;
-    position: static !important;
+    position: relative;
     border-radius: var(--fdInput_Group_Button_Border_Raduis);
     background: var(--fdInput_Group_Button_Background);
     color: var(--fdInput_Group_Button_Text_Color);

--- a/packages/styles/src/step-input.scss
+++ b/packages/styles/src/step-input.scss
@@ -39,6 +39,10 @@ $block: #{$fd-namespace}-step-input;
     @include fd-focus() {
       outline: none;
 
+      &::after {
+        display: none;
+      }
+
       @include fd-hover() {
         z-index: auto;
       }

--- a/packages/styles/stories/Components/step-input/step-input.stories.js
+++ b/packages/styles/stories/Components/step-input/step-input.stories.js
@@ -42,6 +42,22 @@ export const Primary = () => `<label class="fd-form-label" for="step-3">Default 
     <i class="sap-icon--add"></i>
   </button>
 </div>
+<label class="fd-form-label" for="step-3-focused">Focused Step Input</label><br />
+<div class="fd-step-input is-focus">
+  <button aria-label="Step down" class="
+            fd-button
+            fd-button--transparent
+            fd-step-input__button is-focus" onclick="stepInputValue('step-3-focused', 'down');" tabindex="-1" type="button">
+    <i class="sap-icon--less"></i>
+  </button>
+  <input class="fd-input fd-input--no-number-spinner fd-step-input__input" id="step-3-focused" type="number" value="0" />
+  <button aria-label="Step up" class="
+            fd-button
+            fd-button--transparent
+            fd-step-input__button" onclick="stepInputValue('step-3-focused', 'up');" tabindex="-1" type="button">
+    <i class="sap-icon--add"></i>
+  </button>
+</div>
 `;
 
 Primary.storyName = 'Default';


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#

## Description
- Fixed button position when used in input-group and step input and components that are extended from those;
- Added visual representation of focused step input to keep track if something breaks later;

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/6586561/228862119-2e6f61e5-0209-4f8d-bd4d-b54ba6b3399d.png)
![image](https://user-images.githubusercontent.com/6586561/228862215-807fe1fa-5e3b-4115-84cf-14bea0cea1ab.png)

### After:
![image](https://user-images.githubusercontent.com/6586561/228862354-9b0b8ca1-1931-4965-b392-366fa6a6637a.png)
![image](https://user-images.githubusercontent.com/6586561/228862833-d9163773-1d4f-498e-82a2-500c07c223b2.png)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
