### PR TITLE
fix(styles): paddings and margins specificity [ci visual]

### DIFF
--- a/packages/common-css/src/sap-tool-layout.scss
+++ b/packages/common-css/src/sap-tool-layout.scss
@@ -7,7 +7,8 @@ $block: #{$sap-namespace}-tool-layout;
 
 .#{$block} {
   --fdToolLayout_Gap: 0.5rem;
-  --fdToolLayout_Padding: 0.5rem 0.5rem 0 0.5rem;
+  --fdToolLayout_Padding_Block: 0.5rem 0;
+  --fdToolLayout_Padding_Inline: 0.5rem;
   --fdToolLayout_Content_Container_Border_Radius: 0.5rem 0.5rem 0 0;
   --fdToolLayout_Content_Container_Background: var(--sapBackgroundColor);
   --fdToolLayout_Content_Container_BoxShadow: var(--sapContainer_Shadow1);
@@ -20,7 +21,8 @@ $block: #{$sap-namespace}-tool-layout;
 
   width: 100%;
   height: 100%;
-  padding: var(--fdToolLayout_Padding);
+  padding-block: var(--fdToolLayout_Padding_Block);
+  padding-inline: var(--fdToolLayout_Padding_Inline);
   background: var(--fdToolLayout_Background);
 
   &__container {
@@ -90,13 +92,15 @@ $block: #{$sap-namespace}-tool-layout;
   }
 
   &--tablet {
-    --fdToolLayout_Padding: 0.5rem;
+    --fdToolLayout_Padding_Block: 0.5rem;
+    --fdToolLayout_Padding_Inline: 0.5rem;
     --fdToolLayout_Content_Container_Border_Radius: 0.5rem;
   }
 
   &--phone {
     --fdToolLayout_Gap: 0.25rem;
-    --fdToolLayout_Padding: 0.25rem;
+    --fdToolLayout_Padding_Block: 0.25rem;
+    --fdToolLayout_Padding_Inline: 0.25rem;
     --fdToolLayout_Content_Container_Border_Radius: 0.25rem;
   }
 

--- a/packages/cx/src/side-nav.scss
+++ b/packages/cx/src/side-nav.scss
@@ -10,7 +10,8 @@ $block-nested-list: #{$fd-cx-namespace}-nested-list;
 $fd-side-nav-border-radius: 1rem;
 
 .#{$block} {
-  --fdSideNav_Padding: 0.25rem 0;
+  --fdSideNav_Padding_Block: 0.25rem;
+  --fdSideNav_Padding_Inline: 0;
   --fdSideNav_First_Item_Margin_Top: 0.25rem;
   --fdSideNav_Utility_Margin_Bottom: 1rem;
 
@@ -24,7 +25,8 @@ $fd-side-nav-border-radius: 1rem;
 
   width: 15rem;
   height: 100%;
-  padding: var(--fdSideNav_Padding);
+  padding-block: var(--fdSideNav_Padding_Block);
+  padding-inline: var(--fdSideNav_Padding_Inline);
   box-shadow: var(--sapContent_Shadow0);
   background-color: var(--sapGroup_ContentBackground);
   border-radius: 0 $fd-side-nav-border-radius $fd-side-nav-border-radius 0;
@@ -66,7 +68,8 @@ $fd-side-nav-border-radius: 1rem;
   &__popover-body {
     @include fd-set-width(16rem !important);
 
-    padding: 0.25rem 0 !important;
+    padding-block: 0.25rem !important;
+    padding-inline: 0 !important;
     border-radius: $fd-side-nav-border-radius !important;
 
     .#{$block-nested-list} {
@@ -111,7 +114,7 @@ $fd-side-nav-border-radius: 1rem;
   }
 
   @include fd-compact-or-condensed() {
-    --fdSideNav_Padding: 0.125rem 0;
+    --fdSideNav_Padding_Block: 0.125rem;
     --fdSideNav_First_Item_Margin_Top: 0.125rem;
     --fdSideNav_Utility_Margin_Bottom: 0.75rem;
   }

--- a/packages/styles/src/_app.scss
+++ b/packages/styles/src/_app.scss
@@ -31,14 +31,17 @@ $block: #{$fd-namespace}-app;
 
     &--horizontal {
       flex: 1 100%;
-      padding: 0 0.5rem;
+      padding-block: 0;
+      padding-inline: 0.5rem;
 
       @include fd-screen(m) {
-        padding: 0 2rem;
+        padding-block: 0;
+        padding-inline: 2rem;
       }
 
       @include fd-screen(xl) {
-        padding: 0 3rem;
+        padding-block: 0;
+        padding-inline: 3rem;
       }
     }
 

--- a/packages/styles/src/action-sheet.scss
+++ b/packages/styles/src/action-sheet.scss
@@ -10,20 +10,24 @@ $block: #{$fd-namespace}-action-sheet;
   $fd-action-sheet-overlay-color: var(--sapBlockLayer_Background);
 
   // SPACING
-  --fdActionSheet_Padding: 0.25rem 0.5rem;
-  --fdActionSheet_Item_Padding: 0.25rem 0;
+  --fdActionSheet_Padding_Block: 0.25rem;
+  --fdActionSheet_Padding_Inline: 0.5rem;
+  --fdActionSheet_Item_Padding_Block: 0.25rem;
+  --fdActionSheet_Item_Padding_Inline: 0;
 
   @include fd-reset();
 
   width: 100%;
