### PR TITLE
feat(styles): bring indication colors set to Message Strip [ci visual]

### DIFF
--- a/packages/styles/src/message-strip.scss
+++ b/packages/styles/src/message-strip.scss
@@ -13,6 +13,129 @@ $block: #{$fd-namespace}-message-strip;
   --fdMessageStrip_Left_Padding: 2.4375rem;
   --fdMessageStrip_Right_Padding: 0.9375rem;
 
+  $fd-avatar-indication-colors: (
+    "1": (
+      "background-color": var(--sapIndicationColor_1_Background),
+      "text-color": var(--sapIndicationColor_1_TextColor),
+      "border-color": var(--sapIndicationColor_1_BorderColor),
+      "text-shadow": none
+    ),
+    "2": (
+      "background-color": var(--sapIndicationColor_2_Background),
+      "text-color": var(--sapIndicationColor_2_TextColor),
+      "border-color": var(--sapIndicationColor_2_BorderColor),
+      "text-shadow": none
+    ),
+    "3": (
+      "background-color": var(--sapIndicationColor_3_Background),
+      "text-color": var(--sapIndicationColor_3_TextColor),
+      "border-color": var(--sapIndicationColor_3_BorderColor),
+      "text-shadow": none
+    ),
+    "4": (
+      "background-color": var(--sapIndicationColor_4_Background),
+      "text-color": var(--sapIndicationColor_4_TextColor),
+      "border-color": var(--sapIndicationColor_4_BorderColor),
+      "text-shadow": none
+    ),
+    "5": (
+      "background-color": var(--sapIndicationColor_5_Background),
+      "text-color": var(--sapIndicationColor_5_TextColor),
+      "border-color": var(--sapIndicationColor_5_BorderColor),
+      "text-shadow": none
+    ),
+    "6": (
+      "background-color": var(--sapIndicationColor_6_Background),
+      "text-color": var(--sapIndicationColor_6_TextColor),
+      "border-color": var(--sapIndicationColor_6_BorderColor),
+      "text-shadow": none
+    ),
+    "7": (
+      "background-color": var(--sapIndicationColor_7_Background),
+      "text-color": var(--sapIndicationColor_7_TextColor),
+      "border-color": var(--sapIndicationColor_7_BorderColor),
+      "text-shadow": none
+    ),
+    "8": (
+      "background-color": var(--sapIndicationColor_8_Background),
+      "text-color": var(--sapIndicationColor_8_TextColor),
+      "border-color": var(--sapIndicationColor_8_BorderColor),
+      "text-shadow": none
+    ),
+    "9": (
+      "background-color": var(--sapIndicationColor_9_Background),
+      "text-color": var(--sapIndicationColor_9_TextColor),
+      "border-color": var(--sapIndicationColor_9_BorderColor),
+      "text-shadow": none
+    ),
+    "10": (
+      "background-color": var(--sapIndicationColor_10_Background),
+      "text-color": var(--sapIndicationColor_10_TextColor),
+      "border-color": var(--sapIndicationColor_10_BorderColor),
+      "text-shadow": none
+    ),
+    "1b": (
+      "background-color": var(--sapIndicationColor_1b),
+      "text-color": var(--sapIndicationColor_1),
+      "border-color": var(--sapIndicationColor_1b_BorderColor),
+      "text-shadow": var(--sapContent_TextShadow)
+    ),
+    "2b": (
+      "background-color": var(--sapIndicationColor_2b),
+      "text-color": var(--sapIndicationColor_2),
+      "border-color": var(--sapIndicationColor_2b_BorderColor),
+      "text-shadow": var(--sapContent_TextShadow)
+    ),
+    "3b": (
+      "background-color": var(--sapIndicationColor_3b),
+      "text-color": var(--sapIndicationColor_3),
+      "border-color": var(--sapIndicationColor_3b_BorderColor),
+      "text-shadow": var(--sapContent_TextShadow)
+    ),
+    "4b": (
+      "background-color": var(--sapIndicationColor_4b),
+      "text-color": var(--sapIndicationColor_4),
+      "border-color": var(--sapIndicationColor_4b_BorderColor),
+      "text-shadow": var(--sapContent_TextShadow)
+    ),
+    "5b": (
+      "background-color": var(--sapIndicationColor_5b),
+      "text-color": var(--sapIndicationColor_5),
+      "border-color": var(--sapIndicationColor_5b_BorderColor),
+      "text-shadow": var(--sapContent_TextShadow)
+    ),
+    "6b": (
+      "background-color": var(--sapIndicationColor_6b),
+      "text-color": var(--sapIndicationColor_6),
+      "border-color": var(--sapIndicationColor_6b_BorderColor),
+      "text-shadow": var(--sapContent_TextShadow)
+    ),
+    "7b": (
+      "background-color": var(--sapIndicationColor_7b),
+      "text-color": var(--sapIndicationColor_7),
+      "border-color": var(--sapIndicationColor_7b_BorderColor),
+      "text-shadow": var(--sapContent_TextShadow)
+    ),
+    "8b": (
+      "background-color": var(--sapIndicationColor_8b),
+      "text-color": var(--sapIndicationColor_8),
+      "border-color": var(--sapIndicationColor_8b_BorderColor),
+      "text-shadow": var(--sapContent_TextShadow)
+    ),
+    "9b": (
+      "background-color": var(--sapIndicationColor_9b),
+      "text-color": var(--sapIndicationColor_9),
+      "border-color": var(--sapIndicationColor_9b_BorderColor),
+      "text-shadow": var(--sapContent_TextShadow)
+    ),
+    "10b": (
+      "background-color": var(--sapIndicationColor_10b),
+      "text-color": var(--sapIndicationColor_10),
+      "border-color": var(--sapIndicationColor_10b_BorderColor),
+      "text-shadow": var(--sapContent_TextShadow)
+    )
+  );
+
   @include fd-reset();
   @include fd-set-paddings-y-equal(var(--fdMessageStrip_Vertical_Padding));
   @include fd-set-paddings-x(var(--fdMessageStrip_Left_Padding), var(--fdMessageStrip_Right_Padding));
