### PR TITLE
fix: removed fn-icons from publish

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -44,7 +44,7 @@ jobs:
             - name: Publish packages to NPM
               uses: ./.github/actions/npm-publish
               with:
-                  packagePaths: 'dist/packages/styles,dist/packages/common-css,dist/packages/icons,dist/packages/theming-preview,dist/packages/cx'
+                  packagePaths: 'dist/packages/styles,dist/packages/common-css,dist/packages/theming-preview,dist/packages/cx'
                   isPrerelease: ${{ steps.bumpVersion.outputs.isPrerelease }}
                   token: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
Previously I removed fn and fn-icons from repo and forgot to remove fn-icons from list of publish libraries