### PR TITLE
feat(styles): update Message Strip to latest Horizon design [ci visual]

### DIFF
--- a/packages/styles/src/_avatar-variables.scss
+++ b/packages/styles/src/_avatar-variables.scss
@@ -10,52 +10,62 @@ $fd-avatar-accent-colors: (
   "1": (
     "background-color": var(--fdAvatar_Accent_Color_1),
     "text-color": var(--fdAvatar_Accent_Color_1_Text),
-    "border": var(--fdAvatar_Accent_Color_1_Border)
+    "border": var(--fdAvatar_Accent_Color_1_Border),
+    "border-color": var(--sapAvatar_1_BorderColor)
   ),
   "2": (
     "background-color": var(--fdAvatar_Accent_Color_2),
     "text-color": var(--fdAvatar_Accent_Color_2_Text),
-    "border": var(--fdAvatar_Accent_Color_2_Border)
+    "border": var(--fdAvatar_Accent_Color_2_Border),
+    "border-color": var(--sapAvatar_2_BorderColor)
   ),
   "3": (
     "background-color": var(--fdAvatar_Accent_Color_3),
     "text-color": var(--fdAvatar_Accent_Color_3_Text),
-    "border": var(--fdAvatar_Accent_Color_3_Border)
+    "border": var(--fdAvatar_Accent_Color_3_Border),
+    "border-color": var(--sapAvatar_3_BorderColor)
   ),
   "4": (
     "background-color": var(--fdAvatar_Accent_Color_4),
     "text-color": var(--fdAvatar_Accent_Color_4_Text),
-    "border": var(--fdAvatar_Accent_Color_4_Border)
+    "border": var(--fdAvatar_Accent_Color_4_Border),
+    "border-color": var(--sapAvatar_4_BorderColor)
   ),
   "5": (
     "background-color": var(--fdAvatar_Accent_Color_5),
     "text-color": var(--fdAvatar_Accent_Color_5_Text),
-    "border": var(--fdAvatar_Accent_Color_5_Border)
+    "border": var(--fdAvatar_Accent_Color_5_Border),
+    "border-color": var(--sapAvatar_5_BorderColor)
   ),
   "6": (
     "background-color": var(--fdAvatar_Accent_Color_6),
     "text-color": var(--fdAvatar_Accent_Color_6_Text),
-    "border": var(--fdAvatar_Accent_Color_6_Border)
+    "border": var(--fdAvatar_Accent_Color_6_Border),
+    "border-color": var(--sapAvatar_6_BorderColor)
   ),
   "7": (
     "background-color": var(--fdAvatar_Accent_Color_7),
     "text-color": var(--fdAvatar_Accent_Color_7_Text),
-    "border": var(--fdAvatar_Accent_Color_7_Border)
+    "border": var(--fdAvatar_Accent_Color_7_Border),
+    "border-color": var(--sapAvatar_7_BorderColor)
   ),
   "8": (
     "background-color": var(--fdAvatar_Accent_Color_8),
     "text-color": var(--fdAvatar_Accent_Color_8_Text),
-    "border": var(--fdAvatar_Accent_Color_8_Border)
+    "border": var(--fdAvatar_Accent_Color_8_Border),
+    "border-color": var(--sapAvatar_8_BorderColor)
   ),
   "9": (
     "background-color": var(--fdAvatar_Accent_Color_9),
     "text-color": var(--fdAvatar_Accent_Color_9_Text),
-    "border": var(--fdAvatar_Accent_Color_9_Border)
+    "border": var(--fdAvatar_Accent_Color_9_Border),
+    "border-color": var(--sapAvatar_9_BorderColor)
   ),
   "10": (
     "background-color": var(--fdAvatar_Accent_Color_10),
     "text-color": var(--fdAvatar_Accent_Color_10_Text),
-    "border": var(--fdAvatar_Accent_Color_10_Border)
+    "border": var(--fdAvatar_Accent_Color_10_Border),
+    "border-color": var(--sapAvatar_10_BorderColor)
   )
 );
 

--- a/packages/styles/src/message-strip.scss
+++ b/packages/styles/src/message-strip.scss
@@ -1,214 +1,117 @@
 @import "./new-settings";
 @import "./mixins";
+@import "./avatar-variables";
 
-/*!
-.fd-message-strip+(--information, --success, --warning, --error, --no-icon)
-    .fd-message__close
-*/
 $block: #{$fd-namespace}-message-strip;
 
 .#{$block} {
-  $fd-message-strip-padding: 0.4375rem 1rem;
-  $fd-message-strip-padding-default: 1rem;
-  $fd-message-strip-padding-dismissible: 2.5rem;
-  $fd-message-strip-padding-status: 2.5rem;
-  $fd-message-strip-text-color: var(--sapTextColor);
-
-  @mixin fd-message-strip-icon-container {
-    position: absolute;
-    width: 2.5rem;
-    top: 0.5rem;
-    left: 0;
-    line-height: 1;
-  }
-
-  @mixin fd-message-strip-close-btn-container {
-    position: absolute;
-    top: 0.125rem;
-    right: 0.125rem;
-  }
-
-  // SUCCESS
-  $fd-message-strip-background-color--success: var(--sapSuccessBackground) !default;
-  $fd-message-strip-border-color--success: var(--fdMessageStrip_Border_Color_Success) !default;
-
-  // ERROR
-  $fd-message-strip-background-color--error: var(--sapErrorBackground) !default;
-  $fd-message-strip-border-color--error: var(--fdMessageStrip_Border_Color_Error) !default;
-
-  // WARNING
-  $fd-message-strip-background-color--warning: var(--sapWarningBackground) !default;
-  $fd-message-strip-border-color--warning: var(--fdMessageStrip_Border_Color_Warning) !default;
-
-  // INFORMATION
-  $fd-message-strip-background-color--information: var(--sapInformationBackground) !default;
-  $fd-message-strip-border-color--information: var(--fdMessageStrip_Border_Color_Informative) !default;
-
-  // NEUTRAL
-  $fd-message-strip-background-color: var(--sapNeutralBackground) !default;
-  $fd-message-strip-border-color: var(--fdMessageStrip_Border_Color_Neutral) !default;
-
-  // ---------------------------------------------------------------------------
-  // Block
+  --fdMessageStrip_Border_Color: var(--fdMessageStrip_Border_Color_Neutral);
+  --fdMessageStrip_Background_Color: var(--sapNeutralBackground);
+  --fdMessageStrip_Icon_Color: var(--fdMessageStrip_Icon_Color_Neutral);
+  --fdMessageStrip_Text_Color: var(--sapTextColor);
+  --fdMessageStrip_Vertical_Padding: 0.4375rem;
+  --fdMessageStrip_Left_Padding: 2.4375rem;
+  --fdMessageStrip_Right_Padding: 0.9375rem;
 
   @include fd-reset();
+  @include fd-set-paddings-y-equal(var(--fdMessageStrip_Vertical_Padding));
+  @include fd-set-paddings-x(var(--fdMessageStrip_Left_Padding), var(--fdMessageStrip_Right_Padding));
 
-  font-size: var(--sapFontSize);
-  position: relative;
-  color: $fd-message-strip-text-color;
-  background-color: $fd-message-strip-background-color;
-  border-width: var(--fdMessageStrip_Border_Width);
-  border-style: solid;
-  border-color: $fd-message-strip-border-color;
-  border-radius: var(--fdMessageStrip_Border_Radius);
-  padding: $fd-message-strip-padding;
-  display: flex;
-  align-items: center;
+  height: auto;
   min-height: 2rem;
+  position: relative;
+  border-style: solid;
+  font-size: var(--sapFontSize);
+  border-width: var(--fdMessageStrip_Border_Width);
+  border-radius: var(--fdMessageStrip_Border_Radius);
+  background: var(--fdMessageStrip_Background_Color);
+  border-color: var(--fdMessageStrip_Border_Color);
 
