### PR TITLE
fix(styles): add option for a second badge on Cards [ci visual]

### DIFF
--- a/packages/styles/src/card.scss
+++ b/packages/styles/src/card.scss
@@ -535,22 +535,19 @@ $legend-background-colors: (
     margin-block-start: var(--fdCard_Counter_Margin);
   }
 
-  &__badge.#{$object-status} {
+  &__badge-container {
+    @include fd-reset();
     @include fd-set-position-right(0.5rem); 
 
-    --fdObjectStatus_Inverted_Border_Radius: 0.5rem;
-    --fdObjectStatus_Inverted_Padding: 0 0.25rem;
-    --fdObjectStatus_Inverted_Line_Height: 0.875rem;
+    @include fd-flex-vertical-center() {
+      gap: 0.25rem;
+    }
 
     z-index: 10;
     top: -0.5rem;
     position: absolute;
     min-width: 1.375rem;
     max-width: calc(100% - 1rem);
-
-    span {
-      @include fd-ellipsis();
-    }
 
     & + .#{$block}__header {
       --fdCard_Content_Border_Radius: var(--fdCard_Border_Corner_Radius) var(--fdCard_Border_Corner_Radius) 0 0;
@@ -574,6 +571,17 @@ $legend-background-colors: (
         --fdCard_Content_Border_Radius: var(--fdCard_Border_Corner_Radius);
         --fdCard_Focus_Outline_Radius: var(--fdCard_Border_Corner_Radius);
       }
+    }
+
+  }
+
+  &__badge.#{$object-status} {
+    --fdObjectStatus_Inverted_Border_Radius: 0.5rem;
+    --fdObjectStatus_Inverted_Padding: 0 0.25rem;
+    --fdObjectStatus_Inverted_Line_Height: 0.875rem;
+
+    span {
+      @include fd-ellipsis();
     }
   }
 
