### PR TITLE
fix(styles): add word break for text in Message Strip component

### DIFF
--- a/packages/styles/src/message-strip.scss
+++ b/packages/styles/src/message-strip.scss
@@ -163,6 +163,7 @@ $block: #{$fd-namespace}-message-strip;
     @include fd-reset();
 
     line-height: 1rem;
+    word-break: break-word;
     color: var(--fdMessageStrip_Text_Color);
   }
 


### PR DESCRIPTION

## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/5232

## Description
added a css rule to break very long words

Before:
<img width="641" alt="Screenshot 2024-03-14 at 1 36 44 PM" src="https://github.com/SAP/fundamental-styles/assets/39598672/4da82eb1-fd48-4511-9bbb-770f8aedefc4">

After:
<img width="587" alt="Screenshot 2024-03-14 at 1 37 07 PM" src="https://github.com/SAP/fundamental-styles/assets/39598672/bbd367bd-9953-48a6-b176-356c10129e47">

