### PR TITLE
fix(styles): proper scrollbar display

### DIFF
--- a/packages/cx/src/side-nav.scss
+++ b/packages/cx/src/side-nav.scss
@@ -39,7 +39,6 @@ $fd-side-nav-border-radius: 1rem;
       align-items: center;
     }
 
-    display: inline-flex;
     overflow-y: scroll;
     overflow-x: hidden;
 

--- a/packages/cx/src/side-nav.scss
+++ b/packages/cx/src/side-nav.scss
@@ -13,6 +13,8 @@ $fd-side-nav-border-radius: 1rem;
   --fdSideNav_First_Item_Margin_Top: 0.25rem;
   --fdSideNav_Utility_Margin_Bottom: 1rem;
 
+  overflow-y: hidden;
+
   @include fd-reset();
 
   @include fd-flex(column) {
@@ -37,6 +39,7 @@ $fd-side-nav-border-radius: 1rem;
       align-items: center;
     }
 
+    display: inline-flex;
     overflow-y: scroll;
     overflow-x: hidden;
 


### PR DESCRIPTION
## Related Issue##
Relates to [4708](https://github.com/SAP/fundamental-styles/pull/4708)

## Description
Scrollbar was improperly displayed for cx nav-bar.

## Screenshots

### Before:

<img width="267" alt="1" src="https://github.com/SAP/fundamental-styles/assets/132930816/a8e47ae1-6932-4004-9f48-5692a9c4c6d6">

### After:

<img width="265" alt="2" src="https://github.com/SAP/fundamental-styles/assets/132930816/5fda39aa-9bb5-4010-8905-98bd58eeddce">
