### PR TITLE
fix(styles): add option to wrap long label for checkbox and radio button

### DIFF
--- a/packages/styles/src/checkbox.scss
+++ b/packages/styles/src/checkbox.scss
@@ -99,21 +99,35 @@ $block: #{$fd-namespace}-checkbox;
         @include fd-form-radio-checkbox-required-label();
       }
     }
+
+    &--wrap {
+      .#{$block}__label-container {
+        height: auto;
+        white-space: initial;
+      }
+
+      .#{$block}__text {
+        white-space: initial;
+      }
+    }
   }
 
   &__label-container {
     @include fd-reset();
     @include fd-flex-vertical-center();
+    @include fd-ellipsis();
 
-    width: 100%;
     height: 1rem;
     pointer-events: none;
+    max-width: inherit;
   }
 
   &__text {
     @include fd-reset();
     @include fd-ellipsis();
     @include fd-set-margins-x(var(--fdCheckbox_Padding), 0);
+
+    max-width: inherit;
   }
 
   &:checked + .#{$block}__label::before {

--- a/packages/styles/src/radio.scss
+++ b/packages/styles/src/radio.scss
@@ -32,11 +32,11 @@ $block: #{$fd-namespace}-radio;
   &__label {
     @include fd-form-label();
     @include fd-action-cursor();
+    @include fd-ellipsis();
 
     line-height: 1rem;
     display: flex;
     align-items: center;
-    overflow: hidden;
     padding: var(--fdRadio_Outer_Circle_Padding);
     color: var(--sapField_TextColor);
 
@@ -93,6 +93,23 @@ $block: #{$fd-namespace}-radio;
         margin-left: 0;
       }
     }
+
+    &--wrap {
+      .#{$block}__text {
+        white-space: initial;
+      }
+
+      &::after {
+        top: initial;
+      }
+    }
+  }
+
+  &__text {
+    @include fd-reset();
+    @include fd-ellipsis();
+
+    line-height: 1rem;
   }
 
   &:checked + .#{$block}__label::after {

--- a/packages/styles/stories/Components/Forms/checkbox/checkbox.stories.js
+++ b/packages/styles/stories/Components/Forms/checkbox/checkbox.stories.js
@@ -442,3 +442,38 @@ States.parameters = {
         }
     }
 };
+
+export const TextTruncation = () => `
+${localStyles}
+<fieldset class="fd-fieldset">
+    <legend class="fd-fieldset__legend">Truncation Options</legend>
+    <div class="fd-form-group">
+        <div class="fd-form-item">
+            <input type="checkbox" class="fd-checkbox" id="Ai4ez611lw">
+            <label class="fd-checkbox__label" for="Ai4ez611lw" style="max-width: 400px;">
+                <div class="fd-checkbox__label-container">
+                    <span class="fd-checkbox__text">Apple ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. </span>
+                </div>
+            </label>
+        </div>
+        <div class="fd-form-item">
+            <input type="checkbox" class="fd-checkbox" id="Ai4ez612lw" checked>
+            <label class="fd-checkbox__label fd-checkbox__label--wrap" for="Ai4ez612lw" style="max-width: 400px;">
+                <div class="fd-checkbox__label-container">
+                    <span class="fd-checkbox__text">Banana ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</span>
+                </div>
+            </label>
+        </div>
+    </div>
+</fieldset>
+`;
+
+TextTruncation.parameters = {
+    docs: {
+        story: { iframeHeight: 330 },
+        description: {
+            story: `By default, long checkbox label truncates with ellipsis. For this behaviour no modifier class is needed. For checkbox label that wraps on a new line to show the entire content, use \`.fd-checkbox__label--wrap\` modifier class applied with \`.fd-checkbox__label\`. Keep in mind that for this to work <b>max-width</b> should be set on the label.
+        `
+        }
+    }
+};

