### PR TITLE
fix(styles): remove popover --static class, no longer needed

### DIFF
--- a/packages/styles/src/popover.scss
+++ b/packages/styles/src/popover.scss
@@ -344,14 +344,6 @@ $fd-popover-arrow-offset-x: calc(var(--fdIcon_Button_Width) * 0.5 - #{$fd-popove
       }
     }
 
-    // For NGX where we manage positioning with Material Overlay CDK but not CSS
-    &--static {
-      position: relative;
-
-      --fdPopover_Offset: 0%;
-      --fdPopover_Center_Offset: 0%;
-    }
-
     &[aria-hidden="true"],
     &.is-hidden {
       z-index: -1;


### PR DESCRIPTION
fixes none, part of https://github.com/SAP/fundamental-ngx/pull/9924

Removes a class that is no longer needed in NGX and was unused in styles