-  // Elements
   .#{$block}__close {
-    @include fd-message-strip-close-btn-container();
+    @include fd-set-position-right(0.125rem);
 
-    @include fd-rtl() {
-      left: 0.125rem;
-      right: auto;
-    }
-  }
-
-  // Modifiers
-  &--dismissible {
-    padding-right: $fd-message-strip-padding-dismissible;
-
-    @include fd-rtl() {
-      padding-right: $fd-message-strip-padding-default;
-      padding-left: $fd-message-strip-padding-dismissible;
-    }
-  }
-
-  &--warning,
-  &--information,
-  &--success,
-  &--error {
-    &::before,
-    &::after {
-      @include fd-message-strip-icon-container();
-    }
-
-    padding-left: $fd-message-strip-padding-status;
-
-    @include fd-rtl() {
-      padding-right: $fd-message-strip-padding-status;
-      padding-left: $fd-message-strip-padding-default;
-
-      &::before {
-        display: none;
-      }
-    }
-
-    &.#{$block}--dismissible {
-      padding-right: $fd-message-strip-padding-dismissible;
-
-      @include fd-rtl() {
-        padding-left: $fd-message-strip-padding-dismissible;
-      }
-    }
-
-    @include fd-rtl() {
-      @include fd-icon-base("after") {
-        position: absolute;
-        right: 0;
-      }
-    }
-  }
-
-  &--warning {
-    &::before,
-    &::after {
-      color: var(--fdMessageStrip_Icon_Color_Warning);
-    }
-
-    background-color: $fd-message-strip-background-color--warning;
-    border-color: $fd-message-strip-border-color--warning;
-
-    @include fd-icon("alert");
-
-    @include fd-rtl() {
-      &::before {
-        display: none;
-      }
-
-      @include fd-icon("alert", "after");
-    }
-  }
-
-  &--error {
-    &::before,
-    &::after {
-      color: var(--fdMessageStrip_Icon_Color_Error);
-    }
-
-    background-color: $fd-message-strip-background-color--error;
-    border-color: $fd-message-strip-border-color--error;
-
-    @include fd-icon("error");
-
-    @include fd-rtl() {
-      @include fd-icon("error", "after");
-    }
-  }
-
-  &--success {
-    &::before,
-    &::after {
-      color: var(--fdMessageStrip_Icon_Color_Success);
-    }
-
-    background-color: $fd-message-strip-background-color--success;
-    border-color: $fd-message-strip-border-color--success;
-
-    @include fd-icon("sys-enter-2");
-
-    @include fd-rtl() {
-      @include fd-icon("sys-enter-2", "after");
-    }
-  }
-
-  &--information {
-    &::before,
-    &::after {
-      color: var(--fdMessageStrip_Icon_Color_Information);
-    }
-
-    background-color: $fd-message-strip-background-color--information;
-    border-color: $fd-message-strip-border-color--information;
-
-    @include fd-icon("information");
-
-    @include fd-rtl() {
-      @include fd-icon("information", "after");
-    }
-  }
-
-  &--no-icon {
-    padding-left: $fd-message-strip-padding-default;
-
-    &::before {
-      display: none;
-    }
-
-    @include fd-rtl() {
-      padding-right: $fd-message-strip-padding-default;
-
-      &::after {
-        display: none;
-      }
-    }
+    top: 0.125rem;
+    position: absolute;
   }
 
   &__text {
     @include fd-reset();
 
     line-height: 1rem;
+    color: var(-fdMessageStrip_Text_Color);
+  }
+
+  &__icon-container {
+    @include fd-reset();
+    @include fd-flex-center();
+    @include fd-set-width(2.5rem);
+    @include fd-set-position-left(0);
+
+    width: 2.5rem;
+    font-size: 1rem;
+    position: absolute;
+    color: var(--fdMessageStrip_Icon_Color);
+    top: var(--fdMessageStrip_Vertical_Padding);
+
+    [class*=sap-icon] {
+      @include fd-flex-center();
+      @include fd-set-width(1rem);
+      @include fd-set-height(1rem);
+
+      line-height: 1;
+      color: var(--fdMessageStrip_Icon_Color);
+    }
+  }
+
+  &--warning {
+    --fdMessageStrip_Background_Color: var(--sapWarningBackground);
+    --fdMessageStrip_Icon_Color: var(--fdMessageStrip_Icon_Color_Warning);
+    --fdMessageStrip_Border_Color: var(--fdMessageStrip_Border_Color_Warning);
+  }
+
+  &--error {
+    --fdMessageStrip_Background_Color: var(--sapErrorBackground);
+    --fdMessageStrip_Icon_Color: var(--fdMessageStrip_Icon_Color_Error);
+    --fdMessageStrip_Border_Color: var(--fdMessageStrip_Border_Color_Error);
+  }
+
+  &--success {
+    --fdMessageStrip_Background_Color: var(--sapSuccessBackground);
+    --fdMessageStrip_Icon_Color: var(--fdMessageStrip_Icon_Color_Success);
+    --fdMessageStrip_Border_Color: var(--fdMessageStrip_Border_Color_Success);
+  }
+
+  &--information {
+    --fdMessageStrip_Background_Color: var(--sapInformationBackground);
+    --fdMessageStrip_Icon_Color: var(--fdMessageStrip_Icon_Color_Information);
+    --fdMessageStrip_Border_Color: var(--fdMessageStrip_Border_Color_Informative);
+  }
+
+  &--no-icon {
+    --fdMessageStrip_Left_Padding: 0.9375rem;
+    --fdMessageStrip_Right_Padding: 0.9375rem;
+  }
+
+  &--dismissible {
+    --fdMessageStrip_Left_Padding: 2.4375rem;
+    --fdMessageStrip_Right_Padding: 2.4375rem;
+
+    &.#{$block}--no-icon {
+      --fdMessageStrip_Left_Padding: 0.9375rem;
+      --fdMessageStrip_Right_Padding: 2.4375rem;
+    }
+  }
+
+  &--link a {
+    text-shadow: var(--sapContent_TextShadow);
+  }
+
+  @each $set-name, $color-set in $fd-avatar-accent-colors {
+    &--accent-color-#{$set-name} {
+      --fdMessageStrip_Icon_Color: #{map_get($color-set, "text-color")};
+      --fdMessageStrip_Text_Color: #{map_get($color-set, "text-color")};
+      --fdMessageStrip_Border_Color: #{map_get($color-set, "border-color")};
+      --fdMessageStrip_Background_Color: #{map_get($color-set, "background-color")};
+    }
   }
 }

--- a/packages/styles/stories/Components/message-strip/message-strip.stories.js
+++ b/packages/styles/stories/Components/message-strip/message-strip.stories.js
@@ -1,17 +1,12 @@
 import '../../../src/button.scss';
 import '../../../src/message-strip.scss';
 import '../../../src/icon.scss';
