### PR TITLE
fix(styles): menu full width

### DIFF
--- a/packages/styles/src/menu.scss
+++ b/packages/styles/src/menu.scss
@@ -117,6 +117,7 @@ $block: #{$fd-namespace}-menu;
   &__item {
     @include fd-reset();
 
+    max-width: 100%;
     position: relative;
     border-radius: 0;
     background-color: var(--sapList_Background);

--- a/packages/styles/src/menu.scss
+++ b/packages/styles/src/menu.scss
@@ -63,6 +63,7 @@ $block: #{$fd-namespace}-menu;
       flex-wrap: wrap;
     }
 
+    max-width: 20rem;
     list-style: none;
     box-shadow: var(--sapContent_Shadow1);
     border-radius: $fd-menu-border-radius;
@@ -116,7 +117,6 @@ $block: #{$fd-namespace}-menu;
   &__item {
     @include fd-reset();
 
-    max-width: 20rem;
     position: relative;
     border-radius: 0;
     background-color: var(--sapList_Background);


### PR DESCRIPTION
## Description
Menu item should not have width limitation, it should come from entire menu list, items should follow what is coming from parent. If some different width is needed for list item, user cal always override that
