### PR TITLE
fix(styles): add focus improvements to Card [ci visual]

### DIFF
--- a/packages/styles/src/card.scss
+++ b/packages/styles/src/card.scss
@@ -236,9 +236,19 @@ $legend-background-colors: (
       }
     }
 
-    .#{$block}__header-main-container {
-      @include fake-card-outline();
+
+    &[role="button"] {
+      .#{$block}__header-main-container {
+        @include fake-card-outline();
+      }
     }
+
+    &[role="listitem"] {
+      .#{$block}__header-main-container {
+        pointer-events: none;
+      }
+    }
+   
 
     cursor: pointer;
   }
@@ -541,6 +551,18 @@ $legend-background-colors: (
     span {
       @include fd-ellipsis();
     }
+
+    & + .#{$block}__header {
+      --fdCard_Content_Border_Radius: var(--fdCard_Border_Corner_Radius) var(--fdCard_Border_Corner_Radius) 0 0;
+      --fdCard_Focus_Outline_Radius: var(--fdCard_Border_Corner_Radius) var(--fdCard_Border_Corner_Radius) 0 0;
+      --fdCard_Main_Header_Border_Radius: var(--fdCard_Border_Corner_Radius) var(--fdCard_Border_Corner_Radius) 0 0;
+
+      &:is(:last-child) {
+        --fdCard_Content_Border_Radius: var(--fdCard_Border_Corner_Radius);
+        --fdCard_Focus_Outline_Radius: var(--fdCard_Border_Corner_Radius);
+      }
+    }
+
 
     & + .#{$block}__content {
       overflow: hidden;

--- a/packages/styles/stories/Components/card/card-anatomy.example.html
+++ b/packages/styles/stories/Components/card/card-anatomy.example.html
@@ -92,9 +92,9 @@
             <span class="fd-object-status fd-object-status--inverted fd-object-status--indication-6 fd-card__badge">
                 <span class="fd-object-status__text">badge</span>
             </span>
-            <div class="fd-card__header" role="group" aria-roledescription="Card Header">
+            <div class="fd-card__header fd-card__header--interactive" aria-roledescription="Card Header">
                 <div class="fd-card__header-main">
-                    <div class="fd-card__header-main-container">
+                    <div class="fd-card__header-main-container" role="button" tabindex="0"  aria-description="Activate for action/navigation" aria-label="Activate for action/navigation" title="Activate for action/navigation">
                         <span
                             class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--thumbnail fd-card__avatar"
                             style="background-image: url('/assets/images/backgrounds/city.jpg')"
@@ -125,9 +125,9 @@
 
     <div style="width: 300px; height: 400px; margin: 1rem;">
         <div class="fd-card" role="region" aria-roledescription="Card" aria-labelledby="card-title-5d">
-            <div class="fd-card__header" role="group" aria-roledescription="Card Header">
+            <div class="fd-card__header fd-card__header--interactive" role="group" aria-roledescription="Card Header">
                 <div class="fd-card__header-main">
-                    <div class="fd-card__header-main-container">
+                    <div class="fd-card__header-main-container" role="button" tabindex="0"  aria-description="Activate for action/navigation" aria-label="Activate for action/navigation" title="Activate for action/navigation">
                         <span
                             class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--thumbnail fd-card__avatar"
                             style="background-image: url('/assets/images/backgrounds/city.jpg')"

--- a/packages/styles/stories/Components/card/card-non-interactive-header.example.html
+++ b/packages/styles/stories/Components/card/card-non-interactive-header.example.html
@@ -154,7 +154,51 @@
     </div>
 
     <div style="width: 300px; height: 400px; margin: 1rem;">
