### PR TITLE
fix(styles): fix the wrong min-width variable values for Input and Tokenizer

### DIFF
--- a/packages/styles/src/mixins/_forms.scss
+++ b/packages/styles/src/mixins/_forms.scss
@@ -25,7 +25,7 @@ $fd-input-field-height--compact: 1.625rem;
 
   z-index: 1;
   width: 100%;
-  min-width: var(#{$overrideMinWidth}, 2.75rem);
+  min-width: #{$overrideMinWidth};
   border-radius: var(--sapField_BorderCornerRadius);
   padding: var(--fdInput_Field_Padding, 0 0.625rem);
   margin: var(--fdInput_Field_Margin, 0.25rem 0);

--- a/packages/styles/src/tokenizer.scss
+++ b/packages/styles/src/tokenizer.scss
@@ -64,7 +64,7 @@ $block: #{$fd-namespace}-tokenizer;
     &.#{$fd-namespace}-input {
       border: none;
       padding: 0;
-      min-width: var(--fdTokenizer_Input_Width, $fd-tokenizer-input-width);
+      min-width: $fd-tokenizer-input-width;
     }
 
     &:first-child {


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/5406

## Description
the min-width of input field and input in Tokenizer was not working because of wrong variable values
