### PR TITLE
fix: shellbar category dropdown box-shadow invisibility

### DIFF
--- a/packages/styles/src/shellbar.scss
+++ b/packages/styles/src/shellbar.scss
@@ -367,10 +367,11 @@ $block: #{$fd-namespace}-shellbar;
 
           .#{$block}__search-category {
             box-shadow: var(--sapContent_Interaction_Shadow);
+            background-color: var(--fdShellbar_Search_Category_Button_Hover_Background);
           }
 
           .#{$block}__search-dropdown {
-            background-color: var(--fdShellbar_Search_Category_Button_Hover_Background);
+            background-color: transparent;
           }
         }
 


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#

## Description
Fixed shellbar category dropdown outline

## Screenshots

### Before:
<img width="175" alt="before" src="https://github.com/SAP/fundamental-styles/assets/28543391/b4167ea5-9c90-4181-8210-a492ed2a8002">


### After:
<img width="185" alt="after" src="https://github.com/SAP/fundamental-styles/assets/28543391/c15c4b90-5ff0-46fe-808d-e631dc837167">
