### PR TITLE
fix(styles): add fix for information state hover and active [ci visual]

### DIFF
--- a/packages/styles/src/micro-process-flow.scss
+++ b/packages/styles/src/micro-process-flow.scss
@@ -125,6 +125,18 @@ $fd-micro-process-flow-semantic-colors: (
       --fdMicro_Process_Flow_Icon_Color: var(--fdMicro_Process_Flow_Active_Icon_Color);
     }
   }
+
+  &--information .#{$block}__icon-container{
+    @include fd-hover() {
+      --fdMicro_Process_Flow_Icon_Color: var(--sapButton_Information_Hover_TextColor);
+      --fdMicro_Process_Flow_Item_Border_Color: var(--sapInformationBorderColor);
+    }
+
+    @include fd-active() {
+      --fdMicro_Process_Flow_Icon_Color: var(--sapContent_ContrastIconColor);
+      --fdMicro_Process_Flow_Item_Border_Color: var(--sapContent_Selected_ForegroundColor);
+    }
+  }
 }
 
 .#{$block} {


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/5182

Updated the params for the step with state `information`.
It's not the best code solution but otherwise we need to introduce state values for all other states. Since only information is different, I applied the colors for hover and active only for it. 

### Before:
![Screenshot 2024-02-14 at 11 33 18 AM](https://github.com/SAP/fundamental-styles/assets/39598672/485c4413-0a12-4c81-aa8a-e93f76464b0b)


### After:
![Screenshot 2024-02-14 at 11 33 47 AM](https://github.com/SAP/fundamental-styles/assets/39598672/bbf225fc-a209-4b9b-93bb-4301725d8a28)
