### PR TITLE
fix(styles): add fix for Product Switch items jumping on selection

### DIFF
--- a/packages/styles/src/product-switch.scss
+++ b/packages/styles/src/product-switch.scss
@@ -8,6 +8,8 @@
 $block: #{$fd-namespace}-product-switch;
 
 .#{$block} {
+  --fdProduct_Switch_Item_Border_Color: transparent;
+
   @mixin fd-product-pseudo-element-background($background) {
     .#{$block}__title {
       &::after,
@@ -46,6 +48,7 @@ $block: #{$fd-namespace}-product-switch;
     background-color: var(--sapList_Background);
     border-radius: var(--sapElement_BorderCornerRadius);
     box-shadow: var(--fdProductSwitch_Shadow);
+    border: 0.125rem solid var(--fdProduct_Switch_Item_Border_Color);
 
     .#{$block}__title:not(:last-child) {
       @include fd-ellipsis();
@@ -55,19 +58,19 @@ $block: #{$fd-namespace}-product-switch;
 
     @include fd-hover() {
       background-color: var(--sapList_Hover_Background);
-      border: var(--fdProductSwitch_Border);
       cursor: pointer;
 
       @include fd-product-pseudo-element-background(var(--sapList_Hover_Background));
     }
 
     @include fd-active() {
+      --fdProduct_Switch_Item_Border_Color: var(--sapList_Active_Background);
+
       @include fd-fiori-focus() {
         outline-color: var(--sapContent_ContrastFocusColor);
       }
 
       background-color: var(--sapList_Active_Background);
-      border: var(--fdProductSwitch_Border);
 
       .#{$block}__title,
       .#{$block}__subtitle {
@@ -88,8 +91,9 @@ $block: #{$fd-namespace}-product-switch;
     }
 
     &.selected {
+      --fdProduct_Switch_Item_Border_Color: var(--sapList_SelectionBorderColor);
+
       background-color: var(--sapList_SelectionBackgroundColor);
-      border: 0.125rem solid var(--sapList_SelectionBorderColor);
 
       @include fd-product-pseudo-element-background(var(--sapList_SelectionBackgroundColor));
 

--- a/packages/styles/src/theming/sap_fiori_3.scss
+++ b/packages/styles/src/theming/sap_fiori_3.scss
@@ -94,7 +94,6 @@
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: none;
   --fdProductSwitch_Shadow: none;
-  --fdProductSwitch_Border: none;
 
   /* Menu */
   --fdMenu_Text_Shadow: none;

--- a/packages/styles/src/theming/sap_fiori_3_dark.scss
+++ b/packages/styles/src/theming/sap_fiori_3_dark.scss
@@ -100,7 +100,6 @@
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: none;
   --fdProductSwitch_Shadow: none;
-  --fdProductSwitch_Border: none;
 
   /* Menu */
   --fdMenu_Text_Shadow: none;

--- a/packages/styles/src/theming/sap_fiori_3_hcb.scss
+++ b/packages/styles/src/theming/sap_fiori_3_hcb.scss
@@ -104,7 +104,6 @@
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: 0 0 0.125rem #000;
   --fdProductSwitch_Shadow: var(--sapContent_Shadow0);
-  --fdProductSwitch_Border: 0.125rem solid var(--sapList_SelectionBorderColor);
 
   /* Menu */
   --fdMenu_Text_Shadow: 0 0 0.125rem #000;

--- a/packages/styles/src/theming/sap_fiori_3_hcw.scss
+++ b/packages/styles/src/theming/sap_fiori_3_hcw.scss
@@ -103,7 +103,6 @@
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: none;
   --fdProductSwitch_Shadow: var(--sapContent_Shadow0);
-  --fdProductSwitch_Border: 0.125rem solid var(--sapList_SelectionBorderColor);
 
   /* Menu */
   --fdMenu_Text_Shadow: none;

--- a/packages/styles/src/theming/sap_fiori_3_light_dark.scss
+++ b/packages/styles/src/theming/sap_fiori_3_light_dark.scss
@@ -98,7 +98,6 @@
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: none;
   --fdProductSwitch_Shadow: none;
-  --fdProductSwitch_Border: none;
 
   /* Menu */
   --fdMenu_Text_Shadow: none;

--- a/packages/styles/src/theming/sap_horizon.scss
+++ b/packages/styles/src/theming/sap_horizon.scss
@@ -102,7 +102,6 @@
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: none;
   --fdProductSwitch_Shadow: none;
-  --fdProductSwitch_Border: none;
 
   /* Menu */
   --fdMenu_Text_Shadow: none;

--- a/packages/styles/src/theming/sap_horizon_dark.scss
+++ b/packages/styles/src/theming/sap_horizon_dark.scss
@@ -114,7 +114,6 @@
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: none;
   --fdProductSwitch_Shadow: none;
-  --fdProductSwitch_Border: none;
 
   /* Menu */
   --fdMenu_Text_Shadow: none;

--- a/packages/styles/src/theming/sap_horizon_hcb.scss
+++ b/packages/styles/src/theming/sap_horizon_hcb.scss
@@ -101,7 +101,6 @@
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: none;
   --fdProductSwitch_Shadow: none;
-  --fdProductSwitch_Border: none;
 
   /* Menu */
   --fdMenu_Text_Shadow: none;

--- a/packages/styles/src/theming/sap_horizon_hcw.scss
+++ b/packages/styles/src/theming/sap_horizon_hcw.scss
@@ -102,7 +102,6 @@
   /* Product Switch */
   --fdProductSwitch_Text_Shadow: none;
   --fdProductSwitch_Shadow: none;
-  --fdProductSwitch_Border: none;
 
   /* Menu */
   --fdMenu_Text_Shadow: none;


### PR DESCRIPTION


## Related Issue
related to an issue in Fundamental-ngx https://github.com/SAP/fundamental-ngx/issues/11494
## Description
Added a transparent border to the Product switch item so that when the item is selected and a border is applied the content does not "jump" due to different height of the available container. 
