### PR TITLE
fix(styles): tree item active outline

### DIFF
--- a/packages/styles/src/mixins/tree/_mixins.scss
+++ b/packages/styles/src/mixins/tree/_mixins.scss
@@ -20,7 +20,7 @@ $fd-tree-navigated-box-shadow-rtl: inset 0.1875rem 0 0 0 var(--sapSelectedColor)
   }
 
   @include fd-list-fake-outline() {
-    bottom: 0.625rem;
+    bottom: 0.0625rem;
   }
 
   @include fd-active() {


### PR DESCRIPTION
## Related Issue
Closes none

## Description
Fixed outline bottom offset for active tree item when focused

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://user-images.githubusercontent.com/6586561/234497662-0ec5c7c4-bd37-4905-9a46-ad110352a31f.png)


### After:
![image](https://user-images.githubusercontent.com/6586561/234497698-6dd3a8a8-f578-41af-a537-b764ccac7c78.png)