@@ -38,7 +161,7 @@ $block: #{$fd-namespace}-message-strip;
     @include fd-reset();
 
     line-height: 1rem;
-    color: var(-fdMessageStrip_Text_Color);
+    color: var(--fdMessageStrip_Text_Color);
   }
 
   &__icon-container {
@@ -106,8 +229,8 @@ $block: #{$fd-namespace}-message-strip;
     text-shadow: var(--sapContent_TextShadow);
   }
 
-  @each $set-name, $color-set in $fd-avatar-accent-colors {
-    &--accent-color-#{$set-name} {
+  @each $set-name, $color-set in $fd-avatar-indication-colors {
+    &--indication-color-#{$set-name} {
       --fdMessageStrip_Icon_Color: #{map_get($color-set, "text-color")};
       --fdMessageStrip_Text_Color: #{map_get($color-set, "text-color")};
       --fdMessageStrip_Border_Color: #{map_get($color-set, "border-color")};

--- a/packages/styles/stories/Components/message-strip/message-strip-with-accent-colors.example.html
+++ b/packages/styles/stories/Components/message-strip/message-strip-with-accent-colors.example.html
@@ -1,115 +1,219 @@
-<div class="fd-message-strip fd-message-strip--dismissible fd-message-strip--accent-color-1" role="note" aria-live="assertive" id="message-strip-17" aria-labelledby="message-strip-17">
+<div class="fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-1" role="note" aria-live="assertive" id="message-strip-17" aria-labelledby="message-strip-17">
   <div class="fd-message-strip__icon-container" aria-hidden="true">
     <span class="sap-icon sap-icon--master-task-triangle-2" focusable="false" role="presentation" aria-hidden="true"></span>
   </div>
   <p class="fd-message-strip__text">
-    Message Strip with accent color 1 
+    Message Strip with indication color 1 (Dark Red)
   </p>
 </div>
 
 <br>
 
-<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-2" role="note" aria-live="assertive" id="message-strip-18" aria-labelledby="message-strip-18">
+<div class="fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-1b" role="note" aria-live="assertive" id="message-strip-27" aria-labelledby="message-strip-27">
+  <div class="fd-message-strip__icon-container" aria-hidden="true">
+    <span class="sap-icon sap-icon--master-task-triangle-2" focusable="false" role="presentation" aria-hidden="true"></span>
+  </div>
+  <p class="fd-message-strip__text">
+    Message Strip with indication color 1b (Dark Red)
+  </p>
+</div>
+
+<br>
+
+<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-2" role="note" aria-live="assertive" id="message-strip-18" aria-labelledby="message-strip-18">
   <div class="fd-message-strip__icon-container" aria-hidden="true">
     <span class="sap-icon sap-icon--cloud" focusable="false" role="presentation" aria-hidden="true"></span>
   </div>
   <p class="fd-message-strip__text">
-    Message Strip with accent color 2 
+    Message Strip with indication color 2  (Red)
   </p>
 </div>
 
 
 <br>
 
-<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-3" role="note" aria-live="assertive" id="message-strip-19" aria-labelledby="message-strip-19">
+<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-2b" role="note" aria-live="assertive" id="message-strip-28" aria-labelledby="message-strip-28">
+  <div class="fd-message-strip__icon-container" aria-hidden="true">
+    <span class="sap-icon sap-icon--cloud" focusable="false" role="presentation" aria-hidden="true"></span>
+  </div>
+  <p class="fd-message-strip__text">
+    Message Strip with indication color 2b (Red) 
+  </p>
+</div>
+
+<br>
+
+<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-3" role="note" aria-live="assertive" id="message-strip-19" aria-labelledby="message-strip-19">
   <div class="fd-message-strip__icon-container" aria-hidden="true">
     <span class="sap-icon sap-icon--heart-2" focusable="false" role="presentation" aria-hidden="true"></span>
   </div>
   <p class="fd-message-strip__text">
-    Message Strip with accent color 3 
+    Message Strip with indication color 3 (Yellow)
   </p>
 </div>
 
+<br>
+
+<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-3b" role="note" aria-live="assertive" id="message-strip-29" aria-labelledby="message-strip-29">
+  <div class="fd-message-strip__icon-container" aria-hidden="true">
+    <span class="sap-icon sap-icon--heart-2" focusable="false" role="presentation" aria-hidden="true"></span>
+  </div>
+  <p class="fd-message-strip__text">
+    Message Strip with indication color 3b (Yellow) 
+  </p>
+</div>
 
 <br>
 
-<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-4" role="note" aria-live="assertive" id="message-strip-20" aria-labelledby="message-strip-20">
+<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-4" role="note" aria-live="assertive" id="message-strip-20" aria-labelledby="message-strip-20">
   <div class="fd-message-strip__icon-container" aria-hidden="true">
     <span class="sap-icon sap-icon--circle-task" focusable="false" role="presentation" aria-hidden="true"></span>
   </div>
   <p class="fd-message-strip__text">
-    Message Strip with accent color 4 
+    Message Strip with indication color 4 (Green)
   </p>
 </div>
 
+<br>
+
+<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-4b" role="note" aria-live="assertive" id="message-strip-30" aria-labelledby="message-strip-30">
+  <div class="fd-message-strip__icon-container" aria-hidden="true">
+    <span class="sap-icon sap-icon--circle-task" focusable="false" role="presentation" aria-hidden="true"></span>
+  </div>
+  <p class="fd-message-strip__text">
+    Message Strip with indication color 4b (Green)
+  </p>
+</div>
 
 <br>
 
-<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-5" role="note" aria-live="assertive" id="message-strip-21" aria-labelledby="message-strip-21">
+<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-5" role="note" aria-live="assertive" id="message-strip-21" aria-labelledby="message-strip-21">
   <div class="fd-message-strip__icon-container" aria-hidden="true">
     <span class="sap-icon sap-icon--feedback" focusable="false" role="presentation" aria-hidden="true"></span>
   </div>
   <p class="fd-message-strip__text">
-    Message Strip with accent color 5 
+    Message Strip with indication color 5 (Blue)
   </p>
 </div>
 
 
 <br>
 
-<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-6" role="note" aria-live="assertive" id="message-strip-22" aria-labelledby="message-strip-22">
+<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-5b" role="note" aria-live="assertive" id="message-strip-31" aria-labelledby="message-strip-31">
+  <div class="fd-message-strip__icon-container" aria-hidden="true">
+    <span class="sap-icon sap-icon--feedback" focusable="false" role="presentation" aria-hidden="true"></span>
+  </div>
+  <p class="fd-message-strip__text">
+    Message Strip with indication color 5b (Blue)
+  </p>
+</div>
+
+<br>
+
+<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-6" role="note" aria-live="assertive" id="message-strip-22" aria-labelledby="message-strip-22">
   <div class="fd-message-strip__icon-container" aria-hidden="true">
     <span class="sap-icon sap-icon--text-color" focusable="false" role="presentation" aria-hidden="true"></span>
   </div>
   <p class="fd-message-strip__text">
-    Message Strip with accent color 6
+    Message Strip with indication color 6 (Teal)
   </p>
 </div>
 
+<br>
+
+<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-6b" role="note" aria-live="assertive" id="message-strip-32" aria-labelledby="message-strip-32">
+  <div class="fd-message-strip__icon-container" aria-hidden="true">
+    <span class="sap-icon sap-icon--text-color" focusable="false" role="presentation" aria-hidden="true"></span>
+  </div>
+  <p class="fd-message-strip__text">
+    Message Strip with indication color 6b (Teal)
+  </p>
+</div>
 
 <br>
 
-<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-7" role="note" aria-live="assertive" id="message-strip-23" aria-labelledby="message-strip-23">
+<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-7" role="note" aria-live="assertive" id="message-strip-23" aria-labelledby="message-strip-23">
   <div class="fd-message-strip__icon-container" aria-hidden="true">
     <span class="sap-icon sap-icon--away" focusable="false" role="presentation" aria-hidden="true"></span>
   </div>
   <p class="fd-message-strip__text">
-    Message Strip with accent color 7 
+    Message Strip with indication color 7 (Purple)
   </p>
 </div>
 
+<br>
+
+<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-7b" role="note" aria-live="assertive" id="message-strip-33" aria-labelledby="message-strip-33">
+  <div class="fd-message-strip__icon-container" aria-hidden="true">
+    <span class="sap-icon sap-icon--away" focusable="false" role="presentation" aria-hidden="true"></span>
+  </div>
+  <p class="fd-message-strip__text">
+    Message Strip with indication color 7b (Purple)
+  </p>
+</div>
 
 <br>
 
-<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-8" role="note" aria-live="assertive" id="message-strip-24" aria-labelledby="message-strip-24">
+<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-8" role="note" aria-live="assertive" id="message-strip-24" aria-labelledby="message-strip-24">
   <div class="fd-message-strip__icon-container" aria-hidden="true">
     <span class="sap-icon sap-icon--cursor" focusable="false" role="presentation" aria-hidden="true"></span>
   </div>
   <p class="fd-message-strip__text">
-    Message Strip with accent color 8 
+    Message Strip with indication color 8 (Pink)
   </p>
 </div>
 
+<br>
+
+<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-8b" role="note" aria-live="assertive" id="message-strip-34" aria-labelledby="message-strip-34">
+  <div class="fd-message-strip__icon-container" aria-hidden="true">
+    <span class="sap-icon sap-icon--cursor" focusable="false" role="presentation" aria-hidden="true"></span>
+  </div>
+  <p class="fd-message-strip__text">
+    Message Strip with indication color 8b (Pink)
+  </p>
+</div>
 
 <br>
 
-<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-9" role="note" aria-live="assertive" id="message-strip-25" aria-labelledby="message-strip-25">
+<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-9" role="note" aria-live="assertive" id="message-strip-25" aria-labelledby="message-strip-25">
   <div class="fd-message-strip__icon-container" aria-hidden="true">
     <span class="sap-icon sap-icon--copy" focusable="false" role="presentation" aria-hidden="true"></span>
   </div>
   <p class="fd-message-strip__text">
-    Message Strip with accent color 9
+    Message Strip with indication color 9 (Black/White)
   </p>
 </div>
 
+<br>
+
+<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-9b" role="note" aria-live="assertive" id="message-strip-35" aria-labelledby="message-strip-35">
+  <div class="fd-message-strip__icon-container" aria-hidden="true">
+    <span class="sap-icon sap-icon--copy" focusable="false" role="presentation" aria-hidden="true"></span>
+  </div>
+  <p class="fd-message-strip__text">
+    Message Strip with indication color 9b (Black/White)
+  </p>
+</div>
 
 <br>
 
-<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-10" role="note" aria-live="assertive" id="message-strip-26" aria-labelledby="message-strip-26">
+<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-10" role="note" aria-live="assertive" id="message-strip-26" aria-labelledby="message-strip-26">
   <div class="fd-message-strip__icon-container" aria-hidden="true">
     <span class="sap-icon sap-icon--reset" focusable="false" role="presentation" aria-hidden="true"></span>
   </div>
   <p class="fd-message-strip__text">
-    Message Strip with accent color 10
+    Message Strip with indication color 10 (Grey)
+  </p>
+</div>
+
+<br>
+
+<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-10b" role="note" aria-live="assertive" id="message-strip-36" aria-labelledby="message-strip-36">
+  <div class="fd-message-strip__icon-container" aria-hidden="true">
+    <span class="sap-icon sap-icon--reset" focusable="false" role="presentation" aria-hidden="true"></span>
+  </div>
+  <p class="fd-message-strip__text">
+    Message Strip with indication color 10b (Grey)
   </p>
 </div>

--- a/packages/styles/stories/Components/message-strip/message-strip.stories.js
+++ b/packages/styles/stories/Components/message-strip/message-strip.stories.js
@@ -146,14 +146,14 @@ MessageStripWithCustomIcon.parameters = {
   }
 };
 export const MessageStripWithAccentColors = () => messageStripWithAccentColorsExampleHtml;
-MessageStripWithAccentColors.storyName = 'Accent colors';
+MessageStripWithAccentColors.storyName = 'Custom Message Strip';
 MessageStripWithAccentColors.parameters = {
   docs: {
     story: {
       iframeHeight: messageStripHeight
     },
     description: {
-      story: `If the application needs a custom Message Strip, other than the semantic variations, then the colours from <a href='https://sap.github.io/fundamental-styles/?path=/docs/components-avatar--icon' target='_blank' rel='noopener noreferrer' title='click to open Avatar component. Opens in a new window.'>Avatar (Horizon)</a> control should be used. Use the modifier classes \`.fd-message-strip--accent-color-*\`, where \`*\` is a number from 1 to 10. `
+      story: `If the application needs a custom Message Strip, other than the semantic variations, then the colours from Inverted Object Status/Tag control should be used. Use the modifier classes \`.fd-message-strip--indication-color-*\`, where \`*\` is a number from 1 to 10 for the first set, and 1b to 10b for the second set. `
     }
   }
 };

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -17780,119 +17780,223 @@ exports[`Check stories > Components/Message Strip > Story Information > Should m
 `;
 
 exports[`Check stories > Components/Message Strip > Story MessageStripWithAccentColors > Should match snapshot 1`] = `
-"<div class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--accent-color-1\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-17\\" aria-labelledby=\\"message-strip-17\\">
+"<div class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-1\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-17\\" aria-labelledby=\\"message-strip-17\\">
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
     <span class=\\"sap-icon sap-icon--master-task-triangle-2\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
   <p class=\\"fd-message-strip__text\\">
-    Message Strip with accent color 1 
+    Message Strip with indication color 1 (Dark Red)
   </p>
 </div>
 
 <br>
 
-<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-2\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-18\\" aria-labelledby=\\"message-strip-18\\">
+<div class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-1b\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-27\\" aria-labelledby=\\"message-strip-27\\">
+  <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
+    <span class=\\"sap-icon sap-icon--master-task-triangle-2\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+  </div>
+  <p class=\\"fd-message-strip__text\\">
+    Message Strip with indication color 1b (Dark Red)
+  </p>
+</div>
+
+<br>
+
+<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-2\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-18\\" aria-labelledby=\\"message-strip-18\\">
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
     <span class=\\"sap-icon sap-icon--cloud\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
   <p class=\\"fd-message-strip__text\\">
-    Message Strip with accent color 2 
+    Message Strip with indication color 2  (Red)
   </p>
 </div>
 
 
 <br>
 
-<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-3\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-19\\" aria-labelledby=\\"message-strip-19\\">
+<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-2b\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-28\\" aria-labelledby=\\"message-strip-28\\">
+  <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
+    <span class=\\"sap-icon sap-icon--cloud\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+  </div>
+  <p class=\\"fd-message-strip__text\\">
+    Message Strip with indication color 2b (Red) 
+  </p>
+</div>
+
+<br>
+
+<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-3\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-19\\" aria-labelledby=\\"message-strip-19\\">
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
     <span class=\\"sap-icon sap-icon--heart-2\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
   <p class=\\"fd-message-strip__text\\">
-    Message Strip with accent color 3 
+    Message Strip with indication color 3 (Yellow)
   </p>
 </div>
 
+<br>
+
+<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-3b\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-29\\" aria-labelledby=\\"message-strip-29\\">
+  <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
+    <span class=\\"sap-icon sap-icon--heart-2\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+  </div>
+  <p class=\\"fd-message-strip__text\\">
+    Message Strip with indication color 3b (Yellow) 
+  </p>
+</div>
 
 <br>
 
-<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-4\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-20\\" aria-labelledby=\\"message-strip-20\\">
+<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-4\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-20\\" aria-labelledby=\\"message-strip-20\\">
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
     <span class=\\"sap-icon sap-icon--circle-task\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
   <p class=\\"fd-message-strip__text\\">
-    Message Strip with accent color 4 
+    Message Strip with indication color 4 (Green)
   </p>
 </div>
 
+<br>
+
+<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-4b\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-30\\" aria-labelledby=\\"message-strip-30\\">
+  <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
+    <span class=\\"sap-icon sap-icon--circle-task\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+  </div>
+  <p class=\\"fd-message-strip__text\\">
+    Message Strip with indication color 4b (Green)
+  </p>
+</div>
 
 <br>
 
-<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-5\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-21\\" aria-labelledby=\\"message-strip-21\\">
+<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-5\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-21\\" aria-labelledby=\\"message-strip-21\\">
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
     <span class=\\"sap-icon sap-icon--feedback\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
   <p class=\\"fd-message-strip__text\\">
-    Message Strip with accent color 5 
+    Message Strip with indication color 5 (Blue)
   </p>
 </div>
 
 
 <br>
 
-<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-6\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-22\\" aria-labelledby=\\"message-strip-22\\">
+<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-5b\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-31\\" aria-labelledby=\\"message-strip-31\\">
+  <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
+    <span class=\\"sap-icon sap-icon--feedback\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+  </div>
+  <p class=\\"fd-message-strip__text\\">
+    Message Strip with indication color 5b (Blue)
+  </p>
+</div>
+
+<br>
+
+<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-6\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-22\\" aria-labelledby=\\"message-strip-22\\">
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
     <span class=\\"sap-icon sap-icon--text-color\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
   <p class=\\"fd-message-strip__text\\">
-    Message Strip with accent color 6
+    Message Strip with indication color 6 (Teal)
   </p>
 </div>
 
+<br>
+
+<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-6b\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-32\\" aria-labelledby=\\"message-strip-32\\">
+  <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
+    <span class=\\"sap-icon sap-icon--text-color\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+  </div>
+  <p class=\\"fd-message-strip__text\\">
+    Message Strip with indication color 6b (Teal)
+  </p>
+</div>
 
 <br>
 
-<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-7\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-23\\" aria-labelledby=\\"message-strip-23\\">
+<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-7\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-23\\" aria-labelledby=\\"message-strip-23\\">
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
     <span class=\\"sap-icon sap-icon--away\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
   <p class=\\"fd-message-strip__text\\">
-    Message Strip with accent color 7 
+    Message Strip with indication color 7 (Purple)
   </p>
 </div>
 
+<br>
+
+<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-7b\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-33\\" aria-labelledby=\\"message-strip-33\\">
+  <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
+    <span class=\\"sap-icon sap-icon--away\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+  </div>
+  <p class=\\"fd-message-strip__text\\">
+    Message Strip with indication color 7b (Purple)
+  </p>
+</div>
 
 <br>
 
-<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-8\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-24\\" aria-labelledby=\\"message-strip-24\\">
+<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-8\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-24\\" aria-labelledby=\\"message-strip-24\\">
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
     <span class=\\"sap-icon sap-icon--cursor\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
   <p class=\\"fd-message-strip__text\\">
-    Message Strip with accent color 8 
+    Message Strip with indication color 8 (Pink)
   </p>
 </div>
 
+<br>
+
+<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-8b\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-34\\" aria-labelledby=\\"message-strip-34\\">
+  <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
+    <span class=\\"sap-icon sap-icon--cursor\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+  </div>
+  <p class=\\"fd-message-strip__text\\">
+    Message Strip with indication color 8b (Pink)
+  </p>
+</div>
 
 <br>
 
-<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-9\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-25\\" aria-labelledby=\\"message-strip-25\\">
+<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-9\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-25\\" aria-labelledby=\\"message-strip-25\\">
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
     <span class=\\"sap-icon sap-icon--copy\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
   <p class=\\"fd-message-strip__text\\">
-    Message Strip with accent color 9
+    Message Strip with indication color 9 (Black/White)
   </p>
 </div>
 
+<br>
+
+<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-9b\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-35\\" aria-labelledby=\\"message-strip-35\\">
+  <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
+    <span class=\\"sap-icon sap-icon--copy\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+  </div>
+  <p class=\\"fd-message-strip__text\\">
+    Message Strip with indication color 9b (Black/White)
+  </p>
+</div>
 
 <br>
 
-<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--accent-color-10\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-26\\" aria-labelledby=\\"message-strip-26\\">
+<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-10\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-26\\" aria-labelledby=\\"message-strip-26\\">
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
     <span class=\\"sap-icon sap-icon--reset\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
   <p class=\\"fd-message-strip__text\\">
-    Message Strip with accent color 10
+    Message Strip with indication color 10 (Grey)
+  </p>
+</div>
+
+<br>
+
+<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-10b\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-36\\" aria-labelledby=\\"message-strip-36\\">
+  <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
+    <span class=\\"sap-icon sap-icon--reset\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+  </div>
+  <p class=\\"fd-message-strip__text\\">
+    Message Strip with indication color 10b (Grey)
   </p>
 </div>
 "


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/4556

## Description
The custom Message strip now uses 2 sets of indication colors. 
Added new modifier classes:
`fd-message-strip--indication-color-1` ... `fd-message-strip--indication-color-10`
`fd-message-strip--indication-color-1b` ... `fd-message-strip--indication-color-10b`

**BREAKING CHANGE:**
- removed classes `fd-message-strip--accent-color-1`... `fd-message-strip--accent-color-10`
- introduced new classes:
`fd-message-strip--indication-color-1` ... `fd-message-strip--indication-color-10`
`fd-message-strip--indication-color-1b` ... `fd-message-strip--indication-color-10b`

- [x] updated [Wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) Breaking Changes