+import '../../../src/link.scss';
+
 export default {
     title: 'Components/Message Strip',
     parameters: {
-        description: `The message strip displays information bars with semantic colors and icons, indicating different levels of urgency and/or action required by the user. The message strip is fully responsive, with an icon and close button on opposite sides of the message text. Text and links behave differently, and wrap if space is limited.
-
-**The following semantic types are available:**
-
- - Information
- - Warning
- - Error
- - Success
+        description: `Message Strip is a component that enables the embedding of application-related messages in the application. They are useed to draw the user’s attention to information that is important in the context of the page content. This could be a warning or a change of state, that would be easy to miss it.
 
 ##Usage
 **Use the message strip if:**
@@ -24,20 +19,24 @@ export default {
 
 - You want to display information within the object page header, a control, in the master list, or above the page header.
 
+##Anatomy
+- <b>Container </b>- holds the icon, text and Close button.
+- <b>Icon (optional) </b>- graphic element within the component. Use the modifier class \`.fd-message-strip--no-icon\` if you want to omit the icon.
+- <b>Text </b>- it is strongly recommended that you use only text in order to preserve the intended design.
+      - <b>Text with Link </b>- add the \`.fd-message-strip--link\` modifier class if the text message contains a link element.
+- <b>Close button (optional) </b>- each message can have a Close button so it can be removed from the UI, if needed. Add the \`.fd-message-strip--dismissible\` modifier class for a dismissible message strip.
+
         `,
-        tags: ['f3', 'a11y', 'theme']
+        tags: ['f3', 'theme']
     }
 };
 
 const messageStripHeight = 64;
 
-export const DefaultStrip = () => `<div class="fd-message-strip fd-message-strip--dismissible" role="alert"  id="ZvPBg609" >
+export const DefaultStrip = () => `<div class="fd-message-strip fd-message-strip--no-icon" role="note" aria-live="assertive" id="message-strip-1" aria-labelledby="message-strip-1">
   <p class="fd-message-strip__text">
     Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
   </p>
-  <button class="fd-button fd-button--transparent fd-button--compact fd-message-strip__close" aria-controls="ZvPBg609" aria-label="Close">
-    <i class="sap-icon--decline"></i>
-  </button>
 </div>
 `;
 
@@ -47,18 +46,19 @@ DefaultStrip.parameters = {
     docs: {
         iframeHeight: messageStripHeight,
         description: {
-            story: `
-The default message strip can be used for general messages that don’t fit into any of the semantic type use cases. The user should be able to dismiss the message strip (in most cases), so be sure to include the close button and add the \`fd-message-strip--dismissible\` modifier class to the main element.
-        `
+            story: `The default message strip can be used for general messages that don’t fit into any of the semantic type use cases.`
         }
     }
 };
 
-export const Information = () => `<div class="fd-message-strip fd-message-strip--information fd-message-strip--dismissible" role="alert"  id="JwPcf464" >
+export const Information = () => `<div class="fd-message-strip fd-message-strip--information fd-message-strip--dismissible" role="note" aria-live="assertive" id="message-strip-2" aria-labelledby="message-strip-2">
+  <div class="fd-message-strip__icon-container" aria-hidden="true">
+    <span class="sap-icon sap-icon--message-information" focusable="false" role="presentation" aria-hidden="true"></span>
+  </div>
   <p class="fd-message-strip__text">
     Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
   </p>
-  <button class="fd-button fd-button--transparent fd-button--compact fd-message-strip__close" aria-controls="JwPcf464" aria-label="Close">
+  <button class="fd-button fd-button--transparent fd-button--compact fd-message-strip__close" aria-controls="message-strip-2" aria-label="Close" title="Close">
     <i class="sap-icon--decline"></i>
   </button>
 </div>
@@ -68,16 +68,19 @@ Information.parameters = {
     docs: {
         iframeHeight: messageStripHeight,
         description: {
-            story: 'The information message strip simply relays useful information to the users. To display an information message strip, add the `fd-message-strip--information` modifier class to the main element.'
+            story: 'To display an information message strip, add the `fd-message-strip--information` modifier class to the main element.'
         }
     }
 };
 
-export const Success = () => `<div class="fd-message-strip fd-message-strip--success fd-message-strip--dismissible" role="alert" id="ulr5z216">
+export const Success = () => `<div class="fd-message-strip fd-message-strip--success fd-message-strip--dismissible" role="note" aria-live="assertive" id="message-strip-3" aria-labelledby="message-strip-3">
+  <div class="fd-message-strip__icon-container" aria-hidden="true">
+    <span class="sap-icon sap-icon--message-success" focusable="false" role="presentation" aria-hidden="true"></span>
+  </div>
   <p class="fd-message-strip__text">
     Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
   </p>
-  <button class="fd-button fd-button--transparent fd-button--compact fd-message-strip__close" aria-controls="ulr5z216" aria-label="Close">
+  <button class="fd-button fd-button--transparent fd-button--compact fd-message-strip__close" aria-controls="message-strip-3" aria-label="Close" title="Close">
     <i class="sap-icon--decline"></i>
   </button>
 </div>
@@ -87,16 +90,19 @@ Success.parameters = {
     docs: {
         iframeHeight: messageStripHeight,
         description: {
-            story: 'The success message strip communicates to the user that an action they’ve completed was successful. To display a success message strip, add the `fd-message-strip--success` modifier class to the main element.'
+            story: 'To display a success message strip, add the `fd-message-strip--success` modifier class to the main element.'
         }
     }
 };
 
-export const Warning = () => `<div class="fd-message-strip fd-message-strip--warning fd-message-strip--dismissible" role="alert" id="fwYq4606">
+export const Warning = () => `<div class="fd-message-strip fd-message-strip--warning fd-message-strip--dismissible" role="note" aria-live="assertive" id="message-strip-4" aria-labelledby="message-strip-4">
+  <div class="fd-message-strip__icon-container" aria-hidden="true">
+    <span class="sap-icon sap-icon--message-warning" focusable="false" role="presentation" aria-hidden="true"></span>
+  </div>
   <p class="fd-message-strip__text">
     Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
   </p>
-  <button class="fd-button fd-button--transparent fd-button--compact fd-message-strip__close" aria-controls="fwYq4606" aria-label="Close">
+  <button class="fd-button fd-button--transparent fd-button--compact fd-message-strip__close" aria-controls="message-strip-4" aria-label="Close" title="Close">
     <i class="sap-icon--decline"></i>
   </button>
 </div>
@@ -106,18 +112,19 @@ Warning.parameters = {
     docs: {
         iframeHeight: messageStripHeight,
         description: {
-            story: `
-The warning message strip warns the user of potential issues; however, the user can still dismiss the message and continue. To display a warning message strip, add the \`fd-message-strip--warning\` modifier class to the main element.
-`
+            story: `To display a warning message strip, add the \`fd-message-strip--warning\` modifier class to the main element.`
         }
     }
 };
 
-export const Error = () => `<div class="fd-message-strip fd-message-strip--error fd-message-strip--dismissible" role="alert" id="SsoiW591">
+export const Error = () => `<div class="fd-message-strip fd-message-strip--error fd-message-strip--dismissible" role="note" aria-live="assertive" id="message-strip-5" aria-labelledby="message-strip-5">
+  <div class="fd-message-strip__icon-container" aria-hidden="true">
+    <span class="sap-icon sap-icon--message-error" focusable="false" role="presentation" aria-hidden="true"></span>
+  </div>
   <p class="fd-message-strip__text">
     Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
   </p>
-  <button class="fd-button fd-button--transparent fd-button--compact fd-message-strip__close" aria-controls="SsoiW591" aria-label="Close">
+  <button class="fd-button fd-button--transparent fd-button--compact fd-message-strip__close" aria-controls="message-strip-5" aria-label="Close" title="Close">
     <i class="sap-icon--decline"></i>
   </button>
 </div>
@@ -127,19 +134,18 @@ Error.parameters = {
     docs: {
         iframeHeight: messageStripHeight,
         description: {
-            story: `
-The error message strip is triggered after the user enters data incorrectly or when a system error occurs. It should interrupt the user, blocking them from performing any final actions (such as _Submit_) until the error has been rectified. To display the error message strip, add the \`fd-message-strip--error\` modifier class to the main element.
+            story: `To display the error message strip, add the \`fd-message-strip--error\` modifier class to the main element.
 `
         }
     }
 };
 
 export const NoIcons = () => `<div class="fd-message-strip fd-message-strip--information fd-message-strip--no-icon fd-message-strip--dismissible"
-     role="alert" id="SsoiW592">
+     role="note" aria-live="assertive" id="message-strip-6" aria-labelledby="message-strip-6">
   <p class="fd-message-strip__text">
     Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
   </p>
-  <button class="fd-button fd-button--transparent fd-button--compact fd-message-strip__close" aria-controls="SsoiW592" aria-label="Close">
+  <button class="fd-button fd-button--transparent fd-button--compact fd-message-strip__close" aria-controls="message-strip-6" aria-label="Close" title="Close">
     <i class="sap-icon--decline"></i>
   </button>
 </div>
@@ -147,11 +153,11 @@ export const NoIcons = () => `<div class="fd-message-strip fd-message-strip--inf
 <br />
 
 <div class="fd-message-strip fd-message-strip--success fd-message-strip--no-icon fd-message-strip--dismissible"
