### PR TITLE
fix: fixed font path to the sap-theming [ci visual]

### DIFF
--- a/packages/styles/src/fonts/sap_horizon_fonts.scss
+++ b/packages/styles/src/fonts/sap_horizon_fonts.scss
@@ -17,7 +17,7 @@
 @font-face {
   font-family: 'SAP-icons-TNT';
   src:
-    url('@sap-theming/theming-base-content/content/Base/baseLib/horizon/fonts/SAP-icons-TNT.woff')
+    url('@sap-theming/theming-base-content/content/Base/baseLib/sap_horizon/fonts/SAP-icons-TNT.woff')
     format('woff');
   font-weight: normal;
   font-style: normal;


### PR DESCRIPTION
## Description
Previous font path did not exist in theming base content