### PR TITLE
fix(styles): link with icon needs inline-flex

### DIFF
--- a/packages/styles/src/link.scss
+++ b/packages/styles/src/link.scss
@@ -11,7 +11,7 @@ $block: #{$fd-namespace}-link;
     color: var(--sapLinkColor);
     line-height: 1;
 
-    @include fd-flex-center();
+    @include fd-inline-flex-center();
 
     &:first-child {
       @include fd-set-margin-right(var(--fdLink_Icon_Spacing, 0));


### PR DESCRIPTION
fixes none

before:
<img width="99" alt="Screenshot 2023-08-29 at 12 14 55 PM" src="https://github.com/SAP/fundamental-styles/assets/2471874/f8fd9518-f411-4173-b574-0d6c33ae2737">

after:
<img width="107" alt="Screenshot 2023-08-29 at 12 17 27 PM" src="https://github.com/SAP/fundamental-styles/assets/2471874/f5dd01f8-1ea0-4634-9388-be271975afa9">
