### PR TITLE
fix(styles): Avatar component v1.0.0 updates

### DIFF
--- a/packages/styles/src/_avatar-variables.scss
+++ b/packages/styles/src/_avatar-variables.scss
@@ -110,6 +110,14 @@ $fd-avatar-sizes: (
     "zoomIconFontSize": $fd-avatar-zoom-icon-font-size-s,
     "fontStretch": $fd-avatar-font-stretched-condensed
   ),
+  "sm": (
+    "ratio": ($fd-avatar-const-ratio * 3),
+    "font-size": 1.125rem,
+    "zoomIconDimensions": $fd-avatar-zoom-icon-s,
+    "offset": -0.125rem,
+    "zoomIconFontSize": $fd-avatar-zoom-icon-font-size-s,
+    "fontStretch": $fd-avatar-font-stretched-condensed
+  ),
   "m": (
     "ratio": ($fd-avatar-const-ratio * 4),
     "font-size": 1.5rem,
@@ -118,7 +126,23 @@ $fd-avatar-sizes: (
     "zoomIconFontSize": $fd-avatar-zoom-icon-font-size-s,
     "fontStretch": $fd-avatar-font-stretched-normal
   ),
+  "md": (
+    "ratio": ($fd-avatar-const-ratio * 4),
+    "font-size": 1.5rem,
+    "zoomIconDimensions": $fd-avatar-zoom-icon-s,
+    "offset": -0.125rem,
+    "zoomIconFontSize": $fd-avatar-zoom-icon-font-size-s,
+    "fontStretch": $fd-avatar-font-stretched-normal
+  ),
   "l": (
+    "ratio": ($fd-avatar-const-ratio * 5),
+    "font-size": 2.25rem,
+    "zoomIconDimensions": $fd-avatar-zoom-icon-l,
+    "offset": -0.1875rem,
+    "zoomIconFontSize": $fd-avatar-zoom-icon-font-size-l,
+    "fontStretch": $fd-avatar-font-stretched-normal
+  ),
+  "lg": (
     "ratio": ($fd-avatar-const-ratio * 5),
     "font-size": 2.25rem,
     "zoomIconDimensions": $fd-avatar-zoom-icon-l,

--- a/packages/styles/src/avatar.scss
+++ b/packages/styles/src/avatar.scss
@@ -41,15 +41,21 @@ $block: #{$fd-namespace}-avatar;
     }
 
     @include fd-active() {
-      --fdAvatarBorderColor: var(--sapButton_Selected_BorderColor);
-      --fdAvatarBackgroundColor: var(--sapButton_Selected_Background);
-      --fdAvatarColor: var(--sapButton_Selected_TextColor);
+      --fdAvatarBorderColor: var(--sapButton_Active_BorderColor);
+      --fdAvatarBackgroundColor: var(--sapButton_Active_Background);
+      --fdAvatarColor: var(--sapButton_Active_TextColor);
+
+      @include fd-hover() {
+        --fdAvatarBorderColor: var(--sapButton_Selected_Hover_BorderColor);
+        --fdAvatarBackgroundColor: var(--sapButton_Selected_Hover_Background);
+        --fdAvatarColor: var(--sapButton_Selected_TextColor);
+      }
     }
 
     @include fd-toggled() {
-      --fdAvatarBorderColor: var(--sapButton_Selected_BorderColor);
-      --fdAvatarBackgroundColor: var(--sapButton_Selected_Background);
-      --fdAvatarColor: var(--sapButton_Selected_TextColor);
+      --fdAvatarBorderColor: var(--sapButton_Active_BorderColor);
+      --fdAvatarBackgroundColor: var(--sapButton_Active_Background);
+      --fdAvatarColor: var(--sapButton_Active_TextColor);
 
       @include fd-hover() {
         --fdAvatarBorderColor: var(--sapButton_Selected_Hover_BorderColor);

--- a/packages/styles/stories/Components/avatar/accent-colors-shell-header-context.example.html
+++ b/packages/styles/stories/Components/avatar/accent-colors-shell-header-context.example.html
@@ -1,33 +1,33 @@
 
 <div style="background-color: var(--sapShellColor); padding: 1rem;">
-    <span class="fd-avatar fd-avatar--shell fd-avatar--accent-color-1 fd-avatar--m" aria-label="Avatar" aria-role="img">
-        <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <span class="fd-avatar fd-avatar--shell fd-avatar--accent-color-1 fd-avatar--md" aria-label="Avatar" aria-role="img">
+        <i class="fd-avatar__icon sap-icon--product" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
     </span>
-    <span class="fd-avatar fd-avatar--shell fd-avatar--accent-color-2 fd-avatar--m" aria-label="Avatar" aria-role="img">
-        <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <span class="fd-avatar fd-avatar--shell fd-avatar--accent-color-2 fd-avatar--md" aria-label="Avatar" aria-role="img">
+        <i class="fd-avatar__icon sap-icon--product" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
     </span>
-    <span class="fd-avatar fd-avatar--shell fd-avatar--accent-color-3 fd-avatar--m" aria-label="Avatar" aria-role="img">
-        <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <span class="fd-avatar fd-avatar--shell fd-avatar--accent-color-3 fd-avatar--md" aria-label="Avatar" aria-role="img">
+        <i class="fd-avatar__icon sap-icon--product" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
     </span>
-    <span class="fd-avatar fd-avatar--shell fd-avatar--accent-color-4 fd-avatar--m" aria-label="Avatar" aria-role="img">
-        <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <span class="fd-avatar fd-avatar--shell fd-avatar--accent-color-4 fd-avatar--md" aria-label="Avatar" aria-role="img">
+        <i class="fd-avatar__icon sap-icon--product" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
     </span>
-    <span class="fd-avatar fd-avatar--shell fd-avatar--accent-color-5 fd-avatar--m" aria-label="Avatar" aria-role="img">
-        <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <span class="fd-avatar fd-avatar--shell fd-avatar--accent-color-5 fd-avatar--md" aria-label="Avatar" aria-role="img">
+        <i class="fd-avatar__icon sap-icon--product" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
     </span>
-    <span class="fd-avatar fd-avatar--shell fd-avatar--accent-color-6 fd-avatar--m" aria-label="Avatar" aria-role="img">
-        <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <span class="fd-avatar fd-avatar--shell fd-avatar--accent-color-6 fd-avatar--md" aria-label="Avatar" aria-role="img">
+        <i class="fd-avatar__icon sap-icon--product" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
     </span>
-    <span class="fd-avatar fd-avatar--shell fd-avatar--accent-color-7 fd-avatar--m" aria-label="Avatar" aria-role="img">
-        <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <span class="fd-avatar fd-avatar--shell fd-avatar--accent-color-7 fd-avatar--md" aria-label="Avatar" aria-role="img">
+        <i class="fd-avatar__icon sap-icon--product" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
     </span>
-    <span class="fd-avatar fd-avatar--shell fd-avatar--accent-color-8 fd-avatar--m" aria-label="Avatar" aria-role="img">
-        <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <span class="fd-avatar fd-avatar--shell fd-avatar--accent-color-8 fd-avatar--md" aria-label="Avatar" aria-role="img">
+        <i class="fd-avatar__icon sap-icon--product" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
     </span>
-    <span class="fd-avatar fd-avatar--shell fd-avatar--accent-color-9 fd-avatar--m" aria-label="Avatar" aria-role="img">
-        <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <span class="fd-avatar fd-avatar--shell fd-avatar--accent-color-9 fd-avatar--md" aria-label="Avatar" aria-role="img">
+        <i class="fd-avatar__icon sap-icon--product" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
     </span>
-    <span class="fd-avatar fd-avatar--shell fd-avatar--accent-color-10 fd-avatar--m" aria-label="Avatar" aria-role="img">
-        <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <span class="fd-avatar fd-avatar--shell fd-avatar--accent-color-10 fd-avatar--md" aria-label="Avatar" aria-role="img">
+        <i class="fd-avatar__icon sap-icon--product" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
     </span>
 </div>

--- a/packages/styles/stories/Components/avatar/accent-colors.example.html
+++ b/packages/styles/stories/Components/avatar/accent-colors.example.html
@@ -1,31 +1,31 @@
 
-<span class="fd-avatar fd-avatar--accent-color-1 fd-avatar--m" aria-label="Avatar" aria-role="img">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+<span class="fd-avatar fd-avatar--accent-color-1 fd-avatar--md" aria-label="Avatar" aria-role="img">
+    <i class="fd-avatar__icon sap-icon--product" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
-<span class="fd-avatar fd-avatar--accent-color-2 fd-avatar--m" aria-label="Avatar" aria-role="img">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+<span class="fd-avatar fd-avatar--accent-color-2 fd-avatar--md" aria-label="Avatar" aria-role="img">
+    <i class="fd-avatar__icon sap-icon--product" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
-<span class="fd-avatar fd-avatar--accent-color-3 fd-avatar--m" aria-label="Avatar" aria-role="img">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+<span class="fd-avatar fd-avatar--accent-color-3 fd-avatar--md" aria-label="Avatar" aria-role="img">
+    <i class="fd-avatar__icon sap-icon--product" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
-<span class="fd-avatar fd-avatar--accent-color-4 fd-avatar--m" aria-label="Avatar" aria-role="img">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+<span class="fd-avatar fd-avatar--accent-color-4 fd-avatar--md" aria-label="Avatar" aria-role="img">
+    <i class="fd-avatar__icon sap-icon--product" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
-<span class="fd-avatar fd-avatar--accent-color-5 fd-avatar--m" aria-label="Avatar" aria-role="img">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+<span class="fd-avatar fd-avatar--accent-color-5 fd-avatar--md" aria-label="Avatar" aria-role="img">
+    <i class="fd-avatar__icon sap-icon--product" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
-<span class="fd-avatar fd-avatar--accent-color-6 fd-avatar--m" aria-label="Avatar" aria-role="img">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+<span class="fd-avatar fd-avatar--accent-color-6 fd-avatar--md" aria-label="Avatar" aria-role="img">
+    <i class="fd-avatar__icon sap-icon--product" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
-<span class="fd-avatar fd-avatar--accent-color-7 fd-avatar--m" aria-label="Avatar" aria-role="img">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+<span class="fd-avatar fd-avatar--accent-color-7 fd-avatar--md" aria-label="Avatar" aria-role="img">
+    <i class="fd-avatar__icon sap-icon--product" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
-<span class="fd-avatar fd-avatar--accent-color-8 fd-avatar--m" aria-label="Avatar" aria-role="img">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+<span class="fd-avatar fd-avatar--accent-color-8 fd-avatar--md" aria-label="Avatar" aria-role="img">
+    <i class="fd-avatar__icon sap-icon--product" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
-<span class="fd-avatar fd-avatar--accent-color-9 fd-avatar--m" aria-label="Avatar" aria-role="img">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+<span class="fd-avatar fd-avatar--accent-color-9 fd-avatar--md" aria-label="Avatar" aria-role="img">
+    <i class="fd-avatar__icon sap-icon--product" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
-<span class="fd-avatar fd-avatar--accent-color-10 fd-avatar--m" aria-label="Avatar" aria-role="img">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+<span class="fd-avatar fd-avatar--accent-color-10 fd-avatar--md" aria-label="Avatar" aria-role="img">
+    <i class="fd-avatar__icon sap-icon--product" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>

--- a/packages/styles/stories/Components/avatar/avatar.stories.js
+++ b/packages/styles/stories/Components/avatar/avatar.stories.js
@@ -40,14 +40,14 @@ The avatar control is adaptive and has five predefined sizes. These are the same
 | **Size** | **rem** | &nbsp;&nbsp; **Use for images in…** | **Modifier class** |
 | :--------- | ----------: | :----------------------- | :--------------- |
 | XS | 2 rem | &nbsp;&nbsp; Table list items, Card list items &nbsp;&nbsp;  | \`fd-avatar--xs\` |
-| S | 3 rem | &nbsp;&nbsp; Card headers, Card list items &nbsp;&nbsp; | \`fd-avatar--s\` |
-| M | 4 rem | &nbsp;&nbsp; App headers for small screen sizes &nbsp;&nbsp; | \`fd-avatar--m\` |
-| L | 5 rem | &nbsp;&nbsp; App headers for normal screen sizes &nbsp;&nbsp; | \`fd-avatar--l\` |
+| S | 3 rem | &nbsp;&nbsp; Card headers, Card list items &nbsp;&nbsp; | \`fd-avatar--s\` or <br/>\`fd-avatar--sm\` |
+| M | 4 rem | &nbsp;&nbsp; App headers for small screen sizes &nbsp;&nbsp; | \`fd-avatar--m\` or <br/>\`fd-avatar--md\` |
+| L | 5 rem | &nbsp;&nbsp; App headers for normal screen sizes &nbsp;&nbsp; | \`fd-avatar--l\` or <br/>\`fd-avatar--lg\` |
 | XL | 7 rem | &nbsp;&nbsp; App headers for large screen sizes &nbsp;&nbsp; | \`fd-avatar--xl\` |
 
 <br><br><br>
 `,
-    tags: ['a11y', 'f3', 'theme']
+    tags: []
   }
 };
 const localStyles = `
@@ -60,36 +60,14 @@ const localStyles = `
 
 </style>
 `;
-export const Icon = () => iconExampleHtml;
-Icon.parameters = {
-  docs: {
-    description: {
-      story: 'The icon avatar can be used to display non-interactive icons. If you want the icon to be interactive, use the **Button** component with an icon inside instead. <br><br>When using the icon avatar for illustrative purposes only, include `role="presentation"` in the element.'
-    }
-  }
-};
-export const Initials = () => initialsExampleHtml;
-Initials.parameters = {
-  docs: {
-    description: {
-      story: 'The initials avatar can display up to three alphabetical characters representing the first and last name(s) of a person, for example: MvV for Marjolein van Veen. The order in which the first and last name(s) are displayed depends on the language-specific settings.<br><br> When there is no equivalent text for the avatar, include `aria-label` in the element. This isn’t necessary if the avatar is used for illustrative purposes only. See **Icon** above.'
-    }
-  }
-};
-export const Circle = () => circleExampleHtml;
-Circle.parameters = {
-  docs: {
-    description: {
-      story: 'A circle style can be displayed by adding the `fd-avatar--circle` modifier class to the `fd-avatar` base class.'
-    }
-  }
-};
+
 export const BackgroundImage = () => backgroundImageExampleHtml;
+BackgroundImage.storyName = 'Image, Person';
 BackgroundImage.parameters = {
   docs: {
     description: {
-      story: `
-A background image can be displayed by adding the \`fd-avatar--thumbnail\` modifier class.
+      story: `An avatar is a visual representation of an user or a product in the digital space. For representing a person, the circular shape is used. For representing a product or object, the square shape is used. <br/>
+This type of Avatar requires the \`fd-avatar--thumbnail\` modifier class.
 There are two options to set the background: Cover (default) and Contain.
 
 - <b>Cover:</b> The size of the image is scaled up to completely cover the control area. As a result, parts of the image may be outside the shape.
@@ -99,6 +77,34 @@ Changing the default \`background-size: cover\` to \`background-size: contain\` 
     }
   }
 };
+
+export const Initials = () => initialsExampleHtml;
+Initials.parameters = {
+  docs: {
+    description: {
+      story: `The initials avatar can display up to <b style="color: red;">three</b> alphabetical characters representing the first and last name(s) of a person, for example: MvV for Marjolein van Veen. The order in which the first and last name(s) are displayed depends on the language-specific settings. If more than 3 initials are required to display longer names, then a gender-neutral person icon should be displayed instead. If the three letters does not fit in the shape (e.g. WWW), then the genderneutral person icon is used as a fallback.`
+    }
+  }
+};
+
+export const Icon = () => iconExampleHtml;
+Icon.parameters = {
+  docs: {
+    description: {
+      story: 'Placeholders are used when there is no other image available. Avatar and standardized images require placeholders.'
+    }
+  }
+};
+
+export const Circle = () => circleExampleHtml;
+Circle.parameters = {
+  docs: {
+    description: {
+      story: ' The circular shape is used mainly to represent a person. For this type of Avatar use the `fd-avatar--circle` modifier class with the `fd-avatar` base class.'
+    }
+  }
+};
+
 export const Transparent = () => transparentExampleHtml;
 Transparent.parameters = {
   docs: {
@@ -124,14 +130,16 @@ TileIconBackground.parameters = {
   }
 };
 export const AccentColors = () => accentColorsExampleHtml;
+AccentColors.storyName = 'Color variations';
 AccentColors.parameters = {
   docs: {
     description: {
-      story: 'To change the accent background color, add the `fd-avatar--accent-color-*` class with the number indicating the desired color. The color options include numbers ranging from 1 to 10, for example: `fd-avatar--accent-color-10`.'
+      story: 'The Avatar can have different background colors depending on the scenario. To change the accent background color, add the `fd-avatar--accent-color-*` class with the number indicating the desired color. The color options include numbers ranging from 1 to 10, for example: `fd-avatar--accent-color-10`.'
     }
   }
 };
 export const AccentColorsShellHeaderContext = () => accentColorsShellHeaderContextExampleHtml;
+AccentColorsShellHeaderContext.storyName = 'Color variations in Shell header context';
 AccentColorsShellHeaderContext.parameters = {
   docs: {
     description: {
@@ -167,19 +175,19 @@ Borders.parameters = {
 export const Interactive = () => `${localStyles}
 <h3>Regular State</h3>
 <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--accent-color-1" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--accent-color-2" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--accent-color-3" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--accent-color-4" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--accent-color-5" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--accent-color-6 fd-avatar--xs" tabindex="0" role="button" aria-label="Wendy Wallace">WW
 </span>
@@ -192,15 +200,15 @@ export const Interactive = () => `${localStyles}
 <span class="fd-avatar fd-avatar--accent-color-10 fd-avatar--xl" tabindex="0" role="button" aria-label="Wendy Wallace">WW
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--placeholder" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--tile" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--thumbnail" tabindex="0" role="button" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" role="img" aria-label="John Doe"></span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent" tabindex="0" role="button" aria-label="Wendy Wallace">WW</span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--transparent fd-avatar--border" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent fd-avatar--border" tabindex="0" role="button" aria-label="Wendy Wallace">WW
 </span>
@@ -209,19 +217,19 @@ export const Interactive = () => `${localStyles}
 <h3>Hover State</h3>
 
 <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--accent-color-1 is-hover" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--accent-color-2 is-hover" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--accent-color-3 is-hover" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--accent-color-4 is-hover" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--accent-color-5 is-hover" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--accent-color-6 fd-avatar--xs is-hover" tabindex="0" role="button" aria-label="Wendy Wallace">WW
 </span>
@@ -234,15 +242,15 @@ export const Interactive = () => `${localStyles}
 <span class="fd-avatar fd-avatar--accent-color-10 fd-avatar--xl is-hover" tabindex="0" role="button" aria-label="Wendy Wallace">WW
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--placeholder is-hover" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--tile is-hover" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--thumbnail is-hover" tabindex="0" role="button" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" role="img" aria-label="John Doe"></span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent is-hover" tabindex="0" role="button" aria-label="Wendy Wallace">WW</span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--transparent fd-avatar--border is-hover" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent fd-avatar--border is-hover" tabindex="0" role="button" aria-label="Wendy Wallace">WW
 </span>
@@ -252,19 +260,19 @@ export const Interactive = () => `${localStyles}
 <h3>Active/Toggled State</h3>
 
 <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--accent-color-1 is-active" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--accent-color-2 is-active" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--accent-color-3 is-active" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--accent-color-4 is-active" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--accent-color-5 is-active" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--accent-color-6 fd-avatar--xs is-active" tabindex="0" role="button" aria-label="Wendy Wallace">WW
 </span>
@@ -277,15 +285,15 @@ export const Interactive = () => `${localStyles}
 <span class="fd-avatar fd-avatar--accent-color-10 fd-avatar--xl is-active" tabindex="0" role="button" aria-label="Wendy Wallace">WW
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--placeholder is-active" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--tile is-active" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--thumbnail is-active" tabindex="0" role="button" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" role="img" aria-label="John Doe"></span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent is-active" tabindex="0" role="button" aria-label="Wendy Wallace">WW</span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--transparent fd-avatar--border is-active" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent fd-avatar--border is-active" tabindex="0" role="button" aria-label="Wendy Wallace">WW
 </span>
@@ -294,19 +302,19 @@ export const Interactive = () => `${localStyles}
 <h3>Toggled Hover State</h3>
 
 <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--accent-color-1 is-toggled is-hover" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--accent-color-2 is-toggled is-hover" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--accent-color-3 is-toggled is-hover" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--accent-color-4 is-toggled is-hover" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--accent-color-5 is-toggled is-hover" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--accent-color-6 fd-avatar--xs is-toggled is-hover" tabindex="0" role="button" aria-label="Wendy Wallace">WW
 </span>
@@ -319,15 +327,15 @@ export const Interactive = () => `${localStyles}
 <span class="fd-avatar fd-avatar--accent-color-10 fd-avatar--xl is-toggled is-hover" tabindex="0" role="button" aria-label="Wendy Wallace">WW
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--placeholder is-toggled is-hover" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--tile is-toggled is-hover" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--thumbnail is-toggled is-hover" tabindex="0" role="button" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" role="img" aria-label="John Doe"></span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent is-toggled is-hover"  tabindex="0" role="button"aria-label="Wendy Wallace">WW</span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--transparent fd-avatar--border is-toggled is-hover"  tabindex="0" role="button"aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent fd-avatar--border is-toggled is-hover" tabindex="0" role="button" aria-label="Wendy Wallace">WW
 </span>
@@ -336,19 +344,19 @@ export const Interactive = () => `${localStyles}
 <h3>Disabled State</h3>
 
 <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--accent-color-1 is-disabled" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--accent-color-2 is-disabled" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--accent-color-3 is-disabled" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--accent-color-4 is-disabled" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--accent-color-5 is-disabled" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--accent-color-6 fd-avatar--xs is-disabled" role="button" aria-label="Wendy Wallace">WW
 </span>
@@ -361,15 +369,15 @@ export const Interactive = () => `${localStyles}
 <span class="fd-avatar fd-avatar--accent-color-10 fd-avatar--xl is-disabled" role="button" aria-label="Wendy Wallace">WW
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--placeholder is-disabled" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--tile is-disabled" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--thumbnail is-disabled" role="button" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" role="img" aria-label="John Doe"></span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent is-disabled" role="button" aria-label="Wendy Wallace">WW</span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--transparent fd-avatar--border is-disabled"  role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent fd-avatar--border is-disabled" role="button" aria-label="Wendy Wallace">WW
 </span>
@@ -379,19 +387,19 @@ export const Interactive = () => `${localStyles}
 <h3>Focus State</h3>
 
 <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--accent-color-1 is-focus" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--accent-color-2 is-focus" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--accent-color-3 is-focus" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--accent-color-4 is-focus" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--accent-color-5 is-focus" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--accent-color-6 fd-avatar--xs is-focus" tabindex="0" role="button" aria-label="Wendy Wallace">WW
 </span>
@@ -404,15 +412,15 @@ export const Interactive = () => `${localStyles}
 <span class="fd-avatar fd-avatar--accent-color-10 fd-avatar--xl is-focus" tabindex="0" role="button" aria-label="Wendy Wallace">WW
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--placeholder is-focus" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--tile is-focus" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--thumbnail is-focus" tabindex="0" role="button" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" role="img" aria-label="John Doe"></span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent is-focus" tabindex="0" role="button" aria-label="Wendy Wallace">WW</span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--transparent fd-avatar--border is-focus" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent fd-avatar--border is-focus" tabindex="0" role="button" aria-label="Wendy Wallace">WW
 </span>

--- a/packages/styles/stories/Components/avatar/avatar.stories.js
+++ b/packages/styles/stories/Components/avatar/avatar.stories.js
@@ -15,8 +15,8 @@ import '../../../src/icon.scss';
 export default {
   title: 'Components/Avatar',
   parameters: {
-    description: `The avatar component displays an image, icon or user initials, and is used for user profiles, placeholder images, icons or business-related images i.e. product photos. <br>
-        For detailed information check Fiori Design Guidelines for <a target="_blank" href="https://experience.sap.com/fiori-design-web/avatar/">Avatar</a> component. 
+    description: `The avatar control is used for presenting various images, including user profiles, user initials, placeholder images, icons, or business-related images like product pictures.<br>
+    For detailed information check Fiori Design Guidelines for <a target="_blank" href="https://experience.sap.com/fiori-design-web/avatar/">Avatar</a> component. 
 
 
 ## Usage
@@ -91,7 +91,7 @@ export const Icon = () => iconExampleHtml;
 Icon.parameters = {
   docs: {
     description: {
-      story: 'Placeholders are used when there is no other image available. Avatar and standardized images require placeholders.'
+      story: 'Placeholders are used when there is no other image available. Avatar and standardized images require placeholders. The default placeholder for an avatar is a gender-neutral person icon inside a circle. The default placeholder for a business image is a neutral product icon inside a square.'
     }
   }
 };
@@ -100,7 +100,7 @@ export const Circle = () => circleExampleHtml;
 Circle.parameters = {
   docs: {
     description: {
-      story: ' The circular shape is used mainly to represent a person. For this type of Avatar use the `fd-avatar--circle` modifier class with the `fd-avatar` base class.'
+      story: ' The circular shape is used mainly to represent a person. For this type of Avatar use the `fd-avatar--circle` modifier class with the `fd-avatar` base class. Business images display a product, company, object, logo, or other business-related content. Always use a square (default) for business images.'
     }
   }
 };

--- a/packages/styles/stories/Components/avatar/background-image.example.html
+++ b/packages/styles/stories/Components/avatar/background-image.example.html
@@ -1,8 +1,8 @@
 
 <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" role="img" aria-label="John Doe"></span>
-<span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M2.png')" role="img" aria-label="John Doe"></span>
-<span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_F3.png')" role="img" aria-label="John Doe"></span>
-<span class="fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_F4.png')" role="img" aria-label="John Doe"></span>
+<span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M2.png')" role="img" aria-label="John Doe"></span>
+<span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_F3.png')" role="img" aria-label="John Doe"></span>
+<span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_F4.png')" role="img" aria-label="John Doe"></span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" role="img" aria-label="John Doe"></span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--thumbnail" style="background-image: url('/assets/images/landscape/L1.jpg')" role="img" aria-label="John Doe"></span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--thumbnail fd-avatar--background-contain" style="background-image: url('/assets/images/landscape/L2.jpg')" role="img" aria-label="John Doe"></span>

--- a/packages/styles/stories/Components/avatar/borders.example.html
+++ b/packages/styles/stories/Components/avatar/borders.example.html
@@ -1,26 +1,26 @@
 
 <span class="fd-avatar fd-avatar--xs fd-avatar--transparent fd-avatar--border" aria-label="Avatar" aria-role="img">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--product" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
-<span class="fd-avatar fd-avatar--s fd-avatar--transparent fd-avatar--border" aria-label="Avatar" aria-role="img">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+<span class="fd-avatar fd-avatar--sm fd-avatar--transparent fd-avatar--border" aria-label="Avatar" aria-role="img">
+    <i class="fd-avatar__icon sap-icon--product" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
-<span class="fd-avatar fd-avatar--m fd-avatar--transparent fd-avatar--border" aria-label="Avatar" aria-role="img">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+<span class="fd-avatar fd-avatar--md fd-avatar--transparent fd-avatar--border" aria-label="Avatar" aria-role="img">
+    <i class="fd-avatar__icon sap-icon--product" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
-<span class="fd-avatar fd-avatar--l fd-avatar--transparent fd-avatar--border" aria-label="Avatar" aria-role="img">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+<span class="fd-avatar fd-avatar--lg fd-avatar--transparent fd-avatar--border" aria-label="Avatar" aria-role="img">
+    <i class="fd-avatar__icon sap-icon--product" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--transparent fd-avatar--border" aria-label="Avatar" aria-role="img">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--product" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--transparent fd-avatar--border" aria-label="Wendy Wallace" aria-role="img">WW
 </span>
-<span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--transparent fd-avatar--border" aria-label="Wendy Wallace" aria-role="img">WW
+<span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--transparent fd-avatar--border" aria-label="Wendy Wallace" aria-role="img">WW
 </span>
-<span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--transparent fd-avatar--border" aria-label="Wendy Wallace" aria-role="img">WW
+<span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--transparent fd-avatar--border" aria-label="Wendy Wallace" aria-role="img">WW
 </span>
-<span class="fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--transparent fd-avatar--border" aria-label="Wendy Wallace" aria-role="img">WW
+<span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--transparent fd-avatar--border" aria-label="Wendy Wallace" aria-role="img">WW
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent fd-avatar--border" aria-label="Wendy Wallace" aria-role="img">WW
 </span>

--- a/packages/styles/stories/Components/avatar/circle.example.html
+++ b/packages/styles/stories/Components/avatar/circle.example.html
@@ -1,21 +1,21 @@
 
 <span class="fd-avatar fd-avatar--xs fd-avatar--circle" aria-role="img" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
-<span class="fd-avatar fd-avatar--s fd-avatar--circle" aria-role="img" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+<span class="fd-avatar fd-avatar--sm fd-avatar--circle" aria-role="img" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
-<span class="fd-avatar fd-avatar--m fd-avatar--circle" aria-role="img" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+<span class="fd-avatar fd-avatar--md fd-avatar--circle" aria-role="img" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
-<span class="fd-avatar fd-avatar--l fd-avatar--circle" aria-role="img" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+<span class="fd-avatar fd-avatar--lg fd-avatar--circle" aria-role="img" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle" aria-role="img" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--xs fd-avatar--circle" aria-role="img" aria-label="Wendy Wallace">WW</span>
-<span class="fd-avatar fd-avatar--s fd-avatar--circle" aria-role="img" aria-label="Wendy Wallace">WW</span>
-<span class="fd-avatar fd-avatar--m fd-avatar--circle" aria-role="img" aria-label="Wendy Wallace">WW</span>
-<span class="fd-avatar fd-avatar--l fd-avatar--circle" aria-role="img" aria-label="Wendy Wallace">WW</span>
+<span class="fd-avatar fd-avatar--sm fd-avatar--circle" aria-role="img" aria-label="Wendy Wallace">WW</span>
+<span class="fd-avatar fd-avatar--md fd-avatar--circle" aria-role="img" aria-label="Wendy Wallace">WW</span>
+<span class="fd-avatar fd-avatar--lg fd-avatar--circle" aria-role="img" aria-label="Wendy Wallace">WW</span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle" aria-role="img" aria-label="Wendy Wallace">WW</span>

--- a/packages/styles/stories/Components/avatar/icon.example.html
+++ b/packages/styles/stories/Components/avatar/icon.example.html
@@ -1,16 +1,31 @@
-
 <span class="fd-avatar fd-avatar--xs" role="img" aria-label="Avatar">
-    <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+    <i role="presentation" aria-hidden="true" aria-label="Product placeholder" class="fd-avatar__icon sap-icon--product"></i>
 </span>
-<span class="fd-avatar fd-avatar--s" role="img" aria-label="Avatar">
-    <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+<span class="fd-avatar fd-avatar--sm" role="img" aria-label="Avatar">
+    <i role="presentation" aria-hidden="true" aria-label="Product placeholder" class="fd-avatar__icon sap-icon--product"></i>
 </span>
-<span class="fd-avatar fd-avatar--m" role="img" aria-label="Avatar">
-    <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+<span class="fd-avatar fd-avatar--md" role="img" aria-label="Avatar">
+    <i role="presentation" aria-hidden="true" aria-label="Product placeholder" class="fd-avatar__icon sap-icon--product"></i>
 </span>
-<span class="fd-avatar fd-avatar--l" role="img" aria-label="Avatar">
-    <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+<span class="fd-avatar fd-avatar--lg" role="img" aria-label="Avatar">
+    <i role="presentation" aria-hidden="true" aria-label="Product placeholder" class="fd-avatar__icon sap-icon--product"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl" role="img" aria-label="Avatar">
-    <i role="presentation" aria-hidden="true" aria-label="Image placeholder" class="fd-avatar__icon sap-icon--washing-machine"></i>
+    <i role="presentation" aria-hidden="true" aria-label="Product placeholder" class="fd-avatar__icon sap-icon--product"></i>
+</span>
+
+<span class="fd-avatar fd-avatar--xs fd-avatar--circle" role="img" aria-label="Avatar">
+    <i role="presentation" aria-hidden="true" aria-label="User placeholder" class="fd-avatar__icon sap-icon--person-placeholder"></i>
+</span>
+<span class="fd-avatar fd-avatar--sm fd-avatar--circle" role="img" aria-label="Avatar">
+    <i role="presentation" aria-hidden="true" aria-label="User placeholder" class="fd-avatar__icon sap-icon--person-placeholder"></i>
+</span>
+<span class="fd-avatar fd-avatar--md fd-avatar--circle" role="img" aria-label="Avatar">
+    <i role="presentation" aria-hidden="true" aria-label="User placeholder" class="fd-avatar__icon sap-icon--person-placeholder"></i>
+</span>
+<span class="fd-avatar fd-avatar--lg fd-avatar--circle" role="img" aria-label="Avatar">
+    <i role="presentation" aria-hidden="true" aria-label="User placeholder" class="fd-avatar__icon sap-icon--person-placeholder"></i>
+</span>
+<span class="fd-avatar fd-avatar--xl fd-avatar--circle" role="img" aria-label="Avatar">
+    <i role="presentation" aria-hidden="true" aria-label="User placeholder" class="fd-avatar__icon sap-icon--person-placeholder"></i>
 </span>

--- a/packages/styles/stories/Components/avatar/initials.example.html
+++ b/packages/styles/stories/Components/avatar/initials.example.html
@@ -1,6 +1,6 @@
 
 <span class="fd-avatar fd-avatar--xs" aria-role="img" aria-label="Wendy Wallace">WW</span>
-<span class="fd-avatar fd-avatar--s" aria-role="img" aria-label="Wendy Wallace">WW</span>
-<span class="fd-avatar fd-avatar--m" aria-role="img" aria-label="Wendy Wallace">WW</span>
-<span class="fd-avatar fd-avatar--l" aria-role="img" aria-label="Wendy Wallace">WW</span>
+<span class="fd-avatar fd-avatar--sm" aria-role="img" aria-label="Wendy Wallace">WW</span>
+<span class="fd-avatar fd-avatar--md" aria-role="img" aria-label="Wendy Wallace">WW</span>
+<span class="fd-avatar fd-avatar--lg" aria-role="img" aria-label="Wendy Wallace">WW</span>
 <span class="fd-avatar fd-avatar--xl" aria-role="img" aria-label="Wendy Wallace">WW</span>

--- a/packages/styles/stories/Components/avatar/placeholder-background.example.html
+++ b/packages/styles/stories/Components/avatar/placeholder-background.example.html
@@ -1,16 +1,16 @@
 
 <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--placeholder" aria-label="Avatar" aria-role="img">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
-<span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--placeholder" aria-label="Avatar" aria-role="img">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+<span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--placeholder" aria-label="Avatar" aria-role="img">
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
-<span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--placeholder" aria-label="Avatar" aria-role="img">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+<span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--placeholder" aria-label="Avatar" aria-role="img">
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
-<span class="fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--placeholder" aria-label="Avatar" aria-role="img">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+<span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--placeholder" aria-label="Avatar" aria-role="img">
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--placeholder" aria-label="Avatar" aria-role="img">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>

--- a/packages/styles/stories/Components/avatar/tile-icon-background.example.html
+++ b/packages/styles/stories/Components/avatar/tile-icon-background.example.html
@@ -1,16 +1,16 @@
 
 <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--tile" aria-label="Avatar" aria-role="img">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
-<span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--tile" aria-label="Avatar" aria-role="img">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+<span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--tile" aria-label="Avatar" aria-role="img">
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
-<span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--tile" aria-label="Avatar" aria-role="img">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+<span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--tile" aria-label="Avatar" aria-role="img">
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
-<span class="fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--tile" aria-label="Avatar" aria-role="img">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+<span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--tile" aria-label="Avatar" aria-role="img">
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--tile" aria-label="Avatar" aria-role="img">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>

--- a/packages/styles/stories/Components/avatar/transparent.example.html
+++ b/packages/styles/stories/Components/avatar/transparent.example.html
@@ -1,21 +1,21 @@
 
 <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--transparent" aria-label="Avatar" aria-role="img">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
-<span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--transparent" aria-label="Avatar" aria-role="img">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+<span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--transparent" aria-label="Avatar" aria-role="img">
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
-<span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--transparent" aria-label="Avatar" aria-role="img">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+<span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--transparent" aria-label="Avatar" aria-role="img">
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
-<span class="fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--transparent" aria-label="Avatar" aria-role="img">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+<span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--transparent" aria-label="Avatar" aria-role="img">
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent" aria-label="Avatar" aria-role="img">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
 </span>
 <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--transparent" aria-label="Wendy Wallace" role="img">WW</span>
-<span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--transparent" aria-label="Wendy Wallace" role="img">WW</span>
-<span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--transparent" aria-label="Wendy Wallace" role="img">WW</span>
-<span class="fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--transparent" aria-label="Wendy Wallace" role="img">WW</span>
+<span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--transparent" aria-label="Wendy Wallace" role="img">WW</span>
+<span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--transparent" aria-label="Wendy Wallace" role="img">WW</span>
+<span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--transparent" aria-label="Wendy Wallace" role="img">WW</span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent" aria-label="Wendy Wallace" role="img">WW</span>

--- a/packages/styles/stories/Components/avatar/value-states.example.html
+++ b/packages/styles/stories/Components/avatar/value-states.example.html
@@ -1,23 +1,23 @@
 
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--accent-color-1" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
     <i class="fd-avatar__zoom-icon sap-icon--edit" aria-label="Edit" role="presentation" aria-hidden="true"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--accent-color-2" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
-    <i class="fd-avatar__zoom-icon fd-avatar__zoom-icon--negative sap-icon--message-error" aria-label="Edit" role="presentation" aria-hidden="true"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__zoom-icon fd-avatar__zoom-icon--negative sap-icon--error" aria-label="Edit" role="presentation" aria-hidden="true"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--accent-color-3" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
-    <i class="fd-avatar__zoom-icon fd-avatar__zoom-icon--caution sap-icon--message-warning" aria-label="Edit" role="presentation" aria-hidden="true"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__zoom-icon fd-avatar__zoom-icon--caution sap-icon--warning" aria-label="Edit" role="presentation" aria-hidden="true"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--accent-color-4" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
-    <i class="fd-avatar__zoom-icon fd-avatar__zoom-icon--positive sap-icon--message-success" aria-label="Edit" role="presentation" aria-hidden="true"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__zoom-icon fd-avatar__zoom-icon--positive sap-icon--sys-enter-2" aria-label="Edit" role="presentation" aria-hidden="true"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--accent-color-5" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
-    <i class="fd-avatar__zoom-icon fd-avatar__zoom-icon--information sap-icon--message-information" aria-label="Edit" role="presentation" aria-hidden="true"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__zoom-icon fd-avatar__zoom-icon--information sap-icon--information" aria-label="Edit" role="presentation" aria-hidden="true"></i>
 </span>
 <span class="fd-avatar fd-avatar--accent-color-6 fd-avatar--xl" tabindex="0" role="button" aria-label="Wendy Wallace">WW
     <i class="fd-avatar__zoom-icon sap-icon--edit" aria-label="Edit" role="presentation" aria-hidden="true"></i>

--- a/packages/styles/stories/Components/avatar/zoom-icon.example.html
+++ b/packages/styles/stories/Components/avatar/zoom-icon.example.html
@@ -1,34 +1,34 @@
 
 <span class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--accent-color-1" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
     <i class="fd-avatar__zoom-icon sap-icon--edit" aria-label="Edit" role="presentation" aria-hidden="true"></i>
 </span>
-<span class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--accent-color-2" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+<span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-2" tabindex="0" role="button" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
     <i class="fd-avatar__zoom-icon sap-icon--edit" aria-label="Edit" role="presentation" aria-hidden="true"></i>
 </span>
-<span class="fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--accent-color-3" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+<span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--accent-color-3" tabindex="0" role="button" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
     <i class="fd-avatar__zoom-icon sap-icon--edit" aria-label="Edit" role="presentation" aria-hidden="true"></i>
 </span>
-<span class="fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--accent-color-4" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+<span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--accent-color-4" tabindex="0" role="button" aria-label="Avatar">
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
     <i class="fd-avatar__zoom-icon sap-icon--edit" aria-label="Edit" role="presentation" aria-hidden="true"></i>
 </span>
 <span class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--accent-color-5" tabindex="0" role="button" aria-label="Avatar">
-    <i class="fd-avatar__icon sap-icon--money-bills" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+    <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
     <i class="fd-avatar__zoom-icon sap-icon--edit" aria-label="Edit" role="presentation" aria-hidden="true"></i>
 </span>
 <span class="fd-avatar fd-avatar--accent-color-6 fd-avatar--xs" tabindex="0" role="button" aria-label="Wendy Wallace">WW
     <i class="fd-avatar__zoom-icon sap-icon--edit" aria-label="Edit" role="presentation" aria-hidden="true"></i>
 </span>
-<span class="fd-avatar fd-avatar--accent-color-7 fd-avatar--s" tabindex="0" role="button" aria-label="Wendy Wallace">WW
+<span class="fd-avatar fd-avatar--accent-color-7 fd-avatar--sm" tabindex="0" role="button" aria-label="Wendy Wallace">WW
     <i class="fd-avatar__zoom-icon sap-icon--edit" aria-label="Edit" role="presentation" aria-hidden="true"></i>
 </span>
-<span class="fd-avatar fd-avatar--accent-color-8 fd-avatar--m" tabindex="0" role="button" aria-label="Wendy Wallace">WW
+<span class="fd-avatar fd-avatar--accent-color-8 fd-avatar--md" tabindex="0" role="button" aria-label="Wendy Wallace">WW
     <i class="fd-avatar__zoom-icon sap-icon--edit" aria-label="Edit" role="presentation" aria-hidden="true"></i>
 </span>
-<span class="fd-avatar fd-avatar--accent-color-9 fd-avatar--l" tabindex="0" role="button" aria-label="Wendy Wallace">WW
+<span class="fd-avatar fd-avatar--accent-color-9 fd-avatar--lg" tabindex="0" role="button" aria-label="Wendy Wallace">WW
     <i class="fd-avatar__zoom-icon sap-icon--edit" aria-label="Edit" role="presentation" aria-hidden="true"></i>
 </span>
 <span class="fd-avatar fd-avatar--accent-color-10 fd-avatar--xl" tabindex="0" role="button" aria-label="Wendy Wallace">WW

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -7373,35 +7373,35 @@ exports[`Check stories > Components/Action Sheet > Story Default > Should match 
 
 exports[`Check stories > Components/Avatar > Story AccentColors > Should match snapshot 1`] = `
 "
-<span class=\\"fd-avatar fd-avatar--accent-color-1 fd-avatar--m\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+<span class=\\"fd-avatar fd-avatar--accent-color-1 fd-avatar--md\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
+    <i class=\\"fd-avatar__icon sap-icon--product\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
-<span class=\\"fd-avatar fd-avatar--accent-color-2 fd-avatar--m\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+<span class=\\"fd-avatar fd-avatar--accent-color-2 fd-avatar--md\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
+    <i class=\\"fd-avatar__icon sap-icon--product\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
-<span class=\\"fd-avatar fd-avatar--accent-color-3 fd-avatar--m\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+<span class=\\"fd-avatar fd-avatar--accent-color-3 fd-avatar--md\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
+    <i class=\\"fd-avatar__icon sap-icon--product\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
-<span class=\\"fd-avatar fd-avatar--accent-color-4 fd-avatar--m\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+<span class=\\"fd-avatar fd-avatar--accent-color-4 fd-avatar--md\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
+    <i class=\\"fd-avatar__icon sap-icon--product\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
-<span class=\\"fd-avatar fd-avatar--accent-color-5 fd-avatar--m\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+<span class=\\"fd-avatar fd-avatar--accent-color-5 fd-avatar--md\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
+    <i class=\\"fd-avatar__icon sap-icon--product\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
-<span class=\\"fd-avatar fd-avatar--accent-color-6 fd-avatar--m\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+<span class=\\"fd-avatar fd-avatar--accent-color-6 fd-avatar--md\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
+    <i class=\\"fd-avatar__icon sap-icon--product\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
-<span class=\\"fd-avatar fd-avatar--accent-color-7 fd-avatar--m\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+<span class=\\"fd-avatar fd-avatar--accent-color-7 fd-avatar--md\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
+    <i class=\\"fd-avatar__icon sap-icon--product\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
-<span class=\\"fd-avatar fd-avatar--accent-color-8 fd-avatar--m\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+<span class=\\"fd-avatar fd-avatar--accent-color-8 fd-avatar--md\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
+    <i class=\\"fd-avatar__icon sap-icon--product\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
-<span class=\\"fd-avatar fd-avatar--accent-color-9 fd-avatar--m\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+<span class=\\"fd-avatar fd-avatar--accent-color-9 fd-avatar--md\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
+    <i class=\\"fd-avatar__icon sap-icon--product\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
-<span class=\\"fd-avatar fd-avatar--accent-color-10 fd-avatar--m\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+<span class=\\"fd-avatar fd-avatar--accent-color-10 fd-avatar--md\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
+    <i class=\\"fd-avatar__icon sap-icon--product\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 "
 `;
@@ -7409,35 +7409,35 @@ exports[`Check stories > Components/Avatar > Story AccentColors > Should match s
 exports[`Check stories > Components/Avatar > Story AccentColorsShellHeaderContext > Should match snapshot 1`] = `
 "
 <div style=\\"background-color: var(--sapShellColor); padding: 1rem;\\">
-    <span class=\\"fd-avatar fd-avatar--shell fd-avatar--accent-color-1 fd-avatar--m\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-        <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <span class=\\"fd-avatar fd-avatar--shell fd-avatar--accent-color-1 fd-avatar--md\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
+        <i class=\\"fd-avatar__icon sap-icon--product\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
     </span>
-    <span class=\\"fd-avatar fd-avatar--shell fd-avatar--accent-color-2 fd-avatar--m\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-        <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <span class=\\"fd-avatar fd-avatar--shell fd-avatar--accent-color-2 fd-avatar--md\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
+        <i class=\\"fd-avatar__icon sap-icon--product\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
     </span>
-    <span class=\\"fd-avatar fd-avatar--shell fd-avatar--accent-color-3 fd-avatar--m\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-        <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <span class=\\"fd-avatar fd-avatar--shell fd-avatar--accent-color-3 fd-avatar--md\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
+        <i class=\\"fd-avatar__icon sap-icon--product\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
     </span>
-    <span class=\\"fd-avatar fd-avatar--shell fd-avatar--accent-color-4 fd-avatar--m\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-        <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <span class=\\"fd-avatar fd-avatar--shell fd-avatar--accent-color-4 fd-avatar--md\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
+        <i class=\\"fd-avatar__icon sap-icon--product\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
     </span>
-    <span class=\\"fd-avatar fd-avatar--shell fd-avatar--accent-color-5 fd-avatar--m\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-        <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <span class=\\"fd-avatar fd-avatar--shell fd-avatar--accent-color-5 fd-avatar--md\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
+        <i class=\\"fd-avatar__icon sap-icon--product\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
     </span>
-    <span class=\\"fd-avatar fd-avatar--shell fd-avatar--accent-color-6 fd-avatar--m\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-        <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <span class=\\"fd-avatar fd-avatar--shell fd-avatar--accent-color-6 fd-avatar--md\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
+        <i class=\\"fd-avatar__icon sap-icon--product\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
     </span>
-    <span class=\\"fd-avatar fd-avatar--shell fd-avatar--accent-color-7 fd-avatar--m\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-        <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <span class=\\"fd-avatar fd-avatar--shell fd-avatar--accent-color-7 fd-avatar--md\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
+        <i class=\\"fd-avatar__icon sap-icon--product\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
     </span>
-    <span class=\\"fd-avatar fd-avatar--shell fd-avatar--accent-color-8 fd-avatar--m\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-        <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <span class=\\"fd-avatar fd-avatar--shell fd-avatar--accent-color-8 fd-avatar--md\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
+        <i class=\\"fd-avatar__icon sap-icon--product\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
     </span>
-    <span class=\\"fd-avatar fd-avatar--shell fd-avatar--accent-color-9 fd-avatar--m\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-        <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <span class=\\"fd-avatar fd-avatar--shell fd-avatar--accent-color-9 fd-avatar--md\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
+        <i class=\\"fd-avatar__icon sap-icon--product\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
     </span>
-    <span class=\\"fd-avatar fd-avatar--shell fd-avatar--accent-color-10 fd-avatar--m\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-        <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <span class=\\"fd-avatar fd-avatar--shell fd-avatar--accent-color-10 fd-avatar--md\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
+        <i class=\\"fd-avatar__icon sap-icon--product\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
     </span>
 </div>
 "
@@ -7446,9 +7446,9 @@ exports[`Check stories > Components/Avatar > Story AccentColorsShellHeaderContex
 exports[`Check stories > Components/Avatar > Story BackgroundImage > Should match snapshot 1`] = `
 "
 <span class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" role=\\"img\\" aria-label=\\"John Doe\\"></span>
-<span class=\\"fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M2.png')\\" role=\\"img\\" aria-label=\\"John Doe\\"></span>
-<span class=\\"fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_F3.png')\\" role=\\"img\\" aria-label=\\"John Doe\\"></span>
-<span class=\\"fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_F4.png')\\" role=\\"img\\" aria-label=\\"John Doe\\"></span>
+<span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M2.png')\\" role=\\"img\\" aria-label=\\"John Doe\\"></span>
+<span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_F3.png')\\" role=\\"img\\" aria-label=\\"John Doe\\"></span>
+<span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_F4.png')\\" role=\\"img\\" aria-label=\\"John Doe\\"></span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" role=\\"img\\" aria-label=\\"John Doe\\"></span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/landscape/L1.jpg')\\" role=\\"img\\" aria-label=\\"John Doe\\"></span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--thumbnail fd-avatar--background-contain\\" style=\\"background-image: url('/assets/images/landscape/L2.jpg')\\" role=\\"img\\" aria-label=\\"John Doe\\"></span>
@@ -7458,27 +7458,27 @@ exports[`Check stories > Components/Avatar > Story BackgroundImage > Should matc
 exports[`Check stories > Components/Avatar > Story Borders > Should match snapshot 1`] = `
 "
 <span class=\\"fd-avatar fd-avatar--xs fd-avatar--transparent fd-avatar--border\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--product\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
-<span class=\\"fd-avatar fd-avatar--s fd-avatar--transparent fd-avatar--border\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+<span class=\\"fd-avatar fd-avatar--sm fd-avatar--transparent fd-avatar--border\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
+    <i class=\\"fd-avatar__icon sap-icon--product\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
-<span class=\\"fd-avatar fd-avatar--m fd-avatar--transparent fd-avatar--border\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+<span class=\\"fd-avatar fd-avatar--md fd-avatar--transparent fd-avatar--border\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
+    <i class=\\"fd-avatar__icon sap-icon--product\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
-<span class=\\"fd-avatar fd-avatar--l fd-avatar--transparent fd-avatar--border\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+<span class=\\"fd-avatar fd-avatar--lg fd-avatar--transparent fd-avatar--border\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
+    <i class=\\"fd-avatar__icon sap-icon--product\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--transparent fd-avatar--border\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--product\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--transparent fd-avatar--border\\" aria-label=\\"Wendy Wallace\\" aria-role=\\"img\\">WW
 </span>
-<span class=\\"fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--transparent fd-avatar--border\\" aria-label=\\"Wendy Wallace\\" aria-role=\\"img\\">WW
+<span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--transparent fd-avatar--border\\" aria-label=\\"Wendy Wallace\\" aria-role=\\"img\\">WW
 </span>
-<span class=\\"fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--transparent fd-avatar--border\\" aria-label=\\"Wendy Wallace\\" aria-role=\\"img\\">WW
+<span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--transparent fd-avatar--border\\" aria-label=\\"Wendy Wallace\\" aria-role=\\"img\\">WW
 </span>
-<span class=\\"fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--transparent fd-avatar--border\\" aria-label=\\"Wendy Wallace\\" aria-role=\\"img\\">WW
+<span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--transparent fd-avatar--border\\" aria-label=\\"Wendy Wallace\\" aria-role=\\"img\\">WW
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent fd-avatar--border\\" aria-label=\\"Wendy Wallace\\" aria-role=\\"img\\">WW
 </span>
@@ -7488,44 +7488,59 @@ exports[`Check stories > Components/Avatar > Story Borders > Should match snapsh
 exports[`Check stories > Components/Avatar > Story Circle > Should match snapshot 1`] = `
 "
 <span class=\\"fd-avatar fd-avatar--xs fd-avatar--circle\\" aria-role=\\"img\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
-<span class=\\"fd-avatar fd-avatar--s fd-avatar--circle\\" aria-role=\\"img\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+<span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle\\" aria-role=\\"img\\" aria-label=\\"Avatar\\">
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
-<span class=\\"fd-avatar fd-avatar--m fd-avatar--circle\\" aria-role=\\"img\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+<span class=\\"fd-avatar fd-avatar--md fd-avatar--circle\\" aria-role=\\"img\\" aria-label=\\"Avatar\\">
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
-<span class=\\"fd-avatar fd-avatar--l fd-avatar--circle\\" aria-role=\\"img\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+<span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle\\" aria-role=\\"img\\" aria-label=\\"Avatar\\">
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle\\" aria-role=\\"img\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xs fd-avatar--circle\\" aria-role=\\"img\\" aria-label=\\"Wendy Wallace\\">WW</span>
-<span class=\\"fd-avatar fd-avatar--s fd-avatar--circle\\" aria-role=\\"img\\" aria-label=\\"Wendy Wallace\\">WW</span>
-<span class=\\"fd-avatar fd-avatar--m fd-avatar--circle\\" aria-role=\\"img\\" aria-label=\\"Wendy Wallace\\">WW</span>
-<span class=\\"fd-avatar fd-avatar--l fd-avatar--circle\\" aria-role=\\"img\\" aria-label=\\"Wendy Wallace\\">WW</span>
+<span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle\\" aria-role=\\"img\\" aria-label=\\"Wendy Wallace\\">WW</span>
+<span class=\\"fd-avatar fd-avatar--md fd-avatar--circle\\" aria-role=\\"img\\" aria-label=\\"Wendy Wallace\\">WW</span>
+<span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle\\" aria-role=\\"img\\" aria-label=\\"Wendy Wallace\\">WW</span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle\\" aria-role=\\"img\\" aria-label=\\"Wendy Wallace\\">WW</span>
 "
 `;
 
 exports[`Check stories > Components/Avatar > Story Icon > Should match snapshot 1`] = `
-"
-<span class=\\"fd-avatar fd-avatar--xs\\" role=\\"img\\" aria-label=\\"Avatar\\">
-    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+"<span class=\\"fd-avatar fd-avatar--xs\\" role=\\"img\\" aria-label=\\"Avatar\\">
+    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Product placeholder\\" class=\\"fd-avatar__icon sap-icon--product\\"></i>
 </span>
-<span class=\\"fd-avatar fd-avatar--s\\" role=\\"img\\" aria-label=\\"Avatar\\">
-    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+<span class=\\"fd-avatar fd-avatar--sm\\" role=\\"img\\" aria-label=\\"Avatar\\">
+    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Product placeholder\\" class=\\"fd-avatar__icon sap-icon--product\\"></i>
 </span>
-<span class=\\"fd-avatar fd-avatar--m\\" role=\\"img\\" aria-label=\\"Avatar\\">
-    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+<span class=\\"fd-avatar fd-avatar--md\\" role=\\"img\\" aria-label=\\"Avatar\\">
+    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Product placeholder\\" class=\\"fd-avatar__icon sap-icon--product\\"></i>
 </span>
-<span class=\\"fd-avatar fd-avatar--l\\" role=\\"img\\" aria-label=\\"Avatar\\">
-    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+<span class=\\"fd-avatar fd-avatar--lg\\" role=\\"img\\" aria-label=\\"Avatar\\">
+    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Product placeholder\\" class=\\"fd-avatar__icon sap-icon--product\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl\\" role=\\"img\\" aria-label=\\"Avatar\\">
-    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\" class=\\"fd-avatar__icon sap-icon--washing-machine\\"></i>
+    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Product placeholder\\" class=\\"fd-avatar__icon sap-icon--product\\"></i>
+</span>
+
+<span class=\\"fd-avatar fd-avatar--xs fd-avatar--circle\\" role=\\"img\\" aria-label=\\"Avatar\\">
+    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"User placeholder\\" class=\\"fd-avatar__icon sap-icon--person-placeholder\\"></i>
+</span>
+<span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle\\" role=\\"img\\" aria-label=\\"Avatar\\">
+    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"User placeholder\\" class=\\"fd-avatar__icon sap-icon--person-placeholder\\"></i>
+</span>
+<span class=\\"fd-avatar fd-avatar--md fd-avatar--circle\\" role=\\"img\\" aria-label=\\"Avatar\\">
+    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"User placeholder\\" class=\\"fd-avatar__icon sap-icon--person-placeholder\\"></i>
+</span>
+<span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle\\" role=\\"img\\" aria-label=\\"Avatar\\">
+    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"User placeholder\\" class=\\"fd-avatar__icon sap-icon--person-placeholder\\"></i>
+</span>
+<span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle\\" role=\\"img\\" aria-label=\\"Avatar\\">
+    <i role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"User placeholder\\" class=\\"fd-avatar__icon sap-icon--person-placeholder\\"></i>
 </span>
 "
 `;
@@ -7533,9 +7548,9 @@ exports[`Check stories > Components/Avatar > Story Icon > Should match snapshot 
 exports[`Check stories > Components/Avatar > Story Initials > Should match snapshot 1`] = `
 "
 <span class=\\"fd-avatar fd-avatar--xs\\" aria-role=\\"img\\" aria-label=\\"Wendy Wallace\\">WW</span>
-<span class=\\"fd-avatar fd-avatar--s\\" aria-role=\\"img\\" aria-label=\\"Wendy Wallace\\">WW</span>
-<span class=\\"fd-avatar fd-avatar--m\\" aria-role=\\"img\\" aria-label=\\"Wendy Wallace\\">WW</span>
-<span class=\\"fd-avatar fd-avatar--l\\" aria-role=\\"img\\" aria-label=\\"Wendy Wallace\\">WW</span>
+<span class=\\"fd-avatar fd-avatar--sm\\" aria-role=\\"img\\" aria-label=\\"Wendy Wallace\\">WW</span>
+<span class=\\"fd-avatar fd-avatar--md\\" aria-role=\\"img\\" aria-label=\\"Wendy Wallace\\">WW</span>
+<span class=\\"fd-avatar fd-avatar--lg\\" aria-role=\\"img\\" aria-label=\\"Wendy Wallace\\">WW</span>
 <span class=\\"fd-avatar fd-avatar--xl\\" aria-role=\\"img\\" aria-label=\\"Wendy Wallace\\">WW</span>
 "
 `;
@@ -7553,19 +7568,19 @@ exports[`Check stories > Components/Avatar > Story Interactive > Should match sn
 
 <h3>Regular State</h3>
 <span class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--accent-color-1\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--accent-color-2\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--accent-color-3\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--accent-color-4\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--accent-color-5\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--accent-color-6 fd-avatar--xs\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Wendy Wallace\\">WW
 </span>
@@ -7578,15 +7593,15 @@ exports[`Check stories > Components/Avatar > Story Interactive > Should match sn
 <span class=\\"fd-avatar fd-avatar--accent-color-10 fd-avatar--xl\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Wendy Wallace\\">WW
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--placeholder\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--tile\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--thumbnail\\" tabindex=\\"0\\" role=\\"button\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" role=\\"img\\" aria-label=\\"John Doe\\"></span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Wendy Wallace\\">WW</span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--transparent fd-avatar--border\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent fd-avatar--border\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Wendy Wallace\\">WW
 </span>
@@ -7595,19 +7610,19 @@ exports[`Check stories > Components/Avatar > Story Interactive > Should match sn
 <h3>Hover State</h3>
 
 <span class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--accent-color-1 is-hover\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--accent-color-2 is-hover\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--accent-color-3 is-hover\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--accent-color-4 is-hover\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--accent-color-5 is-hover\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--accent-color-6 fd-avatar--xs is-hover\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Wendy Wallace\\">WW
 </span>
@@ -7620,15 +7635,15 @@ exports[`Check stories > Components/Avatar > Story Interactive > Should match sn
 <span class=\\"fd-avatar fd-avatar--accent-color-10 fd-avatar--xl is-hover\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Wendy Wallace\\">WW
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--placeholder is-hover\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--tile is-hover\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--thumbnail is-hover\\" tabindex=\\"0\\" role=\\"button\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" role=\\"img\\" aria-label=\\"John Doe\\"></span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent is-hover\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Wendy Wallace\\">WW</span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--transparent fd-avatar--border is-hover\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent fd-avatar--border is-hover\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Wendy Wallace\\">WW
 </span>
@@ -7638,19 +7653,19 @@ exports[`Check stories > Components/Avatar > Story Interactive > Should match sn
 <h3>Active/Toggled State</h3>
 
 <span class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--accent-color-1 is-active\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--accent-color-2 is-active\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--accent-color-3 is-active\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--accent-color-4 is-active\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--accent-color-5 is-active\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--accent-color-6 fd-avatar--xs is-active\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Wendy Wallace\\">WW
 </span>
@@ -7663,15 +7678,15 @@ exports[`Check stories > Components/Avatar > Story Interactive > Should match sn
 <span class=\\"fd-avatar fd-avatar--accent-color-10 fd-avatar--xl is-active\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Wendy Wallace\\">WW
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--placeholder is-active\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--tile is-active\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--thumbnail is-active\\" tabindex=\\"0\\" role=\\"button\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" role=\\"img\\" aria-label=\\"John Doe\\"></span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent is-active\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Wendy Wallace\\">WW</span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--transparent fd-avatar--border is-active\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent fd-avatar--border is-active\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Wendy Wallace\\">WW
 </span>
@@ -7680,19 +7695,19 @@ exports[`Check stories > Components/Avatar > Story Interactive > Should match sn
 <h3>Toggled Hover State</h3>
 
 <span class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--accent-color-1 is-toggled is-hover\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--accent-color-2 is-toggled is-hover\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--accent-color-3 is-toggled is-hover\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--accent-color-4 is-toggled is-hover\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--accent-color-5 is-toggled is-hover\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--accent-color-6 fd-avatar--xs is-toggled is-hover\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Wendy Wallace\\">WW
 </span>
@@ -7705,15 +7720,15 @@ exports[`Check stories > Components/Avatar > Story Interactive > Should match sn
 <span class=\\"fd-avatar fd-avatar--accent-color-10 fd-avatar--xl is-toggled is-hover\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Wendy Wallace\\">WW
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--placeholder is-toggled is-hover\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--tile is-toggled is-hover\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--thumbnail is-toggled is-hover\\" tabindex=\\"0\\" role=\\"button\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" role=\\"img\\" aria-label=\\"John Doe\\"></span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent is-toggled is-hover\\"  tabindex=\\"0\\" role=\\"button\\"aria-label=\\"Wendy Wallace\\">WW</span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--transparent fd-avatar--border is-toggled is-hover\\"  tabindex=\\"0\\" role=\\"button\\"aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent fd-avatar--border is-toggled is-hover\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Wendy Wallace\\">WW
 </span>
@@ -7722,19 +7737,19 @@ exports[`Check stories > Components/Avatar > Story Interactive > Should match sn
 <h3>Disabled State</h3>
 
 <span class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--accent-color-1 is-disabled\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--accent-color-2 is-disabled\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--accent-color-3 is-disabled\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--accent-color-4 is-disabled\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--accent-color-5 is-disabled\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--accent-color-6 fd-avatar--xs is-disabled\\" role=\\"button\\" aria-label=\\"Wendy Wallace\\">WW
 </span>
@@ -7747,15 +7762,15 @@ exports[`Check stories > Components/Avatar > Story Interactive > Should match sn
 <span class=\\"fd-avatar fd-avatar--accent-color-10 fd-avatar--xl is-disabled\\" role=\\"button\\" aria-label=\\"Wendy Wallace\\">WW
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--placeholder is-disabled\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--tile is-disabled\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--thumbnail is-disabled\\" role=\\"button\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" role=\\"img\\" aria-label=\\"John Doe\\"></span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent is-disabled\\" role=\\"button\\" aria-label=\\"Wendy Wallace\\">WW</span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--transparent fd-avatar--border is-disabled\\"  role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent fd-avatar--border is-disabled\\" role=\\"button\\" aria-label=\\"Wendy Wallace\\">WW
 </span>
@@ -7765,19 +7780,19 @@ exports[`Check stories > Components/Avatar > Story Interactive > Should match sn
 <h3>Focus State</h3>
 
 <span class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--accent-color-1 is-focus\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--accent-color-2 is-focus\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--accent-color-3 is-focus\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--accent-color-4 is-focus\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--accent-color-5 is-focus\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--accent-color-6 fd-avatar--xs is-focus\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Wendy Wallace\\">WW
 </span>
@@ -7790,15 +7805,15 @@ exports[`Check stories > Components/Avatar > Story Interactive > Should match sn
 <span class=\\"fd-avatar fd-avatar--accent-color-10 fd-avatar--xl is-focus\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Wendy Wallace\\">WW
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--placeholder is-focus\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--tile is-focus\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--thumbnail is-focus\\" tabindex=\\"0\\" role=\\"button\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" role=\\"img\\" aria-label=\\"John Doe\\"></span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent is-focus\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Wendy Wallace\\">WW</span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--transparent fd-avatar--border is-focus\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent fd-avatar--border is-focus\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Wendy Wallace\\">WW
 </span>
@@ -7808,19 +7823,19 @@ exports[`Check stories > Components/Avatar > Story Interactive > Should match sn
 exports[`Check stories > Components/Avatar > Story PlaceholderBackground > Should match snapshot 1`] = `
 "
 <span class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--placeholder\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
-<span class=\\"fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--placeholder\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+<span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--placeholder\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
-<span class=\\"fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--placeholder\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+<span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--placeholder\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
-<span class=\\"fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--placeholder\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+<span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--placeholder\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--placeholder\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 "
 `;
@@ -7828,19 +7843,19 @@ exports[`Check stories > Components/Avatar > Story PlaceholderBackground > Shoul
 exports[`Check stories > Components/Avatar > Story TileIconBackground > Should match snapshot 1`] = `
 "
 <span class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--tile\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
-<span class=\\"fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--tile\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+<span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--tile\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
-<span class=\\"fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--tile\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+<span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--tile\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
-<span class=\\"fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--tile\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+<span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--tile\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--tile\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 "
 `;
@@ -7848,24 +7863,24 @@ exports[`Check stories > Components/Avatar > Story TileIconBackground > Should m
 exports[`Check stories > Components/Avatar > Story Transparent > Should match snapshot 1`] = `
 "
 <span class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--transparent\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
-<span class=\\"fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--transparent\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+<span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--transparent\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
-<span class=\\"fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--transparent\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+<span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--transparent\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
-<span class=\\"fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--transparent\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+<span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--transparent\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent\\" aria-label=\\"Avatar\\" aria-role=\\"img\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--transparent\\" aria-label=\\"Wendy Wallace\\" role=\\"img\\">WW</span>
-<span class=\\"fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--transparent\\" aria-label=\\"Wendy Wallace\\" role=\\"img\\">WW</span>
-<span class=\\"fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--transparent\\" aria-label=\\"Wendy Wallace\\" role=\\"img\\">WW</span>
-<span class=\\"fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--transparent\\" aria-label=\\"Wendy Wallace\\" role=\\"img\\">WW</span>
+<span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--transparent\\" aria-label=\\"Wendy Wallace\\" role=\\"img\\">WW</span>
+<span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--transparent\\" aria-label=\\"Wendy Wallace\\" role=\\"img\\">WW</span>
+<span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--transparent\\" aria-label=\\"Wendy Wallace\\" role=\\"img\\">WW</span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--transparent\\" aria-label=\\"Wendy Wallace\\" role=\\"img\\">WW</span>
 "
 `;
@@ -7873,24 +7888,24 @@ exports[`Check stories > Components/Avatar > Story Transparent > Should match sn
 exports[`Check stories > Components/Avatar > Story ValueStates > Should match snapshot 1`] = `
 "
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--accent-color-1\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
     <i class=\\"fd-avatar__zoom-icon sap-icon--edit\\" aria-label=\\"Edit\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--accent-color-2\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
-    <i class=\\"fd-avatar__zoom-icon fd-avatar__zoom-icon--negative sap-icon--message-error\\" aria-label=\\"Edit\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__zoom-icon fd-avatar__zoom-icon--negative sap-icon--error\\" aria-label=\\"Edit\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--accent-color-3\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
-    <i class=\\"fd-avatar__zoom-icon fd-avatar__zoom-icon--caution sap-icon--message-warning\\" aria-label=\\"Edit\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__zoom-icon fd-avatar__zoom-icon--caution sap-icon--warning\\" aria-label=\\"Edit\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--accent-color-4\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
-    <i class=\\"fd-avatar__zoom-icon fd-avatar__zoom-icon--positive sap-icon--message-success\\" aria-label=\\"Edit\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__zoom-icon fd-avatar__zoom-icon--positive sap-icon--sys-enter-2\\" aria-label=\\"Edit\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--accent-color-5\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
-    <i class=\\"fd-avatar__zoom-icon fd-avatar__zoom-icon--information sap-icon--message-information\\" aria-label=\\"Edit\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__zoom-icon fd-avatar__zoom-icon--information sap-icon--information\\" aria-label=\\"Edit\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--accent-color-6 fd-avatar--xl\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Wendy Wallace\\">WW
     <i class=\\"fd-avatar__zoom-icon sap-icon--edit\\" aria-label=\\"Edit\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
@@ -7913,35 +7928,35 @@ exports[`Check stories > Components/Avatar > Story ValueStates > Should match sn
 exports[`Check stories > Components/Avatar > Story ZoomIcon > Should match snapshot 1`] = `
 "
 <span class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--accent-color-1\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
     <i class=\\"fd-avatar__zoom-icon sap-icon--edit\\" aria-label=\\"Edit\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
 </span>
-<span class=\\"fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--accent-color-2\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+<span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-2\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
     <i class=\\"fd-avatar__zoom-icon sap-icon--edit\\" aria-label=\\"Edit\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
 </span>
-<span class=\\"fd-avatar fd-avatar--m fd-avatar--circle fd-avatar--accent-color-3\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+<span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--accent-color-3\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
     <i class=\\"fd-avatar__zoom-icon sap-icon--edit\\" aria-label=\\"Edit\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
 </span>
-<span class=\\"fd-avatar fd-avatar--l fd-avatar--circle fd-avatar--accent-color-4\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+<span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--accent-color-4\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
     <i class=\\"fd-avatar__zoom-icon sap-icon--edit\\" aria-label=\\"Edit\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--accent-color-5\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Avatar\\">
-    <i class=\\"fd-avatar__icon sap-icon--money-bills\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+    <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
     <i class=\\"fd-avatar__zoom-icon sap-icon--edit\\" aria-label=\\"Edit\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--accent-color-6 fd-avatar--xs\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Wendy Wallace\\">WW
     <i class=\\"fd-avatar__zoom-icon sap-icon--edit\\" aria-label=\\"Edit\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
 </span>
-<span class=\\"fd-avatar fd-avatar--accent-color-7 fd-avatar--s\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Wendy Wallace\\">WW
+<span class=\\"fd-avatar fd-avatar--accent-color-7 fd-avatar--sm\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Wendy Wallace\\">WW
     <i class=\\"fd-avatar__zoom-icon sap-icon--edit\\" aria-label=\\"Edit\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
 </span>
-<span class=\\"fd-avatar fd-avatar--accent-color-8 fd-avatar--m\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Wendy Wallace\\">WW
+<span class=\\"fd-avatar fd-avatar--accent-color-8 fd-avatar--md\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Wendy Wallace\\">WW
     <i class=\\"fd-avatar__zoom-icon sap-icon--edit\\" aria-label=\\"Edit\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
 </span>
-<span class=\\"fd-avatar fd-avatar--accent-color-9 fd-avatar--l\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Wendy Wallace\\">WW
+<span class=\\"fd-avatar fd-avatar--accent-color-9 fd-avatar--lg\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Wendy Wallace\\">WW
     <i class=\\"fd-avatar__zoom-icon sap-icon--edit\\" aria-label=\\"Edit\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
 </span>
 <span class=\\"fd-avatar fd-avatar--accent-color-10 fd-avatar--xl\\" tabindex=\\"0\\" role=\\"button\\" aria-label=\\"Wendy Wallace\\">WW


### PR DESCRIPTION
## Related Issue
v1.0.0 

## Description
- added new modifier classes for the Avatar sizes to unify the naming with the other components. The old ones are kept to avoid breaking changes in existing apps.
`fd-avatar--sm`, `fd-avatar--md` and `fd-avatar--lg`
- the examples were updated to use these classes so future users use them instead of the old ones
- updated the examples to use the proper icons representing user and product
- Value states badges were updated to use the correct state icons
- For interactive Avatars the active/toggled states were updated with the latest design
- improvements in the documentation were added