### PR TITLE
fix(styles): redesign line/link Tiles in both static and edit mode

### DIFF
--- a/packages/styles/src/tile.scss
+++ b/packages/styles/src/tile.scss
@@ -110,7 +110,7 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
   @include fd-set-height($fd-tile-height);
   @include fd-set-width($fd-tile-width);
 
-  --fdGenericTileLineTileHeight: 2.25rem;
+  --fdGenericTileLineTileHeight: 2rem;
   --fdGenericTileLineTileMaxHeight: 3.25rem;
   --fdGenericTileLineHeight: 1.625rem;
   --fdGenericTileTitleHorizontalSpacing: 0.625rem;
@@ -767,15 +767,23 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
     width: auto;
     padding-block: 0;
     padding-inline: $fd-line-tile-horizontal-padding;
-    box-shadow: none;
-    background: transparent;
+    box-shadow: var(--sapContent_Shadow0);
+    background: var(--sapTile_Background);
+    border-radius: var(--sapTile_BorderCornerRadius);
+    border: var(--sapTile_BorderColor);
+    display: flex;
+    gap: 0.5rem;
 
     @include fd-hover() {
-      box-shadow: none;
+      box-shadow: var(--sapContentShadow2);
+      background: var(--sapTile_Hover_Background);
     }
 
     @include fd-active() {
       box-shadow: none;
+      background: var(--sapTile_Active_Background);
+      outline-offset: -0.125rem;
+      border: 2px solid var(--sapContent_FocusColor);
     }
 
     @include fd-disabled() {
@@ -806,17 +814,23 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
     .#{$block}__title,
     .#{$block}__subtitle {
       font-size: var(--sapFontSize);
+      font-family: var(--sapFontFamily);
       text-shadow: var(--sapContent_TextShadow);
-      color: var(--sapTile_TextColor);
+      color: var(--sapTile_TitleTextColor);
       line-height: var(--fdGenericTileLineHeight);
       min-width: $fd-line-tile-min-width;
+    }
+
+    .#{$block}__subtitle {
+      color: var(--sapTile_TextColor);
+      font-size: 0.875rem;
     }
 
     .#{$block}__title {
       @include fd-ellipsis();
       @include fd-set-margin-right(var(--fdGenericTileTitleHorizontalSpacing));
 
-      color: var(--sapButton_TextColor);
+      color: var(--sapTile_TitleTextColor);
       display: inline;
       -webkit-line-clamp: initial;
     }
@@ -831,26 +845,30 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
       }
 
       .#{$block}__action-close {
-        @include fd-set-height(1.625rem);
-        @include reset-position-absolute();
-        @include fd-flex-center();
-
+        @include fd-set-height(1.375rem);
+        @include fd-set-width(1.375rem);
+        position: relative;
         padding-block: 0;
         padding-inline: 0.25rem;
+        font-size: 0.75rem;
+        border-radius: 50%;
+        background: var(--sapButton_Background);
+        border: 1px solid var(--sapButton_BorderColor);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        cursor: pointer;
+        top: -0.625rem;
+        right: -0.325rem;
       }
 
       .#{$block}__action-indicator {
         margin-inline: 0;
         margin-block: 0;
-      }
 
-      .#{$block}__action-indicator,
-      .#{$block}__action-close {
-        @include reset-position-absolute();
-
-        @include fd-focus() {
-          @include fd-button-focus(0);
-        }
+        position: relative;
+        height: 1.625rem;
+        width: 1.625rem;
       }
     }
 

--- a/packages/styles/src/tile.scss
+++ b/packages/styles/src/tile.scss
@@ -144,8 +144,6 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
     box-shadow: var(--fdTile_Hover_Box_Shadow);
   }
 
-  @include fake-tile-outline();
-
   // ELEMENTS
   &__header,
   &__content,
@@ -767,23 +765,30 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
     width: auto;
     padding-block: 0;
     padding-inline: $fd-line-tile-horizontal-padding;
-    box-shadow: var(--sapContent_Shadow0);
-    background: var(--sapTile_Background);
+    box-shadow: var(--fdTile_Box_Shadow, var(--sapContent_Shadow0));
+    background: var(--fdTile_Background, var(--sapTile_Background)); 
+    border: var(--fdTile_Border, var(--sapTile_BorderColor));
     border-radius: var(--sapTile_BorderCornerRadius);