-     role="alert" id="SsoiW593">
+     role="note" aria-live="assertive" id="message-strip-7" aria-labelledby="message-strip-7">
   <p class="fd-message-strip__text">
     Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
   </p>
-  <button class="fd-button fd-button--transparent fd-button--compact fd-message-strip__close" aria-controls="SsoiW593" aria-label="Close">
+  <button class="fd-button fd-button--transparent fd-button--compact fd-message-strip__close" aria-controls="message-strip-7" aria-label="Close" title="Close">
     <i class="sap-icon--decline"></i>
   </button>
 </div>
@@ -159,11 +165,11 @@ export const NoIcons = () => `<div class="fd-message-strip fd-message-strip--inf
 <br />
 
 <div class="fd-message-strip fd-message-strip--warning fd-message-strip--no-icon fd-message-strip--dismissible"
-     role="alert" id="SsoiW594">
+     role="note" aria-live="assertive" id="message-strip-8" aria-labelledby="message-strip-8">
   <p class="fd-message-strip__text">
     Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
   </p>
-  <button class="fd-button fd-button--transparent fd-button--compact fd-message-strip__close" aria-controls="SsoiW594" aria-label="Close">
+  <button class="fd-button fd-button--transparent fd-button--compact fd-message-strip__close" aria-controls="message-strip-8" aria-label="Close" title="Close">
     <i class="sap-icon--decline"></i>
   </button>
 </div>
@@ -171,11 +177,11 @@ export const NoIcons = () => `<div class="fd-message-strip fd-message-strip--inf
 <br />
 
 <div class="fd-message-strip fd-message-strip--error fd-message-strip--no-icon fd-message-strip--dismissible"
-     role="alert" id="SsoiW595">
+     role="note" aria-live="assertive" id="message-strip-9" aria-labelledby="message-strip-9">
   <p class="fd-message-strip__text">
     Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
   </p>
-  <button class="fd-button fd-button--transparent fd-button--compact fd-message-strip__close" aria-controls="SsoiW595" aria-label="Close">
+  <button class="fd-button fd-button--transparent fd-button--compact fd-message-strip__close" aria-controls="message-strip-9" aria-label="Close" title="Close">
     <i class="sap-icon--decline"></i>
   </button>
 </div>
@@ -187,7 +193,239 @@ NoIcons.parameters = {
     docs: {
         iframeHeight: messageStripHeight * 4,
         description: {
+            story: 'To display message strip without an icon, add the `fd-message-strip--no-icon` modifier class to the main element. Add the `fd-message-strip--dismissible` modifier class if the element is dismissible.'
+        }
+    }
+};
+
+export const NoIconsNotDismissible = () => `<div class="fd-message-strip fd-message-strip--information fd-message-strip--no-icon"
+     role="note" aria-live="assertive" id="message-strip-10" aria-labelledby="message-strip-10">
+  <p class="fd-message-strip__text">
+    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
+  </p>
+</div>
+
+<br />
+
+<div class="fd-message-strip fd-message-strip--success fd-message-strip--no-icon"
+     role="note" aria-live="assertive" id="message-strip-11" aria-labelledby="message-strip-11">
+  <p class="fd-message-strip__text">
+    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
+  </p>
+</div>
+
+<br />
+
+<div class="fd-message-strip fd-message-strip--warning fd-message-strip--no-icon"
+     role="note" aria-live="assertive" id="message-strip-12" aria-labelledby="message-strip-12">
+  <p class="fd-message-strip__text">
+    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
+  </p>
+</div>
+
+<br />
+
+<div class="fd-message-strip fd-message-strip--error fd-message-strip--no-icon"
+     role="note" aria-live="assertive" id="message-strip-13" aria-labelledby="message-strip-13">
+  <p class="fd-message-strip__text">
+    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
+  </p>
+</div>
+`;
+
+NoIconsNotDismissible.storyName = 'No icon and no dismiss button';
+
+NoIconsNotDismissible.parameters = {
+    docs: {
+        iframeHeight: messageStripHeight * 4,
+        description: {
             story: 'To display message strip without an icon, add the `fd-message-strip--no-icon` modifier class to the main element.'
+        }
+    }
+};
+
+export const MessageStripWithLink = () => `<div class="fd-message-strip fd-message-strip--error fd-message-strip--dismissible fd-message-strip--link" role="note" aria-live="assertive" id="message-strip-14" aria-labelledby="message-strip-14">
+  <div class="fd-message-strip__icon-container" aria-hidden="true">
+    <span class="sap-icon sap-icon--message-error" focusable="false" role="presentation" aria-hidden="true"></span>
+  </div>
+  <p class="fd-message-strip__text">
+    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et. 
+    <a href="#" class="fd-link" tabindex="0"><span class="fd-link__content">Default link</span></a>
+  </p>
+  <button class="fd-button fd-button--transparent fd-button--compact fd-message-strip__close" aria-controls="message-strip-14" aria-label="Close" title="Close">
+    <i class="sap-icon--decline"></i>
+  </button>
+</div>
+`;
+
+MessageStripWithLink.storyName = 'Text with link';
+MessageStripWithLink.parameters = {
+    docs: {
+        iframeHeight: messageStripHeight,
+        description: {
+            story: 'The Link inside Message Strip has additional styling. Add the `fd-message-strip--link` modifier class if the message contains a link element.'
+        }
+    }
+};
+
+export const MessageStripWithCustomIcon = () => `<div class="fd-message-strip fd-message-strip--dismissible" role="note" aria-live="assertive" id="message-strip-15" aria-labelledby="message-strip-15">
+  <div class="fd-message-strip__icon-container" aria-hidden="true">
+    <span class="sap-icon sap-icon--master-task-triangle-2" focusable="false" role="presentation" aria-hidden="true"></span>
+  </div>
+  <p class="fd-message-strip__text">
+    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna. 
+  </p>
+  <button class="fd-button fd-button--transparent fd-button--compact fd-message-strip__close" aria-controls="message-strip-15" aria-label="Close" title="Close">
+    <i class="sap-icon--decline"></i>
+  </button>
+</div>
+<br>
+<div class="fd-message-strip fd-message-strip--dismissible fd-message-strip--error" role="note" aria-live="assertive" id="message-strip-16" aria-labelledby="message-strip-16">
+  <div class="fd-message-strip__icon-container" aria-hidden="true">
+    <span class="sap-icon sap-icon--not-editable" focusable="false" role="presentation" aria-hidden="true"></span>
+  </div>
+  <p class="fd-message-strip__text">
+    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna. 
+  </p>
+  <button class="fd-button fd-button--transparent fd-button--compact fd-message-strip__close" aria-controls="message-strip-16" aria-label="Close" title="Close">
+    <i class="sap-icon--decline"></i>
+  </button>
+</div>
+`;
+
+MessageStripWithCustomIcon.storyName = 'Custom icon';
+MessageStripWithCustomIcon.parameters = {
+    docs: {
+        iframeHeight: messageStripHeight,
+        description: {
+            story: 'The message strip can be customized by changing the status icon. Check <a href="https://sap.github.io/fundamental-styles/?path=/docs/components-icons-sap-icons--sizes" target="_blank" rel="noopener noreferrer" title="click to open Avatar component. Opens in a new window.">Icons</a> control for more icon types.'
+        }
+    }
+};
+
+export const MessageStripWithAccentColors = () => `<div class="fd-message-strip fd-message-strip--dismissible fd-message-strip--accent-color-1" role="note" aria-live="assertive" id="message-strip-17" aria-labelledby="message-strip-17">
+  <div class="fd-message-strip__icon-container" aria-hidden="true">
+    <span class="sap-icon sap-icon--master-task-triangle-2" focusable="false" role="presentation" aria-hidden="true"></span>
+  </div>
+  <p class="fd-message-strip__text">
+    Message Strip with accent color 1 
+  </p>
+</div>
+
+<br>
+
+<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-2" role="note" aria-live="assertive" id="message-strip-18" aria-labelledby="message-strip-18">
+  <div class="fd-message-strip__icon-container" aria-hidden="true">
+    <span class="sap-icon sap-icon--cloud" focusable="false" role="presentation" aria-hidden="true"></span>
+  </div>
+  <p class="fd-message-strip__text">
+    Message Strip with accent color 2 
+  </p>
+</div>
+
+
+<br>
+
+<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-3" role="note" aria-live="assertive" id="message-strip-19" aria-labelledby="message-strip-19">
+  <div class="fd-message-strip__icon-container" aria-hidden="true">
+    <span class="sap-icon sap-icon--heart-2" focusable="false" role="presentation" aria-hidden="true"></span>
+  </div>
+  <p class="fd-message-strip__text">
+    Message Strip with accent color 3 
+  </p>
+</div>
+
+
+<br>
+
+<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-4" role="note" aria-live="assertive" id="message-strip-20" aria-labelledby="message-strip-20">
+  <div class="fd-message-strip__icon-container" aria-hidden="true">
+    <span class="sap-icon sap-icon--circle-task" focusable="false" role="presentation" aria-hidden="true"></span>
+  </div>
+  <p class="fd-message-strip__text">
+    Message Strip with accent color 4 
+  </p>
+</div>
+
+
+<br>
+
+<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-5" role="note" aria-live="assertive" id="message-strip-21" aria-labelledby="message-strip-21">
+  <div class="fd-message-strip__icon-container" aria-hidden="true">
+    <span class="sap-icon sap-icon--feedback" focusable="false" role="presentation" aria-hidden="true"></span>
+  </div>
+  <p class="fd-message-strip__text">
+    Message Strip with accent color 5 
+  </p>
+</div>
+
+
+<br>
+
+<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-6" role="note" aria-live="assertive" id="message-strip-22" aria-labelledby="message-strip-22">
+  <div class="fd-message-strip__icon-container" aria-hidden="true">
+    <span class="sap-icon sap-icon--text-color" focusable="false" role="presentation" aria-hidden="true"></span>
+  </div>
+  <p class="fd-message-strip__text">
+    Message Strip with accent color 6
+  </p>
+</div>
+
+
+<br>
+
+<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-7" role="note" aria-live="assertive" id="message-strip-23" aria-labelledby="message-strip-23">
+  <div class="fd-message-strip__icon-container" aria-hidden="true">
+    <span class="sap-icon sap-icon--away" focusable="false" role="presentation" aria-hidden="true"></span>
+  </div>
+  <p class="fd-message-strip__text">
+    Message Strip with accent color 7 
+  </p>
+</div>
+
+
+<br>
+
+<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-8" role="note" aria-live="assertive" id="message-strip-24" aria-labelledby="message-strip-24">
+  <div class="fd-message-strip__icon-container" aria-hidden="true">
+    <span class="sap-icon sap-icon--cursor" focusable="false" role="presentation" aria-hidden="true"></span>
+  </div>
+  <p class="fd-message-strip__text">
+    Message Strip with accent color 8 
+  </p>
+</div>
+
+
+<br>
+
+<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-9" role="note" aria-live="assertive" id="message-strip-25" aria-labelledby="message-strip-25">
+  <div class="fd-message-strip__icon-container" aria-hidden="true">
+    <span class="sap-icon sap-icon--copy" focusable="false" role="presentation" aria-hidden="true"></span>
+  </div>
+  <p class="fd-message-strip__text">
+    Message Strip with accent color 9
+  </p>
+</div>
+
+
+<br>
+
+<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-10" role="note" aria-live="assertive" id="message-strip-26" aria-labelledby="message-strip-26">
+  <div class="fd-message-strip__icon-container" aria-hidden="true">
+    <span class="sap-icon sap-icon--reset" focusable="false" role="presentation" aria-hidden="true"></span>
+  </div>
+  <p class="fd-message-strip__text">
+    Message Strip with accent color 10
+  </p>
+</div>
+`;
+
+MessageStripWithAccentColors.storyName = 'Accent colors';
+MessageStripWithAccentColors.parameters = {
+    docs: {
+        iframeHeight: messageStripHeight,
+        description: {
+            story: `If the application needs a custom Message Strip, other than the semantic variations, then the colours from <a href="https://sap.github.io/fundamental-styles/?path=/docs/components-avatar--icon" target="_blank" rel="noopener noreferrer" title="click to open Avatar component. Opens in a new window.">Avatar (Horizon)</a> control should be used. Use the modifier classes \`.fd-message-strip--accent-color-*\`, where \`*\` is a number from 1 to 10. `
         }
     }
 };

