### PR TITLE
fix(styles): visible overflow when more dropdown is available

### DIFF
--- a/packages/doc-ui/src/components/DocsPage/custom.scss
+++ b/packages/doc-ui/src/components/DocsPage/custom.scss
@@ -679,10 +679,6 @@ body.sb-show-main {
   height: 11rem;
 }
 
-.fddocs-icon-tab-container .fd-icon-tab-bar__header {
-  overflow: visible;
-}
-
 @media (max-width: 600px) {
   .sbdocs-preview {
     min-width: calc(100% + 20px * 2);

--- a/packages/styles/src/icon-tab-bar.scss
+++ b/packages/styles/src/icon-tab-bar.scss
@@ -304,7 +304,10 @@ $fd-icon-tab-bar-semantic-values: (
     background: var(--sapObjectHeader_Background);
     min-height: 2.75rem;
     position: relative;
-    overflow-x: hidden;
+
+    &:has(.#{$block}__item--overflow) {
+      overflow: visible;
+    }
   }
 
   &__panel {


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#4813

## Description
- Removed `overflow-x: hidden`;
- Added case when overflow dropdown is available. In this case add `overflow: visible` for popovers that are bound inside icon tab bar would still be visible.

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://github.com/SAP/fundamental-styles/assets/6586561/039b80d4-79df-4fa2-95cb-7446403929ca)


### After:
![image](https://github.com/SAP/fundamental-styles/assets/6586561/f052ecc6-cb73-4397-9df0-82eb68a5bb1e)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
