### PR TITLE
fix(styles): address design review comments regarding Horizon 2023 

### DIFF
--- a/.storybook/static/preview-head.js
+++ b/.storybook/static/preview-head.js
@@ -139,7 +139,7 @@
         }
 
         //set the indeterminate state of checkbox - tristate for checkbox examples
-        var triStateCheckboxes = ['Ai4ez613', 'Ai4ez613i1', 'Ai4ez613i2', 'Ai4ez613i3', 'Ai4ez613i4', 'Ai4ez613i5', 'Ai4ez613i6', 'Ai4ez613i7', 'Ai4ez643', 'Ai4ez613c', 'Ai4ez643c', 'Ai4ez1'];
+        var triStateCheckboxes = ['Ai4ez613', 'Ai4ez613i1', 'Ai4ez613i2', 'Ai4ez613i3', 'Ai4ez613i4', 'Ai4ez613i5', 'Ai4ez613i6', 'Ai4ez613i7', 'Ai4ez643', 'Ai4ez613c', 'Ai4ez643c', 'Ai4ez1', 'Ai4ez613i6cc'];
         for (var i = 0; i < triStateCheckboxes.length; i++) {
             const triStateCheckbox = document.getElementById(triStateCheckboxes[i]);
             if (triStateCheckbox) {

--- a/packages/styles/src/checkbox.scss
+++ b/packages/styles/src/checkbox.scss
@@ -86,6 +86,7 @@ $block: #{$fd-namespace}-checkbox;
         --fdCheckbox_Inner_Border_Style: var(--fdCheckbox_Inner_Border_Style_Default_Hover);
         --fdCheckbox_Inner_Border_Color: var(--fdCheckbox_Inner_Border_Color_Default_Hover);
         --fdCheckbox_Check_Mark_Color: var(--fdCheckbox_Check_Mark_Color_Default_Hover);
+        --fdCheckbox_Hover_Background_Color: var(--fdCheckbox_Background_Color_Default_Hover);
       }
     }
 
@@ -108,6 +109,19 @@ $block: #{$fd-namespace}-checkbox;
 
       .#{$block}__text {
         white-space: initial;
+      }
+
+      &-top-aligned {
+        align-items: flex-start;
+
+        .#{$block}__label-container {
+          height: auto;
+          white-space: initial;
+        }
+
+        .#{$block}__text {
+          white-space: initial;
+        }
       }
     }
   }
@@ -204,6 +218,7 @@ $block: #{$fd-namespace}-checkbox;
       --fdCheckbox_Inner_Border_Style: var(--fdCheckbox_Inner_Border_Style_ReadOnly);
       --fdCheckbox_Inner_Border_Color: var(--fdCheckbox_Inner_Border_Color_ReadOnly);
       --fdCheckbox_Check_Mark_Color: var(--fdCheckbox_Check_Mark_Color_ReadOnly);
+      --fdCheckbox_Hover_Background_Color: var(--fdCheckbox_Background_Color_ReadOnly);
     }
   }
 

--- a/packages/styles/src/message-popover.scss
+++ b/packages/styles/src/message-popover.scss
@@ -100,15 +100,19 @@ $fd-trigger-states: (
     text-shadow: var(--fdButtonTextShadow);
     border-width: var(--fdMessagePopover_Trigger_Border_Width);
 
-    @include fd-focus() {
-      &::after {
-        border-color: var(--fdButtonFocusColor);
-      }
-    }
-
     @each $state, $colors in $fd-trigger-states {
       &.#{$block}__trigger--#{$state} {
         @include _fd-message-popover-trigger($colors, "regular");
+
+        @include fd-focus() {
+          &::after {
+            border-color: var(--fdButtonFocusColor);
+          }
+        }
+
+        @if $state == "information" {
+          --fdButtonFocusColor: var(--fdMessagePopover_Information_Focus_Outline_Color);
+        }
 
         @include fd-hover() {
           @include _fd-message-popover-trigger($colors, "hover");
@@ -125,10 +129,6 @@ $fd-trigger-states: (
 
           pointer-events: none;
           opacity: var(--sapContent_DisabledOpacity);
-        }
-
-        @if $state == "information" {
-          --fdButtonFocusColor: var(--fdMessagePopover_Information_Focus_Outline_Color);
         }
       }
     }

--- a/packages/styles/src/mixins/_forms.scss
+++ b/packages/styles/src/mixins/_forms.scss
@@ -98,6 +98,7 @@ $fd-input-field-height--compact: 1.625rem;
 }
 
 @mixin fd-input-readonly() {
+  box-shadow: none;
   border-color: var(--sapField_ReadOnly_BorderColor);
   background: var(--sapField_ReadOnly_BackgroundStyle);
   background-color: var(--sapField_ReadOnly_Background);

--- a/packages/styles/src/radio.scss
+++ b/packages/styles/src/radio.scss
@@ -52,7 +52,6 @@ $block: #{$fd-namespace}-radio;
     &::after {
       @include fd-square(var(--fdRadio_Inner_Content_Size));
 
-      top: var(--fdRadio_Inner_Content_Padding);
       left: var(--fdRadio_Inner_Content_Padding);
     }
 
@@ -99,8 +98,16 @@ $block: #{$fd-namespace}-radio;
         white-space: initial;
       }
 
-      &::after {
-        top: initial;
+      &-top-aligned {
+        align-items: flex-start;
+
+        .#{$block}__text {
+          white-space: initial;
+        }
+
+        &::after {
+          top: var(--fdRadio_Inner_Content_Padding);
+        }
       }
     }
   }
@@ -108,8 +115,6 @@ $block: #{$fd-namespace}-radio;
   &__text {
     @include fd-reset();
     @include fd-ellipsis();
-
-    line-height: 1rem;
   }
 
   &:checked + .#{$block}__label::after {
@@ -172,6 +177,7 @@ $block: #{$fd-namespace}-radio;
       --fdRadio_Inner_Border_Style: var(--fdRadio_Inner_Border_Style_ReadOnly);
       --fdRadio_Inner_Border_Color: var(--fdRadio_Inner_Border_Color_ReadOnly);
       --fdRadio_Active_Dot_Color: var(--fdRadio_Active_Dot_Color_ReadOnly);
+      --fdRadio_Hover_Background_Color: var(--fdRadio_Background_Color_ReadOnly);
     }
   }
 

