### PR TITLE
fix(styles): popover updates, and do not use menu in popover examples

### DIFF
--- a/packages/styles/src/popover.scss
+++ b/packages/styles/src/popover.scss
@@ -3,13 +3,8 @@
 
 $block: #{$fd-namespace}-popover;
 $blockBody: #{$fd-namespace}-popover__body;
-$bar: #{$fd-namespace}-bar;
 
 .#{$block} {
-  .#{$bar} {
-    @include fd-set-paddings-x-equal(0.5rem);
-  }
-
   @include fd-reset();
 
   position: relative;

--- a/packages/styles/src/popover.scss
+++ b/packages/styles/src/popover.scss
@@ -3,8 +3,13 @@
 
 $block: #{$fd-namespace}-popover;
 $blockBody: #{$fd-namespace}-popover__body;
+$bar: #{$fd-namespace}-bar;
 
 .#{$block} {
+  .#{$bar} {
+    @include fd-set-paddings-x-equal(0.5rem);
+  }
+
   @include fd-reset();
 
   position: relative;

--- a/packages/styles/src/theming/sap_fiori_3.scss
+++ b/packages/styles/src/theming/sap_fiori_3.scss
@@ -87,7 +87,7 @@
   /* Popover */
   --fdPopover_Border_Radius: var(--sapElement_BorderCornerRadius);
   --fdPopover_Border_Width: 0.0625rem;
-  --fdPopover_Border_Color: #878787;
+  --fdPopover_Border_Color: var(--sapNeutralBorderColor);
 
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: none;

--- a/packages/styles/src/theming/sap_fiori_3_dark.scss
+++ b/packages/styles/src/theming/sap_fiori_3_dark.scss
@@ -93,7 +93,7 @@
   /* Popover */
   --fdPopover_Border_Radius: var(--sapElement_BorderCornerRadius);
   --fdPopover_Border_Width: 0.0625rem;
-  --fdPopover_Border_Color: #8c8f91;
+  --fdPopover_Border_Color: var(--sapNeutralBorderColor);
 
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: none;

--- a/packages/styles/src/theming/sap_fiori_3_hcb.scss
+++ b/packages/styles/src/theming/sap_fiori_3_hcb.scss
@@ -97,7 +97,7 @@
   /* Popover */
   --fdPopover_Border_Radius: var(--sapElement_BorderCornerRadius);
   --fdPopover_Border_Width: 0.1875rem;
-  --fdPopover_Border_Color: #ffffff;
+  --fdPopover_Border_Color: var(--sapNeutralBorderColor);
 
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: 0 0 0.125rem #000;

--- a/packages/styles/src/theming/sap_fiori_3_hcw.scss
+++ b/packages/styles/src/theming/sap_fiori_3_hcw.scss
@@ -96,7 +96,7 @@
   /* Popover */
   --fdPopover_Border_Radius: var(--sapElement_BorderCornerRadius);
   --fdPopover_Border_Width: 0.1875rem;
-  --fdPopover_Border_Color: #000000;
+  --fdPopover_Border_Color: var(--sapNeutralBorderColor);
 
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: none;

--- a/packages/styles/src/theming/sap_fiori_3_light_dark.scss
+++ b/packages/styles/src/theming/sap_fiori_3_light_dark.scss
@@ -90,7 +90,7 @@
   /* Popover */
   --fdPopover_Border_Radius: var(--sapElement_BorderCornerRadius);
   --fdPopover_Border_Width: 0.0625rem;
-  --fdPopover_Border_Color: #878787;
+  --fdPopover_Border_Color: var(--sapNeutralBorderColor);
 
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: none;

--- a/packages/styles/src/theming/sap_horizon.scss
+++ b/packages/styles/src/theming/sap_horizon.scss
@@ -95,7 +95,7 @@
   /* Popover */
   --fdPopover_Border_Radius: var(--sapPopover_BorderCornerRadius);
   --fdPopover_Border_Width: 0.0625rem;
-  --fdPopover_Border_Color: #acb8c1;
+  --fdPopover_Border_Color: var(--sapNeutralBorderColor);
 
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: none;

--- a/packages/styles/stories/Components/popover/control-examples.example.html
+++ b/packages/styles/stories/Components/popover/control-examples.example.html
@@ -15,30 +15,9 @@
                             tabindex="0"></span>
                 </div>
                 <div class="fd-popover__body fd-popover__body--left" aria-hidden="false" id="popoverB2">
-                    <nav class="fd-menu" aria-label="navigation items">
-                        <ul class="fd-menu__list fd-menu__list--no-shadow">
-                            <li class="fd-menu__item">
-                                <a class="fd-menu__link" href="#">
-                                    <span class="fd-menu__title">Option 1</span>
-                                </a>
-                            </li>
-                            <li class="fd-menu__item">
-                                <a class="fd-menu__link" href="#">
-                                    <span class="fd-menu__title">Option 2</span>
-                                </a>
-                            </li>
-                            <li class="fd-menu__item">
-                                <a class="fd-menu__link" href="#">
-                                    <span class="fd-menu__title">Option 3</span>
-                                </a>
-                            </li>
-                            <li class="fd-menu__item">
-                                <a class="fd-menu__link" href="#">
-                                    <span class="fd-menu__title">Option 4</span>
-                                </a>
-                            </li>
-                        </ul>
-                    </nav>
+                <span class="fd-avatar fd-avatar--xl" role="img" style='margin: 1rem;' aria-label="Avatar">
+                    <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+                </span>
                 </div>
             </div>
         </div>
@@ -58,30 +37,9 @@
                     </button>
                 </div>
                 <div class="fd-popover__body" aria-hidden="false" id="popoverB4">
-                    <nav class="fd-menu" aria-label="options triggered by icon button">
-                        <ul class="fd-menu__list fd-menu__list--no-shadow">
-                            <li class="fd-menu__item">
-                                <a class="fd-menu__link" href="#">
-                                    <span class="fd-menu__title">Option 1</span>
-                                </a>
-                            </li>
-                            <li class="fd-menu__item">
-                                <a class="fd-menu__link" href="#">
-                                    <span class="fd-menu__title">Option 2</span>
-                                </a>
-                            </li>
-                            <li class="fd-menu__item">
-                                <a class="fd-menu__link" href="#">
-                                    <span class="fd-menu__title">Option 3</span>
-                                </a>
-                            </li>
-                            <li class="fd-menu__item">
-                                <a class="fd-menu__link" href="#">
-                                    <span class="fd-menu__title">Option 4</span>
-                                </a>
-                            </li>
-                        </ul>
-                    </nav>
+                    <span class="fd-avatar fd-avatar--xl" role="img" style='margin: 1rem;' aria-label="Avatar">
+                        <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+                    </span>
                 </div>
             </div>
         </div>

--- a/packages/styles/stories/Components/popover/no-arrow.example.html
+++ b/packages/styles/stories/Components/popover/no-arrow.example.html
@@ -13,20 +13,9 @@
     </div>
     <div class="fd-popover__body fd-popover__body--no-arrow" aria-hidden="false" id="popoverF1">
         <div class="fd-popover__wrapper" style="max-height: 250px;">
-            <nav class="fd-menu" aria-label="big navigation menu">
-                <ul class="fd-menu__list fd-menu__list--no-shadow">
-                    <li class="fd-menu__item">
-                        <a class="fd-menu__link" href="#">
-                            <span class="fd-menu__title">Option 1</span>
-                        </a>
-                    </li>
-                    <li class="fd-menu__item">
-                        <a class="fd-menu__link" href="#">
-                            <span class="fd-menu__title">Option 2</span>
-                        </a>
-                    </li>
-                </ul>
-            </nav>
+            <span class="fd-avatar fd-avatar--m" role="img" style='margin: 1rem;' aria-label="Avatar">
+                <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+            </span>
         </div>
     </div>
 </div>

