### PR TITLE
fix(styles): fix the issue with border bottom of Panel header 

### DIFF
--- a/packages/styles/src/panel.scss
+++ b/packages/styles/src/panel.scss
@@ -24,6 +24,7 @@ $block: #{$fd-namespace}-panel;
   }
 
   &__header {
+    overflow: hidden;
     height: var(--fdPanel_Header_Height);
     min-height: var(--fdPanel_Header_Height);
     padding-right: $fd-panel-header-right-padding;


### PR DESCRIPTION


## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/4542

## Description
- checked the latest design changes: no updates needed. We have addressed the changes (paddings of the expanded content) in the previous Panel refactoring. 
- noticed a small bug with the elements overlapping, resulting in Panel border bottom being cut and fixed it.

## Screenshots

### Before:
<img width="653" alt="Screenshot 2023-05-24 at 12 55 46 PM" src="https://github.com/SAP/fundamental-styles/assets/39598672/e3e73665-410c-44bb-bcf8-ef5932555732">
<img width="635" alt="Screenshot 2023-05-24 at 12 55 41 PM" src="https://github.com/SAP/fundamental-styles/assets/39598672/161cb579-e321-4810-9c51-47f629dee61b">



### After:
<img width="729" alt="Screenshot 2023-05-24 at 12 55 14 PM" src="https://github.com/SAP/fundamental-styles/assets/39598672/95ade1b0-fa74-4b6e-af6a-99b3d8093698">