--- a/packages/styles/src/slider.scss
+++ b/packages/styles/src/slider.scss
@@ -175,7 +175,6 @@ $slider-side-padding: calc((var(--fdSlider_Handle_Width) * 0.5) + #{$handle-outl
     border-radius: var(--fdSlider_Handle_Border_Radius);
     background-color: var(--fdSlider_Handle_Background);
     border: var(--fdSlider_Handle_Border);
-    box-shadow: var(--fdSlider_Handle_Box_Shadow);
     z-index: 3;
 
     &::before {
@@ -198,23 +197,44 @@ $slider-side-padding: calc((var(--fdSlider_Handle_Width) * 0.5) + #{$handle-outl
     }
 
     @include fd-focus() {
-      outline: $handle-outline-width var(--sapContent_FocusStyle) var(--fdSlider_Focus_Handle_Outline_Color);
-      outline-offset: $handle-outline-offset;
-      border: var(--fdSlider_Hover_Handle_Border);
-      background-color: var(--fdSlider_Active_Handle_Background);
+      outline: none;
+      background-color: var(--fdSlider_Focus_Handle_Background);
+      border: var(--fdSlider_Focus_Handle_Border);
+
+      &::after {
+        display: none;
+      }
     }
 
     @include fd-hover() {
       border-color: var(--fdSlider_Handle_Border_Hover_Color);
       background-color: var(--fdSlider_Hover_Handle_Background);
       border: var(--fdSlider_Hover_Handle_Border);
-      box-shadow: var(--fdSlider_Hover_Handle_Box_Shadow);
+
+      @include fd-focus() {
+        outline: none;
+        background-color: var(--fdSlider_Focus_Handle_Background);
+        border: var(--fdSlider_Focus_Handle_Border);
+
+        &::after {
+          display: none;
+        }
+      }
     }
 
     @include fd-active() {
       background-color: var(--fdSlider_Active_Handle_Background);
       border: var(--fdSlider_Active_Handle_Border);
-      box-shadow: var(--fdSlider_Active_Handle_Box_Shadow);
+
+      @include fd-focus() {
+        outline: none;
+        background-color: var(--fdSlider_Focus_Handle_Background);
+        border: var(--fdSlider_Focus_Handle_Border);
+
+        &::after {
+          display: none;
+        }
+      }
     }
   }
 
@@ -228,7 +248,7 @@ $slider-side-padding: calc((var(--fdSlider_Handle_Width) * 0.5) + #{$handle-outl
     left: 0;
     right: 0;
     margin: 0 $focus-range-side-margin;
-    border-radius: 0.5rem;
+    border-radius: var(--fdSlider_Range_Track_Border_Radius);
 
     @include fd-focus() {
       outline: var(--fdSlider_Focus_Range_Outline);
@@ -245,31 +265,27 @@ $slider-side-padding: calc((var(--fdSlider_Handle_Width) * 0.5) + #{$handle-outl
       .#{$block}__handle {
         background-color: var(--fdSlider_Range_Handle_Background);
         border: var(--fdSlider_Range_Handle_Border);
-        box-shadow: var(--fdSlider_Range_Handle_Box_Shadow);
 
         @include fd-hover() {
           background-color: var(--fdSlider_Range_Hover_Handle_Background);
           border-color: var(--fdSlider_Range_Hover_Handle_Border_Color);
-          box-shadow: var(--fdSlider_Range_Hover_Handle_Box_Shadow);
         }
 
         @include fd-active() {
           background-color: var(--fdSlider_Range_Active_Handle_Background);
           border-color: var(--fdSlider_Range_Active_Handle_Border_Color);
-          box-shadow: var(--fdSlider_Range_Active_Handle_Box_Shadow);
 
           &::after {
-            display: none;
+            display: var(--fdSlider_Focus_Handle_Display);
           }
         }
 
         @include fd-focus() {
           background-color: var(--fdSlider_Range_Focus_Handle_Background);
           border: var(--fdSlider_Range_Focus_Handle_Border);
-          box-shadow: var(--fdSlider_Range_Focus_Handle_Box_Shadow);
 
           &::after {
-            display: none;
+            display: var(--fdSlider_Focus_Handle_Display);
           }
         }
       }

--- a/packages/styles/src/textarea.scss
+++ b/packages/styles/src/textarea.scss
@@ -26,14 +26,26 @@ $block: #{$fd-namespace}-textarea;
 
   &[readonly],
   &.is-readonly {
-    font-size: var(--sapFontSmallSize);
+    box-shadow: none;
     color: var(--sapField_TextColor);
+    font-size: var(--sapFontSmallSize);
+    background: var(--sapField_ReadOnly_Background);
     border-radius: var(--sapField_BorderCornerRadius);
-    background-color: var(--sapField_ReadOnly_Background);
+    border: var(--sapField_BorderWidth) dashed var(--sapField_ReadOnly_BorderColor);
+
+    @include fd-hover() {
+      background: var(--sapField_ReadOnly_Background);
+    }
+
+    @include fd-focus() {
+      outline-offset: -0.25rem;
+      background: var(--sapField_ReadOnly_Background);
+    }
   }
 
   &::-webkit-scrollbar-track,
   &::-webkit-scrollbar-corner {
+    background: transparent;
     border-radius: 0 var(--sapField_BorderCornerRadius) var(--sapField_BorderCornerRadius) 0 !important;
   }
 

--- a/packages/styles/src/theming/common/slider/_sap_fiori.scss
+++ b/packages/styles/src/theming/common/slider/_sap_fiori.scss
@@ -16,7 +16,6 @@
   --fdSlider_Handle_Height: var(--fdSlider_Handle_Width);
   --fdSlider_Handle_Border: 0.125rem solid var(--sapField_BorderColor);
   --fdSlider_Handle_Border_Hover_Color: var(--sapButton_Hover_BorderColor);
-  --fdSlider_Handle_Box_Shadow: none;
   --fdSlider_Handle_Active_Width: 2rem;
   --fdSlider_Handle_Active_Height: 2rem;
   --fdSlider_Handle_Icon_Display: none;
@@ -28,32 +27,32 @@
 
   // Slider Handle Hover
   --fdSlider_Hover_Handle_Background: var(--sapButton_Hover_Background);
-  --fdSlider_Hover_Handle_Box_Shadow: none;
   --fdSlider_Hover_Handle_Border: 0.125rem solid var(--sapButton_Hover_BorderColor);
 
   // Slider Handle Active
   --fdSlider_Active_Handle_Background: var(--sapButton_Active_Background);
-  --fdSlider_Active_Handle_Box_Shadow: none;
+
+  // Slider Handle Focus
+  --fdSlider_Focus_Handle_Background: var(--sapButton_Active_Background);
+  --fdSlider_Focus_Handle_Border: var(--sapContent_FocusWidth) solid var(--sapButton_Active_BorderColor);
+  --fdSlider_Focus_Handle_Display: none;
 
   // Slider Range Handle
   --fdSlider_Range_Handle_Background: transparent;
   --fdSlider_Range_Handle_Border: solid 0.125rem var(--sapField_BorderColor);
-  --fdSlider_Range_Handle_Box_Shadow: none;
 
   // Slider Range Handle Hover
   --fdSlider_Range_Hover_Handle_Background: transparent;
   --fdSlider_Range_Hover_Handle_Border_Color: var(--sapButton_Hover_BorderColor);
-  --fdSlider_Range_Hover_Handle_Box_Shadow: none;
 
   // Slider Range Handle Active
   --fdSlider_Range_Active_Handle_Background: transparent;
   --fdSlider_Range_Active_Handle_Border_Color: var(--sapButton_Active_BorderColor);
-  --fdSlider_Range_Active_Handle_Box_Shadow: none;
 
   // Slider Range Handle Focus
   --fdSlider_Range_Focus_Handle_Background: transparent;
   --fdSlider_Range_Focus_Handle_Border: solid 0.125rem var(--sapButton_Active_BorderColor);
-  --fdSlider_Range_Focus_Handle_Box_Shadow: none;
+  --fdSlider_Range_Track_Border_Radius: 0;
 
   // Slider Handle Focus
   --fdSlider_Focus_Handle_Outline_Color: var(--sapButton_Hover_BorderColor);

--- a/packages/styles/src/theming/common/slider/_sap_horizon.scss
+++ b/packages/styles/src/theming/common/slider/_sap_horizon.scss
@@ -16,7 +16,6 @@
   --fdSlider_Handle_Height: 1.25rem;
   --fdSlider_Handle_Border: 0.0625rem solid var(--sapSlider_HandleBorderColor);
   --fdSlider_Handle_Border_Hover_Color: var(--sapSlider_Hover_HandleBorderColor);
-  --fdSlider_Handle_Box_Shadow: none;
   --fdSlider_Handle_Active_Width: 2.25rem;
   --fdSlider_Handle_Active_Height: 2rem;
   --fdSlider_Handle_Icon_Display: block;
@@ -28,33 +27,33 @@
 
   // Slider Handle Hover
   --fdSlider_Hover_Handle_Background: var(--sapSlider_Hover_HandleBackground);
-  --fdSlider_Hover_Handle_Box_Shadow: none;
   --fdSlider_Hover_Handle_Border: 0.0625rem solid var(--sapSlider_Hover_HandleBorderColor);
   --fdSlider_Active_Handle_Border: 0.0625rem solid var(--sapSlider_Active_HandleBorderColor);
 
   // Slider Handle Active
   --fdSlider_Active_Handle_Background: var(--sapSlider_Active_HandleBackground);
-  --fdSlider_Active_Handle_Box_Shadow: none;
+
+  // Slider Handle Focus
+  --fdSlider_Focus_Handle_Background: var(--sapSlider_Active_RangeHandleBackground);
+  --fdSlider_Focus_Handle_Border: var(--sapContent_FocusWidth) solid var(--sapContent_FocusColor);
+  --fdSlider_Focus_Handle_Display: none;
 
   // Slider Range Handle
   --fdSlider_Range_Handle_Background: var(--sapSlider_RangeHandleBackground);
   --fdSlider_Range_Handle_Border: 0.0625rem solid var(--sapSlider_HandleBorderColor);
-  --fdSlider_Range_Handle_Box_Shadow: none;
 
   // Slider Range Handle Hover
   --fdSlider_Range_Hover_Handle_Background: var(--sapSlider_Hover_HandleBackground);
   --fdSlider_Range_Hover_Handle_Border_Color: var(--sapSlider_Hover_HandleBorderColor);
-  --fdSlider_Range_Hover_Handle_Box_Shadow: none;
 
   // Slider Range Handle Active
   --fdSlider_Range_Active_Handle_Background: var(--sapSlider_Active_RangeHandleBackground;);
   --fdSlider_Range_Active_Handle_Border_Color: var(--sapContent_FocusColor);
-  --fdSlider_Range_Active_Handle_Box_Shadow: none;
 
   // Slider Range Handle Focus
   --fdSlider_Range_Focus_Handle_Background: var(--sapSlider_Active_RangeHandleBackground;);
   --fdSlider_Range_Focus_Handle_Border: var(--sapContent_FocusWidth) solid var(--sapContent_FocusColor);
-  --fdSlider_Range_Focus_Handle_Box_Shadow: none;
+  --fdSlider_Range_Track_Border_Radius: 0.5rem;
 
   // Slider Handle Focus
   --fdSlider_Focus_Handle_Outline_Color: transparent;

--- a/packages/styles/src/theming/sap_horizon/_css_variables.scss
+++ b/packages/styles/src/theming/sap_horizon/_css_variables.scss
@@ -463,7 +463,7 @@
   --sapField_Hover_BackgroundStyle: 0 100% / 100% 0.0625rem no-repeat linear-gradient(0deg, #0064d9, #0064d9) border-box;
   --sapField_Hover_BorderColor: #0064d9;
   --sapField_Hover_HelpBackground: #fff;
-  --sapField_Hover_Shadow: inset 0 0 0 0.0625rem rgba(85, 107, 129, 0.25);
+  --sapField_Hover_Shadow: inset 0 0 0 0.0625rem rgba(104, 174, 255, 0.5);
   --sapField_Hover_InvalidShadow: inset 0 0 0 0.0625rem rgba(255, 142, 196, 0.45);
   --sapField_Hover_WarningShadow: inset 0 0 0 0.0625rem rgba(255, 213, 10, 0.4);
   --sapField_Hover_SuccessShadow: inset 0 0 0 0.0625rem rgba(48, 145, 76, 0.18);

--- a/packages/styles/stories/Components/Forms/checkbox/checkbox.stories.js
+++ b/packages/styles/stories/Components/Forms/checkbox/checkbox.stories.js
@@ -60,7 +60,15 @@ ${localStyles}
             <input type="checkbox" class="fd-checkbox" id="Ai4ez611">
             <label class="fd-checkbox__label" for="Ai4ez611">
                 <div class="fd-checkbox__label-container">
-                    <span class="fd-checkbox__text">Apple</span>
+                    <span class="fd-checkbox__text">Normal State</span>
+                </div>
+            </label>
+        </div>
+        <div class="fd-form-item">
+            <input type="checkbox" class="fd-checkbox" id="Ai4ez611hov">
+            <label class="fd-checkbox__label is-hover" for="Ai4ez611hov">
+                <div class="fd-checkbox__label-container">
+                    <span class="fd-checkbox__text">Hover State</span>
                 </div>
             </label>
         </div>
@@ -68,7 +76,7 @@ ${localStyles}
             <input type="checkbox" class="fd-checkbox" id="Ai4ez612" checked>
             <label class="fd-checkbox__label" for="Ai4ez612">
                 <div class="fd-checkbox__label-container">
-                    <span class="fd-checkbox__text">Banana</span>
+                    <span class="fd-checkbox__text">Selected/Checked State</span>
                 </div>
             </label>
         </div>
@@ -76,15 +84,15 @@ ${localStyles}
             <input type="checkbox" class="fd-checkbox" id="Ai4ez622" disabled>
             <label class="fd-checkbox__label" for="Ai4ez622">
                 <div class="fd-checkbox__label-container">
-                    <span class="fd-checkbox__text">Kiwi</span>
+                    <span class="fd-checkbox__text">Disabled State</span>
                 </div>
             </label>
         </div>
         <div class="fd-form-item">
-            <input type="checkbox" class="fd-checkbox" id="Ai4ez632"  checked disabled>
+            <input type="checkbox" class="fd-checkbox" id="Ai4ez632" checked disabled>
             <label class="fd-checkbox__label" for="Ai4ez632">
                 <div class="fd-checkbox__label-container">
-                    <span class="fd-checkbox__text">Lemon</span>
+                    <span class="fd-checkbox__text">Selected/Checked Disabled State</span>
                 </div>
             </label>
         </div>
@@ -92,7 +100,7 @@ ${localStyles}
             <input type="checkbox" class="fd-checkbox" id="Ai4ez613">
             <label class="fd-checkbox__label" for="Ai4ez613">
                 <div class="fd-checkbox__label-container">
-                    <span class="fd-checkbox__text">All Fruits (TriState)</span>
+                    <span class="fd-checkbox__text">Tri-State</span>
                 </div>
             </label>
         </div>
@@ -100,7 +108,7 @@ ${localStyles}
             <input type="checkbox" class="fd-checkbox" id="Ai4ez643" disabled>
             <label class="fd-checkbox__label" for="Ai4ez643">
                 <div class="fd-checkbox__label-container">
-                    <span class="fd-checkbox__text">All Fruits (TriState)</span>
+                    <span class="fd-checkbox__text">Tri-State Disabled</span>
                 </div>
             </label>
         </div>
@@ -135,7 +143,15 @@ ${localStyles}
                 <input type="checkbox" class="fd-checkbox is-error" id="Ai4ez6119">
                 <label class="fd-checkbox__label" for="Ai4ez6119">
                     <div class="fd-checkbox__label-container">
-                        <span class="fd-checkbox__text">Text Option</span>
+                        <span class="fd-checkbox__text">Error Regular Stat</span>
+                    </div>
+                </label>
+            </div>
+            <div class="fd-form-item">
+                <input type="checkbox" class="fd-checkbox is-error" id="Ai4ez6119hov">
+                <label class="fd-checkbox__label is-hover" for="Ai4ez6119hov">
+                    <div class="fd-checkbox__label-container">
+                        <span class="fd-checkbox__text">Error Hover Stat</span>
                     </div>
                 </label>
             </div>
@@ -143,7 +159,7 @@ ${localStyles}
                 <input type="checkbox" class="fd-checkbox is-error" id="Ai4ez6129" checked>
                 <label class="fd-checkbox__label" for="Ai4ez6129">
                     <div class="fd-checkbox__label-container">
-                        <span class="fd-checkbox__text">Selected State</span>
+                        <span class="fd-checkbox__text">Error Selected State</span>
                     </div>
                 </label>
             </div>
@@ -151,7 +167,7 @@ ${localStyles}
                 <input type="checkbox" class="fd-checkbox is-error" id="Ai4ez613i1">
                 <label class="fd-checkbox__label" for="Ai4ez613i1">
                     <div class="fd-checkbox__label-container">
-                        <span class="fd-checkbox__text">TriState Text</span>
+                        <span class="fd-checkbox__text">Error Tri-State</span>
                     </div>
                 </label>
             </div>
@@ -165,7 +181,15 @@ ${localStyles}
                 <input type="checkbox" class="fd-checkbox is-success" id="Ai4ez61192">
                 <label class="fd-checkbox__label" for="Ai4ez61192">
                     <div class="fd-checkbox__label-container">
-                        <span class="fd-checkbox__text">Text Option</span>
+                        <span class="fd-checkbox__text">Success Regular State</span>
+                    </div>
+                </label>
+            </div>
+            <div class="fd-form-item">
+                <input type="checkbox" class="fd-checkbox is-success" id="Ai4ez61192hov">
+                <label class="fd-checkbox__label is-hover" for="Ai4ez61192hov">
+                    <div class="fd-checkbox__label-container">
+                        <span class="fd-checkbox__text">Success Hover State</span>
                     </div>
                 </label>
             </div>
@@ -173,7 +197,7 @@ ${localStyles}
                 <input type="checkbox" class="fd-checkbox is-success" id="Ai4ez61292" checked>
                 <label class="fd-checkbox__label" for="Ai4ez61292">
                     <div class="fd-checkbox__label-container">
-                        <span class="fd-checkbox__text">Selected State</span>
+                        <span class="fd-checkbox__text">Success Selected State</span>
                     </div>
                 </label>
             </div>
@@ -181,7 +205,7 @@ ${localStyles}
                 <input type="checkbox" class="fd-checkbox is-success" id="Ai4ez613i2">
                 <label class="fd-checkbox__label" for="Ai4ez613i2">
                     <div class="fd-checkbox__label-container">
-                        <span class="fd-checkbox__text">TriState Text</span>
+                        <span class="fd-checkbox__text">Success Tri-State</span>
                     </div>
                 </label>
             </div>
@@ -195,7 +219,15 @@ ${localStyles}
                 <input type="checkbox" class="fd-checkbox is-warning" id="Ai4ez61193">
                 <label class="fd-checkbox__label" for="Ai4ez61193">
                     <div class="fd-checkbox__label-container">
-                        <span class="fd-checkbox__text">Text Option</span>
+                        <span class="fd-checkbox__text">Warning Regular State</span>
+                    </div>
+                </label>
+            </div>
+            <div class="fd-form-item">
+                <input type="checkbox" class="fd-checkbox is-warning" id="Ai4ez61193hov">
+                <label class="fd-checkbox__label is-hover" for="Ai4ez61193hov">
+                    <div class="fd-checkbox__label-container">
+                        <span class="fd-checkbox__text">Warning Hover State</span>
                     </div>
                 </label>
             </div>
@@ -203,7 +235,7 @@ ${localStyles}
                 <input type="checkbox" class="fd-checkbox is-warning" id="Ai4ez61293" checked>
                 <label class="fd-checkbox__label" for="Ai4ez61293">
                     <div class="fd-checkbox__label-container">
-                        <span class="fd-checkbox__text">Selected State</span>
+                        <span class="fd-checkbox__text">Warning Selected State</span>
                     </div>
                 </label>
             </div>
@@ -211,7 +243,7 @@ ${localStyles}
                 <input type="checkbox" class="fd-checkbox is-warning" id="Ai4ez613i3">
                 <label class="fd-checkbox__label" for="Ai4ez613i3">
                     <div class="fd-checkbox__label-container">
-                        <span class="fd-checkbox__text">TriState Text</span>
+                        <span class="fd-checkbox__text">Warning Tri-State</span>
                     </div>
                 </label>
             </div>
@@ -225,7 +257,15 @@ ${localStyles}
                 <input type="checkbox" class="fd-checkbox is-information" id="Ai4ez61194">
                 <label class="fd-checkbox__label" for="Ai4ez61194">
                     <div class="fd-checkbox__label-container">
-                        <span class="fd-checkbox__text">Text Option</span>
+                        <span class="fd-checkbox__text">Information Regular State</span>
+                    </div>
+                </label>
+            </div>
+            <div class="fd-form-item">
+                <input type="checkbox" class="fd-checkbox is-information" id="Ai4ez61194hov">
+                <label class="fd-checkbox__label is-hover" for="Ai4ez61194hov">
+                    <div class="fd-checkbox__label-container">
+                        <span class="fd-checkbox__text">Information Hover State</span>
                     </div>
                 </label>
             </div>
@@ -233,7 +273,7 @@ ${localStyles}
                 <input type="checkbox" class="fd-checkbox is-information" id="Ai4ez61294" checked>
                 <label class="fd-checkbox__label" for="Ai4ez61294">
                     <div class="fd-checkbox__label-container">
-                        <span class="fd-checkbox__text">Selected State</span>
+                        <span class="fd-checkbox__text">Information Checked State</span>
                     </div>
                 </label>
             </div>
@@ -241,7 +281,7 @@ ${localStyles}
                 <input type="checkbox" class="fd-checkbox is-information" id="Ai4ez613i4">
                 <label class="fd-checkbox__label" for="Ai4ez613i4">
                     <div class="fd-checkbox__label-container">
-                        <span class="fd-checkbox__text">TriState Text</span>
+                        <span class="fd-checkbox__text">Information Tri-State</span>
                     </div>
                 </label>
             </div>
@@ -285,7 +325,15 @@ ${localStyles}
                 <input type="checkbox" class="fd-checkbox" id="Ai4ez611967" readonly>
                 <label class="fd-checkbox__label" for="Ai4ez611967">
                     <div class="fd-checkbox__label-container">
-                        <span class="fd-checkbox__text">Text Option</span>
+                        <span class="fd-checkbox__text">Read Only Regular State</span>
+                    </div>
+                </label>
+            </div>
+            <div class="fd-form-item">
+                <input type="checkbox" class="fd-checkbox" id="Ai4ez611967hov" readonly>
+                <label class="fd-checkbox__label is-hover" for="Ai4ez611967hov">
+                    <div class="fd-checkbox__label-container">
+                        <span class="fd-checkbox__text">Read Only Hover State</span>
                     </div>
                 </label>
             </div>
@@ -293,7 +341,7 @@ ${localStyles}
                 <input type="checkbox" class="fd-checkbox" id="Ai4ez61296cc" checked readonly>
                 <label class="fd-checkbox__label" for="Ai4ez61296cc">
                     <div class="fd-checkbox__label-container">
-                        <span class="fd-checkbox__text">Selected State</span>
+                        <span class="fd-checkbox__text">Read Only Checked State</span>
                     </div>
                 </label>
             </div>
@@ -301,7 +349,7 @@ ${localStyles}
                 <input type="checkbox" class="fd-checkbox" id="Ai4ez613i6cc" readonly>
                 <label class="fd-checkbox__label" for="Ai4ez613i6cc">
                     <div class="fd-checkbox__label-container">
-                        <span class="fd-checkbox__text">TriState Text</span>
+                        <span class="fd-checkbox__text">Read Only Tri-State</span>
                     </div>
                 </label>
             </div>
@@ -349,6 +397,14 @@ ${localStyles}
                 </div>
             </label>
         </div>
+        <div class="fd-form-item">
+            <input type="checkbox" class="fd-checkbox" id="Ai4ez612lwtop" checked>
+            <label class="fd-checkbox__label fd-checkbox__label--wrap-top-aligned" for="Ai4ez612lwtop" style="max-width: 400px;">
+                <div class="fd-checkbox__label-container">
+                    <span class="fd-checkbox__text">Banana ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</span>
+                </div>
+            </label>
+        </div>
     </div>
 </fieldset>
 `;
@@ -358,7 +414,7 @@ TextTruncation.parameters = {
       iframeHeight: 330
     },
     description: {
-      story: `By default, long checkbox label truncates with ellipsis. For this behaviour no modifier class is needed. For checkbox label that wraps on a new line to show the entire content, use \`.fd-checkbox__label--wrap\` modifier class applied with \`.fd-checkbox__label\`. Keep in mind that for this to work <b>max-width</b> should be set on the label.
+      story: `By default, long checkbox label truncates with ellipsis. For this behaviour no modifier class is needed. For checkbox label that wraps on a new line to show the entire content, use \`.fd-checkbox__label--wrap\` modifier class applied with \`.fd-checkbox__label\`. Keep in mind that for this to work <b>max-width</b> should be set on the label. For a <b>top-left aligned</b> label use the \`.fd-checkbox__label--wrap-top-aligned\` modifier class.
         `
     }
   }

--- a/packages/styles/stories/Components/Forms/input/primary.example.html
+++ b/packages/styles/stories/Components/Forms/input/primary.example.html
@@ -1,7 +1,17 @@
 <div style="">
     <div class="fd-form-item">
-        <label class="fd-form-label" for="input-1">Default input:</label>
+        <label class="fd-form-label" for="input-1">Default input (regular):</label>
         <input class="fd-input" type="text" id="input-1" placeholder="Field placeholder text">
+    </div>
+    <br>
+    <div class="fd-form-item">
+        <label class="fd-form-label" for="input-1-hover">Default input (hover):</label>
+        <input class="fd-input is-hover" type="text" id="input-1-hover" placeholder="Field placeholder text">
+    </div>
+    <br>
+    <div class="fd-form-item">
+        <label class="fd-form-label" for="input-1-focus">Default input (focus):</label>
+        <input class="fd-input is-focus" type="text" id="input-1-focus" placeholder="Field placeholder text">
     </div>
     <br>
     <div class="fd-form-item">
@@ -20,8 +30,28 @@
     </div>
     <br />
     <div class="fd-form-item">
+        <label class="fd-form-label" for="input-01-hover">Error Input:</label>
+        <input class="fd-input is-error is-hover" type="text" id="input-01-hover" placeholder="Field placeholder text">
+    </div>
+    <br />
+    <div class="fd-form-item">
+        <label class="fd-form-label" for="input-01-focus">Error Input:</label>
+        <input class="fd-input is-error is-focus" type="text" id="input-01-focus" placeholder="Field placeholder text">
+    </div>
+    <br />
+    <div class="fd-form-item">
         <label class="fd-form-label" for="input-02">Success Input:</label>
         <input class="fd-input is-success" type="text" id="input-02" placeholder="Field placeholder text">
+    </div>
+    <br />
+    <div class="fd-form-item">
+        <label class="fd-form-label" for="input-02-hover">Success Input:</label>
+        <input class="fd-input is-success is-hover" type="text" id="input-02-hover" placeholder="Field placeholder text">
+    </div>
+    <br />
+    <div class="fd-form-item">
+        <label class="fd-form-label" for="input-02-focus">Success Input:</label>
+        <input class="fd-input is-success is-focus" type="text" id="input-02-focus" placeholder="Field placeholder text">
     </div>
     <br />
     <div class="fd-form-item">
@@ -30,13 +60,33 @@
     </div>
     <br />
     <div class="fd-form-item">
+        <label class="fd-form-label" for="input-03-hover">Warning (Alert) Input:</label>
+        <input class="fd-input is-warning is-hover" type="text" id="input-03-hover" placeholder="Field placeholder text">
+    </div>
+    <br />
+    <div class="fd-form-item">
+        <label class="fd-form-label" for="input-03-focus">Warning (Alert) Input:</label>
+        <input class="fd-input is-warning is-focus" type="text" id="input-03-focus" placeholder="Field placeholder text">
+    </div>
+    <br />
+    <div class="fd-form-item">
         <label class="fd-form-label" for="input-04">Information Input:</label>
-        <input class="fd-input is-information" type="text" id="input-04">
+        <input class="fd-input is-information" type="text" id="input-04" placeholder="Field placeholder text">
+    </div>
+    <br />
+    <div class="fd-form-item">
+        <label class="fd-form-label" for="input-04-hover">Information Input:</label>
+        <input class="fd-input is-information is-hover" type="text" id="input-04-hover" placeholder="Field placeholder text">
+    </div>
+    <br />
+    <div class="fd-form-item">
+        <label class="fd-form-label" for="input-04-focus">Information Input:</label>
+        <input class="fd-input is-information is-focus" type="text" id="input-04-focus" placeholder="Field placeholder text">
     </div>
     <br />
     <div class="fd-form-item">
         <label class="fd-form-label" for="input-05">Disabled Input:</label>
-        <input class="fd-input" type="text" id="input-05" disabled value="Field placeholder text">
+        <input class="fd-input" type="text" id="input-05" disabled value="Field placeholder text" placeholder="Field placeholder text">
     </div>
     <br />
     <div class="fd-form-item">

--- a/packages/styles/stories/Components/Forms/radio/interaction-states.example.html
+++ b/packages/styles/stories/Components/Forms/radio/interaction-states.example.html
@@ -1,68 +1,177 @@
-<fieldset class="fd-fieldset" id="radio5">
-    <legend class="fd-fieldset__legend">Interaction States</legend>
+<fieldset class="fd-fieldset" id="radio5a">
+    <legend class="fd-fieldset__legend">Default Interaction States</legend>
     <div class="fd-form-group">
         <div class="fd-form-item">
-            <input type="radio" class="fd-radio" id="iSpDidh761" name="radio5" checked>
+            <input type="radio" class="fd-radio" id="iSpDidh761" name="radio5a">
             <label class="fd-radio__label" for="iSpDidh761">
                 <span class="fd-radio__text">Default Radio Button</span>
             </label>
         </div>
         <div class="fd-form-item">
-            <input type="radio" class="fd-radio is-success" id="iSpDidh7612" name="radio5">
+            <input type="radio" class="fd-radio" id="iSpDidh761cc" name="radio5a" checked>
+            <label class="fd-radio__label" for="iSpDidh761cc">
+                <span class="fd-radio__text">Default Checked Radio Button</span>
+            </label>
+        </div>
+        <div class="fd-form-item">
+            <input type="radio" class="fd-radio" id="iSpDidh761hov" name="radio5a">
+            <label class="fd-radio__label is-hover" for="iSpDidh761hov">
+                <span class="fd-radio__text">Default Hover Radio Button</span>
+            </label>
+        </div>
+    </div>
+</fieldset>
+<br><br>
+<fieldset class="fd-fieldset" id="radio5b">
+    <legend class="fd-fieldset__legend">Success Interaction States</legend>
+    <div class="fd-form-group">
+        <div class="fd-form-item">
+            <input type="radio" class="fd-radio is-success" id="iSpDidh7612" name="radio5b">
             <label class="fd-radio__label" for="iSpDidh7612">
                 <span class="fd-radio__text">Success Radio Button</span>
             </label>
         </div>
         <div class="fd-form-item">
-            <input type="radio" class="fd-radio is-error" id="iSpDidh7613" name="radio5">
+            <input type="radio" class="fd-radio is-success" id="iSpDidh7612cc" name="radio5b" checked>
+            <label class="fd-radio__label" for="iSpDidh7612cc">
+                <span class="fd-radio__text">Success Checked Radio Button</span>
+            </label>
+        </div>
+        <div class="fd-form-item">
+            <input type="radio" class="fd-radio is-success" id="iSpDidh7612hov" name="radio5b">
+            <label class="fd-radio__label is-hover" for="iSpDidh7612hov">
+                <span class="fd-radio__text">Success Hover Radio Button</span>
+            </label>
+        </div>
+    </div>
+</fieldset>
+<br><br>
+<fieldset class="fd-fieldset" id="radio5c">
+    <legend class="fd-fieldset__legend">Error Interaction States</legend>
+    <div class="fd-form-group">
+        <div class="fd-form-item">
+            <input type="radio" class="fd-radio is-error" id="iSpDidh7613" name="radio5c">
             <label class="fd-radio__label" for="iSpDidh7613">
                 <span class="fd-radio__text">Error Radio Button</span>
             </label>
         </div>
         <div class="fd-form-item">
-            <input type="radio" class="fd-radio is-warning" id="iSpDidh7614" name="radio5">
+            <input type="radio" class="fd-radio is-error" id="iSpDidh7613cc" name="radio5c" checked>
+            <label class="fd-radio__label" for="iSpDidh7613cc">
+                <span class="fd-radio__text">Error Checked Radio Button</span>
+            </label>
+        </div>
+        <div class="fd-form-item">
+            <input type="radio" class="fd-radio is-error" id="iSpDidh7613hov" name="radio5c">
+            <label class="fd-radio__label is-hover" for="iSpDidh7613hov">
+                <span class="fd-radio__text">Error Hover Radio Button</span>
+            </label>
+        </div>
+    </div>
+</fieldset>
+<br><br>
+<fieldset class="fd-fieldset" id="radio5d">
+    <legend class="fd-fieldset__legend">Warning Interaction States</legend>
+    <div class="fd-form-group">
+        <div class="fd-form-item">
+            <input type="radio" class="fd-radio is-warning" id="iSpDidh7614" name="radio5d">
             <label class="fd-radio__label" for="iSpDidh7614">
                 <span class="fd-radio__text">Warning Radio Button</span>
             </label>
         </div>
         <div class="fd-form-item">
-            <input type="radio" class="fd-radio is-information" id="iSpDidh7615" name="radio5">
+            <input type="radio" class="fd-radio is-warning" id="iSpDidh7614cc" name="radio5d" checked>
+            <label class="fd-radio__label" for="iSpDidh7614cc">
+                <span class="fd-radio__text">Warning Checked Radio Button</span>
+            </label>
+        </div>
+        <div class="fd-form-item">
+            <input type="radio" class="fd-radio is-warning" id="iSpDidh7614hov" name="radio5d">
+            <label class="fd-radio__label is-hover" for="iSpDidh7614hov">
+                <span class="fd-radio__text">Warning Hover Radio Button</span>
+            </label>
+        </div>
+    </div>
+</fieldset>
+<br><br>
+<fieldset class="fd-fieldset" id="radio5e">
+    <legend class="fd-fieldset__legend">Information Interaction States</legend>
+    <div class="fd-form-group">
+        <div class="fd-form-item">
+            <input type="radio" class="fd-radio is-information" id="iSpDidh7615" name="radio5e">
             <label class="fd-radio__label" for="iSpDidh7615">
                 <span class="fd-radio__text">Information Radio Button</span>
             </label>
         </div>
         <div class="fd-form-item">
-            <input type="radio" class="fd-radio is-readonly" id="iSpDidh76erfg15" name="radio5" readonly>
+            <input type="radio" class="fd-radio is-information" id="iSpDidh7615cc" name="radio5e" checked>
+            <label class="fd-radio__label" for="iSpDidh7615cc">
+                <span class="fd-radio__text">Information Checked Radio Button</span>
+            </label>
+        </div>
+        <div class="fd-form-item">
+            <input type="radio" class="fd-radio is-information" id="iSpDidh7615hov" name="radio5e">
+            <label class="fd-radio__label is-hover" for="iSpDidh7615hov">
+                <span class="fd-radio__text">Information Hover Radio Button</span>
+            </label>
+        </div>
+    </div>
+</fieldset>
+<br><br>
+
+<fieldset class="fd-fieldset" id="radio5f">
+    <legend class="fd-fieldset__legend">Read-Only Interaction States</legend>
+    <div class="fd-form-group">
+        <div class="fd-form-item">
+            <input type="radio" class="fd-radio is-readonly" id="iSpDidh76erfg15" name="radio5f" readonly>
             <label class="fd-radio__label" for="iSpDidh76erfg15">
                 <span class="fd-radio__text">ReadOnly Radio Button</span>
             </label>
         </div>
         <div class="fd-form-item">
-            <input type="radio" class="fd-radio" id="iSpDidh7611" name="radio5" disabled>
+            <input type="radio" class="fd-radio is-readonly" id="iSpDidh76erfg15cc" name="radio5f" readonly checked>
+            <label class="fd-radio__label" for="iSpDidh76erfg15cc">
+                <span class="fd-radio__text">ReadOnly Checked Radio Button</span>
+            </label>
+        </div>
+        <div class="fd-form-item">
+            <input type="radio" class="fd-radio is-readonly" id="iSpDidh76erfg15hov" name="radio5f" readonly>
+            <label class="fd-radio__label is-hover" for="iSpDidh76erfg15hov">
+                <span class="fd-radio__text">ReadOnly Hover Radio Button</span>
+            </label>
+        </div>
+    </div>
+</fieldset>
+<br><br>
+<fieldset class="fd-fieldset" id="radio5g">
+    <legend class="fd-fieldset__legend">Disabled States</legend>
+    <div class="fd-form-group">
+        <div class="fd-form-item">
+            <input type="radio" class="fd-radio" id="iSpDidh7611" name="radio5g" disabled>
             <label class="fd-radio__label" for="iSpDidh7611">
                 <span class="fd-radio__text">Disabled Radio Button</span>
             </label>
         </div>
         <div class="fd-form-item">
-            <input type="radio" class="fd-radio is-success" id="iSpDidh76121" name="radio5" disabled>
+            <input type="radio" class="fd-radio is-success" id="iSpDidh76121" name="radio5g" disabled>
             <label class="fd-radio__label" for="iSpDidh76121">
                 <span class="fd-radio__text">Success Radio Button (disabled)</span>
             </label>
         </div>
         <div class="fd-form-item">
-            <input type="radio" class="fd-radio is-error" id="iSpDidh76131" name="radio5" disabled>
+            <input type="radio" class="fd-radio is-error" id="iSpDidh76131" name="radio5g" disabled>
             <label class="fd-radio__label" for="iSpDidh76131">
                 <span class="fd-radio__text">Error Radio Button (disabled)</span>
             </label>
         </div>
         <div class="fd-form-item">
-            <input type="radio" class="fd-radio is-warning" id="iSpDidh76141" name="radio5" disabled>
+            <input type="radio" class="fd-radio is-warning" id="iSpDidh76141" name="radio5g" disabled>
             <label class="fd-radio__label" for="iSpDidh76141">
                 <span class="fd-radio__text">Warning Radio Button (disabled)</span>
             </label>
         </div>
         <div class="fd-form-item">
-            <input type="radio" class="fd-radio is-information" id="iSpDidh76151" name="radio5" disabled>
+            <input type="radio" class="fd-radio is-information" id="iSpDidh76151" name="radio5g" disabled>
             <label class="fd-radio__label" for="iSpDidh76151">
                 <span class="fd-radio__text">Information Radio Button (disabled)</span>
             </label>

--- a/packages/styles/stories/Components/Forms/radio/radio.stories.js
+++ b/packages/styles/stories/Components/Forms/radio/radio.stories.js
@@ -66,7 +66,7 @@ TextTruncation.parameters = {
       iframeHeight: 250
     },
     description: {
-      story: `By default, long radio label truncates with ellipsis. For this behaviour no modifier class is needed. For radio label that wraps on a new line to show the entire content, use \`.fd-radio__label--wrap\` modifier class applied with \`.fd-radio__label\`. Keep in mind that for this to work <b>max-width</b> should be set on the label.`
+      story: `By default, long radio label truncates with ellipsis. For this behaviour no modifier class is needed. For radio label that wraps on a new line to show the entire content, use \`.fd-radio__label--wrap\` modifier class applied with \`.fd-radio__label\`. Keep in mind that for this to work <b>max-width</b> should be set on the label. For a <b>top-left aligned</b> label use the \`.fd-radio__label--wrap-top-aligned\` modifier class.`
     }
   }
 };

