### PR TITLE
feat(styles): add BTP variant for User Menu [ci visual]

### DIFF
--- a/packages/styles/src/btp/avatar.scss
+++ b/packages/styles/src/btp/avatar.scss
@@ -20,11 +20,11 @@ $block: #{$fd-namespace}-avatar;
 }
 
 .#{$block} {
-  &--40 {
+  &.#{$block}--40 {
     @include fd-avatar-new-size-type(2.5rem, 1rem, 1.25rem);
   }
 
-  &--96 {
+  &.#{$block}--96 {
     @include fd-avatar-new-size-type(6rem, 2.375rem, 3rem);
   }
 }

--- a/packages/styles/src/navigation.scss
+++ b/packages/styles/src/navigation.scss
@@ -68,6 +68,7 @@ $navListContainerSubmenu: #{$block}__list-container--submenu;
   --fdNavigation_Link_Selection_Indicator_Size: 0.5rem;
   --fdNavigation_Link_Has_Child_Indicator_Display: flex;
   --fdNavigation_Link_Selection_Indicator_Display: none;
+  --fdNavigation_Link_Back_Indicator_Icon: "\e1ee";
   --fdNavigation_Link_Has_Child_Indicator_Icon: "\e1ed";
   --fdNavigation_Link_External_Link_Indicator_Icon: "\e04c";
   --fdNavigation_Link_Background: var(--sapNavigation_Background);
@@ -909,6 +910,29 @@ $navListContainerSubmenu: #{$block}__list-container--submenu;
         display: none;
       }
     }
+
+    &--menu {
+      @include fd-expanded() {
+        .#{$navChildrenIndicator} {
+          --fdNavigation_Link_Has_Child_Indicator_Icon: "\e1ed";
+
+          @include fd-rtl() {
+            --fdNavigation_Link_Has_Child_Indicator_Icon: "\e1ee";
+          }
+        }
+
+        --fdNavigation_Link_Child_Indicator_Opacity: 1;
+        --fdNavigation_Link_Background: var(--sapNavigation_Active_Background);
+        --fdNavigation_Link_Border_Color: var(--fdNavigation_Link_Border_Color_Active);
+        --fdNavigation_Link_Border_Bottom_Color: var(--fdNavigation_Link_Border_Color_Active);
+      }
+
+      &.#{$navItemChild} {
+        .#{$navLink} {
+          --fdNavigation_Link_Padding_Left: 0.5rem;
+        }
+      }
+    }
   }
 
   &__icon {
@@ -979,6 +1003,24 @@ $navListContainerSubmenu: #{$block}__list-container--submenu;
 
     @include fd-rtl() {
       --fdNavigation_Link_External_Link_Indicator_Icon: "\e04d";
+    }
+  }
+
+  &__back-indicator {
+    @include fd-reset();
+    @include fd-flex-center();
+    @include fd-set-square(0.75rem);
+
+    color: var(--sapContent_LabelColor);
+
+    &::before {
+      font-size: 0.75rem;
+      font-family: "SAP-icons";
+      content: var(--fdNavigation_Link_Back_Indicator_Icon);
+    }
+
+    @include fd-rtl() {
+      --fdNavigation_Link_Back_Indicator_Icon: "\e1ed";
     }
   }
 }

--- a/packages/styles/src/user-menu.scss
+++ b/packages/styles/src/user-menu.scss
@@ -2,6 +2,7 @@
 @import './mixins';
 
 $block: #{$fd-namespace}-user-menu;
+$navigation: #{$fd-namespace}-navigation;
 
 .#{$block} {
   &__body {
@@ -77,5 +78,85 @@ $block: #{$fd-namespace}-user-menu;
   // even when it's the only child of the header
   .#{$block}__avatar {
     margin: auto;
+  }
+
+  // BTP USER MENU
+  &--tool-header {
+    --fdUserMenu_Body_Padding: 0.75rem;
+
+    .#{$block}__popover-body {
+      border: none;
+      padding: 0.75rem 0;
+      border-radius: 0.75rem;
+      box-shadow: var(--sapMenu_Shadow2);
+      background: var(--sapGroup_ContentBackground);
+    }
+
+    .#{$block}__header {
+      width: 100%;
+      height: auto;
+      margin: 0;
+      padding: 0.75rem;
+      background: transparent;
+    }
+
+    .#{$block}__subheader {
+      padding: 0 0.75rem 0.75rem;
+      margin-bottom: 0;
+    }
+
+    .#{$block}__navigation-menu {
+      padding: 0.75rem;
+
+      .#{$navigation}__item--title {
+        --fdNavigation_Item_Title_Display: flex;
+
+        margin-bottom: 1rem;
+      }
+    }
+
+    .#{$block}__navigation-submenu {
+      @include fd-set-margin-right(0.3875rem);
+
+      top: -0.5rem;
+      border: none;
+      padding: 0.5rem;
+      border-radius: 0.5rem;
+      box-shadow: var(--sapMenu_Shadow1);
+      background: var(--sapGroup_ContentBackground);
+    }
+
+    .#{$block}__navigation-submenu-wrapper {
+      overflow: visible;
+    }
+
+    .#{$block}__user-name {
+      font-family: var(--sapFontBlackFamily);
+      font-size: 1.25rem;
+      line-height: 1.3;
+      color: var(–sapTitleColor);
+    }
+
+    .#{$block}__user-role {
+      font-family: var(--sapFontFamily);
+      font-size: var(--sapFontSize);
+      line-height: var(--sapContent_LineHeight);
+      color: var(–sapContent_LabelColor);
+    }
+
+    .#{$block}__body {
+      padding: 0;
+      overflow: visible;
+    }
+
+    .#{$block}__footer {
+      @include fd-reset();
+
+      @include fd-flex-vertical-center () {
+        justify-content: flex-end;
+      }
+
+      padding: 0.375rem 1.125rem;
+    }
   }
 }

