### PR TITLE
fix(styles): compact switch fiori

### DIFF
--- a/packages/styles/src/theming/common/switch/_sap_fiori.scss
+++ b/packages/styles/src/theming/common/switch/_sap_fiori.scss
@@ -4,8 +4,8 @@
   --fdSwitch_Compact_Height: 1rem;
   --fdSwitch_Compact_Handle_Width: 1.5rem;
   --fdSwitch_Compact_Handle_Height: var(--fdSwitch_Compact_Handle_Width);
-  --fdSwitch_Compact_Handle_Offset: 0.0625rem;
-  --fdSwitch_Compact_Active_Handle_Offset: -0.8125rem;
+  --fdSwitch_Compact_Handle_Offset: -0.8125rem;
+  --fdSwitch_Compact_Active_Handle_Offset: 0.0625rem;
   --fdSwitch_Compact_Padding: 0.625rem 0;
 
   // Standard


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-ngx/issues/11147

## Description
The issue appears with Compact switch and fiori 3 theme only.


## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:
![image](https://github.com/SAP/fundamental-styles/assets/6586561/0f44b06a-478a-4d5c-beea-19352a9a09f4)


### After:
![image](https://github.com/SAP/fundamental-styles/assets/6586561/1e53f77a-e339-4541-b44a-391b9132e25d)

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [x] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [x] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [x] tested Storybook examples with "CSS Resources" `normalize` option 
- [x] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [x] Verified all styles in IE11
- [x] Updated tests
- [x] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [x] Storybook documentation has been created/updated
- [x] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
