### PR TITLE
fix(styles): align the notification indicator icon [ci visual]

### DIFF
--- a/packages/styles/src/notification.scss
+++ b/packages/styles/src/notification.scss
@@ -195,6 +195,7 @@ $block: #{$fd-namespace}-notification;
   &__indicator {
     @include fd-reset();
 
+    padding-block-start: 0.1875rem;
     margin-inline-end: 0.5rem;
     color: var(--fdNotification_Indicator_Color);
 


### PR DESCRIPTION
## Related Issue
Closes none

## Description
these icons are not aligned with the text
![Screenshot 2024-08-15 at 10 41 19 AM](https://github.com/user-attachments/assets/e93a241e-6fa1-4474-ba9b-1be750cb0110)