+        <div class="fd-card" role="region" aria-labelledby="card-title-9a" aria-roledescription="Card">
+            <span class="fd-object-status fd-object-status--inverted fd-object-status--indication-6 fd-card__badge">
+                <span class="fd-object-status__text">badge</span>
+            </span>
+            <div class="fd-card__header fd-card__header--interactive" role="group" aria-roledescription="Card Header">
+                <div class="fd-card__header-main">
+                    <div class="fd-card__header-main-container is-focus"role="button" tabindex="0" aria-description="Activate for action/navigation" aria-label="Activate for action/navigation" title="Activate for action/navigation">
+                        <span
+                            class="fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--thumbnail fd-card__avatar"
+                            style="background-image: url('/assets/images/backgrounds/city.jpg')"
+                            role="img"
+                            aria-label="John Doe">
+                        </span>
+                        <div class="fd-card__header-text">
+                            <div class="fd-card__title-area">
+                                <div class="fd-card__title" id="card-title-9a" role="heading" aria-level="3">Focus Header</div>
+                            </div>
+                            <div class="fd-card__subtitle-area">
+                                <div class="fd-card__subtitle">Card Subtitle</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="fd-card__content" role="group" aria-roledescription="Card content"></div>
+            
+            <div class="fd-card__footer">
+                <div class="fd-card__footer-actions">
+                    <button class="fd-button fd-button--positive">
+                        Button
+                    </button>
+                    <button class="fd-button fd-button--negative">
+                        Button
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div style="width: 300px; height: 400px; margin: 1rem;">
         <div class="fd-card" role="region" aria-labelledby="card-title-7a" aria-roledescription="Card">
+            <span class="fd-object-status fd-object-status--inverted fd-object-status--indication-1 fd-card__badge">
+                <span class="fd-object-status__text">badge</span>
+            </span>
             <div class="fd-card__content" role="group" aria-roledescription="Card content"></div>
             <div class="fd-card__header fd-card__header--interactive" role="group" aria-roledescription="Card Header">
                 <div class="fd-card__header-main">
@@ -181,6 +225,9 @@
 
     <div style="width: 300px; height: 400px; margin: 1rem;">
         <div class="fd-card" role="region" aria-labelledby="card-title-8a" aria-roledescription="Card">
