### PR TITLE
fix(styles): add fix for the Tokens focus being cut in Tokenizer

### DIFF
--- a/packages/styles/src/tokenizer.scss
+++ b/packages/styles/src/tokenizer.scss
@@ -14,7 +14,6 @@ $block: #{$fd-namespace}-tokenizer;
   @include fd-input-field-base();
 
   width: 100%;
-  height: auto;
   display: flex;
   padding: 0;
   margin: 0;
@@ -33,6 +32,7 @@ $block: #{$fd-namespace}-tokenizer;
     float: right;
     white-space: nowrap;
     width: 100%;
+    height: 100%;
     display: flex;
     align-items: center;
     justify-content: flex-end;
@@ -135,7 +135,7 @@ $block: #{$fd-namespace}-tokenizer;
   &--scrollable {
     .#{$block}__inner {
       justify-content: initial;
-      overflow: scroll;
+      overflow-x: scroll;
     }
   }
 }


### PR DESCRIPTION


## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/5248

## Description
the focus of the tokens is being cut vertically

## Screenshots
### Before:

![Screenshot 2024-03-20 at 2 15 54 PM](https://github.com/SAP/fundamental-styles/assets/39598672/be17959c-6a15-470d-97f5-cd2c6e0a796c)

### After:

![Screenshot 2024-03-20 at 2 29 12 PM](https://github.com/SAP/fundamental-styles/assets/39598672/fe5dd3d7-98bb-464b-8ff0-c7de93e10595)
![Screenshot 2024-03-20 at 2 29 19 PM](https://github.com/SAP/fundamental-styles/assets/39598672/989f79b8-2bf7-4796-9ef1-3560f66761e5)

