### PR TITLE
fix(styles): add Horizon 2023 updates for Carousel [ci visual]

### DIFF
--- a/packages/styles/src/carousel.scss
+++ b/packages/styles/src/carousel.scss
@@ -2,45 +2,74 @@
 @import "./mixins";
 
 $block: #{$fd-namespace}-carousel;
+$blockButton: #{$fd-namespace}-carousel__button;
 
-$fd-carousel-button-size: 2.125rem !default;
-$fd-carousel-touchable-button-size: 2.625rem !default;
 $fd-carousel-button-content-offset: 0.5rem !default;
-$fd-carousel-dot-active-size: 0.5rem !default;
 
 .#{$block} {
+  --fdCarousel_Button_Display: block;
+  --fdCarousel_Content_Background: var(--sapBackgroundColor);
+  --fdCarousel_Page_Indicator_Margin: var(--fdCarousel_Dot_Margin);
+  --fdCarousel_Page_Indicator_Size: var(--fdCarousel_Dot_Size);
+  --fdCarousel_Page_Indicator_Background_Color: var(--fdCarousel_Dot_Background);
+  --fdCarousel_Page_Indicator_Border: var(--fdCarousel_Dot_Border);
+  --fdCarousel_Page_Indicator_Container_Background: var(--sapPageFooter_Background);
+
+  @mixin fd-carousel-content-button-hover() {
+    @include fd-hover() {
+      .#{$block}__content {
+        .#{$blockButton} {
+          @content;
+        }
+      }
+    }
+  }
+
   @include fd-reset();
   @include fd-flex(column);
   @include fd-fiori-focus(0);
+
+  @include fd-carousel-content-button-hover() {
+    --fdCarousel_Button_Display: block;
+  }
 
   width: 100%;
   min-width: 15.5rem;
   height: 100%;
   max-width: 100%;
 
-  @include fd-hover() {
-    .#{$block}__content {
-      .#{$block}__button {
-        display: block;
-      }
-    }
-  }
-
-  .#{$block}__content {
+  &__content {
     @include fd-reset();
 
-    background: var(--fdCarousel_Content_Background);
     flex-basis: 100%;
-    position: relative;
     overflow: hidden;
+    position: relative;
+    background: var(--fdCarousel_Content_Background);
 
     .#{$block}__button {
-      box-shadow: var(--sapContent_Shadow1);
-      position: absolute;
+      --fdCarousel_Button_Display: none;
+
       margin: 0;
-      top: calc(50%);
-      transform: translateY(-50%);
-      display: none;
+      position: absolute;
+      box-shadow: var(--sapContent_Shadow1);
+
+      &--left,
+      &--right {
+        top: calc(50%);
+        transform: translateY(-50%);
+      }
+
+      &--up,
+      &--down {
+        left: calc(50%);
+        transform: translateX(-50%);
+
+        @include fd-rtl() {
+          & > [class*=sap-icon] {
+            transform: rotate(0deg);
+          }
+        }
+      }
 
       &--left {
         @include fd-set-position-left($fd-carousel-button-content-offset);
@@ -48,6 +77,14 @@ $fd-carousel-dot-active-size: 0.5rem !default;
 
       &--right {
         @include fd-set-position-right($fd-carousel-button-content-offset);
+      }
+
+      &--up {
+        top: $fd-carousel-button-content-offset;
+      }
+
+      &--down {
+        bottom: $fd-carousel-button-content-offset;
       }
     }
 
@@ -70,6 +107,14 @@ $fd-carousel-dot-active-size: 0.5rem !default;
         width: auto;
         min-width: auto;
       }
+    }
+
+    &--solid {
+      --fdCarousel_Content_Background: var(--sapGroup_ContentBackground);
+    }
+
+    &--transparent {
+      --fdCarousel_Content_Background: transparent;
     }
   }
 
@@ -110,12 +155,29 @@ $fd-carousel-dot-active-size: 0.5rem !default;
     min-height: 2.75rem;
     max-height: 3.5rem;
     padding: 0.375rem 0.5rem;
