### PR TITLE
docs(styles): quick view styles & examples [ci visual]

### DIFF
--- a/packages/styles/stories/Components/quick-view/no-header.example.html
+++ b/packages/styles/stories/Components/quick-view/no-header.example.html
@@ -1,38 +1,41 @@
-<div class="fd-popover" style="margin-bottom: 300px;">
-    <div class="fd-popover__body" aria-hidden="false" id="popoverA1">
-        <div class="fd-quick-view">
-            <div class="fd-quick-view__content">
-                <div class="fd-bar fd-bar--header-with-subheader">
-                    <div class="fd-bar__left">
-                        <span class="fd-avatar fd-avatar--s" role="presentation">
-                            <i role="presentation" class="fd-avatar__icon sap-icon--camera"></i>
-                        </span>
 
-                        <div class="fd-quick-view__subheader-text">
-                            <h5 class="fd-title fd-title--h5">Company B</h5>
-
-                            <div class="fd-quick-view__subtitle">
-                                Michael Adams
+<div style="margin-bottom: 300px;">
+    <div class="fd-popover" >
+        <div class="fd-popover__body" aria-hidden="false" id="popoverA1">
+            <div class="fd-quick-view">
+                <div class="fd-quick-view__content">
+                    <div class="fd-bar fd-bar--header-with-subheader">
+                        <div class="fd-bar__left">
+                            <span class="fd-avatar fd-avatar--s" role="presentation">
+                                <i role="presentation" class="fd-avatar__icon sap-icon--camera"></i>
+                            </span>
+    
+                            <div class="fd-quick-view__subheader-text">
+                                <h5 class="fd-title fd-title--h5">Company B</h5>
+    
+                                <div class="fd-quick-view__subtitle">
+                                    Michael Adams
+                                </div>
                             </div>
                         </div>
                     </div>
-                </div>
-
-                <div class="fd-form-group" role="group">
-                    <div class="fd-form-item">
-                        <label class="fd-form-label">Start Date:</label>
-                        <span class="fd-text">01/01/2015</span>
-                    </div>
-                    <div class="fd-form-item">
-                        <label class="fd-form-label">End Date:</label>
-                        <span class="fd-text">31/12/2015</span>
-                    </div>
-                    <div class="fd-form-item">
-                        <label class="fd-form-label">Occurrence:</label>
-                        <span class="fd-text">Weekly</span>
+    
+                    <div class="fd-form-group" role="group">
+                        <div class="fd-form-item">
+                            <label class="fd-form-label">Start Date:</label>
+                            <span class="fd-text">01/01/2015</span>
+                        </div>
+                        <div class="fd-form-item">
+                            <label class="fd-form-label">End Date:</label>
+                            <span class="fd-text">31/12/2015</span>
+                        </div>
+                        <div class="fd-form-item">
+                            <label class="fd-form-label">Occurrence:</label>
+                            <span class="fd-text">Weekly</span>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
-    </div>
+    </div>    
 </div>

--- a/packages/styles/stories/Components/quick-view/no-header.example.html
+++ b/packages/styles/stories/Components/quick-view/no-header.example.html
@@ -1,4 +1,4 @@
-<div class="fd-popover">
+<div class="fd-popover" style="margin-bottom: 300px;">
     <div class="fd-popover__body" aria-hidden="false" id="popoverA1">
         <div class="fd-quick-view">
             <div class="fd-quick-view__content">

--- a/packages/styles/stories/Components/quick-view/popover.example.html
+++ b/packages/styles/stories/Components/quick-view/popover.example.html
@@ -1,4 +1,4 @@
-<div class="fd-popover">
+<div class="fd-popover" style="margin-bottom: 500px;">
     <div class="fd-popover__body" aria-hidden="false" id="popoverA1">
         <div class="fd-quick-view">
             <div class="fd-bar fd-bar--header">

--- a/packages/styles/stories/Components/quick-view/popover.example.html
+++ b/packages/styles/stories/Components/quick-view/popover.example.html
@@ -1,65 +1,68 @@
-<div class="fd-popover" style="margin-bottom: 500px;">
-    <div class="fd-popover__body" aria-hidden="false" id="popoverA1">
-        <div class="fd-quick-view">
-            <div class="fd-bar fd-bar--header">
-                <div class="fd-bar__middle">
-                    <div class="fd-bar__element">Company</div>
+<div style="margin-bottom: 500px;">
+    <div class="fd-popover" >
+        <div class="fd-popover__body" aria-hidden="false" id="popoverA1">
+            <div class="fd-quick-view">
+                <div class="fd-bar fd-bar--header">
+                    <div class="fd-bar__middle">
+                        <div class="fd-bar__element">Company</div>
+                    </div>
                 </div>
