### PR TITLE
fix(styles): remove the space on hover for the Input group buttons

### DIFF
--- a/packages/styles/src/mixins/_forms.scss
+++ b/packages/styles/src/mixins/_forms.scss
@@ -313,13 +313,6 @@ $fd-input-field-height--compact: 1.625rem;
     )
   );
 
-  @include fd-input-group-button(".#{$block}__button:first-child");
-  @include fd-input-group-button(".#{$block}__button:not(:first-child)", false);
-
-  // To support `fd-input-group__addon` and avoid breaking changes
-  @include fd-input-group-button(".#{$block}__addon:first-child .#{$block}__button");
-  @include fd-input-group-button(".#{$block}__addon:not(:first-child) .#{$block}__button", false);
-
   .#{$block}__button {
     @include fd-ellipsis();
 

--- a/packages/styles/stories/Components/Forms/input-group/input-with-actions.example.html
+++ b/packages/styles/stories/Components/Forms/input-group/input-with-actions.example.html
@@ -24,6 +24,23 @@
 </div>
 <br />
 <div class="fd-form-item">
+    <label class="fd-form-label" for="aqwsde121ef">Input with 2 icon actions</label>
+    <div class="fd-input-group">
+        <input class="fd-input fd-input-group__input" type="text" placeholder="Placeholder" id="aqwsde121ef" name="" value="1000000">
+        <span class="fd-input-group__addon fd-input-group__addon--button">
+            <button class="fd-input-group__button fd-button fd-button--icon fd-button--transparent" aria-label="Navigation">
+                <i class="sap-icon--decline"></i>
+            </button>
+        </span>
+        <span class="fd-input-group__addon fd-input-group__addon--button">
+            <button class="fd-input-group__button fd-button fd-button--icon fd-button--transparent" aria-label="Navigation">
+                <i class="sap-icon--search"></i>
+            </button>
+        </span>
+    </div>
+</div>
+<br />
+<div class="fd-form-item">
     <label class="fd-form-label" for="aqwsde123">Input with text action on left</label>
     <div class="fd-input-group">
         <span class="fd-input-group__addon fd-input-group__addon--button">

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -19896,6 +19896,23 @@ exports[`Check stories > Components/Forms/Input Group > Story InputWithActions >
 </div>
 <br />
 <div class=\\"fd-form-item\\">
+    <label class=\\"fd-form-label\\" for=\\"aqwsde121ef\\">Input with 2 icon actions</label>
+    <div class=\\"fd-input-group\\">
+        <input class=\\"fd-input fd-input-group__input\\" type=\\"text\\" placeholder=\\"Placeholder\\" id=\\"aqwsde121ef\\" name=\\"\\" value=\\"1000000\\">
+        <span class=\\"fd-input-group__addon fd-input-group__addon--button\\">
+            <button class=\\"fd-input-group__button fd-button fd-button--icon fd-button--transparent\\" aria-label=\\"Navigation\\">
+                <i class=\\"sap-icon--decline\\"></i>
+            </button>
+        </span>
+        <span class=\\"fd-input-group__addon fd-input-group__addon--button\\">
+            <button class=\\"fd-input-group__button fd-button fd-button--icon fd-button--transparent\\" aria-label=\\"Navigation\\">
+                <i class=\\"sap-icon--search\\"></i>
+            </button>
+        </span>
+    </div>
+</div>
+<br />
+<div class=\\"fd-form-item\\">
     <label class=\\"fd-form-label\\" for=\\"aqwsde123\\">Input with text action on left</label>
     <div class=\\"fd-input-group\\">
         <span class=\\"fd-input-group__addon fd-input-group__addon--button\\">


### PR DESCRIPTION


## Related Issue
relates to https://github.com/SAP/fundamental-ngx/issues/12260

## Description
there's a space between the addon buttons in input group on hover
