### PR TITLE
fix(styles): add status color only to the status icon of Message Box 

### DIFF
--- a/packages/styles/src/message-box.scss
+++ b/packages/styles/src/message-box.scss
@@ -7,7 +7,6 @@
 $block: #{$fd-namespace}-message-box;
 $bar: #{$fd-namespace}-bar;
 $button: #{$fd-namespace}-button;
-$fd-message-box-icon-text-spacing: 0.5rem;
 $fd-message-box-title-icon-text-size: 1rem;
 $fd-message-box-footer-button-min-width: 4rem;
 $fd-message-box-content-padding-x: (s: 1rem, m: 2rem, l: 2rem, xl: 3rem);
@@ -98,15 +97,10 @@ $message-box-states: (
       .#{$block}__header.#{$bar} {
         box-shadow: map.get($state-set, "boxShadow");
 
-        [class*="sap-icon"] {
+        :not(button) > [class*="sap-icon"] {
           font-size: 1rem;
-          margin-right: $fd-message-box-icon-text-spacing;
+          margin-inline-end: 0.5rem;
           color: map.get($state-set, "iconColor");
-
-          @include fd-rtl() {
-            margin-right: 0;
-            margin-left: $fd-message-box-icon-text-spacing;
-          }
         }
       }
     }


### PR DESCRIPTION
## Related Issue
Closes none, related to an issue in FNGX

## Description
Although not recommended, the user can add a dismiss button in the Message Box header. The dismiss button receives some CSS that is intended only for the status icon, like margin-right and color.

<img width="979" alt="Screenshot 2024-07-04 at 2 59 02 PM" src="https://github.com/SAP/fundamental-styles/assets/39598672/753129f2-20c9-4efb-a776-abea9804c387">

The solution for this issue is to target all icons that are not children of a button.

After the solution:
<img width="1006" alt="Screenshot 2024-07-04 at 3 04 50 PM" src="https://github.com/SAP/fundamental-styles/assets/39598672/3b673b2e-07d1-4f0b-9317-6a5b2176fdd9">

NOTE: the screenshots can't be found in the documentation as this is not something we would like users to do. I added the buttons in the header just to test the solution and removed them after.