### PR TITLE
fix(styles): update Object Status to latest Horizon 2023 [ci visual]

### DIFF
--- a/config/bundlesize.json
+++ b/config/bundlesize.json
@@ -2,7 +2,7 @@
     "files": [
         {
             "path": "./dist/packages/styles/dist/fundamental-styles.css",
-            "maxSize": "130 kB"
+            "maxSize": "140 kB"
         }
     ]
 }

--- a/packages/styles/src/mixins/_states.scss
+++ b/packages/styles/src/mixins/_states.scss
@@ -185,15 +185,25 @@
   }
 }
 
+// NAVIGATED state
 @mixin fd-navigated {
   &.is-navigated {
     @content;
   }
 }
 
+// HIDDEN state
 @mixin fd-hidden {
   &[aria-hidden="true"],
   &.is-hidden {
+    @content;
+  }
+}
+
+// VISITED state
+@mixin fd-visited {
+  &:visited,
+  &.is-visited {
     @content;
   }
 }

--- a/packages/styles/src/object-status.scss
+++ b/packages/styles/src/object-status.scss
@@ -2,111 +2,631 @@
 @import "./functions";
 @import "./mixins";
 
-/*!
-.fd-object-status+(--success | --warning | --error | --informative | --neutral)
-*/
 $block: #{$fd-namespace}-object-status;
 
 $color-states: (
-  "positive": ("color": var(--sapPositiveTextColor), "iconColor": var(--sapPositiveElementColor)),
-  "critical": ("color": var(--sapCriticalTextColor), "iconColor": var(--sapCriticalElementColor)),
-  "negative": ("color": var(--sapNegativeTextColor), "iconColor": var(--sapNegativeElementColor)),
-  "informative": ("color": var(--sapInformativeTextColor), "iconColor": var(--sapInformativeElementColor)),
-  "neutral": ("color": var(--sapNeutralTextColor), "iconColor": var(--sapNeutralElementColor))
+  "positive": (
+    "color": var(--sapPositiveTextColor),
+    "iconColor": var(--sapPositiveElementColor),
+    "focusColor": var(--fdObjectStatus_Positive_Color_Focus),
+    "iconFocusColor": var(--fdObjectStatus_Positive_IconColor_Focus),
+  ),
+  "critical": (
+    "color": var(--sapCriticalTextColor),
+    "iconColor": var(--sapCriticalElementColor),
+    "focusColor": var(--fdObjectStatus_Critical_Color_Focus),
+    "iconFocusColor": var(--fdObjectStatus_Critical_IconColor_Focus),
+  ),
+  "negative": (
+    "color": var(--sapNegativeTextColor),
+    "iconColor": var(--sapNegativeElementColor),
+    "focusColor": var(--fdObjectStatus_Negative_Color_Focus),
+    "iconFocusColor": var(--fdObjectStatus_Negative_IconColor_Focus),
+  ),
+  "informative": (
+    "color": var(--sapInformativeTextColor),
+    "iconColor": var(--sapInformativeElementColor),
+    "focusColor": var(--fdObjectStatus_Informative_Color_Focus),
+    "iconFocusColor": var(--fdObjectStatus_Informative_IconColor_Focus),
+  ),
+  "neutral": (
+    "color": var(--sapNeutralTextColor),
+    "iconColor": var(--sapNeutralElementColor),
+    "focusColor": var(--fdObjectStatus_Neutral_Color_Focus),
+    "iconFocusColor": var(--fdObjectStatus_Neutral_IconColor_Focus),
+  )
 );
 
 $color-accents: (
-  "1": ("color": var(--sapIndicationColor_1), "visited": var(--sapIndicationColor_1)),
-  "2": ("color": var(--sapIndicationColor_2), "visited": var(--sapIndicationColor_2)),
-  "3": ("color": var(--sapIndicationColor_3), "visited": var(--sapIndicationColor_3)),
-  "4": ("color": var(--sapIndicationColor_4), "visited": var(--sapIndicationColor_4)),
-  "5": ("color": var(--sapIndicationColor_5), "visited": var(--sapIndicationColor_5)),
-  "6": ("color": var(--sapAccentColor7), "visited": var(--sapAccentColor7)),
-  "7": ("color": var(--sapAccentColor9), "visited": var(--sapAccentColor9)),
-  "8": ("color": var(--sapAccentColor4), "visited": var(--sapAccentColor4))
+  "1": (
+    "color": var(--sapIndicationColor_1),
+    "visited": var(--sapIndicationColor_1),
+    "focus": var(--fdObjectStatus_Accent_Color_1_Focus)
+  ),
+  "2": (
+    "color": var(--sapIndicationColor_2),
+    "visited": var(--sapIndicationColor_2),
+    "focus": var(--fdObjectStatus_Accent_Color_2_Focus)
+  ),
+  "3": (
+    "color": var(--sapIndicationColor_3),
+    "visited": var(--sapIndicationColor_3),
+    "focus": var(--fdObjectStatus_Accent_Color_3_Focus)
+  ),
+  "4": (
+    "color": var(--sapIndicationColor_4),
+    "visited": var(--sapIndicationColor_4),
+    "focus": var(--fdObjectStatus_Accent_Color_4_Focus)
+  ),
+  "5": (
+    "color": var(--sapIndicationColor_5),
+    "visited": var(--sapIndicationColor_5),
+    "focus": var(--fdObjectStatus_Accent_Color_5_Focus)
+  ),
+  "6": (
+    "color": var(--sapIndicationColor_6),
+    "visited": var(--sapIndicationColor_6),
+    "focus": var(--fdObjectStatus_Accent_Color_6_Focus)
+  ),
+  "7": (
+    "color": var(--sapIndicationColor_7),
+    "visited": var(--sapIndicationColor_7),
+    "focus": var(--fdObjectStatus_Accent_Color_7_Focus)
+  ),
+  "8": (
+    "color": var(--sapIndicationColor_8),
+    "visited": var(--sapIndicationColor_8),
+    "focus": var(--fdObjectStatus_Accent_Color_8_Focus)
+  )
 );
 
 $inverted-color-states: (
   "neutral": (
-    "regular": ("color": var(--sapButton_Neutral_TextColor), "background": var(--sapButton_Neutral_Background), "borderColor": var(--sapButton_Neutral_Hover_BorderColor)),
-    "hover": ("color": var(--sapButton_Neutral_Hover_TextColor), "background": var(--sapButton_Neutral_Hover_Background)),
-    "active": ("color": var(--sapButton_Active_TextColor), "background": var(--sapButton_Neutral_Active_Background)),
-    "visited": ("color": var(--sapButton_Neutral_TextColor), "background": var(--sapButton_Neutral_Background)),
+    "regular": (
+      "color": var(--fdObjectStatus_Inverted_Neutral_Color_Regular),
+      "background": var(--fdObjectStatus_Inverted_Neutral_Background_Regular),
+      "borderColor": var(--fdObjectStatus_Inverted_Neutral_Border_Color_Regular)
+    ),
+    "hover": (
+      "color": var(--sapButton_Neutral_Hover_TextColor),
+      "background": var(--sapButton_Neutral_Hover_Background),
+      "borderColor": var(--sapButton_Neutral_Hover_BorderColor)
+    ),
+    "active": (
+      "color": var(--sapButton_Selected_TextColor),
+      "iconColor": var(--sapButton_Selected_TextColor),
+      "background": var(--sapButton_Neutral_Active_Background),
+      "borderColor": var(--sapButton_Neutral_Active_BorderColor)
+    ),
+    "visited": (
+      "color": var(--sapTextColor),
+      "background": var(--sapNeutralBackground),
+      "borderColor": var(--sapNeutralBorderColor)
+    ),
+    "selected": (
+      "color": var(--sapButton_Selected_TextColor),
+      "iconColor": var(--sapButton_Selected_TextColor),
+      "background": var(--sapButton_Selected_Background),
+      "borderColor": var(--sapButton_Selected_BorderColor),
+      "underline": var(--sapButton_Selected_BorderColor)
+    ),
+    "selectedHover": (
+      "color": var(--sapButton_Selected_TextColor),
+      "iconColor": var(--sapButton_Selected_TextColor),
+      "background": var(--sapButton_Selected_Hover_Background),
+      "borderColor": var(--sapButton_Selected_BorderColor),
+      "underline": var(--sapButton_Selected_BorderColor)
+    )
   ),
   "positive": (
-    "regular": ("color": var(--sapButton_Success_TextColor), "background": var(--sapButton_Success_Background), "borderColor": var(--sapButton_Success_BorderColor)),
-    "hover": ("color": var(--sapButton_Success_Hover_TextColor), "background": var(--sapButton_Success_Hover_Background)),
-    "active": ("color": var(--sapButton_Active_TextColor), "background": var(--sapButton_Success_Active_Background)),
-    "visited": ("color": var(--sapButton_Critical_TextColor), "background": var(--sapButton_Success_Background)),
+    "regular": (
+      "color": var(--sapButton_Success_TextColor),
+      "background": var(--sapButton_Success_Background),
+      "borderColor": var(--sapButton_Success_BorderColor)
+    ),
+    "hover": (
+      "color": var(--sapButton_Success_Hover_TextColor),
+      "background": var(--sapButton_Success_Hover_Background),
+      "borderColor": var(--sapButton_Success_Hover_BorderColor)
+    ),
+    "active": (
+      "color": var(--sapButton_Accept_Selected_TextColor),
+      "iconColor": var(--sapButton_Accept_Selected_TextColor),
+      "background": var(--sapButton_Success_Active_Background),
+      "borderColor": var(--sapButton_Success_Active_BorderColor)
+    ),
+    "visited": (
+      "color": var(--sapButton_Critical_TextColor),
+      "background": var(--sapButton_Success_Background),
+      "borderColor": var(--sapButton_Success_BorderColor)
+    ),
+    "selected": (
+      "color": var(--sapButton_Accept_Selected_TextColor),
+      "iconColor": var(--fdObjectStatus_Inverted_Icon_Color_Selected_Positive),
+      "background": var(--sapButton_Accept_Selected_Background),
+      "borderColor": var(--sapButton_Accept_Selected_BorderColor),
+      "underline": var(--sapPositiveElementColor)
+    ),
+    "selectedHover": (
+      "color": var(--sapButton_Accept_Selected_TextColor),
+      "iconColor": var(--fdObjectStatus_Inverted_Icon_Color_Selected_Positive),
+      "background": var(--sapButton_Accept_Selected_Hover_Background),
+      "borderColor": var(--sapButton_Accept_Selected_Hover_BorderColor),
+      "underline": var(--sapPositiveElementColor)
+    )
   ),
   "critical": (
-    "regular": ("color": var(--sapButton_Critical_TextColor), "background": var(--sapButton_Critical_Background), "borderColor": var(--sapButton_Critical_BorderColor)),
-    "hover": ("color": var(--sapButton_Critical_Hover_TextColor), "background": var(--sapButton_Critical_Hover_Background)),
-    "active": ("color": var(--sapButton_Active_TextColor), "background": var(--sapButton_Critical_Active_Background)),
-    "visited": ("color": var(--sapButton_Critical_TextColor), "background": var(--sapButton_Critical_Background)),
+    "regular": (
+      "color": var(--sapButton_Critical_TextColor),
+      "background": var(--sapButton_Critical_Background),
+      "borderColor": var(--sapButton_Critical_BorderColor)
+    ),
+    "hover": (
+      "color": var(--sapButton_Critical_Hover_TextColor),
+      "background": var(--sapButton_Critical_Hover_Background),
+      "borderColor": var(--sapButton_Critical_Hover_BorderColor)
+    ),
+    "active": (
+      "color": var(--sapButton_Attention_Selected_TextColor),
+      "iconColor": var(--sapButton_Attention_Selected_TextColor),
+      "background": var(--sapButton_Critical_Active_Background),
+      "borderColor": var(--sapButton_Critical_Active_BorderColor)
+    ),
+    "visited": (
+      "color": var(--sapButton_Critical_TextColor),
+      "background": var(--sapButton_Critical_Background),
+      "borderColor": var(--sapButton_Critical_BorderColor)
+    ),
+    "selected": (
+      "color": var(--sapButton_Attention_Selected_TextColor),
+      "iconColor": var(--fdObjectStatus_Inverted_Icon_Color_Selected_Critical),
+      "background": var(--sapButton_Attention_Selected_Background),
+      "borderColor": var(--sapButton_Attention_Selected_BorderColor),
+      "underline": var(--sapCriticalElementColor)
+    ),
+    "selectedHover": (
+      "color": var(--sapButton_Attention_Selected_TextColor),
+      "iconColor": var(--fdObjectStatus_Inverted_Icon_Color_Selected_Critical),
+      "background": var(--sapButton_Attention_Selected_Hover_Background),
+      "borderColor": var(--sapButton_Attention_Selected_Hover_BorderColor),
+      "underline": var(--sapCriticalElementColor)
+    )
   ),
   "negative": (
-    "regular": ("color": var(--sapButton_Negative_TextColor),"background": var(--sapButton_Negative_Background), "borderColor": var(--sapButton_Negative_BorderColor)),
-    "hover": ("color": var(--sapButton_Negative_Hover_TextColor), "background": var(--sapButton_Negative_Hover_Background)),
-    "active": ("color": var(--sapButton_Active_TextColor),"background": var(--sapButton_Negative_Active_Background)),
-    "visited": ("color": var(--sapButton_Negative_TextColor), "background": var(--sapButton_Negative_Background)),
+    "regular": (
+      "color": var(--sapButton_Negative_TextColor),
+      "background": var(--sapButton_Negative_Background),
+      "borderColor": var(--sapButton_Negative_BorderColor)
+    ),
+    "hover": (
+      "color": var(--sapButton_Negative_Hover_TextColor),
+      "background": var(--sapButton_Negative_Hover_Background),
+      "borderColor": var(--sapButton_Negative_Hover_BorderColor)
+    ),
+    "active": (
+      "color": var(--sapButton_Reject_Selected_TextColor),
+      "iconColor": var(--sapButton_Reject_Selected_TextColor),
+      "background": var(--sapButton_Negative_Active_Background),
+      "borderColor": var(--sapButton_Negative_Active_BorderColor)
+    ),
+    "visited": (
+      "color": var(--sapButton_Negative_Background),
+      "background": var(--sapButton_Negative_TextColor)
+    ),
+    "selected": (
+      "color": var(--sapButton_Reject_Selected_TextColor),
+      "iconColor": var(--fdObjectStatus_Inverted_Icon_Color_Selected_Negative),
+      "background": var(--sapButton_Reject_Selected_Background),
+      "borderColor": var(--sapButton_Reject_Selected_BorderColor),
+      "underline": var(--sapNegativeElementColor)
+    ),
+    "selectedHover": (
+      "color": var(--sapButton_Reject_Selected_TextColor),
+      "iconColor": var(--fdObjectStatus_Inverted_Icon_Color_Selected_Negative),
+      "background": var(--sapButton_Reject_Selected_Hover_Background),
+      "borderColor": var(--sapButton_Reject_Selected_Hover_BorderColor),
+      "underline": var(--sapNegativeElementColor)
+    )
   ),
   "informative": (
-    "regular": ("color": var(--sapButton_Information_TextColor), "background": var(--sapButton_Information_Background), "borderColor": var(--sapButton_Information_BorderColor)),
-    "hover": ("color": var(--sapButton_Information_Hover_TextColor), "background": var(--sapButton_Information_Hover_Background)),
-    "active": ("color": var(--sapButton_Active_TextColor), "background": var(--sapButton_Information_Active_Background)),
-    "visited": ("color": var(--sapButton_Information_TextColor), "background": var(--sapButton_Information_Background)),
+    "regular": (
+      "color": var(--sapButton_Information_TextColor),
+      "background": var(--sapButton_Information_Background),
+      "borderColor": var(--sapButton_Information_BorderColor)
+    ),
+    "hover": (
+      "color": var(--sapButton_Information_Hover_TextColor),
+      "background": var(--sapButton_Information_Hover_Background),
+      "borderColor": var(--sapButton_Information_Hover_BorderColor)
+    ),
+    "active": (
+      "color": var(--sapButton_Selected_TextColor),
+      "iconColor": var(--sapButton_Selected_TextColor),
+      "background": var(--sapButton_Information_Active_Background),
+      "borderColor": var(--sapButton_Information_Active_BorderColor)
+    ),
+    "visited": (
+      "color": var(--sapButton_Information_TextColor),
+      "background": var(--sapButton_Information_Background),
+      "borderColor": var(--sapButton_Information_BorderColor)
+    ),
+    "selected": (
+      "color": var(--sapButton_Selected_TextColor),
+      "iconColor": var(--fdObjectStatus_Inverted_Icon_Color_Selected_Informative),
+      "background": var(--sapButton_Selected_Background),
+      "borderColor": var(--sapButton_Selected_BorderColor),
+      "underline": var(--sapInformativeElementColor)
+    ),
+    "selectedHover": (
+      "color": var(--sapButton_Selected_TextColor),
+      "iconColor": var(--fdObjectStatus_Inverted_Icon_Color_Selected_Informative),
+      "background": var(--sapButton_Selected_Hover_Background),
+      "borderColor": var(--sapButton_Selected_Hover_BorderColor),
+      "underline": var(--sapInformativeElementColor)
+    )
   ),
 );
 
 $inverted-color-accents: (
   "1": (
-    "regular": ("color": var(--sapIndicationColor_1_TextColor), "background": var(--sapIndicationColor_1)),
-    "hover": ("color": var(--sapIndicationColor_1_TextColor), "background": var(--sapIndicationColor_1_Hover_Background)),
-    "active": ("color": var(--sapIndicationColor_1_TextColor), "background": var(--sapIndicationColor_1_Active_Background)),
-    "visited": ("color": var(--sapIndicationColor_1_TextColor), "background": var(--sapIndicationColor_1)),
+    "regular": (
+      "color": var(--sapIndicationColor_1_TextColor),
+      "background": var(--fdObjectStatus_Background_Indication_Color_1),
+      "borderColor": var(--sapIndicationColor_1_BorderColor),
+    ),
+    "hover": (
+      "color": var(--sapIndicationColor_1_TextColor),
+      "background": var(--sapIndicationColor_1_Hover_Background),
+      "borderColor": var(--sapIndicationColor_1_BorderColor),
+    ),
+    "active": (
+      "color": var(--fdObjectStatus_Active_Text_Indication_Color_1),
+      "background": var(--sapIndicationColor_1_Active_Background),
+      "borderColor": var(--sapIndicationColor_1_Active_BorderColor),
+    ),
+    "visited": (
+      "color": var(--sapIndicationColor_1_Active_TextColor),
+      "background": var(--sapIndicationColor_1),
+      "borderColor": var(--sapIndicationColor_1_Active_BorderColor),
+    ),
+    "selected": (
+      "color": var(--sapIndicationColor_1_Selected_TextColor),
+      "iconColor": var(--sapIndicationColor_1_Selected_TextColor),
+      "background": var(--sapIndicationColor_1_Selected_Background),
+      "borderColor": var(--sapIndicationColor_1_Selected_BorderColor),
+      "underline": var(--sapIndicationColor_1)
+    ),
+    "selectedHover": (
+      "color": var(--sapIndicationColor_1_Selected_TextColor),
+      "iconColor": var(--sapIndicationColor_1_Selected_TextColor),
+      "background": var(--sapIndicationColor_1_Selected_Background),
+      "borderColor": var(--sapIndicationColor_1_Selected_BorderColor),
+      "underline": var(--sapIndicationColor_1)
+    )
   ),
   "2": (
-    "regular": ("color": var(--sapIndicationColor_2_TextColor), "background": var(--sapIndicationColor_2)),
-    "hover": ("color": var(--sapIndicationColor_2_TextColor), "background": var(--sapIndicationColor_2_Hover_Background)),
-    "active": ("color": var(--sapIndicationColor_2_TextColor), "background": var(--sapIndicationColor_2_Active_Background)),
-    "visited": ("color": var(--sapIndicationColor_2_TextColor), "background": var(--sapIndicationColor_2)),
+    "regular": (
+      "color": var(--sapIndicationColor_2_TextColor),
+      "background": var(--fdObjectStatus_Background_Indication_Color_2),
+      "borderColor": var(--sapIndicationColor_2_BorderColor),
+    ),
+    "hover": (
+      "color": var(--sapIndicationColor_2_TextColor),
+      "background": var(--sapIndicationColor_2_Hover_Background),
+      "borderColor": var(--sapIndicationColor_2_BorderColor),
+    ),
+    "active": (
+      "color": var(--fdObjectStatus_Active_Text_Indication_Color_2),
+      "background": var(--sapIndicationColor_2_Active_Background),
+      "borderColor": var(--sapIndicationColor_2_Active_BorderColor),
+    ),
+    "visited": (
+      "color": var(--sapIndicationColor_2_Active_TextColor),
+      "background": var(--sapIndicationColor_2),
+      "borderColor": var(--sapIndicationColor_2_Active_BorderColor),
+    ),
+    "selected": (
+      "color": var(--sapIndicationColor_2_Selected_TextColor),
+      "iconColor": var(--sapIndicationColor_2_Selected_TextColor),
+      "background": var(--sapIndicationColor_2_Selected_Background),
+      "borderColor": var(--sapIndicationColor_2_Selected_BorderColor),
+      "underline": var(--sapIndicationColor_2)
+    ),
+    "selectedHover": (
+      "color": var(--sapIndicationColor_2_Selected_TextColor),
+      "iconColor": var(--sapIndicationColor_2_Selected_TextColor),
+      "background": var(--sapIndicationColor_2_Selected_Background),
+      "borderColor": var(--sapIndicationColor_2_Selected_BorderColor),
+      "underline": var(--sapIndicationColor_2)
+    )
   ),
   "3": (
-    "regular": ("color": var(--sapIndicationColor_3_TextColor), "background": var(--sapIndicationColor_3)),
-    "hover": ("color": var(--sapIndicationColor_3_TextColor), "background": var(--sapIndicationColor_3_Hover_Background)),
-    "active": ("color": var(--sapIndicationColor_3_TextColor), "background": var(--sapIndicationColor_3_Active_Background)),
-    "visited": ("color": var(--sapIndicationColor_3_TextColor), "background": var(--sapIndicationColor_3)),
+    "regular": (
+      "color": var(--sapIndicationColor_3_TextColor),
+      "background": var(--fdObjectStatus_Background_Indication_Color_3),
+      "borderColor": var(--sapIndicationColor_3_BorderColor),
+    ),
+    "hover": (
+      "color": var(--sapIndicationColor_3_TextColor),
+      "background": var(--sapIndicationColor_3_Hover_Background),
+      "borderColor": var(--sapIndicationColor_3_BorderColor),
+    ),
+    "active": (
+      "color": var(--fdObjectStatus_Active_Text_Indication_Color_3),
+      "background": var(--sapIndicationColor_3_Active_Background),
+      "borderColor": var(--sapIndicationColor_3_Active_BorderColor),
+    ),
+    "visited": (
+      "color": var(--sapIndicationColor_3_Active_TextColor),
+      "background": var(--sapIndicationColor_3),
+      "borderColor": var(--sapIndicationColor_3_Active_BorderColor),
+    ),
+    "selected": (
+      "color": var(--sapIndicationColor_3_Selected_TextColor),
+      "iconColor": var(--sapIndicationColor_3_Selected_TextColor),
+      "background": var(--sapIndicationColor_3_Selected_Background),
+      "borderColor": var(--sapIndicationColor_3_Selected_BorderColor),
+      "underline": var(--sapIndicationColor_3)
+    ),
+    "selectedHover": (
+      "color": var(--sapIndicationColor_3_Selected_TextColor),
+      "iconColor": var(--sapIndicationColor_3_Selected_TextColor),
+      "background": var(--sapIndicationColor_3_Selected_Background),
+      "borderColor": var(--sapIndicationColor_3_Selected_BorderColor),
+      "underline": var(--sapIndicationColor_3)
+    )
   ),
   "4": (
-    "regular": ("color": var(--sapIndicationColor_4_TextColor), "background": var(--sapIndicationColor_4)),
-    "hover": ("color": var(--sapIndicationColor_4_TextColor), "background": var(--sapIndicationColor_4_Hover_Background)),
-    "active": ("color": var(--sapIndicationColor_4_TextColor), "background": var(--sapIndicationColor_4_Active_Background)),
-    "visited": ("color": var(--sapIndicationColor_4_TextColor), "background": var(--sapIndicationColor_4)),
+    "regular": (
+      "color": var(--sapIndicationColor_4_TextColor),
+      "background": var(--fdObjectStatus_Background_Indication_Color_4),
+      "borderColor": var(--sapIndicationColor_4_BorderColor),
+    ),
+    "hover": (
+      "color": var(--sapIndicationColor_4_TextColor),
+      "background": var(--sapIndicationColor_4_Hover_Background),
+      "borderColor": var(--sapIndicationColor_4_BorderColor),
+    ),
+    "active": (
+      "color": var(--fdObjectStatus_Active_Text_Indication_Color_4),
+      "background": var(--sapIndicationColor_4_Active_Background),
+      "borderColor": var(--sapIndicationColor_4_Active_BorderColor),
+    ),
+    "visited": (
+      "color": var(--sapIndicationColor_4_Active_TextColor),
+      "background": var(--sapIndicationColor_4),
+      "borderColor": var(--sapIndicationColor_4_Active_BorderColor),
+    ),
+    "selected": (
+      "color": var(--sapIndicationColor_4_Selected_TextColor),
+      "iconColor": var(--sapIndicationColor_4_Selected_TextColor),
+      "background": var(--sapIndicationColor_4_Selected_Background),
+      "borderColor": var(--sapIndicationColor_4_Selected_BorderColor),
+      "underline": var(--sapIndicationColor_4)
+    ),
+    "selectedHover": (
+      "color": var(--sapIndicationColor_4_Selected_TextColor),
+      "iconColor": var(--sapIndicationColor_4_Selected_TextColor),
+      "background": var(--sapIndicationColor_4_Selected_Background),
+      "borderColor": var(--sapIndicationColor_4_Selected_BorderColor),
+      "underline": var(--sapIndicationColor_4)
+    )
   ),
   "5": (
-    "regular": ("color": var(--sapIndicationColor_5_TextColor), "background": var(--sapIndicationColor_5)),
-    "hover": ("color": var(--sapIndicationColor_5_TextColor), "background": var(--sapIndicationColor_5_Hover_Background)),
-    "active": ("color": var(--sapIndicationColor_5_TextColor), "background": var(--sapIndicationColor_5_Active_Background)),
-    "visited": ("color": var(--sapIndicationColor_5_TextColor), "background": var(--sapIndicationColor_5)),
+    "regular": (
+      "color": var(--sapIndicationColor_5_TextColor),
+      "background": var(--fdObjectStatus_Background_Indication_Color_5),
+      "borderColor": var(--sapIndicationColor_5_BorderColor),
+    ),
+    "hover": (
+      "color": var(--sapIndicationColor_5_TextColor),
+      "background": var(--sapIndicationColor_5_Hover_Background),
+      "borderColor": var(--sapIndicationColor_5_BorderColor),
+    ),
+    "active": (
+      "color": var(--fdObjectStatus_Active_Text_Indication_Color_5),
+      "background": var(--sapIndicationColor_5_Active_Background),
+      "borderColor": var(--sapIndicationColor_5_Active_BorderColor),
+    ),
+    "visited": (
+      "color": var(--sapIndicationColor_5_Active_TextColor),
+      "background": var(--sapIndicationColor_5),
+      "borderColor": var(--sapIndicationColor_5_Active_BorderColor),
+    ),
+    "selected": (
+      "color": var(--sapIndicationColor_5_Selected_TextColor),
+      "iconColor": var(--sapIndicationColor_5_Selected_TextColor),
+      "background": var(--sapIndicationColor_5_Selected_Background),
+      "borderColor": var(--sapIndicationColor_5_Selected_BorderColor),
+      "underline": var(--sapIndicationColor_5)
+    ),
+    "selectedHover": (
+      "color": var(--sapIndicationColor_5_Selected_TextColor),
+      "iconColor": var(--sapIndicationColor_5_Selected_TextColor),
+      "background": var(--sapIndicationColor_5_Selected_Background),
+      "borderColor": var(--sapIndicationColor_5_Selected_BorderColor),
+      "underline": var(--sapIndicationColor_5)
+    )
   ),
   "6": (
-    "regular": ("color": var(--sapIndicationColor_6_TextColor), "background": var(--sapIndicationColor_6)),
-    "hover": ("color": var(--sapIndicationColor_6_TextColor), "background": var(--sapIndicationColor_6_Hover_Background)),
-    "active": ("color": var(--sapIndicationColor_6_TextColor), "background": var(--sapIndicationColor_6_Active_Background)),
-    "visited": ("color": var(--sapIndicationColor_6_TextColor), "background": var(--sapIndicationColor_6)),
+    "regular": (
+      "color": var(--sapIndicationColor_6_TextColor),
+      "background": var(--fdObjectStatus_Background_Indication_Color_6),
+      "borderColor": var(--sapIndicationColor_6_BorderColor),
+    ),
+    "hover": (
+      "color": var(--sapIndicationColor_6_TextColor),
+      "background": var(--sapIndicationColor_6_Hover_Background),
+      "borderColor": var(--sapIndicationColor_6_BorderColor),
+    ),
+    "active": (
+      "color": var(--fdObjectStatus_Active_Text_Indication_Color_6),
+      "background": var(--sapIndicationColor_6_Active_Background),
+      "borderColor": var(--sapIndicationColor_6_Active_BorderColor),
+    ),
+    "visited": (
+      "color": var(--sapIndicationColor_6_Active_TextColor),
+      "background": var(--sapIndicationColor_6),
+      "borderColor": var(--sapIndicationColor_6_Active_BorderColor),
+    ),
+    "selected": (
+      "color": var(--sapIndicationColor_6_Selected_TextColor),
+      "iconColor": var(--sapIndicationColor_6_Selected_TextColor),
+      "background": var(--sapIndicationColor_6_Selected_Background),
+      "borderColor": var(--sapIndicationColor_6_Selected_BorderColor),
+      "underline": var(--sapIndicationColor_6)
+    ),
+    "selectedHover": (
+      "color": var(--sapIndicationColor_6_Selected_TextColor),
+      "iconColor": var(--sapIndicationColor_6_Selected_TextColor),
+      "background": var(--sapIndicationColor_6_Selected_Background),
+      "borderColor": var(--sapIndicationColor_6_Selected_BorderColor),
+      "underline": var(--sapIndicationColor_6)
+    )
   ),
   "7": (
-    "regular": ("color": var(--sapIndicationColor_7_TextColor), "background": var(--sapIndicationColor_7)),
-    "hover": ("color": var(--sapIndicationColor_7_TextColor), "background": var(--sapIndicationColor_7_Hover_Background)),
-    "active": ("color": var(--sapIndicationColor_7_TextColor), "background": var(--sapIndicationColor_7_Active_Background)),
-    "visited": ("color": var(--sapIndicationColor_7_TextColor), "background": var(--sapIndicationColor_7)),
+    "regular": (
+      "color": var(--sapIndicationColor_7_TextColor),
+      "background": var(--fdObjectStatus_Background_Indication_Color_7),
+      "borderColor": var(--sapIndicationColor_7_BorderColor),
+    ),
+    "hover": (
+      "color": var(--sapIndicationColor_7_TextColor),
+      "background": var(--sapIndicationColor_7_Hover_Background),
+      "borderColor": var(--sapIndicationColor_7_BorderColor),
+    ),
+    "active": (
+      "color": var(--fdObjectStatus_Active_Text_Indication_Color_7),
+      "background": var(--sapIndicationColor_7_Active_Background),
+      "borderColor": var(--sapIndicationColor_7_Active_BorderColor),
+    ),
+    "visited": (
+      "color": var(--sapIndicationColor_7_Active_TextColor),
+      "background": var(--sapIndicationColor_7),
+      "borderColor": var(--sapIndicationColor_7_Active_BorderColor),
+    ),
+    "selected": (
+      "color": var(--sapIndicationColor_7_Selected_TextColor),
+      "iconColor": var(--sapIndicationColor_7_Selected_TextColor),
+      "background": var(--sapIndicationColor_7_Selected_Background),
+      "borderColor": var(--sapIndicationColor_7_Selected_BorderColor),
+      "underline": var(--sapIndicationColor_7)
+    ),
+    "selectedHover": (
+      "color": var(--sapIndicationColor_7_Selected_TextColor),
+      "iconColor": var(--sapIndicationColor_7_Selected_TextColor),
+      "background": var(--sapIndicationColor_7_Selected_Background),
+      "borderColor": var(--sapIndicationColor_7_Selected_BorderColor),
+      "underline": var(--sapIndicationColor_7)
+    )
   ),
   "8": (
-    "regular": ("color": var(--sapIndicationColor_8_TextColor), "background": var(--sapIndicationColor_8)),
-    "hover": ("color": var(--sapIndicationColor_8_TextColor), "background": var(--sapIndicationColor_8_Hover_Background)),
-    "active": ("color": var(--sapIndicationColor_8_TextColor), "background": var(--sapIndicationColor_8_Active_Background)),
-    "visited": ("color": var(--sapIndicationColor_8_TextColor), "background": var(--sapIndicationColor_8)),
+    "regular": (
+      "color": var(--sapIndicationColor_8_TextColor),
+      "background": var(--fdObjectStatus_Background_Indication_Color_8),
+      "borderColor": var(--sapIndicationColor_8_BorderColor),
+    ),
+    "hover": (
+      "color": var(--sapIndicationColor_8_TextColor),
+      "background": var(--sapIndicationColor_8_Hover_Background),
+      "borderColor": var(--sapIndicationColor_8_BorderColor),
+    ),
+    "active": (
+      "color": var(--fdObjectStatus_Active_Text_Indication_Color_8),
+      "background": var(--sapIndicationColor_8_Active_Background),
+      "borderColor": var(--sapIndicationColor_8_Active_BorderColor),
+    ),
+    "visited": (
+      "color": var(--sapIndicationColor_8_Active_TextColor),
+      "background": var(--sapIndicationColor_8),
+      "borderColor": var(--sapIndicationColor_8_Active_BorderColor),
+    ),
+    "selected": (
+      "color": var(--sapIndicationColor_8_Selected_TextColor),
+      "iconColor": var(--sapIndicationColor_8_Selected_TextColor),
+      "background": var(--sapIndicationColor_8_Selected_Background),
+      "borderColor": var(--sapIndicationColor_8_Selected_BorderColor),
+      "underline": var(--sapIndicationColor_8)
+    ),
+    "selectedHover": (
+      "color": var(--sapIndicationColor_8_Selected_TextColor),
+      "iconColor": var(--sapIndicationColor_8_Selected_TextColor),
+      "background": var(--sapIndicationColor_8_Selected_Background),
+      "borderColor": var(--sapIndicationColor_8_Selected_BorderColor),
+      "underline": var(--sapIndicationColor_8)
+    )
+  ),
+  "9": (
+    "regular": (
+      "color": var(--sapIndicationColor_9_TextColor),
+      "background": var(--fdObjectStatus_Background_Indication_Color_9),
+      "borderColor": var(--sapIndicationColor_9_BorderColor),
+    ),
+    "hover": (
+      "color": var(--sapIndicationColor_9_TextColor),
+      "background": var(--sapIndicationColor_9_Hover_Background),
+      "borderColor": var(--sapIndicationColor_9_BorderColor),
+    ),
+    "active": (
+      "color": var(--fdObjectStatus_Active_Text_Indication_Color_9),
+      "background": var(--sapIndicationColor_9_Active_Background),
+      "borderColor": var(--sapIndicationColor_9_Active_BorderColor),
+    ),
+    "visited": (
+      "color": var(--sapIndicationColor_9_Active_TextColor),
+      "background": var(--sapIndicationColor_9),
+      "borderColor": var(--sapIndicationColor_9_Active_BorderColor),
+    ),
+    "selected": (
+      "color": var(--sapIndicationColor_9_Selected_TextColor),
+      "iconColor": var(--sapIndicationColor_9_Selected_TextColor),
+      "background": var(--sapIndicationColor_9_Selected_Background),
+      "borderColor": var(--sapIndicationColor_9_Selected_BorderColor),
+      "underline": var(--sapIndicationColor_9)
+    ),
+    "selectedHover": (
+      "color": var(--sapIndicationColor_9_Selected_TextColor),
+      "iconColor": var(--sapIndicationColor_9_Selected_TextColor),
+      "background": var(--sapIndicationColor_9_Selected_Background),
+      "borderColor": var(--sapIndicationColor_9_Selected_BorderColor),
+      "underline": var(--sapIndicationColor_9)
+    )
+  ),
+  "10": (
+    "regular": (
+      "color": var(--sapIndicationColor_10_TextColor),
+      "background": var(--fdObjectStatus_Background_Indication_Color_10),
+      "borderColor": var(--sapIndicationColor_10_BorderColor),
+    ),
+    "hover": (
+      "color": var(--sapIndicationColor_10_TextColor),
+      "background": var(--sapIndicationColor_10_Hover_Background),
+      "borderColor": var(--sapIndicationColor_10_BorderColor),
+    ),
+    "active": (
+      "color": var(--fdObjectStatus_Active_Text_Indication_Color_10),
+      "background": var(--sapIndicationColor_10_Active_Background),
+      "borderColor": var(--sapIndicationColor_10_Active_BorderColor),
+    ),
+    "visited": (
+      "color": var(--sapIndicationColor_10_Active_TextColor),
+      "background": var(--sapIndicationColor_10),
+      "borderColor": var(--sapIndicationColor_10_Active_BorderColor),
+    ),
+    "selected": (
+      "color": var(--sapIndicationColor_10_Selected_TextColor),
+      "iconColor": var(--sapIndicationColor_10_Selected_TextColor),
+      "background": var(--sapIndicationColor_10_Selected_Background),
+      "borderColor": var(--sapIndicationColor_10_Selected_BorderColor),
+      "underline": var(--sapIndicationColor_10)
+    ),
+    "selectedHover": (
+      "color": var(--sapIndicationColor_10_Selected_TextColor),
+      "iconColor": var(--sapIndicationColor_10_Selected_TextColor),
+      "background": var(--sapIndicationColor_10_Selected_Background),
+      "borderColor": var(--sapIndicationColor_10_Selected_BorderColor),
+      "underline": var(--sapIndicationColor_10)
+    )
   ),
 );
 
