### PR TITLE
chore: skipping nx cache in prod builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "transform-stories": "ts-node stories-transformer.ts",
     "build": "npx nx run-many --target=build --all",
-    "build:prod": "yarn run build --configuration=production",
+    "build:prod": "yarn run build --configuration=production --skip-nx-cache",
     "build:theming-preview": "npx nx run theming-preview:build",
     "build:visual-stories": "nx run-many --target=build-visual --all",
     "lint:style": "stylelint \"packages/*/src/**/*.(sa|sc|c)ss\"",


### PR DESCRIPTION
## Related Issue
Old version of the common-css was published

## Description
Disabling cached builds for prod in CI