--- a/packages/styles/stories/Components/popover/placement.example.html
+++ b/packages/styles/stories/Components/popover/placement.example.html
@@ -14,20 +14,9 @@
         </div>
         <div class="fd-popover__body fd-popover__body--above fd-popover__body--arrow-bottom" aria-hidden="false" id="popoverF1">
             <div class="fd-popover__wrapper" style="max-height: 250px;">
-                <nav class="fd-menu" aria-label="big navigation menu">
-                    <ul class="fd-menu__list fd-menu__list--no-shadow">
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 1</span>
-                            </a>
-                        </li>
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 2</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class="fd-avatar fd-avatar--m" role="img" style='margin: 1rem;' aria-label="Avatar">
+                    <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+                </span>
             </div>
         </div>
     </div>
@@ -47,20 +36,9 @@
         </div>
         <div class="fd-popover__body fd-popover__body--above fd-popover__body--center fd-popover__body--arrow-bottom fd-popover__body--arrow-x-center" aria-hidden="false" id="popoverF1a">
             <div class="fd-popover__wrapper" style="max-height: 250px;">
-                <nav class="fd-menu" aria-label="big navigation menu">
-                    <ul class="fd-menu__list fd-menu__list--no-shadow">
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 1</span>
-                            </a>
-                        </li>
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 2</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class="fd-avatar fd-avatar--m" role="img" style='margin: 1rem;' aria-label="Avatar">
+                    <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+                </span>
             </div>
         </div>
     </div>
@@ -80,20 +58,9 @@
         </div>
         <div class="fd-popover__body fd-popover__body--above fd-popover__body--right fd-popover__body--arrow-bottom fd-popover__body--arrow-x-end" aria-hidden="false" id="popoverF1b">
             <div class="fd-popover__wrapper" style="max-height: 250px;">
-                <nav class="fd-menu" aria-label="big navigation menu">
-                    <ul class="fd-menu__list fd-menu__list--no-shadow">
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 1</span>
-                            </a>
-                        </li>
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 2</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class="fd-avatar fd-avatar--m" role="img" style='margin: 1rem;' aria-label="Avatar">
+                    <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+                </span>
             </div>
         </div>
     </div>
@@ -115,20 +82,9 @@
         </div>
         <div class="fd-popover__body fd-popover__body--before fd-popover__body--arrow-right" aria-hidden="false" id="popoverF1c">
             <div class="fd-popover__wrapper" style="max-height: 250px;">
-                <nav class="fd-menu" aria-label="big navigation menu">
-                    <ul class="fd-menu__list fd-menu__list--no-shadow">
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 1</span>
-                            </a>
-                        </li>
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 2</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class="fd-avatar fd-avatar--m" role="img" style='margin: 1rem;' aria-label="Avatar">
+                    <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+                </span>
             </div>
         </div>
     </div>
@@ -148,20 +104,9 @@
         </div>
         <div class="fd-popover__body fd-popover__body--after fd-popover__body--arrow-left" aria-hidden="false" id="popoverF1d">
             <div class="fd-popover__wrapper" style="max-height: 250px;">
-                <nav class="fd-menu" aria-label="big navigation menu">
-                    <ul class="fd-menu__list fd-menu__list--no-shadow">
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 1</span>
-                            </a>
-                        </li>
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 2</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class="fd-avatar fd-avatar--m" role="img" style='margin: 1rem;' aria-label="Avatar">
+                    <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+                </span>
             </div>
         </div>
     </div>
@@ -183,20 +128,9 @@
         </div>
         <div class="fd-popover__body fd-popover__body--before fd-popover__body--middle fd-popover__body--arrow-right fd-popover__body--arrow-y-center" aria-hidden="false" id="popoverF1e">
             <div class="fd-popover__wrapper" style="max-height: 250px;">
-                <nav class="fd-menu" aria-label="big navigation menu">
-                    <ul class="fd-menu__list fd-menu__list--no-shadow">
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 1</span>
-                            </a>
-                        </li>
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 2</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class="fd-avatar fd-avatar--m" role="img" style='margin: 1rem;' aria-label="Avatar">
+                    <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+                </span>
             </div>
         </div>
     </div>
@@ -216,20 +150,9 @@
         </div>
         <div class="fd-popover__body fd-popover__body--after fd-popover__body--middle fd-popover__body--arrow-left fd-popover__body--arrow-y-center" aria-hidden="false" id="popoverF1f">
             <div class="fd-popover__wrapper" style="max-height: 250px;">
-                <nav class="fd-menu" aria-label="big navigation menu">
-                    <ul class="fd-menu__list fd-menu__list--no-shadow">
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 1</span>
-                            </a>
-                        </li>
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 2</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class="fd-avatar fd-avatar--m" role="img" style='margin: 1rem;' aria-label="Avatar">
+                    <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+                </span>
             </div>
         </div>
     </div>
@@ -251,20 +174,9 @@
         </div>
         <div class="fd-popover__body fd-popover__body--before fd-popover__body--bottom fd-popover__body--arrow-right fd-popover__body--arrow-y-bottom" aria-hidden="false" id="popoverF1g">
             <div class="fd-popover__wrapper" style="max-height: 250px;">
-                <nav class="fd-menu" aria-label="big navigation menu">
-                    <ul class="fd-menu__list fd-menu__list--no-shadow">
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 1</span>
-                            </a>
-                        </li>
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 2</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class="fd-avatar fd-avatar--m" role="img" style='margin: 1rem;' aria-label="Avatar">
+                    <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+                </span>
             </div>
         </div>
     </div>
@@ -284,20 +196,9 @@
         </div>
         <div class="fd-popover__body fd-popover__body--after fd-popover__body--bottom fd-popover__body--arrow-left fd-popover__body--arrow-y-bottom" aria-hidden="false" id="popoverF1h">
             <div class="fd-popover__wrapper" style="max-height: 250px;">
-                <nav class="fd-menu" aria-label="big navigation menu">
-                    <ul class="fd-menu__list fd-menu__list--no-shadow">
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 1</span>
-                            </a>
-                        </li>
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 2</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class="fd-avatar fd-avatar--m" role="img" style='margin: 1rem;' aria-label="Avatar">
+                    <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+                </span>
             </div>
         </div>
     </div>
@@ -319,20 +220,9 @@
         </div>
         <div class="fd-popover__body" aria-hidden="false" id="popoverF1i">
             <div class="fd-popover__wrapper" style="max-height: 250px;">
-                <nav class="fd-menu" aria-label="big navigation menu">
-                    <ul class="fd-menu__list fd-menu__list--no-shadow">
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 1</span>
-                            </a>
-                        </li>
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 2</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class="fd-avatar fd-avatar--m" role="img" style='margin: 1rem;' aria-label="Avatar">
+                    <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+                </span>
             </div>
         </div>
     </div>
@@ -352,20 +242,9 @@
         </div>
         <div class="fd-popover__body fd-popover__body--center fd-popover__body--arrow-x-center" aria-hidden="false" id="popoverF1j">
             <div class="fd-popover__wrapper" style="max-height: 250px;">