@@ -144,18 +664,56 @@ $inverted-color-accents: (
     --fdObjectStatus_Text_Color: #{map_deep_get($variablesSet, "visited", "color")};
     --fdObjectStatus_Icon_Color: #{map_deep_get($variablesSet, "visited", "color")};
     --fdObjectStatus_Background_Color: #{map_deep_get($variablesSet, "visited", "background")};
+    --fdObjectStatus_Border_Color: #{map_deep_get($variablesSet, "visited", "borderColor")};
+  }
+
+  @include fd-focus() {
+    border-color: var(--sapContent_FocusColor);
+    outline: var(--fdObjectStatus_Inverted_Outline_Color) 0.0625rem var(--sapContent_FocusStyle);
+    outline-offset: -0.125rem;
+    box-shadow: var(--fdObjectStatus_Inverted_Box_Shadow);
   }
 
   @include fd-hover() {
     --fdObjectStatus_Text_Color: #{map_deep_get($variablesSet, "hover", "color")};
     --fdObjectStatus_Icon_Color: #{map_deep_get($variablesSet, "hover", "color")};
     --fdObjectStatus_Background_Color: #{map_deep_get($variablesSet, "hover", "background")};
+    --fdObjectStatus_Border_Color: #{map_deep_get($variablesSet, "hover", "borderColor")};
   }
 
   @include fd-active() {
     --fdObjectStatus_Text_Color: #{map_deep_get($variablesSet, "active", "color")};
-    --fdObjectStatus_Icon_Color: #{map_deep_get($variablesSet, "active", "color")};
+    --fdObjectStatus_Icon_Color: #{map_deep_get($variablesSet, "active", "iconColor")};
     --fdObjectStatus_Background_Color: #{map_deep_get($variablesSet, "active", "background")};
+    --fdObjectStatus_Border_Color: #{map_deep_get($variablesSet, "active", "borderColor")};
+  }
+
+  @include fd-selected() {
+    --fdObjectStatus_Text_Color: #{map_deep_get($variablesSet, "selected", "color")};
+    --fdObjectStatus_Icon_Color: #{map_deep_get($variablesSet, "selected", "iconColor")};
+    --fdObjectStatus_Background_Color: #{map_deep_get($variablesSet, "selected", "background")};
+    --fdObjectStatus_Underline: #{map_deep_get($variablesSet, "selected", "underline")};
+    --fdObjectStatus_Border_Color: #{map_deep_get($variablesSet, "selected", "borderColor")};
+
+    @include fd-hover() {
+      --fdObjectStatus_Text_Color: #{map_deep_get($variablesSet, "selectedHover", "color")};
+      --fdObjectStatus_Icon_Color: #{map_deep_get($variablesSet, "selectedHover", "iconColor")};
+      --fdObjectStatus_Background_Color: #{map_deep_get($variablesSet, "selectedHover", "background")};
+      --fdObjectStatus_Underline: #{map_deep_get($variablesSet, "selectedHover", "underline")};
+      --fdObjectStatus_Border_Color: #{map_deep_get($variablesSet, "selectedHover", "borderColor")};
+    }
+
+    @include fd-focus() {
+      border-color: var(--sapContent_FocusColor);
+      outline: var(--fdObjectStatus_Inverted_Outline_Color) 0.0625rem var(--sapContent_FocusStyle);
+      outline-offset: -0.125rem;
+      box-shadow: none;
+      position: relative;
+
+      &::before {
+        bottom: 0.0626rem;
+      }
+    }
   }
 }
 
