### PR TITLE
fix(styles): add the proper box-shadow for Card in Quartz Theme

### DIFF
--- a/packages/styles/src/card.scss
+++ b/packages/styles/src/card.scss
@@ -61,7 +61,7 @@ $fd-card-header-outline-offset: 0.0625rem !default;
   border: var(--fdCard_Border);
 
   @include fd-hover() {
-    box-shadow: var(--sapContent_Shadow2);
+    box-shadow: var(--fdCard_Box_Shadow_Hover);
   }
 
   &__header {

--- a/packages/styles/src/theming/common/card/_sap_fiori.scss
+++ b/packages/styles/src/theming/common/card/_sap_fiori.scss
@@ -1,6 +1,7 @@
 :root {
   --fdCard_Background_Color: var(--sapTile_Background);
   --fdCard_Box_Shadow: var(--sapContent_Shadow0);
+  --fdCard_Box_Shadow_Hover: var(--sapContent_Shadow0);
   --fdCard_Border_Radius: var(--sapElement_BorderCornerRadius);
   --fdCard_Header_Border_Bottom: 0.0625rem solid var(--sapTile_SeparatorColor);
   --fdCard_Footer_Border_Top: 0.0625rem solid var(--sapTile_SeparatorColor);

--- a/packages/styles/src/theming/common/card/_sap_horizon.scss
+++ b/packages/styles/src/theming/common/card/_sap_horizon.scss
@@ -1,6 +1,7 @@
 :root {
   --fdCard_Background_Color: var(--sapTile_Background);
   --fdCard_Box_Shadow: var(--sapContent_Shadow0);
+  --fdCard_Box_Shadow_Hover: var(--sapContent_Shadow2);
   --fdCard_Border_Radius: var(--sapTile_BorderCornerRadius);
   --fdCard_Header_Border_Bottom: 0.0625rem solid transparent;
   --fdCard_Footer_Border_Top: 0.0625rem solid transparent;


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/4482

## Description
- apply the correct box-shadow in Quart theme on hover state
