### PR TITLE
docs(styles): increased bottom margin between interactive elements [ci visual]

### DIFF
--- a/packages/styles/stories/Components/avatar/avatar.stories.js
+++ b/packages/styles/stories/Components/avatar/avatar.stories.js
@@ -54,7 +54,7 @@ const localStyles = `
 <style>
 
     .fd-avatar {
-        margin: 0 0.5rem;
+        margin: 0.5rem;
     }
 
 


### PR DESCRIPTION
### **Related Issue:**
Relates to  https://github.com/SAP/fundamental-styles/issues/3955

### **Description:**

increased bottom margin between interactive elements

### **Screenshots:**

**Before**
<img width="573" alt="Screenshot 2023-07-12 at 8 37 56 AM" src="https://github.com/SAP/fundamental-styles/assets/132930816/2851fe42-342f-4297-8e57-1b9bdd371cd3">

**After**
<img width="572" alt="Screenshot 2023-07-11 at 10 05 25 AM" src="https://github.com/SAP/fundamental-styles/assets/132930816/4f8867d7-c897-4ee7-b435-227abcc46d25">