@@ -170,9 +728,12 @@ $inverted-color-accents: (
     @content;
   }
 
+  --fdObjectStatus_Decoration: none;
+  --fdObjectStatus_Underline: transparent;
+  --fdObjectStatus_Text_Decoration: var(--fdObjectStatus_TextDecoration_Regular);
+
   // ICON VARIABLES
   --fdObjectStatus_Icon_Font_Size: 1rem;
-  --fdObjectStatus_Icon_Padding: 0.25rem;
   --fdObjectStatus_Icon_Color: var(--sapNeutralElementColor);
 
   // TEXT VARIABLES
@@ -182,42 +743,23 @@ $inverted-color-accents: (
   --fdObjectStatus_Height: 1rem;
   --fdObjectStatus_Text_Shadow: var(--sapContent_TextShadow);
 
-  // INVERTED OBJECT STATUS VARIABLES
-  $fd-object-status-inverted-border-radius: 0.25rem !default;
-  $fd-object-status-inverted-padding: 0.0625rem 0.25rem !default;
-  $fd-object-status-inverted-padding-empty: 0 0.25rem !default;
-  $fd-object-status-inverted-min-height: 1rem !default;
-  $fd-object-status-inverted-min-width: 1.25rem !default;
-  $fd-object-status-inverted-text-font-weight: bold !default;
-  $fd-object-status-inverted-icon-font-size: 0.75rem !default;
-  $fd-object-status-inverted-icon-spacing: 0.25rem !default;
-
-  // LARGE DESIGN VARIABLES
-  $fd-object-status-icon-text-font-size-large: 1.5rem;
-  $fd-object-status-icon-text-font-size-large-inverted: 1.25rem;
-  $fd-object-status-padding-large-inverted: 0.125rem 0.25rem !default;
-  $fd-object-status-padding-large-inverted-empty: 0 0.25rem !default;
-  $fd-object-status-min-width-large-inverted-empty: 1.75rem !default;
-  $fd-object-status-min-height-large-inverted-empty: 1.5rem !default;
-  $fd-object-status-height-large: 1.5rem !default;
-
   @include fd-reset();
 
-  font-family: var(--fdObjectStatus_Text_Font_Family);
-  font-size: var(--fdObjectStatus_Text_Font_Size);
-  color: var(--fdObjectStatus_Text_Color);
-  text-shadow: var(--fdObjectStatus_Text_Shadow);
+  @include fd-flex-center() {
+    gap: 0.25rem;
+    display: inline-flex;
+  }
+
   max-width: 100%;
+  position: relative;
   word-break: break-word;
-  display: inline-flex;
-  align-items: center;
   height: var(--fdObjectStatus_Height);
+  color: var(--fdObjectStatus_Text_Color);
   max-height: var(--fdObjectStatus_Height);
   line-height: var(--fdObjectStatus_Height);
-
-  @include fd-focus() {
-    outline: none;
-  }
+  text-shadow: var(--fdObjectStatus_Text_Shadow);
+  font-size: var(--fdObjectStatus_Text_Font_Size);
+  font-family: var(--fdObjectStatus_Text_Font_Family);
 
   &__text {
     @include fd-reset();
@@ -231,23 +773,8 @@ $inverted-color-accents: (
       @include fd-flex-center();
 
       font-size: var(--fdObjectStatus_Icon_Font_Size);
-      padding-right: var(--fdObjectStatus_Icon_Padding);
       color: var(--fdObjectStatus_Icon_Color);
       line-height: var(--fdObjectStatus_Height);
-
-      // ICON ONLY MODE
-      @include fd-only-child() {
-        justify-content: center;
-        padding-right: 0;
-        padding-left: 0;
-      }
-    }
-  }
-
-  @include fd-rtl() {
-    @include fd-object-status-icon-selector() {
-      padding-right: 0;
-      padding-left: var(--fdObjectStatus_Icon_Padding);
     }
   }
 
@@ -277,63 +804,79 @@ $inverted-color-accents: (
 
   // CLICKABLE OBJECT STATUS
   &--link {
-    @include fd-fiori-focus(0.0625rem);
-
-    text-decoration: none;
     cursor: pointer;
+    text-decoration: var(--fdObjectStatus_Decoration);
 
-    &:hover {
-      .#{$block}__text {
-        text-decoration: underline;
-      }
+    .#{$block}__text {
+      text-decoration: var(--fdObjectStatus_Text_Decoration);
     }
 
-    &:visited {
-      text-decoration: none;
+    @include fd-visited() {
+      --fdObjectStatus_Text_Decoration: var(--fdObjectStatus_TextDecoration_Visited);
+    }
+
+    @include fd-hover() {
+      --fdObjectStatus_Text_Decoration: var(--fdObjectStatus_TextDecoration_Hover);
+    }
+
+    @include fd-active() {
+      --fdObjectStatus_Text_Decoration: var(--fdObjectStatus_TextDecoration_Down);
+    }
+
+    @include fd-focus() {
+      &:not(:active):not(.#{$block}--inverted) {
+        --fdObjectStatus_Text_Color: var(--fdObjectStatus_Neutral_Color_Focus);
+        --fdObjectStatus_Icon_Color: var(--fdObjectStatus_Neutral_IconColor_Focus);
+        --fdObjectStatus_Text_Decoration: var(--fdObjectStatus_TextDecoration_Focus);
+
+        text-shadow: none;
+        border-radius: var(--fdObjectStatus_Focus_Border_Radius);
+        background: var(--fdObjectStatus_Focus_Background);
+        outline: var(--fdObjectStatus_Focus_Outline);
+      }
     }
   }
 
   // LARGE DESIGN
   &--large {
-    --fdObjectStatus_Text_Font_Size: #{$fd-object-status-icon-text-font-size-large};
-    --fdObjectStatus_Height: #{$fd-object-status-height-large};
-    --fdObjectStatus_Icon_Font_Size: #{ $fd-object-status-icon-text-font-size-large};
+    --fdObjectStatus_Text_Font_Size: 1.5rem;
+    --fdObjectStatus_Height: 1.5rem;
+    --fdObjectStatus_Icon_Font_Size: 1.5rem;
     --fdObjectStatus_Text_Font_Family: var(--sapFontLightFamily);
   }
 
   // INVERTED OBJECT STATUS
   &--inverted {
+    --fdObjectStatus_Text_Shadow: none;
+    --fdObjectStatus_Icon_Font_Size: 0.75rem;
     --fdObjectStatus_Text_Font_Size: var(--sapFontSmallSize);
-    --fdObjectStatus_Text_Shadow: var(--sapContent_ContrastTextShadow);
-    --fdObjectStatus_Icon_Font_Size: #{$fd-object-status-inverted-icon-font-size};
+    --fdObjectStatus_Text_Font_Family: var(--sapFontBoldFamily);
 
-    height: auto;
-    min-height: $fd-object-status-inverted-min-height;
-    width: auto;
-    max-width: 100%;
-    min-width: $fd-object-status-inverted-min-width;
-    padding: $fd-object-status-inverted-padding;
-    border-radius: $fd-object-status-inverted-border-radius;
-    font-weight: $fd-object-status-inverted-text-font-weight;
-    border-width: var(--fdInverted_Object_Border_Width);
+    max-height: none;
+    position: relative;
     border-style: solid;
-    background-color: var(--fdObjectStatus_Background_Color, transparent);
+    overflow: hidden;
+    padding: var(--fdObjectStatus_Inverted_Padding);
+    min-width: var(--fdObjectStatus_Inverted_Min_Width);
+    border-width: var(--fdObjectStatus_Inverted_Border_Width);
+    min-height: var(--fdObjectStatus_Inverted_Line_Height);
     border-color: var(--fdObjectStatus_Border_Color, initial);
+    border-radius: var(--fdObjectStatus_Inverted_Border_Radius);
+    background-color: var(--fdObjectStatus_Background_Color, transparent);
 
     .#{$block}__icon,
     .#{$block}__text {
-      line-height: 0.875rem;
+      line-height: 1rem;
     }
 
-    @include fd-object-status-icon-selector() {
-      padding-right: $fd-object-status-inverted-icon-spacing;
-    }
-
-    @include fd-rtl() {
-      @include fd-object-status-icon-selector() {
-        padding-right: 0;
-        padding-left: $fd-object-status-inverted-icon-spacing;
-      }
+    &::before {
+      content: '';
+      width: 100%;
+      position: absolute;
+      bottom: 0;
+      z-index: 1;
+      height: var(--fdObjectStatus_Inverted_Underline_Width);
+      background: var(--fdObjectStatus_Underline);
     }
 
     // TEXT AND BACKGROUND COLOR FOR INVERTED OBJECT STATUS STATES
@@ -356,11 +899,12 @@ $inverted-color-accents: (
 
     // LARGE DESIGN FOR INVERTED OBJECT STATUS
     &.#{$block}--large {
-      --fdObjectStatus_Text_Font_Size: #{$fd-object-status-icon-text-font-size-large-inverted};
-      --fdObjectStatus_Icon_Font_Size: #{$fd-object-status-icon-text-font-size-large-inverted};
-      --fdObjectStatus_Height: #{$fd-object-status-height-large};
+      --fdObjectStatus_Text_Font_Size: 1.25rem;
+      --fdObjectStatus_Icon_Font_Size: 1.25rem;
+      --fdObjectStatus_Height: 1.5rem;
+      --fdObjectStatus_Text_Font_Family: var(--fdObjectStatus_Inverted_Large_Font_Family);
 
-      padding: $fd-object-status-padding-large-inverted;
+      padding: 0.125rem 0.25rem;
       height: auto;
       max-height: none;
 
@@ -368,26 +912,19 @@ $inverted-color-accents: (
       .#{$block}__text {
         line-height: var(--fdObjectStatus_Height);
       }
-
-      @include fd-object-status-icon-selector() {
-        // ICON ONLY MODE
-        @include fd-only-child() {
-          height: $fd-object-status-min-height-large-inverted-empty;
-          min-width: $fd-object-status-min-width-large-inverted-empty;
-          padding: $fd-object-status-padding-large-inverted-empty;
-        }
-      }
     }
 
     // CLICKABLE INVERTED OBJECT STATUS
     &.#{$block}--link {
       cursor: pointer;
 
+      --fdObjectStatus_Text_Decoration: none;
+
       &:hover,
       &:active,
       &:visited {
         .#{$block}__text {
-          text-decoration: none;
+          --fdObjectStatus_Text_Decoration: none;
         }
       }
 
@@ -406,10 +943,12 @@ $inverted-color-accents: (
       @each $set-name, $color-set in $inverted-color-accents {
         &.#{$block}--indication-#{$set-name} {
           @include inverted-object-interaction-states($color-set);
-
-          border-color: var(--sapContent_ForegroundBorderColor);
         }
       }
+    }
+
+    &.#{$block}--icon-only {
+      padding: 0 0.25rem;
     }
   }
 

