### PR TITLE
fix(styles): toolbar ejected popover scope [ci visual]

### DIFF
--- a/packages/styles/src/toolbar.scss
+++ b/packages/styles/src/toolbar.scss
@@ -1,5 +1,5 @@
-@import "./new-settings";
-@import "./mixins";
+@import './new-settings';
+@import './mixins';
 
 $block: #{$fd-namespace}-toolbar;
 
@@ -11,7 +11,6 @@ $block: #{$fd-namespace}-toolbar;
   --fdToolbar_Separator_Height: 2rem;
   --fdToolbar_Overflow_Max_Width: 100%;
   --fdToolbar_Separator_Width: 0.0625rem;
-  --fdToolbar_Overflow_Padding: 0.25rem 0.5rem;
   --fdToolbar_Info_Color: var(--sapList_TextColor);
   --fdToolbar_Background: var(--sapToolbar_Background);
   --fdToolbar_Border: 0.0625rem solid var(--sapGroup_TitleBorderColor);
@@ -58,11 +57,16 @@ $block: #{$fd-namespace}-toolbar;
     --fdToolbar_Separator_Width: auto;
     --fdToolbar_Separator_Height: 0.0625rem;
     --fdToolbar_Separator_Margin: 0.1875rem 0;
+    --fdToolbar_Overflow_Padding: 0.25rem 0.5rem;
 
     overflow: auto;
     max-height: 50vh;
     padding: var(--fdToolbar_Overflow_Padding);
     max-width: var(--fdToolbar_Overflow_Max_Width);
+
+    @include fd-compact-or-condensed() {
+      --fdToolbar_Overflow_Padding: 0.1875rem 0.375rem;
+    }
 
     & .#{$block}__overflow-button {
       width: auto;
@@ -174,7 +178,6 @@ $block: #{$fd-namespace}-toolbar;
   @include fd-compact-or-condensed() {
     --fdToolbar_Height: 2rem;
     --fdToolbar_Separator_Height: 1.5rem;
-    --fdToolbar_Overflow_Padding: 0.1875rem 0.375rem;
     --fdToolbar_Overflow_Max_Width: 20rem;
 
     &.#{$block}--title {


### PR DESCRIPTION
closes none;

Small fix for ngx side when popover is rendered outside fd-toolbar scope.