--- a/packages/styles/stories/Components/notification/notification.stories.js
+++ b/packages/styles/stories/Components/notification/notification.stories.js
@@ -108,11 +108,14 @@ Notifications can be displayed without an avatar by adding the \`fd-notification
 };
 
 export const Information = () => `<div class="fd-notification">
-  <div class="fd-message-strip fd-message-strip--information fd-message-strip--dismissible" role="alert">
-      <p class="fd-message-strip__text">
+  <div class="fd-message-strip fd-message-strip--information fd-message-strip--dismissible" role="note" aria-live="assertive" id="message-strip-1" aria-labelledby="message-strip-1">
+    <div class="fd-message-strip__icon-container" aria-hidden="true">
+        <span class="sap-icon sap-icon--message-information" focusable="false" role="presentation" aria-hidden="true"></span>
+    </div>
+    <p class="fd-message-strip__text">
         Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet.
       </p>
-       <button class="fd-button fd-button--transparent fd-button--compact fd-message-strip__close" aria-label="Close">
+       <button class="fd-button fd-button--transparent fd-button--compact fd-message-strip__close" aria-controls="message-strip-1" aria-label="Close" title="Close">
         <i class="sap-icon--decline"></i>
       </button>
     </div>
@@ -142,18 +145,21 @@ Information.parameters = {
         iframeHeight: 200,
         description: {
             story: `
-Notifications can also include alerts, and in this case it is informative. You can display information alerts by adding the \`fd-message-strip fd-message-strip--information fd-message-strip--dismissible\` class together with \`role="alert"\`. To add text to the message, add the \`fd-message-strip\\__text\` class before the text in paragraph tags.
+Notifications can also include alerts, and in this case it is informative. You can display information alerts by adding the \`fd-message-strip fd-message-strip--information fd-message-strip--dismissible\`. To add text to the message, add the \`fd-message-strip\\__text\` class before the text in paragraph tags.
 `
         }
     }
 };
 
 export const Warning = () => `<div class="fd-notification">
-    <div class="fd-message-strip fd-message-strip--warning fd-message-strip--dismissible" role="alert">
-      <p class="fd-message-strip__text">
+    <div class="fd-message-strip fd-message-strip--warning fd-message-strip--dismissible" role="note" aria-live="assertive" id="message-strip-2" aria-labelledby="message-strip-2">
+    <div class="fd-message-strip__icon-container" aria-hidden="true">
+        <span class="sap-icon sap-icon--message-warning" focusable="false" role="presentation" aria-hidden="true"></span>
+    </div>
+    <p class="fd-message-strip__text">
         Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet.
       </p>
-      <button class="fd-button fd-button--transparent fd-button--compact fd-message-strip__close" aria-label="Close">
+      <button class="fd-button fd-button--transparent fd-button--compact fd-message-strip__close" aria-controls="message-strip-2" aria-label="Close" title="Close">
         <i class="sap-icon--decline"></i>
       </button>
     </div>
@@ -184,18 +190,21 @@ Warning.parameters = {
         iframeHeight: 200,
         description: {
             story: `