--- a/packages/styles/src/theming/common/object-status/_sap_fiori.scss
+++ b/packages/styles/src/theming/common/object-status/_sap_fiori.scss
@@ -1,0 +1,64 @@
+:root {
+  --fdObjectStatus_TextDecoration_Regular: none;
+  --fdObjectStatus_TextDecoration_Hover: underline;
+  --fdObjectStatus_TextDecoration_Down: underline;
+  --fdObjectStatus_TextDecoration_Visited: none;
+  --fdObjectStatus_TextDecoration_Focus: none;
+
+  // Focus State
+  --fdObjectStatus_Focus_Background: inherit;
+  --fdObjectStatus_Focus_Border_Radius: 0;
+  --fdObjectStatus_Focus_Outline: 0.0625rem dotted var(--sapContent_FocusColor);
+  --fdObjectStatus_Positive_Color_Focus: var(--sapPositiveTextColor);
+  --fdObjectStatus_Positive_IconColor_Focus: var(--sapPositiveElementColor);
+  --fdObjectStatus_Critical_Color_Focus: var(--sapCriticalTextColor);
+  --fdObjectStatus_Critical_IconColor_Focus: var(--sapCriticalElementColor);
+  --fdObjectStatus_Negative_Color_Focus: var(--sapNegativeTextColor);
+  --fdObjectStatus_Negative_IconColor_Focus: var(--sapNegativeElementColor);
+  --fdObjectStatus_Informative_Color_Focus: var(--sapInformativeTextColor);
+  --fdObjectStatus_Informative_IconColor_Focus: var(--sapInformativeElementColor);
+  --fdObjectStatus_Neutral_Color_Focus: var(--sapNeutralTextColor);
+  --fdObjectStatus_Neutral_IconColor_Focus: var(--sapNeutralElementColor);
+  --fdObjectStatus_Accent_Color_1_Focus: var(--sapIndicationColor_1);
+  --fdObjectStatus_Accent_Color_2_Focus: var(--sapIndicationColor_2);
+  --fdObjectStatus_Accent_Color_3_Focus: var(--sapIndicationColor_3);
+  --fdObjectStatus_Accent_Color_4_Focus: var(--sapIndicationColor_4);
+  --fdObjectStatus_Accent_Color_5_Focus: var(--sapIndicationColor_5);
+  --fdObjectStatus_Accent_Color_6_Focus: var(--sapIndicationColor_6);
+  --fdObjectStatus_Accent_Color_7_Focus: var(--sapIndicationColor_7);
+  --fdObjectStatus_Accent_Color_8_Focus: var(--sapIndicationColor_8);
+
+  // Inverted Object Status
+  --fdObjectStatus_Inverted_Border_Width: 0;
+  --fdObjectStatus_Inverted_Underline_Width: 0;
+  --fdObjectStatus_Inverted_Min_Width: 1.25rem;
+  --fdObjectStatus_Inverted_Padding: 0.0625rem 0.25rem;
+  --fdObjectStatus_Inverted_Line_Height: 1.125rem;
+  --fdObjectStatus_Inverted_Border_Radius: 0.25rem;
+  --fdObjectStatus_Inverted_Large_Font_Family: var(--sapFontLightFamily);
+  --fdObjectStatus_Inverted_Neutral_Background_Regular: var(--sapButton_Neutral_Background);
+  --fdObjectStatus_Inverted_Neutral_Color_Regular: var(--sapButton_Neutral_TextColor);
+  --fdObjectStatus_Inverted_Neutral_Border_Color_Regular: var(--sapNeutralBorderColor);
+  --fdObjectStatus_Inverted_Box_Shadow: none;
+  --fdObjectStatus_Inverted_Outline_Color: var(--sapContent_ContrastFocusColor);
+  --fdObjectStatus_Background_Indication_Color_1: var(--sapIndicationColor_1);
+  --fdObjectStatus_Background_Indication_Color_2: var(--sapIndicationColor_2);
+  --fdObjectStatus_Background_Indication_Color_3: var(--sapIndicationColor_3);
+  --fdObjectStatus_Background_Indication_Color_4: var(--sapIndicationColor_4);
+  --fdObjectStatus_Background_Indication_Color_5: var(--sapIndicationColor_5);
+  --fdObjectStatus_Background_Indication_Color_6: var(--sapIndicationColor_6);
+  --fdObjectStatus_Background_Indication_Color_7: var(--sapIndicationColor_7);
+  --fdObjectStatus_Background_Indication_Color_8: var(--sapIndicationColor_8);
+  --fdObjectStatus_Background_Indication_Color_9: var(--sapIndicationColor_9);
+  --fdObjectStatus_Background_Indication_Color_10: var(--sapIndicationColor_10);
+  --fdObjectStatus_Active_Text_Indication_Color_1: var(--sapIndicationColor_1_TextColor);
+  --fdObjectStatus_Active_Text_Indication_Color_2: var(--sapIndicationColor_2_TextColor);
+  --fdObjectStatus_Active_Text_Indication_Color_3: var(--sapIndicationColor_3_TextColor);
+  --fdObjectStatus_Active_Text_Indication_Color_4: var(--sapIndicationColor_4_TextColor);
+  --fdObjectStatus_Active_Text_Indication_Color_5: var(--sapIndicationColor_5_TextColor);
+  --fdObjectStatus_Active_Text_Indication_Color_6: var(--sapIndicationColor_6_TextColor);
+  --fdObjectStatus_Active_Text_Indication_Color_7: var(--sapIndicationColor_7_TextColor);
+  --fdObjectStatus_Active_Text_Indication_Color_8: var(--sapIndicationColor_8_TextColor);
+  --fdObjectStatus_Active_Text_Indication_Color_9: var(--sapIndicationColor_9_TextColor);
+  --fdObjectStatus_Active_Text_Indication_Color_10: var(--sapIndicationColor_10_TextColor);
+}

