### PR TITLE
fix(styles): add optimization for margins and paddings [ci visual]

### DIFF
--- a/packages/common-css/src/common-css.scss
+++ b/packages/common-css/src/common-css.scss
@@ -19,7 +19,6 @@
 @import './sap-shadow';
 @import './sap-sr-only';
 @import './sap-text';
+@import './sap-title';
 @import './sap-tool-layout';
 @import './sap-typography';
-@import './sap-title';
-

--- a/packages/cx/src/_nested-list.scss
+++ b/packages/cx/src/_nested-list.scss
@@ -224,7 +224,7 @@ $button: #{$fd-cx-namespace}-button;
     @include fd-reset();
 
     width: 100%;
-    text-align: left;
+    text-align: start;
     color: currentColor;
     display: inline-block;
     font-size: var(--sapFontSize);
@@ -233,10 +233,6 @@ $button: #{$fd-cx-namespace}-button;
     @include fd-set-paddings-y-equal(0.75rem);
 
     line-height: normal;
-
-    @include fd-rtl() {
-      text-align: right;
-    }
 
     @include fd-compact () {
       @include fd-set-paddings-y-equal(0);

--- a/packages/doc-ui/src/components/DocsPage/DocsPage.scss
+++ b/packages/doc-ui/src/components/DocsPage/DocsPage.scss
@@ -11,6 +11,6 @@ a[title='Open canvas in new tab'] {
 /* make room for TOCBot */
 @media (width >= 1024px) {
   .sbdocs.sbdocs-content {
-    margin-right: 200px;
+    margin-inline-end: 200px;
   }
 }

--- a/packages/styles/src/_message-view.scss
+++ b/packages/styles/src/_message-view.scss
@@ -27,11 +27,8 @@ $block: #{$fd-namespace}-message-view;
     display: none;
     position: absolute;
     inset: 0;
-    padding: 1rem 1rem 1rem 3.5rem;
-
-    @include fd-rtl() {
-      padding: 1rem 3.5rem 1rem 1rem;
-    }
+    padding-block: 1rem;
+    padding-inline: 3.5rem 1rem;
 
     &-title {
       @include fd-reset();
@@ -47,11 +44,8 @@ $block: #{$fd-namespace}-message-view;
 
       .#{$block}__icon {
         font-size: 1rem;
-        margin: 0 0.5rem 0 -2rem;
-
-        @include fd-rtl() {
-          margin: 0 -2rem 0 0.5rem;
-        }
+        margin-block: 0;
+        margin-inline: -2rem 0.5rem;
       }
     }
 

--- a/packages/styles/src/_nested-list.scss
+++ b/packages/styles/src/_nested-list.scss
@@ -215,11 +215,7 @@ $button: #{$fd-namespace}-button;
         height: 100%;
 
         > .#{$block}__title {
-          padding-right: 0;
-
-          @include fd-rtl() {
-            padding-left: 0;
-          }
+          padding-inline-end: 0;
         }
       }
     }
@@ -265,23 +261,13 @@ $button: #{$fd-namespace}-button;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    padding-right: 1rem;
+    padding-inline-end: 1rem;
     display: flex;
     align-items: center;
+    text-align: start;
 
     &:first-child {
-      padding-left: 2.75rem;
-    }
-
-    @include fd-rtl() {
-      text-align: right;
-      padding-right: 0;
-      padding-left: 1rem;
-
-      &:first-child {
-        padding-right: 2.75rem;
-        padding-left: 0;
-      }
+      padding-inline-start: 2.75rem;
     }
   }
 

--- a/packages/styles/src/alert.scss
+++ b/packages/styles/src/alert.scss
@@ -8,10 +8,6 @@ $block: #{$fd-namespace}-alert;
 .#{$block} {
   $fd-alert-border: 1px solid;
   $fd-alert-border-radius: 0.25rem;
-  $fd-alert-padding: 0.4375rem 1rem;
-  $fd-alert-padding-default: 1rem;
-  $fd-alert-padding-dismissible: 2.5rem;
-  $fd-alert-padding-status: 2.5rem;
   $fd-alert-text-color: var(--sapTextColor);
 
   @mixin fd-alert-icon-container {
@@ -61,7 +57,8 @@ $block: #{$fd-namespace}-alert;
   border: $fd-alert-border;
   border-color: $fd-alert-border-color;
   border-radius: $fd-alert-border-radius;
-  padding: $fd-alert-padding;
+  padding-block: 0.4375rem;
+  padding-inline: 1rem 1rem;
   display: flex;
   align-items: center;
   min-height: 2rem;
@@ -87,12 +84,7 @@ $block: #{$fd-namespace}-alert;
 
   // Modifiers
   &--dismissible {
-    padding-right: $fd-alert-padding-dismissible;
-
-    @include fd-rtl() {
-      padding-right: $fd-alert-padding-default;
-      padding-left: $fd-alert-padding-dismissible;
-    }
+    padding-inline-end: 2.5rem;
   }
 
   &--warning,
@@ -104,12 +96,9 @@ $block: #{$fd-namespace}-alert;
       @include fd-alert-icon-container();
     }
 