-            </div>
-
-            <div class="fd-quick-view__content">
-                <div class="fd-bar fd-bar--header-with-subheader">
-                    <div class="fd-bar__left">
-                        <span class="fd-avatar fd-avatar--s" role="presentation">
-                            <i role="presentation" class="fd-avatar__icon sap-icon--building"></i>
-                        </span>
-
-                        <div class="fd-quick-view__subheader-text">
-                            <h5 class="fd-title fd-title--h5">Company B</h5>
-
-                            <div class="fd-quick-view__subtitle">
-                                Michael Adams
+    
+                <div class="fd-quick-view__content">
+                    <div class="fd-bar fd-bar--header-with-subheader">
+                        <div class="fd-bar__left">
+                            <span class="fd-avatar fd-avatar--s" role="presentation">
+                                <i role="presentation" class="fd-avatar__icon sap-icon--building"></i>
+                            </span>
+    
+                            <div class="fd-quick-view__subheader-text">
+                                <h5 class="fd-title fd-title--h5">Company B</h5>
+    
+                                <div class="fd-quick-view__subtitle">
+                                    Michael Adams
+                                </div>
                             </div>
                         </div>
                     </div>
-                </div>
-
-
-                <div class="fd-form-group" role="group">
-                    <div class="fd-form-group__header" aria-labelledby="contactDetails">
-                        <h1 class="fd-form-group__header-text" id="contactDetails">Contact Details</h1>
+    
+    
+                    <div class="fd-form-group" role="group">
+                        <div class="fd-form-group__header" aria-labelledby="contactDetails">
+                            <h1 class="fd-form-group__header-text" id="contactDetails">Contact Details</h1>
+                        </div>
+                        <div class="fd-form-item">
+                            <label class="fd-form-label">Phone</label>
+                            <a class="fd-link" href="tel:+1 605 555 5555"><span class="fd-link__content">+1 605 555 5555</span></a>
+                        </div>
+                        <div class="fd-form-item">
+                            <label class="fd-form-label">Address</label>
+                            <span class="fd-text">
+                                781 Main Street <br>
+                                Anytown, SD 57401, USA
+                            </span>
+                        </div>
                     </div>
-                    <div class="fd-form-item">
-                        <label class="fd-form-label">Phone</label>
-                        <a class="fd-link" href="tel:+1 605 555 5555"><span class="fd-link__content">+1 605 555 5555</span></a>
-                    </div>
-                    <div class="fd-form-item">
-                        <label class="fd-form-label">Address</label>
-                        <span class="fd-text">
-                            781 Main Street <br>
-                            Anytown, SD 57401, USA
-                        </span>
-                    </div>
-                </div>
-
-                <div class="fd-form-group" role="group">
-                    <div class="fd-form-group__header" aria-labelledby="mainContact">
-                        <h1 class="fd-form-group__header-text" id="mainContact">Main Contact</h1>
-                    </div>
-                    <div class="fd-form-item">
-                        <label class="fd-form-label">Name</label>
-                        <span class="fd-text">Michael Adams</span>
-                    </div>
-                    <div class="fd-form-item">
-                        <label class="fd-form-label">Mobile</label>
-                        <a class="fd-link" href="tel:+1 605 555 5555"><span class="fd-link__content">+1 605 555 5555</span></a>
-                    </div>
-                    <div class="fd-form-item">
-                        <label class="fd-form-label">Mobile</label>
-                        <a class="fd-link" href="tel:+1 605 555 5555"><span class="fd-link__content">+1 605 555 5555</span></a>
+    
+                    <div class="fd-form-group" role="group">
+                        <div class="fd-form-group__header" aria-labelledby="mainContact">
+                            <h1 class="fd-form-group__header-text" id="mainContact">Main Contact</h1>
+                        </div>
+                        <div class="fd-form-item">
+                            <label class="fd-form-label">Name</label>
+                            <span class="fd-text">Michael Adams</span>
+                        </div>
+                        <div class="fd-form-item">
+                            <label class="fd-form-label">Mobile</label>
+                            <a class="fd-link" href="tel:+1 605 555 5555"><span class="fd-link__content">+1 605 555 5555</span></a>
+                        </div>
+                        <div class="fd-form-item">
+                            <label class="fd-form-label">Mobile</label>
+                            <a class="fd-link" href="tel:+1 605 555 5555"><span class="fd-link__content">+1 605 555 5555</span></a>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
+    
 </div>


### PR DESCRIPTION
## Related Issue
Relates to  https://github.com/SAP/fundamental-styles/issues/3955#issuecomment-1355378065

## Description
Added bottom margin to improve clarity for quick view 

## Screenshots
**Before**

<img width="387" alt="1" src="https://github.com/SAP/fundamental-styles/assets/132930816/1860a5df-13bb-4c19-8e01-2ee317f35aff">

<img width="385" alt="2" src="https://github.com/SAP/fundamental-styles/assets/132930816/d880f63e-db91-4b70-b620-70c811340b5a">



**After**

<img width="362" alt="3" src="https://github.com/SAP/fundamental-styles/assets/132930816/76755f1e-73f4-4e36-a852-3c1f318134ce">

<img width="344" alt="4" src="https://github.com/SAP/fundamental-styles/assets/132930816/463a9ad2-ccc3-4184-987d-d8f523a382d0">


