### PR TITLE
fix(styles): inline form group margin block start issue [ci visual]

### DIFF
--- a/packages/styles/src/form-group.scss
+++ b/packages/styles/src/form-group.scss
@@ -13,6 +13,11 @@ $block: #{$fd-namespace}-form-group;
       justify-content: flex-start;
       flex-wrap: wrap;
     }
+
+    .#{$block}-form-item + .#{$block}-form-item {
+      -webkit-margin-before: 0;
+      margin-block-start: 0;
+    }
   }
 
   &__header {


### PR DESCRIPTION
fixes none

Found this on ngx radio button page. Before:
<img width="448" alt="Screenshot 2024-10-02 at 10 18 26 AM" src="https://github.com/user-attachments/assets/a2473c59-d14e-4900-b007-0fc4fda64b33">

After:
<img width="479" alt="Screenshot 2024-10-02 at 10 20 19 AM" src="https://github.com/user-attachments/assets/7336090a-9f30-4b2e-b931-ba02fbd297da">