-    padding-left: $fd-alert-padding-status;
+    padding-inline-start: 2.5rem;
 
     @include fd-rtl() {
-      padding-right: $fd-alert-padding-status;
-      padding-left: $fd-alert-padding-default;
-
       &::before,
       &::after {
         left: auto;
@@ -118,11 +107,7 @@ $block: #{$fd-namespace}-alert;
     }
 
     &.#{$block}--dismissible {
-      padding-right: $fd-alert-padding-dismissible;
-
-      @include fd-rtl() {
-        padding-left: $fd-alert-padding-dismissible;
-      }
+      padding-inline-end: 2.5rem;
     }
 
     @include fd-rtl() {
@@ -198,15 +183,13 @@ $block: #{$fd-namespace}-alert;
   }
 
   &--no-icon {
-    padding-left: $fd-alert-padding-default;
+    padding-inline-start: 1rem;
 
     &::before {
       display: none;
     }
 
     @include fd-rtl() {
-      padding-right: $fd-alert-padding-default;
-
       &::after {
         display: none;
       }

--- a/packages/styles/src/breadcrumb.scss
+++ b/packages/styles/src/breadcrumb.scss
@@ -3,7 +3,6 @@
 @import "./new-settings";
 @import "./mixins";
 
-$fd-breadcrumb-spacing: 0.25rem;
 $fd-breadcrumb-separator-color: var(--sapContent_LabelColor);
 $fd-breadcrumb-item-color: var(--sapContent_LabelColor);
 $block: #{$fd-namespace}-breadcrumb;
@@ -28,8 +27,7 @@ $fd-breadcrumb-overflow-active-color: var(--sapLink_Active_Color);
     &::after {
       content: "/";
       color: $fd-breadcrumb-separator-color;
-      margin-right: $fd-breadcrumb-spacing;
-      margin-left: $fd-breadcrumb-spacing;
+      margin-inline:  0.25rem;
     }
 
     &:last-child::after {

--- a/packages/styles/src/button.scss
+++ b/packages/styles/src/button.scss
@@ -124,12 +124,12 @@ $fd-button-badge-spacing: 0.25rem;
 
   &--text-alignment {
     &-left {
-      text-align: left;
+      text-align: start;
       justify-content: flex-start;
     }
 
     &-right {
-      text-align: right;
+      text-align: end;
       justify-content: flex-end;
     }
   }

--- a/packages/styles/src/calendar.scss
+++ b/packages/styles/src/calendar.scss
@@ -201,16 +201,15 @@ $fd-calendar-special-days: (
     flex-grow: 1;
 
     &:not(:last-child, :first-child) {
-      margin-left: var(--fdCalendar_Action_Padding);
-      margin-right: var(--fdCalendar_Action_Padding);
+      margin-inline: var(--fdCalendar_Action_Padding);
     }
 
     &:first-child {
-      margin-right: var(--fdCalendar_Action_Padding);
+      margin-inline-end: var(--fdCalendar_Action_Padding);
     }
 
     &:last-child {
-      margin-left: var(--fdCalendar_Action_Padding);
+      margin-inline-start: var(--fdCalendar_Action_Padding);
     }
 
     > [type='button'] {

--- a/packages/styles/src/card.scss
+++ b/packages/styles/src/card.scss
@@ -437,7 +437,7 @@ $legend-background-colors: (
   &__indicator-value {
     @include fd-reset();
 
-    text-align: right;
+    text-align: end;
     color: var(--sapTile_TitleTextColor); 
     font-size: var(--sapFontSmallSize);
   } 
@@ -646,7 +646,7 @@ $legend-background-colors: (
 
     @include fd-rtl() {
       direction: ltr;
-      text-align: right;
+      text-align: end;
     }
   }
 

--- a/packages/styles/src/dynamic-page.scss
+++ b/packages/styles/src/dynamic-page.scss
@@ -13,7 +13,6 @@ $block: #{$fd-namespace}-dynamic-page;
   $fd-dynamic-page-button-group-width: 4rem;
   $fd-dynamic-page-button-group-height: 0.0625rem;
   $fd-dynamic-page-focus-outline-offset: -0.25rem;
-  $fd-dynamic-page-toolbar-space: 1rem;
 
   @mixin fd-background-page($background-color) {
     .#{$block}__content {
@@ -196,12 +195,9 @@ $block: #{$fd-namespace}-dynamic-page;
     @include fd-reset();
     @include fd-ellipsis();
 
-    padding: 0 0 0 1rem;
+    padding-block: 0;
+    padding-inline: 1rem 0;
     vertical-align: baseline;
-
-    @include fd-rtl() {
-      padding: 0 1rem 0 0;
-    }
   }
 
   &__title-subtitle-container {
@@ -214,24 +210,14 @@ $block: #{$fd-namespace}-dynamic-page;
     @include fd-reset();
     @include fd-flex-vertical-center();
 
-    margin-left: auto;
-
-    @include fd-rtl() {
-      margin-right: auto;
-      margin-left: 0;
-    }
+    margin-inline-start: auto;
   }
 
   .#{$block}__toolbar {
     @include fd-reset-spacing();
 
-    padding-left: $fd-dynamic-page-toolbar-space;
+    padding-inline-start: 1rem;
     background: transparent;
-
-    @include fd-rtl() {
-      padding-left: 0;
-      padding-right: $fd-dynamic-page-toolbar-space;
-    }
 
     &--actions,
     &--content {
@@ -410,22 +396,11 @@ $block: #{$fd-namespace}-dynamic-page;
     }
 
     .#{$block}__toolbar {
-      padding-left: $fd-dynamic-page-toolbar-space;
-      margin-left: auto;
-
-      @include fd-rtl() {
-        margin-left: 0;
-        margin-right: auto;
-        padding-left: 0;
-        padding-right: $fd-dynamic-page-toolbar-space;
-      }
+      padding-inline-start: 1rem;
+      margin-inline-start: auto;
 
       &--content {
-        margin-left: 0;
-
-        @include fd-rtl() {
-          margin-right: 0;
-        }
+        margin-inline-start: 0;
       }
     }
   }

--- a/packages/styles/src/feed-input.scss
+++ b/packages/styles/src/feed-input.scss
@@ -8,24 +8,14 @@ $block: #{$fd-namespace}-feed-input;
 .#{$block} {
   $fd-feed-input-min-height: 3rem;
   $fd-feed-input-max-height: 20rem;
-  $fd-feed-input-padding-start: 1rem;
-  $fd-feed-input-padding-end: 0.5rem;
-  $fd-feed-input-thumb-margin-start: 0;
-  $fd-feed-input-thumb-margin-end: 0.5rem;
-  $fd-feed-input-btn-margin-start: 0.5rem;
-  $fd-feed-input-btn-margin-end: 0;
 
   @include fd-reset();
 
   display: flex;
   flex-direction: row;
-  padding: 1rem $fd-feed-input-padding-end 1rem $fd-feed-input-padding-start;
+  padding-block: 1rem;
+  padding-inline: 1rem 0.5rem;
   background-color: var(--sapField_Background);
-
-  @include fd-rtl() {
-    padding-right: $fd-feed-input-padding-start;
-    padding-left: $fd-feed-input-padding-end;
-  }
 
   @include fd-disabled() {
     cursor: not-allowed;
@@ -43,13 +33,7 @@ $block: #{$fd-namespace}-feed-input;
   .#{$block}__thumb {
     display: none;
     flex: 1 0 auto;
-    margin-left: $fd-feed-input-thumb-margin-start;
-    margin-right: $fd-feed-input-thumb-margin-end;
-
-    @include fd-rtl() {
-      margin-left: $fd-feed-input-thumb-margin-end;
-      margin-right: $fd-feed-input-thumb-margin-start;
-    }
+    margin-inline: 0 0.5rem;
   }
 
   .#{$block}__textarea {
@@ -61,11 +45,10 @@ $block: #{$fd-namespace}-feed-input;
 
   // It's needed to have stronger selector to override fd-button styles
   .#{$block}__submit-button {
-    margin: auto $fd-feed-input-btn-margin-end 0.375rem $fd-feed-input-btn-margin-start;
+    margin-block: auto 0.375rem;
+    margin-inline: 0.5rem 0;
 
     @include fd-rtl() {
-      margin-left: $fd-feed-input-btn-margin-end;
-      margin-right: $fd-feed-input-btn-margin-start;
       transform: rotate(180deg);
     }
   }

--- a/packages/styles/src/feed-list.scss
+++ b/packages/styles/src/feed-list.scss
@@ -7,8 +7,6 @@ $block: #{$fd-namespace}-feed-list;
 .#{$block} {
   $fd-feed-list-padding-start: 1rem;
   $fd-feed-list-padding-end: 0.5rem;
-  $fd-feed-list-margin-start: 0.75rem;
-  $fd-feed-list-margin-end: 0;
   $fd-feed-list-padding-group: 0.75rem;
   $fd-feed-list-padding-action-small: 0.75rem;
   $fd-feed-list-icon-color: var(--sapContent_IconColor);
@@ -23,13 +21,7 @@ $block: #{$fd-namespace}-feed-list;
     @include fd-reset();
 
     display: inline-flex;
-    margin-left: $fd-feed-list-margin-end;
-    margin-right: $fd-feed-list-margin-start;
-
-    @include fd-rtl() {
-      margin-left: $fd-feed-list-margin-start;
-      margin-right: $fd-feed-list-margin-end;
-    }
+    margin-inline: 0 0.75rem;
   }
 
   &__body {

--- a/packages/styles/src/form-item.scss
+++ b/packages/styles/src/form-item.scss
@@ -4,7 +4,6 @@
 @import "./mixins";
 
 $block: #{$fd-namespace}-form-item;
-$fd-form-label-spacing: 0.5rem !default;
 
 .#{$block} {
   @include fd-reset();
@@ -20,11 +19,8 @@ $fd-form-label-spacing: 0.5rem !default;
 
     .#{$fd-namespace}-form-label {
       padding-bottom: 0;
-      margin: auto $fd-form-label-spacing auto 0;
-
-      @include fd-rtl() {
-        margin: auto 0 auto $fd-form-label-spacing;
-      }
+      margin-block: auto;
+      margin-inline: 0 0.5rem;
     }
 
     .#{$fd-namespace}-input {

--- a/packages/styles/src/form-label.scss
+++ b/packages/styles/src/form-label.scss
@@ -6,10 +6,6 @@
 $block: #{$fd-namespace}-form-label;
 
 .#{$block} {
-  $fd-unit-description-padding: 0.25rem;
-  $fd-require-space-padding: 0.5rem;
-  $fd-colon-space-padding: 0.125rem;
-  $fd-require-colon-space-spacing: 0.75rem;
   $fd-require-colon-spacing: 0.5rem;
   $fd-require-asterix-spacing: 0.125rem;
 
@@ -20,19 +16,15 @@ $block: #{$fd-namespace}-form-label;
   }
 
   &--unit-description {
-    padding: 0 0 0 $fd-unit-description-padding;
     color: var(--sapField_TextColor);
     margin: 0;
-
-    @include fd-rtl() {
-      margin: 0;
-      padding: 0 $fd-unit-description-padding 0 0;
-    }
+    padding-block: 0;
+    padding-inline: 0.25rem 0;
   }
 
   &--required,
   &[aria-required='true'] {
-    padding-right: $fd-require-space-padding;
+    padding-inline-end: 0.5rem;
 
     &::after {
       content: '*';
@@ -45,9 +37,6 @@ $block: #{$fd-namespace}-form-label;
     }
 
     @include fd-rtl() {
-      padding-right: 0;
-      padding-left: $fd-require-space-padding;
-
       &::after {
         right: auto;
         left: 0;
@@ -56,7 +45,7 @@ $block: #{$fd-namespace}-form-label;
   }
 
   &--colon {
-    padding-right: $fd-colon-space-padding;
+    padding-inline-end: 0.125rem;
 
     &::before {
       content: ':';
@@ -68,9 +57,6 @@ $block: #{$fd-namespace}-form-label;
     }
 
     @include fd-rtl() {
-      padding-left: $fd-colon-space-padding;
-      padding-right: 0;
-
       &::before {
         right: auto;
         left: 0;
@@ -79,16 +65,13 @@ $block: #{$fd-namespace}-form-label;
 
     &.#{$block}--required,
     &[aria-required='true'] {
-      padding-right: $fd-require-colon-space-spacing;
+      padding-inline-end: 0.75rem;
 
       &::before {
         right: $fd-require-colon-spacing;
       }
 
       @include fd-rtl() {
-        padding-left: $fd-require-colon-space-spacing;
-        padding-right: 0;
-
         &::before {
           right: auto;
           left: $fd-require-colon-spacing;

--- a/packages/styles/src/form-layout-grid.scss
+++ b/packages/styles/src/form-layout-grid.scss
@@ -34,13 +34,12 @@ $gridCol: #{$fd-namespace}-col;
       .#{$colSelector}--#{$col} {
         > .#{$fd-namespace}-form-label {
           float: right;
-          text-align: right;
+          text-align: end;
           padding-bottom: 0;
           width: 100%;
 
           @include fd-rtl() {
             float: left;
-            text-align: left;
           }
         }
       }
@@ -50,12 +49,11 @@ $gridCol: #{$fd-namespace}-col;
     .#{$colSelector}--12 {
       > .#{$fd-namespace}-form-label {
         float: left;
-        text-align: left;
+        text-align: start;
         width: auto;
         padding-bottom: 0.125rem;
 
         @include fd-rtl() {
-          text-align: right;
           float: right;
         }
       }

--- a/packages/styles/src/form-message.scss
+++ b/packages/styles/src/form-message.scss
@@ -47,17 +47,12 @@ $form-message-states: (
 
   @include fd-rtl() {
     right: 0;
-
-    &::before {
-      margin-right: 0;
-      margin-left: 0.375rem;
-    }
   }
 
   &::before {
     display: var(--fdMessage_Icon_Display);
     align-self: flex-start;
-    margin-right: 0.375rem;
+    margin-inline-end: 0.375rem;
     font-family: SAP-icons;
     font-size: 1rem;
   }

--- a/packages/styles/src/grid-list.scss
+++ b/packages/styles/src/grid-list.scss
@@ -217,12 +217,11 @@ $fd-grid-list-highlight: (
       @include fd-flex-center();
       @include fd-set-margin-right(-1rem);
 
-      margin-left: 0;
+      margin-inline-start: 0;
       width: 2.5rem;
       color: var(--sapContent_NonInteractiveIconColor);
 
       @include fd-rtl() {
-        margin-right: 0;
         transform: rotate(180deg);
       }
     }

--- a/packages/styles/src/input-group.scss
+++ b/packages/styles/src/input-group.scss
@@ -5,7 +5,6 @@
 @import "./mixins/button/button-helper";
 
 $block: #{$fd-namespace}-input-group;
-$fd-input-padding: 0.625rem;
 $fd-input-border-radius: var(--sapField_BorderCornerRadius);
 
 .#{$block} {
@@ -34,8 +33,7 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
     flex: 1 1 10rem;
     background: none;
     background-color: var(--fdInputGroup_Input_Background, transparent);
-    padding-left: 0.25rem;
-    padding-right: 0.25rem;
+    padding-inline: 0.25rem 0.25rem;
     text-shadow: var(--fdInputGroup_Text_Shadow);
     border: var(--fdInputGroup_Input_Border, none);
     color: var(--fdInputGroup_Input_Color, inherit);
@@ -58,16 +56,11 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
     }
 
     &:nth-child(1) {
-      @include fd-set-padding-left($fd-input-padding);
+      padding-inline-start: 0.625rem;
     }
 
     &:nth-last-child(1) {
-      padding-right: $fd-input-padding;
-
-      @include fd-rtl() {
-        padding-left: $fd-input-padding;
-        padding-right: 0.25rem;
-      }
+      padding-inline-end: 0.625rem;
     }
   }
 

--- a/packages/styles/src/input.scss
+++ b/packages/styles/src/input.scss
@@ -32,7 +32,7 @@ $block: #{$fd-namespace}-input;
   }
 
   &.right-align {
-    text-align: right;
+    text-align: end;
   }
 
   @include fd-input-field-states();

--- a/packages/styles/src/margins.scss
+++ b/packages/styles/src/margins.scss
@@ -43,193 +43,138 @@ $block: #{$fd-namespace}-margin;
   // margin top
   &-top {
     &--tiny {
-      margin-top: $fd-margin-tiny !important;
+      margin-block-start: $fd-margin-tiny !important;
     }
 
     &--sm {
-      margin-top: $fd-margin-small !important;
+      margin-block-start: $fd-margin-small !important;
     }
 
     &--md {
-      margin-top: $fd-margin-medium !important;
+      margin-block-start: $fd-margin-medium !important;
     }
 
     &--lg {
-      margin-top: $fd-margin-large !important;
+      margin-block-start: $fd-margin-large !important;
     }
 
     &--none {
-      margin-top: 0 !important;
+      margin-block-start: 0 !important;
     }
   }
 
   // margin end
   &-end {
     &--tiny {
-      margin-right: $fd-margin-tiny !important;
-
-      @include fd-rtl() {
-        margin-left: $fd-margin-tiny !important;
-        margin-right: 0 !important;
-      }
+      margin-inline-end: $fd-margin-tiny !important;
     }
 
     &--sm {
-      margin-right: $fd-margin-small !important;
-
-      @include fd-rtl() {
-        margin-left: $fd-margin-small !important;
-        margin-right: 0 !important;
-      }
+      margin-inline-end: $fd-margin-small !important;
     }
 
     &--md {
-      margin-right: $fd-margin-medium !important;
-
-      @include fd-rtl() {
-        margin-left: $fd-margin-medium !important;
-        margin-right: 0 !important;
-      }
+      margin-inline-end: $fd-margin-medium !important;
     }
 
     &--lg {
-      margin-right: $fd-margin-large !important;
-
-      @include fd-rtl() {
-        margin-left: $fd-margin-large !important;
-        margin-right: 0 !important;
-      }
+      margin-inline-end: $fd-margin-large !important;
     }
 
     &--none {
-      margin-right: 0;
-
-      @include fd-rtl() {
-        margin-left: 0 !important;
-      }
+      margin-inline-end: 0;
     }
   }
 
   // margin bottom
   &-bottom {
     &--tiny {
-      margin-bottom: $fd-margin-tiny !important;
+      margin-block-end: $fd-margin-tiny !important;
     }
 
     &--sm {
-      margin-bottom: $fd-margin-small !important;
+      margin-block-end: $fd-margin-small !important;
     }
 
     &--md {
-      margin-bottom: $fd-margin-medium !important;
+      margin-block-end: $fd-margin-medium !important;
     }
 
     &--lg {
-      margin-bottom: $fd-margin-large !important;
+      margin-block-end: $fd-margin-large !important;
     }
 
     &--none {
-      margin-bottom: 0 !important;
+      margin-block-end: 0 !important;
     }
   }
 
   // margin begin
   &-begin {
     &--tiny {
-      margin-left: $fd-margin-tiny !important;
-
-      @include fd-rtl() {
-        margin-right: $fd-margin-tiny !important;
-        margin-left: 0 !important;
-      }
+      margin-inline-start: $fd-margin-tiny !important;
     }
 
     &--sm {
-      margin-left: $fd-margin-small !important;
-
-      @include fd-rtl() {
-        margin-right: $fd-margin-small !important;
-        margin-left: 0 !important;
-      }
+      margin-inline-start: $fd-margin-small !important;
     }
 
     &--md {
-      margin-left: $fd-margin-medium !important;
-
-      @include fd-rtl() {
-        margin-right: $fd-margin-medium !important;
-        margin-left: 0 !important;
-      }
+      margin-inline-start: $fd-margin-medium !important;
     }
 
     &--lg {
-      margin-left: $fd-margin-large !important;
-
-      @include fd-rtl() {
-        margin-right: $fd-margin-large !important;
-        margin-left: 0 !important;
-      }
+      margin-inline-start: $fd-margin-large !important;
     }
 
     &--none {
-      margin-left: 0;
-
-      @include fd-rtl() {
-        margin-right: 0 !important;
-      }
+      margin-inline-start: 0;
     }
   }
 
   // double-sided top bottom margin
   &-top-bottom {
     &--tiny {
-      margin-top: $fd-margin-tiny !important;
-      margin-bottom: $fd-margin-tiny !important;
+      margin-block: $fd-margin-tiny $fd-margin-tiny !important;
     }
 
     &--sm {
-      margin-top: $fd-margin-small !important;
-      margin-bottom: $fd-margin-small !important;
+      margin-block: $fd-margin-small $fd-margin-small !important;
     }
 
     &--md {
-      margin-top: $fd-margin-medium !important;
-      margin-bottom: $fd-margin-medium !important;
+      margin-block: $fd-margin-medium $fd-margin-medium !important;
     }
 
     &--lg {
-      margin-top: $fd-margin-large !important;
-      margin-bottom: $fd-margin-large !important;
+      margin-block: $fd-margin-large $fd-margin-large !important;
     }
   }
 
   // double-sided begin end margin
   &-begin-end {
     &--tiny {
-      margin-left: $fd-margin-tiny !important;
-      margin-right: $fd-margin-tiny !important;
+      margin-inline: $fd-margin-tiny $fd-margin-tiny !important;
     }
 
     &--sm {
-      margin-left: $fd-margin-small !important;
-      margin-right: $fd-margin-small !important;
+      margin-inline: $fd-margin-small $fd-margin-small !important;
     }
 
     &--md {
-      margin-left: $fd-margin-medium !important;
-      margin-right: $fd-margin-medium !important;
+      margin-inline: $fd-margin-medium $fd-margin-medium !important;
     }
 
     &--lg {
-      margin-left: $fd-margin-large !important;
-      margin-right: $fd-margin-large !important;
+      margin-inline: $fd-margin-large $fd-margin-large !important;
     }
   }
 
   // responsive margin
   &-responsive {
     &--sm {
-      margin: 0 0 $fd-margin-responsive-vertical 0 !important;
+      margin-block: 0 $fd-margin-responsive-vertical;
+      margin-inline: 0;
     }
 
     &--md {
@@ -237,11 +182,13 @@ $block: #{$fd-namespace}-margin;
     }
 
     &--lg {
-      margin: $fd-margin-responsive-vertical $fd-margin-responsive-large !important;
+      margin-block: $fd-margin-responsive-vertical !important;
+      margin-inline: $fd-margin-responsive-large !important;
     }
 
     &--xl {
-      margin: $fd-margin-responsive-vertical $fd-margin-responsive-extra-large !important;
+      margin-block: $fd-margin-responsive-vertical !important;
+      margin-inline: $fd-margin-responsive-extra-large !important;
     }
   }
 

--- a/packages/styles/src/menu.scss
+++ b/packages/styles/src/menu.scss
@@ -12,8 +12,6 @@ $block: #{$fd-namespace}-menu;
 .#{$block} {
   $fd-menu-border-radius: var(--fdButton_Menu_Border_Radius) !default;
   $fd-menu-item-color-active: var(--sapList_Active_TextColor) !default;
-  $fd-menu-link-padding-top: 0.25rem !default;
-  $fd-menu-link-padding-left: -0.25rem !default;
 
   --fdMenu_Icon_Width: 2.25rem;
   --fdMenu_Icon_Before_Margin: 0 0 0 -0.75rem;
@@ -82,13 +80,13 @@ $block: #{$fd-namespace}-menu;
     top: 0;
     left: 100%;
     z-index: 2;
-    margin: $fd-menu-link-padding-top 0 0 $fd-menu-link-padding-left;
     min-width: 100%;
+    margin-block: 0.25rem 0;
+    margin-inline: -0.25rem 0;
 
     @include fd-rtl() {
       right: 100%;
       left: initial;
-      margin: $fd-menu-link-padding-top $fd-menu-link-padding-left 0 0;
     }
 
     &[aria-hidden='true'] {
@@ -209,15 +207,11 @@ $block: #{$fd-namespace}-menu;
     @include fd-ellipsis();
 
     width: 100%;
-    text-align: left;
+    text-align: start;
     font-size: var(--sapFontSize);
     color: var(--fdMenu_Text_Color);
     font-family: var(--sapFontFamily);
     text-shadow: var(--fdMenu_Text_Shadow);
-
-    @include fd-rtl() {
-      text-align: right;
-    }
 
     &:has(+ .#{$block}__input) {
       width: fit-content;
@@ -371,8 +365,7 @@ $block: #{$fd-namespace}-menu;
 
       input,
       .#{$block}__input {
-        margin-left: 1rem;
-        margin-right: 1rem;
+        margin-inline: 1rem 1rem;
       }
     }
   }
@@ -393,8 +386,7 @@ $block: #{$fd-namespace}-menu;
 
       input,
       .#{$block}__input {
-        margin-left: 0.5rem;
-        margin-right: 0.5rem;
+        margin-inline: 0.5rem 0.5rem;
       }
     }
   }