-Notifications can display warning alerts by adding the \`fd-message-strip fd-message-strip--warning fd-message-strip--dismissible\` class together with \`role="alert"\`.
+Notifications can display warning alerts by adding the \`fd-message-strip fd-message-strip--warning fd-message-strip--dismissible\` class.
 `
         }
     }
 };
 
 export const Error = () => `<div class="fd-notification">
-    <div class="fd-message-strip fd-message-strip--error fd-message-strip--dismissible" role="alert">
+    <div class="fd-message-strip fd-message-strip--error fd-message-strip--dismissible" role="note" aria-live="assertive" id="message-strip-3" aria-labelledby="message-strip-3">
+        <div class="fd-message-strip__icon-container" aria-hidden="true">
+            <span class="sap-icon sap-icon--message-information" focusable="false" role="presentation" aria-hidden="true"></span>
+        </div>
         <p class="fd-message-strip__text">
           Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet.
         </p>
-          <button class="fd-button fd-button--transparent fd-button--compact fd-message-strip__close" aria-label="Close">
+          <button class="fd-button fd-button--transparent fd-button--compact fd-message-strip__close" aria-controls="message-strip-3" aria-label="Close" title="Close">
             <i class="sap-icon--decline"></i>
           </button>
     </div>
@@ -226,7 +235,7 @@ Error.parameters = {
         iframeHeight: 200,
         description: {
             story: `