--- a/packages/styles/stories/Components/Forms/radio/text-truncation.example.html
+++ b/packages/styles/stories/Components/Forms/radio/text-truncation.example.html
@@ -10,8 +10,16 @@
             </label>
         </div>
         <div class="fd-form-item">
-            <input type="radio" class="fd-radio" id="pDidh7612tt" name="radio1Truncation">
+            <input type="radio" class="fd-radio" id="pDidh7612tt" name="radio2Truncation" checked>
             <label class="fd-radio__label fd-radio__label--wrap" for="pDidh7612tt" style="max-width: 400px;">
+                <span class="fd-radio__text">
+                    Field label  ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                </span>
+            </label>
+        </div>
+        <div class="fd-form-item">
+            <input type="radio" class="fd-radio" id="pDidh7612ttop" name="radio3Truncation" checked>
+            <label class="fd-radio__label fd-radio__label--wrap-top-aligned" for="pDidh7612ttop" style="max-width: 400px;">
                 <span class="fd-radio__text">
                     Field label  ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
                 </span>

--- a/packages/styles/stories/Components/Forms/textarea/disabled-and-read-only.example.html
+++ b/packages/styles/stories/Components/Forms/textarea/disabled-and-read-only.example.html
@@ -6,3 +6,7 @@
     <label class="fd-form-label" for="textarea-8">Text area:</label>
     <textarea class="fd-textarea" id="textarea-8" readonly>Read Only textarea</textarea>
 </div>