--- a/packages/styles/stories/Components/Forms/form-fieldset/form-fieldset.stories.js
+++ b/packages/styles/stories/Components/Forms/form-fieldset/form-fieldset.stories.js
@@ -119,19 +119,19 @@ export const RadioButtonGroups = () => `<fieldset class="fd-fieldset" id="radio1
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio" id="pDidh761" name="radio1" checked>
                 <label class="fd-radio__label" for="pDidh761">
-                    Field label
+                    <span class="fd-radio__text">Field label</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio" id="pDidh7612" name="radio1">
                 <label class="fd-radio__label" for="pDidh7612">
-                    Field label
+                    <span class="fd-radio__text">Field label</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio" id="pDidh7613" name="radio1">
                 <label class="fd-radio__label" for="pDidh7613">
-                    Field label
+                    <span class="fd-radio__text">Field label</span>
                 </label>
             </div>
         </div>

--- a/packages/styles/stories/Components/Forms/radio/radio.stories.js
+++ b/packages/styles/stories/Components/Forms/radio/radio.stories.js
@@ -30,19 +30,19 @@ export const Primary = () => `<div style="display:flex;justify-content:space-bet
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio" id="pDidh761" name="radio1" checked>
                 <label class="fd-radio__label" for="pDidh761">
-                    Field label
+                    <span class="fd-radio__text">Field label</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio" id="pDidh7612" name="radio1">
                 <label class="fd-radio__label" for="pDidh7612">
-                    Field label
+                    <span class="fd-radio__text">Field label</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio" id="pDidh764" name="radio3" disabled>
                 <label class="fd-radio__label" for="pDidh764">
-                    Field label (disabled)
+                    <span class="fd-radio__text">Field label (disabled)</span>
                 </label>
             </div>
         </div>
@@ -53,19 +53,19 @@ export const Primary = () => `<div style="display:flex;justify-content:space-bet
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio fd-radio--compact" id="pDidh76111" name="radio2" checked>
                 <label class="fd-radio__label" for="pDidh76111">
-                    Field label
+                    <span class="fd-radio__text">Field label</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio fd-radio--compact" id="pDidh761211" name="radio2">
                 <label class="fd-radio__label" for="pDidh761211">
-                    Field label
+                    <span class="fd-radio__text">Field label</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio fd-radio--compact" id="pDidh76131133" name="radio2" disabled>
                 <label class="fd-radio__label" for="pDidh76131133">
-                    Field label (disabled)
+                    <span class="fd-radio__text">Field label (disabled)</span> 
                 </label>
             </div>
         </div>
@@ -89,19 +89,19 @@ export const Inline = () => `<fieldset class="fd-fieldset" id="radio4">
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio" id="pDidh767" name="radio4" checked>
                 <label class="fd-radio__label" for="pDidh767">
-                    Field label
+                    <span class="fd-radio__text">Field label</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio" id="pDidh7618" name="radio4" >
                 <label class="fd-radio__label" for="pDidh7618">
-                    Field label
+                    <span class="fd-radio__text">Field label</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio" id="pDidh7619" name="radio4">
                 <label class="fd-radio__label" for="pDidh7619">
-                    Field label
+                    <span class="fd-radio__text">Field label</span>
                 </label>
             </div>
         </div>
