### PR TITLE
feat(styles): add full width modifier to Step Input [ci visual]

### DIFF
--- a/packages/styles/src/step-input.scss
+++ b/packages/styles/src/step-input.scss
@@ -23,6 +23,10 @@ $block: #{$fd-namespace}-step-input;
   align-items: center;
   padding: 0;
 
+  &--full-width {
+    width: 100%;
+  }
+
   & &__button.#{$fd-namespace}-button {
     width: var(--fdStepInput_Button_Width);
     min-width: var(--fdStepInput_Button_Width);

--- a/packages/styles/stories/Components/step-input/full-width.example.html
+++ b/packages/styles/stories/Components/step-input/full-width.example.html
@@ -1,0 +1,124 @@
+<label class="fd-form-label" for="step-3f">Default Step Input</label><br />
+<div class="fd-step-input fd-step-input--full-width">
+  <button aria-label="Step down" class="
+            fd-button
+            fd-button--transparent
+            fd-step-input__button" onclick="stepInputValue('step-3f', 'down');" tabindex="-1" type="button">
+    <i class="sap-icon--less"></i>
+  </button>
+  <input class="fd-input fd-input--no-number-spinner fd-step-input__input" id="step-3f" type="number" value="0" />
+  <button aria-label="Step up" class="
+            fd-button
+            fd-button--transparent
+            fd-step-input__button" onclick="stepInputValue('step-3f', 'up');" tabindex="-1" type="button">
+    <i class="sap-icon--add"></i>
+  </button>
+</div>
+
+<br><br>
+
+<label class="fd-form-label" for="step-5f">Success Step Input</label><br />
+<div class="fd-step-input is-success fd-step-input--full-width">
+        <button aria-label="Step down" class="
+            fd-button
+            fd-button--transparent
+            fd-step-input__button"
+            onclick="stepInputValue('step-5f', 'down');"
+            tabindex="-1" type="button">
+                <i class="sap-icon--less"></i>
+        </button>
+    <input class="
+            fd-input
+            fd-input--no-number-spinner
+            fd-step-input__input
+    " id="step-5f" type="number" value="0">
+        <button aria-label="Step up" class="
+            fd-button
+            fd-button--transparent
+            fd-step-input__button"
+            onclick="stepInputValue('step-5f', 'up');"
+            tabindex="-1" type="button">
+                <i class="sap-icon--add"></i>
+        </button>
+</div>
+
+<br><br>
+
+<label class="fd-form-label" for="step-6f">Information Step Input</label><br />
+<div class="fd-step-input is-information fd-step-input--full-width">
+        <button aria-label="Step down" class="
+            fd-button
+            fd-button--transparent
+            fd-step-input__button"
+            onclick="stepInputValue('step-6f', 'down');"
+            tabindex="-1" type="button">
+                <i class="sap-icon--less"></i>
+        </button>
+    <input class="
+            fd-input
+            fd-input--no-number-spinner
+            fd-step-input__input
+    " id="step-6f" type="number" value="0">
+        <button aria-label="Step up" class="
+            fd-button
+            fd-button--transparent
+            fd-step-input__button"
+            onclick="stepInputValue('step-6f', 'up');"
+            tabindex="-1" type="button">
+                <i class="sap-icon--add"></i>
+        </button>
+</div>
+
+<br><br>
+
+<label class="fd-form-label" for="step-7f">Error Step Input</label><br />
+<div class="fd-step-input is-error fd-step-input--full-width">
+        <button aria-label="Step down" class="
+            fd-button
+            fd-button--transparent
+            fd-step-input__button"
+            onclick="stepInputValue('step-7f', 'down');"
+            tabindex="-1" type="button">
+                <i class="sap-icon--less"></i>
+        </button>
+    <input class="
+            fd-input
+            fd-input--no-number-spinner
+            fd-step-input__input
+    " id="step-7f" type="number" value="0">
+        <button aria-label="Step up" class="
+            fd-button
+            fd-button--transparent
+            fd-step-input__button"
+            onclick="stepInputValue('step-7f', 'up');"
+            tabindex="-1" type="button">
+                <i class="sap-icon--add"></i>
+        </button>
+</div>
+
+<br><br>
+
+<label class="fd-form-label" for="step-8f">Warning Step Input</label><br />
+<div class="fd-step-input is-warning fd-step-input--full-width">
+    <button aria-label="Step down" class="
+        fd-button
+        fd-button--transparent
+        fd-step-input__button"
+        onclick="stepInputValue('step-8f', 'down');"
+        tabindex="-1" type="button">
+            <i class="sap-icon--less"></i>
+    </button>
+    <input class="
+        fd-input
+        fd-input--no-number-spinner
+        fd-step-input__input
+    " id="step-8f" type="number" value="0">
+    <button aria-label="Step up" class="
+        fd-button
+        fd-button--transparent
+        fd-step-input__button"
+        onclick="stepInputValue('step-8f', 'up');"
+        tabindex="-1" type="button">
+            <i class="sap-icon--add"></i>
+    </button>
+</div>

