### PR TITLE
docs: hide old versions links to small resolutions

### DIFF
--- a/packages/doc-ui/src/components/DocsPage/custom.scss
+++ b/packages/doc-ui/src/components/DocsPage/custom.scss
@@ -200,6 +200,12 @@ ul.fddocs-versions {
   }
 }
 
+@media (width <= 1200px) {
+  ul.fddocs-versions {
+    display: none;
+  }
+}
+
 .fddocs-community,
 .fddocs-versions {
   /* stylelint-disable no-descending-specificity */


### PR DESCRIPTION
hide old versions links to small resolutions