@@ -129,67 +129,67 @@ export const InteractionStates = () => `<div style="display:flex;justify-content
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio" id="iSpDidh761" name="radio5" checked>
                 <label class="fd-radio__label" for="iSpDidh761">
-                    Default Radio Button
+                    <span class="fd-radio__text">Default Radio Button</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio is-success" id="iSpDidh7612" name="radio5">
                 <label class="fd-radio__label" for="iSpDidh7612">
-                    Success Radio Button
+                    <span class="fd-radio__text">Success Radio Button</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio is-error" id="iSpDidh7613" name="radio5">
                 <label class="fd-radio__label" for="iSpDidh7613">
-                    Error Radio Button
+                    <span class="fd-radio__text">Error Radio Button</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio is-warning" id="iSpDidh7614" name="radio5">
                 <label class="fd-radio__label" for="iSpDidh7614">
-                    Warning Radio Button
+                    <span class="fd-radio__text">Warning Radio Button</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio is-information" id="iSpDidh7615" name="radio5">
                 <label class="fd-radio__label" for="iSpDidh7615">
-                    Information Radio Button
+                    <span class="fd-radio__text">Information Radio Button</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio is-readonly" id="iSpDidh76erfg15" name="radio5" readonly>
                 <label class="fd-radio__label" for="iSpDidh76erfg15">
-                    ReadOnly Radio Button
+                    <span class="fd-radio__text">ReadOnly Radio Button</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio" id="iSpDidh7611" name="radio5" disabled>
                 <label class="fd-radio__label" for="iSpDidh7611">
-                    Disabled Radio Button
+                    <span class="fd-radio__text">Disabled Radio Button</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio is-success" id="iSpDidh76121" name="radio5" disabled>
                 <label class="fd-radio__label" for="iSpDidh76121">
-                    Success Radio Button (disabled)
+                    <span class="fd-radio__text">Success Radio Button (disabled)</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio is-error" id="iSpDidh76131" name="radio5" disabled>
                 <label class="fd-radio__label" for="iSpDidh76131">
-                    Error Radio Button (disabled)
+                    <span class="fd-radio__text">Error Radio Button (disabled)</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio is-warning" id="iSpDidh76141" name="radio5" disabled>
                 <label class="fd-radio__label" for="iSpDidh76141">
-                    Warning Radio Button (disabled)
+                    <span class="fd-radio__text">Warning Radio Button (disabled)</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio is-information" id="iSpDidh76151" name="radio5" disabled>
                 <label class="fd-radio__label" for="iSpDidh76151">
-                    Information Radio Button (disabled)
+                    <span class="fd-radio__text">Information Radio Button (disabled)</span>
                 </label>
             </div>
         </div>
@@ -200,67 +200,67 @@ export const InteractionStates = () => `<div style="display:flex;justify-content
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio fd-radio--compact" id="iSpDidh7619" name="radio6" checked>
                 <label class="fd-radio__label" for="iSpDidh7619">
-                    Default Radio Button
+                    <span class="fd-radio__text">Default Radio Button</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio fd-radio--compact is-success" id="iSpDidh76129" name="radio6">
                 <label class="fd-radio__label" for="iSpDidh76129">
-                    Success Radio Button
+                    <span class="fd-radio__text">Success Radio Button</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio fd-radio--compact is-error" id="iSpDidh76139" name="radio6">
                 <label class="fd-radio__label" for="iSpDidh76139">
-                    Error Radio Button
+                    <span class="fd-radio__text">Error Radio Button</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio fd-radio--compact is-warning" id="iSpDidh76149" name="radio6">
                 <label class="fd-radio__label" for="iSpDidh76149">
-                    Warning Radio Button
+                    <span class="fd-radio__text">Warning Radio Button</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio fd-radio--compact is-information" id="iSpDidh76159" name="radio6">
                 <label class="fd-radio__label" for="iSpDidh76159">
-                    Information Radio Button
+                    <span class="fd-radio__text">Information Radio Button</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio fd-radio--compact is-readonly" id="iSpDidh76erfg15fe" name="radio5" readonly>
                 <label class="fd-radio__label" for="iSpDidh76erfg15fe">
-                    ReadOnly Radio Button
+                    <span class="fd-radio__text">ReadOnly Radio Button</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio fd-radio--compact" id="iSpDidh76193" name="radio6" disabled>
                 <label class="fd-radio__label" for="iSpDidh76193">
-                    Radio Button (disabled)
+                    <span class="fd-radio__text">Radio Button (disabled)</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio fd-radio--compact is-success" id="iSpDidh761293" name="radio6" disabled>
                 <label class="fd-radio__label" for="iSpDidh761293">
-                    Success Radio Button (disabled)
+                    <span class="fd-radio__text">Success Radio Button (disabled)</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio fd-radio--compact is-error" id="iSpDidh761393" name="radio6" disabled>
                 <label class="fd-radio__label" for="iSpDidh761393">
