### PR TITLE
feat(common-css): add data attribute to common css Text [ci visual]

### DIFF
--- a/packages/common-css/src/_common-mixins.scss
+++ b/packages/common-css/src/_common-mixins.scss
@@ -1081,10 +1081,36 @@
     background-color: var(--sapSelectedColor);
   }
 
+  &[data-lines] {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  &[data-hyphens] {
+    hyphens: auto;
+  }
+
+  &[data-wrap] {
+    white-space: pre-wrap;
+  }
+
+  @for $i from 0 through 20 {
+    &[data-lines="#{$i}"] {
+      -webkit-line-clamp: #{$i};
+    }
+  }
+
   @if $modifier == 'max-lines' {
     display: -webkit-box;
     -webkit-box-orient: vertical;
     overflow: hidden;
+
+    @for $i from 0 through 20 {
+      &[data-lines="#{$i}"] {
+        -webkit-line-clamp: #{$i};
+      }
+    }
   }
 
   @if $modifier == 'pre-wrap' {

--- a/packages/common-css/stories/text/hyphenation.example.html
+++ b/packages/common-css/stories/text/hyphenation.example.html
@@ -10,6 +10,15 @@
 
         <div class="fddocs-text">
             <h3>Hyphenation</h3>
+            <p class="sap-text" data-hyphens>Lorem ipsum dolor sit amet, con&shy;sectetur adip&shy;iscing el&shy;it, sed do eiusmod tempor
+            incididunt ut labore et do&shy;lore magna aliqua. Ut enim ad mi&shy;nim veniam, quis nostrud exer&shy;citation ullamco laboris nisi ut
+            aliquip ex ea commodo conse&shy;quat. Duis aute irure dolor in repre&shy;henderit in vo&shy;luptate velit esse cillum dolore
+            eu fu&shy;giat nulla pari&shy;atur. Excepteur sint occaecat cupidatat non pro&shy;ident, sunt in culpa qui officia
+            deserunt mollit anim id est la&shy;bo&shy;rum.</p>
+        </div>
+
+        <div class="fddocs-text">
+            <h3>Hyphenation with modifier class</h3>
             <p class="sap-text-hyphenation">Lorem ipsum dolor sit amet, con&shy;sectetur adip&shy;iscing el&shy;it, sed do eiusmod tempor
             incididunt ut labore et do&shy;lore magna aliqua. Ut enim ad mi&shy;nim veniam, quis nostrud exer&shy;citation ullamco laboris nisi ut
             aliquip ex ea commodo conse&shy;quat. Duis aute irure dolor in repre&shy;henderit in vo&shy;luptate velit esse cillum dolore

--- a/packages/common-css/stories/text/max-lines.example.html
+++ b/packages/common-css/stories/text/max-lines.example.html
@@ -16,7 +16,7 @@
     Dolor magna eget est lorem ipsum dolor sit. Aliquam nulla facilisi cras fermentum odio eu feugiat pretium nibh.
     Augue neque gravida in fermentum et. Proin fermentum leo vel orci porta non pulvinar.</p>
 
-    <h3>2 max lines</h3>
+    <h3>2 max lines (with class)</h3>
     <p class="sap-text-max-lines" style="-webkit-line-clamp: 2;">
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
     eiusmod tempor incididunt ut labore et dolore magna aliqua. Malesuada bibendum arcu vitae elementum. Ut etiam sit
@@ -35,7 +35,26 @@
     Augue neque gravida in fermentum et. Proin fermentum leo vel orci porta non pulvinar.</p>
 
     <h3>3 max lines</h3>
-    <p class="sap-text-max-lines" style="-webkit-line-clamp: 3;">
+    <p class="sap-text" data-lines="3">
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+    eiusmod tempor incididunt ut labore et dolore magna aliqua. Malesuada bibendum arcu vitae elementum. Ut etiam sit
+    amet nisl. Laoreet suspendisse interdum consectetur libero id faucibus nisl. Tellus in metus vulputate eu
+    scelerisque felis imperdiet proin fermentum. Ullamcorper morbi tincidunt ornare massa eget egestas purus viverra
+    accumsan. Mauris vitae ultricies leo integer malesuada nunc vel risus. Nisi est sit amet facilisis. Eu turpis
+    egestas pretium aenean. Nunc id cursus metus aliquam eleifend. Placerat in egestas erat imperdiet. Etiam dignissim
+    diam quis enim lobortis scelerisque. A erat nam at lectus. Amet nisl purus in mollis nunc sed id. Purus semper eget
+    duis at tellus at urna.
+    Aliquet eget sit amet tellus cras adipiscing enim. Risus ultricies tristique nulla aliquet enim tortor. Varius quam
+    quisque id diam vel quam elementum pulvinar. Eget aliquet nibh praesent tristique magna. Id interdum velit laoreet
+    id donec ultrices tincidunt arcu. Suspendisse ultrices gravida dictum fusce ut placerat orci nulla. Montes nascetur
+    ridiculus mus mauris vitae ultricies. In nisl nisi scelerisque eu. Suspendisse interdum consectetur libero id
+    faucibus. Ut lectus arcu bibendum at varius. Placerat vestibulum lectus mauris ultrices eros in cursus turpis massa.
+    Dolor magna eget est lorem ipsum dolor sit. Aliquam nulla facilisi cras fermentum odio eu feugiat pretium nibh.
+    Augue neque gravida in fermentum et. Proin fermentum leo vel orci porta non pulvinar.</p>
+
+
+    <h3>4 max lines</h3>
+    <p class="sap-text" data-lines="4">
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
     eiusmod tempor incididunt ut labore et dolore magna aliqua. Malesuada bibendum arcu vitae elementum. Ut etiam sit
     amet nisl. Laoreet suspendisse interdum consectetur libero id faucibus nisl. Tellus in metus vulputate eu

--- a/packages/common-css/stories/text/text.stories.js
+++ b/packages/common-css/stories/text/text.stories.js
@@ -39,7 +39,7 @@ Whitespace.parameters = {
     description: {
       story: `The text component has a property that allows browsers to render specified indents and
         whitespace. To display indents and/or whitespace, use the
-        \`.fd-text-pre-wrap\` class.`
+        \`.fd-text-pre-wrap\` class or \`data-wrap\` attribute to \`.fd-text\` class.`
     }
   }
 };
@@ -54,6 +54,8 @@ use the \`.fd-text-max-lines\` class and an inline style rule with the number of
 lines to the main element. For example, add \`style="-webkit-line-clamp: 3;"\` to display
 three lines of text.
 
+You can also add the \`data-lines\` attribute to \`.fd-text\` class and specify the number of lines. 
+
 **Note**: The property \`-webkit-line-clamp\` doesn't work in IE11 and should be changed
 to \`height\`. For example, \`style="height: 200px;"\`.
 `
@@ -65,7 +67,7 @@ Hyphenation.parameters = {
   docs: {
     description: {
       story: `The text component can display words that are broken at appropriate hyphenation
-points in a text block. To display hyphens, use the \`.fd-text-hyphenation\` element.
+points in a text block. To display hyphens, use the \`.fd-text-hyphenation\` class or or \`data-hyphens\` attribute to \`.fd-text\` class.
 
 **It is also possible to suggest line break opportunities with two Unicode characters that manually specify
 potential line breakpoints:**

--- a/packages/common-css/stories/text/whitespace.example.html
+++ b/packages/common-css/stories/text/whitespace.example.html
@@ -6,8 +6,18 @@
     eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
     deserunt mollit anim id est laborum.</p>
 
-    <h3>Wrapped text with indents and whitespace</h3>
+    <h3>Wrapped text with indents and whitespace (with modifier class)</h3>
     <p class="sap-text-pre-wrap">
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididuntut labore et
+dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquip ex ea commodo consequat.
+
+    Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore
+eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
+deserunt mollit anim id est laborum.</p>
+
+    <h3>Wrapped text with indents and whitespace</h3>
+    <p class="sap-text" data-wrap>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididuntut labore et
 dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
 aliquip ex ea commodo consequat.


### PR DESCRIPTION
## Related Issue
Closes none, improvements suggested by @trilodge 

## Description
add data attr as alternative to modifier classes to handle hyphens, wrap, line-clamp in Text (common CSS)