-                <nav class="fd-menu" aria-label="big navigation menu">
-                    <ul class="fd-menu__list fd-menu__list--no-shadow">
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 1</span>
-                            </a>
-                        </li>
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 2</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class="fd-avatar fd-avatar--m" role="img" style='margin: 1rem;' aria-label="Avatar">
+                    <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+                </span>
             </div>
         </div>
     </div>
@@ -385,20 +264,9 @@
         </div>
         <div class="fd-popover__body fd-popover__body--right fd-popover__body--arrow-x-end" aria-hidden="false" id="popoverF1k">
             <div class="fd-popover__wrapper" style="max-height: 250px;">
-                <nav class="fd-menu" aria-label="big navigation menu">
-                    <ul class="fd-menu__list fd-menu__list--no-shadow">
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 1</span>
-                            </a>
-                        </li>
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 2</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class="fd-avatar fd-avatar--m" role="img" style='margin: 1rem;' aria-label="Avatar">
+                    <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+                </span>
             </div>
         </div>
     </div>

--- a/packages/styles/stories/Components/popover/resizable.example.html
+++ b/packages/styles/stories/Components/popover/resizable.example.html
@@ -14,20 +14,9 @@
         </div>
         <div class="fd-popover__body fd-popover__body--above fd-popover__body--arrow-bottom fd-popover__body--resizable" aria-hidden="false" id="popoverF1r">
             <div class="fd-popover__wrapper" style="max-height: 250px;">
-                <nav class="fd-menu" aria-label="big navigation menu">
-                    <ul class="fd-menu__list fd-menu__list--no-shadow">
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 1</span>
-                            </a>
-                        </li>
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 2</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class="fd-avatar fd-avatar--m" role="img" style='margin: 1rem;' aria-label="Avatar">
+                    <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+                </span>
                 <span class="fd-popover__resize-handle"></span>
             </div>
         </div>
@@ -48,20 +37,9 @@
         </div>
         <div class="fd-popover__body fd-popover__body--above fd-popover__body--center fd-popover__body--arrow-bottom fd-popover__body--arrow-x-center fd-popover__body--resizable" aria-hidden="false" id="popoverF2r">
             <div class="fd-popover__wrapper" style="max-height: 250px;">
-                <nav class="fd-menu" aria-label="big navigation menu">
-                    <ul class="fd-menu__list fd-menu__list--no-shadow">
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 3</span>
-                            </a>
-                        </li>
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 4</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class="fd-avatar fd-avatar--m" role="img" style='margin: 1rem;' aria-label="Avatar">
+                    <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+                </span>
                 <span class="fd-popover__resize-handle"></span>
             </div>
         </div>
@@ -82,20 +60,9 @@
         </div>
         <div class="fd-popover__body fd-popover__body--above fd-popover__body--right fd-popover__body--arrow-bottom fd-popover__body--arrow-x-end fd-popover__body--resizable" aria-hidden="false" id="popoverF3r">
             <div class="fd-popover__wrapper" style="max-height: 250px;">
-                <nav class="fd-menu" aria-label="big navigation menu">
-                    <ul class="fd-menu__list fd-menu__list--no-shadow">
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 5</span>
-                            </a>
-                        </li>
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 6</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class="fd-avatar fd-avatar--m" role="img" style='margin: 1rem;' aria-label="Avatar">
+                    <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+                </span>
                 <span class="fd-popover__resize-handle"></span>
             </div>
         </div>
@@ -118,20 +85,9 @@
         </div>
         <div class="fd-popover__body fd-popover__body--before fd-popover__body--arrow-right fd-popover__body--resizable" aria-hidden="false" id="popoverF4r">
             <div class="fd-popover__wrapper" style="max-height: 250px;">
-                <nav class="fd-menu" aria-label="big navigation menu">
-                    <ul class="fd-menu__list fd-menu__list--no-shadow">
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 7</span>
-                            </a>
-                        </li>
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 8</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class="fd-avatar fd-avatar--m" role="img" style='margin: 1rem;' aria-label="Avatar">
+                    <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+                </span>
                 <span class="fd-popover__resize-handle"></span>
             </div>
         </div>
@@ -152,20 +108,9 @@
         </div>
         <div class="fd-popover__body fd-popover__body--after fd-popover__body--arrow-left fd-popover__body--resizable" aria-hidden="false" id="popoverF5r">
             <div class="fd-popover__wrapper" style="max-height: 250px;">
-                <nav class="fd-menu" aria-label="big navigation menu">
-                    <ul class="fd-menu__list fd-menu__list--no-shadow">
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 9</span>
-                            </a>
-                        </li>
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 10</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class="fd-avatar fd-avatar--m" role="img" style='margin: 1rem;' aria-label="Avatar">
+                    <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+                </span>
                 <span class="fd-popover__resize-handle"></span>
             </div>
         </div>
@@ -188,20 +133,9 @@
         </div>
         <div class="fd-popover__body fd-popover__body--before fd-popover__body--middle fd-popover__body--arrow-right fd-popover__body--arrow-y-center fd-popover__body--resizable" aria-hidden="false" id="popoverF6r">
             <div class="fd-popover__wrapper" style="max-height: 250px;">
-                <nav class="fd-menu" aria-label="big navigation menu">
-                    <ul class="fd-menu__list fd-menu__list--no-shadow">
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 11</span>
-                            </a>
-                        </li>
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 12</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class="fd-avatar fd-avatar--m" role="img" style='margin: 1rem;' aria-label="Avatar">
+                    <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+                </span>
                 <span class="fd-popover__resize-handle"></span>
             </div>
         </div>
@@ -222,20 +156,9 @@
         </div>
         <div class="fd-popover__body fd-popover__body--after fd-popover__body--middle fd-popover__body--arrow-left fd-popover__body--arrow-y-center fd-popover__body--resizable" aria-hidden="false" id="popoverF7r">
             <div class="fd-popover__wrapper" style="max-height: 250px;">
-                <nav class="fd-menu" aria-label="big navigation menu">
-                    <ul class="fd-menu__list fd-menu__list--no-shadow">
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 13</span>
-                            </a>
-                        </li>
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 14</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class="fd-avatar fd-avatar--m" role="img" style='margin: 1rem;' aria-label="Avatar">
+                    <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+                </span>
                 <span class="fd-popover__resize-handle"></span>
             </div>
         </div>
@@ -258,20 +181,9 @@
         </div>
         <div class="fd-popover__body fd-popover__body--before fd-popover__body--bottom fd-popover__body--arrow-right fd-popover__body--arrow-y-bottom fd-popover__body--resizable" aria-hidden="false" id="popoverF8r">
             <div class="fd-popover__wrapper" style="max-height: 250px;">
-                <nav class="fd-menu" aria-label="big navigation menu">
-                    <ul class="fd-menu__list fd-menu__list--no-shadow">
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 15</span>
-                            </a>
-                        </li>
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 16</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class="fd-avatar fd-avatar--m" role="img" style='margin: 1rem;' aria-label="Avatar">
+                    <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+                </span>
                 <span class="fd-popover__resize-handle"></span>
             </div>
         </div>
@@ -292,20 +204,9 @@
         </div>
         <div class="fd-popover__body fd-popover__body--after fd-popover__body--bottom fd-popover__body--arrow-left fd-popover__body--arrow-y-bottom fd-popover__body--resizable" aria-hidden="false" id="popoverF9r">
             <div class="fd-popover__wrapper" style="max-height: 250px;">