--- a/packages/styles/stories/Components/step-input/step-input.stories.js
+++ b/packages/styles/stories/Components/step-input/step-input.stories.js
@@ -3,6 +3,7 @@ import disabledExampleHtml from "./disabled.example.html?raw";
 import focusedExampleHtml from "./focused.example.html?raw";
 import statesExampleHtml from "./states.example.html?raw";
 import primaryExampleHtml from "./primary.example.html?raw";
+import fullWidthExampleHtml from "./full-width.example.html?raw";
 import '../../../src/button.scss';
 import '../../../src/icon.scss';
 import '../../../src/form-item.scss';
@@ -10,7 +11,7 @@ import '../../../src/step-input.scss';
 import '../../../src/form-label.scss';
 import '../../../src/input.scss';
 export default {
-  title: 'Components/StepInput',
+  title: 'Components/Step Input',
   parameters: {
     description: `
 The step input control allows the user to change the input values in predefined increments (steps).
@@ -83,6 +84,17 @@ ReadOnly.parameters = {
   docs: {
     description: {
       story: `Step input can be displayed as read-only by adding the \`is-readonly\` class to the main element.
+        `
+    }
+  }
+};
+
+export const FullWidth = () => fullWidthExampleHtml;
+FullWidth.storyName = 'Full Width';
+FullWidth.parameters = {
+  docs: {
+    description: {
+      story: `For Step Input that takes the whole width of the container element add the \`fd-step-input--full-width\` modifier class to the main element.
         `
     }
   }

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -5111,11 +5111,8 @@ exports[`Check stories > BTP/Splitter > Story GripAnatomy > Should match snapsho
 
 exports[`Check stories > BTP/Splitter > Story PaginationBarAnatomy > Should match snapshot 1`] = `
 "<div class=\\"fd-splitter\\" style=\\"height: 100px\\">
-    <div class='fd-splitter__pane-container fd-splitter__pane-container--vertical'>
-        <div class=\\"fd-splitter__split-pane fd-splitter__split-pane--solid\\">
-            Pane content
-        </div>
-        <div class='fd-splitter__pagination'>
+    <div class=\\"fd-splitter__pane-container fd-splitter__pane-container--horizontal\\">
+        <div class=\\"fd-splitter__pagination\\">
             <button class=\\"fd-button fd-button--nested fd-splitter__pagination-item\\">
                 <span class=\\"fd-splitter__pagination-item-dot\\"></span>
             </button>
@@ -39665,7 +39662,7 @@ exports[`Check stories > Components/Status Indicator > Story StatusIndicatorRadi
 "
 `;
 
-exports[`Check stories > Components/StepInput > Story Disabled > Should match snapshot 1`] = `
+exports[`Check stories > Components/Step Input > Story Disabled > Should match snapshot 1`] = `
 "<label class=\\"fd-form-label\\" for=\\"step-13\\">Disabled Step Input</label><br />
 <div class=\\"fd-step-input is-disabled\\">
         <button aria-label=\\"Step down\\" class=\\"
@@ -39693,7 +39690,7 @@ exports[`Check stories > Components/StepInput > Story Disabled > Should match sn
 "
 `;
 
-exports[`Check stories > Components/StepInput > Story Focused > Should match snapshot 1`] = `
+exports[`Check stories > Components/Step Input > Story Focused > Should match snapshot 1`] = `
 "<label class=\\"fd-form-label\\" for=\\"step-20\\">Focused Step Input</label><br />
 <div class=\\"fd-step-input is-focus\\">
         <button aria-label=\\"Step down\\" class=\\"
@@ -39825,7 +39822,135 @@ exports[`Check stories > Components/StepInput > Story Focused > Should match sna
 "
 `;
 
-exports[`Check stories > Components/StepInput > Story Primary > Should match snapshot 1`] = `
+exports[`Check stories > Components/Step Input > Story FullWidth > Should match snapshot 1`] = `
+"<label class=\\"fd-form-label\\" for=\\"step-3f\\">Default Step Input</label><br />
+<div class=\\"fd-step-input fd-step-input--full-width\\">
+  <button aria-label=\\"Step down\\" class=\\"
+            fd-button
+            fd-button--transparent
+            fd-step-input__button\\" onclick=\\"stepInputValue('step-3f', 'down');\\" tabindex=\\"-1\\" type=\\"button\\">
+    <i class=\\"sap-icon--less\\"></i>
+  </button>
+  <input class=\\"fd-input fd-input--no-number-spinner fd-step-input__input\\" id=\\"step-3f\\" type=\\"number\\" value=\\"0\\" />
+  <button aria-label=\\"Step up\\" class=\\"
+            fd-button
+            fd-button--transparent
+            fd-step-input__button\\" onclick=\\"stepInputValue('step-3f', 'up');\\" tabindex=\\"-1\\" type=\\"button\\">
+    <i class=\\"sap-icon--add\\"></i>
+  </button>
+</div>
+
+<br><br>
+
+<label class=\\"fd-form-label\\" for=\\"step-5f\\">Success Step Input</label><br />
+<div class=\\"fd-step-input is-success fd-step-input--full-width\\">
+        <button aria-label=\\"Step down\\" class=\\"
+            fd-button
+            fd-button--transparent
+            fd-step-input__button\\"
+            onclick=\\"stepInputValue('step-5f', 'down');\\"
+            tabindex=\\"-1\\" type=\\"button\\">
+                <i class=\\"sap-icon--less\\"></i>
+        </button>
+    <input class=\\"
+            fd-input
+            fd-input--no-number-spinner
+            fd-step-input__input
+    \\" id=\\"step-5f\\" type=\\"number\\" value=\\"0\\">
+        <button aria-label=\\"Step up\\" class=\\"
+            fd-button
+            fd-button--transparent
+            fd-step-input__button\\"
+            onclick=\\"stepInputValue('step-5f', 'up');\\"
+            tabindex=\\"-1\\" type=\\"button\\">
+                <i class=\\"sap-icon--add\\"></i>
+        </button>
+</div>
+
+<br><br>
+
+<label class=\\"fd-form-label\\" for=\\"step-6f\\">Information Step Input</label><br />
+<div class=\\"fd-step-input is-information fd-step-input--full-width\\">
+        <button aria-label=\\"Step down\\" class=\\"
+            fd-button
+            fd-button--transparent
+            fd-step-input__button\\"
+            onclick=\\"stepInputValue('step-6f', 'down');\\"
+            tabindex=\\"-1\\" type=\\"button\\">
+                <i class=\\"sap-icon--less\\"></i>
+        </button>
+    <input class=\\"
+            fd-input
+            fd-input--no-number-spinner
+            fd-step-input__input
+    \\" id=\\"step-6f\\" type=\\"number\\" value=\\"0\\">
+        <button aria-label=\\"Step up\\" class=\\"
+            fd-button
+            fd-button--transparent
+            fd-step-input__button\\"
+            onclick=\\"stepInputValue('step-6f', 'up');\\"
+            tabindex=\\"-1\\" type=\\"button\\">
+                <i class=\\"sap-icon--add\\"></i>
+        </button>
+</div>
+
+<br><br>
+
+<label class=\\"fd-form-label\\" for=\\"step-7f\\">Error Step Input</label><br />
+<div class=\\"fd-step-input is-error fd-step-input--full-width\\">
+        <button aria-label=\\"Step down\\" class=\\"
+            fd-button
+            fd-button--transparent
+            fd-step-input__button\\"
+            onclick=\\"stepInputValue('step-7f', 'down');\\"
+            tabindex=\\"-1\\" type=\\"button\\">
+                <i class=\\"sap-icon--less\\"></i>
+        </button>
+    <input class=\\"
+            fd-input
+            fd-input--no-number-spinner
+            fd-step-input__input
+    \\" id=\\"step-7f\\" type=\\"number\\" value=\\"0\\">
+        <button aria-label=\\"Step up\\" class=\\"
+            fd-button
+            fd-button--transparent
+            fd-step-input__button\\"
+            onclick=\\"stepInputValue('step-7f', 'up');\\"
+            tabindex=\\"-1\\" type=\\"button\\">
+                <i class=\\"sap-icon--add\\"></i>
+        </button>
+</div>
+
+<br><br>
+
+<label class=\\"fd-form-label\\" for=\\"step-8f\\">Warning Step Input</label><br />
+<div class=\\"fd-step-input is-warning fd-step-input--full-width\\">
+    <button aria-label=\\"Step down\\" class=\\"
+        fd-button
+        fd-button--transparent
+        fd-step-input__button\\"
+        onclick=\\"stepInputValue('step-8f', 'down');\\"
+        tabindex=\\"-1\\" type=\\"button\\">
+            <i class=\\"sap-icon--less\\"></i>
+    </button>
+    <input class=\\"
+        fd-input
+        fd-input--no-number-spinner
+        fd-step-input__input
+    \\" id=\\"step-8f\\" type=\\"number\\" value=\\"0\\">
+    <button aria-label=\\"Step up\\" class=\\"
+        fd-button
+        fd-button--transparent
+        fd-step-input__button\\"
+        onclick=\\"stepInputValue('step-8f', 'up');\\"
+        tabindex=\\"-1\\" type=\\"button\\">
+            <i class=\\"sap-icon--add\\"></i>
+    </button>
+</div>
+"
+`;
+
+exports[`Check stories > Components/Step Input > Story Primary > Should match snapshot 1`] = `
 "<label class=\\"fd-form-label\\" for=\\"step-3\\">Default Step Input</label><br />
 <div class=\\"fd-step-input\\">
   <button aria-label=\\"Step down\\" class=\\"
@@ -39862,7 +39987,7 @@ exports[`Check stories > Components/StepInput > Story Primary > Should match sna
 "
 `;
 
-exports[`Check stories > Components/StepInput > Story ReadOnly > Should match snapshot 1`] = `
+exports[`Check stories > Components/Step Input > Story ReadOnly > Should match snapshot 1`] = `
 "<label class=\\"fd-form-label\\" for=\\"step-14\\">Temperature set to</label><br />
 <div class=\\"fd-form-item fd-form-item--horizontal\\">
     <div class=\\"fd-step-input is-readonly\\">
@@ -39893,7 +40018,7 @@ exports[`Check stories > Components/StepInput > Story ReadOnly > Should match sn
 "
 `;
 
-exports[`Check stories > Components/StepInput > Story States > Should match snapshot 1`] = `
+exports[`Check stories > Components/Step Input > Story States > Should match snapshot 1`] = `
 "<label class=\\"fd-form-label\\" for=\\"step-5\\">Success Step Input</label><br />
 <div class=\\"fd-step-input is-success\\">
         <button aria-label=\\"Step down\\" class=\\"


### PR DESCRIPTION
## Related Issue
Closes none
Requested by CX app

## Description
The Step Input doesn't take the whole width of the container as it has by default `width: auto`. Added a new modifier class `fd-step-input--full-width` that would allow it to take the entire width of the container element.
