### PR TITLE
fix(styles): change the font-size of Side Nav icon [ci visual]

### DIFF
--- a/packages/cx/src/_nested-list.scss
+++ b/packages/cx/src/_nested-list.scss
@@ -216,7 +216,7 @@ $button: #{$fd-cx-namespace}-button;
       @include fd-set-height(100%);
 
       color: currentColor;
-      font-size: var(--sapFontSize);
+      font-size: var(--sapContent_IconHeight);
     }
   }
 


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-styles/issues/5308

## Description
change the icon size from 14px to 16px as requested from the designers
