### PR TITLE
fix(styles): less and more words capitalize not uppercase [ci visual]

### DIFF
--- a/packages/styles/src/text.scss
+++ b/packages/styles/src/text.scss
@@ -29,7 +29,7 @@ $block: #{$fd-namespace}-text;
 
   &__link {
     &--more {
-      text-transform: uppercase;
+      text-transform: capitalize;
       cursor: pointer;
     }
   }

--- a/packages/styles/stories/Components/text/text.stories.js
+++ b/packages/styles/stories/Components/text/text.stories.js
@@ -54,7 +54,7 @@ export const Expand = () => expandExampleHtml;
 Expand.parameters = {
   docs: {
     description: {
-      story: `Along with max lines, text component can display "MORE" and "LESS" links that can show
+      story: `Along with max lines, text component can display "More" and "Less" links that can show
 more or less of the text.`
     }
   }


### PR DESCRIPTION
Truncation in Text component
**BEFORE:** 
![Screenshot 2024-02-26 at 11 18 22 AM](https://github.com/SAP/fundamental-styles/assets/39598672/2dedc7dc-fafc-4e26-80e5-fd21910b5d00)

**AFTER:**
![Screenshot 2024-02-26 at 11 18 32 AM](https://github.com/SAP/fundamental-styles/assets/39598672/ee732061-22b0-45d3-98d3-759b97a5772e)