-Notifications can display error alerts by adding the \`fd-message-strip fd-message-strip--error fd-message-strip--dismissible\` class together with \`role="alert"\`.
+Notifications can display error alerts by adding the \`fd-message-strip fd-message-strip--error fd-message-strip--dismissible\` class.
 `
         }
     }

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -17654,23 +17654,23 @@ exports[`Check stories > Components/Message Popover > Story DetailsView > Should
 `;
 
 exports[`Check stories > Components/Message Strip > Story DefaultStrip > Should match snapshot 1`] = `
-"<div class=\\"fd-message-strip fd-message-strip--dismissible\\" role=\\"alert\\"  id=\\"ZvPBg609\\" >
+"<div class=\\"fd-message-strip fd-message-strip--no-icon\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-1\\" aria-labelledby=\\"message-strip-1\\">
   <p class=\\"fd-message-strip__text\\">
     Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
   </p>
-  <button class=\\"fd-button fd-button--transparent fd-button--compact fd-message-strip__close\\" aria-controls=\\"ZvPBg609\\" aria-label=\\"Close\\">
-    <i class=\\"sap-icon--decline\\"></i>
-  </button>
 </div>
 "
 `;
 
 exports[`Check stories > Components/Message Strip > Story Error > Should match snapshot 1`] = `
-"<div class=\\"fd-message-strip fd-message-strip--error fd-message-strip--dismissible\\" role=\\"alert\\" id=\\"SsoiW591\\">
+"<div class=\\"fd-message-strip fd-message-strip--error fd-message-strip--dismissible\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-5\\" aria-labelledby=\\"message-strip-5\\">
+  <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
+    <span class=\\"sap-icon sap-icon--message-error\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+  </div>
   <p class=\\"fd-message-strip__text\\">
     Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
   </p>
-  <button class=\\"fd-button fd-button--transparent fd-button--compact fd-message-strip__close\\" aria-controls=\\"SsoiW591\\" aria-label=\\"Close\\">
+  <button class=\\"fd-button fd-button--transparent fd-button--compact fd-message-strip__close\\" aria-controls=\\"message-strip-5\\" aria-label=\\"Close\\" title=\\"Close\\">
     <i class=\\"sap-icon--decline\\"></i>
   </button>
 </div>
@@ -17678,11 +17678,176 @@ exports[`Check stories > Components/Message Strip > Story Error > Should match s
 `;
 
 exports[`Check stories > Components/Message Strip > Story Information > Should match snapshot 1`] = `
-"<div class=\\"fd-message-strip fd-message-strip--information fd-message-strip--dismissible\\" role=\\"alert\\"  id=\\"JwPcf464\\" >
+"<div class=\\"fd-message-strip fd-message-strip--information fd-message-strip--dismissible\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-2\\" aria-labelledby=\\"message-strip-2\\">
+  <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
+    <span class=\\"sap-icon sap-icon--message-information\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+  </div>
   <p class=\\"fd-message-strip__text\\">
     Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
   </p>
-  <button class=\\"fd-button fd-button--transparent fd-button--compact fd-message-strip__close\\" aria-controls=\\"JwPcf464\\" aria-label=\\"Close\\">
+  <button class=\\"fd-button fd-button--transparent fd-button--compact fd-message-strip__close\\" aria-controls=\\"message-strip-2\\" aria-label=\\"Close\\" title=\\"Close\\">
+    <i class=\\"sap-icon--decline\\"></i>
+  </button>
+</div>
+"
+`;
+
+exports[`Check stories > Components/Message Strip > Story MessageStripWithAccentColors > Should match snapshot 1`] = `
+"<div class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--accent-color-1\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-17\\" aria-labelledby=\\"message-strip-17\\">
+  <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
+    <span class=\\"sap-icon sap-icon--master-task-triangle-2\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+  </div>
+  <p class=\\"fd-message-strip__text\\">
+    Message Strip with accent color 1 
+  </p>
+</div>
+
+<br>
+
+<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-2\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-18\\" aria-labelledby=\\"message-strip-18\\">
+  <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
+    <span class=\\"sap-icon sap-icon--cloud\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+  </div>
+  <p class=\\"fd-message-strip__text\\">
+    Message Strip with accent color 2 
+  </p>
+</div>
+
+
+<br>
+
+<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-3\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-19\\" aria-labelledby=\\"message-strip-19\\">
+  <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
+    <span class=\\"sap-icon sap-icon--heart-2\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+  </div>
+  <p class=\\"fd-message-strip__text\\">
+    Message Strip with accent color 3 
+  </p>
+</div>
+
+
+<br>
+
+<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-4\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-20\\" aria-labelledby=\\"message-strip-20\\">
+  <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
+    <span class=\\"sap-icon sap-icon--circle-task\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+  </div>
+  <p class=\\"fd-message-strip__text\\">
+    Message Strip with accent color 4 
+  </p>
+</div>
+
+
+<br>
+
+<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-5\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-21\\" aria-labelledby=\\"message-strip-21\\">
+  <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
+    <span class=\\"sap-icon sap-icon--feedback\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+  </div>
+  <p class=\\"fd-message-strip__text\\">
+    Message Strip with accent color 5 
+  </p>
+</div>
+
+
+<br>
+
+<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-6\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-22\\" aria-labelledby=\\"message-strip-22\\">
+  <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
+    <span class=\\"sap-icon sap-icon--text-color\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+  </div>
+  <p class=\\"fd-message-strip__text\\">
+    Message Strip with accent color 6
+  </p>
+</div>
+
+
+<br>
+
+<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-7\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-23\\" aria-labelledby=\\"message-strip-23\\">
+  <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
+    <span class=\\"sap-icon sap-icon--away\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+  </div>
+  <p class=\\"fd-message-strip__text\\">
+    Message Strip with accent color 7 
+  </p>
+</div>
+
+
+<br>
+
+<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-8\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-24\\" aria-labelledby=\\"message-strip-24\\">
+  <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
+    <span class=\\"sap-icon sap-icon--cursor\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+  </div>
+  <p class=\\"fd-message-strip__text\\">
+    Message Strip with accent color 8 
+  </p>
+</div>
+
+
+<br>
+
+<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-9\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-25\\" aria-labelledby=\\"message-strip-25\\">
+  <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
+    <span class=\\"sap-icon sap-icon--copy\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+  </div>
+  <p class=\\"fd-message-strip__text\\">
+    Message Strip with accent color 9
+  </p>
+</div>
+
+
+<br>
+
+<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-10\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-26\\" aria-labelledby=\\"message-strip-26\\">
+  <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
+    <span class=\\"sap-icon sap-icon--reset\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+  </div>
+  <p class=\\"fd-message-strip__text\\">
+    Message Strip with accent color 10
+  </p>
+</div>
+"
+`;
+
+exports[`Check stories > Components/Message Strip > Story MessageStripWithCustomIcon > Should match snapshot 1`] = `
+"<div class=\\"fd-message-strip fd-message-strip--dismissible\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-15\\" aria-labelledby=\\"message-strip-15\\">
+  <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
+    <span class=\\"sap-icon sap-icon--master-task-triangle-2\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+  </div>
+  <p class=\\"fd-message-strip__text\\">
+    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna. 
+  </p>
+  <button class=\\"fd-button fd-button--transparent fd-button--compact fd-message-strip__close\\" aria-controls=\\"message-strip-15\\" aria-label=\\"Close\\" title=\\"Close\\">
+    <i class=\\"sap-icon--decline\\"></i>
+  </button>
+</div>
+<br>
+<div class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--error\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-16\\" aria-labelledby=\\"message-strip-16\\">
+  <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
+    <span class=\\"sap-icon sap-icon--not-editable\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+  </div>
+  <p class=\\"fd-message-strip__text\\">
+    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna. 
+  </p>
+  <button class=\\"fd-button fd-button--transparent fd-button--compact fd-message-strip__close\\" aria-controls=\\"message-strip-16\\" aria-label=\\"Close\\" title=\\"Close\\">
+    <i class=\\"sap-icon--decline\\"></i>
+  </button>
+</div>
+"
+`;
+
+exports[`Check stories > Components/Message Strip > Story MessageStripWithLink > Should match snapshot 1`] = `
+"<div class=\\"fd-message-strip fd-message-strip--error fd-message-strip--dismissible fd-message-strip--link\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-14\\" aria-labelledby=\\"message-strip-14\\">
+  <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
+    <span class=\\"sap-icon sap-icon--message-error\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+  </div>
+  <p class=\\"fd-message-strip__text\\">
+    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et. 
+    <a href=\\"#\\" class=\\"fd-link\\" tabindex=\\"0\\"><span class=\\"fd-link__content\\">Default link</span></a>
+  </p>
+  <button class=\\"fd-button fd-button--transparent fd-button--compact fd-message-strip__close\\" aria-controls=\\"message-strip-14\\" aria-label=\\"Close\\" title=\\"Close\\">
     <i class=\\"sap-icon--decline\\"></i>
   </button>
 </div>
@@ -17691,11 +17856,11 @@ exports[`Check stories > Components/Message Strip > Story Information > Should m
 
 exports[`Check stories > Components/Message Strip > Story NoIcons > Should match snapshot 1`] = `
 "<div class=\\"fd-message-strip fd-message-strip--information fd-message-strip--no-icon fd-message-strip--dismissible\\"
-     role=\\"alert\\" id=\\"SsoiW592\\">
+     role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-6\\" aria-labelledby=\\"message-strip-6\\">
   <p class=\\"fd-message-strip__text\\">
     Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
   </p>
-  <button class=\\"fd-button fd-button--transparent fd-button--compact fd-message-strip__close\\" aria-controls=\\"SsoiW592\\" aria-label=\\"Close\\">
+  <button class=\\"fd-button fd-button--transparent fd-button--compact fd-message-strip__close\\" aria-controls=\\"message-strip-6\\" aria-label=\\"Close\\" title=\\"Close\\">
     <i class=\\"sap-icon--decline\\"></i>
   </button>
 </div>
@@ -17703,11 +17868,11 @@ exports[`Check stories > Components/Message Strip > Story NoIcons > Should match
 <br />
 
 <div class=\\"fd-message-strip fd-message-strip--success fd-message-strip--no-icon fd-message-strip--dismissible\\"
-     role=\\"alert\\" id=\\"SsoiW593\\">
+     role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-7\\" aria-labelledby=\\"message-strip-7\\">
   <p class=\\"fd-message-strip__text\\">
     Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
   </p>
-  <button class=\\"fd-button fd-button--transparent fd-button--compact fd-message-strip__close\\" aria-controls=\\"SsoiW593\\" aria-label=\\"Close\\">
+  <button class=\\"fd-button fd-button--transparent fd-button--compact fd-message-strip__close\\" aria-controls=\\"message-strip-7\\" aria-label=\\"Close\\" title=\\"Close\\">
     <i class=\\"sap-icon--decline\\"></i>
   </button>
 </div>
@@ -17715,11 +17880,11 @@ exports[`Check stories > Components/Message Strip > Story NoIcons > Should match
 <br />
 
 <div class=\\"fd-message-strip fd-message-strip--warning fd-message-strip--no-icon fd-message-strip--dismissible\\"
-     role=\\"alert\\" id=\\"SsoiW594\\">
+     role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-8\\" aria-labelledby=\\"message-strip-8\\">
   <p class=\\"fd-message-strip__text\\">
     Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
   </p>
-  <button class=\\"fd-button fd-button--transparent fd-button--compact fd-message-strip__close\\" aria-controls=\\"SsoiW594\\" aria-label=\\"Close\\">
+  <button class=\\"fd-button fd-button--transparent fd-button--compact fd-message-strip__close\\" aria-controls=\\"message-strip-8\\" aria-label=\\"Close\\" title=\\"Close\\">
     <i class=\\"sap-icon--decline\\"></i>
   </button>
 </div>
@@ -17727,23 +17892,63 @@ exports[`Check stories > Components/Message Strip > Story NoIcons > Should match
 <br />
 
 <div class=\\"fd-message-strip fd-message-strip--error fd-message-strip--no-icon fd-message-strip--dismissible\\"
-     role=\\"alert\\" id=\\"SsoiW595\\">
+     role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-9\\" aria-labelledby=\\"message-strip-9\\">
   <p class=\\"fd-message-strip__text\\">
     Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
   </p>
-  <button class=\\"fd-button fd-button--transparent fd-button--compact fd-message-strip__close\\" aria-controls=\\"SsoiW595\\" aria-label=\\"Close\\">
+  <button class=\\"fd-button fd-button--transparent fd-button--compact fd-message-strip__close\\" aria-controls=\\"message-strip-9\\" aria-label=\\"Close\\" title=\\"Close\\">
     <i class=\\"sap-icon--decline\\"></i>
   </button>
 </div>
 "
 `;
 
-exports[`Check stories > Components/Message Strip > Story Success > Should match snapshot 1`] = `
-"<div class=\\"fd-message-strip fd-message-strip--success fd-message-strip--dismissible\\" role=\\"alert\\" id=\\"ulr5z216\\">
+exports[`Check stories > Components/Message Strip > Story NoIconsNotDismissible > Should match snapshot 1`] = `
+"<div class=\\"fd-message-strip fd-message-strip--information fd-message-strip--no-icon\\"
+     role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-10\\" aria-labelledby=\\"message-strip-10\\">
   <p class=\\"fd-message-strip__text\\">
     Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
   </p>
-  <button class=\\"fd-button fd-button--transparent fd-button--compact fd-message-strip__close\\" aria-controls=\\"ulr5z216\\" aria-label=\\"Close\\">
+</div>
+
+<br />
+
+<div class=\\"fd-message-strip fd-message-strip--success fd-message-strip--no-icon\\"
+     role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-11\\" aria-labelledby=\\"message-strip-11\\">
+  <p class=\\"fd-message-strip__text\\">
+    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
+  </p>
+</div>
+
+<br />
+
+<div class=\\"fd-message-strip fd-message-strip--warning fd-message-strip--no-icon\\"
+     role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-12\\" aria-labelledby=\\"message-strip-12\\">
+  <p class=\\"fd-message-strip__text\\">
+    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
+  </p>
+</div>
+
+<br />
+
+<div class=\\"fd-message-strip fd-message-strip--error fd-message-strip--no-icon\\"
+     role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-13\\" aria-labelledby=\\"message-strip-13\\">
+  <p class=\\"fd-message-strip__text\\">
+    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
+  </p>
+</div>
+"
+`;
+
+exports[`Check stories > Components/Message Strip > Story Success > Should match snapshot 1`] = `
+"<div class=\\"fd-message-strip fd-message-strip--success fd-message-strip--dismissible\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-3\\" aria-labelledby=\\"message-strip-3\\">
+  <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
+    <span class=\\"sap-icon sap-icon--message-success\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+  </div>
+  <p class=\\"fd-message-strip__text\\">
+    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
+  </p>
+  <button class=\\"fd-button fd-button--transparent fd-button--compact fd-message-strip__close\\" aria-controls=\\"message-strip-3\\" aria-label=\\"Close\\" title=\\"Close\\">
     <i class=\\"sap-icon--decline\\"></i>
   </button>
 </div>
@@ -17751,11 +17956,14 @@ exports[`Check stories > Components/Message Strip > Story Success > Should match
 `;
 
 exports[`Check stories > Components/Message Strip > Story Warning > Should match snapshot 1`] = `
-"<div class=\\"fd-message-strip fd-message-strip--warning fd-message-strip--dismissible\\" role=\\"alert\\" id=\\"fwYq4606\\">
+"<div class=\\"fd-message-strip fd-message-strip--warning fd-message-strip--dismissible\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-4\\" aria-labelledby=\\"message-strip-4\\">
+  <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
+    <span class=\\"sap-icon sap-icon--message-warning\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+  </div>
   <p class=\\"fd-message-strip__text\\">
     Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
   </p>
-  <button class=\\"fd-button fd-button--transparent fd-button--compact fd-message-strip__close\\" aria-controls=\\"fwYq4606\\" aria-label=\\"Close\\">
+  <button class=\\"fd-button fd-button--transparent fd-button--compact fd-message-strip__close\\" aria-controls=\\"message-strip-4\\" aria-label=\\"Close\\" title=\\"Close\\">
     <i class=\\"sap-icon--decline\\"></i>
   </button>
 </div>
@@ -27024,6 +27232,22 @@ exports[`Check stories > Components/StepInput > Story Primary > Should match sna
             fd-button
             fd-button--transparent
             fd-step-input__button\\" onclick=\\"stepInputValue('step-3', 'up');\\" tabindex=\\"-1\\" type=\\"button\\">
+    <i class=\\"sap-icon--add\\"></i>
+  </button>
+</div>
+<label class=\\"fd-form-label\\" for=\\"step-3-focused\\">Focused Step Input</label><br />
+<div class=\\"fd-step-input is-focus\\">
+  <button aria-label=\\"Step down\\" class=\\"
+            fd-button
+            fd-button--transparent
+            fd-step-input__button is-focus\\" onclick=\\"stepInputValue('step-3-focused', 'down');\\" tabindex=\\"-1\\" type=\\"button\\">
+    <i class=\\"sap-icon--less\\"></i>
+  </button>
+  <input class=\\"fd-input fd-input--no-number-spinner fd-step-input__input\\" id=\\"step-3-focused\\" type=\\"number\\" value=\\"0\\" />
+  <button aria-label=\\"Step up\\" class=\\"
+            fd-button
+            fd-button--transparent
+            fd-step-input__button\\" onclick=\\"stepInputValue('step-3-focused', 'up');\\" tabindex=\\"-1\\" type=\\"button\\">
     <i class=\\"sap-icon--add\\"></i>
   </button>
 </div>

--- a/packages/theming-preview/src/semantic-colors.html
+++ b/packages/theming-preview/src/semantic-colors.html
@@ -225,8 +225,8 @@
             </div>
             <div class="fd-panel__content fd-theming__flex fd-theming__flex-column">
     
-                <div class="fd-message-strip fd-message-strip--information fd-message-strip--dismissible fd-theming__margin-bottom-03" 
-                role="alert" id="SsoiW592">
+                <div class="fd-message-strip fd-message-strip--information fd-message-strip--no-icon fd-message-strip--dismissible fd-theming__margin-bottom-03" 
+                role="note" aria-live="assertive" id="SsoiW592" aria-labelledby="SsoiW592">
                     <p class="fd-message-strip__text">
                         Message of type "Information" with icon, close button and <a href="#" class="fd-link" tabindex="0">link</a>
                     </p>
@@ -235,8 +235,8 @@
                     </button>
                 </div>
     
-                <div class="fd-message-strip fd-message-strip--success fd-message-strip--dismissible fd-theming__margin-bottom-03" 
-                    role="alert" id="SsoiW593">
+                <div class="fd-message-strip fd-message-strip--success fd-message-strip--no-icon fd-message-strip--dismissible fd-theming__margin-bottom-03" 
+                    role="note" aria-live="assertive" id="SsoiW593" aria-labelledby="SsoiW593">
                     <p class="fd-message-strip__text">
                         Message of type "Success" with icon, close button and <a href="#" class="fd-link" tabindex="0">link</a>
                     </p>
@@ -245,8 +245,8 @@
                     </button>
                 </div>
     
-                <div class="fd-message-strip fd-message-strip--warning fd-message-strip--dismissible fd-theming__margin-bottom-03" 
-                    role="alert" id="SsoiW594">
+                <div class="fd-message-strip fd-message-strip--warning fd-message-strip--no-icon fd-message-strip--dismissible fd-theming__margin-bottom-03" 
+                    role="note" aria-live="assertive" id="SsoiW594" aria-labelledby="SsoiW594">
                     <p class="fd-message-strip__text">
                         Message of type "Warning" with icon, close button and <a href="#" class="fd-link" tabindex="0">link</a>
                     </p>
@@ -255,8 +255,8 @@
                     </button>
                 </div>
     
-                <div class="fd-message-strip fd-message-strip--error fd-message-strip--dismissible fd-theming__margin-bottom-03" 
-                    role="alert" id="SsoiW595">
+                <div class="fd-message-strip fd-message-strip--error fd-message-strip--no-icon fd-message-strip--dismissible fd-theming__margin-bottom-03" 
+                role="note" aria-live="assertive" id="SsoiW595" aria-labelledby="SsoiW595">
                     <p class="fd-message-strip__text">
                         Message of type "Error" with icon, close button and <a href="#" class="fd-link" tabindex="0">link</a>
                     </p>


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/4383

## Description
- added custom icon
- added custom colors (accent colors)
- text with Link option
- a11y improvements: aria-role is changed, added aria-live, aria-labelledby, etc.

BREAKING CHANGE:
**Markup change:** - the ability to add custom icon required change in the markup. The status icon is no longer added by the modifier class, but is wrapped in a container.

### Before:
```
<div class="fd-message-strip fd-message-strip--information fd-message-strip--dismissible" role="alert">
  <p class="fd-message-strip__text">...</p>
</div>
```

### After:
```
<div class="fd-message-strip fd-message-strip--information fd-message-strip--dismissible" role="note" aria-live="assertive" id="message-strip-2" aria-labelledby="message-strip-2">
  <div class="fd-message-strip__icon-container" aria-hidden="true">
    <span class="sap-icon sap-icon--message-information" focusable="false" role="presentation" aria-hidden="true"></span>
  </div>
  <p class="fd-message-strip__text">...</p>
</div>
```

**New modifier classes:**
- `fd-message-strip--link` - for when the text has a link (The Link inside Message Strip has additional styling.)
- `fd-message-strip--accent-color-*`, where * is a number from 1 to 10. - for custom color

**A11y**
- replaced `aria-role="alert"` with `role="note"`
- added `aria-live="assertive"`, id and aria-labelledby