-                    Error Radio Button (disabled)
+                    <span class="fd-radio__text">Error Radio Button (disabled)</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio fd-radio--compact is-warning" id="iSpDidh761493" name="radio6" disabled>
                 <label class="fd-radio__label" for="iSpDidh761493">
-                    Warning Radio Button (disabled)
+                    <span class="fd-radio__text">Warning Radio Button (disabled)</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio fd-radio--compact is-information" id="iSpDidh761593" name="radio6" disabled>
                 <label class="fd-radio__label" for="iSpDidh761593">
-                    Information Radio Button (disabled)
+                    <span class="fd-radio__text">Information Radio Button (disabled)</span>
                 </label>
             </div>
         </div>
@@ -273,6 +273,62 @@ InteractionStates.parameters = {
         story: { iframeHeight: 550 },
         description: {
             story: 'A radio button can have different states that affect its appearance value states, such as “error” or “warning”, which are indicated using semantic colors'
+        }
+    }
+};
+
+export const TextTruncation = () => `<div style="display:flex;justify-content:space-between">
+    <fieldset class="fd-fieldset" id="radio1Truncation">
+        <legend class="fd-fieldset__legend">Radio Buttons Cozy Mode</legend>
+        <div class="fd-form__group">
+            <div class="fd-form-item">
+                <input type="radio" class="fd-radio" id="pDidh761tt" name="radio1Truncation" checked>
+                <label class="fd-radio__label" for="pDidh761tt" style="max-width: 400px;">
+                   <span class="fd-radio__text">
+                    Field label  ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                   </span>
+                </label>
+            </div>
+            <div class="fd-form-item">
+                <input type="radio" class="fd-radio" id="pDidh7612tt" name="radio1Truncation">
+                <label class="fd-radio__label fd-radio__label--wrap" for="pDidh7612tt" style="max-width: 400px;">
+                    <span class="fd-radio__text">
+                        Field label  ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                    </span>
+                </label>
+            </div>
+        </div>
+    </fieldset>
+
+    <fieldset class="fd-fieldset is-compact" id="radio2Truncation">
+        <legend class="fd-fieldset__legend">Radio Buttons Compact Mode</legend>
+        <div class="fd-form__group">
+            <div class="fd-form-item">
+                <input type="radio" class="fd-radio" id="pDidh761tt2" name="radio2Truncation" checked>
+                <label class="fd-radio__label" for="pDidh761tt2" style="max-width: 400px;">
+                   <span class="fd-radio__text">
+                    Field label  ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                   </span>
+                </label>
+            </div>
+            <div class="fd-form-item">
+                <input type="radio" class="fd-radio" id="pDidh7612tt2" name="radio2Truncation">
+                <label class="fd-radio__label fd-radio__label--wrap" for="pDidh7612tt2" style="max-width: 400px;">
+                    <span class="fd-radio__text">
+                        Field label  ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                    </span>
+                </label>
+            </div>
+        </div>
+    </fieldset>
+</div>
+`;
+
+TextTruncation.parameters = {
+    docs: {
+        story: { iframeHeight: 250 },
+        description: {
+            story: `By default, long radio label truncates with ellipsis. For this behaviour no modifier class is needed. For radio label that wraps on a new line to show the entire content, use \`.fd-radio__label--wrap\` modifier class applied with \`.fd-radio__label\`. Keep in mind that for this to work <b>max-width</b> should be set on the label.`
         }
     }
 };

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -6620,6 +6620,39 @@ exports[`Check stories > Components/Forms/Checkbox > Story States > Should match
 "
 `;
 
+exports[`Check stories > Components/Forms/Checkbox > Story TextTruncation > Should match snapshot 1`] = `
+"
+
+<style>
+    .checkbox-example-container > fieldset {
+        max-width: 100%;
+    }
+</style>
+
+<fieldset class=\\"fd-fieldset\\">
+    <legend class=\\"fd-fieldset__legend\\">Truncation Options</legend>
+    <div class=\\"fd-form-group\\">
+        <div class=\\"fd-form-item\\">
+            <input type=\\"checkbox\\" class=\\"fd-checkbox\\" id=\\"Ai4ez611lw\\">
+            <label class=\\"fd-checkbox__label\\" for=\\"Ai4ez611lw\\" style=\\"max-width: 400px;\\">
+                <div class=\\"fd-checkbox__label-container\\">
+                    <span class=\\"fd-checkbox__text\\">Apple ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. </span>
+                </div>
+            </label>
+        </div>
+        <div class=\\"fd-form-item\\">
+            <input type=\\"checkbox\\" class=\\"fd-checkbox\\" id=\\"Ai4ez612lw\\" checked>
+            <label class=\\"fd-checkbox__label fd-checkbox__label--wrap\\" for=\\"Ai4ez612lw\\" style=\\"max-width: 400px;\\">
+                <div class=\\"fd-checkbox__label-container\\">
+                    <span class=\\"fd-checkbox__text\\">Banana ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</span>
+                </div>
+            </label>
+        </div>
+    </div>
+</fieldset>
+"
+`;
+
 exports[`Check stories > Components/Forms/Field Set > Story CheckboxGroups > Should match snapshot 1`] = `
 "
     <fieldset class=\\"fd-fieldset\\">
@@ -9589,19 +9622,19 @@ exports[`Check stories > Components/Forms/Radio > Story Inline > Should match sn
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio\\" id=\\"pDidh767\\" name=\\"radio4\\" checked>
                 <label class=\\"fd-radio__label\\" for=\\"pDidh767\\">
-                    Field label
+                    <span class=\\"fd-radio__text\\">Field label</span>
                 </label>
             </div>
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio\\" id=\\"pDidh7618\\" name=\\"radio4\\" >
                 <label class=\\"fd-radio__label\\" for=\\"pDidh7618\\">
-                    Field label
+                    <span class=\\"fd-radio__text\\">Field label</span>
                 </label>
             </div>
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio\\" id=\\"pDidh7619\\" name=\\"radio4\\">
                 <label class=\\"fd-radio__label\\" for=\\"pDidh7619\\">
-                    Field label
+                    <span class=\\"fd-radio__text\\">Field label</span>
                 </label>
             </div>
         </div>
@@ -9617,67 +9650,67 @@ exports[`Check stories > Components/Forms/Radio > Story InteractionStates > Shou
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio\\" id=\\"iSpDidh761\\" name=\\"radio5\\" checked>
                 <label class=\\"fd-radio__label\\" for=\\"iSpDidh761\\">
-                    Default Radio Button
+                    <span class=\\"fd-radio__text\\">Default Radio Button</span>
                 </label>
             </div>
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio is-success\\" id=\\"iSpDidh7612\\" name=\\"radio5\\">
                 <label class=\\"fd-radio__label\\" for=\\"iSpDidh7612\\">
-                    Success Radio Button
+                    <span class=\\"fd-radio__text\\">Success Radio Button</span>
                 </label>
             </div>
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio is-error\\" id=\\"iSpDidh7613\\" name=\\"radio5\\">
                 <label class=\\"fd-radio__label\\" for=\\"iSpDidh7613\\">
-                    Error Radio Button
+                    <span class=\\"fd-radio__text\\">Error Radio Button</span>
                 </label>
             </div>
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio is-warning\\" id=\\"iSpDidh7614\\" name=\\"radio5\\">
                 <label class=\\"fd-radio__label\\" for=\\"iSpDidh7614\\">
-                    Warning Radio Button
+                    <span class=\\"fd-radio__text\\">Warning Radio Button</span>
                 </label>
             </div>
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio is-information\\" id=\\"iSpDidh7615\\" name=\\"radio5\\">
                 <label class=\\"fd-radio__label\\" for=\\"iSpDidh7615\\">
-                    Information Radio Button
+                    <span class=\\"fd-radio__text\\">Information Radio Button</span>
                 </label>
             </div>
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio is-readonly\\" id=\\"iSpDidh76erfg15\\" name=\\"radio5\\" readonly>
                 <label class=\\"fd-radio__label\\" for=\\"iSpDidh76erfg15\\">
-                    ReadOnly Radio Button
+                    <span class=\\"fd-radio__text\\">ReadOnly Radio Button</span>
                 </label>
             </div>
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio\\" id=\\"iSpDidh7611\\" name=\\"radio5\\" disabled>
                 <label class=\\"fd-radio__label\\" for=\\"iSpDidh7611\\">
-                    Disabled Radio Button
+                    <span class=\\"fd-radio__text\\">Disabled Radio Button</span>
                 </label>
             </div>
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio is-success\\" id=\\"iSpDidh76121\\" name=\\"radio5\\" disabled>
                 <label class=\\"fd-radio__label\\" for=\\"iSpDidh76121\\">
-                    Success Radio Button (disabled)
+                    <span class=\\"fd-radio__text\\">Success Radio Button (disabled)</span>
                 </label>
             </div>
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio is-error\\" id=\\"iSpDidh76131\\" name=\\"radio5\\" disabled>
                 <label class=\\"fd-radio__label\\" for=\\"iSpDidh76131\\">
-                    Error Radio Button (disabled)
+                    <span class=\\"fd-radio__text\\">Error Radio Button (disabled)</span>
                 </label>
             </div>
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio is-warning\\" id=\\"iSpDidh76141\\" name=\\"radio5\\" disabled>
                 <label class=\\"fd-radio__label\\" for=\\"iSpDidh76141\\">
-                    Warning Radio Button (disabled)
+                    <span class=\\"fd-radio__text\\">Warning Radio Button (disabled)</span>
                 </label>
             </div>
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio is-information\\" id=\\"iSpDidh76151\\" name=\\"radio5\\" disabled>
                 <label class=\\"fd-radio__label\\" for=\\"iSpDidh76151\\">
-                    Information Radio Button (disabled)
+                    <span class=\\"fd-radio__text\\">Information Radio Button (disabled)</span>
                 </label>
             </div>
         </div>
@@ -9688,67 +9721,67 @@ exports[`Check stories > Components/Forms/Radio > Story InteractionStates > Shou
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio fd-radio--compact\\" id=\\"iSpDidh7619\\" name=\\"radio6\\" checked>
                 <label class=\\"fd-radio__label\\" for=\\"iSpDidh7619\\">
-                    Default Radio Button
+                    <span class=\\"fd-radio__text\\">Default Radio Button</span>
                 </label>
             </div>
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio fd-radio--compact is-success\\" id=\\"iSpDidh76129\\" name=\\"radio6\\">
                 <label class=\\"fd-radio__label\\" for=\\"iSpDidh76129\\">
-                    Success Radio Button
+                    <span class=\\"fd-radio__text\\">Success Radio Button</span>
                 </label>
             </div>
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio fd-radio--compact is-error\\" id=\\"iSpDidh76139\\" name=\\"radio6\\">
                 <label class=\\"fd-radio__label\\" for=\\"iSpDidh76139\\">
-                    Error Radio Button
+                    <span class=\\"fd-radio__text\\">Error Radio Button</span>
                 </label>
             </div>
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio fd-radio--compact is-warning\\" id=\\"iSpDidh76149\\" name=\\"radio6\\">
                 <label class=\\"fd-radio__label\\" for=\\"iSpDidh76149\\">
-                    Warning Radio Button
+                    <span class=\\"fd-radio__text\\">Warning Radio Button</span>
                 </label>
             </div>
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio fd-radio--compact is-information\\" id=\\"iSpDidh76159\\" name=\\"radio6\\">
                 <label class=\\"fd-radio__label\\" for=\\"iSpDidh76159\\">
-                    Information Radio Button
+                    <span class=\\"fd-radio__text\\">Information Radio Button</span>
                 </label>
             </div>
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio fd-radio--compact is-readonly\\" id=\\"iSpDidh76erfg15fe\\" name=\\"radio5\\" readonly>
                 <label class=\\"fd-radio__label\\" for=\\"iSpDidh76erfg15fe\\">
-                    ReadOnly Radio Button
+                    <span class=\\"fd-radio__text\\">ReadOnly Radio Button</span>
                 </label>
             </div>
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio fd-radio--compact\\" id=\\"iSpDidh76193\\" name=\\"radio6\\" disabled>
                 <label class=\\"fd-radio__label\\" for=\\"iSpDidh76193\\">
-                    Radio Button (disabled)
+                    <span class=\\"fd-radio__text\\">Radio Button (disabled)</span>
                 </label>
             </div>
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio fd-radio--compact is-success\\" id=\\"iSpDidh761293\\" name=\\"radio6\\" disabled>
                 <label class=\\"fd-radio__label\\" for=\\"iSpDidh761293\\">
-                    Success Radio Button (disabled)
+                    <span class=\\"fd-radio__text\\">Success Radio Button (disabled)</span>
                 </label>
             </div>
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio fd-radio--compact is-error\\" id=\\"iSpDidh761393\\" name=\\"radio6\\" disabled>
                 <label class=\\"fd-radio__label\\" for=\\"iSpDidh761393\\">
-                    Error Radio Button (disabled)
+                    <span class=\\"fd-radio__text\\">Error Radio Button (disabled)</span>
                 </label>
             </div>
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio fd-radio--compact is-warning\\" id=\\"iSpDidh761493\\" name=\\"radio6\\" disabled>
                 <label class=\\"fd-radio__label\\" for=\\"iSpDidh761493\\">
-                    Warning Radio Button (disabled)
+                    <span class=\\"fd-radio__text\\">Warning Radio Button (disabled)</span>
                 </label>
             </div>
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio fd-radio--compact is-information\\" id=\\"iSpDidh761593\\" name=\\"radio6\\" disabled>
                 <label class=\\"fd-radio__label\\" for=\\"iSpDidh761593\\">
-                    Information Radio Button (disabled)
+                    <span class=\\"fd-radio__text\\">Information Radio Button (disabled)</span>
                 </label>
             </div>
         </div>
@@ -9765,19 +9798,19 @@ exports[`Check stories > Components/Forms/Radio > Story Primary > Should match s
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio\\" id=\\"pDidh761\\" name=\\"radio1\\" checked>
                 <label class=\\"fd-radio__label\\" for=\\"pDidh761\\">
-                    Field label
+                    <span class=\\"fd-radio__text\\">Field label</span>
                 </label>
             </div>
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio\\" id=\\"pDidh7612\\" name=\\"radio1\\">
                 <label class=\\"fd-radio__label\\" for=\\"pDidh7612\\">
-                    Field label
+                    <span class=\\"fd-radio__text\\">Field label</span>
                 </label>
             </div>
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio\\" id=\\"pDidh764\\" name=\\"radio3\\" disabled>
                 <label class=\\"fd-radio__label\\" for=\\"pDidh764\\">
-                    Field label (disabled)
+                    <span class=\\"fd-radio__text\\">Field label (disabled)</span>
                 </label>
             </div>
         </div>
@@ -9788,19 +9821,68 @@ exports[`Check stories > Components/Forms/Radio > Story Primary > Should match s
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio fd-radio--compact\\" id=\\"pDidh76111\\" name=\\"radio2\\" checked>
                 <label class=\\"fd-radio__label\\" for=\\"pDidh76111\\">
-                    Field label
+                    <span class=\\"fd-radio__text\\">Field label</span>
                 </label>
             </div>
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio fd-radio--compact\\" id=\\"pDidh761211\\" name=\\"radio2\\">
                 <label class=\\"fd-radio__label\\" for=\\"pDidh761211\\">
-                    Field label
+                    <span class=\\"fd-radio__text\\">Field label</span>
                 </label>
             </div>
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio fd-radio--compact\\" id=\\"pDidh76131133\\" name=\\"radio2\\" disabled>
                 <label class=\\"fd-radio__label\\" for=\\"pDidh76131133\\">
-                    Field label (disabled)
+                    <span class=\\"fd-radio__text\\">Field label (disabled)</span> 
+                </label>
+            </div>
+        </div>
+    </fieldset>
+</div>
+"
+`;
+
+exports[`Check stories > Components/Forms/Radio > Story TextTruncation > Should match snapshot 1`] = `
+"<div style=\\"display:flex;justify-content:space-between\\">
+    <fieldset class=\\"fd-fieldset\\" id=\\"radio1Truncation\\">
+        <legend class=\\"fd-fieldset__legend\\">Radio Buttons Cozy Mode</legend>
+        <div class=\\"fd-form__group\\">
+            <div class=\\"fd-form-item\\">
+                <input type=\\"radio\\" class=\\"fd-radio\\" id=\\"pDidh761tt\\" name=\\"radio1Truncation\\" checked>
+                <label class=\\"fd-radio__label\\" for=\\"pDidh761tt\\" style=\\"max-width: 400px;\\">
+                   <span class=\\"fd-radio__text\\">
+                    Field label  ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                   </span>
+                </label>
+            </div>
+            <div class=\\"fd-form-item\\">
+                <input type=\\"radio\\" class=\\"fd-radio\\" id=\\"pDidh7612tt\\" name=\\"radio1Truncation\\">
+                <label class=\\"fd-radio__label fd-radio__label--wrap\\" for=\\"pDidh7612tt\\" style=\\"max-width: 400px;\\">
+                    <span class=\\"fd-radio__text\\">
+                        Field label  ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                    </span>
+                </label>
+            </div>
+        </div>
+    </fieldset>
+
+    <fieldset class=\\"fd-fieldset is-compact\\" id=\\"radio2Truncation\\">
+        <legend class=\\"fd-fieldset__legend\\">Radio Buttons Compact Mode</legend>
+        <div class=\\"fd-form__group\\">
+            <div class=\\"fd-form-item\\">
+                <input type=\\"radio\\" class=\\"fd-radio\\" id=\\"pDidh761tt2\\" name=\\"radio2Truncation\\" checked>
+                <label class=\\"fd-radio__label\\" for=\\"pDidh761tt2\\" style=\\"max-width: 400px;\\">
+                   <span class=\\"fd-radio__text\\">
+                    Field label  ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                   </span>
+                </label>
+            </div>
+            <div class=\\"fd-form-item\\">
+                <input type=\\"radio\\" class=\\"fd-radio\\" id=\\"pDidh7612tt2\\" name=\\"radio2Truncation\\">
+                <label class=\\"fd-radio__label fd-radio__label--wrap\\" for=\\"pDidh7612tt2\\" style=\\"max-width: 400px;\\">
+                    <span class=\\"fd-radio__text\\">
+                        Field label  ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                    </span>
                 </label>
             </div>
         </div>


### PR DESCRIPTION
## Related Issue
Closes none

## Description
By default, long checkbox and radio button labels should truncate with ellipsis. Currently this behaviour is not working (a bug). For checkbox the fix was easy, achieved only with css. 
For radio button the fix required breaking changes as the label is a flex container and in order for the ellipsis to work on the text, the text should be wrapped in an element. 
For more information regarding this flex issue please check: https://stackoverflow.com/questions/51351137/css-text-overflow-ellipsis-not-working-in-grid-flex

- added modifier class to the label to allow text wrap on a new line to chow the whole text: `fd-checkbox__label--wrap` and `fd-radio__label--wrap`

BREAKING CHANGE:
Radio Button: added a child element for the label.

**Before:**
```
<div class="fd-form-item">
    <input type="radio" class="fd-radio" id="radio1" name="radio1">
    <label class="fd-radio__label" for="radio1">
         Text
     </label>
</div>
```

**After:**
```
<div class="fd-form-item">
    <input type="radio" class="fd-radio" id="radio1" name="radio1">
    <label class="fd-radio__label" for="radio1">
         <span class="fd-radio__text">Text</span>
     </label>
</div>
```