+            <span class="fd-object-status fd-object-status--inverted fd-object-status--indication-3 fd-card__badge">
+                <span class="fd-object-status__text">badge</span>
+            </span>
             <div class="fd-card__content" role="group" aria-roledescription="Card content"></div>
             <div class="fd-card__header fd-card__header--interactive" role="group" aria-roledescription="Card Header">
                 <div class="fd-card__header-main">

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -11959,9 +11959,9 @@ exports[`Check stories > Components/Card/Card > Story CardAnatomy > Should match
             <span class=\\"fd-object-status fd-object-status--inverted fd-object-status--indication-6 fd-card__badge\\">
                 <span class=\\"fd-object-status__text\\">badge</span>
             </span>
-            <div class=\\"fd-card__header\\" role=\\"group\\" aria-roledescription=\\"Card Header\\">
+            <div class=\\"fd-card__header fd-card__header--interactive\\" aria-roledescription=\\"Card Header\\">
                 <div class=\\"fd-card__header-main\\">
-                    <div class=\\"fd-card__header-main-container\\">
+                    <div class=\\"fd-card__header-main-container\\" role=\\"button\\" tabindex=\\"0\\"  aria-description=\\"Activate for action/navigation\\" aria-label=\\"Activate for action/navigation\\" title=\\"Activate for action/navigation\\">
                         <span
                             class=\\"fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--thumbnail fd-card__avatar\\"
                             style=\\"background-image: url('/assets/images/backgrounds/city.jpg')\\"
@@ -11992,9 +11992,9 @@ exports[`Check stories > Components/Card/Card > Story CardAnatomy > Should match
 
     <div style=\\"width: 300px; height: 400px; margin: 1rem;\\">
         <div class=\\"fd-card\\" role=\\"region\\" aria-roledescription=\\"Card\\" aria-labelledby=\\"card-title-5d\\">
-            <div class=\\"fd-card__header\\" role=\\"group\\" aria-roledescription=\\"Card Header\\">
+            <div class=\\"fd-card__header fd-card__header--interactive\\" role=\\"group\\" aria-roledescription=\\"Card Header\\">
                 <div class=\\"fd-card__header-main\\">
-                    <div class=\\"fd-card__header-main-container\\">
+                    <div class=\\"fd-card__header-main-container\\" role=\\"button\\" tabindex=\\"0\\"  aria-description=\\"Activate for action/navigation\\" aria-label=\\"Activate for action/navigation\\" title=\\"Activate for action/navigation\\">
                         <span
                             class=\\"fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--thumbnail fd-card__avatar\\"
                             style=\\"background-image: url('/assets/images/backgrounds/city.jpg')\\"
@@ -12886,7 +12886,51 @@ exports[`Check stories > Components/Card/Card > Story CardNonInteractiveHeader >
     </div>
 
     <div style=\\"width: 300px; height: 400px; margin: 1rem;\\">
+        <div class=\\"fd-card\\" role=\\"region\\" aria-labelledby=\\"card-title-9a\\" aria-roledescription=\\"Card\\">
+            <span class=\\"fd-object-status fd-object-status--inverted fd-object-status--indication-6 fd-card__badge\\">
+                <span class=\\"fd-object-status__text\\">badge</span>
+            </span>
+            <div class=\\"fd-card__header fd-card__header--interactive\\" role=\\"group\\" aria-roledescription=\\"Card Header\\">
+                <div class=\\"fd-card__header-main\\">
+                    <div class=\\"fd-card__header-main-container is-focus\\"role=\\"button\\" tabindex=\\"0\\" aria-description=\\"Activate for action/navigation\\" aria-label=\\"Activate for action/navigation\\" title=\\"Activate for action/navigation\\">
+                        <span
+                            class=\\"fd-avatar fd-avatar--s fd-avatar--circle fd-avatar--thumbnail fd-card__avatar\\"
+                            style=\\"background-image: url('/assets/images/backgrounds/city.jpg')\\"
+                            role=\\"img\\"
+                            aria-label=\\"John Doe\\">
+                        </span>
+                        <div class=\\"fd-card__header-text\\">
+                            <div class=\\"fd-card__title-area\\">
+                                <div class=\\"fd-card__title\\" id=\\"card-title-9a\\" role=\\"heading\\" aria-level=\\"3\\">Focus Header</div>
+                            </div>
+                            <div class=\\"fd-card__subtitle-area\\">
+                                <div class=\\"fd-card__subtitle\\">Card Subtitle</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class=\\"fd-card__content\\" role=\\"group\\" aria-roledescription=\\"Card content\\"></div>
+            
+            <div class=\\"fd-card__footer\\">
+                <div class=\\"fd-card__footer-actions\\">
+                    <button class=\\"fd-button fd-button--positive\\">
+                        Button
+                    </button>
+                    <button class=\\"fd-button fd-button--negative\\">
+                        Button
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div style=\\"width: 300px; height: 400px; margin: 1rem;\\">
         <div class=\\"fd-card\\" role=\\"region\\" aria-labelledby=\\"card-title-7a\\" aria-roledescription=\\"Card\\">
+            <span class=\\"fd-object-status fd-object-status--inverted fd-object-status--indication-1 fd-card__badge\\">
+                <span class=\\"fd-object-status__text\\">badge</span>
+            </span>
             <div class=\\"fd-card__content\\" role=\\"group\\" aria-roledescription=\\"Card content\\"></div>
             <div class=\\"fd-card__header fd-card__header--interactive\\" role=\\"group\\" aria-roledescription=\\"Card Header\\">
                 <div class=\\"fd-card__header-main\\">
@@ -12913,6 +12957,9 @@ exports[`Check stories > Components/Card/Card > Story CardNonInteractiveHeader >
 
     <div style=\\"width: 300px; height: 400px; margin: 1rem;\\">
         <div class=\\"fd-card\\" role=\\"region\\" aria-labelledby=\\"card-title-8a\\" aria-roledescription=\\"Card\\">
+            <span class=\\"fd-object-status fd-object-status--inverted fd-object-status--indication-3 fd-card__badge\\">
+                <span class=\\"fd-object-status__text\\">badge</span>
+            </span>
             <div class=\\"fd-card__content\\" role=\\"group\\" aria-roledescription=\\"Card content\\"></div>
             <div class=\\"fd-card__header fd-card__header--interactive\\" role=\\"group\\" aria-roledescription=\\"Card Header\\">
                 <div class=\\"fd-card__header-main\\">


### PR DESCRIPTION
## Related Issue
Closes none

## Description
- when the Card itself is interactive and has role listitem, the header should not get focus. 
- when the Card has a badge the header border radius was wrong