### PR TITLE
fix(styles): remove the default background for autofill input

### DIFF
--- a/packages/styles/src/input-group.scss
+++ b/packages/styles/src/input-group.scss
@@ -64,6 +64,13 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
     &:nth-last-child(1) {
       padding-inline-end: $fd-input-padding;
     }
+
+    &:-webkit-autofill,
+    &:-webkit-autofill:hover,
+    &:-webkit-autofill:focus,
+    &:-webkit-autofill:active {
+        background-clip: text;
+    }
   }
 
   &--inline {


### PR DESCRIPTION


## Related Issue
Closes none

## Description
related to a bug reported in fngx Search input (a fix is also provided there https://github.com/SAP/fundamental-ngx/pull/12234). The control is built on top of Input Group therefore the fix is there. 
