### PR TITLE
fix(styles): add fix for focused read-only input missing underline 

### DIFF
--- a/packages/styles/src/mixins/_forms.scss
+++ b/packages/styles/src/mixins/_forms.scss
@@ -94,6 +94,8 @@ $fd-input-field-height--compact: 1.625rem;
 }
 
 @mixin fd-input-readonly() {
+  --fdInput_Outline_Offset: -0.25rem;
+
   box-shadow: none;
   border-color: var(--sapField_ReadOnly_BorderColor);
   background: var(--sapField_ReadOnly_BackgroundStyle);


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/5437

## Description
add bigger outline offset on focus so that the dotted underline is visisble

## Screenshots
### Before:
<img width="813" alt="Screenshot 2024-06-11 at 11 05 06 AM" src="https://github.com/SAP/fundamental-styles/assets/39598672/e859e875-31f7-4cf8-9744-2befdda0bbeb">


### After:
<img width="799" alt="Screenshot 2024-06-11 at 11 05 14 AM" src="https://github.com/SAP/fundamental-styles/assets/39598672/c421f1b4-8c9d-4831-b8fe-e1e8c51b7c14">