--- a/packages/styles/src/theming/common/object-status/_sap_fiori_hc.scss
+++ b/packages/styles/src/theming/common/object-status/_sap_fiori_hc.scss
@@ -1,0 +1,8 @@
+@import "./sap_fiori";
+
+:root {
+  --fdObjectStatus_Inverted_Border_Width: 0.0625rem;
+  --fdObjectStatus_Inverted_Underline_Width: 0;
+  --fdObjectStatus_Inverted_Box_Shadow: none;
+  --fdObjectStatus_Inverted_Outline_Color: var(--sapContent_ContrastFocusColor);
+}

--- a/packages/styles/src/theming/common/object-status/_sap_horizon.scss
+++ b/packages/styles/src/theming/common/object-status/_sap_horizon.scss
@@ -1,0 +1,68 @@
+:root {
+  --fdObjectStatus_TextDecoration_Regular: underline;
+  --fdObjectStatus_TextDecoration_Hover: none;
+  --fdObjectStatus_TextDecoration_Down: none;
+  --fdObjectStatus_TextDecoration_Visited: underline;
+  --fdObjectStatus_TextDecoration_Focus: underline;
+
+  // Focus State
+  --fdObjectStatus_Focus_Background: var(--sapContent_FocusColor);
+  --fdObjectStatus_Focus_Border_Radius: 0.125rem;
+  --fdObjectStatus_Focus_Outline: 0.125rem solid var(--sapContent_FocusColor);
+  --fdObjectStatus_Positive_Color_Focus: var(--sapContent_ContrastTextColor);
+  --fdObjectStatus_Positive_IconColor_Focus: var(--sapContent_ContrastTextColor);
+  --fdObjectStatus_Critical_Color_Focus: var(--sapContent_ContrastTextColor);
+  --fdObjectStatus_Critical_IconColor_Focus: var(--sapContent_ContrastTextColor);
+  --fdObjectStatus_Negative_Color_Focus: var(--sapContent_ContrastTextColor);
+  --fdObjectStatus_Negative_IconColor_Focus: var(--sapContent_ContrastTextColor);
+  --fdObjectStatus_Informative_Color_Focus: var(--sapContent_ContrastTextColor);
+  --fdObjectStatus_Informative_IconColor_Focus: var(--sapContent_ContrastTextColor);
+  --fdObjectStatus_Neutral_Color_Focus: var(--sapContent_ContrastTextColor);
+  --fdObjectStatus_Neutral_IconColor_Focus: var(--sapContent_ContrastTextColor);
+  --fdObjectStatus_Accent_Color_1_Focus: var(--sapContent_ContrastTextColor);
+  --fdObjectStatus_Accent_Color_2_Focus: var(--sapContent_ContrastTextColor);
+  --fdObjectStatus_Accent_Color_3_Focus: var(--sapContent_ContrastTextColor);
+  --fdObjectStatus_Accent_Color_4_Focus: var(--sapContent_ContrastTextColor);
+  --fdObjectStatus_Accent_Color_5_Focus: var(--sapContent_ContrastTextColor);
+  --fdObjectStatus_Accent_Color_6_Focus: var(--sapContent_ContrastTextColor);
+  --fdObjectStatus_Accent_Color_7_Focus: var(--sapContent_ContrastTextColor);
+  --fdObjectStatus_Accent_Color_8_Focus: var(--sapContent_ContrastTextColor);
+
+  // Inverted Object Status
+  --fdObjectStatus_Inverted_Border_Width: 0.0625rem;
+  --fdObjectStatus_Inverted_Underline_Width: 0.125rem;
+  --fdObjectStatus_Inverted_Min_Width: 1.375rem;
+  --fdObjectStatus_Inverted_Padding: 0.1875rem 0.25rem;
+  --fdObjectStatus_Inverted_Line_Height: 1.375rem;
+  --fdObjectStatus_Inverted_Border_Radius: var(--sapButton_BorderCornerRadius);
+  --fdObjectStatus_Inverted_Large_Font_Family: var(--sapFontSemiBoldFamily);
+  --fdObjectStatus_Inverted_Neutral_Background_Regular: var(--sapNeutralBackground);
+  --fdObjectStatus_Inverted_Neutral_Color_Regular: var(--sapTextColor);
+  --fdObjectStatus_Inverted_Neutral_Border_Color_Regular: var(--sapNeutralBorderColor);
+  --fdObjectStatus_Inverted_Box_Shadow: inset 0 0 0 0.125rem var(--sapContent_ContrastFocusColor);
+  --fdObjectStatus_Inverted_Outline_Color: var(--sapContent_FocusColor);
+  --fdObjectStatus_Inverted_Icon_Color_Selected_Negative: var(--sapNegativeElementColor);
+  --fdObjectStatus_Inverted_Icon_Color_Selected_Critical: var(--sapCriticalElementColor);
+  --fdObjectStatus_Inverted_Icon_Color_Selected_Positive: var(--sapPositiveElementColor);
+  --fdObjectStatus_Inverted_Icon_Color_Selected_Informative: var(--sapInformativeElementColor);
+  --fdObjectStatus_Background_Indication_Color_1: var(--sapIndicationColor_1_Background);
+  --fdObjectStatus_Background_Indication_Color_2: var(--sapIndicationColor_2_Background);
+  --fdObjectStatus_Background_Indication_Color_3: var(--sapIndicationColor_3_Background);
+  --fdObjectStatus_Background_Indication_Color_4: var(--sapIndicationColor_4_Background);
+  --fdObjectStatus_Background_Indication_Color_5: var(--sapIndicationColor_5_Background);
+  --fdObjectStatus_Background_Indication_Color_6: var(--sapIndicationColor_6_Background);
+  --fdObjectStatus_Background_Indication_Color_7: var(--sapIndicationColor_7_Background);
+  --fdObjectStatus_Background_Indication_Color_8: var(--sapIndicationColor_8_Background);
+  --fdObjectStatus_Background_Indication_Color_9: var(--sapIndicationColor_9_Background);
+  --fdObjectStatus_Background_Indication_Color_10: var(--sapIndicationColor_10_Background);
+  --fdObjectStatus_Active_Text_Indication_Color_1: var(--sapIndicationColor_1_Active_TextColor);
+  --fdObjectStatus_Active_Text_Indication_Color_2: var(--sapIndicationColor_2_Active_TextColor);
+  --fdObjectStatus_Active_Text_Indication_Color_3: var(--sapIndicationColor_3_Active_TextColor);
+  --fdObjectStatus_Active_Text_Indication_Color_4: var(--sapIndicationColor_4_Active_TextColor);
+  --fdObjectStatus_Active_Text_Indication_Color_5: var(--sapIndicationColor_5_Active_TextColor);
+  --fdObjectStatus_Active_Text_Indication_Color_6: var(--sapIndicationColor_6_Active_TextColor);
+  --fdObjectStatus_Active_Text_Indication_Color_7: var(--sapIndicationColor_7_Active_TextColor);
+  --fdObjectStatus_Active_Text_Indication_Color_8: var(--sapIndicationColor_8_Active_TextColor);
+  --fdObjectStatus_Active_Text_Indication_Color_9: var(--sapIndicationColor_9_Active_TextColor);
+  --fdObjectStatus_Active_Text_Indication_Color_10: var(--sapIndicationColor_10_Active_TextColor);
+}

