### PR TITLE
fix(styles): add option to make header cells non interactive [ci visual]

### DIFF
--- a/packages/styles/src/table.scss
+++ b/packages/styles/src/table.scss
@@ -82,6 +82,18 @@ $table-z-index: (
         color: var(--fdTable_Header_Cell_Hover_Active_Color);
       }
     }
+
+    &--non-interactive {
+      .#{$block}__cell {
+        @include fd-hover() {
+          background-color: var(--sapList_HeaderBackground);
+        }
+
+        @include fd-active() {
+          background-color: var(--sapList_HeaderBackground);
+        }
+      }
+    }
   }
 
   &__text {

--- a/packages/styles/stories/Components/table/primary.example.html
+++ b/packages/styles/stories/Components/table/primary.example.html
@@ -52,3 +52,60 @@
         </tr>
     </tbody>
 </table>
+
+<br><br>
+<h4>Non-interactive header cells</h4>
+<div class="fd-toolbar fd-toolbar--title fd-toolbar-active">
+    <h4 class="fd-title fd-title--h4 fd-toolbar__title">Default Table</h4>
+    <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
+</div>
+<table class="fd-table">
+    <thead class="fd-table__header fd-table__header--non-interactive">
+        <tr class="fd-table__row">
+            <th class="fd-table__cell" scope="col">Column Header</th>
+            <th class="fd-table__cell" scope="col">Column Header</th>
+            <th class="fd-table__cell" scope="col">Column Header</th>
+            <th class="fd-table__cell" scope="col">Column Header</th>
+            <th class="fd-table__cell" scope="col">Column Header</th>
+        </tr>
+    </thead>
+    <tbody class="fd-table__body">
+        <tr class="fd-table__row">
+            <td class="fd-table__cell"><a class="fd-link"><span class="fd-link__content">user.name@email.com</span></a></td>
+            <td class="fd-table__cell">
+                <div class="fd-table__text fd-table__text--no-wrap" style="max-width: 250px">
+                    Very long Text Not Wrapped, limited by max-width
+                    Very long Text Not Wrapped, limited by max-width
+                    Very long Text Not Wrapped, limited by max-width
+                    Very long Text Not Wrapped, limited by max-width
+                    Very long Text Not Wrapped, limited by max-width
+                    Very long Text Not Wrapped, limited by max-width
+                </div>
+            </td>
+            <td class="fd-table__cell">Middle Name</td>
+            <td class="fd-table__cell">Last Name</td>
+            <td class="fd-table__cell">01/26/17</td>
+        </tr>
+        <tr class="fd-table__row">
+            <td class="fd-table__cell"><a class="fd-link"><span class="fd-link__content">user.name@email.com</span></a></td>
+            <td class="fd-table__cell">
+                <div class="fd-table__text" style="max-width: 250px">
+                    Very long Text Wrapped, limited by max-width
+                    Very long Text Wrapped, limited by max-width
+                    Very long Text Wrapped, limited by max-width
+                    Very long Text Wrapped, limited by max-width
+                </div>
+            </td>
+            <td class="fd-table__cell">Middle Name</td>
+            <td class="fd-table__cell">Last Name</td>
+            <td class="fd-table__cell">01/26/17</td>
+        </tr>
+        <tr class="fd-table__row">
+            <td class="fd-table__cell"><a class="fd-link"><span class="fd-link__content">user.name@email.com</span></a></td>
+            <td class="fd-table__cell">First Name</td>
+            <td class="fd-table__cell">Middle Name</td>
+            <td class="fd-table__cell">Last Name</td>
+            <td class="fd-table__cell">01/26/17</td>
+        </tr>
+    </tbody>
+</table>

--- a/packages/styles/stories/Components/table/table.stories.js
+++ b/packages/styles/stories/Components/table/table.stories.js
@@ -93,7 +93,8 @@ Primary.parameters = {
   docs: {
     description: {
       story: `
-The primary table contains columns with headers, and rows with links. In the first column, links are displayed. To display links within a table, add the \`fd-link\` class within the table data.
+The primary table contains columns with headers, and rows with links. In the first column, links are displayed. To display links within a table, add the \`fd-link\` class within the table data. <br>
+To disable the hover and active states on header cells apply the <code>fd-table__header--non-interactive</code> modifier to <code>fd-table__header</code> base class.
     `
     }
   }

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -43578,7 +43578,63 @@ exports[`Check stories > Components/Table > Story Primary > Should match snapsho
         </tr>
     </tbody>
 </table>
-"
+
+<br><br>
+<h4>Non-interactive header cells</h4>
+<div class=\\"fd-toolbar fd-toolbar--title fd-toolbar-active\\">
+    <h4 class=\\"fd-title fd-title--h4 fd-toolbar__title\\">Default Table</h4>
+    <span class=\\"fd-toolbar__spacer fd-toolbar__spacer--auto\\"></span>
+</div>
+<table class=\\"fd-table\\">
+    <thead class=\\"fd-table__header fd-table__header--non-interactive\\">
+        <tr class=\\"fd-table__row\\">
+            <th class=\\"fd-table__cell\\" scope=\\"col\\">Column Header</th>
+            <th class=\\"fd-table__cell\\" scope=\\"col\\">Column Header</th>
+            <th class=\\"fd-table__cell\\" scope=\\"col\\">Column Header</th>
+            <th class=\\"fd-table__cell\\" scope=\\"col\\">Column Header</th>
+            <th class=\\"fd-table__cell\\" scope=\\"col\\">Column Header</th>
+        </tr>
+    </thead>
+    <tbody class=\\"fd-table__body\\">
+        <tr class=\\"fd-table__row\\">
+            <td class=\\"fd-table__cell\\"><a class=\\"fd-link\\"><span class=\\"fd-link__content\\">user.name@email.com</span></a></td>
+            <td class=\\"fd-table__cell\\">
+                <div class=\\"fd-table__text fd-table__text--no-wrap\\" style=\\"max-width: 250px\\">
+                    Very long Text Not Wrapped, limited by max-width
+                    Very long Text Not Wrapped, limited by max-width
+                    Very long Text Not Wrapped, limited by max-width
+                    Very long Text Not Wrapped, limited by max-width
+                    Very long Text Not Wrapped, limited by max-width
+                    Very long Text Not Wrapped, limited by max-width
+                </div>
+            </td>
+            <td class=\\"fd-table__cell\\">Middle Name</td>
+            <td class=\\"fd-table__cell\\">Last Name</td>
+            <td class=\\"fd-table__cell\\">01/26/17</td>
+        </tr>
+        <tr class=\\"fd-table__row\\">
+            <td class=\\"fd-table__cell\\"><a class=\\"fd-link\\"><span class=\\"fd-link__content\\">user.name@email.com</span></a></td>
+            <td class=\\"fd-table__cell\\">
+                <div class=\\"fd-table__text\\" style=\\"max-width: 250px\\">
+                    Very long Text Wrapped, limited by max-width
+                    Very long Text Wrapped, limited by max-width
+                    Very long Text Wrapped, limited by max-width
+                    Very long Text Wrapped, limited by max-width
+                </div>
+            </td>
+            <td class=\\"fd-table__cell\\">Middle Name</td>
+            <td class=\\"fd-table__cell\\">Last Name</td>
+            <td class=\\"fd-table__cell\\">01/26/17</td>
+        </tr>
+        <tr class=\\"fd-table__row\\">
+            <td class=\\"fd-table__cell\\"><a class=\\"fd-link\\"><span class=\\"fd-link__content\\">user.name@email.com</span></a></td>
+            <td class=\\"fd-table__cell\\">First Name</td>
+            <td class=\\"fd-table__cell\\">Middle Name</td>
+            <td class=\\"fd-table__cell\\">Last Name</td>
+            <td class=\\"fd-table__cell\\">01/26/17</td>
+        </tr>
+    </tbody>
+</table>"
 `;
 
 exports[`Check stories > Components/Table > Story ResponsiveTable > Should match snapshot 1`] = `


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/5392

## Description

adds a modifier class to the header to remove the hover and active states