-                <nav class="fd-menu" aria-label="big navigation menu">
-                    <ul class="fd-menu__list fd-menu__list--no-shadow">
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 17</span>
-                            </a>
-                        </li>
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 18</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class="fd-avatar fd-avatar--m" role="img" style='margin: 1rem;' aria-label="Avatar">
+                    <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+                </span>
                 <span class="fd-popover__resize-handle"></span>
             </div>
         </div>
@@ -328,20 +229,9 @@
         </div>
         <div class="fd-popover__body fd-popover__body--resizable" aria-hidden="false" id="popoverF10r">
             <div class="fd-popover__wrapper" style="max-height: 250px;">
-                <nav class="fd-menu" aria-label="big navigation menu">
-                    <ul class="fd-menu__list fd-menu__list--no-shadow">
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 19</span>
-                            </a>
-                        </li>
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 20</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class="fd-avatar fd-avatar--m" role="img" style='margin: 1rem;' aria-label="Avatar">
+                    <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+                </span>
                 <span class="fd-popover__resize-handle"></span>
             </div>
         </div>
@@ -362,20 +252,9 @@
         </div>
         <div class="fd-popover__body fd-popover__body--center fd-popover__body--arrow-x-center fd-popover__body--resizable" aria-hidden="false" id="popoverF11r">
             <div class="fd-popover__wrapper" style="max-height: 250px;">
-                <nav class="fd-menu" aria-label="big navigation menu">
-                    <ul class="fd-menu__list fd-menu__list--no-shadow">
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 21</span>
-                            </a>
-                        </li>
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 22</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class="fd-avatar fd-avatar--m" role="img" style='margin: 1rem;' aria-label="Avatar">
+                    <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+                </span>
                 <span class="fd-popover__resize-handle"></span>
             </div>
         </div>
@@ -396,20 +275,9 @@
         </div>
         <div class="fd-popover__body fd-popover__body--right fd-popover__body--arrow-x-end fd-popover__body--resizable" aria-hidden="false" id="popoverF12r">
             <div class="fd-popover__wrapper" style="max-height: 250px;">
-                <nav class="fd-menu" aria-label="big navigation menu">
-                    <ul class="fd-menu__list fd-menu__list--no-shadow">
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 23</span>
-                            </a>
-                        </li>
-                        <li class="fd-menu__item">
-                            <a class="fd-menu__link" href="#">
-                                <span class="fd-menu__title">Option 24</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class="fd-avatar fd-avatar--m" role="img" style='margin: 1rem;' aria-label="Avatar">
+                    <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+                </span>
                 <span class="fd-popover__resize-handle"></span>
             </div>
         </div>

--- a/packages/styles/stories/Components/popover/scrollable.example.html
+++ b/packages/styles/stories/Components/popover/scrollable.example.html
@@ -13,50 +13,29 @@
     </div>
     <div class="fd-popover__body" aria-hidden="false" id="popoverF1">
         <div class="fd-popover__wrapper" style="max-height: 250px;">
-            <nav class="fd-menu" aria-label="big navigation menu">
-                <ul class="fd-menu__list fd-menu__list--no-shadow">
-                    <li class="fd-menu__item">
-                        <a class="fd-menu__link" href="#">
-                            <span class="fd-menu__title">Option 1</span>
-                        </a>
-                    </li>
-                    <li class="fd-menu__item">
-                        <a class="fd-menu__link" href="#">
-                            <span class="fd-menu__title">Option 2</span>
-                        </a>
-                    </li>
-                    <li class="fd-menu__item">
-                        <a class="fd-menu__link" href="#">
-                            <span class="fd-menu__title">Option 3</span>
-                        </a>
-                    </li>
-                    <li class="fd-menu__item">
-                        <a class="fd-menu__link" href="#">
-                            <span class="fd-menu__title">Option 4</span>
-                        </a>
-                    </li>
-                                    <li class="fd-menu__item">
-                        <a class="fd-menu__link" href="#">
-                            <span class="fd-menu__title">Option 5</span>
-                        </a>
-                    </li>
-                    <li class="fd-menu__item">
-                        <a class="fd-menu__link" href="#">
-                            <span class="fd-menu__title">Option 6</span>
-                        </a>
-                    </li>
-                    <li class="fd-menu__item">
-                        <a class="fd-menu__link" href="#">
-                            <span class="fd-menu__title">Option 7</span>
-                        </a>
-                    </li>
-                    <li class="fd-menu__item">
-                        <a class="fd-menu__link" href="#">
-                            <span class="fd-menu__title">Option 8</span>
-                        </a>
-                    </li>
-                </ul>
-            </nav>
+            <span class="fd-avatar fd-avatar--xl" role="img" style='margin: 1rem;' aria-label="Avatar">
+                <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+            </span>
+            <br/>
+            <span class="fd-avatar fd-avatar--xl" role="img" style='margin: 1rem;' aria-label="Avatar">
+                <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--customer"></i>
+            </span>
+            <br/>
+            <span class="fd-avatar fd-avatar--xl" role="img" style='margin: 1rem;' aria-label="Avatar">
+                <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--calendar"></i>
+            </span>
+            <br/>
+            <span class="fd-avatar fd-avatar--xl" role="img" style='margin: 1rem;' aria-label="Avatar">
+                <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--money-bills"></i>
+            </span>
+            <br/>
+            <span class="fd-avatar fd-avatar--xl" role="img" style='margin: 1rem;' aria-label="Avatar">
+                <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--cart"></i>
+            </span>
+            <br/>
+            <span class="fd-avatar fd-avatar--xl" role="img" style='margin: 1rem;' aria-label="Avatar">
+                <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+            </span>
         </div>
     </div>
 </div>

--- a/packages/styles/stories/Components/popover/variants.example.html
+++ b/packages/styles/stories/Components/popover/variants.example.html
@@ -27,25 +27,9 @@
                     </div>
                 </div>
             </div>
-            <nav class="fd-menu" aria-label="options with header">
-                <ul class="fd-menu__list fd-menu__list--no-shadow">
-                    <li class="fd-menu__item">
-                        <a class="fd-menu__link" href="#">
-                            <span class="fd-menu__title">Option 1</span>
-                        </a>
-                    </li>
-                    <li class="fd-menu__item">
-                        <a class="fd-menu__link" href="#">
-                            <span class="fd-menu__title">Option 2</span>
-                        </a>
-                    </li>
-                    <li class="fd-menu__item">
-                        <a class="fd-menu__link" href="#">
-                            <span class="fd-menu__title">Option 3</span>
-                        </a>
-                    </li>
-                </ul>
-            </nav>
+            <span class="fd-avatar fd-avatar--xl" role="img" style='margin: 1rem;' aria-label="Avatar">
+                <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+            </span>
         </div>
     </div>
 
@@ -63,25 +47,9 @@
                 </button>
         </div>
         <div class="fd-popover__body" aria-hidden="false" id="popoverHSF2">
-            <nav class="fd-menu" aria-label="options with footer">
-                <ul class="fd-menu__list fd-menu__list--no-shadow">
-                    <li class="fd-menu__item">
-                        <a class="fd-menu__link" href="#">
-                            <span class="fd-menu__title">Option 1</span>
-                        </a>
-                    </li>
-                    <li class="fd-menu__item">
-                        <a class="fd-menu__link" href="#">
-                            <span class="fd-menu__title">Option 2</span>
-                        </a>
-                    </li>
-                    <li class="fd-menu__item">
-                        <a class="fd-menu__link" href="#">
-                            <span class="fd-menu__title">Option 3</span>
-                        </a>
-                    </li>
-                </ul>
-            </nav>
+            <span class="fd-avatar fd-avatar--xl" role="img" style='margin: 1rem;' aria-label="Avatar">
+                <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+            </span>
             <div class="fd-popover__body-footer">
                 <div class="fd-bar is-compact fd-bar--footer">
                     <div class="fd-bar__right">