--- a/packages/styles/src/micro-process-flow.scss
+++ b/packages/styles/src/micro-process-flow.scss
@@ -60,27 +60,13 @@ $fd-micro-process-flow-semantic-colors: (
 
 @mixin fd-set-padding-left-after($left: 0) {
   &::after {
-    padding-left: $left;
-  }
-
-  @include fd-rtl() {
-    &::after {
-      padding-left: 0;
-      padding-right: $left;
-    }
+    padding-inline-start: $left;
   }
 }
 
 @mixin fd-set-padding-right-before($right: 0) {
   &::before {
-    padding-right: $right;
-  }
-
-  @include fd-rtl() {
-    &::before {
-      padding-right: 0;
-      padding-left: $right;
-    }
+    padding-inline-end: $right;
   }
 }
 

--- a/packages/styles/src/mixins/_forms.scss
+++ b/packages/styles/src/mixins/_forms.scss
@@ -465,14 +465,7 @@ $fd-input-field-height--compact: 1.625rem;
     font-weight: bold;
     color: var(--sapField_RequiredColor);
     position: absolute;
-    padding-left: 0.125rem;
-  }
-
-  @include fd-rtl() {
-    &::after {
-      padding-left: 0;
-      padding-right: 0.125rem;
-    }
+    padding-inline-start: 0.125rem;
   }
 }
 
