### PR TITLE
fix(styles): add a fix for hover state in Grid List [ci visual]

### DIFF
--- a/packages/styles/src/grid-list.scss
+++ b/packages/styles/src/grid-list.scss
@@ -20,7 +20,7 @@ $fd-grid-list-highlight: (
 
 @mixin fd-grid-list-item-interactive($setActive) {
   @include fd-hover() {
-    box-shadow: 0 0 0 0.0625rem var(--fdGrid_List_Item_Hover_Border_Color);
+    box-shadow: 0 0 0 0.0625rem var(--fdGrid_List_Item_Hover_Border_Color), var(--sapContent_Shadow2);
     background-color: $fd-grid-list-item-hover-background-color;
   }
 


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/5102

## Description
adds box-shadow --sapContent_Shadow2 on hover

Per design specs, on hover state the grid list item gets an all around border 0.0625rem solid var(--sapTile_Interactive_BorderColor) and box shadow --sapContent_Shadow2. 
Since the other states don't have border we implemented the border with box-shadow to not affect the size of the element. The box-shadow on hover is added as second in the chain. 