--- a/packages/styles/src/theming/common/object-status/_sap_horizon_hc.scss
+++ b/packages/styles/src/theming/common/object-status/_sap_horizon_hc.scss
@@ -1,0 +1,11 @@
+@import "./sap_horizon";
+
+:root {
+  --fdObjectStatus_Inverted_Underline_Width: 0;
+  --fdObjectStatus_Inverted_Icon_Color_Selected_Negative: var(--sapButton_Reject_Selected_TextColor);
+  --fdObjectStatus_Inverted_Icon_Color_Selected_Critical: var(--sapButton_Attention_Selected_TextColor);
+  --fdObjectStatus_Inverted_Icon_Color_Selected_Positive: var(--sapButton_Accept_Selected_TextColor);
+  --fdObjectStatus_Inverted_Icon_Color_Selected_Informative: var(--sapButton_Selected_TextColor);
+  --fdObjectStatus_Inverted_Box_Shadow: none;
+  --fdObjectStatus_Inverted_Outline_Color: var(--sapContent_FocusColor);
+}

--- a/packages/styles/src/theming/common/rating-indicator/_sap_horizon_hc.scss
+++ b/packages/styles/src/theming/common/rating-indicator/_sap_horizon_hc.scss
@@ -1,7 +1,6 @@
 @import "sap_horizon";
 
 :root {
-  --fdInverted_Object_Border_Width: 0;
   --fdOverlay_Background_Opacity: 0.6;
   --fdRating_Indicator_Border_Radius: 0;
 }

--- a/packages/styles/src/theming/sap_fiori_3.scss
+++ b/packages/styles/src/theming/sap_fiori_3.scss
@@ -38,10 +38,10 @@
 @import "./common/token/sap_fiori";
 @import "./common/calendar/sap_fiori";
 @import "./common/step-input/sap_fiori";