@@ -485,8 +478,6 @@ $fd-input-field-height--compact: 1.625rem;
 }
 
 @mixin fd-form-label() {
-  $fd-label-spacing: 0.5rem;
-
   @include fd-reset();
   @include fd-ellipsis();
 
@@ -495,12 +486,7 @@ $fd-input-field-height--compact: 1.625rem;
   max-width: 100%;
   font-size: var(--sapFontSize);
   color: var(--sapContent_LabelColor);
-  margin-right: $fd-label-spacing;
+  margin-inline-end: 0.5rem;
   cursor: text;
   align-self: flex-start;
-
-  @include fd-rtl() {
-    margin-left: $fd-label-spacing;
-    margin-right: 0;
-  }
 }

--- a/packages/styles/src/mixins/_mixins.scss
+++ b/packages/styles/src/mixins/_mixins.scss
@@ -479,46 +479,27 @@
 }
 
 @mixin fd-set-margins-x($left: 0, $right: 0) {
-  margin-left: $left;
-  margin-right: $right;
-
-  @include fd-rtl() {
-    margin-right: $left;
-    margin-left: $right;
-  }
+  margin-inline: $left $right;
 }
 
 @mixin fd-set-margins-x-equal($value: 0) {
-  margin-left: $value;
-  margin-right: $value;
+  margin-inline: $value $value;
 }
 
 @mixin fd-set-margins-y($top: 0, $bottom: 0) {
-  margin-top: $top;
-  margin-bottom: $bottom;
+  margin-block: $top $bottom;
 }
 
 @mixin fd-set-margins-y-equal($value: 0) {
-  margin-top: $value;
-  margin-bottom: $value;
+  margin-block: $value $value;
 }
 
 @mixin fd-set-margin-left($left: 0) {
-  margin-left: $left;
-
-  @include fd-rtl() {
-    margin-right: $left;
-    margin-left: 0;
-  }
+  margin-inline-start: $left;
 }
 
 @mixin fd-set-margin-right($right: 0) {
-  margin-right: $right;
-
-  @include fd-rtl() {
-    margin-right: 0;
-    margin-left: $right;
-  }
+  margin-inline-end: $right;
 }
 
 @mixin fd-reset-paddings() {
@@ -526,56 +507,35 @@
 }
 
 @mixin fd-reset-paddings-x() {
-  padding-left: 0;
-  padding-right: 0;
+  padding-inline: 0 0;
 }
 
 @mixin fd-reset-paddings-y() {
-  padding-top: 0;
-  padding-bottom: 0;
+  padding-block: 0 0;
 }
 
 @mixin fd-set-paddings-x($left: 0, $right: 0) {
-  padding-left: $left;
-  padding-right: $right;
-
-  @include fd-rtl() {
-    padding-right: $left;
-    padding-left: $right;
-  }
+  padding-inline: $left $right;
 }
 
 @mixin fd-set-paddings-x-equal($value: 0) {
-  padding-left: $value;
-  padding-right: $value;
+  padding-inline: $value $value;
 }
 
 @mixin fd-set-paddings-y($top: 0, $bottom: 0) {
-  padding-top: $top;
-  padding-bottom: $bottom;
+  padding-block: $top $bottom;
 }
 
 @mixin fd-set-paddings-y-equal($value: 0) {
-  padding-top: $value;
-  padding-bottom: $value;
+  padding-block: $value $value;
 }
 
 @mixin fd-set-padding-left($left: 0) {
-  padding-left: $left;
-
-  @include fd-rtl() {
-    padding-right: $left;
-    padding-left: 0;
-  }
+  padding-inline-start: $left;
 }
 
 @mixin fd-set-padding-right($right: 0) {
-  padding-right: $right;
-
-  @include fd-rtl() {
-    padding-right: 0;
-    padding-left: $right;
-  }
+  padding-inline-end: $right;
 }
 
 @mixin fd-set-position-right($right) {

--- a/packages/styles/src/mixins/list/_list-base.scss
+++ b/packages/styles/src/mixins/list/_list-base.scss
@@ -149,7 +149,7 @@
     @include fd-set-padding-left(1rem);
 
     max-width: 40%;
-    text-align: right;
+    text-align: end;
     font-size: var(--sapFontSize);
     color: var(--fdList_Status_Text_Color);
 
@@ -167,10 +167,6 @@
 
     &--informative {
       --fdList_Status_Text_Color: var(--sapInformativeTextColor);
-    }
-
-    @include fd-rtl() {
-      text-align: left;
     }
   }
 

