### PR TITLE
fix(styles): add more spacing between text and colon [ci visual]

### DIFF
--- a/packages/styles/src/form-label.scss
+++ b/packages/styles/src/form-label.scss
@@ -43,7 +43,7 @@ $block: #{$fd-namespace}-form-label;
   }
 
   &--colon {
-    padding-inline-end: 0.125rem;
+    padding-inline-end: 0.25rem;
 
     &::before {
       content: ':';


### PR DESCRIPTION
## Related Issue
Closes none

## Description

### Before:
<img width="574" alt="Screenshot 2024-10-03 at 3 44 22 PM" src="https://github.com/user-attachments/assets/64f19b65-a058-4e66-81e2-a3e77ffb373f">


### After:
<img width="559" alt="Screenshot 2024-10-03 at 3 44 04 PM" src="https://github.com/user-attachments/assets/eacb659f-ad80-4c9e-b57c-5d229e31489e">