--- a/packages/styles/stories/BTP/user-menu/user-menu-phone.example.html
+++ b/packages/styles/stories/BTP/user-menu/user-menu-phone.example.html
@@ -1,0 +1,232 @@
+<div style="height: 40rem; display: flex; justify-content: flex-end;">
+    <div class="is-cozy">
+        <div class="fd-popover fd-popover--right fd-user-menu fd-user-menu--tool-header">
+            <div class="fd-popover__control">
+                <span
+                    class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail"
+                    aria-controls="popoverA3TH"
+                    aria-expanded="true"
+                    aria-haspopup="true"
+                    aria-label="Avatar"
+                    style="background-image: url('assets/images/avatars/3.svg');"
+                    onclick="onPopoverClick('popoverA3TH');"
+                    role="button"
+                    tabindex="0"></span>
+            </div>
+            <div class="fd-popover__body fd-popover__body--right fd-user-menu__popover-body" aria-hidden="false" id="popoverA3TH">
+                <div class="fd-user-menu__body fd-popover__wrapper">
+                    <div class="fd-user-menu__header">
+                        <span
+                            class="fd-avatar fd-avatar--96 fd-avatar--circle fd-avatar--thumbnail fd-user-menu__avatar"
+                            aria-label="Avatar"
+                            style="background-image: url('assets/images/avatars/3.svg');"></span>
+                    </div>
+                    <div class="fd-user-menu__subheader">
+                        <div class="fd-user-menu__user-name">Kevin Miller</div>
+                        <div class="fd-user-menu__user-role">Design Expert</div>
+                    </div>
+                    <div class="fd-user-menu__navigation-menu">
+                        <div class="fd-navigation fd-navigation--phone">
+                            <ul class="fd-navigation__list" role="tree">
+                                <li class="fd-navigation__list-item" role="treeitem">
+                                    <div 
+                                        class="fd-navigation__item fd-navigation__item--menu"
+                                        title="User Account"
+                                        aria-roledescription="Navigation List Tree Item"
+                                        aria-selected="false"
+                                        aria-expanded="false"
+                                    >
+                                        <a class="fd-navigation__link" role="link" href="#">
+                                            <span class="fd-navigation__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></span>
+                                            <span class="fd-navigation__text">User Account</span>
+                                            <span class="fd-navigation__selection-indicator" aria-label="selection indicator"></span>
+                                        </a>
+                                    </div>
+                                    
+                                </li>
+                                <li class="fd-navigation__list-item" role="treeitem">
+                                    <div 
+                                        class="fd-navigation__item fd-navigation__item--menu"
+                                        title="Settings"
+                                        aria-roledescription="Navigation List Tree Item"
+                                        aria-selected="false"
+                                        aria-expanded="true"
+                                    >
+                                        <a class="fd-navigation__link" role="link" href="#">
+                                            <span class="fd-navigation__icon sap-icon--action-settings" role="presentation" aria-hidden="true"></span>
+                                            <span class="fd-navigation__text">Settings</span>
+                                            <span class="fd-navigation__selection-indicator" aria-label="selection indicator"></span>
+                                            <span class="fd-navigation__has-children-indicator" role="presentation" aria-hidden="true" aria-label="has children indicator, expanded"></span>
+                                        </a>
+                                    </div>
+                                </li>
+                                <li class="fd-navigation__list-item" role="treeitem">
+                                    <div 
+                                        class="fd-navigation__item fd-navigation__item--menu"
+                                        title="Product Specific"
+                                        aria-roledescription="Navigation List Tree Item"
+                                        aria-selected="false"
+                                        aria-expanded="false"
+                                    >
+                                        <a class="fd-navigation__link" role="link" href="#">
+                                            <span class="fd-navigation__icon sap-icon--product" role="presentation" aria-hidden="true"></span>
+                                            <span class="fd-navigation__text">Product Specific</span>
+                                            <span class="fd-navigation__selection-indicator" aria-label="selection indicator"></span>
+                                        </a>
+                                    </div>
+                                </li>
+                                <li class="fd-navigation__list-item" role="treeitem">
+                                    <div 
+                                        class="fd-navigation__item fd-navigation__item--menu"
+                                        title="Product Specific"
+                                        aria-roledescription="Navigation List Tree Item"
+                                        aria-selected="true"
+                                        aria-expanded="false"
+                                    >
+                                        <a class="fd-navigation__link" role="link" href="#">
+                                            <span class="fd-navigation__icon sap-icon--flag" role="presentation" aria-hidden="true"></span>
+                                            <span class="fd-navigation__text">Product Specific</span>
+                                            <span class="fd-navigation__selection-indicator" aria-label="selection indicator"></span>
+                                        </a>
+                                    </div>
+                                </li>
+                                <li class="fd-navigation__list-item" role="treeitem">
+                                    <div 
+                                        class="fd-navigation__item fd-navigation__item--menu"
+                                        title="Product Specific"
+                                        aria-roledescription="Navigation List Tree Item"
+                                        aria-selected="false"
+                                        aria-expanded="false"
+                                    >
+                                        <a class="fd-navigation__link" role="link" href="#">
+                                            <span class="fd-navigation__icon sap-icon--card" role="presentation" aria-hidden="true"></span>
+                                            <span class="fd-navigation__text">Product Specific</span>
+                                            <span class="fd-navigation__selection-indicator" aria-label="selection indicator"></span>
+                                        </a>
+                                    </div>
+                                </li>
+                                <li class="fd-navigation__list-item" role="treeitem">
+                                    <div 
+                                        class="fd-navigation__item fd-navigation__item--menu"
+                                        title="Legal Information"
+                                        aria-roledescription="Navigation List Tree Item"
+                                        aria-selected="false"
+                                        aria-expanded="false"
+                                    >
+                                        <a class="fd-navigation__link" role="link" href="#">
+                                            <span class="fd-navigation__icon sap-icon--card" role="presentation" aria-hidden="true"></span>
+                                            <span class="fd-navigation__text">Legal Information</span>
+                                            <span class="fd-navigation__selection-indicator" aria-label="selection indicator"></span>
+                                            <span class="fd-navigation__has-children-indicator" role="presentation" aria-hidden="true" aria-label="has children indicator, expanded"></span>
+                                        </a>
+                                    </div>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+                <div class="fd-user-menu__footer">
+                    <button class="fd-button fd-button--compact">Sign Out</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<br><br>
+<div style="height: 40rem; display: flex; justify-content: flex-end;">
+    <div class="is-cozy">
+        <div class="fd-popover fd-popover--right fd-user-menu fd-user-menu--tool-header">
+            <div class="fd-popover__control">
+                <span
+                    class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail"
+                    aria-controls="popoverA4TH"
+                    aria-expanded="true"
+                    aria-haspopup="true"
+                    aria-label="Avatar"
+                    style="background-image: url('assets/images/avatars/3.svg');"
+                    onclick="onPopoverClick('popoverA4TH');"
+                    role="button"
+                    tabindex="0"></span>
+            </div>
+            <div class="fd-popover__body fd-popover__body--right fd-user-menu__popover-body" aria-hidden="false" id="popoverA4TH">
+                <div class="fd-user-menu__body fd-popover__wrapper">
+                   <div class="fd-user-menu__navigation-menu">
+                        <div class="fd-navigation fd-navigation--phone">
+                            <ul class="fd-navigation__list" 
+                            role="tree"
+                            aria-roledescription="Navigation List Tree"
+                            aria-hidden="false">
+                                <li class="fd-navigation__list-item" aria-hidden="true">
+                                    <div class="fd-navigation__item fd-navigation__item--title" aria-level="1" role="treeitem" aria-expanded="true" aria-selected="false" >
+                                        <a class="fd-navigation__link" role="button" tabindex="0">
+                                            <span class="fd-navigation__icon sap-icon--navigation-left-arrow" role="presentation" aria-hidden="true"></span>
+                                            <span class="fd-navigation__back-indicator" role="presentation" aria-hidden="true"></span>
+                                            <span class="fd-navigation__text">Settings</span>
+                                            <span class="fd-navigation__selection-indicator"></span>
+                                        </a>
+                                    </div>
+                                    <ul 
+                                        class="fd-navigation__list fd-navigation__list--child-items" 
+                                        role="group" 
+                                        aria-roledescription="Navigation List Tree - Child Items" 
+                                        tabindex="-1"
+                                        aria-hidden="true"
+                                    >
+                                        <li class="fd-navigation__list-item" aria-hidden="true">
+                                            <div 
+                                                class="fd-navigation__item fd-navigation__item--child fd-navigation__item--menu" 
+                                                aria-level="2" 
+                                                role="treeitem" 
+                                                title="Personalization"
+                                                aria-roledescription="Navigation List Menu Item - Child"
+                                                aria-expanded="false" 
+                                                aria-selected="false"
+                                            >
+                                                <a class="fd-navigation__link" role="link" href="#">
+                                                    <span class="fd-navigation__text">Personalization</span>
+                                                    <span class="fd-navigation__selection-indicator" role="presentation" aria-hidden="true" aria-label="selection indicator"></span>
+                                                </a>
+                                            </div>
+                                        </li>
+                                        <li class="fd-navigation__list-item" aria-hidden="true">
+                                            <div 
+                                                class="fd-navigation__item fd-navigation__item--child fd-navigation__item--menu" 
+                                                aria-level="2" 
+                                                role="treeitem" 
+                                                title="Users and Permissions"
+                                                aria-roledescription="Navigation List Menu Item - Child"
+                                                aria-expanded="false" 
+                                                aria-selected="true"
+                                            >
+                                                <a class="fd-navigation__link" role="link" href="#">
+                                                    <span class="fd-navigation__text">Users and Permissions</span>
+                                                    <span class="fd-navigation__selection-indicator" role="presentation" aria-hidden="true" aria-label="selection indicator"></span>
+                                                </a>
+                                            </div>
+                                        </li>
+                                        <li class="fd-navigation__list-item" aria-hidden="true">
+                                            <div 
+                                                class="fd-navigation__item fd-navigation__item--child fd-navigation__item--menu" 
+                                                aria-level="2" 
+                                                role="treeitem" 
+                                                title="Product Settings"
+                                                aria-roledescription="Navigation List Menu Item - Child"
+                                                aria-expanded="false" 
+                                                aria-selected="false"
+                                            >
+                                                <a class="fd-navigation__link" role="link" href="#">
+                                                    <span class="fd-navigation__text">Product Settings</span>
+                                                    <span class="fd-navigation__selection-indicator" role="presentation" aria-hidden="true" aria-label="selection indicator"></span>
+                                                </a>
+                                            </div>
+                                        </li>
+                                    </ul>
+                                </li>
+                            </ul>
+                        </div>
+                   </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/packages/styles/stories/BTP/user-menu/user-menu-tablet.example.html
+++ b/packages/styles/stories/BTP/user-menu/user-menu-tablet.example.html
@@ -1,0 +1,183 @@
+<div style="height: 40rem; display: flex; justify-content: flex-end;">
+    <div class="is-cozy">
+        <div class="fd-popover fd-popover--right fd-user-menu fd-user-menu--tool-header">
+            <div class="fd-popover__control">
+                <span
+                    class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail"
+                    aria-controls="popoverA2TH"
+                    aria-expanded="true"
+                    aria-haspopup="true"
+                    aria-label="Avatar"
+                    style="background-image: url('assets/images/avatars/3.svg');"
+                    onclick="onPopoverClick('popoverA2TH');"
+                    role="button"
+                    tabindex="0"></span>
+            </div>
+            <div class="fd-popover__body fd-popover__body--right fd-user-menu__popover-body" aria-hidden="false" id="popoverA2TH">
+                <div class="fd-user-menu__body fd-popover__wrapper">
+                    <div class="fd-user-menu__header">
+                        <span
+                            class="fd-avatar fd-avatar--96 fd-avatar--circle fd-avatar--thumbnail fd-user-menu__avatar"
+                            aria-label="Avatar"
+                            style="background-image: url('assets/images/avatars/3.svg');"></span>
+                    </div>
+                    <div class="fd-user-menu__subheader">
+                        <div class="fd-user-menu__user-name">Kevin Miller</div>
+                        <div class="fd-user-menu__user-role">Design Expert</div>
+                    </div>
+                    <div class="fd-user-menu__navigation-menu">
+                        <div class="fd-navigation fd-navigation--tablet">
+                            <ul class="fd-navigation__list" role="tree">
+                                <li class="fd-navigation__list-item" role="treeitem">
+                                    <div 
+                                        class="fd-navigation__item fd-navigation__item--menu"
+                                        title="User Account"
+                                        aria-roledescription="Navigation List Tree Item"
+                                        aria-selected="false"
+                                        aria-expanded="false"
+                                    >
+                                        <a class="fd-navigation__link" role="link" href="#">
+                                            <span class="fd-navigation__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></span>
+                                            <span class="fd-navigation__text">User Account</span>
+                                            <span class="fd-navigation__selection-indicator" aria-label="selection indicator"></span>
+                                        </a>
+                                    </div>
+                                    
+                                </li>
+                                <li class="fd-navigation__list-item fd-popover" role="treeitem">
+                                    <div 
+                                        class="fd-navigation__item fd-navigation__item--menu fd-popover__control"
+                                        title="Settings"
+                                        aria-roledescription="Navigation List Tree Item"
+                                        aria-selected="false"
+                                        aria-expanded="true"
+                                        aria-haspopup="tree"
+                                    >
+                                        <a class="fd-navigation__link" role="link" href="#">
+                                            <span class="fd-navigation__icon sap-icon--action-settings" role="presentation" aria-hidden="true"></span>
+                                            <span class="fd-navigation__text">Settings</span>
+                                            <span class="fd-navigation__selection-indicator" aria-label="selection indicator"></span>
+                                            <span class="fd-navigation__has-children-indicator" role="presentation" aria-hidden="true" aria-label="has children indicator, expanded"></span>
+                                        </a>
+                                    </div>
+                                    <div class="fd-user-menu__navigation-submenu fd-popover__body fd-popover__body--before fd-popover__body--no-arrow" role="tree" aria-roledescription="User Menu Submenu">
+                                        <div class="fd-popover__wrapper fd-user-menu__navigation-submenu-wrapper">
+                                            <ul class="fd-navigation__list fd-navigation__list--child-items">
+                                                <li class="fd-navigation__list-item" role="treeitem">
+                                                    <div 
+                                                        class="fd-navigation__item fd-navigation__item--menu fd-navigation__item--child"
+                                                        title="Personalization"
+                                                        aria-roledescription="Navigation List Tree Item"
+                                                        aria-selected="false"
+                                                        aria-expanded="false"
+                                                    >
+                                                        <a class="fd-navigation__link" role="link" href="#">
+                                                            <span class="fd-navigation__text">Personalization</span>
+                                                            <span class="fd-navigation__selection-indicator" aria-label="selection indicator"></span>
+                                                        </a>
+                                                    </div>
+                                                </li>
+                                                <li class="fd-navigation__list-item" role="treeitem">
+                                                    <div 
+                                                        class="fd-navigation__item fd-navigation__item--menu fd-navigation__item--child"
+                                                        title="Users and Permissions"
+                                                        aria-roledescription="Navigation List Tree Item"
+                                                        aria-selected="false"
+                                                        aria-expanded="false"
+                                                    >
+                                                        <a class="fd-navigation__link" role="link" href="#">
+                                                            <span class="fd-navigation__text">Users and Permissions</span>
+                                                            <span class="fd-navigation__selection-indicator" aria-label="selection indicator"></span>
+                                                        </a>
+                                                    </div>
+                                                </li>
+                                                <li class="fd-navigation__list-item" role="treeitem">
+                                                    <div 
+                                                        class="fd-navigation__item fd-navigation__item--menu fd-navigation__item--child"
+                                                        title="Product Settings"
+                                                        aria-roledescription="Navigation List Tree Item"
+                                                        aria-selected="false"
+                                                        aria-expanded="false"
+                                                    >
+                                                        <a class="fd-navigation__link" role="link" href="#">
+                                                            <span class="fd-navigation__text">Product Settings</span>
+                                                            <span class="fd-navigation__selection-indicator" aria-label="selection indicator"></span>
+                                                        </a>
+                                                    </div>
+                                                </li>
+                                            </ul>
+                                        </div>
+                                    </div>
+                                </li>
+                                <li class="fd-navigation__list-item" role="treeitem">
+                                    <div 
+                                        class="fd-navigation__item fd-navigation__item--menu"
+                                        title="Product Specific"
+                                        aria-roledescription="Navigation List Tree Item"
+                                        aria-selected="false"
+                                        aria-expanded="false"
+                                    >
+                                        <a class="fd-navigation__link" role="link" href="#">
+                                            <span class="fd-navigation__icon sap-icon--product" role="presentation" aria-hidden="true"></span>
+                                            <span class="fd-navigation__text">Product Specific</span>
+                                            <span class="fd-navigation__selection-indicator" aria-label="selection indicator"></span>
+                                        </a>
+                                    </div>
+                                </li>
+                                <li class="fd-navigation__list-item" role="treeitem">
+                                    <div 
+                                        class="fd-navigation__item fd-navigation__item--menu"
+                                        title="Product Specific"
+                                        aria-roledescription="Navigation List Tree Item"
+                                        aria-selected="true"
+                                        aria-expanded="false"
+                                    >
+                                        <a class="fd-navigation__link" role="link" href="#">
+                                            <span class="fd-navigation__icon sap-icon--flag" role="presentation" aria-hidden="true"></span>
+                                            <span class="fd-navigation__text">Product Specific</span>
+                                            <span class="fd-navigation__selection-indicator" aria-label="selection indicator"></span>
+                                        </a>
+                                    </div>
+                                </li>
+                                <li class="fd-navigation__list-item" role="treeitem">
+                                    <div 
+                                        class="fd-navigation__item fd-navigation__item--menu"
+                                        title="Product Specific"
+                                        aria-roledescription="Navigation List Tree Item"
+                                        aria-selected="false"
+                                        aria-expanded="false"
+                                    >
+                                        <a class="fd-navigation__link" role="link" href="#">
+                                            <span class="fd-navigation__icon sap-icon--card" role="presentation" aria-hidden="true"></span>
+                                            <span class="fd-navigation__text">Product Specific</span>
+                                            <span class="fd-navigation__selection-indicator" aria-label="selection indicator"></span>
+                                        </a>
+                                    </div>
+                                </li>
+                                <li class="fd-navigation__list-item" role="treeitem">
+                                    <div 
+                                        class="fd-navigation__item fd-navigation__item--menu"
+                                        title="Legal Information"
+                                        aria-roledescription="Navigation List Tree Item"
+                                        aria-selected="false"
+                                        aria-expanded="false"
+                                    >
+                                        <a class="fd-navigation__link" role="link" href="#">
+                                            <span class="fd-navigation__icon sap-icon--card" role="presentation" aria-hidden="true"></span>
+                                            <span class="fd-navigation__text">Legal Information</span>
+                                            <span class="fd-navigation__selection-indicator" aria-label="selection indicator"></span>
+                                            <span class="fd-navigation__has-children-indicator" role="presentation" aria-hidden="true" aria-label="has children indicator, expanded"></span>
+                                        </a>
+                                    </div>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+                <div class="fd-user-menu__footer">
+                    <button class="fd-button">Sign Out</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/packages/styles/stories/BTP/user-menu/user-menu.example.html
+++ b/packages/styles/stories/BTP/user-menu/user-menu.example.html
@@ -1,0 +1,183 @@
+<div style="height: 40rem; display: flex; justify-content: flex-end;">
+    <div class="is-cozy">
+        <div class="fd-popover fd-popover--right fd-user-menu fd-user-menu--tool-header">
+            <div class="fd-popover__control">
+                <span
+                    class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail"
+                    aria-controls="popoverA1TH"
+                    aria-expanded="true"
+                    aria-haspopup="true"
+                    aria-label="Avatar"
+                    style="background-image: url('assets/images/avatars/3.svg');"
+                    onclick="onPopoverClick('popoverA1TH');"
+                    role="button"
+                    tabindex="0"></span>
+            </div>
+            <div class="fd-popover__body fd-popover__body--right fd-user-menu__popover-body" aria-hidden="false" id="popoverA1TH">
+                <div class="fd-user-menu__body fd-popover__wrapper">
+                    <div class="fd-user-menu__header">
+                        <span
+                            class="fd-avatar fd-avatar--96 fd-avatar--circle fd-avatar--thumbnail fd-user-menu__avatar"
+                            aria-label="Avatar"
+                            style="background-image: url('assets/images/avatars/3.svg');"></span>
+                    </div>
+                    <div class="fd-user-menu__subheader">
+                        <div class="fd-user-menu__user-name">Kevin Miller</div>
+                        <div class="fd-user-menu__user-role">Design Expert</div>
+                    </div>
+                    <div class="fd-user-menu__navigation-menu">
+                        <div class="fd-navigation">
+                            <ul class="fd-navigation__list" role="tree">
+                                <li class="fd-navigation__list-item" role="treeitem">
+                                    <div 
+                                        class="fd-navigation__item fd-navigation__item--menu"
+                                        title="User Account"
+                                        aria-roledescription="Navigation List Tree Item"
+                                        aria-selected="false"
+                                        aria-expanded="false"
+                                    >
+                                        <a class="fd-navigation__link" role="link" href="#">
+                                            <span class="fd-navigation__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></span>
+                                            <span class="fd-navigation__text">User Account</span>
+                                            <span class="fd-navigation__selection-indicator" aria-label="selection indicator"></span>
+                                        </a>
+                                    </div>
+                                    
+                                </li>
+                                <li class="fd-navigation__list-item fd-popover" role="treeitem">
+                                    <div 
+                                        class="fd-navigation__item fd-navigation__item--menu fd-popover__control"
+                                        title="Settings"
+                                        aria-roledescription="Navigation List Tree Item"
+                                        aria-selected="false"
+                                        aria-expanded="true"
+                                        aria-haspopup="tree"
+                                    >
+                                        <a class="fd-navigation__link" role="link" href="#">
+                                            <span class="fd-navigation__icon sap-icon--action-settings" role="presentation" aria-hidden="true"></span>
+                                            <span class="fd-navigation__text">Settings</span>
+                                            <span class="fd-navigation__selection-indicator" aria-label="selection indicator"></span>
+                                            <span class="fd-navigation__has-children-indicator" role="presentation" aria-hidden="true" aria-label="has children indicator, expanded"></span>
+                                        </a>
+                                    </div>
+                                    <div class="fd-user-menu__navigation-submenu fd-popover__body fd-popover__body--before fd-popover__body--no-arrow" role="tree" aria-roledescription="User Menu Submenu">
+                                        <div class="fd-popover__wrapper fd-user-menu__navigation-submenu-wrapper">
+                                            <ul class="fd-navigation__list fd-navigation__list--child-items">
+                                                <li class="fd-navigation__list-item" role="treeitem">
+                                                    <div 
+                                                        class="fd-navigation__item fd-navigation__item--menu fd-navigation__item--child"
+                                                        title="Personalization"
+                                                        aria-roledescription="Navigation List Tree Item"
+                                                        aria-selected="false"
+                                                        aria-expanded="false"
+                                                    >
+                                                        <a class="fd-navigation__link" role="link" href="#">
+                                                            <span class="fd-navigation__text">Personalization</span>
+                                                            <span class="fd-navigation__selection-indicator" aria-label="selection indicator"></span>
+                                                        </a>
+                                                    </div>
+                                                </li>
+                                                <li class="fd-navigation__list-item" role="treeitem">
+                                                    <div 
+                                                        class="fd-navigation__item fd-navigation__item--menu fd-navigation__item--child"
+                                                        title="Users and Permissions"
+                                                        aria-roledescription="Navigation List Tree Item"
+                                                        aria-selected="false"
+                                                        aria-expanded="false"
+                                                    >
+                                                        <a class="fd-navigation__link" role="link" href="#">
+                                                            <span class="fd-navigation__text">Users and Permissions</span>
+                                                            <span class="fd-navigation__selection-indicator" aria-label="selection indicator"></span>
+                                                        </a>
+                                                    </div>
+                                                </li>
+                                                <li class="fd-navigation__list-item" role="treeitem">
+                                                    <div 
+                                                        class="fd-navigation__item fd-navigation__item--menu fd-navigation__item--child"
+                                                        title="Product Settings"
+                                                        aria-roledescription="Navigation List Tree Item"
+                                                        aria-selected="false"
+                                                        aria-expanded="false"
+                                                    >
+                                                        <a class="fd-navigation__link" role="link" href="#">
+                                                            <span class="fd-navigation__text">Product Settings</span>
+                                                            <span class="fd-navigation__selection-indicator" aria-label="selection indicator"></span>
+                                                        </a>
+                                                    </div>
+                                                </li>
+                                            </ul>
+                                        </div>
+                                    </div>
+                                </li>
+                                <li class="fd-navigation__list-item" role="treeitem">
+                                    <div 
+                                        class="fd-navigation__item fd-navigation__item--menu"
+                                        title="Product Specific"
+                                        aria-roledescription="Navigation List Tree Item"
+                                        aria-selected="false"
+                                        aria-expanded="false"
+                                    >
+                                        <a class="fd-navigation__link" role="link" href="#">
+                                            <span class="fd-navigation__icon sap-icon--product" role="presentation" aria-hidden="true"></span>
+                                            <span class="fd-navigation__text">Product Specific</span>
+                                            <span class="fd-navigation__selection-indicator" aria-label="selection indicator"></span>
+                                        </a>
+                                    </div>
+                                </li>
+                                <li class="fd-navigation__list-item" role="treeitem">
+                                    <div 
+                                        class="fd-navigation__item fd-navigation__item--menu"
+                                        title="Product Specific"
+                                        aria-roledescription="Navigation List Tree Item"
+                                        aria-selected="true"
+                                        aria-expanded="false"
+                                    >
+                                        <a class="fd-navigation__link" role="link" href="#">
+                                            <span class="fd-navigation__icon sap-icon--flag" role="presentation" aria-hidden="true"></span>
+                                            <span class="fd-navigation__text">Product Specific</span>
+                                            <span class="fd-navigation__selection-indicator" aria-label="selection indicator"></span>
+                                        </a>
+                                    </div>
+                                </li>
+                                <li class="fd-navigation__list-item" role="treeitem">
+                                    <div 
+                                        class="fd-navigation__item fd-navigation__item--menu"
+                                        title="Product Specific"
+                                        aria-roledescription="Navigation List Tree Item"
+                                        aria-selected="false"
+                                        aria-expanded="false"
+                                    >
+                                        <a class="fd-navigation__link" role="link" href="#">
+                                            <span class="fd-navigation__icon sap-icon--card" role="presentation" aria-hidden="true"></span>
+                                            <span class="fd-navigation__text">Product Specific</span>
+                                            <span class="fd-navigation__selection-indicator" aria-label="selection indicator"></span>
+                                        </a>
+                                    </div>
+                                </li>
+                                <li class="fd-navigation__list-item" role="treeitem">
+                                    <div 
+                                        class="fd-navigation__item fd-navigation__item--menu"
+                                        title="Legal Information"
+                                        aria-roledescription="Navigation List Tree Item"
+                                        aria-selected="false"
+                                        aria-expanded="false"
+                                    >
+                                        <a class="fd-navigation__link" role="link" href="#">
+                                            <span class="fd-navigation__icon sap-icon--card" role="presentation" aria-hidden="true"></span>
+                                            <span class="fd-navigation__text">Legal Information</span>
+                                            <span class="fd-navigation__selection-indicator" aria-label="selection indicator"></span>
+                                            <span class="fd-navigation__has-children-indicator" role="presentation" aria-hidden="true" aria-label="has children indicator, expanded"></span>
+                                        </a>
+                                    </div>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+                <div class="fd-user-menu__footer">
+                    <button class="fd-button fd-button--compact">Sign Out</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/packages/styles/stories/BTP/user-menu/user-menu.stories.js
+++ b/packages/styles/stories/BTP/user-menu/user-menu.stories.js
@@ -1,0 +1,58 @@
+
+import userMenuExampleHtml from "./user-menu.example.html?raw";
+import userMenuTabletExampleHtml from "./user-menu-tablet.example.html?raw";
+import userMenuPhoneExampleHtml from "./user-menu-phone.example.html?raw";
+
+import '../../../src/avatar.scss';
+import '../../../src/btp/avatar.scss';
+import '../../../src/icon.scss';
+import '../../../src/popover.scss';
+import '../../../src/button.scss';
+import '../../../src/navigation.scss';
+import '../../../src/user-menu.scss';
+
+export default {
+  title: 'BTP/User Menu',
+  parameters: {
+    description: `The User Menu offers a range of options that are specific to the user and is accessible on all BTP tool screens. Users can access it by clicking on the avatar on the end side of the Tool Header. Apart from always available options, the User Menu can also contain tool-specific actions.
+
+The BTP implementation extends the Visual Core implementation by adding the <code>.fd-user-menu--tool-header</code> modifier class to the <code>.fd-user-menu</code> base class.
+`,
+    tags: ['btp']
+  }
+};
+export const UserMenuExample = () => userMenuExampleHtml;
+UserMenuExample.storyName = 'Desktop';
+UserMenuExample.parameters = {
+  docs: {
+    story: {
+    },
+    description: {
+      story: ``
+    }
+  }
+};
+
+export const UserMenuTabletExample = () => userMenuTabletExampleHtml;
+UserMenuTabletExample.storyName = 'Tablet';
+UserMenuTabletExample.parameters = {
+  docs: {
+    story: {
+    },
+    description: {
+      story: `The interaction behavior for desktop and tablet is identical. The only difference is in the sizes of the components used. `
+    }
+  }
+};
+
+export const UserMenuPhoneExample = () => userMenuPhoneExampleHtml;
+UserMenuPhoneExample.storyName = 'Phone';
+UserMenuPhoneExample.parameters = {
+  docs: {
+    story: {
+    },
+    description: {
+      story: `For mobile phones, in addition to tablet deltas, the cascading of menus happens in place. In the sub-menus, a title with a back button appears. `
+    }
+  }
+};

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -4150,6 +4150,248 @@ exports[`Check stories > BTP/Search Field > Story Default > Should match snapsho
 "
 `;
 
+exports[`Check stories > BTP/Title Bar > Story Desktop > Should match snapshot 1`] = `
+"<div class=\\"fd-toolbar fd-toolbar--clear fd-toolbar--title-bar\\" role=\\"toolbar\\" aria-label=\\"Left, center, and right-aligned toolbar\\">
+    <div class=\\"fd-title-bar\\">
+        <div class=\\"fd-title-bar__container\\">
+            <div class=\\"fd-title-bar__title-container\\">
+                <h4 class=\\"fd-title-bar__title\\">Title</h4>
+            </div>
+        </div>
+    </div>
+    <span class=\\"fd-toolbar__spacer\\"></span>
+    <div class=\\"fd-segmented-button\\" role=\\"group\\" aria-label=\\"Group label\\">
+        <button class=\\"fd-button fd-button--compact\\">View 1</button>
+        <button class=\\"fd-button fd-button--compact fd-button--toggled\\" aria-pressed=\\"true\\">View 2</button>
+        <button class=\\"fd-button fd-button--compact\\">View 3</button>
+    </div>
+    <span class=\\"fd-toolbar__spacer\\"></span>
+    <button class=\\"fd-button fd-button--compact fd-button--transparent\\" aria-label=\\"Filter\\">
+        <i class=\\"sap-icon--filter\\" role=\\"presentation\\"></i>
+    </button>
+    <button class=\\"fd-button fd-button--compact fd-button--transparent\\" aria-label=\\"Sort\\">
+        <i class=\\"sap-icon--sort\\" role=\\"presentation\\"></i>
+    </button>
+    <button class=\\"fd-button fd-button--compact fd-button--transparent\\" aria-label=\\"Group\\">
+        <i class=\\"sap-icon--group-2\\" role=\\"presentation\\"></i>
+    </button>
+</div>
+
+<br><br>
+<div class=\\"fd-toolbar fd-toolbar--clear fd-toolbar--title-bar\\" role=\\"toolbar\\" aria-label=\\"Left, center, and right-aligned toolbar\\">
+    <div class=\\"fd-title-bar\\">
+        <div class=\\"fd-title-bar__container\\">
+            <div class=\\"fd-title-bar__title-container\\">
+                <h4 class=\\"fd-title-bar__title\\">Title</h4>
+                <button class=\\"fd-button fd-button--nested\\" aria-label=\\"information\\">
+                    <i class=\\"sap-icon--hint\\" role=\\"presentation\\"></i>
+                </button>
+            </div>
+            <span class=\\"fd-title-bar__subtitle\\">Subtitle, byline, description</span>
+        </div>
+    </div>
+    <span class=\\"fd-toolbar__spacer\\"></span>
+    <div class=\\"fd-segmented-button\\" role=\\"group\\" aria-label=\\"Group label\\">
+        <button class=\\"fd-button fd-button--compact\\">View 1</button>
+        <button class=\\"fd-button fd-button--compact fd-button--toggled\\" aria-pressed=\\"true\\">View 2</button>
+        <button class=\\"fd-button fd-button--compact\\">View 3</button>
+    </div>
+    <span class=\\"fd-toolbar__spacer\\"></span>
+    <button class=\\"fd-button fd-button--compact fd-button--transparent\\" aria-label=\\"Filter\\">
+        <i class=\\"sap-icon--filter\\" role=\\"presentation\\"></i>
+    </button>
+    <button class=\\"fd-button fd-button--compact fd-button--transparent\\" aria-label=\\"Sort\\">
+        <i class=\\"sap-icon--sort\\" role=\\"presentation\\"></i>
+    </button>
+    <button class=\\"fd-button fd-button--compact fd-button--transparent\\" aria-label=\\"Group\\">
+        <i class=\\"sap-icon--group-2\\" role=\\"presentation\\"></i>
+    </button>
+</div>
+
+<br><br>
+<div class=\\"fd-toolbar fd-toolbar--clear fd-toolbar--title-bar\\" role=\\"toolbar\\" aria-label=\\"Left, center, and right-aligned toolbar\\">
+    <div class=\\"fd-title-bar\\">
+        <div class=\\"fd-title-bar__container\\">
+            <button class=\\"fd-button fd-button--compact fd-button--transparent\\" aria-label=\\"Back\\">
+                <i class=\\"sap-icon--navigation-left-arrow\\" role=\\"presentation\\"></i>
+            </button>
+        </div>
+        <div class=\\"fd-title-bar__container\\">
+            <div class=\\"fd-title-bar__title-container\\">
+                <h4 class=\\"fd-title-bar__title\\">Title</h4>
+                <button class=\\"fd-button fd-button--nested\\" aria-label=\\"information\\">
+                    <i class=\\"sap-icon--hint\\" role=\\"presentation\\"></i>
+                </button>
+            </div>
+            <span class=\\"fd-title-bar__subtitle\\">Subtitle, byline, description</span>
+        </div>
+    </div>
+    <span class=\\"fd-toolbar__spacer\\"></span>
+    <div class=\\"fd-segmented-button\\" role=\\"group\\" aria-label=\\"Group label\\">
+        <button class=\\"fd-button fd-button--compact\\">View 1</button>
+        <button class=\\"fd-button fd-button--compact fd-button--toggled\\" aria-pressed=\\"true\\">View 2</button>
+        <button class=\\"fd-button fd-button--compact\\">View 3</button>
+    </div>
+    <span class=\\"fd-toolbar__spacer\\"></span>
+    <button class=\\"fd-button fd-button--compact fd-button--transparent\\" aria-label=\\"Filter\\">
+        <i class=\\"sap-icon--filter\\" role=\\"presentation\\"></i>
+    </button>
+    <button class=\\"fd-button fd-button--compact fd-button--transparent\\" aria-label=\\"Sort\\">
+        <i class=\\"sap-icon--sort\\" role=\\"presentation\\"></i>
+    </button>
+    <button class=\\"fd-button fd-button--compact fd-button--transparent\\" aria-label=\\"Group\\">
+        <i class=\\"sap-icon--group-2\\" role=\\"presentation\\"></i>
+    </button>
+</div>
+
+<br><br>
+<div class=\\"fd-toolbar fd-toolbar--clear fd-toolbar--title-bar\\" role=\\"toolbar\\" aria-label=\\"Left, center, and right-aligned toolbar\\">
+    <div class=\\"fd-title-bar\\">
+        <div class=\\"fd-title-bar__container\\">
+            <ul class=\\"fd-breadcrumb\\">
+                <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Products</span></a></li>
+                <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Suppliers</span></a></li>
+            </ul>
+            <div class=\\"fd-title-bar__title-container\\">
+                <h4 class=\\"fd-title-bar__title\\">Title</h4>
+                <button class=\\"fd-button fd-button--nested\\" aria-label=\\"information\\">
+                    <i class=\\"sap-icon--hint\\" role=\\"presentation\\"></i>
+                </button>
+            </div>
+            <span class=\\"fd-title-bar__subtitle\\">Subtitle, byline, description</span>
+        </div>
+    </div>
+    <span class=\\"fd-toolbar__spacer\\"></span>
+    <div class=\\"fd-segmented-button\\" role=\\"group\\" aria-label=\\"Group label\\">
+        <button class=\\"fd-button fd-button--compact\\">View 1</button>
+        <button class=\\"fd-button fd-button--compact fd-button--toggled\\" aria-pressed=\\"true\\">View 2</button>
+        <button class=\\"fd-button fd-button--compact\\">View 3</button>
+    </div>
+    <span class=\\"fd-toolbar__spacer\\"></span>
+    <button class=\\"fd-button fd-button--compact fd-button--transparent\\" aria-label=\\"Filter\\">
+        <i class=\\"sap-icon--filter\\" role=\\"presentation\\"></i>
+    </button>
+    <button class=\\"fd-button fd-button--compact fd-button--transparent\\" aria-label=\\"Sort\\">
+        <i class=\\"sap-icon--sort\\" role=\\"presentation\\"></i>
+    </button>
+    <button class=\\"fd-button fd-button--compact fd-button--transparent\\" aria-label=\\"Group\\">
+        <i class=\\"sap-icon--group-2\\" role=\\"presentation\\"></i>
+    </button>
+</div>
+
+<br><br>
+<div class=\\"fd-toolbar fd-toolbar--clear fd-toolbar--title-bar\\" role=\\"toolbar\\" aria-label=\\"Left, center, and right-aligned toolbar\\">
+    <div class=\\"fd-title-bar\\">
+        <div class=\\"fd-title-bar__container\\">
+            <button class=\\"fd-button fd-button--compact fd-button--transparent\\" aria-label=\\"Back\\">
+                <i class=\\"sap-icon--navigation-left-arrow\\" role=\\"presentation\\"></i>
+            </button>
+        </div>
+        <div class=\\"fd-title-bar__container\\">
+            <ul class=\\"fd-breadcrumb\\">
+                <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Products</span></a></li>
+                <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Suppliers</span></a></li>
+            </ul>
+            <div class=\\"fd-title-bar__title-container\\">
+                <h4 class=\\"fd-title-bar__title\\">Title</h4>
+                <button class=\\"fd-button fd-button--nested\\" aria-label=\\"information\\">
+                    <i class=\\"sap-icon--hint\\" role=\\"presentation\\"></i>
+                </button>
+            </div>
+            <span class=\\"fd-title-bar__subtitle\\">Subtitle, byline, description</span>
+        </div>
+    </div>
+    <span class=\\"fd-toolbar__spacer\\"></span>
+    <div class=\\"fd-segmented-button\\" role=\\"group\\" aria-label=\\"Group label\\">
+        <button class=\\"fd-button fd-button--compact\\">View 1</button>
+        <button class=\\"fd-button fd-button--compact fd-button--toggled\\" aria-pressed=\\"true\\">View 2</button>
+        <button class=\\"fd-button fd-button--compact\\">View 3</button>
+    </div>
+    <span class=\\"fd-toolbar__spacer\\"></span>
+    <button class=\\"fd-button fd-button--compact fd-button--transparent\\" aria-label=\\"Filter\\">
+        <i class=\\"sap-icon--filter\\" role=\\"presentation\\"></i>
+    </button>
+    <button class=\\"fd-button fd-button--compact fd-button--transparent\\" aria-label=\\"Sort\\">
+        <i class=\\"sap-icon--sort\\" role=\\"presentation\\"></i>
+    </button>
+    <button class=\\"fd-button fd-button--compact fd-button--transparent\\" aria-label=\\"Group\\">
+        <i class=\\"sap-icon--group-2\\" role=\\"presentation\\"></i>
+    </button>
+</div>"
+`;
+
+exports[`Check stories > BTP/Title Bar > Story Mobile > Should match snapshot 1`] = `
+"<div style=\\"max-width: 600px;\\">
+    <div class=\\"fd-toolbar fd-toolbar--clear fd-toolbar--title-bar\\" role=\\"toolbar\\" aria-label=\\"Left, center, and right-aligned toolbar\\">
+        <div class=\\"fd-title-bar\\">
+            <div class=\\"fd-title-bar__container\\">
+                <button class=\\"fd-button fd-button--transparent\\" aria-label=\\"Back\\">
+                    <i class=\\"sap-icon--navigation-left-arrow\\" role=\\"presentation\\"></i>
+                </button>
+            </div>
+            <div class=\\"fd-title-bar__container\\">
+                <div class=\\"fd-title-bar__title-container\\">
+                    <h4 class=\\"fd-title-bar__title\\">Title</h4>
+                    <button class=\\"fd-button fd-button--nested\\" aria-label=\\"information\\">
+                        <i class=\\"sap-icon--hint\\" role=\\"presentation\\"></i>
+                    </button>
+                </div>
+                <span class=\\"fd-title-bar__subtitle\\">Subtitle, byline, description</span>
+            </div>
+        </div>
+        <span class=\\"fd-toolbar__spacer\\"></span>
+        
+        <button class=\\"fd-button fd-button--transparent\\" aria-label=\\"Filter\\">
+            <i class=\\"sap-icon--filter\\" role=\\"presentation\\"></i>
+        </button>
+        <button class=\\"fd-button fd-button--transparent\\" aria-label=\\"Sort\\">
+            <i class=\\"sap-icon--sort\\" role=\\"presentation\\"></i>
+        </button>
+        <button class=\\"fd-button fd-button--transparent\\" aria-label=\\"Overflow\\">
+            <i class=\\"sap-icon--overflow\\" role=\\"presentation\\"></i>
+        </button>
+    </div>
+</div>"
+`;
+
+exports[`Check stories > BTP/Title Bar > Story Tablet > Should match snapshot 1`] = `
+"<div style=\\"max-width: 860px;\\">
+    <div class=\\"fd-toolbar fd-toolbar--clear fd-toolbar--title-bar\\" role=\\"toolbar\\" aria-label=\\"Left, center, and right-aligned toolbar\\">
+        <div class=\\"fd-title-bar\\">
+            <div class=\\"fd-title-bar__container\\">
+                <button class=\\"fd-button fd-button--transparent\\" aria-label=\\"Back\\">
+                    <i class=\\"sap-icon--navigation-left-arrow\\" role=\\"presentation\\"></i>
+                </button>
+            </div>
+            <div class=\\"fd-title-bar__container\\">
+                <div class=\\"fd-title-bar__title-container\\">
+                    <h4 class=\\"fd-title-bar__title\\">Title</h4>
+                    <button class=\\"fd-button fd-button--nested\\" aria-label=\\"information\\">
+                        <i class=\\"sap-icon--hint\\" role=\\"presentation\\"></i>
+                    </button>
+                </div>
+                <span class=\\"fd-title-bar__subtitle\\">Subtitle, byline, description</span>
+            </div>
+        </div>
+        <span class=\\"fd-toolbar__spacer\\"></span>
+        <div class=\\"fd-segmented-button\\" role=\\"group\\" aria-label=\\"Group label\\">
+            <button class=\\"fd-button\\">View 1</button>
+            <button class=\\"fd-button fd-button--toggled\\" aria-pressed=\\"true\\">View 2</button>
+            <button class=\\"fd-button\\">View 3</button>
+        </div>
+        <button class=\\"fd-button fd-button--transparent\\" aria-label=\\"Filter\\">
+            <i class=\\"sap-icon--filter\\" role=\\"presentation\\"></i>
+        </button>
+        <button class=\\"fd-button fd-button--transparent\\" aria-label=\\"Sort\\">
+            <i class=\\"sap-icon--sort\\" role=\\"presentation\\"></i>
+        </button>
+        <button class=\\"fd-button fd-button--transparent\\" aria-label=\\"Group\\">
+            <i class=\\"sap-icon--group-2\\" role=\\"presentation\\"></i>
+        </button>
+    </div>
+</div>"
+`;
+
 exports[`Check stories > BTP/Tool Header > Story Desktop > Should match snapshot 1`] = `
 "<h4>Without Menu Button (default)</h4>
 <div class=\\"fd-tool-header fd-tool-header--compact\\">
@@ -5141,6 +5383,613 @@ exports[`Check stories > BTP/Tool Layout > Story Tablet > Should match snapshot 
     </div>
 </div>
 "
+`;
+
+exports[`Check stories > BTP/User Menu > Story UserMenuExample > Should match snapshot 1`] = `
+"<div style=\\"height: 40rem; display: flex; justify-content: flex-end;\\">
+    <div class=\\"is-cozy\\">
+        <div class=\\"fd-popover fd-popover--right fd-user-menu fd-user-menu--tool-header\\">
+            <div class=\\"fd-popover__control\\">
+                <span
+                    class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail\\"
+                    aria-controls=\\"popoverA1TH\\"
+                    aria-expanded=\\"true\\"
+                    aria-haspopup=\\"true\\"
+                    aria-label=\\"Avatar\\"
+                    style=\\"background-image: url('assets/images/avatars/3.svg');\\"
+                    onclick=\\"onPopoverClick('popoverA1TH');\\"
+                    role=\\"button\\"
+                    tabindex=\\"0\\"></span>
+            </div>
+            <div class=\\"fd-popover__body fd-popover__body--right fd-user-menu__popover-body\\" aria-hidden=\\"false\\" id=\\"popoverA1TH\\">
+                <div class=\\"fd-user-menu__body fd-popover__wrapper\\">
+                    <div class=\\"fd-user-menu__header\\">
+                        <span
+                            class=\\"fd-avatar fd-avatar--96 fd-avatar--circle fd-avatar--thumbnail fd-user-menu__avatar\\"
+                            aria-label=\\"Avatar\\"
+                            style=\\"background-image: url('assets/images/avatars/3.svg');\\"></span>
+                    </div>
+                    <div class=\\"fd-user-menu__subheader\\">
+                        <div class=\\"fd-user-menu__user-name\\">Kevin Miller</div>
+                        <div class=\\"fd-user-menu__user-role\\">Design Expert</div>
+                    </div>
+                    <div class=\\"fd-user-menu__navigation-menu\\">
+                        <div class=\\"fd-navigation\\">
+                            <ul class=\\"fd-navigation__list\\" role=\\"tree\\">
+                                <li class=\\"fd-navigation__list-item\\" role=\\"treeitem\\">
+                                    <div 
+                                        class=\\"fd-navigation__item fd-navigation__item--menu\\"
+                                        title=\\"User Account\\"
+                                        aria-roledescription=\\"Navigation List Tree Item\\"
+                                        aria-selected=\\"false\\"
+                                        aria-expanded=\\"false\\"
+                                    >
+                                        <a class=\\"fd-navigation__link\\" role=\\"link\\" href=\\"#\\">
+                                            <span class=\\"fd-navigation__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+                                            <span class=\\"fd-navigation__text\\">User Account</span>
+                                            <span class=\\"fd-navigation__selection-indicator\\" aria-label=\\"selection indicator\\"></span>
+                                        </a>
+                                    </div>
+                                    
+                                </li>
+                                <li class=\\"fd-navigation__list-item fd-popover\\" role=\\"treeitem\\">
+                                    <div 
+                                        class=\\"fd-navigation__item fd-navigation__item--menu fd-popover__control\\"
+                                        title=\\"Settings\\"
+                                        aria-roledescription=\\"Navigation List Tree Item\\"
+                                        aria-selected=\\"false\\"
+                                        aria-expanded=\\"true\\"
+                                        aria-haspopup=\\"tree\\"
+                                    >
+                                        <a class=\\"fd-navigation__link\\" role=\\"link\\" href=\\"#\\">
+                                            <span class=\\"fd-navigation__icon sap-icon--action-settings\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+                                            <span class=\\"fd-navigation__text\\">Settings</span>
+                                            <span class=\\"fd-navigation__selection-indicator\\" aria-label=\\"selection indicator\\"></span>
+                                            <span class=\\"fd-navigation__has-children-indicator\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"has children indicator, expanded\\"></span>
+                                        </a>
+                                    </div>
+                                    <div class=\\"fd-user-menu__navigation-submenu fd-popover__body fd-popover__body--before fd-popover__body--no-arrow\\" role=\\"tree\\" aria-roledescription=\\"User Menu Submenu\\">
+                                        <div class=\\"fd-popover__wrapper fd-user-menu__navigation-submenu-wrapper\\">
+                                            <ul class=\\"fd-navigation__list fd-navigation__list--child-items\\">
+                                                <li class=\\"fd-navigation__list-item\\" role=\\"treeitem\\">
+                                                    <div 
+                                                        class=\\"fd-navigation__item fd-navigation__item--menu fd-navigation__item--child\\"
+                                                        title=\\"Personalization\\"
+                                                        aria-roledescription=\\"Navigation List Tree Item\\"
+                                                        aria-selected=\\"false\\"
+                                                        aria-expanded=\\"false\\"
+                                                    >
+                                                        <a class=\\"fd-navigation__link\\" role=\\"link\\" href=\\"#\\">
+                                                            <span class=\\"fd-navigation__text\\">Personalization</span>
+                                                            <span class=\\"fd-navigation__selection-indicator\\" aria-label=\\"selection indicator\\"></span>
+                                                        </a>
+                                                    </div>
+                                                </li>
+                                                <li class=\\"fd-navigation__list-item\\" role=\\"treeitem\\">
+                                                    <div 
+                                                        class=\\"fd-navigation__item fd-navigation__item--menu fd-navigation__item--child\\"
+                                                        title=\\"Users and Permissions\\"
+                                                        aria-roledescription=\\"Navigation List Tree Item\\"
+                                                        aria-selected=\\"false\\"
+                                                        aria-expanded=\\"false\\"
+                                                    >
+                                                        <a class=\\"fd-navigation__link\\" role=\\"link\\" href=\\"#\\">
+                                                            <span class=\\"fd-navigation__text\\">Users and Permissions</span>
+                                                            <span class=\\"fd-navigation__selection-indicator\\" aria-label=\\"selection indicator\\"></span>
+                                                        </a>
+                                                    </div>
+                                                </li>
+                                                <li class=\\"fd-navigation__list-item\\" role=\\"treeitem\\">
+                                                    <div 
+                                                        class=\\"fd-navigation__item fd-navigation__item--menu fd-navigation__item--child\\"
+                                                        title=\\"Product Settings\\"
+                                                        aria-roledescription=\\"Navigation List Tree Item\\"
+                                                        aria-selected=\\"false\\"
+                                                        aria-expanded=\\"false\\"
+                                                    >
+                                                        <a class=\\"fd-navigation__link\\" role=\\"link\\" href=\\"#\\">
+                                                            <span class=\\"fd-navigation__text\\">Product Settings</span>
+                                                            <span class=\\"fd-navigation__selection-indicator\\" aria-label=\\"selection indicator\\"></span>
+                                                        </a>
+                                                    </div>
+                                                </li>
+                                            </ul>
+                                        </div>
+                                    </div>
+                                </li>
+                                <li class=\\"fd-navigation__list-item\\" role=\\"treeitem\\">
+                                    <div 
+                                        class=\\"fd-navigation__item fd-navigation__item--menu\\"
+                                        title=\\"Product Specific\\"
+                                        aria-roledescription=\\"Navigation List Tree Item\\"
+                                        aria-selected=\\"false\\"
+                                        aria-expanded=\\"false\\"
+                                    >
+                                        <a class=\\"fd-navigation__link\\" role=\\"link\\" href=\\"#\\">
+                                            <span class=\\"fd-navigation__icon sap-icon--product\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+                                            <span class=\\"fd-navigation__text\\">Product Specific</span>
+                                            <span class=\\"fd-navigation__selection-indicator\\" aria-label=\\"selection indicator\\"></span>
+                                        </a>
+                                    </div>
+                                </li>
+                                <li class=\\"fd-navigation__list-item\\" role=\\"treeitem\\">
+                                    <div 
+                                        class=\\"fd-navigation__item fd-navigation__item--menu\\"
+                                        title=\\"Product Specific\\"
+                                        aria-roledescription=\\"Navigation List Tree Item\\"
+                                        aria-selected=\\"true\\"
+                                        aria-expanded=\\"false\\"
+                                    >
+                                        <a class=\\"fd-navigation__link\\" role=\\"link\\" href=\\"#\\">
+                                            <span class=\\"fd-navigation__icon sap-icon--flag\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+                                            <span class=\\"fd-navigation__text\\">Product Specific</span>
+                                            <span class=\\"fd-navigation__selection-indicator\\" aria-label=\\"selection indicator\\"></span>
+                                        </a>
+                                    </div>
+                                </li>
+                                <li class=\\"fd-navigation__list-item\\" role=\\"treeitem\\">
+                                    <div 
+                                        class=\\"fd-navigation__item fd-navigation__item--menu\\"
+                                        title=\\"Product Specific\\"
+                                        aria-roledescription=\\"Navigation List Tree Item\\"
+                                        aria-selected=\\"false\\"
+                                        aria-expanded=\\"false\\"
+                                    >
+                                        <a class=\\"fd-navigation__link\\" role=\\"link\\" href=\\"#\\">
+                                            <span class=\\"fd-navigation__icon sap-icon--card\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+                                            <span class=\\"fd-navigation__text\\">Product Specific</span>
+                                            <span class=\\"fd-navigation__selection-indicator\\" aria-label=\\"selection indicator\\"></span>
+                                        </a>
+                                    </div>
+                                </li>
+                                <li class=\\"fd-navigation__list-item\\" role=\\"treeitem\\">
+                                    <div 
+                                        class=\\"fd-navigation__item fd-navigation__item--menu\\"
+                                        title=\\"Legal Information\\"
+                                        aria-roledescription=\\"Navigation List Tree Item\\"
+                                        aria-selected=\\"false\\"
+                                        aria-expanded=\\"false\\"
+                                    >
+                                        <a class=\\"fd-navigation__link\\" role=\\"link\\" href=\\"#\\">
+                                            <span class=\\"fd-navigation__icon sap-icon--card\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+                                            <span class=\\"fd-navigation__text\\">Legal Information</span>
+                                            <span class=\\"fd-navigation__selection-indicator\\" aria-label=\\"selection indicator\\"></span>
+                                            <span class=\\"fd-navigation__has-children-indicator\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"has children indicator, expanded\\"></span>
+                                        </a>
+                                    </div>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+                <div class=\\"fd-user-menu__footer\\">
+                    <button class=\\"fd-button fd-button--compact\\">Sign Out</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>"
+`;
+
+exports[`Check stories > BTP/User Menu > Story UserMenuPhoneExample > Should match snapshot 1`] = `
+"<div style=\\"height: 40rem; display: flex; justify-content: flex-end;\\">
+    <div class=\\"is-cozy\\">
+        <div class=\\"fd-popover fd-popover--right fd-user-menu fd-user-menu--tool-header\\">
+            <div class=\\"fd-popover__control\\">
+                <span
+                    class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail\\"
+                    aria-controls=\\"popoverA3TH\\"
+                    aria-expanded=\\"true\\"
+                    aria-haspopup=\\"true\\"
+                    aria-label=\\"Avatar\\"
+                    style=\\"background-image: url('assets/images/avatars/3.svg');\\"
+                    onclick=\\"onPopoverClick('popoverA3TH');\\"
+                    role=\\"button\\"
+                    tabindex=\\"0\\"></span>
+            </div>
+            <div class=\\"fd-popover__body fd-popover__body--right fd-user-menu__popover-body\\" aria-hidden=\\"false\\" id=\\"popoverA3TH\\">
+                <div class=\\"fd-user-menu__body fd-popover__wrapper\\">
+                    <div class=\\"fd-user-menu__header\\">
+                        <span
+                            class=\\"fd-avatar fd-avatar--96 fd-avatar--circle fd-avatar--thumbnail fd-user-menu__avatar\\"
+                            aria-label=\\"Avatar\\"
+                            style=\\"background-image: url('assets/images/avatars/3.svg');\\"></span>
+                    </div>
+                    <div class=\\"fd-user-menu__subheader\\">
+                        <div class=\\"fd-user-menu__user-name\\">Kevin Miller</div>
+                        <div class=\\"fd-user-menu__user-role\\">Design Expert</div>
+                    </div>
+                    <div class=\\"fd-user-menu__navigation-menu\\">
+                        <div class=\\"fd-navigation fd-navigation--phone\\">
+                            <ul class=\\"fd-navigation__list\\" role=\\"tree\\">
+                                <li class=\\"fd-navigation__list-item\\" role=\\"treeitem\\">
+                                    <div 
+                                        class=\\"fd-navigation__item fd-navigation__item--menu\\"
+                                        title=\\"User Account\\"
+                                        aria-roledescription=\\"Navigation List Tree Item\\"
+                                        aria-selected=\\"false\\"
+                                        aria-expanded=\\"false\\"
+                                    >
+                                        <a class=\\"fd-navigation__link\\" role=\\"link\\" href=\\"#\\">
+                                            <span class=\\"fd-navigation__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+                                            <span class=\\"fd-navigation__text\\">User Account</span>
+                                            <span class=\\"fd-navigation__selection-indicator\\" aria-label=\\"selection indicator\\"></span>
+                                        </a>
+                                    </div>
+                                    
+                                </li>
+                                <li class=\\"fd-navigation__list-item\\" role=\\"treeitem\\">
+                                    <div 
+                                        class=\\"fd-navigation__item fd-navigation__item--menu\\"
+                                        title=\\"Settings\\"
+                                        aria-roledescription=\\"Navigation List Tree Item\\"
+                                        aria-selected=\\"false\\"
+                                        aria-expanded=\\"true\\"
+                                    >
+                                        <a class=\\"fd-navigation__link\\" role=\\"link\\" href=\\"#\\">
+                                            <span class=\\"fd-navigation__icon sap-icon--action-settings\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+                                            <span class=\\"fd-navigation__text\\">Settings</span>
+                                            <span class=\\"fd-navigation__selection-indicator\\" aria-label=\\"selection indicator\\"></span>
+                                            <span class=\\"fd-navigation__has-children-indicator\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"has children indicator, expanded\\"></span>
+                                        </a>
+                                    </div>
+                                </li>
+                                <li class=\\"fd-navigation__list-item\\" role=\\"treeitem\\">
+                                    <div 
+                                        class=\\"fd-navigation__item fd-navigation__item--menu\\"
+                                        title=\\"Product Specific\\"
+                                        aria-roledescription=\\"Navigation List Tree Item\\"
+                                        aria-selected=\\"false\\"
+                                        aria-expanded=\\"false\\"
+                                    >
+                                        <a class=\\"fd-navigation__link\\" role=\\"link\\" href=\\"#\\">
+                                            <span class=\\"fd-navigation__icon sap-icon--product\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+                                            <span class=\\"fd-navigation__text\\">Product Specific</span>
+                                            <span class=\\"fd-navigation__selection-indicator\\" aria-label=\\"selection indicator\\"></span>
+                                        </a>
+                                    </div>
+                                </li>
+                                <li class=\\"fd-navigation__list-item\\" role=\\"treeitem\\">
+                                    <div 
+                                        class=\\"fd-navigation__item fd-navigation__item--menu\\"
+                                        title=\\"Product Specific\\"
+                                        aria-roledescription=\\"Navigation List Tree Item\\"
+                                        aria-selected=\\"true\\"
+                                        aria-expanded=\\"false\\"
+                                    >
+                                        <a class=\\"fd-navigation__link\\" role=\\"link\\" href=\\"#\\">
+                                            <span class=\\"fd-navigation__icon sap-icon--flag\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+                                            <span class=\\"fd-navigation__text\\">Product Specific</span>
+                                            <span class=\\"fd-navigation__selection-indicator\\" aria-label=\\"selection indicator\\"></span>
+                                        </a>
+                                    </div>
+                                </li>
+                                <li class=\\"fd-navigation__list-item\\" role=\\"treeitem\\">
+                                    <div 
+                                        class=\\"fd-navigation__item fd-navigation__item--menu\\"
+                                        title=\\"Product Specific\\"
+                                        aria-roledescription=\\"Navigation List Tree Item\\"
+                                        aria-selected=\\"false\\"
+                                        aria-expanded=\\"false\\"
+                                    >
+                                        <a class=\\"fd-navigation__link\\" role=\\"link\\" href=\\"#\\">
+                                            <span class=\\"fd-navigation__icon sap-icon--card\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+                                            <span class=\\"fd-navigation__text\\">Product Specific</span>
+                                            <span class=\\"fd-navigation__selection-indicator\\" aria-label=\\"selection indicator\\"></span>
+                                        </a>
+                                    </div>
+                                </li>
+                                <li class=\\"fd-navigation__list-item\\" role=\\"treeitem\\">
+                                    <div 
+                                        class=\\"fd-navigation__item fd-navigation__item--menu\\"
+                                        title=\\"Legal Information\\"
+                                        aria-roledescription=\\"Navigation List Tree Item\\"
+                                        aria-selected=\\"false\\"
+                                        aria-expanded=\\"false\\"
+                                    >
+                                        <a class=\\"fd-navigation__link\\" role=\\"link\\" href=\\"#\\">
+                                            <span class=\\"fd-navigation__icon sap-icon--card\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+                                            <span class=\\"fd-navigation__text\\">Legal Information</span>
+                                            <span class=\\"fd-navigation__selection-indicator\\" aria-label=\\"selection indicator\\"></span>
+                                            <span class=\\"fd-navigation__has-children-indicator\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"has children indicator, expanded\\"></span>
+                                        </a>
+                                    </div>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+                <div class=\\"fd-user-menu__footer\\">
+                    <button class=\\"fd-button fd-button--compact\\">Sign Out</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<br><br>
+<div style=\\"height: 40rem; display: flex; justify-content: flex-end;\\">
+    <div class=\\"is-cozy\\">
+        <div class=\\"fd-popover fd-popover--right fd-user-menu fd-user-menu--tool-header\\">
+            <div class=\\"fd-popover__control\\">
+                <span
+                    class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail\\"
+                    aria-controls=\\"popoverA4TH\\"
+                    aria-expanded=\\"true\\"
+                    aria-haspopup=\\"true\\"
+                    aria-label=\\"Avatar\\"
+                    style=\\"background-image: url('assets/images/avatars/3.svg');\\"
+                    onclick=\\"onPopoverClick('popoverA4TH');\\"
+                    role=\\"button\\"
+                    tabindex=\\"0\\"></span>
+            </div>
+            <div class=\\"fd-popover__body fd-popover__body--right fd-user-menu__popover-body\\" aria-hidden=\\"false\\" id=\\"popoverA4TH\\">
+                <div class=\\"fd-user-menu__body fd-popover__wrapper\\">
+                   <div class=\\"fd-user-menu__navigation-menu\\">
+                        <div class=\\"fd-navigation fd-navigation--phone\\">
+                            <ul class=\\"fd-navigation__list\\" 
+                            role=\\"tree\\"
+                            aria-roledescription=\\"Navigation List Tree\\"
+                            aria-hidden=\\"false\\">
+                                <li class=\\"fd-navigation__list-item\\" aria-hidden=\\"true\\">
+                                    <div class=\\"fd-navigation__item fd-navigation__item--title\\" aria-level=\\"1\\" role=\\"treeitem\\" aria-expanded=\\"true\\" aria-selected=\\"false\\" >
+                                        <a class=\\"fd-navigation__link\\" role=\\"button\\" tabindex=\\"0\\">
+                                            <span class=\\"fd-navigation__icon sap-icon--navigation-left-arrow\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+                                            <span class=\\"fd-navigation__back-indicator\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+                                            <span class=\\"fd-navigation__text\\">Settings</span>
+                                            <span class=\\"fd-navigation__selection-indicator\\"></span>
+                                        </a>
+                                    </div>
+                                    <ul 
+                                        class=\\"fd-navigation__list fd-navigation__list--child-items\\" 
+                                        role=\\"group\\" 
+                                        aria-roledescription=\\"Navigation List Tree - Child Items\\" 
+                                        tabindex=\\"-1\\"
+                                        aria-hidden=\\"true\\"
+                                    >
+                                        <li class=\\"fd-navigation__list-item\\" aria-hidden=\\"true\\">
+                                            <div 
+                                                class=\\"fd-navigation__item fd-navigation__item--child fd-navigation__item--menu\\" 
+                                                aria-level=\\"2\\" 
+                                                role=\\"treeitem\\" 
+                                                title=\\"Personalization\\"
+                                                aria-roledescription=\\"Navigation List Menu Item - Child\\"
+                                                aria-expanded=\\"false\\" 
+                                                aria-selected=\\"false\\"
+                                            >
+                                                <a class=\\"fd-navigation__link\\" role=\\"link\\" href=\\"#\\">
+                                                    <span class=\\"fd-navigation__text\\">Personalization</span>
+                                                    <span class=\\"fd-navigation__selection-indicator\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"selection indicator\\"></span>
+                                                </a>
+                                            </div>
+                                        </li>
+                                        <li class=\\"fd-navigation__list-item\\" aria-hidden=\\"true\\">
+                                            <div 
+                                                class=\\"fd-navigation__item fd-navigation__item--child fd-navigation__item--menu\\" 
+                                                aria-level=\\"2\\" 
+                                                role=\\"treeitem\\" 
+                                                title=\\"Users and Permissions\\"
+                                                aria-roledescription=\\"Navigation List Menu Item - Child\\"
+                                                aria-expanded=\\"false\\" 
+                                                aria-selected=\\"true\\"
+                                            >
+                                                <a class=\\"fd-navigation__link\\" role=\\"link\\" href=\\"#\\">
+                                                    <span class=\\"fd-navigation__text\\">Users and Permissions</span>
+                                                    <span class=\\"fd-navigation__selection-indicator\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"selection indicator\\"></span>
+                                                </a>
+                                            </div>
+                                        </li>
+                                        <li class=\\"fd-navigation__list-item\\" aria-hidden=\\"true\\">
+                                            <div 
+                                                class=\\"fd-navigation__item fd-navigation__item--child fd-navigation__item--menu\\" 
+                                                aria-level=\\"2\\" 
+                                                role=\\"treeitem\\" 
+                                                title=\\"Product Settings\\"
+                                                aria-roledescription=\\"Navigation List Menu Item - Child\\"
+                                                aria-expanded=\\"false\\" 
+                                                aria-selected=\\"false\\"
+                                            >
+                                                <a class=\\"fd-navigation__link\\" role=\\"link\\" href=\\"#\\">
+                                                    <span class=\\"fd-navigation__text\\">Product Settings</span>
+                                                    <span class=\\"fd-navigation__selection-indicator\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"selection indicator\\"></span>
+                                                </a>
+                                            </div>
+                                        </li>
+                                    </ul>
+                                </li>
+                            </ul>
+                        </div>
+                   </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>"
+`;
+
+exports[`Check stories > BTP/User Menu > Story UserMenuTabletExample > Should match snapshot 1`] = `
+"<div style=\\"height: 40rem; display: flex; justify-content: flex-end;\\">
+    <div class=\\"is-cozy\\">
+        <div class=\\"fd-popover fd-popover--right fd-user-menu fd-user-menu--tool-header\\">
+            <div class=\\"fd-popover__control\\">
+                <span
+                    class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail\\"
+                    aria-controls=\\"popoverA2TH\\"
+                    aria-expanded=\\"true\\"
+                    aria-haspopup=\\"true\\"
+                    aria-label=\\"Avatar\\"
+                    style=\\"background-image: url('assets/images/avatars/3.svg');\\"
+                    onclick=\\"onPopoverClick('popoverA2TH');\\"
+                    role=\\"button\\"
+                    tabindex=\\"0\\"></span>
+            </div>
+            <div class=\\"fd-popover__body fd-popover__body--right fd-user-menu__popover-body\\" aria-hidden=\\"false\\" id=\\"popoverA2TH\\">
+                <div class=\\"fd-user-menu__body fd-popover__wrapper\\">
+                    <div class=\\"fd-user-menu__header\\">
+                        <span
+                            class=\\"fd-avatar fd-avatar--96 fd-avatar--circle fd-avatar--thumbnail fd-user-menu__avatar\\"
+                            aria-label=\\"Avatar\\"
+                            style=\\"background-image: url('assets/images/avatars/3.svg');\\"></span>
+                    </div>
+                    <div class=\\"fd-user-menu__subheader\\">
+                        <div class=\\"fd-user-menu__user-name\\">Kevin Miller</div>
+                        <div class=\\"fd-user-menu__user-role\\">Design Expert</div>
+                    </div>
+                    <div class=\\"fd-user-menu__navigation-menu\\">
+                        <div class=\\"fd-navigation fd-navigation--tablet\\">
+                            <ul class=\\"fd-navigation__list\\" role=\\"tree\\">
+                                <li class=\\"fd-navigation__list-item\\" role=\\"treeitem\\">
+                                    <div 
+                                        class=\\"fd-navigation__item fd-navigation__item--menu\\"
+                                        title=\\"User Account\\"
+                                        aria-roledescription=\\"Navigation List Tree Item\\"
+                                        aria-selected=\\"false\\"
+                                        aria-expanded=\\"false\\"
+                                    >
+                                        <a class=\\"fd-navigation__link\\" role=\\"link\\" href=\\"#\\">
+                                            <span class=\\"fd-navigation__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+                                            <span class=\\"fd-navigation__text\\">User Account</span>
+                                            <span class=\\"fd-navigation__selection-indicator\\" aria-label=\\"selection indicator\\"></span>
+                                        </a>
+                                    </div>
+                                    
+                                </li>
+                                <li class=\\"fd-navigation__list-item fd-popover\\" role=\\"treeitem\\">
+                                    <div 
+                                        class=\\"fd-navigation__item fd-navigation__item--menu fd-popover__control\\"
+                                        title=\\"Settings\\"
+                                        aria-roledescription=\\"Navigation List Tree Item\\"
+                                        aria-selected=\\"false\\"
+                                        aria-expanded=\\"true\\"
+                                        aria-haspopup=\\"tree\\"
+                                    >
+                                        <a class=\\"fd-navigation__link\\" role=\\"link\\" href=\\"#\\">
+                                            <span class=\\"fd-navigation__icon sap-icon--action-settings\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+                                            <span class=\\"fd-navigation__text\\">Settings</span>
+                                            <span class=\\"fd-navigation__selection-indicator\\" aria-label=\\"selection indicator\\"></span>
+                                            <span class=\\"fd-navigation__has-children-indicator\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"has children indicator, expanded\\"></span>
+                                        </a>
+                                    </div>
+                                    <div class=\\"fd-user-menu__navigation-submenu fd-popover__body fd-popover__body--before fd-popover__body--no-arrow\\" role=\\"tree\\" aria-roledescription=\\"User Menu Submenu\\">
+                                        <div class=\\"fd-popover__wrapper fd-user-menu__navigation-submenu-wrapper\\">
+                                            <ul class=\\"fd-navigation__list fd-navigation__list--child-items\\">
+                                                <li class=\\"fd-navigation__list-item\\" role=\\"treeitem\\">
+                                                    <div 
+                                                        class=\\"fd-navigation__item fd-navigation__item--menu fd-navigation__item--child\\"
+                                                        title=\\"Personalization\\"
+                                                        aria-roledescription=\\"Navigation List Tree Item\\"
+                                                        aria-selected=\\"false\\"
+                                                        aria-expanded=\\"false\\"
+                                                    >
+                                                        <a class=\\"fd-navigation__link\\" role=\\"link\\" href=\\"#\\">
+                                                            <span class=\\"fd-navigation__text\\">Personalization</span>
+                                                            <span class=\\"fd-navigation__selection-indicator\\" aria-label=\\"selection indicator\\"></span>
+                                                        </a>
+                                                    </div>
+                                                </li>
+                                                <li class=\\"fd-navigation__list-item\\" role=\\"treeitem\\">
+                                                    <div 
+                                                        class=\\"fd-navigation__item fd-navigation__item--menu fd-navigation__item--child\\"
+                                                        title=\\"Users and Permissions\\"
+                                                        aria-roledescription=\\"Navigation List Tree Item\\"
+                                                        aria-selected=\\"false\\"
+                                                        aria-expanded=\\"false\\"
+                                                    >
+                                                        <a class=\\"fd-navigation__link\\" role=\\"link\\" href=\\"#\\">
+                                                            <span class=\\"fd-navigation__text\\">Users and Permissions</span>
+                                                            <span class=\\"fd-navigation__selection-indicator\\" aria-label=\\"selection indicator\\"></span>
+                                                        </a>
+                                                    </div>
+                                                </li>
+                                                <li class=\\"fd-navigation__list-item\\" role=\\"treeitem\\">
+                                                    <div 
+                                                        class=\\"fd-navigation__item fd-navigation__item--menu fd-navigation__item--child\\"
+                                                        title=\\"Product Settings\\"
+                                                        aria-roledescription=\\"Navigation List Tree Item\\"
+                                                        aria-selected=\\"false\\"
+                                                        aria-expanded=\\"false\\"
+                                                    >
+                                                        <a class=\\"fd-navigation__link\\" role=\\"link\\" href=\\"#\\">
+                                                            <span class=\\"fd-navigation__text\\">Product Settings</span>
+                                                            <span class=\\"fd-navigation__selection-indicator\\" aria-label=\\"selection indicator\\"></span>
+                                                        </a>
+                                                    </div>
+                                                </li>
+                                            </ul>
+                                        </div>
+                                    </div>
+                                </li>
+                                <li class=\\"fd-navigation__list-item\\" role=\\"treeitem\\">
+                                    <div 
+                                        class=\\"fd-navigation__item fd-navigation__item--menu\\"
+                                        title=\\"Product Specific\\"
+                                        aria-roledescription=\\"Navigation List Tree Item\\"
+                                        aria-selected=\\"false\\"
+                                        aria-expanded=\\"false\\"
+                                    >
+                                        <a class=\\"fd-navigation__link\\" role=\\"link\\" href=\\"#\\">
+                                            <span class=\\"fd-navigation__icon sap-icon--product\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+                                            <span class=\\"fd-navigation__text\\">Product Specific</span>
+                                            <span class=\\"fd-navigation__selection-indicator\\" aria-label=\\"selection indicator\\"></span>
+                                        </a>
+                                    </div>
+                                </li>
+                                <li class=\\"fd-navigation__list-item\\" role=\\"treeitem\\">
+                                    <div 
+                                        class=\\"fd-navigation__item fd-navigation__item--menu\\"
+                                        title=\\"Product Specific\\"
+                                        aria-roledescription=\\"Navigation List Tree Item\\"
+                                        aria-selected=\\"true\\"
+                                        aria-expanded=\\"false\\"
+                                    >
+                                        <a class=\\"fd-navigation__link\\" role=\\"link\\" href=\\"#\\">
+                                            <span class=\\"fd-navigation__icon sap-icon--flag\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+                                            <span class=\\"fd-navigation__text\\">Product Specific</span>
+                                            <span class=\\"fd-navigation__selection-indicator\\" aria-label=\\"selection indicator\\"></span>
+                                        </a>
+                                    </div>
+                                </li>
+                                <li class=\\"fd-navigation__list-item\\" role=\\"treeitem\\">
+                                    <div 
+                                        class=\\"fd-navigation__item fd-navigation__item--menu\\"
+                                        title=\\"Product Specific\\"
+                                        aria-roledescription=\\"Navigation List Tree Item\\"
+                                        aria-selected=\\"false\\"
+                                        aria-expanded=\\"false\\"
+                                    >
+                                        <a class=\\"fd-navigation__link\\" role=\\"link\\" href=\\"#\\">
+                                            <span class=\\"fd-navigation__icon sap-icon--card\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+                                            <span class=\\"fd-navigation__text\\">Product Specific</span>
+                                            <span class=\\"fd-navigation__selection-indicator\\" aria-label=\\"selection indicator\\"></span>
+                                        </a>
+                                    </div>
+                                </li>
+                                <li class=\\"fd-navigation__list-item\\" role=\\"treeitem\\">
+                                    <div 
+                                        class=\\"fd-navigation__item fd-navigation__item--menu\\"
+                                        title=\\"Legal Information\\"
+                                        aria-roledescription=\\"Navigation List Tree Item\\"
+                                        aria-selected=\\"false\\"
+                                        aria-expanded=\\"false\\"
+                                    >
+                                        <a class=\\"fd-navigation__link\\" role=\\"link\\" href=\\"#\\">
+                                            <span class=\\"fd-navigation__icon sap-icon--card\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+                                            <span class=\\"fd-navigation__text\\">Legal Information</span>
+                                            <span class=\\"fd-navigation__selection-indicator\\" aria-label=\\"selection indicator\\"></span>
+                                            <span class=\\"fd-navigation__has-children-indicator\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"has children indicator, expanded\\"></span>
+                                        </a>
+                                    </div>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+                <div class=\\"fd-user-menu__footer\\">
+                    <button class=\\"fd-button\\">Sign Out</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>"
 `;
 
 exports[`Check stories > Components/Action Bar > Story Actions > Should match snapshot 1`] = `


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/4313

## Description
- introduces the BTP variation of User Menu.
- the examples are placed under the BTP section
- adds new modifier class in the Navigation component for Menu Item `fd-navigation__item--menu`
- adds new element to Title Item for Back navigation `fd-navigation__back-indicator`