+@import "./common/object-status/sap_fiori";
 @import "./sap_fiori_3/css_variables";
 
 :root {
-  --fdInverted_Object_Border_Width: 0;
   --fdOverlay_Background_Opacity: 0.6;
 
   /* Dynamic Page Layout */

--- a/packages/styles/src/theming/sap_fiori_3_dark.scss
+++ b/packages/styles/src/theming/sap_fiori_3_dark.scss
@@ -38,10 +38,10 @@
 @import "./common/token/sap_fiori";
 @import "./common/calendar/sap_fiori";
 @import "./common/step-input/sap_fiori";
+@import "./common/object-status/sap_fiori";
 @import "./sap_fiori_3_dark/css_variables";
 
 :root {
-  --fdInverted_Object_Border_Width: 0;
   --fdOverlay_Background_Opacity: 0.6;
 
   /* Rating Indicator */

--- a/packages/styles/src/theming/sap_fiori_3_hcb.scss
+++ b/packages/styles/src/theming/sap_fiori_3_hcb.scss
@@ -45,10 +45,10 @@
 @import "./common/token/sap_fiori_hc";
 @import "./common/calendar/sap_fiori";
 @import "./common/step-input/sap_fiori";
+@import "./common/object-status/sap_fiori_hc";
 @import "./sap_fiori_3_hcb/css_variables";
 
 :root {
-  --fdInverted_Object_Border_Width: 0.0625rem;
   --fdOverlay_Background_Opacity: 0.8;
 
   /* Dynamic Page Layout */

--- a/packages/styles/src/theming/sap_fiori_3_hcw.scss
+++ b/packages/styles/src/theming/sap_fiori_3_hcw.scss
@@ -39,10 +39,10 @@
 @import "./common/token/sap_fiori_hc";
 @import "./common/calendar/sap_fiori";
 @import "./sap_fiori_3_hcw/css_variables";
+@import "./common/object-status/sap_fiori_hc";
 @import "./common/step-input/sap_fiori";
 
 :root {
-  --fdInverted_Object_Border_Width: 0.0625rem;
   --fdOverlay_Background_Opacity: 0.8;
 
   /* Rating Indicator */

--- a/packages/styles/src/theming/sap_fiori_3_light_dark.scss
+++ b/packages/styles/src/theming/sap_fiori_3_light_dark.scss
@@ -37,10 +37,10 @@
 @import "./common/token/sap_fiori";
 @import "./common/calendar/sap_fiori";
 @import "./common/step-input/sap_fiori";
+@import "./common/object-status/sap_fiori";
 @import "./sap_fiori_3_light_dark/css_variables";
 
 :root {
-  --fdInverted_Object_Border_Width: 0;
   --fdOverlay_Background_Opacity: 0.6;
 
   /* Rating Indicator */

--- a/packages/styles/src/theming/sap_horizon.scss
+++ b/packages/styles/src/theming/sap_horizon.scss
@@ -40,15 +40,13 @@
 @import "./common/token/sap_horizon";
 @import "./common/calendar/sap_horizon";
 @import "./common/step-input/sap_horizon";
+@import "./common/object-status/sap_horizon";
 @import "./sap_horizon/css_variables";
 
 :root {
   /* Switch */
   --fdSwitch_Semantic_Error_Handle_Border_Color: var(--sapButton_Track_Negative_Background);
   --fdSwitch_Semantic_Success_Handle_Border_Color: var(--sapButton_Track_Positive_Background);
-
-  /* Object status */
-  --fdInverted_Object_Border_Width: 0;
 
   /* Action sheet */
   --fdOverlay_Background_Opacity: 0.6;

--- a/packages/styles/src/theming/sap_horizon_dark.scss
+++ b/packages/styles/src/theming/sap_horizon_dark.scss
@@ -40,6 +40,7 @@
 @import "./common/token/sap_horizon";
 @import "./common/calendar/sap_horizon";
 @import "./common/step-input/sap_horizon";
+@import "./common/object-status/sap_horizon";
 @import "./sap_horizon_dark/css_variables";
 
 :root {
@@ -52,9 +53,6 @@
   /* Switch */
   --fdSwitch_Semantic_Error_Handle_Border_Color: var(--sapButton_Track_Negative_Background);
   --fdSwitch_Semantic_Success_Handle_Border_Color: var(--sapButton_Track_Positive_Background);
-
-  /* Object status */
-  --fdInverted_Object_Border_Width: 0;
 
   /* Action sheet */
   --fdOverlay_Background_Opacity: 0.6;

--- a/packages/styles/src/theming/sap_horizon_hcb.scss
+++ b/packages/styles/src/theming/sap_horizon_hcb.scss
@@ -40,6 +40,7 @@
 @import "./common/token/sap_horizon_hc";
 @import "./common/calendar/sap_horizon";
 @import "./common/step-input/sap_horizon";
+@import "./common/object-status/sap_horizon_hc";
 @import "./sap_horizon_hcb/css_variables";
 
 :root {

--- a/packages/styles/src/theming/sap_horizon_hcw.scss
+++ b/packages/styles/src/theming/sap_horizon_hcw.scss
@@ -41,6 +41,7 @@
 @import "./common/token/sap_horizon_hc";
 @import "./common/calendar/sap_horizon";
 @import "./common/step-input/sap_horizon";
+@import "./common/object-status/sap_horizon_hc";
 @import "./sap_horizon_hcw/css_variables";
 
 :root {

--- a/packages/styles/stories/Components/object-status/clickable-object-status.example.html
+++ b/packages/styles/stories/Components/object-status/clickable-object-status.example.html
@@ -1,3 +1,4 @@
+<h3>Regular State</h3>
 <div class="fddocs-container">
     <a href="#"  class="fd-object-status fd-object-status--negative fd-object-status--link">
         <i class="fd-object-status__icon sap-icon--message-error" role="presentation"></i>
@@ -41,6 +42,198 @@
         <span class="fd-object-status__text">Purple</span>
     </span>
     <span role="button" class="fd-object-status fd-object-status--link fd-object-status--indication-8" tabindex="0">
+        <span class="fd-object-status__text">Pink</span>
+    </span>
+</div>
+<br><br>
+<h3>Hover State</h3>
+<div class="fddocs-container">
+    <a href="#"  class="fd-object-status fd-object-status--negative fd-object-status--link is-hover">
+        <i class="fd-object-status__icon sap-icon--message-error" role="presentation"></i>
+        <span class="fd-object-status__text">Negative</span>
+    </a>
+    <a href="#"  class="fd-object-status fd-object-status--critical fd-object-status--link is-hover">
+        <i class="fd-object-status__icon sap-icon--message-warning" role="presentation"></i>
+        <span class="fd-object-status__text">Critical</span>
+    </a>
+    <a href="#"class="fd-object-status fd-object-status--positive fd-object-status--link is-hover">
+        <i class="fd-object-status__icon sap-icon--message-success" role="presentation"></i>
+        <span class="fd-object-status__text">Positive</span>
+    </a>
+    <span role="button" class="fd-object-status fd-object-status--informative fd-object-status--link is-hover" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-information" role="presentation"></i>
+        <span class="fd-object-status__text">Info</span>
+    </span>
+    <span role="button" class="fd-object-status fd-object-status--link is-hover" tabindex="0">
+        <span class="fd-object-status__text">Neutral</span>
+    </span>
+
+    <a href="#"  class="fd-object-status fd-object-status--link fd-object-status--indication-1 is-hover">
+        <span class="fd-object-status__text">Dark Red</span>
+    </a>
+    <a href="#"  class="fd-object-status fd-object-status--link fd-object-status--indication-2 is-hover">
+        <span class="fd-object-status__text">Red</span>
+    </a>
+    <a href="#"  class="fd-object-status fd-object-status--link fd-object-status--indication-3 is-hover">
+        <span class="fd-object-status__text">Yellow</span>
+    </a>
+    <a href="#"  class="fd-object-status fd-object-status--link fd-object-status--indication-4 is-hover">
+        <span class="fd-object-status__text">Green</span>
+    </a>
+    <a href="#"  class="fd-object-status fd-object-status--link fd-object-status--indication-5 is-hover">
+        <span class="fd-object-status__text">Blue</span>
+    </a>
+    <span role="button" class="fd-object-status fd-object-status--link fd-object-status--indication-6 is-hover" tabindex="0">
+        <span class="fd-object-status__text">Teal</span>
+    </span>
+    <span role="button" class="fd-object-status fd-object-status--link fd-object-status--indication-7 is-hover" tabindex="0">
+        <span class="fd-object-status__text">Purple</span>
+    </span>
+    <span role="button" class="fd-object-status fd-object-status--link fd-object-status--indication-8 is-hover" tabindex="0">
+        <span class="fd-object-status__text">Pink</span>
+    </span>
+</div>
+<br><br>
+<h3>Down State</h3>
+<div class="fddocs-container">
+    <a href="#"  class="fd-object-status fd-object-status--negative fd-object-status--link is-active">
+        <i class="fd-object-status__icon sap-icon--message-error" role="presentation"></i>
+        <span class="fd-object-status__text">Negative</span>
+    </a>
+    <a href="#"  class="fd-object-status fd-object-status--critical fd-object-status--link is-active">
+        <i class="fd-object-status__icon sap-icon--message-warning" role="presentation"></i>
+        <span class="fd-object-status__text">Critical</span>
+    </a>
+    <a href="#"class="fd-object-status fd-object-status--positive fd-object-status--link is-active">
+        <i class="fd-object-status__icon sap-icon--message-success" role="presentation"></i>
+        <span class="fd-object-status__text">Positive</span>
+    </a>
+    <span role="button" class="fd-object-status fd-object-status--informative fd-object-status--link is-active" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-information" role="presentation"></i>
+        <span class="fd-object-status__text">Info</span>
+    </span>
+    <span role="button" class="fd-object-status fd-object-status--link is-active" tabindex="0">
+        <span class="fd-object-status__text">Neutral</span>
+    </span>
+
+    <a href="#"  class="fd-object-status fd-object-status--link fd-object-status--indication-1 is-active">
+        <span class="fd-object-status__text">Dark Red</span>
+    </a>
+    <a href="#"  class="fd-object-status fd-object-status--link fd-object-status--indication-2 is-active">
+        <span class="fd-object-status__text">Red</span>
+    </a>
+    <a href="#"  class="fd-object-status fd-object-status--link fd-object-status--indication-3 is-active">
+        <span class="fd-object-status__text">Yellow</span>
+    </a>
+    <a href="#"  class="fd-object-status fd-object-status--link fd-object-status--indication-4 is-active">
+        <span class="fd-object-status__text">Green</span>
+    </a>
+    <a href="#"  class="fd-object-status fd-object-status--link fd-object-status--indication-5 is-active">
+        <span class="fd-object-status__text">Blue</span>
+    </a>
+    <span role="button" class="fd-object-status fd-object-status--link fd-object-status--indication-6 is-active" tabindex="0">
+        <span class="fd-object-status__text">Teal</span>
+    </span>
+    <span role="button" class="fd-object-status fd-object-status--link fd-object-status--indication-7 is-active" tabindex="0">
+        <span class="fd-object-status__text">Purple</span>
+    </span>
+    <span role="button" class="fd-object-status fd-object-status--link fd-object-status--indication-8 is-active" tabindex="0">
+        <span class="fd-object-status__text">Pink</span>
+    </span>
+</div>
+<br><br>
+<h3>Visited State</h3>
+<div class="fddocs-container">
+    <a href="#"  class="fd-object-status fd-object-status--negative fd-object-status--link is-visited">
+        <i class="fd-object-status__icon sap-icon--message-error" role="presentation"></i>
+        <span class="fd-object-status__text">Negative</span>
+    </a>
+    <a href="#"  class="fd-object-status fd-object-status--critical fd-object-status--link is-visited">
+        <i class="fd-object-status__icon sap-icon--message-warning" role="presentation"></i>
+        <span class="fd-object-status__text">Critical</span>
+    </a>
+    <a href="#"class="fd-object-status fd-object-status--positive fd-object-status--link is-visited">
+        <i class="fd-object-status__icon sap-icon--message-success" role="presentation"></i>
+        <span class="fd-object-status__text">Positive</span>
+    </a>
+    <span role="button" class="fd-object-status fd-object-status--informative fd-object-status--link is-visited" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-information" role="presentation"></i>
+        <span class="fd-object-status__text">Info</span>
+    </span>
+    <span role="button" class="fd-object-status fd-object-status--link is-visited" tabindex="0">
+        <span class="fd-object-status__text">Neutral</span>
+    </span>
+
+    <a href="#"  class="fd-object-status fd-object-status--link fd-object-status--indication-1 is-visited">
+        <span class="fd-object-status__text">Dark Red</span>
+    </a>
+    <a href="#"  class="fd-object-status fd-object-status--link fd-object-status--indication-2 is-visited">
+        <span class="fd-object-status__text">Red</span>
+    </a>
+    <a href="#"  class="fd-object-status fd-object-status--link fd-object-status--indication-3 is-visited">
+        <span class="fd-object-status__text">Yellow</span>
+    </a>
+    <a href="#"  class="fd-object-status fd-object-status--link fd-object-status--indication-4 is-visited">
+        <span class="fd-object-status__text">Green</span>
+    </a>
+    <a href="#"  class="fd-object-status fd-object-status--link fd-object-status--indication-5 is-visited">
+        <span class="fd-object-status__text">Blue</span>
+    </a>
+    <span role="button" class="fd-object-status fd-object-status--link fd-object-status--indication-6 is-visited" tabindex="0">
+        <span class="fd-object-status__text">Teal</span>
+    </span>
+    <span role="button" class="fd-object-status fd-object-status--link fd-object-status--indication-7 is-visited" tabindex="0">
+        <span class="fd-object-status__text">Purple</span>
+    </span>
+    <span role="button" class="fd-object-status fd-object-status--link fd-object-status--indication-8 is-visited" tabindex="0">
+        <span class="fd-object-status__text">Pink</span>
+    </span>
+</div>
+<br><br>
+<h3>Focus State</h3>
+<div class="fddocs-container">
+    <a href="#"  class="fd-object-status fd-object-status--negative fd-object-status--link is-focus">
+        <i class="fd-object-status__icon sap-icon--message-error" role="presentation"></i>
+        <span class="fd-object-status__text">Negative</span>
+    </a>
+    <a href="#"  class="fd-object-status fd-object-status--critical fd-object-status--link is-focus">
+        <i class="fd-object-status__icon sap-icon--message-warning" role="presentation"></i>
+        <span class="fd-object-status__text">Critical</span>
+    </a>
+    <a href="#"class="fd-object-status fd-object-status--positive fd-object-status--link is-focus">
+        <i class="fd-object-status__icon sap-icon--message-success" role="presentation"></i>
+        <span class="fd-object-status__text">Positive</span>
+    </a>
+    <span role="button" class="fd-object-status fd-object-status--informative fd-object-status--link is-focus" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-information" role="presentation"></i>
+        <span class="fd-object-status__text">Info</span>
+    </span>
+    <span role="button" class="fd-object-status fd-object-status--link is-focus" tabindex="0">
+        <span class="fd-object-status__text">Neutral</span>
+    </span>
+
+    <a href="#"  class="fd-object-status fd-object-status--link fd-object-status--indication-1 is-focus">
+        <span class="fd-object-status__text">Dark Red</span>
+    </a>
+    <a href="#"  class="fd-object-status fd-object-status--link fd-object-status--indication-2 is-focus">
+        <span class="fd-object-status__text">Red</span>
+    </a>
+    <a href="#"  class="fd-object-status fd-object-status--link fd-object-status--indication-3 is-focus">
+        <span class="fd-object-status__text">Yellow</span>
+    </a>
+    <a href="#"  class="fd-object-status fd-object-status--link fd-object-status--indication-4 is-focus">
+        <span class="fd-object-status__text">Green</span>
+    </a>
+    <a href="#"  class="fd-object-status fd-object-status--link fd-object-status--indication-5 is-focus">
+        <span class="fd-object-status__text">Blue</span>
+    </a>
+    <span role="button" class="fd-object-status fd-object-status--link fd-object-status--indication-6 is-focus" tabindex="0">
+        <span class="fd-object-status__text">Teal</span>
+    </span>
+    <span role="button" class="fd-object-status fd-object-status--link fd-object-status--indication-7 is-focus" tabindex="0">
+        <span class="fd-object-status__text">Purple</span>
+    </span>
+    <span role="button" class="fd-object-status fd-object-status--link fd-object-status--indication-8 is-focus" tabindex="0">
         <span class="fd-object-status__text">Pink</span>
     </span>
 </div>

--- a/packages/styles/stories/Components/object-status/inverted-indication.example.html
+++ b/packages/styles/stories/Components/object-status/inverted-indication.example.html
@@ -23,9 +23,15 @@
     <span class="fd-object-status fd-object-status--inverted fd-object-status--indication-8">
         <span class="fd-object-status__text">Indication8</span>
     </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--indication-9">
+        <span class="fd-object-status__text">Indication9</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--indication-10">
+        <span class="fd-object-status__text">Indication10</span>
+    </span>
 </div>
-
-<h4>Clickable Inverted Object Status</h4>
+<br><br>
+<h4>Clickable Inverted Object Status (Regular)</h4>
 <div class="fddocs-container">
     <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-1" tabindex="0">
         <span class="fd-object-status__text">Indication1</span>
@@ -51,4 +57,224 @@
     <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-8" tabindex="0">
         <span class="fd-object-status__text">Indication8</span>
     </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-9" tabindex="0">
+        <span class="fd-object-status__text">Indication9</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-10" tabindex="0">
+        <span class="fd-object-status__text">Indication10</span>
+    </span>
 </div>
+
+<br><br>
+<h4>Clickable Inverted Object Status (Hover)</h4>
+<div class="fddocs-container">
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-1 is-hover" tabindex="0">
+        <span class="fd-object-status__text">Indication1</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-2 is-hover" tabindex="0">
+        <span class="fd-object-status__text">Indication2</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-3 is-hover" tabindex="0">
+        <span class="fd-object-status__text">Indication3</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-4 is-hover" tabindex="0">
+        <span class="fd-object-status__text">Indication4</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-5 is-hover" tabindex="0">
+        <span class="fd-object-status__text">Indication5</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-6 is-hover" tabindex="0">
+        <span class="fd-object-status__text">Indication6</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-7 is-hover" tabindex="0">
+        <span class="fd-object-status__text">Indication7</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-8 is-hover" tabindex="0">
+        <span class="fd-object-status__text">Indication8</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-9 is-hover" tabindex="0">
+        <span class="fd-object-status__text">Indication9</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-10 is-hover" tabindex="0">
+        <span class="fd-object-status__text">Indication10</span>
+    </span>
+</div>
+
+<br><br>
+<h4>Clickable Inverted Object Status (Selected)</h4>
+<div class="fddocs-container">
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-1 is-selected" tabindex="0">
+        <span class="fd-object-status__text">Indication1</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-2 is-selected" tabindex="0">
+        <span class="fd-object-status__text">Indication2</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-3 is-selected" tabindex="0">
+        <span class="fd-object-status__text">Indication3</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-4 is-selected" tabindex="0">
+        <span class="fd-object-status__text">Indication4</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-5 is-selected" tabindex="0">
+        <span class="fd-object-status__text">Indication5</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-6 is-selected" tabindex="0">
+        <span class="fd-object-status__text">Indication6</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-7 is-selected" tabindex="0">
+        <span class="fd-object-status__text">Indication7</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-8 is-selected" tabindex="0">
+        <span class="fd-object-status__text">Indication8</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-9 is-selected" tabindex="0">
+        <span class="fd-object-status__text">Indication9</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-10 is-selected" tabindex="0">
+        <span class="fd-object-status__text">Indication10</span>
+    </span>
+</div>
+
+
+<br><br>
+<h4>Clickable Inverted Object Status (Selected Hover)</h4>
+<div class="fddocs-container">
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-1 is-hover is-selected" tabindex="0">
+        <span class="fd-object-status__text">Indication1</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-2 is-hover is-selected" tabindex="0">
+        <span class="fd-object-status__text">Indication2</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-3 is-hover is-selected" tabindex="0">
+        <span class="fd-object-status__text">Indication3</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-4 is-hover is-selected" tabindex="0">
+        <span class="fd-object-status__text">Indication4</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-5 is-hover is-selected" tabindex="0">
+        <span class="fd-object-status__text">Indication5</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-6 is-hover is-selected" tabindex="0">
+        <span class="fd-object-status__text">Indication6</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-7 is-hover is-selected" tabindex="0">
+        <span class="fd-object-status__text">Indication7</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-8 is-hover is-selected" tabindex="0">
+        <span class="fd-object-status__text">Indication8</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-9 is-hover is-selected" tabindex="0">
+        <span class="fd-object-status__text">Indication9</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-10 is-hover is-selected" tabindex="0">
+        <span class="fd-object-status__text">Indication10</span>
+    </span>
+</div>
+
+
+<br><br>
+<h4>Clickable Inverted Object Status (Active/Down)</h4>
+<div class="fddocs-container">
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-1 is-active" tabindex="0">
+        <span class="fd-object-status__text">Indication1</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-2 is-active" tabindex="0">
+        <span class="fd-object-status__text">Indication2</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-3 is-active" tabindex="0">
+        <span class="fd-object-status__text">Indication3</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-4 is-active" tabindex="0">
+        <span class="fd-object-status__text">Indication4</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-5 is-active" tabindex="0">
+        <span class="fd-object-status__text">Indication5</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-6 is-active" tabindex="0">
+        <span class="fd-object-status__text">Indication6</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-7 is-active" tabindex="0">
+        <span class="fd-object-status__text">Indication7</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-8 is-active" tabindex="0">
+        <span class="fd-object-status__text">Indication8</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-9 is-active" tabindex="0">
+        <span class="fd-object-status__text">Indication9</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-10 is-active" tabindex="0">
+        <span class="fd-object-status__text">Indication10</span>
+    </span>
+</div>
+
+<br><br>
+<h4>Clickable Inverted Object Status (Focus)</h4>
+<div class="fddocs-container">
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-1 is-focus" tabindex="0">
+        <span class="fd-object-status__text">Indication1</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-2 is-focus" tabindex="0">
+        <span class="fd-object-status__text">Indication2</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-3 is-focus" tabindex="0">
+        <span class="fd-object-status__text">Indication3</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-4 is-focus" tabindex="0">
+        <span class="fd-object-status__text">Indication4</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-5 is-focus" tabindex="0">
+        <span class="fd-object-status__text">Indication5</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-6 is-focus" tabindex="0">
+        <span class="fd-object-status__text">Indication6</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-7 is-focus" tabindex="0">
+        <span class="fd-object-status__text">Indication7</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-8 is-focus" tabindex="0">
+        <span class="fd-object-status__text">Indication8</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-9 is-focus" tabindex="0">
+        <span class="fd-object-status__text">Indication9</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-10 is-focus" tabindex="0">
+        <span class="fd-object-status__text">Indication10</span>
+    </span>
+</div>
+
+
+<br><br>
+<h4>Clickable Inverted Object Status (Selcted, Focus)</h4>
+<div class="fddocs-container">
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-1 is-focus is-selected" tabindex="0">
+        <span class="fd-object-status__text">Indication1</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-2 is-focus is-selected" tabindex="0">
+        <span class="fd-object-status__text">Indication2</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-3 is-focus is-selected" tabindex="0">
+        <span class="fd-object-status__text">Indication3</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-4 is-focus is-selected" tabindex="0">
+        <span class="fd-object-status__text">Indication4</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-5 is-focus is-selected" tabindex="0">
+        <span class="fd-object-status__text">Indication5</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-6 is-focus is-selected" tabindex="0">
+        <span class="fd-object-status__text">Indication6</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-7 is-focus is-selected" tabindex="0">
+        <span class="fd-object-status__text">Indication7</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-8 is-focus is-selected" tabindex="0">
+        <span class="fd-object-status__text">Indication8</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-9 is-focus is-selected" tabindex="0">
+        <span class="fd-object-status__text">Indication9</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--indication-10 is-focus is-selected" tabindex="0">
+        <span class="fd-object-status__text">Indication10</span>
+    </span>
+</div>
+

--- a/packages/styles/stories/Components/object-status/inverted-states.example.html
+++ b/packages/styles/stories/Components/object-status/inverted-states.example.html
@@ -1,0 +1,207 @@
+<h4>Regular</h4>
+<div class="fddocs-container">
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link" tabindex="0">
+        <span class="fd-object-status__text">Neutral</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--informative" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-information" role="presentation"></i>
+        <span class="fd-object-status__text">Information</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--critical" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-warning" role="presentation"></i>
+        <span class="fd-object-status__text">Caution</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--positive" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-success" role="presentation"></i>
+        <span class="fd-object-status__text">Positive</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--negative" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-error" role="presentation"></i>
+        <span class="fd-object-status__text">Negative</span>
+    </span>
+</div>
+<br><br>
+<h4>Hover</h4>
+<div class="fddocs-container">
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link is-hover" tabindex="0">
+        <span class="fd-object-status__text">Neutral</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--informative is-hover" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-information" role="presentation"></i>
+        <span class="fd-object-status__text">Information</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--critical is-hover" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-warning" role="presentation"></i>
+        <span class="fd-object-status__text">Caution</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--positive is-hover" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-success" role="presentation"></i>
+        <span class="fd-object-status__text">Positive</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--negative is-hover" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-error" role="presentation"></i>
+        <span class="fd-object-status__text">Negative</span>
+    </span>
+</div>
+<br><br>
+<h4>Selected</h4>
+<div class="fddocs-container">
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link is-selected" tabindex="0">
+        <span class="fd-object-status__text">Neutral</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--informative is-selected" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-information" role="presentation"></i>
+        <span class="fd-object-status__text">Information</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--critical is-selected" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-warning" role="presentation"></i>
+        <span class="fd-object-status__text">Caution</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--positive is-selected" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-success" role="presentation"></i>
+        <span class="fd-object-status__text">Positive</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--negative is-selected" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-error" role="presentation"></i>
+        <span class="fd-object-status__text">Negative</span>
+    </span>
+</div>
+<br><br>
+<h4>Selected, Hover</h4>
+<div class="fddocs-container">
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link is-hover is-selected" tabindex="0">
+        <span class="fd-object-status__text">Neutral</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--informative is-hover is-selected" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-information" role="presentation"></i>
+        <span class="fd-object-status__text">Information</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--critical is-hover is-selected" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-warning" role="presentation"></i>
+        <span class="fd-object-status__text">Caution</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--positive is-hover is-selected" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-success" role="presentation"></i>
+        <span class="fd-object-status__text">Positive</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--negative is-hover is-selected" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-error" role="presentation"></i>
+        <span class="fd-object-status__text">Negative</span>
+    </span>
+</div>
+<br><br>
+<h4>Down</h4>
+<div class="fddocs-container">
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link is-active" tabindex="0">
+        <span class="fd-object-status__text">Neutral</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--informative is-active" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-information" role="presentation"></i>
+        <span class="fd-object-status__text">Information</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--critical is-active" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-warning" role="presentation"></i>
+        <span class="fd-object-status__text">Caution</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--positive is-active" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-success" role="presentation"></i>
+        <span class="fd-object-status__text">Positive</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--negative is-active" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-error" role="presentation"></i>
+        <span class="fd-object-status__text">Negative</span>
+    </span>
+</div>
+
+
+<h4>Regular, Focus</h4>
+<div class="fddocs-container">
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link is-focus" tabindex="0">
+        <span class="fd-object-status__text">Neutral</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--informative is-focus" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-information" role="presentation"></i>
+        <span class="fd-object-status__text">Information</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--critical is-focus" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-warning" role="presentation"></i>
+        <span class="fd-object-status__text">Caution</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--positive is-focus" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-success" role="presentation"></i>
+        <span class="fd-object-status__text">Positive</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--negative is-focus" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-error" role="presentation"></i>
+        <span class="fd-object-status__text">Negative</span>
+    </span>
+</div>
+<br><br>
+<h4>Hover, Focus</h4>
+<div class="fddocs-container">
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link is-hover is-focus" tabindex="0">
+        <span class="fd-object-status__text">Neutral</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--informative is-hover is-focus" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-information" role="presentation"></i>
+        <span class="fd-object-status__text">Information</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--critical is-hover is-focus" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-warning" role="presentation"></i>
+        <span class="fd-object-status__text">Caution</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--positive is-hover is-focus" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-success" role="presentation"></i>
+        <span class="fd-object-status__text">Positive</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--negative is-hover is-focus" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-error" role="presentation"></i>
+        <span class="fd-object-status__text">Negative</span>
+    </span>
+</div>
+<br><br>
+<h4>Selected, Focus</h4>
+<div class="fddocs-container">
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link is-selected is-focus" tabindex="0">
+        <span class="fd-object-status__text">Neutral</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--informative is-selected is-focus" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-information" role="presentation"></i>
+        <span class="fd-object-status__text">Information</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--critical is-selected is-focus" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-warning" role="presentation"></i>
+        <span class="fd-object-status__text">Caution</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--positive is-selected is-focus" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-success" role="presentation"></i>
+        <span class="fd-object-status__text">Positive</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--negative is-selected is-focus" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-error" role="presentation"></i>
+        <span class="fd-object-status__text">Negative</span>
+    </span>
+</div>
+<br><br>
+<h4>Selected, Hover, Focus</h4>
+<div class="fddocs-container">
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link is-hover is-selected is-focus" tabindex="0">
+        <span class="fd-object-status__text">Neutral</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--informative is-hover is-selected is-focus" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-information" role="presentation"></i>
+        <span class="fd-object-status__text">Information</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--critical is-hover is-selected is-focus" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-warning" role="presentation"></i>
+        <span class="fd-object-status__text">Caution</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--positive is-hover is-selected is-focus" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-success" role="presentation"></i>
+        <span class="fd-object-status__text">Positive</span>
+    </span>
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--link fd-object-status--negative is-hover is-selected is-focus" tabindex="0">
+        <i class="fd-object-status__icon sap-icon--message-error" role="presentation"></i>
+        <span class="fd-object-status__text">Negative</span>
+    </span>
+</div>

--- a/packages/styles/stories/Components/object-status/inverted.example.html
+++ b/packages/styles/stories/Components/object-status/inverted.example.html
@@ -38,31 +38,9 @@
     </span>
 </div>
 
-    <h4>Clickable Inverted Object Status</h4>
-<div class="fddocs-container">
-    <a class="fd-object-status fd-object-status--link fd-object-status--negative fd-object-status--inverted">
-        <i class="fd-object-status__icon sap-icon--message-error" role="presentation"></i>
-        <span class="fd-object-status__text">Inverted Negative</span>
-    </a>
-    <a class="fd-object-status fd-object-status--link fd-object-status--critical fd-object-status--inverted">
-        <i class="fd-object-status__icon sap-icon--message-warning" role="presentation"></i>
-        <span class="fd-object-status__text">Inverted Warning</span>
-    </a>
-    <a class="fd-object-status fd-object-status--link fd-object-status--positive fd-object-status--inverted">
-        <i class="fd-object-status__icon sap-icon--message-success" role="presentation"></i>
-        <span class="fd-object-status__text">Inverted Success</span>
-    </a>
-    <a class="fd-object-status fd-object-status--link fd-object-status--informative fd-object-status--inverted">
-        <i class="fd-object-status__icon sap-icon--message-information" role="presentation"></i>
-        <span class="fd-object-status__text">Inverted informative</span>
-    </a>
-    <a class="fd-object-status fd-object-status--link fd-object-status--inverted">
-        <span class="fd-object-status__text">Inverted Neutral</span>
-    </a>
-</div>
-
-  <h4>Large Inverted Object Status</h4>
-  <div class="fddocs-container" style="align-items: baseline;">
+<br><br>
+<h4>Large Inverted Object Status</h4>
+<div class="fddocs-container" style="align-items: baseline;">
     <span class="fd-object-status fd-object-status--negative fd-object-status--inverted fd-object-status--large">
         <span class="fd-object-status__text">Inverted Negative</span>
     </span>
@@ -78,7 +56,7 @@
     <span class="fd-object-status fd-object-status--inverted fd-object-status--large">
         <span class="fd-object-status__text">Inverted Neutral</span>
     </span>
-    <span class="fd-object-status fd-object-status--inverted fd-object-status--negative fd-object-status--large">
+    <span class="fd-object-status fd-object-status--inverted fd-object-status--negative fd-object-status--large fd-object-status--icon-only">
         <i class="fd-object-status__icon sap-icon--message-error" role="presentation"></i>
     </span>
     <span class="fd-object-status fd-object-status--inverted fd-object-status--negative fd-object-status--large">

--- a/packages/styles/stories/Components/object-status/object-status.stories.js
+++ b/packages/styles/stories/Components/object-status/object-status.stories.js
@@ -1,6 +1,7 @@
 import truncateExampleExampleHtml from "./truncate-example.example.html?raw";
 import invertedIndicationExampleHtml from "./inverted-indication.example.html?raw";
 import invertedExampleHtml from "./inverted.example.html?raw";
+import invertedStatesExampleHtml from "./inverted-states.example.html?raw";
 import largeObjectStatusExampleHtml from "./large-object-status.example.html?raw";
 import clickableObjectStatusExampleHtml from "./clickable-object-status.example.html?raw";
 import genericIndicationColorsExampleHtml from "./generic-indication-colors.example.html?raw";
@@ -84,6 +85,16 @@ Inverted.parameters = {
  Inverted Object Status(optional inverted visualization) determines whether the background color reflects the set state
  instead of the control's text. Use the inverted object status if the information is crucial for the user’s actions and needs to stand out visually.
  Inverted Object Status is achieved by adding the \`fd-object-status--inverted\` modifier class.
+            `
+    }
+  }
+};
+export const InvertedStates = () => invertedStatesExampleHtml;
+InvertedStates.parameters = {
+  docs: {
+    description: {
+      story: `
+ 
             `
     }
   }


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/4630

## Description
- update to latest design changes
- introduces new modifier class for icon only: `fd-object-status--icon-only`

BREAKING CHANGE:
Icon only Object status now needs a modifier class `fd-object-status--icon-only`

**Before:**
```
<span class="fd-object-status fd-object-status--inverted fd-object-status--negative fd-object-status--large">
        <i class="fd-object-status__icon sap-icon--message-error" role="presentation"></i>
</span>
```

**After:**
```
<span class="fd-object-status fd-object-status--inverted fd-object-status--negative fd-object-status--large fd-object-status--icon-only">
        <i class="fd-object-status__icon sap-icon--message-error" role="presentation"></i>
</span>
```