--- a/packages/styles/src/mixins/list/_list-byline.scss
+++ b/packages/styles/src/mixins/list/_list-byline.scss
@@ -154,12 +154,8 @@ $fd-list-byline-section-text-color: var(--sapContent_LabelColor) !default;
       width: 40%;
       color: $fd-list-byline-section-text-color;
       line-height: $fd-list-byline-text-line-height;
-      text-align: right;
+      text-align: end;
       align-self: flex-end;
-
-      @include fd-rtl() {
-        text-align: left;
-      }
 
       @each $set-name, $color-set in $semantic-color {
         &--#{$set-name} {

--- a/packages/styles/src/mixins/list/_list-dropdown.scss
+++ b/packages/styles/src/mixins/list/_list-dropdown.scss
@@ -34,12 +34,9 @@ $fd-checkbox-dimensions: 1.375rem !default;
     .#{$block}__item {
       @include fd-list-item-states();
 
-      padding: 0 1rem 0 0;
+      padding-block: 0;
+      padding-inline: 0 1rem;
       height: auto;
-
-      @include fd-rtl() {
-        padding: 0 0 0 1rem;
-      }
     }
 
     .#{$block}__label {
@@ -74,7 +71,7 @@ $fd-checkbox-dimensions: 1.375rem !default;
 
     .#{$block}__footer {
       height: auto;
-      text-align: right;
+      text-align: end;
       justify-content: flex-end;
       line-height: 1rem;
       background-color: var(--sapList_Background);

--- a/packages/styles/src/mixins/list/_list-selection.scss
+++ b/packages/styles/src/mixins/list/_list-selection.scss
@@ -89,11 +89,7 @@
     // SELECTION + SELECT OBJECT ROW
     &.#{$block}--selection-row {
       .#{$block}__item {
-        padding-left: 1rem;
-
-        @include fd-rtl() {
-          padding-right: 1rem;
-        }
+        padding-inline-start: 1rem;
       }
     }
   }

--- a/packages/styles/src/mixins/vertical-nav/_vertical-nav-navigation.scss
+++ b/packages/styles/src/mixins/vertical-nav/_vertical-nav-navigation.scss
@@ -24,15 +24,13 @@ $fd-list-second-level-popover-position: 3.25rem !default;
         background-color: var(--sapSelectedColor);
         color: var(--sapSelectedColor);
         border-radius: var(--sapField_BorderCornerRadius);
-        margin-right: $fd-list-navigation-item-indicator-spacing;
+        margin-inline-end: $fd-list-navigation-item-indicator-spacing;
       }
 
       @include fd-rtl() {
         &::after {
           right: unset;
-          margin-right: 0;
           left: 0;
-          margin-left: $fd-list-navigation-item-indicator-spacing;
         }
       }
     }
@@ -278,8 +276,8 @@ $fd-list-second-level-popover-position: 3.25rem !default;
             content: '';
             min-width: 0;
             min-height: 0;
-            margin-right: 0.75rem;
-            margin-bottom: 0.5625rem;
+            margin-inline-end: 0.75rem;
+            margin-block-end: 0.5625rem;
             border-style: solid;
             border-width: 0.25rem 0.25rem 0 0;
             border-color: transparent var(--sapContent_NonInteractiveIconColor) transparent transparent;
@@ -289,8 +287,6 @@ $fd-list-second-level-popover-position: 3.25rem !default;
 
             @include fd-rtl() {
               right: unset;
-              margin-right: 0;
-              margin-left: 0.75rem;
               left: 0;
             }
           }

--- a/packages/styles/src/numeric-content.scss
+++ b/packages/styles/src/numeric-content.scss
@@ -25,13 +25,8 @@ $fd-numeric-content-elements-spacing-s: 0.5rem !default;
 
   .#{$block}__launch-icon-container,
   .#{$block}__kpi-container {
-    padding-top: 0.5rem;
-    margin-right: $fd-numeric-content-elements-spacing;
-
-    @include fd-rtl() {
-      margin-right: 0;
-      margin-left: $fd-numeric-content-elements-spacing;
-    }
+    padding-block-start: 0.5rem;
+    margin-inline-end: $fd-numeric-content-elements-spacing;
   }
 
   .#{$block}__launch-icon-container {
@@ -39,8 +34,7 @@ $fd-numeric-content-elements-spacing-s: 0.5rem !default;
   }
 
   .#{$block}__scale-container {
-    padding-top: 0.25rem;
-    padding-bottom: 0.25rem;
+    padding-block: 0.25rem 0.25rem;
   }
 
   .#{$block}__launch-icon {
@@ -75,13 +69,8 @@ $fd-numeric-content-elements-spacing-s: 0.5rem !default;
 
     height: 100%;
     overflow: hidden;
-    padding-top: 0.125rem;
-    margin-right: $fd-numeric-content-elements-spacing;
-
-    @include fd-rtl() {
-      margin-right: 0;
-      margin-left: $fd-numeric-content-elements-spacing;
-    }
+    padding-block-start: 0.125rem;
+    margin-inline-end: $fd-numeric-content-elements-spacing;
 
     &:first-child:last-child {
       margin: 0;
@@ -98,8 +87,7 @@ $fd-numeric-content-elements-spacing-s: 0.5rem !default;
     display: flex;
     height: 100%;
     overflow: hidden;
-    padding-top: 0.5rem;
-    padding-bottom: 0.375rem;
+    padding-block: 0.5rem 0.375rem;
 
     &:first-child:last-child {
       margin: 0;
@@ -185,13 +173,8 @@ $fd-numeric-content-elements-spacing-s: 0.5rem !default;
 
     .#{$block}__launch-icon-container,
     .#{$block}__kpi-container {
-      padding-top: 0;
-      margin-right: $fd-numeric-content-elements-spacing-m;
-
-      @include fd-rtl() {
-        margin-right: 0;
-        margin-left: $fd-numeric-content-elements-spacing-m;
-      }
+      padding-block-start: 0;
+      margin-inline-end: $fd-numeric-content-elements-spacing-m;
     }
 
     .#{$block}__launch-icon-container {
@@ -199,8 +182,7 @@ $fd-numeric-content-elements-spacing-s: 0.5rem !default;
     }
 
     .#{$block}__scale-container {
-      padding-top: 0.375rem;
-      padding-bottom: 0.188rem;
+      padding-block: 0.375rem 0.188rem;
     }
 
     .#{$block}__kpi {
@@ -213,18 +195,12 @@ $fd-numeric-content-elements-spacing-s: 0.5rem !default;
 
     .#{$block}__launch-icon-container,
     .#{$block}__kpi-container {
-      padding-top: 0;
-      margin-right: $fd-numeric-content-elements-spacing-s;
-
-      @include fd-rtl() {
-        margin-right: 0;
-        margin-left: $fd-numeric-content-elements-spacing-s;
-      }
+      padding-block-start: 0;
+      margin-inline-end: $fd-numeric-content-elements-spacing-s;
     }
 
     .#{$block}__scale-container {
-      padding-top: 0;
-      padding-bottom: 0.313rem;
+      padding-block: 0 0.313rem;
     }
 
     .#{$block}__kpi {
@@ -246,7 +222,7 @@ $fd-numeric-content-elements-spacing-s: 0.5rem !default;
     &.#{$block}--s {
       @include small-tile-values() {
         .#{$block}__scale-container {
-          padding-top: 0;
+          padding-block-start: 0;
         }
       }
     }