+<div class="fd-form-item">
+    <label class="fd-form-label" for="textarea-9">Text area:</label>
+    <textarea class="fd-textarea is-focus" id="textarea-9" readonly>Focussed Read Only textarea</textarea>
+</div>

--- a/packages/styles/stories/Components/slider/range.example.html
+++ b/packages/styles/stories/Components/slider/range.example.html
@@ -1,4 +1,4 @@
-
+<h3>Regular</h3>
 <div class="slider-container slider-container--range">
     <div class="fd-slider fd-slider--range">
         <div class="fd-slider__inner">
@@ -12,3 +12,55 @@
         </div>
     </div>
 </div>
+
+<br><br>
+<h3>Hover (on one handle)</h3>
+<div class="slider-container slider-container--range">
+  <div class="fd-slider fd-slider--range">
+      <div class="fd-slider__inner">
+          <div class="fd-slider__track">
+            <div class="fd-slider__track-range" style="width: 40%">
+              <div class="fd-slider__track-focus-range" tabindex="0"></div>
+            </div>
+          </div>
+          <div class="fd-slider__handle is-hover" tabindex="0" role="slider" aria-label="range slider left" aria-valuemin="1" aria-valuemax="80" aria-valuenow="40" style="left: 40%;"></div>
+          <div class="fd-slider__handle" tabindex="0" role="slider" aria-label="range slider right" aria-valuemin="40" aria-valuemax="100" aria-valuenow="80" style="left: 80%;"></div>
+      </div>
+  </div>
+</div>
+
+<br><br>
+<h3>Active (on one handle)</h3>
+<div class="slider-container slider-container--range">
+  <div class="fd-slider fd-slider--range">
+      <div class="fd-slider__inner">
+          <div class="fd-slider__track">
+            <div class="fd-slider__track-range" style="width: 40%">
+              <div class="fd-slider__track-focus-range" tabindex="0"></div>
+            </div>
+          </div>
+          <div class="fd-slider__handle is-active" tabindex="0" role="slider" aria-label="range slider left" aria-valuemin="1" aria-valuemax="80" aria-valuenow="40" style="left: 40%;"></div>
+          <div class="fd-slider__handle tabindex="0" role="slider" aria-label="range slider right" aria-valuemin="40" aria-valuemax="100" aria-valuenow="80" style="left: 80%;"></div>
+      </div>
+  </div>
+</div>
+
+
+<br><br>
+<h3>Focus</h3>
+<div class="slider-container slider-container--range">
+  <div class="fd-slider fd-slider--range">
+      <div class="fd-slider__inner">
+          <div class="fd-slider__track">
+            <div class="fd-slider__track-range" style="width: 40%">
+              <div class="fd-slider__track-focus-range is-focus" tabindex="0"></div>
+            </div>
+          </div>
+          <div class="fd-slider__handle" tabindex="0" role="slider" aria-label="range slider left" aria-valuemin="1" aria-valuemax="80" aria-valuenow="40" style="left: 40%;"></div>
+          <div class="fd-slider__handle" tabindex="0" role="slider" aria-label="range slider right" aria-valuemin="40" aria-valuemax="100" aria-valuenow="80" style="left: 80%;"></div>
+      </div>
+  </div>
+</div>
+
+
+

