### PR TITLE
fix(styles): add fix for correct height for Title Bar ToolBar in compact state

### DIFF
--- a/packages/styles/src/toolbar.scss
+++ b/packages/styles/src/toolbar.scss
@@ -191,5 +191,9 @@ $block: #{$fd-namespace}-toolbar;
     &.#{$block}--title {
       --fdToolbar_Height: 2.75rem;
     }
+
+    &.#{$block}--title-bar {
+      --fdToolbar_Height: auto;
+    }
   }
 }


### PR DESCRIPTION

## Related Issue
Closes none

## Description
The height of Tool Bar when used with Title Bar should be auto in compact state.