### PR TITLE
fix(styles): btp nav expander spanned state [ci visual]

### DIFF
--- a/packages/styles/src/navigation.scss
+++ b/packages/styles/src/navigation.scss
@@ -864,15 +864,19 @@ $navListContainerSubmenu: #{$block}__list-container--submenu;
     .#{$navItemWithExpander} {
       position: relative;
 
-      .#{$navLink} {
-        --fdNavigation_Link_Padding_Right: 2.1975rem;
-      }
-
       .#{$navExpander} {
         @include fd-set-position-right(var(--fdNavigation_Expander_Position_Right));
 
         position: absolute;
         z-index: 20;
+      }
+    }
+
+    &:not(.#{$block}--snapped) {
+      .#{$navItemWithExpander} {
+        .#{$navLink} {
+          --fdNavigation_Link_Padding_Right: 2.1975rem;
+        }
       }
     }
   }


### PR DESCRIPTION
## Related Issue
Closes none

## Description
Fixes the issue with list item with external expander button when navigation in snapped state

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://github.com/SAP/fundamental-styles/assets/6586561/6ae7924d-462a-4059-897e-324f9abd97cc)


### After:
![image](https://github.com/SAP/fundamental-styles/assets/6586561/081dcefa-e3c2-450c-bca1-fa2226827708)