--- a/packages/styles/stories/Components/slider/standard.example.html
+++ b/packages/styles/stories/Components/slider/standard.example.html
@@ -9,3 +9,37 @@
         </div>
     </div>
 </div>
+<br><br>
+<div class="slider-container">
+    <div class="fd-slider">
+        <div class="fd-slider__inner">
+        <div class="fd-slider__handle is-hover" tabindex="0" role="slider" aria-label="slider" aria-valuemin="1" aria-valuemax="100" aria-valuenow="50" style="left: 50%;"></div>
+            <div class="fd-slider__track">
+                <div class="fd-slider__track-range" style="width: 50%;"></div>
+            </div>
+        </div>
+    </div>
+</div>
+<br><br>
+<div class="slider-container">
+    <div class="fd-slider">
+        <div class="fd-slider__inner">
+        <div class="fd-slider__handle is-active" tabindex="0" role="slider" aria-label="slider" aria-valuemin="1" aria-valuemax="100" aria-valuenow="50" style="left: 50%;"></div>
+            <div class="fd-slider__track">
+                <div class="fd-slider__track-range" style="width: 50%;"></div>
+            </div>
+        </div>
+    </div>
+</div>
+<br><br>
+<div class="slider-container">
+    <div class="fd-slider">
+        <div class="fd-slider__inner">
+        <div class="fd-slider__handle is-focus" tabindex="0" role="slider" aria-label="slider" aria-valuemin="1" aria-valuemax="100" aria-valuenow="50" style="left: 50%;"></div>
+            <div class="fd-slider__track">
+                <div class="fd-slider__track-range" style="width: 50%;"></div>
+            </div>
+        </div>
+    </div>
+</div>
+

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -6845,7 +6845,15 @@ exports[`Check stories > Components/Forms/Checkbox > Story Default > Should matc
             <input type=\\"checkbox\\" class=\\"fd-checkbox\\" id=\\"Ai4ez611\\">
             <label class=\\"fd-checkbox__label\\" for=\\"Ai4ez611\\">
                 <div class=\\"fd-checkbox__label-container\\">
-                    <span class=\\"fd-checkbox__text\\">Apple</span>
+                    <span class=\\"fd-checkbox__text\\">Normal State</span>
+                </div>
+            </label>
+        </div>
+        <div class=\\"fd-form-item\\">
+            <input type=\\"checkbox\\" class=\\"fd-checkbox\\" id=\\"Ai4ez611hov\\">
+            <label class=\\"fd-checkbox__label is-hover\\" for=\\"Ai4ez611hov\\">
+                <div class=\\"fd-checkbox__label-container\\">
+                    <span class=\\"fd-checkbox__text\\">Hover State</span>
                 </div>
             </label>
         </div>
@@ -6853,7 +6861,7 @@ exports[`Check stories > Components/Forms/Checkbox > Story Default > Should matc
             <input type=\\"checkbox\\" class=\\"fd-checkbox\\" id=\\"Ai4ez612\\" checked>
             <label class=\\"fd-checkbox__label\\" for=\\"Ai4ez612\\">
                 <div class=\\"fd-checkbox__label-container\\">
-                    <span class=\\"fd-checkbox__text\\">Banana</span>
+                    <span class=\\"fd-checkbox__text\\">Selected/Checked State</span>
                 </div>
             </label>
         </div>
@@ -6861,15 +6869,15 @@ exports[`Check stories > Components/Forms/Checkbox > Story Default > Should matc
             <input type=\\"checkbox\\" class=\\"fd-checkbox\\" id=\\"Ai4ez622\\" disabled>
             <label class=\\"fd-checkbox__label\\" for=\\"Ai4ez622\\">
                 <div class=\\"fd-checkbox__label-container\\">
-                    <span class=\\"fd-checkbox__text\\">Kiwi</span>
+                    <span class=\\"fd-checkbox__text\\">Disabled State</span>
                 </div>
             </label>
         </div>
         <div class=\\"fd-form-item\\">
-            <input type=\\"checkbox\\" class=\\"fd-checkbox\\" id=\\"Ai4ez632\\"  checked disabled>
+            <input type=\\"checkbox\\" class=\\"fd-checkbox\\" id=\\"Ai4ez632\\" checked disabled>
             <label class=\\"fd-checkbox__label\\" for=\\"Ai4ez632\\">
                 <div class=\\"fd-checkbox__label-container\\">
-                    <span class=\\"fd-checkbox__text\\">Lemon</span>
+                    <span class=\\"fd-checkbox__text\\">Selected/Checked Disabled State</span>
                 </div>
             </label>
         </div>
@@ -6877,7 +6885,7 @@ exports[`Check stories > Components/Forms/Checkbox > Story Default > Should matc
             <input type=\\"checkbox\\" class=\\"fd-checkbox\\" id=\\"Ai4ez613\\">
             <label class=\\"fd-checkbox__label\\" for=\\"Ai4ez613\\">
                 <div class=\\"fd-checkbox__label-container\\">
-                    <span class=\\"fd-checkbox__text\\">All Fruits (TriState)</span>
+                    <span class=\\"fd-checkbox__text\\">Tri-State</span>
                 </div>
             </label>
         </div>
@@ -6885,7 +6893,7 @@ exports[`Check stories > Components/Forms/Checkbox > Story Default > Should matc
             <input type=\\"checkbox\\" class=\\"fd-checkbox\\" id=\\"Ai4ez643\\" disabled>
             <label class=\\"fd-checkbox__label\\" for=\\"Ai4ez643\\">
                 <div class=\\"fd-checkbox__label-container\\">
-                    <span class=\\"fd-checkbox__text\\">All Fruits (TriState)</span>
+                    <span class=\\"fd-checkbox__text\\">Tri-State Disabled</span>
                 </div>
             </label>
         </div>
@@ -6961,7 +6969,15 @@ exports[`Check stories > Components/Forms/Checkbox > Story States > Should match
                 <input type=\\"checkbox\\" class=\\"fd-checkbox is-error\\" id=\\"Ai4ez6119\\">
                 <label class=\\"fd-checkbox__label\\" for=\\"Ai4ez6119\\">
                     <div class=\\"fd-checkbox__label-container\\">
-                        <span class=\\"fd-checkbox__text\\">Text Option</span>
+                        <span class=\\"fd-checkbox__text\\">Error Regular Stat</span>
+                    </div>
+                </label>
+            </div>
+            <div class=\\"fd-form-item\\">
+                <input type=\\"checkbox\\" class=\\"fd-checkbox is-error\\" id=\\"Ai4ez6119hov\\">
+                <label class=\\"fd-checkbox__label is-hover\\" for=\\"Ai4ez6119hov\\">
+                    <div class=\\"fd-checkbox__label-container\\">
+                        <span class=\\"fd-checkbox__text\\">Error Hover Stat</span>
                     </div>
                 </label>
             </div>
@@ -6969,7 +6985,7 @@ exports[`Check stories > Components/Forms/Checkbox > Story States > Should match
                 <input type=\\"checkbox\\" class=\\"fd-checkbox is-error\\" id=\\"Ai4ez6129\\" checked>
                 <label class=\\"fd-checkbox__label\\" for=\\"Ai4ez6129\\">
                     <div class=\\"fd-checkbox__label-container\\">
-                        <span class=\\"fd-checkbox__text\\">Selected State</span>
+                        <span class=\\"fd-checkbox__text\\">Error Selected State</span>
                     </div>
                 </label>
             </div>
@@ -6977,7 +6993,7 @@ exports[`Check stories > Components/Forms/Checkbox > Story States > Should match
                 <input type=\\"checkbox\\" class=\\"fd-checkbox is-error\\" id=\\"Ai4ez613i1\\">
                 <label class=\\"fd-checkbox__label\\" for=\\"Ai4ez613i1\\">
                     <div class=\\"fd-checkbox__label-container\\">
-                        <span class=\\"fd-checkbox__text\\">TriState Text</span>
+                        <span class=\\"fd-checkbox__text\\">Error Tri-State</span>
                     </div>
                 </label>
             </div>
@@ -6991,7 +7007,15 @@ exports[`Check stories > Components/Forms/Checkbox > Story States > Should match
                 <input type=\\"checkbox\\" class=\\"fd-checkbox is-success\\" id=\\"Ai4ez61192\\">
                 <label class=\\"fd-checkbox__label\\" for=\\"Ai4ez61192\\">
                     <div class=\\"fd-checkbox__label-container\\">
-                        <span class=\\"fd-checkbox__text\\">Text Option</span>
+                        <span class=\\"fd-checkbox__text\\">Success Regular State</span>
+                    </div>
+                </label>
+            </div>
+            <div class=\\"fd-form-item\\">
+                <input type=\\"checkbox\\" class=\\"fd-checkbox is-success\\" id=\\"Ai4ez61192hov\\">
+                <label class=\\"fd-checkbox__label is-hover\\" for=\\"Ai4ez61192hov\\">
+                    <div class=\\"fd-checkbox__label-container\\">
+                        <span class=\\"fd-checkbox__text\\">Success Hover State</span>
                     </div>
                 </label>
             </div>
@@ -6999,7 +7023,7 @@ exports[`Check stories > Components/Forms/Checkbox > Story States > Should match
                 <input type=\\"checkbox\\" class=\\"fd-checkbox is-success\\" id=\\"Ai4ez61292\\" checked>
                 <label class=\\"fd-checkbox__label\\" for=\\"Ai4ez61292\\">
                     <div class=\\"fd-checkbox__label-container\\">
-                        <span class=\\"fd-checkbox__text\\">Selected State</span>
+                        <span class=\\"fd-checkbox__text\\">Success Selected State</span>
                     </div>
                 </label>
             </div>
@@ -7007,7 +7031,7 @@ exports[`Check stories > Components/Forms/Checkbox > Story States > Should match
                 <input type=\\"checkbox\\" class=\\"fd-checkbox is-success\\" id=\\"Ai4ez613i2\\">
                 <label class=\\"fd-checkbox__label\\" for=\\"Ai4ez613i2\\">
                     <div class=\\"fd-checkbox__label-container\\">
-                        <span class=\\"fd-checkbox__text\\">TriState Text</span>
+                        <span class=\\"fd-checkbox__text\\">Success Tri-State</span>
                     </div>
                 </label>
             </div>
@@ -7021,7 +7045,15 @@ exports[`Check stories > Components/Forms/Checkbox > Story States > Should match
                 <input type=\\"checkbox\\" class=\\"fd-checkbox is-warning\\" id=\\"Ai4ez61193\\">
                 <label class=\\"fd-checkbox__label\\" for=\\"Ai4ez61193\\">
                     <div class=\\"fd-checkbox__label-container\\">
-                        <span class=\\"fd-checkbox__text\\">Text Option</span>
+                        <span class=\\"fd-checkbox__text\\">Warning Regular State</span>
+                    </div>
+                </label>
+            </div>
+            <div class=\\"fd-form-item\\">
+                <input type=\\"checkbox\\" class=\\"fd-checkbox is-warning\\" id=\\"Ai4ez61193hov\\">
+                <label class=\\"fd-checkbox__label is-hover\\" for=\\"Ai4ez61193hov\\">
+                    <div class=\\"fd-checkbox__label-container\\">
+                        <span class=\\"fd-checkbox__text\\">Warning Hover State</span>
                     </div>
                 </label>
             </div>
@@ -7029,7 +7061,7 @@ exports[`Check stories > Components/Forms/Checkbox > Story States > Should match
                 <input type=\\"checkbox\\" class=\\"fd-checkbox is-warning\\" id=\\"Ai4ez61293\\" checked>
                 <label class=\\"fd-checkbox__label\\" for=\\"Ai4ez61293\\">
                     <div class=\\"fd-checkbox__label-container\\">
-                        <span class=\\"fd-checkbox__text\\">Selected State</span>
+                        <span class=\\"fd-checkbox__text\\">Warning Selected State</span>
                     </div>
                 </label>
             </div>
@@ -7037,7 +7069,7 @@ exports[`Check stories > Components/Forms/Checkbox > Story States > Should match
                 <input type=\\"checkbox\\" class=\\"fd-checkbox is-warning\\" id=\\"Ai4ez613i3\\">
                 <label class=\\"fd-checkbox__label\\" for=\\"Ai4ez613i3\\">
                     <div class=\\"fd-checkbox__label-container\\">
-                        <span class=\\"fd-checkbox__text\\">TriState Text</span>
+                        <span class=\\"fd-checkbox__text\\">Warning Tri-State</span>
                     </div>
                 </label>
             </div>
@@ -7051,7 +7083,15 @@ exports[`Check stories > Components/Forms/Checkbox > Story States > Should match
                 <input type=\\"checkbox\\" class=\\"fd-checkbox is-information\\" id=\\"Ai4ez61194\\">
                 <label class=\\"fd-checkbox__label\\" for=\\"Ai4ez61194\\">
                     <div class=\\"fd-checkbox__label-container\\">
-                        <span class=\\"fd-checkbox__text\\">Text Option</span>
+                        <span class=\\"fd-checkbox__text\\">Information Regular State</span>
+                    </div>
+                </label>
+            </div>
+            <div class=\\"fd-form-item\\">
+                <input type=\\"checkbox\\" class=\\"fd-checkbox is-information\\" id=\\"Ai4ez61194hov\\">
+                <label class=\\"fd-checkbox__label is-hover\\" for=\\"Ai4ez61194hov\\">
+                    <div class=\\"fd-checkbox__label-container\\">
+                        <span class=\\"fd-checkbox__text\\">Information Hover State</span>
                     </div>
                 </label>
             </div>
@@ -7059,7 +7099,7 @@ exports[`Check stories > Components/Forms/Checkbox > Story States > Should match
                 <input type=\\"checkbox\\" class=\\"fd-checkbox is-information\\" id=\\"Ai4ez61294\\" checked>
                 <label class=\\"fd-checkbox__label\\" for=\\"Ai4ez61294\\">
                     <div class=\\"fd-checkbox__label-container\\">
-                        <span class=\\"fd-checkbox__text\\">Selected State</span>
+                        <span class=\\"fd-checkbox__text\\">Information Checked State</span>
                     </div>
                 </label>
             </div>
@@ -7067,7 +7107,7 @@ exports[`Check stories > Components/Forms/Checkbox > Story States > Should match
                 <input type=\\"checkbox\\" class=\\"fd-checkbox is-information\\" id=\\"Ai4ez613i4\\">
                 <label class=\\"fd-checkbox__label\\" for=\\"Ai4ez613i4\\">
                     <div class=\\"fd-checkbox__label-container\\">
-                        <span class=\\"fd-checkbox__text\\">TriState Text</span>
+                        <span class=\\"fd-checkbox__text\\">Information Tri-State</span>
                     </div>
                 </label>
             </div>
@@ -7111,7 +7151,15 @@ exports[`Check stories > Components/Forms/Checkbox > Story States > Should match
                 <input type=\\"checkbox\\" class=\\"fd-checkbox\\" id=\\"Ai4ez611967\\" readonly>
                 <label class=\\"fd-checkbox__label\\" for=\\"Ai4ez611967\\">
                     <div class=\\"fd-checkbox__label-container\\">
-                        <span class=\\"fd-checkbox__text\\">Text Option</span>
+                        <span class=\\"fd-checkbox__text\\">Read Only Regular State</span>
+                    </div>
+                </label>
+            </div>
+            <div class=\\"fd-form-item\\">
+                <input type=\\"checkbox\\" class=\\"fd-checkbox\\" id=\\"Ai4ez611967hov\\" readonly>
+                <label class=\\"fd-checkbox__label is-hover\\" for=\\"Ai4ez611967hov\\">
+                    <div class=\\"fd-checkbox__label-container\\">
+                        <span class=\\"fd-checkbox__text\\">Read Only Hover State</span>
                     </div>
                 </label>
             </div>
@@ -7119,7 +7167,7 @@ exports[`Check stories > Components/Forms/Checkbox > Story States > Should match
                 <input type=\\"checkbox\\" class=\\"fd-checkbox\\" id=\\"Ai4ez61296cc\\" checked readonly>
                 <label class=\\"fd-checkbox__label\\" for=\\"Ai4ez61296cc\\">
                     <div class=\\"fd-checkbox__label-container\\">
-                        <span class=\\"fd-checkbox__text\\">Selected State</span>
+                        <span class=\\"fd-checkbox__text\\">Read Only Checked State</span>
                     </div>
                 </label>
             </div>
@@ -7127,7 +7175,7 @@ exports[`Check stories > Components/Forms/Checkbox > Story States > Should match
                 <input type=\\"checkbox\\" class=\\"fd-checkbox\\" id=\\"Ai4ez613i6cc\\" readonly>
                 <label class=\\"fd-checkbox__label\\" for=\\"Ai4ez613i6cc\\">
                     <div class=\\"fd-checkbox__label-container\\">
-                        <span class=\\"fd-checkbox__text\\">TriState Text</span>
+                        <span class=\\"fd-checkbox__text\\">Read Only Tri-State</span>
                     </div>
                 </label>
             </div>
@@ -7160,6 +7208,14 @@ exports[`Check stories > Components/Forms/Checkbox > Story TextTruncation > Shou
         <div class=\\"fd-form-item\\">
             <input type=\\"checkbox\\" class=\\"fd-checkbox\\" id=\\"Ai4ez612lw\\" checked>
             <label class=\\"fd-checkbox__label fd-checkbox__label--wrap\\" for=\\"Ai4ez612lw\\" style=\\"max-width: 400px;\\">
+                <div class=\\"fd-checkbox__label-container\\">
+                    <span class=\\"fd-checkbox__text\\">Banana ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</span>
+                </div>
+            </label>
+        </div>
+        <div class=\\"fd-form-item\\">
+            <input type=\\"checkbox\\" class=\\"fd-checkbox\\" id=\\"Ai4ez612lwtop\\" checked>
+            <label class=\\"fd-checkbox__label fd-checkbox__label--wrap-top-aligned\\" for=\\"Ai4ez612lwtop\\" style=\\"max-width: 400px;\\">
                 <div class=\\"fd-checkbox__label-container\\">
                     <span class=\\"fd-checkbox__text\\">Banana ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</span>
                 </div>
@@ -9062,8 +9118,18 @@ exports[`Check stories > Components/Forms/Form Message > Story Warning > Should 
 exports[`Check stories > Components/Forms/Input > Story Primary > Should match snapshot 1`] = `
 "<div style=\\"\\">
     <div class=\\"fd-form-item\\">
-        <label class=\\"fd-form-label\\" for=\\"input-1\\">Default input:</label>
+        <label class=\\"fd-form-label\\" for=\\"input-1\\">Default input (regular):</label>
         <input class=\\"fd-input\\" type=\\"text\\" id=\\"input-1\\" placeholder=\\"Field placeholder text\\">
+    </div>
+    <br>
+    <div class=\\"fd-form-item\\">
+        <label class=\\"fd-form-label\\" for=\\"input-1-hover\\">Default input (hover):</label>
+        <input class=\\"fd-input is-hover\\" type=\\"text\\" id=\\"input-1-hover\\" placeholder=\\"Field placeholder text\\">
+    </div>
+    <br>
+    <div class=\\"fd-form-item\\">
+        <label class=\\"fd-form-label\\" for=\\"input-1-focus\\">Default input (focus):</label>
+        <input class=\\"fd-input is-focus\\" type=\\"text\\" id=\\"input-1-focus\\" placeholder=\\"Field placeholder text\\">
     </div>
     <br>
     <div class=\\"fd-form-item\\">
@@ -9082,8 +9148,28 @@ exports[`Check stories > Components/Forms/Input > Story Primary > Should match s
     </div>
     <br />
     <div class=\\"fd-form-item\\">
+        <label class=\\"fd-form-label\\" for=\\"input-01-hover\\">Error Input:</label>
+        <input class=\\"fd-input is-error is-hover\\" type=\\"text\\" id=\\"input-01-hover\\" placeholder=\\"Field placeholder text\\">
+    </div>
+    <br />
+    <div class=\\"fd-form-item\\">
+        <label class=\\"fd-form-label\\" for=\\"input-01-focus\\">Error Input:</label>
+        <input class=\\"fd-input is-error is-focus\\" type=\\"text\\" id=\\"input-01-focus\\" placeholder=\\"Field placeholder text\\">
+    </div>
+    <br />
+    <div class=\\"fd-form-item\\">
         <label class=\\"fd-form-label\\" for=\\"input-02\\">Success Input:</label>
         <input class=\\"fd-input is-success\\" type=\\"text\\" id=\\"input-02\\" placeholder=\\"Field placeholder text\\">
+    </div>
+    <br />
+    <div class=\\"fd-form-item\\">
+        <label class=\\"fd-form-label\\" for=\\"input-02-hover\\">Success Input:</label>
+        <input class=\\"fd-input is-success is-hover\\" type=\\"text\\" id=\\"input-02-hover\\" placeholder=\\"Field placeholder text\\">
+    </div>
+    <br />
+    <div class=\\"fd-form-item\\">
+        <label class=\\"fd-form-label\\" for=\\"input-02-focus\\">Success Input:</label>
+        <input class=\\"fd-input is-success is-focus\\" type=\\"text\\" id=\\"input-02-focus\\" placeholder=\\"Field placeholder text\\">
     </div>
     <br />
     <div class=\\"fd-form-item\\">
@@ -9092,13 +9178,33 @@ exports[`Check stories > Components/Forms/Input > Story Primary > Should match s
     </div>
     <br />
     <div class=\\"fd-form-item\\">
+        <label class=\\"fd-form-label\\" for=\\"input-03-hover\\">Warning (Alert) Input:</label>
+        <input class=\\"fd-input is-warning is-hover\\" type=\\"text\\" id=\\"input-03-hover\\" placeholder=\\"Field placeholder text\\">
+    </div>
+    <br />
+    <div class=\\"fd-form-item\\">
+        <label class=\\"fd-form-label\\" for=\\"input-03-focus\\">Warning (Alert) Input:</label>
+        <input class=\\"fd-input is-warning is-focus\\" type=\\"text\\" id=\\"input-03-focus\\" placeholder=\\"Field placeholder text\\">
+    </div>
+    <br />
+    <div class=\\"fd-form-item\\">
         <label class=\\"fd-form-label\\" for=\\"input-04\\">Information Input:</label>
-        <input class=\\"fd-input is-information\\" type=\\"text\\" id=\\"input-04\\">
+        <input class=\\"fd-input is-information\\" type=\\"text\\" id=\\"input-04\\" placeholder=\\"Field placeholder text\\">
+    </div>
+    <br />
+    <div class=\\"fd-form-item\\">
+        <label class=\\"fd-form-label\\" for=\\"input-04-hover\\">Information Input:</label>
+        <input class=\\"fd-input is-information is-hover\\" type=\\"text\\" id=\\"input-04-hover\\" placeholder=\\"Field placeholder text\\">
+    </div>
+    <br />
+    <div class=\\"fd-form-item\\">
+        <label class=\\"fd-form-label\\" for=\\"input-04-focus\\">Information Input:</label>
+        <input class=\\"fd-input is-information is-focus\\" type=\\"text\\" id=\\"input-04-focus\\" placeholder=\\"Field placeholder text\\">
     </div>
     <br />
     <div class=\\"fd-form-item\\">
         <label class=\\"fd-form-label\\" for=\\"input-05\\">Disabled Input:</label>
-        <input class=\\"fd-input\\" type=\\"text\\" id=\\"input-05\\" disabled value=\\"Field placeholder text\\">
+        <input class=\\"fd-input\\" type=\\"text\\" id=\\"input-05\\" disabled value=\\"Field placeholder text\\" placeholder=\\"Field placeholder text\\">
     </div>
     <br />
     <div class=\\"fd-form-item\\">
@@ -10006,71 +10112,180 @@ exports[`Check stories > Components/Forms/Radio > Story Inline > Should match sn
 `;
 
 exports[`Check stories > Components/Forms/Radio > Story InteractionStates > Should match snapshot 1`] = `
-"<fieldset class=\\"fd-fieldset\\" id=\\"radio5\\">
-    <legend class=\\"fd-fieldset__legend\\">Interaction States</legend>
+"<fieldset class=\\"fd-fieldset\\" id=\\"radio5a\\">
+    <legend class=\\"fd-fieldset__legend\\">Default Interaction States</legend>
     <div class=\\"fd-form-group\\">
         <div class=\\"fd-form-item\\">
-            <input type=\\"radio\\" class=\\"fd-radio\\" id=\\"iSpDidh761\\" name=\\"radio5\\" checked>
+            <input type=\\"radio\\" class=\\"fd-radio\\" id=\\"iSpDidh761\\" name=\\"radio5a\\">
             <label class=\\"fd-radio__label\\" for=\\"iSpDidh761\\">
                 <span class=\\"fd-radio__text\\">Default Radio Button</span>
             </label>
         </div>
         <div class=\\"fd-form-item\\">
-            <input type=\\"radio\\" class=\\"fd-radio is-success\\" id=\\"iSpDidh7612\\" name=\\"radio5\\">
+            <input type=\\"radio\\" class=\\"fd-radio\\" id=\\"iSpDidh761cc\\" name=\\"radio5a\\" checked>
+            <label class=\\"fd-radio__label\\" for=\\"iSpDidh761cc\\">
+                <span class=\\"fd-radio__text\\">Default Checked Radio Button</span>
+            </label>
+        </div>
+        <div class=\\"fd-form-item\\">
+            <input type=\\"radio\\" class=\\"fd-radio\\" id=\\"iSpDidh761hov\\" name=\\"radio5a\\">
+            <label class=\\"fd-radio__label is-hover\\" for=\\"iSpDidh761hov\\">
+                <span class=\\"fd-radio__text\\">Default Hover Radio Button</span>
+            </label>
+        </div>
+    </div>
+</fieldset>
+<br><br>
+<fieldset class=\\"fd-fieldset\\" id=\\"radio5b\\">
+    <legend class=\\"fd-fieldset__legend\\">Success Interaction States</legend>
+    <div class=\\"fd-form-group\\">
+        <div class=\\"fd-form-item\\">
+            <input type=\\"radio\\" class=\\"fd-radio is-success\\" id=\\"iSpDidh7612\\" name=\\"radio5b\\">
             <label class=\\"fd-radio__label\\" for=\\"iSpDidh7612\\">
                 <span class=\\"fd-radio__text\\">Success Radio Button</span>
             </label>
         </div>
         <div class=\\"fd-form-item\\">
-            <input type=\\"radio\\" class=\\"fd-radio is-error\\" id=\\"iSpDidh7613\\" name=\\"radio5\\">
+            <input type=\\"radio\\" class=\\"fd-radio is-success\\" id=\\"iSpDidh7612cc\\" name=\\"radio5b\\" checked>
+            <label class=\\"fd-radio__label\\" for=\\"iSpDidh7612cc\\">
+                <span class=\\"fd-radio__text\\">Success Checked Radio Button</span>
+            </label>
+        </div>
+        <div class=\\"fd-form-item\\">
+            <input type=\\"radio\\" class=\\"fd-radio is-success\\" id=\\"iSpDidh7612hov\\" name=\\"radio5b\\">
+            <label class=\\"fd-radio__label is-hover\\" for=\\"iSpDidh7612hov\\">
+                <span class=\\"fd-radio__text\\">Success Hover Radio Button</span>
+            </label>
+        </div>
+    </div>
+</fieldset>
+<br><br>
+<fieldset class=\\"fd-fieldset\\" id=\\"radio5c\\">
+    <legend class=\\"fd-fieldset__legend\\">Error Interaction States</legend>
+    <div class=\\"fd-form-group\\">
+        <div class=\\"fd-form-item\\">
+            <input type=\\"radio\\" class=\\"fd-radio is-error\\" id=\\"iSpDidh7613\\" name=\\"radio5c\\">
             <label class=\\"fd-radio__label\\" for=\\"iSpDidh7613\\">
                 <span class=\\"fd-radio__text\\">Error Radio Button</span>
             </label>
         </div>
         <div class=\\"fd-form-item\\">
-            <input type=\\"radio\\" class=\\"fd-radio is-warning\\" id=\\"iSpDidh7614\\" name=\\"radio5\\">
+            <input type=\\"radio\\" class=\\"fd-radio is-error\\" id=\\"iSpDidh7613cc\\" name=\\"radio5c\\" checked>
+            <label class=\\"fd-radio__label\\" for=\\"iSpDidh7613cc\\">
+                <span class=\\"fd-radio__text\\">Error Checked Radio Button</span>
+            </label>
+        </div>
+        <div class=\\"fd-form-item\\">
+            <input type=\\"radio\\" class=\\"fd-radio is-error\\" id=\\"iSpDidh7613hov\\" name=\\"radio5c\\">
+            <label class=\\"fd-radio__label is-hover\\" for=\\"iSpDidh7613hov\\">
+                <span class=\\"fd-radio__text\\">Error Hover Radio Button</span>
+            </label>
+        </div>
+    </div>
+</fieldset>
+<br><br>
+<fieldset class=\\"fd-fieldset\\" id=\\"radio5d\\">
+    <legend class=\\"fd-fieldset__legend\\">Warning Interaction States</legend>
+    <div class=\\"fd-form-group\\">
+        <div class=\\"fd-form-item\\">
+            <input type=\\"radio\\" class=\\"fd-radio is-warning\\" id=\\"iSpDidh7614\\" name=\\"radio5d\\">
             <label class=\\"fd-radio__label\\" for=\\"iSpDidh7614\\">
                 <span class=\\"fd-radio__text\\">Warning Radio Button</span>
             </label>
         </div>
         <div class=\\"fd-form-item\\">
-            <input type=\\"radio\\" class=\\"fd-radio is-information\\" id=\\"iSpDidh7615\\" name=\\"radio5\\">
+            <input type=\\"radio\\" class=\\"fd-radio is-warning\\" id=\\"iSpDidh7614cc\\" name=\\"radio5d\\" checked>
+            <label class=\\"fd-radio__label\\" for=\\"iSpDidh7614cc\\">
+                <span class=\\"fd-radio__text\\">Warning Checked Radio Button</span>
+            </label>
+        </div>
+        <div class=\\"fd-form-item\\">
+            <input type=\\"radio\\" class=\\"fd-radio is-warning\\" id=\\"iSpDidh7614hov\\" name=\\"radio5d\\">
+            <label class=\\"fd-radio__label is-hover\\" for=\\"iSpDidh7614hov\\">
+                <span class=\\"fd-radio__text\\">Warning Hover Radio Button</span>
+            </label>
+        </div>
+    </div>
+</fieldset>
+<br><br>
+<fieldset class=\\"fd-fieldset\\" id=\\"radio5e\\">
+    <legend class=\\"fd-fieldset__legend\\">Information Interaction States</legend>
+    <div class=\\"fd-form-group\\">
+        <div class=\\"fd-form-item\\">
+            <input type=\\"radio\\" class=\\"fd-radio is-information\\" id=\\"iSpDidh7615\\" name=\\"radio5e\\">
             <label class=\\"fd-radio__label\\" for=\\"iSpDidh7615\\">
                 <span class=\\"fd-radio__text\\">Information Radio Button</span>
             </label>
         </div>
         <div class=\\"fd-form-item\\">
-            <input type=\\"radio\\" class=\\"fd-radio is-readonly\\" id=\\"iSpDidh76erfg15\\" name=\\"radio5\\" readonly>
+            <input type=\\"radio\\" class=\\"fd-radio is-information\\" id=\\"iSpDidh7615cc\\" name=\\"radio5e\\" checked>
+            <label class=\\"fd-radio__label\\" for=\\"iSpDidh7615cc\\">
+                <span class=\\"fd-radio__text\\">Information Checked Radio Button</span>
+            </label>
+        </div>
+        <div class=\\"fd-form-item\\">
+            <input type=\\"radio\\" class=\\"fd-radio is-information\\" id=\\"iSpDidh7615hov\\" name=\\"radio5e\\">
+            <label class=\\"fd-radio__label is-hover\\" for=\\"iSpDidh7615hov\\">
+                <span class=\\"fd-radio__text\\">Information Hover Radio Button</span>
+            </label>
+        </div>
+    </div>
+</fieldset>
+<br><br>
+
+<fieldset class=\\"fd-fieldset\\" id=\\"radio5f\\">
+    <legend class=\\"fd-fieldset__legend\\">Read-Only Interaction States</legend>
+    <div class=\\"fd-form-group\\">
+        <div class=\\"fd-form-item\\">
+            <input type=\\"radio\\" class=\\"fd-radio is-readonly\\" id=\\"iSpDidh76erfg15\\" name=\\"radio5f\\" readonly>
             <label class=\\"fd-radio__label\\" for=\\"iSpDidh76erfg15\\">
                 <span class=\\"fd-radio__text\\">ReadOnly Radio Button</span>
             </label>
         </div>
         <div class=\\"fd-form-item\\">
-            <input type=\\"radio\\" class=\\"fd-radio\\" id=\\"iSpDidh7611\\" name=\\"radio5\\" disabled>
+            <input type=\\"radio\\" class=\\"fd-radio is-readonly\\" id=\\"iSpDidh76erfg15cc\\" name=\\"radio5f\\" readonly checked>
+            <label class=\\"fd-radio__label\\" for=\\"iSpDidh76erfg15cc\\">
+                <span class=\\"fd-radio__text\\">ReadOnly Checked Radio Button</span>
+            </label>
+        </div>
+        <div class=\\"fd-form-item\\">
+            <input type=\\"radio\\" class=\\"fd-radio is-readonly\\" id=\\"iSpDidh76erfg15hov\\" name=\\"radio5f\\" readonly>
+            <label class=\\"fd-radio__label is-hover\\" for=\\"iSpDidh76erfg15hov\\">
+                <span class=\\"fd-radio__text\\">ReadOnly Hover Radio Button</span>
+            </label>
+        </div>
+    </div>
+</fieldset>
+<br><br>
+<fieldset class=\\"fd-fieldset\\" id=\\"radio5g\\">
+    <legend class=\\"fd-fieldset__legend\\">Disabled States</legend>
+    <div class=\\"fd-form-group\\">
+        <div class=\\"fd-form-item\\">
+            <input type=\\"radio\\" class=\\"fd-radio\\" id=\\"iSpDidh7611\\" name=\\"radio5g\\" disabled>
             <label class=\\"fd-radio__label\\" for=\\"iSpDidh7611\\">
                 <span class=\\"fd-radio__text\\">Disabled Radio Button</span>
             </label>
         </div>
         <div class=\\"fd-form-item\\">
-            <input type=\\"radio\\" class=\\"fd-radio is-success\\" id=\\"iSpDidh76121\\" name=\\"radio5\\" disabled>
+            <input type=\\"radio\\" class=\\"fd-radio is-success\\" id=\\"iSpDidh76121\\" name=\\"radio5g\\" disabled>
             <label class=\\"fd-radio__label\\" for=\\"iSpDidh76121\\">
                 <span class=\\"fd-radio__text\\">Success Radio Button (disabled)</span>
             </label>
         </div>
         <div class=\\"fd-form-item\\">
-            <input type=\\"radio\\" class=\\"fd-radio is-error\\" id=\\"iSpDidh76131\\" name=\\"radio5\\" disabled>
+            <input type=\\"radio\\" class=\\"fd-radio is-error\\" id=\\"iSpDidh76131\\" name=\\"radio5g\\" disabled>
             <label class=\\"fd-radio__label\\" for=\\"iSpDidh76131\\">
                 <span class=\\"fd-radio__text\\">Error Radio Button (disabled)</span>
             </label>
         </div>
         <div class=\\"fd-form-item\\">
-            <input type=\\"radio\\" class=\\"fd-radio is-warning\\" id=\\"iSpDidh76141\\" name=\\"radio5\\" disabled>
+            <input type=\\"radio\\" class=\\"fd-radio is-warning\\" id=\\"iSpDidh76141\\" name=\\"radio5g\\" disabled>
             <label class=\\"fd-radio__label\\" for=\\"iSpDidh76141\\">
                 <span class=\\"fd-radio__text\\">Warning Radio Button (disabled)</span>
             </label>
         </div>
         <div class=\\"fd-form-item\\">
-            <input type=\\"radio\\" class=\\"fd-radio is-information\\" id=\\"iSpDidh76151\\" name=\\"radio5\\" disabled>
+            <input type=\\"radio\\" class=\\"fd-radio is-information\\" id=\\"iSpDidh76151\\" name=\\"radio5g\\" disabled>
             <label class=\\"fd-radio__label\\" for=\\"iSpDidh76151\\">
                 <span class=\\"fd-radio__text\\">Information Radio Button (disabled)</span>
             </label>
@@ -10119,8 +10334,16 @@ exports[`Check stories > Components/Forms/Radio > Story TextTruncation > Should 
             </label>
         </div>
         <div class=\\"fd-form-item\\">
-            <input type=\\"radio\\" class=\\"fd-radio\\" id=\\"pDidh7612tt\\" name=\\"radio1Truncation\\">
+            <input type=\\"radio\\" class=\\"fd-radio\\" id=\\"pDidh7612tt\\" name=\\"radio2Truncation\\" checked>
             <label class=\\"fd-radio__label fd-radio__label--wrap\\" for=\\"pDidh7612tt\\" style=\\"max-width: 400px;\\">
+                <span class=\\"fd-radio__text\\">
+                    Field label  ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                </span>
+            </label>
+        </div>
+        <div class=\\"fd-form-item\\">
+            <input type=\\"radio\\" class=\\"fd-radio\\" id=\\"pDidh7612ttop\\" name=\\"radio3Truncation\\" checked>
+            <label class=\\"fd-radio__label fd-radio__label--wrap-top-aligned\\" for=\\"pDidh7612ttop\\" style=\\"max-width: 400px;\\">
                 <span class=\\"fd-radio__text\\">
                     Field label  ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
                 </span>
@@ -10147,6 +10370,10 @@ exports[`Check stories > Components/Forms/Textarea > Story DisabledAndReadOnly >
 <div class=\\"fd-form-item\\">
     <label class=\\"fd-form-label\\" for=\\"textarea-8\\">Text area:</label>
     <textarea class=\\"fd-textarea\\" id=\\"textarea-8\\" readonly>Read Only textarea</textarea>
+</div>
+<div class=\\"fd-form-item\\">
+    <label class=\\"fd-form-label\\" for=\\"textarea-9\\">Text area:</label>
+    <textarea class=\\"fd-textarea is-focus\\" id=\\"textarea-9\\" readonly>Focussed Read Only textarea</textarea>
 </div>
 "
 `;
@@ -26663,7 +26890,7 @@ exports[`Check stories > Components/Slider > Story MobileMode > Should match sna
 `;
 
 exports[`Check stories > Components/Slider > Story Range > Should match snapshot 1`] = `
-"
+"<h3>Regular</h3>
 <div class=\\"slider-container slider-container--range\\">
     <div class=\\"fd-slider fd-slider--range\\">
         <div class=\\"fd-slider__inner\\">
@@ -26677,6 +26904,58 @@ exports[`Check stories > Components/Slider > Story Range > Should match snapshot
         </div>
     </div>
 </div>
+
+<br><br>
+<h3>Hover (on one handle)</h3>
+<div class=\\"slider-container slider-container--range\\">
+  <div class=\\"fd-slider fd-slider--range\\">
+      <div class=\\"fd-slider__inner\\">
+          <div class=\\"fd-slider__track\\">
+            <div class=\\"fd-slider__track-range\\" style=\\"width: 40%\\">
+              <div class=\\"fd-slider__track-focus-range\\" tabindex=\\"0\\"></div>
+            </div>
+          </div>
+          <div class=\\"fd-slider__handle is-hover\\" tabindex=\\"0\\" role=\\"slider\\" aria-label=\\"range slider left\\" aria-valuemin=\\"1\\" aria-valuemax=\\"80\\" aria-valuenow=\\"40\\" style=\\"left: 40%;\\"></div>
+          <div class=\\"fd-slider__handle\\" tabindex=\\"0\\" role=\\"slider\\" aria-label=\\"range slider right\\" aria-valuemin=\\"40\\" aria-valuemax=\\"100\\" aria-valuenow=\\"80\\" style=\\"left: 80%;\\"></div>
+      </div>
+  </div>
+</div>
+
+<br><br>
+<h3>Active (on one handle)</h3>
+<div class=\\"slider-container slider-container--range\\">
+  <div class=\\"fd-slider fd-slider--range\\">
+      <div class=\\"fd-slider__inner\\">
+          <div class=\\"fd-slider__track\\">
+            <div class=\\"fd-slider__track-range\\" style=\\"width: 40%\\">
+              <div class=\\"fd-slider__track-focus-range\\" tabindex=\\"0\\"></div>
+            </div>
+          </div>
+          <div class=\\"fd-slider__handle is-active\\" tabindex=\\"0\\" role=\\"slider\\" aria-label=\\"range slider left\\" aria-valuemin=\\"1\\" aria-valuemax=\\"80\\" aria-valuenow=\\"40\\" style=\\"left: 40%;\\"></div>
+          <div class=\\"fd-slider__handle tabindex=\\"0\\" role=\\"slider\\" aria-label=\\"range slider right\\" aria-valuemin=\\"40\\" aria-valuemax=\\"100\\" aria-valuenow=\\"80\\" style=\\"left: 80%;\\"></div>
+      </div>
+  </div>
+</div>
+
+
+<br><br>
+<h3>Focus</h3>
+<div class=\\"slider-container slider-container--range\\">
+  <div class=\\"fd-slider fd-slider--range\\">
+      <div class=\\"fd-slider__inner\\">
+          <div class=\\"fd-slider__track\\">
+            <div class=\\"fd-slider__track-range\\" style=\\"width: 40%\\">
+              <div class=\\"fd-slider__track-focus-range is-focus\\" tabindex=\\"0\\"></div>
+            </div>
+          </div>
+          <div class=\\"fd-slider__handle\\" tabindex=\\"0\\" role=\\"slider\\" aria-label=\\"range slider left\\" aria-valuemin=\\"1\\" aria-valuemax=\\"80\\" aria-valuenow=\\"40\\" style=\\"left: 40%;\\"></div>
+          <div class=\\"fd-slider__handle\\" tabindex=\\"0\\" role=\\"slider\\" aria-label=\\"range slider right\\" aria-valuemin=\\"40\\" aria-valuemax=\\"100\\" aria-valuenow=\\"80\\" style=\\"left: 80%;\\"></div>
+      </div>
+  </div>
+</div>
+
+
+
 "
 `;
 
@@ -26692,6 +26971,40 @@ exports[`Check stories > Components/Slider > Story Standard > Should match snaps
         </div>
     </div>
 </div>
+<br><br>
+<div class=\\"slider-container\\">
+    <div class=\\"fd-slider\\">
+        <div class=\\"fd-slider__inner\\">
+        <div class=\\"fd-slider__handle is-hover\\" tabindex=\\"0\\" role=\\"slider\\" aria-label=\\"slider\\" aria-valuemin=\\"1\\" aria-valuemax=\\"100\\" aria-valuenow=\\"50\\" style=\\"left: 50%;\\"></div>
+            <div class=\\"fd-slider__track\\">
+                <div class=\\"fd-slider__track-range\\" style=\\"width: 50%;\\"></div>
+            </div>
+        </div>
+    </div>
+</div>
+<br><br>
+<div class=\\"slider-container\\">
+    <div class=\\"fd-slider\\">
+        <div class=\\"fd-slider__inner\\">
+        <div class=\\"fd-slider__handle is-active\\" tabindex=\\"0\\" role=\\"slider\\" aria-label=\\"slider\\" aria-valuemin=\\"1\\" aria-valuemax=\\"100\\" aria-valuenow=\\"50\\" style=\\"left: 50%;\\"></div>
+            <div class=\\"fd-slider__track\\">
+                <div class=\\"fd-slider__track-range\\" style=\\"width: 50%;\\"></div>
+            </div>
+        </div>
+    </div>
+</div>
+<br><br>
+<div class=\\"slider-container\\">
+    <div class=\\"fd-slider\\">
+        <div class=\\"fd-slider__inner\\">
+        <div class=\\"fd-slider__handle is-focus\\" tabindex=\\"0\\" role=\\"slider\\" aria-label=\\"slider\\" aria-valuemin=\\"1\\" aria-valuemax=\\"100\\" aria-valuenow=\\"50\\" style=\\"left: 50%;\\"></div>
+            <div class=\\"fd-slider__track\\">
+                <div class=\\"fd-slider__track-range\\" style=\\"width: 50%;\\"></div>
+            </div>
+        </div>
+    </div>
+</div>
+
 "
 `;
 


### PR DESCRIPTION

## Related Issue
Closes NONE

## Description
This PR includes multiple fixes reported by the designers regarding components already migrated to latest Horizon 2023 design specs.

1. Missing Read only tristate square in all 4 Horizon themes.

**Before:**
<img width="255" alt="Screenshot 2023-05-26 at 2 00 20 PM" src="https://github.com/SAP/fundamental-styles/assets/39598672/5cd8099d-6245-4898-95e6-e7957f6ddf6f">

**After:**
<img width="296" alt="Screenshot 2023-05-26 at 2 00 46 PM" src="https://github.com/SAP/fundamental-styles/assets/39598672/e5255b4e-e674-4a80-bc9d-c8cb5255c032">

2. Readonly state for Radio and Checkbox shouldn't have hover
 
3. For HCB and HCW – the hover colour is wrong

**Before:**
<img width="271" alt="Screenshot 2023-05-26 at 2 02 37 PM" src="https://github.com/SAP/fundamental-styles/assets/39598672/2d827ca9-5a5c-4fdd-aeb8-1de1bd441b38">

**After:**
<img width="236" alt="Screenshot 2023-05-26 at 2 03 01 PM" src="https://github.com/SAP/fundamental-styles/assets/39598672/6d32de91-c604-40f7-88a3-5234bd9fca8d">

4. Wrapping of long label for Checkbox and Radio. Now we have top-aligned wrapping:

<img width="448" alt="Screenshot 2023-05-26 at 2 04 05 PM" src="https://github.com/SAP/fundamental-styles/assets/39598672/34a47d62-cd23-4c5d-97f5-a5fe598fb5ba">

5. Slider missing focus state

**Before:**
<img width="908" alt="Screenshot 2023-05-26 at 2 06 09 PM" src="https://github.com/SAP/fundamental-styles/assets/39598672/fd45d3d7-42ba-4325-b198-764b82a55192">

**After:**
<img width="349" alt="Screenshot 2023-05-26 at 2 06 21 PM" src="https://github.com/SAP/fundamental-styles/assets/39598672/0d0e2d82-284e-4bf0-b528-c21fe0c84190">

6. Textarea, the scrollbar overlaps the border and box shadow

**Before:**
<img width="799" alt="Screenshot 2023-05-26 at 2 07 58 PM" src="https://github.com/SAP/fundamental-styles/assets/39598672/72808e20-4560-43ff-8fc6-79667bf322f0">

**After:**
<img width="547" alt="Screenshot 2023-05-26 at 2 08 12 PM" src="https://github.com/SAP/fundamental-styles/assets/39598672/e7045de1-8b69-4949-a3f9-5a1df2a19049">

7. Textarea in Read-only state should have dashed border around all sides and the focus should be inside (with an offset)

**Before:**
<img width="384" alt="Screenshot 2023-05-26 at 2 09 33 PM" src="https://github.com/SAP/fundamental-styles/assets/39598672/c44d3081-d47c-4336-b7d9-57e2a7153624">
<img width="377" alt="Screenshot 2023-05-26 at 2 09 30 PM" src="https://github.com/SAP/fundamental-styles/assets/39598672/cb32b497-3197-4365-ae2c-66387daaeb5f">

**After:**
<img width="472" alt="Screenshot 2023-05-26 at 2 09 40 PM" src="https://github.com/SAP/fundamental-styles/assets/39598672/f7dc4d82-e491-4292-b71e-379eeab2bf62">

8. Input field in read-only state should have shadow

**Before:**
<img width="516" alt="Screenshot 2023-05-26 at 2 10 56 PM" src="https://github.com/SAP/fundamental-styles/assets/39598672/7f43117a-dfac-446d-bbe5-b4d40bca6f54">

**After:**
<img width="588" alt="Screenshot 2023-05-26 at 2 11 09 PM" src="https://github.com/SAP/fundamental-styles/assets/39598672/00443dd6-d017-4b30-8e8b-8523a4a087b5">
