### PR TITLE
fix(styles): input and select disabled placeholder

### DIFF
--- a/config/bundlesize.json
+++ b/config/bundlesize.json
@@ -2,7 +2,7 @@
     "files": [
         {
             "path": "./dist/packages/styles/dist/fundamental-styles.css",
-            "maxSize": "140 kB"
+            "maxSize": "150 kB"
         }
     ]
 }

--- a/packages/styles/src/mixins/_forms.scss
+++ b/packages/styles/src/mixins/_forms.scss
@@ -239,6 +239,7 @@ $fd-input-field-height--compact: 1.625rem;
 
     @if ($supportsText) {
       &::placeholder {
+        opacity: 0;
         color: var(--fdInput_Non_Interactive_State_Placeholder_Color);
       }
     }
@@ -249,6 +250,7 @@ $fd-input-field-height--compact: 1.625rem;
 
     @if ($supportsText) {
       &::placeholder {
+        opacity: 0;
         color: var(--fdInput_Non_Interactive_State_Placeholder_Color);
       }
     }

--- a/packages/styles/src/select.scss
+++ b/packages/styles/src/select.scss
@@ -63,8 +63,22 @@ $fd-select-padding-x-compact: 0.5rem;
         --fdSelect_Min_Width: 5rem;
       }
 
+      &[aria-selected='false'] {
+        .#{$block}__text-content {
+          visibility: hidden;
+        }
+      }
+
       .#{$block}__button {
         opacity: 0;
+      }
+    }
+
+    @include fd-disabled() {
+      &[aria-selected='false'] {
+        .#{$block}__text-content {
+          visibility: hidden;
+        }
       }
     }
 

--- a/packages/styles/stories/Components/Forms/input/primary.example.html
+++ b/packages/styles/stories/Components/Forms/input/primary.example.html
@@ -86,7 +86,7 @@
     <br />
     <div class="fd-form-item">
         <label class="fd-form-label" for="input-05">Disabled Input:</label>
-        <input class="fd-input" type="text" id="input-05" disabled value="Field placeholder text" placeholder="Field placeholder text">
+        <input class="fd-input" type="text" id="input-05" disabled placeholder="Field placeholder text">
     </div>
     <br />
     <div class="fd-form-item">

--- a/packages/styles/stories/Components/select/cozy.example.html
+++ b/packages/styles/stories/Components/select/cozy.example.html
@@ -114,7 +114,7 @@
 </div>
 
 <div style="height: 100px">
-    <label class="fd-form-label" id="cozySelectLabel">Disabled, Placeholder text</label><br />
+    <label class="fd-form-label" id="cozySelectLabel">In disabled state placeholder should not be visible</label><br />
     <div class="fd-popover">
         <div class="fd-popover__control" aria-expanded="false" aria-haspopup="true">
             <div class="fd-select">
@@ -137,7 +137,7 @@
 </div>
 
 <div style="height: 100px">
-    <label class="fd-form-label" id="cozySelectLabel">Read Only, Placeholder text</label><br />
+    <label class="fd-form-label" id="cozySelectLabel">In read-only state placeholder should not be visible</label><br />
     <div class="fd-popover">
         <div class="fd-popover__control" aria-expanded="false" aria-haspopup="true">
             <div class="fd-select">


### PR DESCRIPTION
## Related Issue
relates https://github.com/SAP/fundamental-styles/issues/4912

## Description
- Visual core states that placeholder should not be visible for any input when it's state is `readonly` or `disabled`. Same logic should be applied to a select component;
- Updated doc examples to resemble such visual states

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).