-  padding: var(--fdActionSheet_Padding);
+  padding-block: var(--fdActionSheet_Padding_Block);
+  padding-inline: var(--fdActionSheet_Padding_Inline);
 
   &__item {
     @include fd-reset();
 
     display: block;
     width: 100%;
-    padding: var(--fdActionSheet_Item_Padding);
+    padding-block: var(--fdActionSheet_Item_Padding_Block);
+    padding-inline: var(--fdActionSheet_Item_Padding_Inline);
   }
 
   &__wrapper {
@@ -64,8 +68,10 @@ $block: #{$fd-namespace}-action-sheet;
   }
 
   @include fd-compact-or-condensed() {
-    --fdActionSheet_Padding: 0.1875rem 0.375rem;
-    --fdActionSheet_Item_Padding: 0.1875rem 0;
+    --fdActionSheet_Padding_Block: 0.1875rem;
+    --fdActionSheet_Padding_Inline: 0.375rem;
+    --fdActionSheet_Item_Padding_Block: 0.1875rem;
+    --fdActionSheet_Item_Padding_Inline: 0;
   }
 
   &--mobile {

--- a/packages/styles/src/card.scss
+++ b/packages/styles/src/card.scss
@@ -446,7 +446,8 @@ $legend-background-colors: (
     @include fd-reset();
     @include fd-flex-vertical-center();
 
-    padding: var(--fdCard_Footer_Padding);
+    padding-block: var(--fdCard_Footer_Padding) 1rem;
+    padding-inline: 1rem;
     background: var(--fdCard_Footer_Background, var(--sapTile_Background));
     border-radius: var(--fdCard_Footer_Border_Radius);
     border-top: var(--fdCard_Footer_Border_Top);
@@ -577,7 +578,8 @@ $legend-background-colors: (
 
   &__badge.#{$object-status} {
     --fdObjectStatus_Inverted_Border_Radius: 0.5rem;
-    --fdObjectStatus_Inverted_Padding: 0 0.25rem;
+    --fdObjectStatus_Inverted_Padding_Block: 0;
+    --fdObjectStatus_Inverted_Padding_Inline: 0.25rem;
     --fdObjectStatus_Inverted_Line_Height: 0.875rem;
 
     span {

--- a/packages/styles/src/dynamic-page.scss
+++ b/packages/styles/src/dynamic-page.scss
@@ -273,7 +273,8 @@ $block: #{$fd-namespace}-dynamic-page;
     @include fd-reset();
 
     background-color: $fd-dynamic-page-background-color;
-    padding: $fd-dynamic-page-header-padding-top-bottom 0;
+    padding-block: $fd-dynamic-page-header-padding-top-bottom;
+    padding-inline: 0;
 
     &[aria-hidden="true"] {
       display: none;

--- a/packages/styles/src/form-layout-grid.scss
+++ b/packages/styles/src/form-layout-grid.scss
@@ -118,7 +118,8 @@ $gridCol: #{$fd-namespace}-col;
     padding-inline: $gutter;
 
     .#{$gridRow} {
-      margin: 0 -#{$gutter};
+      margin-block: 0;
+      margin-inline: -#{$gutter};
       min-width: calc(100% + #{$gutter} * 2);
 
       .#{$gridCol} {

--- a/packages/styles/src/icon-tab-bar.scss
+++ b/packages/styles/src/icon-tab-bar.scss
@@ -26,19 +26,19 @@ $fd-icon-tab-bar-dnd-separator-circle-size: 0.5rem !default;
 $fd-icon-tab-bar-focus-offset: var(--fdIcon_Tab_Bar_Focus_Offset) !default;
 $fd-icon-tab-bar-responsive-paddings: (
   'sm': (
-    'padding': 0 1rem
+    'padding': 1rem
   ),
   'md': (
-    'padding': 0 2rem
+    'padding': 2rem
   ),
   'lg': (
-    'padding': 0 2rem
+    'padding': 2rem
   ),
   'xl': (
-    'padding': 0 3rem
+    'padding': 3rem
   ),
   'xxl': (
-    'padding': 0 3rem
+    'padding': 3rem
   )
 );
 $fd-icon-tab-bar-semantic-values: (
@@ -1532,7 +1532,8 @@ $fd-icon-tab-bar-semantic-values: (
   @each $set-name, $set-padding in $fd-icon-tab-bar-responsive-paddings {
     &--#{$set-name} {
       .#{$block}__header {
-        padding: map.get($set-padding, 'padding');
+        padding-block: 0;
+        padding-inline: map.get($set-padding, 'padding');
       }
     }
   }

--- a/packages/styles/src/illustrated-message.scss
+++ b/packages/styles/src/illustrated-message.scss
@@ -10,12 +10,14 @@ $block: #{$fd-namespace}-illustrated-message;
   --illustratedMessageMaxWidth: 30rem;
   --illustrationW: 20rem;
   --illustrationH: 15rem;
-  --illustrationMargin: 2rem 0;
+  --illustrationMarginBlock: 2rem;
+  --illustrationMarginInline: 0;
   --figcaptionMaxWidth: 25rem;
   --titleMarginBottom: 1rem;
   --titleFontSize: var(--sapFontHeader2Size);
   --textMarginBottom: 0.5rem;
-  --actionsMargin: 1rem 0;
+  --actionsMarginBlock: 1rem;
+  --actionsMarginInline: 0;
 
   @include fd-reset();
 
@@ -45,7 +47,8 @@ $block: #{$fd-namespace}-illustrated-message;
 
     width: var(--illustrationW);
     height: var(--illustrationH);
-    margin: var(--illustrationMargin);
+    margin-block: var(--illustrationMarginBlock);
+    margin-inline: var(--illustrationMarginInline);
   }
 
   &__figcaption {
@@ -87,7 +90,8 @@ $block: #{$fd-namespace}-illustrated-message;
     }
 
     width: 100%;
-    margin: var(--actionsMargin);
+    margin-block: var(--actionsMarginBlock);
+    margin-inline: var(--actionsMarginInline);
   }
 
   @media screen and (width <= 599px) {
@@ -100,18 +104,18 @@ $block: #{$fd-namespace}-illustrated-message;
   &--dialog {
     --illustrationW: 10rem;
     --illustrationH: 10rem;
-    --illustrationMargin: 1rem 0;
+    --illustrationMarginBlock: 1rem;
     --titleMarginBottom: 0.5rem;
     --titleFontSize: var(--sapFontHeader3Size);
-    --actionsMargin: 0.5rem 0 1rem 0;
+    --actionsMarginBlock: 0.5rem 1rem;
   }
 
   &--spot {
     --illustratedMessagePadding: 0.5rem;
     --illustrationW: 8rem;
     --illustrationH: 8rem;
-    --illustrationMargin: 0 0 0.5rem 0;
-    --actionsMargin: 0.5rem 0;
+    --illustrationMarginBlock: 0 0.5rem;
+    --actionsMarginBlock: 0.5rem;
     --titleMarginBottom: 0.5rem;
     --titleFontSize: var(--sapFontHeader4Size);
   }
@@ -120,17 +124,17 @@ $block: #{$fd-namespace}-illustrated-message;
     --illustratedMessagePadding: 0.25rem;
     --illustrationW: 2.813rem;
     --illustrationH: 2.813rem;
-    --illustrationMargin: 0;
+    --illustrationMarginBlock: 0;
     --textMarginBottom: 0.313rem;
     --titleMarginBottom: 0.25rem;
     --titleFontSize: var(--sapFontHeader5Size);
-    --actionsMargin: 0.25rem 0;
+    --actionsMarginBlock: 0.25rem;
     --illustrationMarginRight: 0.25rem;
 
     flex-flow: row wrap;
 
     .#{$block}__illustration {
-      @include fd-set-margin-right(var(--illustrationMarginRight));
+      margin-inline-end: var(--illustrationMarginRight);
 
       & + .#{$block}__figcaption {
         width: calc(100% - var(--illustrationW) - var(--illustrationMarginRight));

--- a/packages/styles/src/info-label.scss
+++ b/packages/styles/src/info-label.scss
@@ -77,7 +77,8 @@ $color-accents: (
   width: auto;
   color: var(--fdInfoLabel_Color);
   height: var(--fdInfoLabel_Height);
-  padding: 0 var(--fdInfoLabel_Padding);
+  padding-block: 0;
+  padding-inline: var(--fdInfoLabel_Padding);
   border-radius: var(--fdInfoLabel_Border_Radius);
   background-color: var(--fdInfoLabel_Background);
   border: 0.0625rem solid var(--fdInfoLabel_Border_Color);

--- a/packages/styles/src/input-group.scss
+++ b/packages/styles/src/input-group.scss
@@ -117,8 +117,8 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
   @include fd-compact-or-condensed() {
     height: var(--sapElement_Compact_Height);
 
-    --fdInput_Field_Margin: 0.1875rem 0;
-    --fdInput_Field_Compact_Margin: 0;
+    --fdInput_Field_Margin_Block: 0.1875rem;
+    --fdInput_Field_Compact_Margin_Block: 0;
     --fdInput_Group_Addon_Width: 2rem;
     --fdInput_Group_Addon_Height: var(--fdInput_Compact_Height);
   }

--- a/packages/styles/src/menu.scss
+++ b/packages/styles/src/menu.scss
@@ -12,12 +12,8 @@ $block: #{$fd-namespace}-menu;
 .#{$block} {
   $fd-menu-border-radius: var(--fdButton_Menu_Border_Radius) !default;
   $fd-menu-item-color-active: var(--sapList_Active_TextColor) !default;
-  $fd-menu-link-padding-top: 0.25rem !default;
-  $fd-menu-link-padding-left: -0.25rem !default;
 
   --fdMenu_Icon_Width: 2.25rem;
-  --fdMenu_Icon_Before_Margin: 0 0 0 -0.75rem;
-  --fdMenu_Icon_After_Margin: 0 -1rem 0 0;
   --fdMenu_Link_Height: 2.75rem;
   --fdMenu_Item_Spacing_Left: 0.75rem;
   --fdMenu_Item_Spacing_Right: 0.75rem;
@@ -82,13 +78,13 @@ $block: #{$fd-namespace}-menu;
     top: 0;
     left: 100%;
     z-index: 2;
-    margin: $fd-menu-link-padding-top 0 0 $fd-menu-link-padding-left;
+    margin-block: 0.25rem 0;
+    margin-inline: -0.25rem 0;
     min-width: 100%;
 
     @include fd-rtl() {
       right: 100%;
       left: initial;
-      margin: $fd-menu-link-padding-top $fd-menu-link-padding-left 0 0;
     }
 
     &[aria-hidden='true'] {
@@ -345,8 +341,6 @@ $block: #{$fd-namespace}-menu;
     max-width: 100%;
     width: 100%;
 
-    --fdMenu_Icon_Before_Margin: 0 0 0 -1rem;
-    --fdMenu_Icon_After_Margin: 0 -1rem 0 0;
     --fdMenu_Icon_Width: 2.75rem;
     --fdMenu_Item_Spacing_Left: 1rem;
     --fdMenu_Item_Spacing_Right: 1rem;
@@ -358,7 +352,8 @@ $block: #{$fd-namespace}-menu;
       border-radius: 0;
       box-shadow: none;
       position: static;
-      margin: 0;
+      margin-inline: 0;
+      margin-block: 0;
 
       .#{$block}__item {
         border-radius: 0;
@@ -377,8 +372,6 @@ $block: #{$fd-namespace}-menu;
   }
 
   @include fd-compact-or-condensed() {
-    --fdMenu_Icon_Before_Margin: 0 0 0 -0.5rem;
-    --fdMenu_Icon_After_Margin: 0 -0.75rem 0 0;
     --fdMenu_Icon_Width: 2rem;
     --fdMenu_Link_Height: 2rem;
     --fdMenu_Item_Spacing_Left: 0.5rem;

--- a/packages/styles/src/message-page.scss
+++ b/packages/styles/src/message-page.scss
@@ -29,7 +29,8 @@ $block: #{$fd-namespace}-message-page;
       align-items: center;
     }
 
-    padding: 1rem;
+    padding-block: 1rem;
+    padding-inline: 1rem;
     background: var(--fdMessage_Page_Container_Background);
     border-radius: var(--fdMessage_Page_Container_Corner_Radius);
   }

--- a/packages/styles/src/micro-process-flow.scss
+++ b/packages/styles/src/micro-process-flow.scss
@@ -202,7 +202,8 @@ $fd-micro-process-flow-semantic-colors: (
     @include fd-set-padding-left($fd-micro-process-flow-item-padding);
 
     position: relative;
-    margin: calc(var(--sapContent_FocusWidth) + var(--sapContent_FocusWidth)) 0;
+    margin-block: calc(var(--sapContent_FocusWidth) + var(--sapContent_FocusWidth));
+    margin-inline: 0;
     justify-content: flex-start;
 
     .#{$fd-namespace}-status-indicator {

--- a/packages/styles/src/mixins/_forms.scss
+++ b/packages/styles/src/mixins/_forms.scss
@@ -27,8 +27,10 @@ $fd-input-field-height--compact: 1.625rem;
   width: 100%;
   min-width: #{$overrideMinWidth};
   border-radius: var(--sapField_BorderCornerRadius);
-  padding: var(--fdInput_Field_Padding, 0 0.625rem);
-  margin: var(--fdInput_Field_Margin, 0.25rem 0);
+  padding-block: 0;
+  padding-inline: var(--fdInput_Field_Padding_Inline, 0.625rem);
+  margin-block: var(--fdInput_Field_Margin_Block, 0.25rem);
+  margin-inline: 0;
   box-shadow: var(--sapField_Shadow);
   color: var(--sapField_TextColor);
   text-shadow: var(--fdInput_Text_Shadow);
@@ -88,8 +90,10 @@ $fd-input-field-height--compact: 1.625rem;
   @include fd-set-min-height(var(--fdInput_Compact_Height, var(--sapElement_Compact_Height)));
 
   min-width: var(--fdInput_Field_Compact_Min_Width, 2rem);
-  margin: var(--fdInput_Field_Compact_Margin, 0.1875rem 0);
-  padding: var(--fdInput_Field_Compact_Padding, 0 0.5rem);
+  margin-block: var(--fdInput_Field_Compact_Margin_Block, 0.1875rem);
+  margin-inline: 0;
+  padding-block: 0;
+  padding-inline: var(--fdInput_Field_Compact_Padding, 0.5rem);
   box-sizing: border-box;
 }
 

--- a/packages/styles/src/mixins/list/_list-base.scss
+++ b/packages/styles/src/mixins/list/_list-base.scss
@@ -70,7 +70,8 @@
         color: var(--sapButton_TextColor);
         pointer-events: all;
         cursor: pointer;
-        margin: var(--fdList_Item_Action_Button_Spacing);
+        margin-block: var(--fdList_Item_Action_Button_Spacing);
+        margin-inline: var(--fdList_Item_Action_Button_Spacing);
         border: var(--fdList_Item_Action_Button_Border);
         border-radius: var(--fdList_Item_Action_Button_Border_Radius);
 

--- a/packages/styles/src/mixins/list/_list-dropdown.scss
+++ b/packages/styles/src/mixins/list/_list-dropdown.scss
@@ -2,8 +2,6 @@
 
 @import "./list-definitions";
 
-$fd-list-dropdown-vertical-padding: 0.75rem !default;
-$fd-list-dropdown-vertical-compact-padding: 0.5rem !default;
 $fd-checkbox-dimensions: 1.375rem !default;
 
 .#{$block} {
@@ -80,7 +78,7 @@ $fd-checkbox-dimensions: 1.375rem !default;
 
     .#{$block}__footer,
     .#{$block}__label {
-      padding-block: $fd-list-dropdown-vertical-padding;
+      padding-block: 0.75rem;
       padding-inline: $fd-list-item-padding-x;
     }
 
@@ -101,7 +99,7 @@ $fd-checkbox-dimensions: 1.375rem !default;
 
       .#{$block}__footer,
       .#{$block}__label {
-        padding-block: $fd-list-dropdown-vertical-compact-padding;
+        padding-block: 0.5rem;
         padding-inline: $fd-list-item-padding-x;
       }
     }

--- a/packages/styles/src/notification.scss
+++ b/packages/styles/src/notification.scss
@@ -46,7 +46,8 @@ $block: #{$fd-namespace}-notification;
   --fdNotification_Group_Item_Background: var(--sapList_Background);
 
   // Notification Limit
-  --fdNotification_Limit_Padding: 1rem;
+  --fdNotification_Limit_Padding_Block: 1rem;
+  --fdNotification_Limit_Padding_Inline: 1rem;
 
   // Border
   $fd-notification-border: var(--sapList_BorderWidth) solid var(--sapList_BorderColor);
@@ -174,7 +175,8 @@ $block: #{$fd-namespace}-notification;
     @include fd-reset();
 
     text-align: center;
-    padding: var(--fdNotification_Limit_Padding);
+    padding-block: var(--fdNotification_Limit_Padding_Block);
+    padding-inline: var(--fdNotification_Limit_Padding_Inline);
 
     &--title {
       @include fd-reset();
@@ -332,7 +334,8 @@ $block: #{$fd-namespace}-notification;
     --fdNotification_Item_Footer_Font_Size: var(--sapFontSmallSize);
 
     // Notification Limit
-    --fdNotification_Limit_Padding: 1.5rem 0;
+    --fdNotification_Limit_Padding_Block: 1.5rem;
+    --fdNotification_Limit_Padding_Inline: 0;
 
     .#{$block}__body {
       cursor: pointer;

--- a/packages/styles/src/object-status.scss
+++ b/packages/styles/src/object-status.scss
@@ -853,7 +853,8 @@ $inverted-color-accents-b: (
     position: relative;
     border-style: solid;
     overflow: hidden;
-    padding: var(--fdObjectStatus_Inverted_Padding);
+    padding-block: var(--fdObjectStatus_Inverted_Padding_Block);
+    padding-inline: var(--fdObjectStatus_Inverted_Padding_Inline);
     min-width: var(--fdObjectStatus_Inverted_Min_Width);
     border-width: var(--fdObjectStatus_Inverted_Border_Width);
     min-height: var(--fdObjectStatus_Inverted_Line_Height);

--- a/packages/styles/src/progress-indicator.scss
+++ b/packages/styles/src/progress-indicator.scss
@@ -47,7 +47,7 @@ $fd-progress-indicator-states: (
 );
 
 .#{$block} {
-  --rootMargin: 0.5rem 0;
+  --rootMarginBlock: 0.5rem;
   --progressBarBackground: var(--fdProgress_Indicator_Background_Color_Neutral);
   --progressBarBorderColor: var(--fdProgress_Indicator_Progress_Bar_Border_Color_Neutral, transparent);
   --progressBarBorderRightColor: var(--fdProgress_Indicator_Border_Right_Color, var(--progressBarBorderColor));
@@ -62,20 +62,23 @@ $fd-progress-indicator-states: (
 
   width: 100%;
   height: var(--fdProgress_Indicator_Height);
-  margin: var(--rootMargin);
-  padding: var(--fdProgress_Indicator_Container_Margin);
+  margin-block: var(--rootMarginBlock);
+  margin-inline: 0;
+  padding-block: var(--fdProgress_Indicator_Container_Margin_Block);
+  padding-inline: var(--fdProgress_Indicator_Container_Margin_Inline);
 
   &.#{$fd-namespace}-popover {
-    margin: var(--rootMargin);
     cursor: pointer;
+    margin-block: var(--rootMarginBlock);
+    margin-inline: 0;
   }
 
   &--mobile {
-    --rootMargin: 0.875rem 0;
+    --rootMarginBlock: 0.875rem;
   }
 
   &--display {
-    margin: 0;
+    --rootMarginBlock: 0;
 
     &.#{$fd-namespace}-popover {
       margin-inline: 0;
@@ -156,7 +159,8 @@ $fd-progress-indicator-states: (
     }
 
     height: var(--fdProgress_Indicator_Progress_Bar_Height);
-    margin: var(--fdProgress_Indicator_Progress_Bar_Margin);
+    margin-block: var(--fdProgress_Indicator_Progress_Bar_Margin_Block);
+    margin-inline: 0;
     border: var(--fdProgress_Indicator_Progress_Bar_Border) var(--progressBarBorderColor);
     border-right: var(--fdProgress_Indicator_Border_Right) var(--progressBarBorderRightColor);
     border-radius: var(--fdProgress_Indicator_Progress_Bar_Border_Radius);

--- a/packages/styles/src/resizable-card-layout.scss
+++ b/packages/styles/src/resizable-card-layout.scss
@@ -54,12 +54,12 @@ $block: #{$fd-namespace}-resizable-card-layout;
     bottom: 0;
     right: 0;
     z-index: $fd-resize-handle-index;
-    padding: 0 $fd-resize-icon-padding $fd-resize-icon-padding 0;
+    padding-block: 0 $fd-resize-icon-padding;
+    padding-inline: 0 $fd-resize-icon-padding;
 
     @include fd-rtl() {
       right: auto;
       left: 0;
-      padding: 0 0 $fd-resize-icon-padding $fd-resize-icon-padding;
     }
   }
 
@@ -81,9 +81,8 @@ $block: #{$fd-namespace}-resizable-card-layout;
       transform: rotate(90deg);
       position: relative;
       cursor: nesw-resize;
-      padding: 0 $fd-resize-icon-padding $fd-resize-icon-padding 0.5rem;
-
-      // padding-left is needed after rotation
+      padding-block: 0 $fd-resize-icon-padding;
+      padding-inline: $fd-resize-icon-padding 0.5rem;
     }
 
     &--vertical {

--- a/packages/styles/src/section.scss
+++ b/packages/styles/src/section.scss
@@ -5,14 +5,11 @@
 $block: #{$fd-namespace}-section;
 
 .#{$block} {
-  $fd-section-padding--top: 1rem !default;
-  $fd-section-padding--bottom: 1.5rem !default;
-  $fd-section-header-margin--bottom: 1.5rem !default;
-
   @include fd-reset();
   @include fd-clearfix();
 
-  padding: $fd-section-padding--top 0.5rem $fd-section-padding--bottom 0.5rem;
+  padding-block: 1rem 1.5rem;
+  padding-inline: 0.5rem;
 
   @include fd-screen(m) {
     padding-inline: 2rem;
@@ -56,7 +53,7 @@ $block: #{$fd-namespace}-section;
     min-height: 1.5rem;
     display: flex;
     align-items: center;
-    margin-block-end: $fd-section-header-margin--bottom;
+    margin-block-end: 1.5rem;
   }
 
   &__title {

--- a/packages/styles/src/shellbar.scss
+++ b/packages/styles/src/shellbar.scss
@@ -30,9 +30,6 @@ $block: #{$fd-namespace}-shellbar;
   // Brand
   $fd-shellbar-logo-background-image-url: "data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0MTIuMzggMjA0Ij48ZGVmcz48c3R5bGU+LmNscy0xLC5jbHMtMntmaWxsLXJ1bGU6ZXZlbm9kZH0uY2xzLTF7ZmlsbDp1cmwoI2xpbmVhci1ncmFkaWVudCl9LmNscy0ye2ZpbGw6I2ZmZn08L3N0eWxlPjxsaW5lYXJHcmFkaWVudCBpZD0ibGluZWFyLWdyYWRpZW50IiB4MT0iMjA2LjE5IiB4Mj0iMjA2LjE5IiB5Mj0iMjA0IiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSI+PHN0b3Agb2Zmc2V0PSIwIiBzdG9wLWNvbG9yPSIjMDBiOGYxIi8+PHN0b3Agb2Zmc2V0PSIuMDIiIHN0b3AtY29sb3I9IiMwMWI2ZjAiLz48c3RvcCBvZmZzZXQ9Ii4zMSIgc3RvcC1jb2xvcj0iIzBkOTBkOSIvPjxzdG9wIG9mZnNldD0iLjU4IiBzdG9wLWNvbG9yPSIjMTc3NWM4Ii8+PHN0b3Agb2Zmc2V0PSIuODIiIHN0b3AtY29sb3I9IiMxYzY1YmYiLz48c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiMxZTVmYmIiLz48L2xpbmVhckdyYWRpZW50PjwvZGVmcz48dGl0bGU+U0FQX2dyYWRfUl9zY3JuX1plaWNoZW5mbMOkY2hlIDE8L3RpdGxlPjxwYXRoIGNsYXNzPSJjbHMtMSIgZD0iTTAgMjA0aDIwOC40MUw0MTIuMzggMEgwdjIwNCIvPjxwYXRoIGNsYXNzPSJjbHMtMiIgZD0iTTI0NC43MyAzOC4zNmgtNDAuNnY5Ni41MmwtMzUuNDYtOTYuNTVoLTM1LjE2bC0zMC4yNyA4MC43MkMxMDAgOTguNyA3OSA5MS42NyA2Mi40IDg2LjQgNTEuNDYgODIuODkgMzkuODUgNzcuNzIgNDAgNzJjLjA5LTQuNjggNi4yMy05IDE4LjM4LTguMzggOC4xNy40MyAxNS4zNyAxLjA5IDI5LjcxIDhsMTQuMS0yNC41NUM4OS4wNiA0MC40MiA3MSAzNi4yMSA1Ni4xNyAzNi4xOWgtLjA5Yy0xNy4yOCAwLTMxLjY4IDUuNi00MC42IDE0LjgzQTM0LjIzIDM0LjIzIDAgMCAwIDUuNzcgNzQuN0M1LjU0IDg3LjE1IDEwLjExIDk2IDE5LjcxIDEwM2M4LjEgNS45NCAxOC40NiA5Ljc5IDI3LjYgMTIuNjIgMTEuMjcgMy40OSAyMC40NyA2LjUzIDIwLjM2IDEzQTkuNTcgOS41NyAwIDAgMSA2NSAxMzVjLTIuODEgMi45LTcuMTMgNC0xMy4wOSA0LjEtMTEuNDkuMjQtMjAtMS41Ni0zMy42MS05LjU5TDUuNzcgMTU0LjQyYTkzLjc3IDkzLjc3IDAgMCAwIDQ2IDEyLjIyaDIuMTFjMTQuMjQtLjI1IDI1Ljc0LTQuMzEgMzQuOTItMTEuNzEuNTMtLjQxIDEtLjg0IDEuNDktMS4yOGwtNC4xMiAxMC44NUgxMjNsNi4xOS0xOC44MmE2Ny40NiA2Ny40NiAwIDAgMCAyMS42OCAzLjQzIDY4LjMzIDY4LjMzIDAgMCAwIDIxLjE2LTMuMjVsNiAxOC42NGg2MC4xNHYtMzloMTMuMTFjMzEuNzEgMCA1MC40Ni0xNi4xNSA1MC40Ni00My4yIDAtMzAuMTEtMTguMjItNDMuOTQtNTcuMDEtNDMuOTR6TTE1MC45MSAxMjFhMzYuOTMgMzYuOTMgMCAwIDEtMTMtMi4yOGwxMi44Ny00MC41OWguMjJsMTIuNjUgNDAuNzFhMzguNSAzOC41IDAgMCAxLTEyLjc0IDIuMTZ6bTk2LjItMjMuMzNoLTguOTRWNjQuOTFoOC45NGMxMS45MyAwIDIxLjQ0IDQgMjEuNDQgMTYuMTQgMCAxMi42LTkuNTEgMTYuNTctMjEuNDQgMTYuNTciLz48L3N2Zz4=" !default;
 
-  // Paddings
-  $fd-shellbar-item-spacing: 0.5rem !default;
-
   // Colors
   $fd-shellbar-color: var(--sapShell_TextColor) !default;
 
@@ -125,7 +122,7 @@ $block: #{$fd-namespace}-shellbar;
 
     @include fd-flex-vertical-center() {
       flex: 1 1 0;
-      gap: $fd-shellbar-item-spacing;
+      gap: 0.5rem;
 
       &--shrink {
         flex-grow: 0;
@@ -146,7 +143,8 @@ $block: #{$fd-namespace}-shellbar;
       order: 2;
       display: none;
       justify-content: center;
-      margin: 0 $fd-shellbar-item-spacing;
+      margin-block: 0;
+      margin-inline: 0.5rem;
 
       .#{$block}__action {
         width: 100%;

--- a/packages/styles/src/slider.scss
+++ b/packages/styles/src/slider.scss
@@ -30,7 +30,8 @@ $slider-side-padding: calc((var(--fdSlider_Handle_Width) * 0.5) + #{$handle-outl
 
   min-width: 4rem;
   max-width: 100%;
-  padding: 1rem $slider-side-padding;
+  padding-block: 1rem;
+  padding-inline: $slider-side-padding;
   position: relative;
 
   &--lg {

--- a/packages/styles/src/status-indicator.scss
+++ b/packages/styles/src/status-indicator.scss
@@ -22,7 +22,6 @@ $color-states: (
   $fd-status-indicator-default-color-fill: transparent !default;
   $fd-status-indicator-default-color: var(--sapContent_LabelColor) !default;
   $fd-status-indicator-default-font-size: var(--sapFontSmallSize, 0.75rem);
-  $fd-status-indicator-default-margin: 0.375rem !default;
 
   font-family: var(--sapFontFamily);
   border-color: var(--sapContent_ForegroundBorderColor);

--- a/packages/styles/src/step-input.scss
+++ b/packages/styles/src/step-input.scss
@@ -6,11 +6,6 @@
 $block: #{$fd-namespace}-step-input;
 
 .#{$block} {
-  $fd-button-icon-font-size: 0.875rem;
-  $fd-step-input-cozy-height: 2.25rem;
-  $fd-step-input-compact-height: 1.625rem;
-  $fd-step-input-description-padding: 0.5rem;
-
   --fdStepInput_Button_Width: var(--fdStepInput_Button_Width_Cozy);
   --fdStepInput_Bordered_Button_Width: var(--fdStepInput_Button_Width_Semantic_Cozy);
 
@@ -36,7 +31,7 @@ $block: #{$fd-namespace}-step-input;
 
     &::before,
     &::after {
-      font-size: $fd-button-icon-font-size;
+      font-size: 0.875rem;
       margin-inline: 0;
       margin-block: 0;
     }
@@ -55,7 +50,7 @@ $block: #{$fd-namespace}-step-input;
   }
 
   &__input.#{$fd-namespace}-input {
-    --fdInput_Field_Padding: 0 0.25rem;
+    --fdInput_Field_Padding_Inline: 0.25rem;
 
     text-align: right;
     border: none;
@@ -97,23 +92,23 @@ $block: #{$fd-namespace}-step-input;
   @include fd-compact-or-condensed() {
     --fdStepInput_Button_Width: var(--fdStepInput_Button_Width_Compact);
     --fdStepInput_Bordered_Button_Width: var(--fdStepInput_Button_Width_Semantic_Compact);
-    --fdInput_Field_Compact_Padding: 0 0.25rem;
+    --fdInput_Field_Compact_Padding: 0.25rem;
 
-    height: $fd-step-input-compact-height;
-    min-height: $fd-step-input-compact-height;
+    height: 1.625rem;
+    min-height: 1.625rem;
 
     .#{$block}__input.#{$fd-namespace}-input {
       height: 100%;
     }
 
     &.is-readonly {
-      --fdInput_Field_Compact_Padding: 0 0.5rem;
+      --fdInput_Field_Compact_Padding: 0.5rem;
     }
   }
 
   &.is-readonly {
     .#{$block}__input.#{$fd-namespace}-input {
-      --fdInput_Field_Padding: 0 0.625rem;
+      --fdInput_Field_Padding_Inline: 0.625rem;
     }
 
     .#{$block}__button.#{$fd-namespace}-button {

--- a/packages/styles/src/switch.scss
+++ b/packages/styles/src/switch.scss
@@ -89,7 +89,8 @@ $block: #{$fd-namespace}-switch;
   display: flex;
   align-items: center;
   cursor: pointer;
-  padding: var(--fdSwitch_Padding);
+  padding-block: var(--fdSwitch_Padding, 0.625rem);
+  padding-inline: 0;
 
   @include fd-disabled() {
     cursor: auto;
@@ -285,7 +286,7 @@ $block: #{$fd-namespace}-switch;
   }
 
   @include fd-compact-or-condensed() {
-    --fdSwitch_Padding: var(--fdSwitch_Compact_Padding);
+    --fdSwitch_Padding: var(--fdSwitch_Compact_Padding_Block);
     --fdSwitch_Handle_Width: var(--fdSwitch_Compact_Handle_Width);
     --fdSwitch_Handle_Height: var(--fdSwitch_Compact_Handle_Height);
     --fdSwitch_Width: var(--fdSwitch_Compact_Width);

--- a/packages/styles/src/theming/common/card/_sap_fiori.scss
+++ b/packages/styles/src/theming/common/card/_sap_fiori.scss
@@ -8,7 +8,6 @@
   --fdCard_Footer_Border_Top: 0.0625rem solid var(--sapTile_SeparatorColor);
   --fdCard_Border: none;
   --fdCard_Counter_Margin: 0.188rem;
-  --fdCard_Bottom_Positioned_Header_Padding: 1rem;
   --fdCard_Footer_Padding: 1rem;
   --fdCard_Footer_Actions_Item_Spacing: 0.5rem;
   --fdCard_Title_Font_Size: var(--sapFontHeader5Size);

--- a/packages/styles/src/theming/common/card/_sap_horizon.scss
+++ b/packages/styles/src/theming/common/card/_sap_horizon.scss
@@ -8,8 +8,7 @@
   --fdCard_Footer_Border_Top: 0.0625rem solid transparent;
   --fdCard_Border: 0.0625rem solid var(--sapTile_BorderColor);
   --fdCard_Counter_Margin: 0.125rem;
-  --fdCard_Bottom_Positioned_Header_Padding: 0.75rem 1rem 1rem;
-  --fdCard_Footer_Padding: 0.75rem 1rem 1rem;
+  --fdCard_Footer_Padding: 0.75rem;
   --fdCard_Footer_Actions_Item_Spacing: 0.5rem;
   --fdCard_Title_Font_Size: var(--sapFontHeader6Size);
   --fdCard_Title_Font_Weight: bold;

--- a/packages/styles/src/theming/common/object-status/_sap_fiori.scss
+++ b/packages/styles/src/theming/common/object-status/_sap_fiori.scss
@@ -34,7 +34,8 @@
   --fdObjectStatus_Inverted_Border_Width: 0;
   --fdObjectStatus_Inverted_Underline_Width: 0;
   --fdObjectStatus_Inverted_Min_Width: 1.25rem;
-  --fdObjectStatus_Inverted_Padding: 0.0625rem 0.25rem;
+  --fdObjectStatus_Inverted_Padding_Block: 0.0625rem;
+  --fdObjectStatus_Inverted_Padding_Inline: 0.25rem;
   --fdObjectStatus_Inverted_Line_Height: 1.125rem;
   --fdObjectStatus_Inverted_Border_Radius: 0.25rem;
   --fdObjectStatus_Inverted_Large_Font_Family: var(--sapFontLightFamily);

--- a/packages/styles/src/theming/common/object-status/_sap_horizon.scss
+++ b/packages/styles/src/theming/common/object-status/_sap_horizon.scss
@@ -34,7 +34,8 @@
   --fdObjectStatus_Inverted_Border_Width: 0.0625rem;
   --fdObjectStatus_Inverted_Underline_Width: 0.125rem;
   --fdObjectStatus_Inverted_Min_Width: 1.375rem;
-  --fdObjectStatus_Inverted_Padding: 0.1875rem 0.25rem;
+  --fdObjectStatus_Inverted_Padding_Block: 0.1875rem;
+  --fdObjectStatus_Inverted_Padding_Inline: 0.25rem;
   --fdObjectStatus_Inverted_Line_Height: 1.375rem;
   --fdObjectStatus_Inverted_Border_Radius: var(--sapButton_BorderCornerRadius);
   --fdObjectStatus_Inverted_Large_Font_Family: var(--sapFontSemiBoldFamily);

--- a/packages/styles/src/theming/common/progress-indicator/_sap_fiori.scss
+++ b/packages/styles/src/theming/common/progress-indicator/_sap_fiori.scss
@@ -14,10 +14,11 @@
   --fdProgress_Icon_Negative: '';
   --fdProgress_Icon_Critical: '';
   --fdProgress_Indicator_Container_Height: 1rem;
-  --fdProgress_Indicator_Container_Margin: 0;
+  --fdProgress_Indicator_Container_Margin_Block: 0;
+  --fdProgress_Indicator_Container_Margin_Inline: 0;
   --fdProgress_Indicator_Container_Overflow: hidden;
   --fdProgress_Indicator_Progress_Bar_Height: 1rem;
-  --fdProgress_Indicator_Progress_Bar_Margin: 0;
+  --fdProgress_Indicator_Progress_Bar_Margin_Block: 0;
   --fdProgress_Indicator_Label_Margin_Start: 0.375rem;
   --fdProgress_Indicator_Label_Margin_End: 0.375rem;
   --fdProgress_Indicator_Label_Color: var(--sapField_TextColor);

--- a/packages/styles/src/theming/common/progress-indicator/_sap_horizon.scss
+++ b/packages/styles/src/theming/common/progress-indicator/_sap_horizon.scss
@@ -29,7 +29,8 @@
   --fdProgress_Icon_Color_Negative: var(--sapProgress_Value_NegativeTextColor);
   --fdProgress_Indicator_Container_Position: relative;
   --fdProgress_Indicator_Container_Height: 0.375rem;
-  --fdProgress_Indicator_Container_Margin: 1.25rem 0 0.375rem;
+  --fdProgress_Indicator_Container_Margin_Block: 1.25rem 0.375rem;
+  --fdProgress_Indicator_Container_Margin_Inline: 0;
   --fdProgress_Indicator_Container_Overflow: visible;
   --fdProgress_Indicator_Progress_Bar_Border: 0.0625rem solid;
   --fdProgress_Indicator_Progress_Bar_Border_Color_Neutral: var(--sapProgress_Value_BorderColor);
@@ -38,7 +39,7 @@
   --fdProgress_Indicator_Progress_Bar_Border_Color_Negative: var(--sapProgress_Value_NegativeBorderColor);
   --fdProgress_Indicator_Progress_Bar_Border_Color_Critical: var(--sapProgress_Value_CriticalBorderColor);
   --fdProgress_Indicator_Progress_Bar_Height: 0.625rem;
-  --fdProgress_Indicator_Progress_Bar_Margin: -0.1875rem 0 0;
+  --fdProgress_Indicator_Progress_Bar_Margin_Block: -0.1875rem 0;
   --fdProgress_Indicator_Progress_Bar_Border_Radius: 0.5rem;
   --fdProgress_Indicator_Progress_Bar_Position: absolute;
   --fdProgress_Indicator_Progress_Bar_Position_Left: -0.0625rem;

--- a/packages/styles/src/theming/common/switch/_sap_fiori.scss
+++ b/packages/styles/src/theming/common/switch/_sap_fiori.scss
@@ -8,7 +8,7 @@
   --fdSwitch_Compact_Handle_Height: var(--fdSwitch_Compact_Handle_Width);
   --fdSwitch_Compact_Handle_Offset: -0.8125rem;
   --fdSwitch_Compact_Active_Handle_Offset: 0.0625rem;
-  --fdSwitch_Compact_Padding: 0.625rem 0;
+  --fdSwitch_Compact_Padding_Block: 0.625rem;
 
   /* Standard */
   --fdSwitch_Track_Background: var(--sapButton_Track_Background);
@@ -37,7 +37,6 @@
   --fdSwitch_Border_Color: var(--fdSwitch_Handle_Border_Color);
   --fdSwitch_Border: var(--fdSwitch_Border_Width) solid var(--fdSwitch_Border_Color);
   --fdSwitch_Slider_Box_Sizing: content-box;
-  --fdSwitch_Padding: 0.625rem 0;
   --fdSwitch_Focus_Outline_Vertical_Offset: -0.375rem;
   --fdSwitch_Focus_Outline_Horizontal_Offset: 0;
   --fdSwitch_Focus_Outline_Border_Radius: 0;

--- a/packages/styles/src/theming/common/switch/_sap_horizon.scss
+++ b/packages/styles/src/theming/common/switch/_sap_horizon.scss
@@ -8,7 +8,7 @@
   --fdSwitch_Compact_Handle_Height: 1rem;
   --fdSwitch_Active_Handle_Offset: 0.5075rem;
   --fdSwitch_Compact_Handle_Offset: -0.8125rem;
-  --fdSwitch_Compact_Padding: 0.375rem 0;
+  --fdSwitch_Compact_Padding_Block: 0.375rem;
 
   /* Standard */
   --fdSwitch_Track_Background: var(--sapButton_Track_Background);
@@ -37,7 +37,6 @@
   --fdSwitch_Border_Color: transparent;
   --fdSwitch_Border: none;
   --fdSwitch_Slider_Box_Sizing: content-box;
-  --fdSwitch_Padding: 0.625rem 0;
   --fdSwitch_Focus_Outline_Vertical_Offset: calc(var(--sapContent_FocusWidth) * -2);
   --fdSwitch_Focus_Outline_Horizontal_Offset: calc(var(--sapContent_FocusWidth) * -2);
   --fdSwitch_Focus_Outline_Border_Radius: calc(var(--fdSwitch_Border_Radius) + (var(--sapContent_FocusWidth) * 2));

--- a/packages/styles/src/theming/common/user-menu/_sap_fiori.scss
+++ b/packages/styles/src/theming/common/user-menu/_sap_fiori.scss
@@ -2,8 +2,10 @@
 
 :root {
   --fdUserMenu_Body_Width: 18rem;
-  --fdUserMenu_Body_Padding: 1rem 0;
-  --fdUserMenu_Body_Padding_Compact: 1rem 0.5rem;
+  --fdUserMenu_Body_Padding_Block: 1rem;
+  --fdUserMenu_Body_Padding_Inline: 0;
+  --fdUserMenu_Body_Padding_Compact_Block: 1rem;
+  --fdUserMenu_Body_Padding_Compact_Inline: 0.5rem;
   --fdUserMenu_SubHeader_Margin_Bottom: 1rem;
   --fdUserMenu_SubHeader_Margin_Bottom_Compact: 1rem;
   --fdUserMenu_User_Name_Font_Size: var(--sapFontLargeSize);

--- a/packages/styles/src/theming/common/user-menu/_sap_horizon.scss
+++ b/packages/styles/src/theming/common/user-menu/_sap_horizon.scss
@@ -2,8 +2,10 @@
 
 :root {
   --fdUserMenu_Body_Width: auto;
-  --fdUserMenu_Body_Padding: 1rem;
-  --fdUserMenu_Body_Padding_Compact: 0.5rem;
+  --fdUserMenu_Body_Padding_Block: 1rem;
+  --fdUserMenu_Body_Padding_Inline: 1rem;
+  --fdUserMenu_Body_Padding_Compact_Block: 0.5rem;
+  --fdUserMenu_Body_Padding_Compact_Inline: 0.5rem;
   --fdUserMenu_SubHeader_Margin_Bottom: 1rem;
   --fdUserMenu_SubHeader_Margin_Bottom_Compact: 0.5rem;
   --fdUserMenu_User_Name_Font_Size: var(--sapFontHeader5Size);

--- a/packages/styles/src/tile.scss
+++ b/packages/styles/src/tile.scss
@@ -123,7 +123,8 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
   }
 
   position: relative;
-  padding: $fd-tile-padding;
+  padding-block: $fd-tile-padding;
+  padding-inline: $fd-tile-padding;
   background: var(--sapTile_Background);
   box-shadow: var(--sapContent_Shadow0);
   border-radius: $fd-tile-border-radius;
@@ -259,7 +260,8 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
     @include fd-set-height($fd-tile-height-s);
     @include fd-set-width($fd-tile-width-s);
 
-    padding: $fd-tile-small-padding;
+    padding-block: $fd-tile-small-padding;
+    padding-inline: $fd-tile-small-padding;
 
     &.#{$block}--double {
       @include fd-set-width($fd-tile-double-width-s);
@@ -540,9 +542,9 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
     &.#{$block}--s {
       .#{$block}__container {
         @include fd-set-height(5.25rem);
-        @include fd-set-paddings-x-equal($fd-tile-small-padding);
 
         padding-block-start: 0.1875rem;
+        padding-inline: $fd-tile-small-padding;
       }
 
       .#{$block}__title,
@@ -763,7 +765,8 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
     min-width: $fd-line-tile-min-width;
     max-width: 100%;
     width: auto;
-    padding: 0 $fd-line-tile-horizontal-padding;
+    padding-block: 0;
+    padding-inline: $fd-line-tile-horizontal-padding;
     box-shadow: none;
     background: transparent;
 

--- a/packages/styles/src/time.scss
+++ b/packages/styles/src/time.scss
@@ -17,7 +17,7 @@ $block: #{$fd-namespace}-time;
   $fd-time-item-width: 3rem;
 
   --fdTime_Item_Height: #{$fd-time-item-height};
-  --fdTime_Dropdown_Padding: #{$fd-time-dropdown-padding};
+  --fdTime_Dropdown_Padding: 1rem;
   --fdTime_Wrapper_Height: #{$fd-time-wrapper-height};
   --fdTime_Unit_Line_Height: 2.75rem;
 
@@ -25,7 +25,8 @@ $block: #{$fd-namespace}-time;
     justify-content: center;
   }
 
-  padding: var(--fdTime_Dropdown_Padding);
+  padding-block: var(--fdTime_Dropdown_Padding);
+  padding-inline: var(--fdTime_Dropdown_Padding);
 
   &__col {
     @include fd-reset();

--- a/packages/styles/src/timepicker.scss
+++ b/packages/styles/src/timepicker.scss
@@ -10,7 +10,8 @@ $block: #{$fd-namespace}-time-picker;
   --fdTimePickerClockFace: 18rem;
   --fdTimePickerTickWidth: 0.125rem;
   --fdTimePickerTickHeight: 0.1875rem;
-  --fdTimePickerTickMargin: 0 auto 0.375rem auto;
+  --fdTimePickerTickMarginBlock: 0 0.375rem;
+  --fdTimePickerTickMarginInline: auto;
 
   &__dropdown {
     @include fd-reset();
@@ -129,18 +130,19 @@ $block: #{$fd-namespace}-time-picker;
     background: var(--sapField_BorderColor);
     width: var(--fdTimePickerTickWidth);
     height: var(--fdTimePickerTickHeight);
-    margin: var(--fdTimePickerTickMargin);
+    margin-block: var(--fdTimePickerTickMarginBlock);
+    margin-inline: var(--fdTimePickerTickMarginInline);
 
     &--hour {
       --fdTimePickerTickWidth: 0.25rem;
       --fdTimePickerTickHeight: 0.3125rem;
-      --fdTimePickerTickMargin: 0 auto 0.25rem auto;
+      --fdTimePickerTickMarginBlock: 0 0.25rem;
     }
 
     &--selected {
       --fdTimePickerTickWidth: 0.25rem;
       --fdTimePickerTickHeight: 0.5625rem;
-      --fdTimePickerTickMargin: 0 auto;
+      --fdTimePickerTickMarginBlock: 0;
 
       background: var(--sapButton_Selected_BorderColor);
       border: 0.0625rem solid var(--sapButton_Selected_BorderColor);

--- a/packages/styles/src/token.scss
+++ b/packages/styles/src/token.scss
@@ -31,7 +31,8 @@ $block: #{$fd-namespace}-token;
   --fdToken_Height: 1.625rem;
   --fdToken_Min_Width: 3.625rem;
   --fdToken_Close_Color: var(--sapContent_IconColor);
-  --fdToken_Close_Padding: 0.25rem 0.5rem;
+  --fdToken_Close_Padding_Block: 0.25rem;
+  --fdToken_Close_Padding_Inline: 0.5rem;
   --fdToken_Close_Width: 1.75rem;
 
   cursor: default;
@@ -77,7 +78,8 @@ $block: #{$fd-namespace}-token;
 
     font-size: var(--sapFontSmallSize);
     color: var(--fdToken_Close_Color);
-    padding: var(--fdToken_Close_Padding);
+    padding-block: var(--fdToken_Close_Padding_Block);
+    padding-inline: var(--fdToken_Close_Padding_Inline);
     width: var(--fdToken_Close_Width);
     min-width: var(--fdToken_Close_Width);
     height: var(--fdToken_Height);
@@ -106,7 +108,8 @@ $block: #{$fd-namespace}-token;
   @include fd-compact-or-condensed() {
     --fdToken_Padding_Inline: 0.25rem 0;
     --fdToken_Height: 1.25rem;
-    --fdToken_Close_Padding: 0.125rem 0.25rem;
+    --fdToken_Close_Padding_Block: 0.125rem;
+    --fdToken_Close_Padding_Inline: 0.25rem;
     --fdToken_Close_Width: 1.25rem;
 
     min-width: 3rem;

--- a/packages/styles/src/tokenizer.scss
+++ b/packages/styles/src/tokenizer.scss
@@ -29,7 +29,8 @@ $block: #{$fd-namespace}-tokenizer;
   &__inner {
     @include fd-remove-scrollbar();
 
-    padding: var(--fdTokenizer_Inner_Padding, #{0 $fd-tokenizer-spacing});
+    padding-block: 0;
+    padding-inline: var(--fdTokenizer_Inner_Padding, #{$fd-tokenizer-spacing});
     overflow: hidden;
     float: right;
     white-space: nowrap;
@@ -67,7 +68,8 @@ $block: #{$fd-namespace}-tokenizer;
     }
 
     &:first-child {
-      padding: 0 $fd-tokenizer-spacing;
+      padding-block: 0;
+      padding-inline: $fd-tokenizer-spacing;
     }
 
     &:last-child {
@@ -96,7 +98,7 @@ $block: #{$fd-namespace}-tokenizer;
   @include fd-compact-or-condensed() {
     @include fd-set-min-height($fd-input-field-height--compact);
 
-    --fdTokenizer_Inner_Padding: #{0 $fd-tokenizer-compact-spacing};
+    --fdTokenizer_Inner_Padding: #{$fd-tokenizer-compact-spacing};
     --fdInput_Field_Compact_Min_Width: #{$fd-tokenizer-input-width-compact};
 
     .#{$block}__input:first-child {

--- a/packages/styles/src/tool-layout.scss
+++ b/packages/styles/src/tool-layout.scss
@@ -7,7 +7,8 @@ $block: #{$fd-namespace}-tool-layout;
 
 .#{$block} {
   --fdToolLayout_Gap: 0.5rem;
-  --fdToolLayout_Padding: 0.5rem 0.5rem 0 0.5rem;
+  --fdToolLayout_Padding_Block: 0.5rem 0;
+  --fdToolLayout_Padding_Inline: 0.5rem;
   --fdToolLayout_Content_Container_Border_Radius: 0.5rem 0.5rem 0 0;
   --fdToolLayout_Content_Container_Background: var(--sapBackgroundColor);
   --fdToolLayout_Content_Container_BoxShadow: var(--sapContainer_Shadow1);
@@ -20,7 +21,8 @@ $block: #{$fd-namespace}-tool-layout;
 
   width: 100%;
   height: 100%;
-  padding: var(--fdToolLayout_Padding);
+  padding-block: var(--fdToolLayout_Padding_Block);
+  padding-inline: var(--fdToolLayout_Padding_Inline);
   background: var(--fdToolLayout_Background);
 
   &__container {
@@ -90,13 +92,15 @@ $block: #{$fd-namespace}-tool-layout;
   }
 
   &--tablet {
-    --fdToolLayout_Padding: 0.5rem;
+    --fdToolLayout_Padding_Block: 0.5rem;
+    --fdToolLayout_Padding_Inline: 0.5rem;
     --fdToolLayout_Content_Container_Border_Radius: 0.5rem;
   }
 
   &--phone {
     --fdToolLayout_Gap: 0.25rem;
-    --fdToolLayout_Padding: 0.25rem;
+    --fdToolLayout_Padding_Block: 0.25rem;
+    --fdToolLayout_Padding_Inline: 0.25rem;
     --fdToolLayout_Content_Container_Border_Radius: 0.25rem;
   }
 

--- a/packages/styles/src/toolbar.scss
+++ b/packages/styles/src/toolbar.scss
@@ -61,15 +61,18 @@ $block: #{$fd-namespace}-toolbar;
     --fdToolbar_Separator_Width: auto;
     --fdToolbar_Separator_Height: 0.0625rem;
     --fdToolbar_Separator_Margin: 0.1875rem;
-    --fdToolbar_Overflow_Padding: 0.25rem 0.5rem;
+    --fdToolbar_Overflow_Padding_Block: 0.25rem;
+    --fdToolbar_Overflow_Padding_Inline: 0.5rem;
 
     overflow: auto;
     max-height: 50vh;
-    padding: var(--fdToolbar_Overflow_Padding);
+    padding-block: var(--fdToolbar_Overflow_Padding_Block);
+    padding-inline: var(--fdToolbar_Overflow_Padding_Inline);
     max-width: var(--fdToolbar_Overflow_Max_Width);
 
     @include fd-compact-or-condensed() {
-      --fdToolbar_Overflow_Padding: 0.1875rem 0.375rem;
+      --fdToolbar_Overflow_Padding_Block: 0.1875rem;
+      --fdToolbar_Overflow_Padding_Inline: 0.375rem;
     }
 
     & .#{$block}__overflow-button {

--- a/packages/styles/src/user-menu.scss
+++ b/packages/styles/src/user-menu.scss
@@ -11,10 +11,12 @@ $navigation: #{$fd-namespace}-navigation;
     @include fd-reset();
 
     width: 18rem;
-    padding: var(--fdUserMenu_Body_Padding);
+    padding-block: var(--fdUserMenu_Body_Padding_Block);
+    padding-inline: var(--fdUserMenu_Body_Padding_Inline);
 
     &.#{$block}__body--compact {
-      padding: var(--fdUserMenu_Body_Padding_Compact);
+      padding-block: var(--fdUserMenu_Body_Padding_Compact_Block);
+      padding-inline: var(--fdUserMenu_Body_Padding_Compact_Inline);
 
       .#{$block}__subheader {
         margin-block-end: var(--fdUserMenu_SubHeader_Margin_Bottom_Compact);
@@ -88,7 +90,8 @@ $navigation: #{$fd-namespace}-navigation;
 
   // BTP USER MENU
   &--tool-header {
-    --fdUserMenu_Body_Padding: 0.75rem;
+    --fdUserMenu_Body_Padding_Block: 0.75rem;
+    --fdUserMenu_Body_Padding_Inline: 0.75rem;
 
     .#{$block}__popover-body {
       border: none;

--- a/packages/styles/src/wizard.scss
+++ b/packages/styles/src/wizard.scss
@@ -325,7 +325,8 @@ $fd-wizard-stacked-upcoming-step-offset: 2.375rem !default;
     @include fd-reset();
     @include fd-wizard-responsive-paddings();
 
-    padding: var(--fdWizard_Step_Content_Container_Spacing);
+    padding-block: var(--fdWizard_Step_Content_Container_Spacing);
+    padding-inline: var(--fdWizard_Step_Content_Container_Spacing);
     background-color: var(--fdWizard_Step_Content_Container_Background_Color);
     border-radius: var(--sapElement_BorderCornerRadius);
   }


### PR DESCRIPTION
## Related Issue
Closes none

## Description
in FNGX we noticed that padding and margin rules are overwritten by the reset `padding-inline`, `padding-block`, `margin-inline`, margin-block` which are more specific. This for some reason happens only in production when the code is optimized. This PR makes sure the reset rules are overwritten using `padding-inline`, `padding-block`, `margin-inline`, margin-block`.