-    background: var(--sapPageFooter_Background);
+    background: var(--fdCarousel_Page_Indicator_Container_Background);
     border-top: var(--fdCarousel_Pagination_Border);
 
     &:first-child {
       border-top: none;
       border-bottom: var(--fdCarousel_Pagination_Border);
+    }
+
+    &--translucent {
+      --fdCarousel_Page_Indicator_Container_Background: var(--sapBackgroundColor);
+    }
+
+    &--transparent {
+      --fdCarousel_Page_Indicator_Container_Background: transparent;
+    }
+
+    &--no-border {
+      border-top-color: transparent;
+
+      &:first-child {
+        border-top: none;
+        border-bottom-color: transparent;
+      }
     }
   }
 
@@ -130,21 +192,19 @@ $fd-carousel-dot-active-size: 0.5rem !default;
 
   &__page-indicator {
     @include fd-reset();
+    @include fd-set-square(var(--fdCarousel_Page_Indicator_Size));
 
-    list-style-type: none;
-    margin: var(--fdCarousel_Dot_Margin);
-    width: var(--fdCarousel_Dot_Size);
-    height: var(--fdCarousel_Dot_Size);
     border-radius: 50%;
-    background-color: var(--fdCarousel_Dot_Background);
-    border: var(--fdCarousel_Dot_Border);
+    list-style-type: none;
+    margin: var(--fdCarousel_Page_Indicator_Margin);
+    border: var(--fdCarousel_Page_Indicator_Border);
+    background-color: var(--fdCarousel_Page_Indicator_Background_Color);
 
     &--active {
-      margin: 0 0.25rem;
-      width: $fd-carousel-dot-active-size;
-      height: $fd-carousel-dot-active-size;
-      background-color: var(--fdCarousel_Dot_Selected_Background);
-      border: var(--fdCarousel_Dot_Selected_Border);
+      --fdCarousel_Page_Indicator_Size: 0.5rem;
+      --fdCarousel_Page_Indicator_Margin: 0 0.25rem;
+      --fdCarousel_Page_Indicator_Border: var(--fdCarousel_Dot_Selected_Border);
+      --fdCarousel_Page_Indicator_Background_Color: var(--fdCarousel_Dot_Selected_Background);
     }
   }
 
@@ -152,24 +212,22 @@ $fd-carousel-dot-active-size: 0.5rem !default;
     @include fd-reset();
     @include fd-ellipsis();
 
-    color: var(--sapPageFooter_TextColor);
     text-align: center;
+    color: var(--sapPageFooter_TextColor);
   }
 
-  .#{$block}__button {
+  .#{$blockButton} {
     @include fd-flex-center();
-    @include fd-set-width($fd-carousel-button-size);
-    @include fd-set-height($fd-carousel-button-size);
+    @include fd-set-square(2.125rem);
 
-    border-radius: 50%;
     padding: 0;
     margin: 0.25rem;
+    border-radius: 50%;
+    display: var(--fdCarousel_Button_Display);
 
     &::before {
-      left: -0.25rem;
-      right: -0.25rem;
-      bottom: -0.25rem;
-      top: -0.25rem;
+      @include fd-set-equal-positions(-0.25rem);
+
       width: auto;
     }
 
@@ -182,19 +240,21 @@ $fd-carousel-dot-active-size: 0.5rem !default;
     @include fd-hover() {
       box-shadow: var(--sapContent_Shadow1);
     }
+
+    @include fd-focus() {
+      &::after {
+        --fdButton_Focus_Border_Radius: 50%;
+      }
+    }
   }
 
   &--no-navigation {
-    .#{$block}__button {
-      display: none;
+    .#{$blockButton} {
+      --fdCarousel_Button_Display: none;
     }
 
-    @include fd-hover() {
-      .#{$block}__content {
-        .#{$block}__button {
-          display: none;
-        }
-      }
+    @include fd-carousel-content-button-hover() {
+      --fdCarousel_Button_Display: none;
     }
   }
 }

--- a/packages/styles/src/mixins/_mixins.scss
+++ b/packages/styles/src/mixins/_mixins.scss
@@ -747,6 +747,15 @@
   min-width: $size;
 }
 
