### PR TITLE
fix(styles): fixed semantics of the popover vertical arrow positioning

### DIFF
--- a/packages/styles/src/popover.scss
+++ b/packages/styles/src/popover.scss
@@ -321,7 +321,8 @@ $fd-popover-arrow-offset-x: calc(var(--fdIcon_Button_Width) * 0.5 - #{$fd-popove
         }
       }
 
-      &-y-end {
+      &-y-end,
+      &-y-bottom {
         &::before {
           top: auto;
           bottom: calc(#{$fd-popover-arrow-offset-y} + var(--fdPopover_Border_Width));
@@ -445,7 +446,8 @@ $fd-popover-arrow-offset-x: calc(var(--fdIcon_Button_Width) * 0.5 - #{$fd-popove
           --fdPopover_Resize_Handle_Rotate_Angle: -90deg;
         }
 
-        &.#{$blockBody}--bottom.#{$blockBody}--arrow-y-end {
+        &.#{$blockBody}--bottom.#{$blockBody}--arrow-y-end,
+        &.#{$blockBody}--bottom.#{$blockBody}--arrow-y-bottom {
           --fdPopover_Resize_Handle_Position_Top: 0;
           --fdPopover_Resize_Handle_Position_Bottom: auto;
           --fdPopover_Resize_Handle_Position_Right: 0;
@@ -466,7 +468,8 @@ $fd-popover-arrow-offset-x: calc(var(--fdIcon_Button_Width) * 0.5 - #{$fd-popove
         --fdPopover_Resize_Handle_Transform_Scale: -1;
 
         &.#{$blockBody}--middle.#{$blockBody}--arrow-y-center,
-        &.#{$blockBody}--bottom.#{$blockBody}--arrow-y-end {
+        &.#{$blockBody}--bottom.#{$blockBody}--arrow-y-end,
+        &.#{$blockBody}--bottom.#{$blockBody}--arrow-y-bottom {
           --fdPopover_Resize_Handle_Position_Top: 0;
           --fdPopover_Resize_Handle_Position_Bottom: auto;
           --fdPopover_Resize_Handle_Rotate_Angle: 90deg;

--- a/packages/styles/stories/Components/popover/placement.example.html
+++ b/packages/styles/stories/Components/popover/placement.example.html
@@ -249,7 +249,7 @@
                 <i class="sap-icon--navigation-left-arrow" role="presentation"></i>
             </button>
         </div>
-        <div class="fd-popover__body fd-popover__body--before fd-popover__body--bottom fd-popover__body--arrow-right fd-popover__body--arrow-y-end" aria-hidden="false" id="popoverF1g">
+        <div class="fd-popover__body fd-popover__body--before fd-popover__body--bottom fd-popover__body--arrow-right fd-popover__body--arrow-y-bottom" aria-hidden="false" id="popoverF1g">
             <div class="fd-popover__wrapper" style="max-height: 250px;">
                 <nav class="fd-menu" aria-label="big navigation menu">
                     <ul class="fd-menu__list fd-menu__list--no-shadow">
@@ -282,7 +282,7 @@
                 <i class="sap-icon--navigation-right-arrow" role="presentation"></i>
             </button>
         </div>
-        <div class="fd-popover__body fd-popover__body--after fd-popover__body--bottom fd-popover__body--arrow-left fd-popover__body--arrow-y-end" aria-hidden="false" id="popoverF1h">
+        <div class="fd-popover__body fd-popover__body--after fd-popover__body--bottom fd-popover__body--arrow-left fd-popover__body--arrow-y-bottom" aria-hidden="false" id="popoverF1h">
             <div class="fd-popover__wrapper" style="max-height: 250px;">
                 <nav class="fd-menu" aria-label="big navigation menu">
                     <ul class="fd-menu__list fd-menu__list--no-shadow">

--- a/packages/styles/stories/Components/popover/popover.stories.js
+++ b/packages/styles/stories/Components/popover/popover.stories.js
@@ -111,7 +111,9 @@ To align the popover arrow with the trigger apply the following modifier classes
 | \`fd-popover__body--arrow-x-center\` | Positions the arrow horizontally centered on the popover. |
 | \`fd-popover__body--arrow-x-end\` | Positions the arrow to the end by horizontal line of the popover body. |
 | \`fd-popover__body--arrow-y-center\` | Positions the arrow vertically centered on the popover. |
-| \`fd-popover__body--arrow-y-end\` | Positions the arrow to the end by vertical line of the popover. |
+| \`fd-popover__body--arrow-y-bottom\` | Positions the arrow to the end by vertical line of the popover. |
+
+**note:** \`fd-popover__body--arrow-y--end\` class has been deprecated in favor of \`fd-popover__body--arrow-y-bottom\`!
         `
     }
   }

--- a/packages/styles/stories/Components/popover/resizable.example.html
+++ b/packages/styles/stories/Components/popover/resizable.example.html
@@ -256,7 +256,7 @@
                 <i class="sap-icon--navigation-left-arrow" role="presentation"></i>
             </button>
         </div>
-        <div class="fd-popover__body fd-popover__body--before fd-popover__body--bottom fd-popover__body--arrow-right fd-popover__body--arrow-y-end fd-popover__body--resizable" aria-hidden="false" id="popoverF8r">
+        <div class="fd-popover__body fd-popover__body--before fd-popover__body--bottom fd-popover__body--arrow-right fd-popover__body--arrow-y-bottom fd-popover__body--resizable" aria-hidden="false" id="popoverF8r">
             <div class="fd-popover__wrapper" style="max-height: 250px;">
                 <nav class="fd-menu" aria-label="big navigation menu">
                     <ul class="fd-menu__list fd-menu__list--no-shadow">
@@ -290,7 +290,7 @@
                 <i class="sap-icon--navigation-right-arrow" role="presentation"></i>
             </button>
         </div>
-        <div class="fd-popover__body fd-popover__body--after fd-popover__body--bottom fd-popover__body--arrow-left fd-popover__body--arrow-y-end fd-popover__body--resizable" aria-hidden="false" id="popoverF9r">
+        <div class="fd-popover__body fd-popover__body--after fd-popover__body--bottom fd-popover__body--arrow-left fd-popover__body--arrow-y-bottom fd-popover__body--resizable" aria-hidden="false" id="popoverF9r">
             <div class="fd-popover__wrapper" style="max-height: 250px;">
                 <nav class="fd-menu" aria-label="big navigation menu">
                     <ul class="fd-menu__list fd-menu__list--no-shadow">

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -22338,7 +22338,7 @@ exports[`Check stories > Components/Popover > Story Placement > Should match sna
                 <i class=\\"sap-icon--navigation-left-arrow\\" role=\\"presentation\\"></i>
             </button>
         </div>
-        <div class=\\"fd-popover__body fd-popover__body--before fd-popover__body--bottom fd-popover__body--arrow-right fd-popover__body--arrow-y-end\\" aria-hidden=\\"false\\" id=\\"popoverF1g\\">
+        <div class=\\"fd-popover__body fd-popover__body--before fd-popover__body--bottom fd-popover__body--arrow-right fd-popover__body--arrow-y-bottom\\" aria-hidden=\\"false\\" id=\\"popoverF1g\\">
             <div class=\\"fd-popover__wrapper\\" style=\\"max-height: 250px;\\">
                 <nav class=\\"fd-menu\\" aria-label=\\"big navigation menu\\">
                     <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
@@ -22371,7 +22371,7 @@ exports[`Check stories > Components/Popover > Story Placement > Should match sna
                 <i class=\\"sap-icon--navigation-right-arrow\\" role=\\"presentation\\"></i>
             </button>
         </div>
-        <div class=\\"fd-popover__body fd-popover__body--after fd-popover__body--bottom fd-popover__body--arrow-left fd-popover__body--arrow-y-end\\" aria-hidden=\\"false\\" id=\\"popoverF1h\\">
+        <div class=\\"fd-popover__body fd-popover__body--after fd-popover__body--bottom fd-popover__body--arrow-left fd-popover__body--arrow-y-bottom\\" aria-hidden=\\"false\\" id=\\"popoverF1h\\">
             <div class=\\"fd-popover__wrapper\\" style=\\"max-height: 250px;\\">
                 <nav class=\\"fd-menu\\" aria-label=\\"big navigation menu\\">
                     <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
@@ -22754,7 +22754,7 @@ exports[`Check stories > Components/Popover > Story Resizable > Should match sna
                 <i class=\\"sap-icon--navigation-left-arrow\\" role=\\"presentation\\"></i>
             </button>
         </div>
-        <div class=\\"fd-popover__body fd-popover__body--before fd-popover__body--bottom fd-popover__body--arrow-right fd-popover__body--arrow-y-end fd-popover__body--resizable\\" aria-hidden=\\"false\\" id=\\"popoverF8r\\">
+        <div class=\\"fd-popover__body fd-popover__body--before fd-popover__body--bottom fd-popover__body--arrow-right fd-popover__body--arrow-y-bottom fd-popover__body--resizable\\" aria-hidden=\\"false\\" id=\\"popoverF8r\\">
             <div class=\\"fd-popover__wrapper\\" style=\\"max-height: 250px;\\">
                 <nav class=\\"fd-menu\\" aria-label=\\"big navigation menu\\">
                     <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
@@ -22788,7 +22788,7 @@ exports[`Check stories > Components/Popover > Story Resizable > Should match sna
                 <i class=\\"sap-icon--navigation-right-arrow\\" role=\\"presentation\\"></i>
             </button>
         </div>
-        <div class=\\"fd-popover__body fd-popover__body--after fd-popover__body--bottom fd-popover__body--arrow-left fd-popover__body--arrow-y-end fd-popover__body--resizable\\" aria-hidden=\\"false\\" id=\\"popoverF9r\\">
+        <div class=\\"fd-popover__body fd-popover__body--after fd-popover__body--bottom fd-popover__body--arrow-left fd-popover__body--arrow-y-bottom fd-popover__body--resizable\\" aria-hidden=\\"false\\" id=\\"popoverF9r\\">
             <div class=\\"fd-popover__wrapper\\" style=\\"max-height: 250px;\\">
                 <nav class=\\"fd-menu\\" aria-label=\\"big navigation menu\\">
                     <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">


### PR DESCRIPTION
## Related Issue
Part of SAP/fundamental-ngx#9747

## Description
The name should be `bottom` not the `end` in case of the vertical placement. Deprecated previous modifier. No visual changes