### PR TITLE
fix(styles): change body border to allow optional footer [ci visual]

### DIFF
--- a/packages/styles/src/layout-panel.scss
+++ b/packages/styles/src/layout-panel.scss
@@ -90,7 +90,6 @@ $fd-layout-panel-element-border: solid 0.0625rem var(--sapGroup_TitleBorderColor
     height: 100%;
     padding: 1rem;
     display: block;
-    border-bottom: $fd-layout-panel-element-border;
 
     &--full-bleed,
     &--bleed {
@@ -111,6 +110,7 @@ $fd-layout-panel-element-border: solid 0.0625rem var(--sapGroup_TitleBorderColor
     @include fd-flex-horizontal-center();
 
     padding: 0.5rem 1rem;
+    border-top: $fd-layout-panel-element-border;
 
     &--end {
       justify-content: flex-end;


### PR DESCRIPTION
## Related Issue
Closes none, reported by CCP

## Description
When the border-bottom is applied to the body of the Layout Panel it appears when the footer is omitted. By moving the border to the footer it would allow to make the footer optional.