-    border: var(--sapTile_BorderColor);
-    display: flex;
-    gap: 0.5rem;
+
+    @include fd-flex() {
+      gap: 0.5rem;
+    }
 
     @include fd-hover() {
-      box-shadow: var(--sapContentShadow2);
-      background: var(--sapTile_Hover_Background);
+      border-radius: var(--sapTile_BorderCornerRadius);
+
+      --fdTile_Box_Shadow: var(--sapContent_Shadow2);
+      --fdTile_Background: var(--sapTile_Hover_Background);
     }
 
     @include fd-active() {
-      box-shadow: none;
-      background: var(--sapTile_Active_Background);
+      --fdTile_Background: var(--sapTile_Active_Background);
+    }
+
+    
+    @include fd-focus() {
+      outline: 0.125rem solid var(--sapContent_FocusColor);
       outline-offset: -0.125rem;
-      border: 2px solid var(--sapContent_FocusColor);
     }
 
     @include fd-disabled() {
@@ -845,30 +850,51 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
       }
 
       .#{$block}__action-close {
-        @include fd-set-height(1.375rem);
-        @include fd-set-width(1.375rem);
+        @include fd-square(1.375rem);
+        @include fd-flex-center();
+        @include fd-set-position-right(-0.425rem);
+
+
         position: relative;
         padding-block: 0;
         padding-inline: 0.25rem;
         font-size: 0.75rem;
         border-radius: 50%;
         background: var(--sapButton_Background);
-        border: 1px solid var(--sapButton_BorderColor);
-        display: flex;
-        justify-content: center;
-        align-items: center;
+        border: var(--sapButton_BorderColor);
         cursor: pointer;
         top: -0.625rem;
-        right: -0.325rem;
+
+        &::after {
+          border-radius: 50%;
+        }
       }
 
       .#{$block}__action-indicator {
+        @include fd-set-square(1.625rem);
+
+        min-width: auto;
         margin-inline: 0;
         margin-block: 0;
-
         position: relative;
-        height: 1.625rem;
-        width: 1.625rem;
+        line-height: 1.625rem;
+
+        &::after {
+          @include fd-set-square(2rem);
+          
+          @include fd-rtl() {
+            right: 50%;
+            left: auto;
+            transform: translate(50%, -50%);
+          }
+
+          content: '';
+          position: absolute;
+          left: 60%;
+          top: 50%;
+          transform: translate(-50%, -50%);
+           
+        }
       }
     }
 

--- a/packages/styles/src/tile.scss
+++ b/packages/styles/src/tile.scss
@@ -754,8 +754,8 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
       justify-content: space-between;
     }
 
-    @include fd-set-margin-right($fd-line-tile-horizontal-spacing);
-    @include fd-set-margins-y-equal($fd-line-tile-vertical-spacing);
+    @include fd-set-margins-y-equal(0.25rem);
+    @include fd-set-margin-right(0.5rem);
 
     min-height: var(--fdGenericTileLineTileHeight);
     max-height: var(--fdGenericTileLineTileHeight);
@@ -767,7 +767,7 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
     padding-inline: $fd-line-tile-horizontal-padding;
     box-shadow: var(--fdTile_Box_Shadow, var(--sapContent_Shadow0));
     background: var(--fdTile_Background, var(--sapTile_Background)); 
-    border: var(--fdTile_Border, var(--sapTile_BorderColor));
+    border: 0.0625rem solid var(--fdTile_Border, var(--sapTile_BorderColor));
     border-radius: var(--sapTile_BorderCornerRadius);
 
     @include fd-flex() {
@@ -852,8 +852,6 @@ $fd-line-tile-badge-horizontal-spacing: 0.375rem !default;
       .#{$block}__action-close {
         @include fd-square(1.375rem);
         @include fd-flex-center();
-        @include fd-set-position-right(-0.425rem);
-
 
         position: relative;
         padding-block: 0;


### PR DESCRIPTION
## Related Issue
related to https://github.com/SAP/fundamental-ngx/issues/11490

## Description
Design changes to the generic line tiles according to the specs
## Screenshots

### Before:
<img width="1238" alt="Screenshot 2024-10-03 at 9 08 49 AM" src="https://github.com/user-attachments/assets/fb9a0b14-5955-4695-a0e8-f66c531bea0d">


### After:
[
<img width="1262" alt="Screenshot 2024-10-03 at 9 09 23 AM" src="https://github.com/user-attachments/assets/7bad3e41-588e-4ac6-aceb-80f45923c495">
](url)