--- a/packages/styles/src/page-footer.scss
+++ b/packages/styles/src/page-footer.scss
@@ -14,13 +14,9 @@ $fd-page-footer-sizes: (
 .#{$block} {
   @include fd-reset();
 
-  $fd-footer-margin-right: 1.5rem !default;
-  $fd-footer-label-padding-top: 0.75rem !default;
-
   background: var(--sapBaseColor);
   position: relative;
-  padding-top: 1.5rem;
-  padding-bottom: 2rem;
+  padding-block: 1.5rem 2rem;
 
   &__logo {
     @include fd-reset();
@@ -37,12 +33,7 @@ $fd-page-footer-sizes: (
     width: 70%;
 
     &-item {
-      margin-right: $fd-footer-margin-right;
-
-      @include fd-rtl() {
-        margin-right: 0;
-        margin-left: $fd-footer-margin-right;
-      }
+      margin-inline-end: 1.5rem;
     }
 
     &-image {
@@ -50,7 +41,7 @@ $fd-page-footer-sizes: (
     }
 
     &:not(:first-child) {
-      padding-top: 0.25rem;
+      padding-block-start: 0.25rem;
     }
   }
 
@@ -60,23 +51,18 @@ $fd-page-footer-sizes: (
 
     align-self: flex-end;
     width: 30%;
-    text-align: right;
+    text-align: end;
     position: absolute;
-
-    @include fd-rtl() {
-      text-align: left;
-    }
   }
 
   // sizes
   @each $set-name, $size-set in $fd-page-footer-sizes {
     &--#{$set-name} {
-      padding-right: map.get($size-set, 'padding');
-      padding-left: map.get($size-set, 'padding');
+      padding-inline: map.get($size-set, 'padding') map.get($size-set, 'padding');
       .#{$block}__container {
         @include fd-flex(column);
 
-        padding-top: $fd-footer-label-padding-top;
+        padding-block-start: 0.75rem;
       }
     }
   }
@@ -84,22 +70,22 @@ $fd-page-footer-sizes: (
   @media (width <= 768px) {
 
     .#{$block}__row {
-      margin-right: 0;
+      margin-inline-end: 0;
       width: 100%;
 
       &:not(:first-child) {
-        padding-top: 0;
+        padding-block-start: 0;
       }
 
       &-item {
-        padding-top: 0.25rem;
+        padding-block-start: 0.25rem;
       }
     }
 
     .#{$block}__text {
       width: 90%;
-      text-align: left;
-      padding-top: $fd-footer-label-padding-top;
+      text-align: start;
+      padding-block-start: 0.75rem;
     }
 
     .#{$block}__container {

--- a/packages/styles/src/panel.scss
+++ b/packages/styles/src/panel.scss
@@ -8,9 +8,6 @@ $block: #{$fd-namespace}-panel;
 .#{$block} {
   --fdPanel_Header_Height: 2.75rem;
 
-  $fd-panel-header-right-padding: 0.5rem;
-  $fd-panel-header-fixed-left-padding: 1rem;
-
   &,
   &__content,
   &__title,
@@ -23,14 +20,14 @@ $block: #{$fd-namespace}-panel;
   overflow: hidden;
 
   &:not(:last-child) {
-    margin-bottom: var(--fdPanel_Margin_Bottom);
+    margin-block-end: var(--fdPanel_Margin_Bottom);
   }
 
   &__header {
     overflow: hidden;
     height: var(--fdPanel_Header_Height);
     min-height: var(--fdPanel_Header_Height);
-    padding-right: $fd-panel-header-right-padding;
+    padding-inline-end: 0.5rem;
     background-color: var(--sapGroup_TitleBackground);
     border-bottom: solid 0.0625rem var(--sapGroup_TitleBorderColor);
 
@@ -47,7 +44,8 @@ $block: #{$fd-namespace}-panel;
   &__content {
     @include fd-scrollbar(var(--fdScrollbar_Border_Radius));
 
-    padding: 0.625rem 1rem;
+    padding-block: 0.625rem;
+    padding-inline: 1rem;
     overflow: auto;
     border-bottom: solid 0.0625rem var(--fdPanel_Content_Border_Bottom_Color);
     background: var(--fdPanel_Content_Background_Color);
@@ -75,21 +73,9 @@ $block: #{$fd-namespace}-panel;
     }
   }
 
-  @include fd-rtl() {
-    .#{$block}__header {
-      padding-right: 0;
-      padding-left: $fd-panel-header-right-padding;
-    }
-  }
-
   &--fixed {
     .#{$block}__header {
-      padding-left: $fd-panel-header-fixed-left-padding;
-
-      @include fd-rtl() {
-        padding-left: $fd-panel-header-right-padding;
-        padding-right: $fd-panel-header-fixed-left-padding;
-      }
+      padding-inline-start: 1rem;
     }
   }
 

--- a/packages/styles/src/product-switch.scss
+++ b/packages/styles/src/product-switch.scss
@@ -43,8 +43,8 @@ $block: #{$fd-namespace}-product-switch;
     max-width: 11.25rem;
     flex: 1 0 25%;
     padding: 0.5rem;
-    margin-right: 0.5rem;
-    margin-bottom: 0.5rem;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0.5rem;
     background-color: var(--sapList_Background);
     border-radius: var(--sapElement_BorderCornerRadius);
     box-shadow: var(--fdProductSwitch_Shadow);
@@ -148,7 +148,7 @@ $block: #{$fd-namespace}-product-switch;
   &__icon {
     @include fd-icon-element-base() {
       font-size: 1.5rem;
-      margin-bottom: 0.5rem;
+      margin-block-end: 0.5rem;
       color: var(--sapContent_IconColor);
       min-width: 3rem;
       min-height: 3rem;
@@ -209,7 +209,8 @@ $block: #{$fd-namespace}-product-switch;
     width: fit-content;
     max-height: calc(100vh - 76px);
     overflow-y: auto;
-    padding: 1.5rem 0.5rem 1rem 1rem;
+    padding-block: 1.5rem 1rem;
+    padding-inline: 1rem 0.5rem;
     background-color: var(--sapList_Background);
     border-radius: var(--sapElement_BorderCornerRadius);
   }
@@ -240,7 +241,7 @@ $block: #{$fd-namespace}-product-switch;
       max-width: 100%;
       max-height: 5rem;
       padding: 1rem;
-      text-align: left;
+      text-align: start;
       border-radius: 0;
       border: none;
       border-bottom: 0.0625rem solid;
@@ -302,19 +303,12 @@ $block: #{$fd-namespace}-product-switch;
 
     .#{$block}__icon {
       @include fd-icon-selector() {
-        margin-bottom: 0;
-        margin-right: 0.75rem;
+        margin-block-end: 0;
+        margin-inline-end: 0.75rem;
       }
     }
 
     @include fd-rtl() {
-      .#{$block}__icon {
-        @include fd-icon-selector() {
-          margin-right: 0;
-          margin-left: 0.75rem;
-        }
-      }
-
       .#{$block}__text {
         align-items: flex-start;
 
@@ -350,7 +344,7 @@ $block: #{$fd-namespace}-product-switch;
           &::before {
             right: $before-right;
             width: $before-width;
-            text-align: right;
+            text-align: end;
             z-index: 2;
           }
 

--- a/packages/styles/src/progress-indicator.scss
+++ b/packages/styles/src/progress-indicator.scss
@@ -196,14 +196,11 @@ $fd-progress-indicator-states: (
     right: -1.25rem;
     bottom: -0.625rem;
     display: var(--iconDisplay);
-    margin-left: var(--fdProgress_Indicator_Label_Margin_Start);
-    margin-right: var(--fdProgress_Icon_Space_Before_Label);
+    margin-inline: var(--fdProgress_Indicator_Label_Margin_Start) var(--fdProgress_Icon_Space_Before_Label);
 
     @include fd-rtl() {
       left: -1.25rem;
       right: initial;
-      margin-left: var(--fdProgress_Icon_Space_Before_Label);
-      margin-right: var(--fdProgress_Indicator_Label_Margin_Start);
     }
 
     &::before {
@@ -215,12 +212,7 @@ $fd-progress-indicator-states: (
     }
 
     & + .#{$block}__label {
-      margin-left: 0;
-
-      @include fd-rtl() {
-        margin-left: inherit;
-        margin-right: 0;
-      }
+      margin-inline-start: 0;
     }
   }
 
@@ -230,8 +222,7 @@ $fd-progress-indicator-states: (
 
     display: inline-block;
     max-width: 100%;
-    margin-left: var(--labelMarginStart);
-    margin-right: var(--labelMarginEnd);
+    margin-inline: var(--labelMarginStart) var(--labelMarginEnd);
     position: var(--fdProgress_Indicator_Label_Position, static);
     top: -1.25rem;
     left: 0;
@@ -243,8 +234,6 @@ $fd-progress-indicator-states: (
     @include fd-rtl() {
       left: initial;
       right: 0;
-      margin-left: var(--labelMarginEnd);
-      margin-right: var(--labelMarginStart);
     }
   }
 

--- a/packages/styles/src/radio.scss
+++ b/packages/styles/src/radio.scss
@@ -43,7 +43,7 @@ $block: #{$fd-namespace}-radio;
       @include fd-form-radio-icon-base(var(--fdRadio_Inner_Circle_Diameter));
 
       border-radius: 50%;
-      margin-right: var(--fdRadio_Outer_Circle_Padding);
+      margin-inline-end: var(--fdRadio_Outer_Circle_Padding);
       background-color: var(--fdRadio_Background_Color);
       border: var(--fdRadio_Inner_Border_Width) var(--fdRadio_Inner_Border_Style) var(--fdRadio_Inner_Border_Color);
     }
@@ -71,11 +71,6 @@ $block: #{$fd-namespace}-radio;
     }
 
     @include fd-rtl() {
-      &::before {
-        margin-left: var(--fdRadio_Outer_Circle_Padding);
-        margin-right: 0;
-      }
-
       &::after {
         right: var(--fdRadio_Inner_Content_Padding);
       }
@@ -87,8 +82,7 @@ $block: #{$fd-namespace}-radio;
 
       &::before,
       &::after {
-        margin-right: 0;
-        margin-left: 0;
+        margin-inline: 0;
       }
     }
 

