### PR TITLE
fix(styles): an attempt to fix the padding issue in FNGX [ci visual]

### DIFF
--- a/packages/styles/src/calendar.scss
+++ b/packages/styles/src/calendar.scss
@@ -181,7 +181,8 @@ $fd-calendar-special-days: (
   @include fd-reset();
 
   width: var(--fdCalendar_Width);
-  padding: var(--fdCalendar_Padding);
+  padding-inline: var(--fdCalendar_Padding);
+  padding-block: var(--fdCalendar_Padding);
   background-color: var(--fdCalendar_Background);
   border-radius: var(--fdCalendar_Border_Radius);
 
@@ -466,6 +467,8 @@ $fd-calendar-special-days: (
   }
 
   &--mobile-portrait {
-    --fdCalendar_Padding: 1rem 0 0 0;
+    --fdCalendar_Padding: 0;
+
+    padding-block-start: 1rem;
   }
 }


### PR DESCRIPTION
## Related Issue
Closes none, a bug in FNGX

## Description
the reset function sets `padding-inline` and `padding-block` to 0. Setting `padding: var(--fdCalendar_Padding);` in fund-styles correctly overwrites the reset, but in FNGX the `padding-inline` and `padding-block` and rendered after `padding: var(--fdCalendar_Padding);` and the Calendar loses its padding. Trying now to see if using explicitly `padding-inline` and `padding-block` will fix this problem