@@ -898,9 +906,8 @@ $legend-background-colors: (
   &__media-text {
     @include fd-reset();
 
-    font-weight: regular;
+    font-weight: normal;
     font-size: var(--sapFontSize);
-    font-family: var(--sapFontHeaderFamily);
     color: var(--fdCard_Media_Text_Color, var(--sapTile_TextColor));
   }
 

--- a/packages/styles/stories/Components/card/analytical-card.example.html
+++ b/packages/styles/stories/Components/card/analytical-card.example.html
@@ -86,10 +86,12 @@
                         </div>
                     </div>
                 </div>
-                <span class="fd-object-status fd-object-status--inverted fd-object-status--indication-5b fd-card__badge">
-                    <i class="fd-object-status__icon sap-icon--example" role="presentation"></i>
-                    <span class="fd-object-status__text">badge</span>
-                </span>
+                <div class="fd-card__badge-container">
+                    <span class="fd-object-status fd-object-status--inverted fd-object-status--indication-5b fd-card__badge">
+                        <i class="fd-object-status__icon sap-icon--example" role="presentation"></i>
+                        <span class="fd-object-status__text">badge</span>
+                    </span>
+                </div>
                 
             </div>
             <div class="fd-card__content" role="group" aria-roledescription="Card content"></div>

--- a/packages/styles/stories/Components/card/card-anatomy.example.html
+++ b/packages/styles/stories/Components/card/card-anatomy.example.html
@@ -89,9 +89,11 @@
 
     <div style="width: 300px; height: 400px; margin: 1rem;">
         <div class="fd-card" role="region" aria-roledescription="Card" aria-labelledby="card-title-4d">
+           <div class="fd-card__badge-container">
             <span class="fd-object-status fd-object-status--inverted fd-object-status--indication-6 fd-card__badge">
                 <span class="fd-object-status__text">badge</span>
             </span>
+           </div>
             <div class="fd-card__header fd-card__header--interactive" aria-roledescription="Card Header">
                 <div class="fd-card__header-main">
                     <div class="fd-card__header-main-container" role="button" tabindex="0"  aria-description="Activate for action/navigation" aria-label="Activate for action/navigation" title="Activate for action/navigation">
@@ -197,10 +199,12 @@
 
     <div style="width: 300px; height: 400px; margin: 1rem;">
         <div class="fd-card" role="region" aria-roledescription="Card" aria-labelledby="card-title-6d">
-            <span class="fd-object-status fd-object-status--inverted fd-object-status--indication-3 fd-card__badge">
-                <i class="fd-object-status__icon sap-icon--example" role="presentation"></i>
-                <span class="fd-object-status__text">badge lorem ipsum dolor sit amet consectetur adipisicing elit. Repudiandae distinctio natus aperiam doloremque beatae quas, fuga sequi iste officia similique sunt, iusto ad obcaecati voluptatum. Commodi perferendis assumenda modi laudantium.</span>
-            </span>
+            <div class="fd-card__badge-container">
+                <span class="fd-object-status fd-object-status--inverted fd-object-status--indication-3 fd-card__badge">
+                    <i class="fd-object-status__icon sap-icon--example" role="presentation"></i>
+                    <span class="fd-object-status__text">badge lorem ipsum dolor sit amet consectetur adipisicing elit. Repudiandae distinctio natus aperiam doloremque beatae quas, fuga sequi iste officia similique sunt, iusto ad obcaecati voluptatum. Commodi perferendis assumenda modi laudantium.</span>
+                </span>
+            </div>
             <div class="fd-card__header" role="group" aria-roledescription="Card Header">
                 <div class="fd-card__header-main">
                     <div class="fd-card__header-main-container">
@@ -227,10 +231,12 @@
 
     <div style="width: 300px; height: 400px; margin: 1rem;">
         <div class="fd-card" role="region" aria-roledescription="Card" aria-labelledby="card-title-7d">
-            <span class="fd-object-status fd-object-status--inverted fd-object-status--indication-5b fd-card__badge">
-                <i class="fd-object-status__icon sap-icon--example" role="presentation"></i>
-                <span class="fd-object-status__text">badge</span>
-            </span>
+            <div class="fd-card__badge-container">
+                <span class="fd-object-status fd-object-status--inverted fd-object-status--indication-5b fd-card__badge">
+                    <i class="fd-object-status__icon sap-icon--example" role="presentation"></i>
+                    <span class="fd-object-status__text">badge</span>
+                </span>
+            </div>
             <div class="fd-card__header" role="group" aria-roledescription="Card Header">
                 <div class="fd-card__header-main">
                     <div class="fd-card__header-main-container">

--- a/packages/styles/stories/Components/card/card-non-interactive-header.example.html
+++ b/packages/styles/stories/Components/card/card-non-interactive-header.example.html
@@ -155,9 +155,11 @@
 
     <div style="width: 300px; height: 400px; margin: 1rem;">
         <div class="fd-card" role="region" aria-labelledby="card-title-9a" aria-roledescription="Card">
-            <span class="fd-object-status fd-object-status--inverted fd-object-status--indication-6 fd-card__badge">
-                <span class="fd-object-status__text">badge</span>
-            </span>
+            <div class="fd-card__badge-container">
+                <span class="fd-object-status fd-object-status--inverted fd-object-status--indication-6 fd-card__badge">
+                    <span class="fd-object-status__text">badge</span>
+                </span>
+            </div>
             <div class="fd-card__header fd-card__header--interactive" role="group" aria-roledescription="Card Header">
                 <div class="fd-card__header-main">
                     <div class="fd-card__header-main-container is-focus"role="button" tabindex="0" aria-description="Activate for action/navigation" aria-label="Activate for action/navigation" title="Activate for action/navigation">
@@ -196,9 +198,11 @@
 
     <div style="width: 300px; height: 400px; margin: 1rem;">
         <div class="fd-card" role="region" aria-labelledby="card-title-7a" aria-roledescription="Card">
-            <span class="fd-object-status fd-object-status--inverted fd-object-status--indication-1 fd-card__badge">
-                <span class="fd-object-status__text">badge</span>
-            </span>
+            <div class="fd-card__badge-container">
+                <span class="fd-object-status fd-object-status--inverted fd-object-status--indication-1 fd-card__badge">
+                    <span class="fd-object-status__text">badge</span>
+                </span>
+            </div>
             <div class="fd-card__content" role="group" aria-roledescription="Card content"></div>
             <div class="fd-card__header fd-card__header--interactive" role="group" aria-roledescription="Card Header">
                 <div class="fd-card__header-main">
@@ -225,9 +229,14 @@
 
     <div style="width: 300px; height: 400px; margin: 1rem;">
         <div class="fd-card" role="region" aria-labelledby="card-title-8a" aria-roledescription="Card">
-            <span class="fd-object-status fd-object-status--inverted fd-object-status--indication-3 fd-card__badge">
-                <span class="fd-object-status__text">badge</span>
-            </span>
+            <div class="fd-card__badge-container">
+                <span class="fd-object-status fd-object-status--inverted fd-object-status--indication-3 fd-card__badge">
+                    <span class="fd-object-status__text">badge</span>
+                </span>
+                <span class="fd-object-status fd-object-status--inverted fd-object-status--indication-3 fd-card__badge">
+                    <i class="fd-object-status__icon sap-icon--example" role="presentation"></i>
+                </span>
+            </div>
             <div class="fd-card__content" role="group" aria-roledescription="Card content"></div>
             <div class="fd-card__header fd-card__header--interactive" role="group" aria-roledescription="Card Header">
                 <div class="fd-card__header-main">

--- a/packages/styles/stories/Components/card/card.stories.js
+++ b/packages/styles/stories/Components/card/card.stories.js
@@ -49,7 +49,7 @@ Card sizes vary depending on the layout, and they are not editable. A card can f
   - <b>extended header</b>: the extended header is a flexible block to hold various other components, like time stamp, rating, tags, label/value, long text, numeric values, etc. The components can be arranged in left column or right column, each column is suggested to have maximum 3 lines for placing the components.
   - <b>numeric header</b>: the numeric header block is designed for displaying numeric information. It consumes Numeric Content (Horizon) and can show additional qualifying information and side indicators, if required. 
 
-- <b>badge</b> (optional): The Badge for Cards can contain Icon and Text, Text only or Icon only. There are no interaction states on Badge for Cards. Badge on Cards consumes the <b>Inverted Object Status/Tag</b> with some modifications. A Badge can only expand to the max width of the card that it is applied to. Text on it will not wrap, but truncate. 
+- <b>badge</b> (optional): The Badge for Cards can contain Icon and Text, Text only or Icon only. There are no interaction states on Badge for Cards. Badge on Cards consumes the <b>Inverted Object Status/Tag</b> with some modifications. A Badge can only expand to the max width of the card that it is applied to. Text on it will not wrap, but truncate. <b>There can be max 2 badges per Card.</b>
 - <b>content</b> (main): the content area is reserved for application content.
     
 - <b>footer</b> (optional): the footer displays a list of actions that can be performed on the card. When link is too long, or there is no more place for actions, overflow button should appear.

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -11851,10 +11851,12 @@ exports[`Check stories > Components/Card/Card > Story AnalyticalCard > Should ma
                         </div>
                     </div>
                 </div>
-                <span class=\\"fd-object-status fd-object-status--inverted fd-object-status--indication-5b fd-card__badge\\">
-                    <i class=\\"fd-object-status__icon sap-icon--example\\" role=\\"presentation\\"></i>
-                    <span class=\\"fd-object-status__text\\">badge</span>
-                </span>
+                <div class=\\"fd-card__badge-container\\">
+                    <span class=\\"fd-object-status fd-object-status--inverted fd-object-status--indication-5b fd-card__badge\\">
+                        <i class=\\"fd-object-status__icon sap-icon--example\\" role=\\"presentation\\"></i>
+                        <span class=\\"fd-object-status__text\\">badge</span>
+                    </span>
+                </div>
                 
             </div>
             <div class=\\"fd-card__content\\" role=\\"group\\" aria-roledescription=\\"Card content\\"></div>
@@ -11956,9 +11958,11 @@ exports[`Check stories > Components/Card/Card > Story CardAnatomy > Should match
 
     <div style=\\"width: 300px; height: 400px; margin: 1rem;\\">
         <div class=\\"fd-card\\" role=\\"region\\" aria-roledescription=\\"Card\\" aria-labelledby=\\"card-title-4d\\">
+           <div class=\\"fd-card__badge-container\\">
             <span class=\\"fd-object-status fd-object-status--inverted fd-object-status--indication-6 fd-card__badge\\">
                 <span class=\\"fd-object-status__text\\">badge</span>
             </span>
+           </div>
             <div class=\\"fd-card__header fd-card__header--interactive\\" aria-roledescription=\\"Card Header\\">
                 <div class=\\"fd-card__header-main\\">
                     <div class=\\"fd-card__header-main-container\\" role=\\"button\\" tabindex=\\"0\\"  aria-description=\\"Activate for action/navigation\\" aria-label=\\"Activate for action/navigation\\" title=\\"Activate for action/navigation\\">
@@ -12064,10 +12068,12 @@ exports[`Check stories > Components/Card/Card > Story CardAnatomy > Should match
 
     <div style=\\"width: 300px; height: 400px; margin: 1rem;\\">
         <div class=\\"fd-card\\" role=\\"region\\" aria-roledescription=\\"Card\\" aria-labelledby=\\"card-title-6d\\">
-            <span class=\\"fd-object-status fd-object-status--inverted fd-object-status--indication-3 fd-card__badge\\">
-                <i class=\\"fd-object-status__icon sap-icon--example\\" role=\\"presentation\\"></i>
-                <span class=\\"fd-object-status__text\\">badge lorem ipsum dolor sit amet consectetur adipisicing elit. Repudiandae distinctio natus aperiam doloremque beatae quas, fuga sequi iste officia similique sunt, iusto ad obcaecati voluptatum. Commodi perferendis assumenda modi laudantium.</span>
-            </span>
+            <div class=\\"fd-card__badge-container\\">
+                <span class=\\"fd-object-status fd-object-status--inverted fd-object-status--indication-3 fd-card__badge\\">
+                    <i class=\\"fd-object-status__icon sap-icon--example\\" role=\\"presentation\\"></i>
+                    <span class=\\"fd-object-status__text\\">badge lorem ipsum dolor sit amet consectetur adipisicing elit. Repudiandae distinctio natus aperiam doloremque beatae quas, fuga sequi iste officia similique sunt, iusto ad obcaecati voluptatum. Commodi perferendis assumenda modi laudantium.</span>
+                </span>
+            </div>
             <div class=\\"fd-card__header\\" role=\\"group\\" aria-roledescription=\\"Card Header\\">
                 <div class=\\"fd-card__header-main\\">
                     <div class=\\"fd-card__header-main-container\\">
@@ -12094,10 +12100,12 @@ exports[`Check stories > Components/Card/Card > Story CardAnatomy > Should match
 
     <div style=\\"width: 300px; height: 400px; margin: 1rem;\\">
         <div class=\\"fd-card\\" role=\\"region\\" aria-roledescription=\\"Card\\" aria-labelledby=\\"card-title-7d\\">
-            <span class=\\"fd-object-status fd-object-status--inverted fd-object-status--indication-5b fd-card__badge\\">
-                <i class=\\"fd-object-status__icon sap-icon--example\\" role=\\"presentation\\"></i>
-                <span class=\\"fd-object-status__text\\">badge</span>
-            </span>
+            <div class=\\"fd-card__badge-container\\">
+                <span class=\\"fd-object-status fd-object-status--inverted fd-object-status--indication-5b fd-card__badge\\">
+                    <i class=\\"fd-object-status__icon sap-icon--example\\" role=\\"presentation\\"></i>
+                    <span class=\\"fd-object-status__text\\">badge</span>
+                </span>
+            </div>
             <div class=\\"fd-card__header\\" role=\\"group\\" aria-roledescription=\\"Card Header\\">
                 <div class=\\"fd-card__header-main\\">
                     <div class=\\"fd-card__header-main-container\\">
@@ -12887,9 +12895,11 @@ exports[`Check stories > Components/Card/Card > Story CardNonInteractiveHeader >
 
     <div style=\\"width: 300px; height: 400px; margin: 1rem;\\">
         <div class=\\"fd-card\\" role=\\"region\\" aria-labelledby=\\"card-title-9a\\" aria-roledescription=\\"Card\\">
-            <span class=\\"fd-object-status fd-object-status--inverted fd-object-status--indication-6 fd-card__badge\\">
-                <span class=\\"fd-object-status__text\\">badge</span>
-            </span>
+            <div class=\\"fd-card__badge-container\\">
+                <span class=\\"fd-object-status fd-object-status--inverted fd-object-status--indication-6 fd-card__badge\\">
+                    <span class=\\"fd-object-status__text\\">badge</span>
+                </span>
+            </div>
             <div class=\\"fd-card__header fd-card__header--interactive\\" role=\\"group\\" aria-roledescription=\\"Card Header\\">
                 <div class=\\"fd-card__header-main\\">
                     <div class=\\"fd-card__header-main-container is-focus\\"role=\\"button\\" tabindex=\\"0\\" aria-description=\\"Activate for action/navigation\\" aria-label=\\"Activate for action/navigation\\" title=\\"Activate for action/navigation\\">
@@ -12928,9 +12938,11 @@ exports[`Check stories > Components/Card/Card > Story CardNonInteractiveHeader >
 
     <div style=\\"width: 300px; height: 400px; margin: 1rem;\\">
         <div class=\\"fd-card\\" role=\\"region\\" aria-labelledby=\\"card-title-7a\\" aria-roledescription=\\"Card\\">
-            <span class=\\"fd-object-status fd-object-status--inverted fd-object-status--indication-1 fd-card__badge\\">
-                <span class=\\"fd-object-status__text\\">badge</span>
-            </span>
+            <div class=\\"fd-card__badge-container\\">
+                <span class=\\"fd-object-status fd-object-status--inverted fd-object-status--indication-1 fd-card__badge\\">
+                    <span class=\\"fd-object-status__text\\">badge</span>
+                </span>
+            </div>
             <div class=\\"fd-card__content\\" role=\\"group\\" aria-roledescription=\\"Card content\\"></div>
             <div class=\\"fd-card__header fd-card__header--interactive\\" role=\\"group\\" aria-roledescription=\\"Card Header\\">
                 <div class=\\"fd-card__header-main\\">
@@ -12957,9 +12969,14 @@ exports[`Check stories > Components/Card/Card > Story CardNonInteractiveHeader >
 
     <div style=\\"width: 300px; height: 400px; margin: 1rem;\\">
         <div class=\\"fd-card\\" role=\\"region\\" aria-labelledby=\\"card-title-8a\\" aria-roledescription=\\"Card\\">
-            <span class=\\"fd-object-status fd-object-status--inverted fd-object-status--indication-3 fd-card__badge\\">
-                <span class=\\"fd-object-status__text\\">badge</span>
-            </span>
+            <div class=\\"fd-card__badge-container\\">
+                <span class=\\"fd-object-status fd-object-status--inverted fd-object-status--indication-3 fd-card__badge\\">
+                    <span class=\\"fd-object-status__text\\">badge</span>
+                </span>
+                <span class=\\"fd-object-status fd-object-status--inverted fd-object-status--indication-3 fd-card__badge\\">
+                    <i class=\\"fd-object-status__icon sap-icon--example\\" role=\\"presentation\\"></i>
+                </span>
+            </div>
             <div class=\\"fd-card__content\\" role=\\"group\\" aria-roledescription=\\"Card content\\"></div>
             <div class=\\"fd-card__header fd-card__header--interactive\\" role=\\"group\\" aria-roledescription=\\"Card Header\\">
                 <div class=\\"fd-card__header-main\\">


### PR DESCRIPTION
## Description
- added an option to have 2 badges on Card as defined in the latest design specs
- changed the font-family of the description text for Media Cards

BREAKING CHANAGE:
- badges are wrapped in an element with class `fd-card__badge-container`

Before:
```
<span class="fd-object-status fd-object-status--inverted fd-object-status--indication-5b fd-card__badge">
    <i class="fd-object-status__icon sap-icon--example" role="presentation"></i>
    <span class="fd-object-status__text">badge</span>
</span>

```

After:
```
<div class="fd-card__badge-container">
    <span class="fd-object-status fd-object-status--inverted fd-object-status--indication-5b fd-card__badge">
        <i class="fd-object-status__icon sap-icon--example" role="presentation"></i>
        <span class="fd-object-status__text">badge</span>
    </span>
 </div>
```