### PR TITLE
fix(styles): icon tab bar nested paddings fix

### DIFF
--- a/packages/styles/src/icon-tab-bar.scss
+++ b/packages/styles/src/icon-tab-bar.scss
@@ -624,8 +624,7 @@ $fd-icon-tab-bar-semantic-values: (
   &__arrow {
     @include fd-reset();
     @include fd-flex-center();
-    @include fd-set-margins-x(
-      var(--fdIcon_Tab_Bar_Single_Click_Icon_Container_Padding_Left), var(--fdIcon_Tab_Bar_Single_Click_Icon_Container_Padding_Right));
+    @include fd-set-margins-x(var(--fdIcon_Tab_Bar_Single_Click_Icon_Container_Padding_Left), var(--fdIcon_Tab_Bar_Single_Click_Icon_Container_Padding_Right));
 
     height: $fd-icon-tab-bar-single-click-arrow-size;
     width: var(--fdIcon_Tab_Bar_Single_Click_Icon_Container_Width);
@@ -634,7 +633,6 @@ $fd-icon-tab-bar-semantic-values: (
       @include fd-flex-center();
 
       font-size: 1rem;
-      // color: var(--sapTextColor);
       color: var(--fdIconTabBar_Arrow_Color);
       width: $fd-icon-tab-bar-single-click-arrow-size;
       height: $fd-icon-tab-bar-single-click-arrow-size;
@@ -1002,9 +1000,8 @@ $fd-icon-tab-bar-semantic-values: (
         $offsetSeparator: ($i * 0.5rem) + $fd-icon-tab-bar-list-padding-right;
 
         &[aria-level='#{$i}'] {
-          & > * {
-            @include fd-set-paddings-x($offset, $fd-icon-tab-bar-list-padding-right);
-          }
+          --fdList_Navigation_Link_Padding_Left: #{$offset};
+          --fdList_Navigation_Link_Padding_Right: #{$fd-icon-tab-bar-list-padding-right};
 
           & + .#{$block}__line-separator {
             @include fd-set-margins-x($offsetSeparator, $fd-icon-tab-bar-list-padding-right);
@@ -1034,7 +1031,7 @@ $fd-icon-tab-bar-semantic-values: (
 
     .#{$block}__list-item--closable {
       .#{$block}__list-link {
-        @include fd-set-paddings-x(1rem, 2rem);
+        --fdList_Navigation_Link_Padding_Right: 2rem;
 
         position: relative;
       }
@@ -1199,7 +1196,9 @@ $fd-icon-tab-bar-semantic-values: (
     @include fd-compact-or-condensed() {
       .#{$block}__container {
         .#{$block}__counter {
-          @include fd-set-position-left($fd-icon-tab-bar-icon-circle-size-compact + $fd-icon-tab-bar-icon-spacing);
+          @include fd-set-position-left(
+            $fd-icon-tab-bar-icon-circle-size-compact + $fd-icon-tab-bar-icon-spacing
+          );
         }
 
         .#{$block}__badge {

--- a/packages/styles/stories/Components/icon-tab-bar/text-only-closable.example.html
+++ b/packages/styles/stories/Components/icon-tab-bar/text-only-closable.example.html
@@ -199,45 +199,123 @@
 
 <br /><br />
 <h4>Single Click Area</h4>
-<div class="fd-icon-tab-bar">
-    <ul role="tablist" class="fd-icon-tab-bar__header">
-        <li
-            role="presentation"
-            class="fd-icon-tab-bar__item fd-icon-tab-bar__item--single-click fd-icon-tab-bar__item--closable"
-        >
-            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab1single">
-                <div class="fd-icon-tab-bar__tab-container">
-                    <span class="fd-icon-tab-bar__tag">Section 1</span>
-                    <span class="fd-icon-tab-bar__arrow">
-                        <i class="sap-icon--slim-arrow-down" role="presentation"></i>
-                    </span>
+<div class="fddocs-icon-tab-container" style="min-height: 100px">
+    <div class="fd-icon-tab-bar">
+        <ul role="tablist" class="fd-icon-tab-bar__header">
+            <li
+                role="presentation"
+                class="fd-icon-tab-bar__item fd-icon-tab-bar__item--single-click fd-icon-tab-bar__item--closable"
+            >
+                <div class="fd-popover">
+                    <div class="fd-popover__control">
+                        <a
+                            role="tab"
+                            class="fd-icon-tab-bar__tab"
+                            aria-selected="true"
+                            id="tab8"
+                            tabindex="0"
+                            aria-controls="popoverITB1"
+                            aria-expanded="true"
+                            aria-haspopup="true"
+                            onclick="onPopoverClick('popoverITB1');"
+                        >
+                            <div class="fd-icon-tab-bar__tab-container">
+                                <span class="fd-icon-tab-bar__tag">Section 1</span>
+                                <span class="fd-icon-tab-bar__arrow">
+                                    <i class="sap-icon--slim-arrow-down" role="presentation"></i>
+                                </span>
+                            </div>
+                        </a>
+                    </div>
+                    <div
+                        class="fd-popover__body fd-popover__body--no-arrow fd-popover__body--right fd-icon-tab-bar__popover-body"
+                        aria-hidden="false"
+                        id="popoverITB1"
+                    >
+                        <ul class="fd-list fd-list--navigation fd-list--no-border fd-icon-tab-bar__list" role="list">
+                            <li
+                                tabindex="-1"
+                                role="listitem"
+                                aria-level="1"
+                                class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item fd-icon-tab-bar__list-item--closable"
+                            >
+                                <a tabindex="0" class="fd-list__link fd-icon-tab-bar__list-link">
+                                    <span class="fd-list__title">Subsection 1</span>
+                                </a>
+                                <div class="fd-icon-tab-bar__button-container">
+                                    <button
+                                        class="fd-button fd-button--transparent fd-icon-tab-bar__button"
+                                        aria-label="close tab"
+                                    >
+                                        <i class="sap-icon--decline"></i>
+                                    </button>
+                                </div>
+                            </li>
+                            <li
+                                tabindex="-1"
+                                role="listitem"
+                                aria-level="2"
+                                class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item fd-icon-tab-bar__list-item--closable"
+                            >
+                                <a tabindex="0" class="fd-list__link fd-icon-tab-bar__list-link">
+                                    <span class="fd-list__title">Subsection 1.1</span>
+                                </a>
+                                <div class="fd-icon-tab-bar__button-container">
+                                    <button
+                                        class="fd-button fd-button--transparent fd-icon-tab-bar__button"
+                                        aria-label="close tab"
+                                    >
+                                        <i class="sap-icon--decline"></i>
+                                    </button>
+                                </div>
+                            </li>
+                            <li
+                                tabindex="-1"
+                                role="listitem"
+                                aria-level="1"
+                                class="fd-list__item fd-list__item--link fd-icon-tab-bar__list-item fd-icon-tab-bar__list-item--closable"
+                            >
+                                <a tabindex="0" class="fd-list__link fd-icon-tab-bar__list-link">
+                                    <span class="fd-list__title">Subsection 2</span>
+                                </a>
+                                <div class="fd-icon-tab-bar__button-container">
+                                    <button
+                                        class="fd-button fd-button--transparent fd-icon-tab-bar__button"
+                                        aria-label="close tab"
+                                    >
+                                        <i class="sap-icon--decline"></i>
+                                    </button>
+                                </div>
+                            </li>
+                        </ul>
+                    </div>
                 </div>
-            </a>
-            <div class="fd-icon-tab-bar__button-container">
-                <button class="fd-button fd-button--transparent fd-icon-tab-bar__button" aria-label="close tab">
-                    <i class="sap-icon--decline"></i>
-                </button>
-            </div>
-        </li>
-        <li
-            role="presentation"
-            class="fd-icon-tab-bar__item fd-icon-tab-bar__item--single-click fd-icon-tab-bar__item--closable"
-        >
-            <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab2single">
-                <div class="fd-icon-tab-bar__tab-container">
-                    <span class="fd-icon-tab-bar__tag">Section 2</span>
-                    <span class="fd-icon-tab-bar__arrow">
-                        <i class="sap-icon--slim-arrow-down" role="presentation"></i>
-                    </span>
+                <div class="fd-icon-tab-bar__button-container">
+                    <button class="fd-button fd-button--transparent fd-icon-tab-bar__button" aria-label="close tab">
+                        <i class="sap-icon--decline"></i>
+                    </button>
                 </div>
-            </a>
-            <div class="fd-icon-tab-bar__button-container">
-                <button class="fd-button fd-button--transparent fd-icon-tab-bar__button" aria-label="close tab">
-                    <i class="sap-icon--decline"></i>
-                </button>
-            </div>
-        </li>
-    </ul>
+            </li>
+            <li
+                role="presentation"
+                class="fd-icon-tab-bar__item fd-icon-tab-bar__item--single-click fd-icon-tab-bar__item--closable"
+            >
+                <a role="tab" class="fd-icon-tab-bar__tab" href="#" id="tab2single">
+                    <div class="fd-icon-tab-bar__tab-container">
+                        <span class="fd-icon-tab-bar__tag">Section 2</span>
+                        <span class="fd-icon-tab-bar__arrow">
+                            <i class="sap-icon--slim-arrow-down" role="presentation"></i>
+                        </span>
+                    </div>
+                </a>
+                <div class="fd-icon-tab-bar__button-container">
+                    <button class="fd-button fd-button--transparent fd-icon-tab-bar__button" aria-label="close tab">
+                        <i class="sap-icon--decline"></i>
+                    </button>
+                </div>
+            </li>
+        </ul>
+    </div>
 </div>
 
 <br /><br />
@@ -399,8 +477,7 @@
                     </button>
                 </div>
             </li>
-            
-           
+
             <li role="presentation" class="fd-icon-tab-bar__item fd-icon-tab-bar__item--overflow" style="left: 23rem">
                 <div class="fd-popover">
                     <div class="fd-popover__control">
@@ -429,7 +506,10 @@
                                     <span class="fd-list__counter fd-icon-tab-bar__list-item-counter">(12)</span>
                                 </a>
                                 <div class="fd-icon-tab-bar__button-container">
-                                    <button class="fd-button fd-button--transparent fd-icon-tab-bar__button" aria-label="close tab">
+                                    <button
+                                        class="fd-button fd-button--transparent fd-icon-tab-bar__button"
+                                        aria-label="close tab"
+                                    >
                                         <i class="sap-icon--decline"></i>
                                     </button>
                                 </div>
@@ -449,7 +529,10 @@
                                     <span class="fd-list__counter fd-icon-tab-bar__list-item-counter">(227)</span>
                                 </a>
                                 <div class="fd-icon-tab-bar__button-container">
-                                    <button class="fd-button fd-button--transparent fd-icon-tab-bar__button" aria-label="close tab">
+                                    <button
+                                        class="fd-button fd-button--transparent fd-icon-tab-bar__button"
+                                        aria-label="close tab"
+                                    >
                                         <i class="sap-icon--decline"></i>
                                     </button>
                                 </div>
@@ -469,7 +552,10 @@
                                     <span class="fd-list__counter fd-icon-tab-bar__list-item-counter">(0)</span>
                                 </a>
                                 <div class="fd-icon-tab-bar__button-container">
-                                    <button class="fd-button fd-button--transparent fd-icon-tab-bar__button" aria-label="close tab">
+                                    <button
+                                        class="fd-button fd-button--transparent fd-icon-tab-bar__button"
+                                        aria-label="close tab"
+                                    >
                                         <i class="sap-icon--decline"></i>
                                     </button>
                                 </div>


### PR DESCRIPTION
closes none;

Fixes the issue with the padding of nested list items with closable items.

Before:
![image](https://github.com/SAP/fundamental-styles/assets/6586561/6cbb55b2-0d62-4c00-8447-81e6da35eec2)
After:
![image](https://github.com/SAP/fundamental-styles/assets/6586561/c45d1cca-4207-4b34-8b11-beb4338c4a82)