--- a/packages/styles/src/rating-indicator.scss
+++ b/packages/styles/src/rating-indicator.scss
@@ -13,24 +13,15 @@ $block: #{$fd-namespace}-rating-indicator;
     }
 
     &__label {
-      margin-right: 0;
+      margin-inline-end: 0;
 
       &:nth-child(4n + 6) {
-        margin-right: $spacing-between-icons;
+        margin-inline-end: $spacing-between-icons;
         flex-direction: row-reverse;
-
-        @include fd-rtl() {
-          margin-right: 0;
-          margin-left: $spacing-between-icons;
-
-          &:last-child {
-            margin-left: 0;
-          }
-        }
       }
 
       &:last-child {
-        margin-right: 0;
+        margin-inline-end: 0;
       }
 
       overflow: hidden;
@@ -207,10 +198,10 @@ $block: #{$fd-namespace}-rating-indicator;
     float: left;
     opacity: 1;
     height: var(--fontSize);
-    margin-right: var(--spacingBetweenIcons);
+    margin-inline-end: var(--spacingBetweenIcons);
 
     &:last-child {
-      margin-right: 0;
+      margin-inline-end: 0;
     }
 
     &:hover::before {
@@ -231,31 +222,12 @@ $block: #{$fd-namespace}-rating-indicator;
 
     font-size: var(--sapFontSmallSize);
     color: var(--sapContent_LabelColor);
-    margin-left: $fd-rating-indicator-dynamic-text-space;
+    margin-inline-start: $fd-rating-indicator-dynamic-text-space;
   }
 
   &--hide-dynamic-text {
     > .#{$block}__dynamic-text {
       display: none;
-    }
-  }
-
-  @include fd-rtl() {
-    .#{$block}__input:first-child + label {
-      margin-right: 0;
-    }
-
-    .#{$block}__label {
-      float: right;
-
-      &:last-child {
-        margin-right: var(--spacingBetweenIcons);
-      }
-    }
-
-    .#{$block}__dynamic-text {
-      margin-left: 0;
-      margin-right: $fd-rating-indicator-dynamic-text-space;
     }
   }
 
@@ -281,16 +253,11 @@ $block: #{$fd-namespace}-rating-indicator;
     --fontSize: 1rem;
 
     .#{$block}__label {
-      margin-right: 0.125rem;
+      margin-inline-end: 0.125rem;
 
       @include fd-icon-glyph('favorite') {
         font-size: var(--fontSize);
         color: var(--fdRating_Indicator_Display_Only_Selected_Color);
-      }
-
-      @include fd-rtl() {
-        margin-right: 0;
-        margin-left: 0.125rem;
       }
     }
   }

--- a/packages/styles/src/resizable-card-layout.scss
+++ b/packages/styles/src/resizable-card-layout.scss
@@ -57,12 +57,12 @@ $block: #{$fd-namespace}-resizable-card-layout;
     bottom: 0;
     right: 0;
     z-index: $fd-resize-handle-index;
-    padding: 0 $fd-resize-icon-padding $fd-resize-icon-padding 0;
+    padding-block: 0 $fd-resize-icon-padding;
+    padding-inline: 0 $fd-resize-icon-padding;
 
     @include fd-rtl() {
       right: auto;
       left: 0;
-      padding: 0 0 $fd-resize-icon-padding $fd-resize-icon-padding;
     }
   }
 

--- a/packages/styles/src/side-nav.scss
+++ b/packages/styles/src/side-nav.scss
@@ -6,7 +6,6 @@
 
 $block: #{$fd-namespace}-side-nav;
 $block-nested-list: #{$fd-namespace}-nested-list;
-$has-child-content-arrow-margin: 0.125rem;
 
 .#{$block} {
   @include fd-reset();
@@ -46,8 +45,7 @@ $has-child-content-arrow-margin: 0.125rem;
     font-size: var(--sapFontSize);
     font-weight: bold;
     line-height: 2rem;
-    padding-right: 1rem;
-    padding-left: 1rem;
+    padding-inline: 1rem 1rem;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -67,7 +65,8 @@ $has-child-content-arrow-margin: 0.125rem;
       display: block;
       border-top: 0.125rem solid;
       border-top-color: var(--sapList_GroupHeaderBorderColor);
-      margin: 0.25rem 0.5rem;
+      margin-block: 0.25rem;
+      margin-inline: 0.5rem;
     }
   }
 
@@ -98,8 +97,8 @@ $has-child-content-arrow-margin: 0.125rem;
             content: "";
             min-width: 0;
             min-height: 0;
-            margin-right: $has-child-content-arrow-margin;
-            margin-bottom: 0.0625rem;
+            margin-inline-end: 0.125rem;
+            margin-block-end: 0.0625rem;
             border-style: solid;
             border-width: 0.375rem 0.375rem 0 0;
             border-color: transparent var(--sapContent_IconColor) transparent transparent;
@@ -143,8 +142,6 @@ $has-child-content-arrow-margin: 0.125rem;
         .#{$block-nested-list}__link {
           &.has-child {
             &::after {
-              margin-right: 0;
-              margin-left: $has-child-content-arrow-margin;
               right: auto;
               left: 0;
               transform: rotate(90deg);
@@ -157,8 +154,7 @@ $has-child-content-arrow-margin: 0.125rem;
         .#{$block-nested-list}__item {
           .#{$block-nested-list}__link,
           .#{$block-nested-list}__content {
-            padding-right: 1rem;
-            padding-left: 1rem;
+            padding-inline: 1rem 1rem;
           }
         }
       }

--- a/packages/styles/src/status-indicator.scss
+++ b/packages/styles/src/status-indicator.scss
@@ -59,28 +59,24 @@ $color-states: (
       &--#{$set-name} {
         font-size: map.get($size-set, 'font-size');
         &.#{$block}__label--top {
-          margin-bottom: map.get($size-set, 'margin');
+          margin-block-end: map.get($size-set, 'margin');
         }
         &.#{$block}__label--right {
-          margin-left: map.get($size-set, 'margin');
+          margin-inline-start: map.get($size-set, 'margin');
 
           @include fd-rtl() {
-            margin-left: 0;
-            margin-right: map.get($size-set, 'margin');
             transform: matrix(1, 0, 0, 1, 22, 1);
           }
         }
         &.#{$block}__label--left {
-          margin-right: map.get($size-set, 'margin');
+          margin-inline-end: map.get($size-set, 'margin');
 
           @include fd-rtl() {
-            margin-right: 0;
-            margin-left: map.get($size-set, 'margin');
             transform: matrix(1, 0, 0, 1, -22, 1);
           }
         }
         &.#{$block}__label--bottom {
-          margin-top: map.get($size-set, 'margin');
+          margin-block-start: map.get($size-set, 'margin');
         }
       }
     }

--- a/packages/styles/src/step-input.scss
+++ b/packages/styles/src/step-input.scss
@@ -55,16 +55,12 @@ $block: #{$fd-namespace}-step-input;
   &__input.#{$fd-namespace}-input {
     --fdInput_Field_Padding: 0 0.25rem;
 
-    text-align: right;
+    text-align: end;
     border: none;
     margin: 0;
     background: none;
     box-shadow: none;
     background-color: transparent;
-
-    @include fd-rtl() {
-      text-align: left;
-    }
 
     @include fd-hover() {
       @include fd-input-field-nested-reset();

--- a/packages/styles/src/table.scss
+++ b/packages/styles/src/table.scss
@@ -109,7 +109,7 @@ $table-z-index: (
   }
 
   &__cell {
-    text-align: left;
+    text-align: start;
     height: var(--fdTable_Cell_Height);
     padding: 0 0.5rem;
     color: inherit;
@@ -120,10 +120,6 @@ $table-z-index: (
 
     @include fd-last-child() {
       @include fd-set-border-right(var(--sapList_BorderWidth) var(--fdTable_Cell_Vertical_Border_Style, solid) var(--sapList_BorderColor));
-    }
-
-    @include fd-rtl() {
-      text-align: right;
     }
 
     &--no-data {
@@ -292,16 +288,12 @@ $table-z-index: (
     display: flex;
 
     .#{$block}__icon:not(:last-child) {
-      margin-right: 0.25rem;
+      margin-inline-end: 0.25rem;
     }
 
     @include fd-rtl() {
       .#{$block}__icon {
         margin-right: 0;
-      }
-
-      .#{$block}__icon:not(:last-child) {
-        margin-left: 0.25rem;
       }
     }
   }

--- a/packages/styles/src/tabs.scss
+++ b/packages/styles/src/tabs.scss
@@ -70,7 +70,7 @@ $fd-tabs-link-active-line-offset-x: 0.1875rem;
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  padding-left: 0;
+  padding-inline-start: 0;
   list-style: none;
   box-shadow: var(--sapContent_HeaderShadow);
   background-color: var(--sapObjectHeader_Background);
@@ -243,7 +243,7 @@ $fd-tabs-link-active-line-offset-x: 0.1875rem;
     font-size: 1.5rem;
     line-height: 1.5rem;
     color: $fd-tabs-label-color;
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   &__overflow {
@@ -251,7 +251,7 @@ $fd-tabs-link-active-line-offset-x: 0.1875rem;
     @include fd-icon-element-base();
     @include fd-flex-center();
 
-    margin-left: auto;
+    margin-inline-start: auto;
   }
 
   &__process-icon {
@@ -350,7 +350,8 @@ $fd-tabs-link-active-line-offset-x: 0.1875rem;
 
   &--process {
     .#{$block}__item {
-      margin: 0 $fd-tabs-item-spacing-x 0 0;
+      margin-block: 0;
+      margin-inline: 0 $fd-tabs-item-spacing-x;
       display: flex;
       align-items: center;
     }
@@ -374,14 +375,10 @@ $fd-tabs-link-active-line-offset-x: 0.1875rem;
     }
 
     @include fd-rtl() {
-      .#{$block}__item {
-        margin: 0 0 0 $fd-tabs-item-spacing-x;
-
-        &:first-child {
-          .#{$block}__link {
-            padding-right: 0;
-            padding-left: 0;
-          }
+      .#{$block}__item:first-child {
+        .#{$block}__link {
+          padding-right: 0;
+          padding-left: 0;
         }
       }
     }