+@mixin fd-set-square($size) {
+  width: $size;
+  min-width: $size;
+  max-width: $size;
+  height: $size;
+  min-height: $size;
+  max-height: $size;
+}
+
 @mixin fd-scrollbar($borderRadius: '') {
   @include fd-focus() {
     outline: none;

--- a/packages/styles/src/theming/common/carousel/_sap_fiori.scss
+++ b/packages/styles/src/theming/common/carousel/_sap_fiori.scss
@@ -1,6 +1,4 @@
 :root {
-  --fdCarousel_Content_Background: var(sapBackgroundColor);
-
   /* Pagination */
   --fdCarousel_Pagination_Border: 0.0625rem solid var(--sapPageFooter_BorderColor);
 

--- a/packages/styles/src/theming/common/carousel/_sap_horizon.scss
+++ b/packages/styles/src/theming/common/carousel/_sap_horizon.scss
@@ -1,6 +1,4 @@
 :root {
-  --fdCarousel_Content_Background: var(--sapGroup_ContentBackground);
-
   /* Pagination */
   --fdCarousel_Pagination_Border: 0.0625rem solid var(--sapList_BorderColor);
 

--- a/packages/styles/stories/Components/carousel/carousel-backgrounds.example.html
+++ b/packages/styles/stories/Components/carousel/carousel-backgrounds.example.html
@@ -1,11 +1,11 @@
 <div style="display: flex; flex-direction: column; align-items: center">
-    <h4>Navigation buttons in page indicator (focussed)</h4>
+    <h4>Transparent Carousel Content</h4>
 
-    <div class="fd-carousel is-focus" data-ride="carousel" style="margin-bottom: 3rem; max-width: 20rem; max-height: 15.5rem">
-        <div class="fd-carousel__content">
+    <div class="fd-carousel" data-ride="carousel" style="margin-bottom: 3rem; max-width: 20rem; max-height: 15.5rem">
+        <div class="fd-carousel__content fd-carousel__content--transparent">
             <div class="fd-carousel__slides">
                 <div class="fd-carousel__item fd-carousel__item--active">
-                    <img src="https://placehold.co/320x200" alt="first image" />
+                    <span style="width: 300px; height: 200px; display: flex;"></span>
                 </div>
             </div>
         </div>
@@ -43,12 +43,12 @@
         </div>
     </div>
 
-    <h4>Navigation buttons in page indicator (vertical)</h4>
+    <h4>Solid Carousel Content</h4>
     <div class="fd-carousel" data-ride="carousel" style="margin-bottom: 3rem; max-width: 20rem; max-height: 15.5rem">
-        <div class="fd-carousel__content">
+        <div class="fd-carousel__content fd-carousel__content--solid">
             <div class="fd-carousel__slides">
                 <div class="fd-carousel__item fd-carousel__item--active">
-                    <img src="https://placehold.co/320x200" alt="first image" />
+                    <span style="width: 300px; height: 200px; display: flex;"></span>
                 </div>
             </div>
         </div>
@@ -88,7 +88,7 @@
 
     <div style="display: none" role="region" id="carousel-1" aria-live="polite">Displaying item 1 of 4</div>
 
-    <h4>Content navigation buttons</h4>
+    <h4>Transparent Page Indicator Container</h4>
 
     <div class="fd-carousel" data-ride="carousel" style="margin-bottom: 3rem; max-width: 20rem; max-height: 15.5rem">
         <div class="fd-carousel__content">
@@ -115,7 +115,7 @@
             </button>
         </div>
 
-        <div class="fd-carousel__page-indicator-container">
+        <div class="fd-carousel__page-indicator-container fd-carousel__page-indicator-container--transparent">
             <ol class="fd-carousel__page-indicators">
                 <li data-slide-to="1" class="fd-carousel__page-indicator"></li>
                 <li data-slide-to="2" class="fd-carousel__page-indicator"></li>
@@ -128,7 +128,7 @@
         </div>
     </div>
 
-    <h4>Content navigation buttons (vertical)</h4>
+    <h4>Translucent Page Indicator Container</h4>
     <div class="fd-carousel" data-ride="carousel" style="margin-bottom: 3rem; max-width: 20rem; max-height: 15.5rem">
         <div class="fd-carousel__content">
             <button
@@ -154,7 +154,7 @@
             </button>
         </div>
 
-        <div class="fd-carousel__page-indicator-container">
+        <div class="fd-carousel__page-indicator-container fd-carousel__page-indicator-container--translucent">
             <ol class="fd-carousel__page-indicators">
                 <li data-slide-to="1" class="fd-carousel__page-indicator"></li>
                 <li data-slide-to="2" class="fd-carousel__page-indicator"></li>
@@ -167,71 +167,49 @@
         </div>
     </div>
 
+    <h4>Page Indicator Container with no border</h4>
+
+    <div class="fd-carousel" data-ride="carousel" style="margin-bottom: 3rem; max-width: 20rem; max-height: 15.5rem">
+        <div class="fd-carousel__content fd-carousel__content--solid">
+            <div class="fd-carousel__slides">
+                <div class="fd-carousel__item fd-carousel__item--active">
+                    <span style="width: 300px; height: 200px; display: flex;"></span>
+                </div>
+            </div>
+        </div>
+
+        <div class="fd-carousel__page-indicator-container fd-carousel__page-indicator-container--no-border">
+            <button
+                class="fd-button fd-carousel__button fd-carousel__button--left"
+                data-slide="prev"
+                aria-label="Go to previous item"
+            >
+                <i class="sap-icon--slim-arrow-left"></i>
+            </button>
+
+            <ol class="fd-carousel__page-indicators">
+                <li data-slide-to="1" class="fd-carousel__page-indicator"></li>
+                <li data-slide-to="2" class="fd-carousel__page-indicator"></li>
+                <li data-slide-to="3" class="fd-carousel__page-indicator"></li>
+                <li data-slide-to="4" class="fd-carousel__page-indicator"></li>
+                <li
+                    data-slide-to="5"
+                    aria-label="Displaying item 5 of 7"
+                    class="fd-carousel__page-indicator fd-carousel__page-indicator--active"
+                ></li>
+                <li data-slide-to="6" class="fd-carousel__page-indicator"></li>
+                <li data-slide-to="7" class="fd-carousel__page-indicator"></li>
+            </ol>
+
+            <button
+                class="fd-button fd-carousel__button fd-carousel__button--right"
+                data-slide="next"
+                aria-label="Go to next item"
+            >
+                <i class="sap-icon--slim-arrow-right"></i>
+            </button>
+        </div>
+    </div>
+
     <div style="display: none" role="region" id="carousel-2" aria-live="polite">Displaying item 1 of 4</div>
-
-    <h4>Numeric page indicator</h4>
-
-    <div class="fd-carousel" data-ride="carousel" style="margin-bottom: 3rem; max-width: 20rem; max-height: 15.5rem">
-        <div class="fd-carousel__content">
-            <div class="fd-carousel__slides">
-                <div class="fd-carousel__item fd-carousel__item--active">
-                    <img src="https://placehold.co/320x200" alt="first image" />
-                </div>
-            </div>
-        </div>
-
-        <div class="fd-carousel__page-indicator-container">
-            <button
-                class="fd-button fd-carousel__button fd-carousel__button--left"
-                data-slide="prev"
-                aria-label="Go to previous item"
-            >
-                <i class="sap-icon--slim-arrow-left"></i>
-            </button>
-
-            <div class="fd-carousel__page-indicators">
-                <div class="fd-carousel__text">1 of 4</div>
-            </div>
-
-            <button
-                class="fd-button fd-carousel__button fd-carousel__button--right"
-                data-slide="next"
-                aria-label="Go to next item"
-            >
-                <i class="sap-icon--slim-arrow-right"></i>
-            </button>
-        </div>
-    </div>
-
-    <div style="display: none" role="region" id="carousel-3" aria-live="polite">Displaying item 1 of 4</div>
-
-    <h4>No page indicator</h4>
-
-    <div class="fd-carousel" data-ride="carousel" style="margin-bottom: 3rem; max-width: 20rem; max-height: 15.5rem">
-        <div class="fd-carousel__content">
-            <button
-                class="fd-button fd-carousel__button fd-carousel__button--left"
-                data-slide="prev"
-                aria-label="Go to previous item"
-            >
-                <i class="sap-icon--slim-arrow-left"></i>
-            </button>
-
-            <div class="fd-carousel__slides">
-                <div class="fd-carousel__item fd-carousel__item--active">
-                    <img src="https://placehold.co/320x200" alt="first image" />
-                </div>
-            </div>
-
-            <button
-                class="fd-button fd-carousel__button fd-carousel__button--right"
-                data-slide="next"
-                aria-label="Go to next item"
-            >
-                <i class="sap-icon--slim-arrow-right"></i>
-            </button>
-        </div>
-    </div>
-
-    <div style="display: none" role="region" id="carousel-4" aria-live="polite">Displaying item 1 of 4</div>
 </div>

--- a/packages/styles/stories/Components/carousel/carousel.stories.js
+++ b/packages/styles/stories/Components/carousel/carousel.stories.js
@@ -1,6 +1,7 @@
 import errorExampleHtml from "./error.example.html?raw";
 import horizontalCarouselExampleHtml from "./horizontal-carousel.example.html?raw";
 import carouselNoNavigationExampleHtml from "./carousel-no-navigation.example.html?raw";
+import carouselBackgroundsExampleHtml from "./carousel-backgrounds.example.html?raw";
 import carouselTopExampleHtml from "./carousel-top.example.html?raw";
 import carouselBottomExampleHtml from "./carousel-bottom.example.html?raw";
 import '../../../src/carousel.scss';
@@ -36,13 +37,15 @@ To ensure that the carousel is accessible, a div element with class \`fd-carouse
 ## Structure
 
 * \`fd-carousel\` The carousel container.
-  * \`fd-carousel__content\` The carousel content.
+  * \`fd-carousel__content\` The carousel content. <b>Modifier classes:</b> \`fd-carousel__content--horizontal\`, \`fd-carousel__content--solid\`, and  \`fd-carousel__content--transparent\`.
     * \`fd-carousel__button\` The carousel button in content.
     * \`fd-carousel__button--left\` The carousel button in content for previous page.
     * \`fd-carousel__button--right\` The carousel button in content for next page.
+    * \`fd-carousel__button--up\` The carousel button in content for previous page in vertical mode.
+    * \`fd-carousel__button--down\` The carousel button in content for next page in vertical mode.
     * \`fd-carousel__slides\` The carousel slides.
       * \`fd-carousel__item\` The carousel item.
-  * \`fd-carousel__page-indicator-container\` The carousel page indicator container.
+  * \`fd-carousel__page-indicator-container\` The carousel page indicator container. <br> <b>Modifier classes:</b> \`fd-carousel__page-indicator-container--translucent\`, \`fd-carousel__page-indicator-container--transparent\` and \`fd-carousel__page-indicator-container--no-border\`
     * \`fd-carousel__button\` The carousel button.
     * \`fd-carousel__button--left\` The carousel button for previous page.
     * \`fd-carousel__button--right\` The carousel button for next page.
@@ -81,6 +84,17 @@ CarouselNoNavigation.parameters = {
     }
   }
 };
+
+export const CarouselBackgrounds = () => carouselBackgroundsExampleHtml;
+CarouselBackgrounds.storyName = 'Background modifiers';
+CarouselBackgrounds.parameters = {
+  docs: {
+    description: {
+      story: `The background of the Carousel Content and Page Indicator Container can be changed by modifier classes. <br><b>Carousel Content</b><br>The <b>default</b> background for the Carousel Content is <b>translucent</b>. For <b>transparent</b> background apply \`fd-carousel__content--transparent\` modifier class. For <b>solid</b> background apply \`fd-carousel__content--solid\` modifier class to the \`fd-carousel__content\` base class.<br><br><b>Page Indicator Container</b><br>The <b>default</b> background for the container is <b>solid</b>. For <b>transparent</b> background apply \`fd-carousel__page-indicator-container--transparent\` modifier class. For <b>translucent</b> background apply \`fd-carousel__page-indicator-container--translucent\` modifier class to the \`fd-carousel__page-indicator-container\` base class. The  \`fd-carousel__page-indicator-container--no-border\` will remove the border top or bottom of the container. `
+    }
+  }
+};
+
 export const HorizontalCarousel = () => horizontalCarouselExampleHtml;
 HorizontalCarousel.storyName = 'Items in horizontal direction';
 HorizontalCarousel.parameters = {


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/4371

## Description
- Horizon 2023 updates
- Code refactor
- Vertical mode: new modifier classes for the buttons `fd-carousel__button--up` and `fd-carousel__button--down`
- Backgrounds: new modifier classes for the Content background and Page Indicator Container.
**Content background:**  `fd-carousel__content--transparent`, `fd-carousel__content--solid`
**Page Indicator Container:** `fd-carousel__page-indicator-container--transparent`, `fd-carousel__page-indicator-container--translucent` , `fd-carousel__page-indicator-container--no-border`