### PR TITLE
fix(styles): improve the truncate behavior for Object Status [ci visual]

### DIFF
--- a/packages/styles/src/card.scss
+++ b/packages/styles/src/card.scss
@@ -577,7 +577,7 @@ $legend-background-colors: (
 
   &__badge.#{$object-status} {
     --fdObjectStatus_Inverted_Border_Radius: 0.5rem;
-    --fdObjectStatus_Inverted_Padding: 0 0.25rem;
+    --fdObjectStatus_Inverted_Padding: 0;
     --fdObjectStatus_Inverted_Line_Height: 0.875rem;
 
     span {

--- a/packages/styles/src/object-status.scss
+++ b/packages/styles/src/object-status.scss
@@ -728,7 +728,7 @@ $inverted-color-accents-b: (
 
   @include fd-reset();
 
-  @include fd-flex-center() {
+  @include fd-flex() {
     gap: 0.25rem;
     display: inline-flex;
   }
@@ -748,13 +748,16 @@ $inverted-color-accents-b: (
     @include fd-reset();
     @include fd-object-status-text-inherit();
 
-    line-height: var(--fdObjectStatus_Height);
+    line-height: var(--fdObjectStatus_Text_Line_Height, normal);
+    vertical-align: top;
+    display: inline-block;
   }
 
   &__icon {
     @include fd-icon-element-base() {
       @include fd-flex-center();
 
+      align-self: center;
       font-size: var(--fdObjectStatus_Icon_Font_Size);
       color: var(--fdObjectStatus_Icon_Color);
       line-height: var(--fdObjectStatus_Height);
@@ -836,6 +839,7 @@ $inverted-color-accents-b: (
 
   // LARGE DESIGN
   &--large {
+    --fdObjectStatus_Text_Line_Height: 1;
     --fdObjectStatus_Text_Font_Size: 1.5rem;
     --fdObjectStatus_Height: 1.5rem;
     --fdObjectStatus_Icon_Font_Size: 1.5rem;
@@ -853,7 +857,7 @@ $inverted-color-accents-b: (
     position: relative;
     border-style: solid;
     overflow: hidden;
-    padding: var(--fdObjectStatus_Inverted_Padding);
+    padding-inline: 0.25rem;
     min-width: var(--fdObjectStatus_Inverted_Min_Width);
     border-width: var(--fdObjectStatus_Inverted_Border_Width);
     min-height: var(--fdObjectStatus_Inverted_Line_Height);
@@ -861,9 +865,13 @@ $inverted-color-accents-b: (
     border-radius: var(--fdObjectStatus_Inverted_Border_Radius);
     background-color: var(--fdObjectStatus_Background_Color, transparent);
 
-    .#{$block}__icon,
-    .#{$block}__text {
+    .#{$block}__icon {
       line-height: 1rem;
+    }
+
+    .#{$block}__text {
+      line-height: normal;
+      padding-block: var(--fdObjectStatus_Inverted_Padding);
     }
 
     &::before {

--- a/packages/styles/src/theming/common/object-status/_sap_fiori.scss
+++ b/packages/styles/src/theming/common/object-status/_sap_fiori.scss
@@ -34,7 +34,7 @@
   --fdObjectStatus_Inverted_Border_Width: 0;
   --fdObjectStatus_Inverted_Underline_Width: 0;
   --fdObjectStatus_Inverted_Min_Width: 1.25rem;
-  --fdObjectStatus_Inverted_Padding: 0.0625rem 0.25rem;
+  --fdObjectStatus_Inverted_Padding: 0.125rem 0.0625rem;
   --fdObjectStatus_Inverted_Line_Height: 1.125rem;
   --fdObjectStatus_Inverted_Border_Radius: 0.25rem;
   --fdObjectStatus_Inverted_Large_Font_Family: var(--sapFontLightFamily);

--- a/packages/styles/src/theming/common/object-status/_sap_horizon.scss
+++ b/packages/styles/src/theming/common/object-status/_sap_horizon.scss
@@ -34,7 +34,7 @@
   --fdObjectStatus_Inverted_Border_Width: 0.0625rem;
   --fdObjectStatus_Inverted_Underline_Width: 0.125rem;
   --fdObjectStatus_Inverted_Min_Width: 1.375rem;
-  --fdObjectStatus_Inverted_Padding: 0.1875rem 0.25rem;
+  --fdObjectStatus_Inverted_Padding: 0.1875rem;
   --fdObjectStatus_Inverted_Line_Height: 1.375rem;
   --fdObjectStatus_Inverted_Border_Radius: var(--sapButton_BorderCornerRadius);
   --fdObjectStatus_Inverted_Large_Font_Family: var(--sapFontSemiBoldFamily);

--- a/packages/styles/stories/Components/object-status/truncate-example.example.html
+++ b/packages/styles/stories/Components/object-status/truncate-example.example.html
@@ -1,5 +1,5 @@
 <div class="fddocs-container">
-    <span class="fd-object-status fd-object-status--negative fd-object-status--truncate" style="max-width: 15rem;">
+    <span class="fd-object-status fd-object-status--negative" style="max-width: 15rem;">
         <i class="fd-object-status__icon sap-icon--error" role="presentation"></i>
         <span class="fd-object-status__text">Default behaviour of Object Status with very long text. The text goes on multiple lines.</span>
     </span>


### PR DESCRIPTION
## Related Issue
Closes none

## Description
the long text should be top aligned, not center aligned

Before:
<img width="299" alt="Screenshot 2024-06-13 at 1 44 24 PM" src="https://github.com/SAP/fundamental-styles/assets/39598672/23361dbe-6fde-430a-b705-c54da9e00c6a">


After:
<img width="285" alt="Screenshot 2024-06-13 at 1 44 30 PM" src="https://github.com/SAP/fundamental-styles/assets/39598672/f5bd60fc-2a26-4328-b347-3808748cfb9a">