@@ -422,7 +419,8 @@ $fd-tabs-link-active-line-offset-x: 0.1875rem;
 
     .#{$block}__link {
       height: var(--fdTabs_Filter_Link_Height);
-      padding: 0.875rem $fd-tabs-selection-padding-x 0.625rem $fd-tabs-selection-padding-x;
+      padding-block: 0.875rem 0.625rem;
+      padding-inline: $fd-tabs-selection-padding-x;
       text-align: center;
       display: flex;
       justify-content: center;
@@ -475,16 +473,6 @@ $fd-tabs-link-active-line-offset-x: 0.1875rem;
   @include fd-rtl() {
     .#{$block}__process-icon {
       transform: rotate(180deg);
-    }
-
-    .#{$block}__counter-header {
-      padding-right: 0;
-      padding-left: 0.5rem;
-    }
-
-    .#{$block}__overflow {
-      margin-left: 0;
-      margin-right: auto;
     }
   }
 }

--- a/packages/styles/src/tile.scss
+++ b/packages/styles/src/tile.scss
@@ -38,14 +38,10 @@ $fd-tile-toggle-button-position: -0.0625rem !default;
 $fd-tile-close-button-position: -0.375rem !default;
 $fd-tile-close-button-offset: 0.5rem !default;
 
-// ACTION INDICATOR
-$fd-tile-action-indicator-offset: 0.25rem !default;
-
 // LINE TILE
 $fd-line-tile-min-width: 2rem !default;
 $fd-line-tile-vertical-spacing: 0.125rem !default;
 $fd-line-tile-horizontal-spacing: 1.25rem !default;
-$fd-line-tile-horizontal-padding: 0.5rem !default;
 $fd-line-tile-action-container-horizontal-spacing: 0.25rem !default;
 $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
 
@@ -631,15 +627,13 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
       position: absolute;
       bottom: 0;
       right: 0;
-      margin-bottom: $fd-tile-action-indicator-offset;
-      margin-right: $fd-tile-action-indicator-offset;
+      margin-block-end: 0.25rem;
+      margin-inline-end: 0.25rem;
       z-index: 5;
 
       @include fd-rtl() {
         right: auto;
         left: 0;
-        margin-right: auto;
-        margin-left: $fd-tile-action-indicator-offset;
       }
 
       @include fd-icon-element-base() {
@@ -761,7 +755,8 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
     min-width: $fd-line-tile-min-width;
     max-width: 100%;
     width: auto;
-    padding: 0 $fd-line-tile-horizontal-padding;
+    padding-block: 0;
+    padding-inline: 0.5rem 0.5rem;
     box-shadow: none;
     background: transparent;
 
@@ -816,12 +811,7 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
     }
 
     &.#{$block}--action {
-      padding-right: 0;
-
-      @include fd-rtl() {
-        padding-left: 0;
-        padding-right: $fd-line-tile-horizontal-padding;
-      }
+      padding-inline-end: 0;
 
       .#{$block}__action-container {
         @include fd-reset();

--- a/packages/styles/src/time.scss
+++ b/packages/styles/src/time.scss
@@ -35,10 +35,10 @@ $block: #{$fd-namespace}-time;
       flex-direction: column;
     }
 
-    margin-right: $fd-time-column-margin-x;
+    margin-block-end: $fd-time-column-margin-x;
 
     &:last-child {
-      margin-right: 0;
+      margin-block-end: 0;
     }
   }
 
@@ -77,11 +77,11 @@ $block: #{$fd-namespace}-time;
     &--meridian {
       .#{$block}__item {
         &:first-child {
-          margin-top: calc(var(--fdTime_Item_Height) * 3);
+          margin-block-start: calc(var(--fdTime_Item_Height) * 3);
         }
 
         &:last-child {
-          margin-bottom: calc(var(--fdTime_Item_Height) * 3);
+          margin-block-end: calc(var(--fdTime_Item_Height) * 3);
         }
       }
 
@@ -176,11 +176,6 @@ $block: #{$fd-namespace}-time;
     padding: 0;
     margin: 0;
     align-self: auto;
-
-    @include fd-rtl() {
-      padding: 0;
-      margin: 0;
-    }
   }
 
   &__control {
@@ -202,17 +197,6 @@ $block: #{$fd-namespace}-time;
   &--scrollable {
     .#{$block}__list {
       overflow: auto;
-    }
-  }
-
-  @include fd-rtl() {
-    .#{$block}__col {
-      margin-right: 0;
-      margin-left: $fd-time-column-margin-x;
-
-      &:last-child {
-        margin-left: 0;
-      }
     }
   }
 }

--- a/packages/styles/src/tokenizer.scss
+++ b/packages/styles/src/tokenizer.scss
@@ -16,7 +16,8 @@ $block: #{$fd-namespace}-tokenizer;
   width: 100%;
   display: flex;
   padding: 0;
-  margin: 0;
+  margin-inline: 0 0;
+  margin-block: 0;
   border: none;
   align-items: center;
 
@@ -39,12 +40,8 @@ $block: #{$fd-namespace}-tokenizer;
   }
 
   .#{$fd-namespace}-token {
-    margin-right: $fd-tokenizer-spacing;
+    margin-inline-end: $fd-tokenizer-spacing;
     max-width: calc(100% - #{$fd-tokenizer-input-width} - #{$fd-tokenizer-spacing});
-
-    @include fd-rtl() {
-      margin: 0 0 0 $fd-tokenizer-spacing;
-    }
   }
 
   &__indicator {
@@ -105,12 +102,8 @@ $block: #{$fd-namespace}-tokenizer;
     }
 
     .#{$fd-namespace}-token {
-      margin-right: $fd-tokenizer-compact-spacing;
+      margin-inline-end: $fd-tokenizer-compact-spacing;
       max-width: calc(100% - #{$fd-tokenizer-input-width-compact} - #{$fd-tokenizer-compact-spacing});
-
-      @include fd-rtl() {
-        margin: 0 0 0 $fd-tokenizer-spacing;
-      }
     }
   }
 

--- a/packages/styles/src/toolbar.scss
+++ b/packages/styles/src/toolbar.scss
@@ -72,13 +72,9 @@ $block: #{$fd-namespace}-toolbar;
 
     & .#{$block}__overflow-button {
       width: auto;
-      text-align: left;
+      text-align: start;
       margin: 0.1875rem 0;
       justify-content: flex-start;
-
-      @include fd-rtl() {
-        text-align: right;
-      }
 
       &--menu {
         @include fd-flex-center() {

--- a/packages/styles/src/tree.scss
+++ b/packages/styles/src/tree.scss
@@ -9,7 +9,6 @@
 $block: #{$fd-namespace}-tree;
 $button: #{$fd-namespace}-button;
 $fd-tree-item-padding-right: 1rem !default;
-$fd-tree-item-padding-right-negative: -1rem !default;
 $fd-tree-item-transparent-border-bottom: var(--sapList_BorderWidth) solid transparent !default;
 $fd-tree-item-selected-border-bottom: var(--sapList_BorderWidth) solid var(--sapList_SelectionBorderColor) !default;
 
@@ -187,14 +186,7 @@ $fd-tree-item-selected-border-bottom: var(--sapList_BorderWidth) solid var(--sap
       }
 
       &:last-child {
-        margin-right: $fd-tree-item-padding-right-negative;
-      }
-
-      @include fd-rtl() {
-        &:last-child {
-          margin-right: 0;
-          margin-left: $fd-tree-item-padding-right-negative;
-        }
+        margin-inline-end: -1rem;
       }
     }
   }


### PR DESCRIPTION
## Related Issue
Closes none

## Description
if we use padding-inline or margin-inline we won't need to handle the RTL. This PR optimizes the code where the RTL mixin is used to handle margin-right, margin-left, etc.