@@ -151,25 +119,9 @@
                     </div>
                 </div>
             </header>
-            <nav class="fd-menu" aria-label="options with header, subheader and footer">
-                <ul class="fd-menu__list fd-menu__list--no-shadow">
-                    <li class="fd-menu__item">
-                        <a class="fd-menu__link" href="#">
-                            <span class="fd-menu__title">Option 1</span>
-                        </a>
-                    </li>
-                    <li class="fd-menu__item">
-                        <a class="fd-menu__link" href="#">
-                            <span class="fd-menu__title">Option 2</span>
-                        </a>
-                    </li>
-                    <li class="fd-menu__item">
-                        <a class="fd-menu__link" href="#">
-                            <span class="fd-menu__title">Option 3</span>
-                        </a>
-                    </li>
-                </ul>
-            </nav>
+            <span class="fd-avatar fd-avatar--xl" role="img" style='margin: 1rem;' aria-label="Avatar">
+                <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+            </span>
             <footer class="fd-popover__body-footer">
                 <div class="fd-bar is-compact fd-bar--footer">
                     <div class="fd-bar__right">

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -31494,30 +31494,9 @@ exports[`Check stories > Components/Popover > Story ControlExamples > Should mat
                             tabindex=\\"0\\"></span>
                 </div>
                 <div class=\\"fd-popover__body fd-popover__body--left\\" aria-hidden=\\"false\\" id=\\"popoverB2\\">
-                    <nav class=\\"fd-menu\\" aria-label=\\"navigation items\\">
-                        <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                            <li class=\\"fd-menu__item\\">
-                                <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                    <span class=\\"fd-menu__title\\">Option 1</span>
-                                </a>
-                            </li>
-                            <li class=\\"fd-menu__item\\">
-                                <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                    <span class=\\"fd-menu__title\\">Option 2</span>
-                                </a>
-                            </li>
-                            <li class=\\"fd-menu__item\\">
-                                <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                    <span class=\\"fd-menu__title\\">Option 3</span>
-                                </a>
-                            </li>
-                            <li class=\\"fd-menu__item\\">
-                                <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                    <span class=\\"fd-menu__title\\">Option 4</span>
-                                </a>
-                            </li>
-                        </ul>
-                    </nav>
+                <span class=\\"fd-avatar fd-avatar--xl\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+                </span>
                 </div>
             </div>
         </div>
@@ -31537,30 +31516,9 @@ exports[`Check stories > Components/Popover > Story ControlExamples > Should mat
                     </button>
                 </div>
                 <div class=\\"fd-popover__body\\" aria-hidden=\\"false\\" id=\\"popoverB4\\">
-                    <nav class=\\"fd-menu\\" aria-label=\\"options triggered by icon button\\">
-                        <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                            <li class=\\"fd-menu__item\\">
-                                <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                    <span class=\\"fd-menu__title\\">Option 1</span>
-                                </a>
-                            </li>
-                            <li class=\\"fd-menu__item\\">
-                                <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                    <span class=\\"fd-menu__title\\">Option 2</span>
-                                </a>
-                            </li>
-                            <li class=\\"fd-menu__item\\">
-                                <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                    <span class=\\"fd-menu__title\\">Option 3</span>
-                                </a>
-                            </li>
-                            <li class=\\"fd-menu__item\\">
-                                <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                    <span class=\\"fd-menu__title\\">Option 4</span>
-                                </a>
-                            </li>
-                        </ul>
-                    </nav>
+                    <span class=\\"fd-avatar fd-avatar--xl\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                        <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+                    </span>
                 </div>
             </div>
         </div>
@@ -31643,23 +31601,13 @@ exports[`Check stories > Components/Popover > Story NoArrow > Should match snaps
     </div>
     <div class=\\"fd-popover__body fd-popover__body--no-arrow\\" aria-hidden=\\"false\\" id=\\"popoverF1\\">
         <div class=\\"fd-popover__wrapper\\" style=\\"max-height: 250px;\\">
-            <nav class=\\"fd-menu\\" aria-label=\\"big navigation menu\\">
-                <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                    <li class=\\"fd-menu__item\\">
-                        <a class=\\"fd-menu__link\\" href=\\"#\\">
-                            <span class=\\"fd-menu__title\\">Option 1</span>
-                        </a>
-                    </li>
-                    <li class=\\"fd-menu__item\\">
-                        <a class=\\"fd-menu__link\\" href=\\"#\\">
-                            <span class=\\"fd-menu__title\\">Option 2</span>
-                        </a>
-                    </li>
-                </ul>
-            </nav>
+            <span class=\\"fd-avatar fd-avatar--m\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+            </span>
         </div>
     </div>
-</div>"
+</div>
+"
 `;
 
 exports[`Check stories > Components/Popover > Story Placement > Should match snapshot 1`] = `
@@ -31679,20 +31627,9 @@ exports[`Check stories > Components/Popover > Story Placement > Should match sna
         </div>
         <div class=\\"fd-popover__body fd-popover__body--above fd-popover__body--arrow-bottom\\" aria-hidden=\\"false\\" id=\\"popoverF1\\">
             <div class=\\"fd-popover__wrapper\\" style=\\"max-height: 250px;\\">
-                <nav class=\\"fd-menu\\" aria-label=\\"big navigation menu\\">
-                    <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 1</span>
-                            </a>
-                        </li>
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 2</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class=\\"fd-avatar fd-avatar--m\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+                </span>
             </div>
         </div>
     </div>
@@ -31712,20 +31649,9 @@ exports[`Check stories > Components/Popover > Story Placement > Should match sna
         </div>
         <div class=\\"fd-popover__body fd-popover__body--above fd-popover__body--center fd-popover__body--arrow-bottom fd-popover__body--arrow-x-center\\" aria-hidden=\\"false\\" id=\\"popoverF1a\\">
             <div class=\\"fd-popover__wrapper\\" style=\\"max-height: 250px;\\">
-                <nav class=\\"fd-menu\\" aria-label=\\"big navigation menu\\">
-                    <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 1</span>
-                            </a>
-                        </li>
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 2</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class=\\"fd-avatar fd-avatar--m\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+                </span>
             </div>
         </div>
     </div>
@@ -31745,20 +31671,9 @@ exports[`Check stories > Components/Popover > Story Placement > Should match sna
         </div>
         <div class=\\"fd-popover__body fd-popover__body--above fd-popover__body--right fd-popover__body--arrow-bottom fd-popover__body--arrow-x-end\\" aria-hidden=\\"false\\" id=\\"popoverF1b\\">
             <div class=\\"fd-popover__wrapper\\" style=\\"max-height: 250px;\\">
-                <nav class=\\"fd-menu\\" aria-label=\\"big navigation menu\\">
-                    <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 1</span>
-                            </a>
-                        </li>
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 2</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class=\\"fd-avatar fd-avatar--m\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+                </span>
             </div>
         </div>
     </div>
@@ -31780,20 +31695,9 @@ exports[`Check stories > Components/Popover > Story Placement > Should match sna
         </div>
         <div class=\\"fd-popover__body fd-popover__body--before fd-popover__body--arrow-right\\" aria-hidden=\\"false\\" id=\\"popoverF1c\\">
             <div class=\\"fd-popover__wrapper\\" style=\\"max-height: 250px;\\">
-                <nav class=\\"fd-menu\\" aria-label=\\"big navigation menu\\">
-                    <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 1</span>
-                            </a>
-                        </li>
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 2</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class=\\"fd-avatar fd-avatar--m\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+                </span>
             </div>
         </div>
     </div>
@@ -31813,20 +31717,9 @@ exports[`Check stories > Components/Popover > Story Placement > Should match sna
         </div>
         <div class=\\"fd-popover__body fd-popover__body--after fd-popover__body--arrow-left\\" aria-hidden=\\"false\\" id=\\"popoverF1d\\">
             <div class=\\"fd-popover__wrapper\\" style=\\"max-height: 250px;\\">
-                <nav class=\\"fd-menu\\" aria-label=\\"big navigation menu\\">
-                    <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 1</span>
-                            </a>
-                        </li>
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 2</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class=\\"fd-avatar fd-avatar--m\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+                </span>
             </div>
         </div>
     </div>
@@ -31848,20 +31741,9 @@ exports[`Check stories > Components/Popover > Story Placement > Should match sna
         </div>
         <div class=\\"fd-popover__body fd-popover__body--before fd-popover__body--middle fd-popover__body--arrow-right fd-popover__body--arrow-y-center\\" aria-hidden=\\"false\\" id=\\"popoverF1e\\">
             <div class=\\"fd-popover__wrapper\\" style=\\"max-height: 250px;\\">
-                <nav class=\\"fd-menu\\" aria-label=\\"big navigation menu\\">
-                    <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 1</span>
-                            </a>
-                        </li>
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 2</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class=\\"fd-avatar fd-avatar--m\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+                </span>
             </div>
         </div>
     </div>
@@ -31881,20 +31763,9 @@ exports[`Check stories > Components/Popover > Story Placement > Should match sna
         </div>
         <div class=\\"fd-popover__body fd-popover__body--after fd-popover__body--middle fd-popover__body--arrow-left fd-popover__body--arrow-y-center\\" aria-hidden=\\"false\\" id=\\"popoverF1f\\">
             <div class=\\"fd-popover__wrapper\\" style=\\"max-height: 250px;\\">
-                <nav class=\\"fd-menu\\" aria-label=\\"big navigation menu\\">
-                    <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 1</span>
-                            </a>
-                        </li>
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 2</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class=\\"fd-avatar fd-avatar--m\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+                </span>
             </div>
         </div>
     </div>
@@ -31916,20 +31787,9 @@ exports[`Check stories > Components/Popover > Story Placement > Should match sna
         </div>
         <div class=\\"fd-popover__body fd-popover__body--before fd-popover__body--bottom fd-popover__body--arrow-right fd-popover__body--arrow-y-bottom\\" aria-hidden=\\"false\\" id=\\"popoverF1g\\">
             <div class=\\"fd-popover__wrapper\\" style=\\"max-height: 250px;\\">
-                <nav class=\\"fd-menu\\" aria-label=\\"big navigation menu\\">
-                    <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 1</span>
-                            </a>
-                        </li>
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 2</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class=\\"fd-avatar fd-avatar--m\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+                </span>
             </div>
         </div>
     </div>
@@ -31949,20 +31809,9 @@ exports[`Check stories > Components/Popover > Story Placement > Should match sna
         </div>
         <div class=\\"fd-popover__body fd-popover__body--after fd-popover__body--bottom fd-popover__body--arrow-left fd-popover__body--arrow-y-bottom\\" aria-hidden=\\"false\\" id=\\"popoverF1h\\">
             <div class=\\"fd-popover__wrapper\\" style=\\"max-height: 250px;\\">
-                <nav class=\\"fd-menu\\" aria-label=\\"big navigation menu\\">
-                    <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 1</span>
-                            </a>
-                        </li>
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 2</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class=\\"fd-avatar fd-avatar--m\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+                </span>
             </div>
         </div>
     </div>
@@ -31984,20 +31833,9 @@ exports[`Check stories > Components/Popover > Story Placement > Should match sna
         </div>
         <div class=\\"fd-popover__body\\" aria-hidden=\\"false\\" id=\\"popoverF1i\\">
             <div class=\\"fd-popover__wrapper\\" style=\\"max-height: 250px;\\">
-                <nav class=\\"fd-menu\\" aria-label=\\"big navigation menu\\">
-                    <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 1</span>
-                            </a>
-                        </li>
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 2</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class=\\"fd-avatar fd-avatar--m\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+                </span>
             </div>
         </div>
     </div>
@@ -32017,20 +31855,9 @@ exports[`Check stories > Components/Popover > Story Placement > Should match sna
         </div>
         <div class=\\"fd-popover__body fd-popover__body--center fd-popover__body--arrow-x-center\\" aria-hidden=\\"false\\" id=\\"popoverF1j\\">
             <div class=\\"fd-popover__wrapper\\" style=\\"max-height: 250px;\\">
-                <nav class=\\"fd-menu\\" aria-label=\\"big navigation menu\\">
-                    <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 1</span>
-                            </a>
-                        </li>
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 2</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class=\\"fd-avatar fd-avatar--m\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+                </span>
             </div>
         </div>
     </div>
@@ -32050,20 +31877,9 @@ exports[`Check stories > Components/Popover > Story Placement > Should match sna
         </div>
         <div class=\\"fd-popover__body fd-popover__body--right fd-popover__body--arrow-x-end\\" aria-hidden=\\"false\\" id=\\"popoverF1k\\">
             <div class=\\"fd-popover__wrapper\\" style=\\"max-height: 250px;\\">
-                <nav class=\\"fd-menu\\" aria-label=\\"big navigation menu\\">
-                    <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 1</span>
-                            </a>
-                        </li>
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 2</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class=\\"fd-avatar fd-avatar--m\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+                </span>
             </div>
         </div>
     </div>
@@ -32088,20 +31904,9 @@ exports[`Check stories > Components/Popover > Story Resizable > Should match sna
         </div>
         <div class=\\"fd-popover__body fd-popover__body--above fd-popover__body--arrow-bottom fd-popover__body--resizable\\" aria-hidden=\\"false\\" id=\\"popoverF1r\\">
             <div class=\\"fd-popover__wrapper\\" style=\\"max-height: 250px;\\">
-                <nav class=\\"fd-menu\\" aria-label=\\"big navigation menu\\">
-                    <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 1</span>
-                            </a>
-                        </li>
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 2</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class=\\"fd-avatar fd-avatar--m\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+                </span>
                 <span class=\\"fd-popover__resize-handle\\"></span>
             </div>
         </div>
@@ -32122,20 +31927,9 @@ exports[`Check stories > Components/Popover > Story Resizable > Should match sna
         </div>
         <div class=\\"fd-popover__body fd-popover__body--above fd-popover__body--center fd-popover__body--arrow-bottom fd-popover__body--arrow-x-center fd-popover__body--resizable\\" aria-hidden=\\"false\\" id=\\"popoverF2r\\">
             <div class=\\"fd-popover__wrapper\\" style=\\"max-height: 250px;\\">
-                <nav class=\\"fd-menu\\" aria-label=\\"big navigation menu\\">
-                    <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 3</span>
-                            </a>
-                        </li>
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 4</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class=\\"fd-avatar fd-avatar--m\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+                </span>
                 <span class=\\"fd-popover__resize-handle\\"></span>
             </div>
         </div>
@@ -32156,20 +31950,9 @@ exports[`Check stories > Components/Popover > Story Resizable > Should match sna
         </div>
         <div class=\\"fd-popover__body fd-popover__body--above fd-popover__body--right fd-popover__body--arrow-bottom fd-popover__body--arrow-x-end fd-popover__body--resizable\\" aria-hidden=\\"false\\" id=\\"popoverF3r\\">
             <div class=\\"fd-popover__wrapper\\" style=\\"max-height: 250px;\\">
-                <nav class=\\"fd-menu\\" aria-label=\\"big navigation menu\\">
-                    <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 5</span>
-                            </a>
-                        </li>
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 6</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class=\\"fd-avatar fd-avatar--m\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+                </span>
                 <span class=\\"fd-popover__resize-handle\\"></span>
             </div>
         </div>
@@ -32192,20 +31975,9 @@ exports[`Check stories > Components/Popover > Story Resizable > Should match sna
         </div>
         <div class=\\"fd-popover__body fd-popover__body--before fd-popover__body--arrow-right fd-popover__body--resizable\\" aria-hidden=\\"false\\" id=\\"popoverF4r\\">
             <div class=\\"fd-popover__wrapper\\" style=\\"max-height: 250px;\\">
-                <nav class=\\"fd-menu\\" aria-label=\\"big navigation menu\\">
-                    <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 7</span>
-                            </a>
-                        </li>
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 8</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class=\\"fd-avatar fd-avatar--m\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+                </span>
                 <span class=\\"fd-popover__resize-handle\\"></span>
             </div>
         </div>
@@ -32226,20 +31998,9 @@ exports[`Check stories > Components/Popover > Story Resizable > Should match sna
         </div>
         <div class=\\"fd-popover__body fd-popover__body--after fd-popover__body--arrow-left fd-popover__body--resizable\\" aria-hidden=\\"false\\" id=\\"popoverF5r\\">
             <div class=\\"fd-popover__wrapper\\" style=\\"max-height: 250px;\\">
-                <nav class=\\"fd-menu\\" aria-label=\\"big navigation menu\\">
-                    <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 9</span>
-                            </a>
-                        </li>
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 10</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class=\\"fd-avatar fd-avatar--m\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+                </span>
                 <span class=\\"fd-popover__resize-handle\\"></span>
             </div>
         </div>
@@ -32262,20 +32023,9 @@ exports[`Check stories > Components/Popover > Story Resizable > Should match sna
         </div>
         <div class=\\"fd-popover__body fd-popover__body--before fd-popover__body--middle fd-popover__body--arrow-right fd-popover__body--arrow-y-center fd-popover__body--resizable\\" aria-hidden=\\"false\\" id=\\"popoverF6r\\">
             <div class=\\"fd-popover__wrapper\\" style=\\"max-height: 250px;\\">
-                <nav class=\\"fd-menu\\" aria-label=\\"big navigation menu\\">
-                    <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 11</span>
-                            </a>
-                        </li>
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 12</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class=\\"fd-avatar fd-avatar--m\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+                </span>
                 <span class=\\"fd-popover__resize-handle\\"></span>
             </div>
         </div>
@@ -32296,20 +32046,9 @@ exports[`Check stories > Components/Popover > Story Resizable > Should match sna
         </div>
         <div class=\\"fd-popover__body fd-popover__body--after fd-popover__body--middle fd-popover__body--arrow-left fd-popover__body--arrow-y-center fd-popover__body--resizable\\" aria-hidden=\\"false\\" id=\\"popoverF7r\\">
             <div class=\\"fd-popover__wrapper\\" style=\\"max-height: 250px;\\">
-                <nav class=\\"fd-menu\\" aria-label=\\"big navigation menu\\">
-                    <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 13</span>
-                            </a>
-                        </li>
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 14</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class=\\"fd-avatar fd-avatar--m\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+                </span>
                 <span class=\\"fd-popover__resize-handle\\"></span>
             </div>
         </div>
@@ -32332,20 +32071,9 @@ exports[`Check stories > Components/Popover > Story Resizable > Should match sna
         </div>
         <div class=\\"fd-popover__body fd-popover__body--before fd-popover__body--bottom fd-popover__body--arrow-right fd-popover__body--arrow-y-bottom fd-popover__body--resizable\\" aria-hidden=\\"false\\" id=\\"popoverF8r\\">
             <div class=\\"fd-popover__wrapper\\" style=\\"max-height: 250px;\\">
-                <nav class=\\"fd-menu\\" aria-label=\\"big navigation menu\\">
-                    <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 15</span>
-                            </a>
-                        </li>
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 16</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class=\\"fd-avatar fd-avatar--m\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+                </span>
                 <span class=\\"fd-popover__resize-handle\\"></span>
             </div>
         </div>
@@ -32366,20 +32094,9 @@ exports[`Check stories > Components/Popover > Story Resizable > Should match sna
         </div>
         <div class=\\"fd-popover__body fd-popover__body--after fd-popover__body--bottom fd-popover__body--arrow-left fd-popover__body--arrow-y-bottom fd-popover__body--resizable\\" aria-hidden=\\"false\\" id=\\"popoverF9r\\">
             <div class=\\"fd-popover__wrapper\\" style=\\"max-height: 250px;\\">
-                <nav class=\\"fd-menu\\" aria-label=\\"big navigation menu\\">
-                    <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 17</span>
-                            </a>
-                        </li>
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 18</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class=\\"fd-avatar fd-avatar--m\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+                </span>
                 <span class=\\"fd-popover__resize-handle\\"></span>
             </div>
         </div>
@@ -32402,20 +32119,9 @@ exports[`Check stories > Components/Popover > Story Resizable > Should match sna
         </div>
         <div class=\\"fd-popover__body fd-popover__body--resizable\\" aria-hidden=\\"false\\" id=\\"popoverF10r\\">
             <div class=\\"fd-popover__wrapper\\" style=\\"max-height: 250px;\\">
-                <nav class=\\"fd-menu\\" aria-label=\\"big navigation menu\\">
-                    <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 19</span>
-                            </a>
-                        </li>
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 20</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class=\\"fd-avatar fd-avatar--m\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+                </span>
                 <span class=\\"fd-popover__resize-handle\\"></span>
             </div>
         </div>
@@ -32436,20 +32142,9 @@ exports[`Check stories > Components/Popover > Story Resizable > Should match sna
         </div>
         <div class=\\"fd-popover__body fd-popover__body--center fd-popover__body--arrow-x-center fd-popover__body--resizable\\" aria-hidden=\\"false\\" id=\\"popoverF11r\\">
             <div class=\\"fd-popover__wrapper\\" style=\\"max-height: 250px;\\">
-                <nav class=\\"fd-menu\\" aria-label=\\"big navigation menu\\">
-                    <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 21</span>
-                            </a>
-                        </li>
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 22</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class=\\"fd-avatar fd-avatar--m\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+                </span>
                 <span class=\\"fd-popover__resize-handle\\"></span>
             </div>
         </div>
@@ -32470,20 +32165,9 @@ exports[`Check stories > Components/Popover > Story Resizable > Should match sna
         </div>
         <div class=\\"fd-popover__body fd-popover__body--right fd-popover__body--arrow-x-end fd-popover__body--resizable\\" aria-hidden=\\"false\\" id=\\"popoverF12r\\">
             <div class=\\"fd-popover__wrapper\\" style=\\"max-height: 250px;\\">
-                <nav class=\\"fd-menu\\" aria-label=\\"big navigation menu\\">
-                    <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 23</span>
-                            </a>
-                        </li>
-                        <li class=\\"fd-menu__item\\">
-                            <a class=\\"fd-menu__link\\" href=\\"#\\">
-                                <span class=\\"fd-menu__title\\">Option 24</span>
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
+                <span class=\\"fd-avatar fd-avatar--m\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+                </span>
                 <span class=\\"fd-popover__resize-handle\\"></span>
             </div>
         </div>
@@ -32508,50 +32192,29 @@ exports[`Check stories > Components/Popover > Story Scrollable > Should match sn
     </div>
     <div class=\\"fd-popover__body\\" aria-hidden=\\"false\\" id=\\"popoverF1\\">
         <div class=\\"fd-popover__wrapper\\" style=\\"max-height: 250px;\\">
-            <nav class=\\"fd-menu\\" aria-label=\\"big navigation menu\\">
-                <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                    <li class=\\"fd-menu__item\\">
-                        <a class=\\"fd-menu__link\\" href=\\"#\\">
-                            <span class=\\"fd-menu__title\\">Option 1</span>
-                        </a>
-                    </li>
-                    <li class=\\"fd-menu__item\\">
-                        <a class=\\"fd-menu__link\\" href=\\"#\\">
-                            <span class=\\"fd-menu__title\\">Option 2</span>
-                        </a>
-                    </li>
-                    <li class=\\"fd-menu__item\\">
-                        <a class=\\"fd-menu__link\\" href=\\"#\\">
-                            <span class=\\"fd-menu__title\\">Option 3</span>
-                        </a>
-                    </li>
-                    <li class=\\"fd-menu__item\\">
-                        <a class=\\"fd-menu__link\\" href=\\"#\\">
-                            <span class=\\"fd-menu__title\\">Option 4</span>
-                        </a>
-                    </li>
-                                    <li class=\\"fd-menu__item\\">
-                        <a class=\\"fd-menu__link\\" href=\\"#\\">
-                            <span class=\\"fd-menu__title\\">Option 5</span>
-                        </a>
-                    </li>
-                    <li class=\\"fd-menu__item\\">
-                        <a class=\\"fd-menu__link\\" href=\\"#\\">
-                            <span class=\\"fd-menu__title\\">Option 6</span>
-                        </a>
-                    </li>
-                    <li class=\\"fd-menu__item\\">
-                        <a class=\\"fd-menu__link\\" href=\\"#\\">
-                            <span class=\\"fd-menu__title\\">Option 7</span>
-                        </a>
-                    </li>
-                    <li class=\\"fd-menu__item\\">
-                        <a class=\\"fd-menu__link\\" href=\\"#\\">
-                            <span class=\\"fd-menu__title\\">Option 8</span>
-                        </a>
-                    </li>
-                </ul>
-            </nav>
+            <span class=\\"fd-avatar fd-avatar--xl\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+            </span>
+            <br/>
+            <span class=\\"fd-avatar fd-avatar--xl\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--customer\\"></i>
+            </span>
+            <br/>
+            <span class=\\"fd-avatar fd-avatar--xl\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--calendar\\"></i>
+            </span>
+            <br/>
+            <span class=\\"fd-avatar fd-avatar--xl\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--money-bills\\"></i>
+            </span>
+            <br/>
+            <span class=\\"fd-avatar fd-avatar--xl\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--cart\\"></i>
+            </span>
+            <br/>
+            <span class=\\"fd-avatar fd-avatar--xl\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+            </span>
         </div>
     </div>
 </div>
@@ -32588,25 +32251,9 @@ exports[`Check stories > Components/Popover > Story Variants > Should match snap
                     </div>
                 </div>
             </div>
-            <nav class=\\"fd-menu\\" aria-label=\\"options with header\\">
-                <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                    <li class=\\"fd-menu__item\\">
-                        <a class=\\"fd-menu__link\\" href=\\"#\\">
-                            <span class=\\"fd-menu__title\\">Option 1</span>
-                        </a>
-                    </li>
-                    <li class=\\"fd-menu__item\\">
-                        <a class=\\"fd-menu__link\\" href=\\"#\\">
-                            <span class=\\"fd-menu__title\\">Option 2</span>
-                        </a>
-                    </li>
-                    <li class=\\"fd-menu__item\\">
-                        <a class=\\"fd-menu__link\\" href=\\"#\\">
-                            <span class=\\"fd-menu__title\\">Option 3</span>
-                        </a>
-                    </li>
-                </ul>
-            </nav>
+            <span class=\\"fd-avatar fd-avatar--xl\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+            </span>
         </div>
     </div>
 
@@ -32624,25 +32271,9 @@ exports[`Check stories > Components/Popover > Story Variants > Should match snap
                 </button>
         </div>
         <div class=\\"fd-popover__body\\" aria-hidden=\\"false\\" id=\\"popoverHSF2\\">
-            <nav class=\\"fd-menu\\" aria-label=\\"options with footer\\">
-                <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                    <li class=\\"fd-menu__item\\">
-                        <a class=\\"fd-menu__link\\" href=\\"#\\">
-                            <span class=\\"fd-menu__title\\">Option 1</span>
-                        </a>
-                    </li>
-                    <li class=\\"fd-menu__item\\">
-                        <a class=\\"fd-menu__link\\" href=\\"#\\">
-                            <span class=\\"fd-menu__title\\">Option 2</span>
-                        </a>
-                    </li>
-                    <li class=\\"fd-menu__item\\">
-                        <a class=\\"fd-menu__link\\" href=\\"#\\">
-                            <span class=\\"fd-menu__title\\">Option 3</span>
-                        </a>
-                    </li>
-                </ul>
-            </nav>
+            <span class=\\"fd-avatar fd-avatar--xl\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+            </span>
             <div class=\\"fd-popover__body-footer\\">
                 <div class=\\"fd-bar is-compact fd-bar--footer\\">
                     <div class=\\"fd-bar__right\\">
@@ -32712,25 +32343,9 @@ exports[`Check stories > Components/Popover > Story Variants > Should match snap
                     </div>
                 </div>
             </header>
-            <nav class=\\"fd-menu\\" aria-label=\\"options with header, subheader and footer\\">
-                <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                    <li class=\\"fd-menu__item\\">
-                        <a class=\\"fd-menu__link\\" href=\\"#\\">
-                            <span class=\\"fd-menu__title\\">Option 1</span>
-                        </a>
-                    </li>
-                    <li class=\\"fd-menu__item\\">
-                        <a class=\\"fd-menu__link\\" href=\\"#\\">
-                            <span class=\\"fd-menu__title\\">Option 2</span>
-                        </a>
-                    </li>
-                    <li class=\\"fd-menu__item\\">
-                        <a class=\\"fd-menu__link\\" href=\\"#\\">
-                            <span class=\\"fd-menu__title\\">Option 3</span>
-                        </a>
-                    </li>
-                </ul>
-            </nav>
+            <span class=\\"fd-avatar fd-avatar--xl\\" role=\\"img\\" style='margin: 1rem;' aria-label=\\"Avatar\\">
+                <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+            </span>
             <footer class=\\"fd-popover__body-footer\\">
                 <div class=\\"fd-bar is-compact fd-bar--footer\\">
                     <div class=\\"fd-bar__right\\">


### PR DESCRIPTION
part of #4912 

In the fundamental-ngx repo, we decided against using menus inside the popover examples, since menus have become their own thing with some quirks that make them not work well when inside popover bodies. So, like with the fundamental-ngx docs, I replaced the menus with avatars