### PR TITLE
fix(styles): remove redundant spacing between form items [ci visual]

### DIFF
--- a/packages/styles/src/form-group.scss
+++ b/packages/styles/src/form-group.scss
@@ -7,12 +7,15 @@ $block: #{$fd-namespace}-form-group;
 
 .#{$block} {
   @include fd-reset();
+  @include fd-flex(column);
 
   &--inline {
-    @include fd-flex() {
-      justify-content: flex-start;
-      flex-wrap: wrap;
-    }
+    flex-flow: row wrap;
+    justify-content: flex-start;
+  }
+
+  &--with-spacing {
+    gap: 0.625rem;
   }
 
   &__header {

--- a/packages/styles/src/form-item.scss
+++ b/packages/styles/src/form-item.scss
@@ -8,14 +8,11 @@ $block: #{$fd-namespace}-form-item;
 .#{$block} {
   @include fd-reset();
 
-  position: relative;
-  display: flex;
-  align-content: center;
-  flex-direction: column;
-
-  & + .#{$block} {
-    margin-block-start: 0.625rem;
+  @include fd-flex(column) {
+    flex: 1;
   }
+
+  position: relative;
 
   &__label-container {
     @include fd-flex() {
@@ -48,5 +45,9 @@ $block: #{$fd-namespace}-form-item;
 
   .#{$fd-namespace}-form-message:not(:first-child) {
     margin-top: -0.25rem;
+  }
+
+  &.#{$fd-namespace}-list__form-item {
+    flex: initial;
   }
 }

--- a/packages/styles/stories/AI/Patterns/ai-guided-prompt/ai-guided-prompt.example.html
+++ b/packages/styles/stories/AI/Patterns/ai-guided-prompt/ai-guided-prompt.example.html
@@ -27,7 +27,7 @@
             </div>
         </header>
    
-        <div style="padding: 1rem; min-width: 500px;">
+        <div class="fd-form-group fd-form-group--with-spacing" style="padding: 1rem; min-width: 500px;">
             <div class="fd-form-item">
                 <label class="fd-form-label" id="structureLabel">Structure:</label>
                 <div class="fd-popover">

--- a/packages/styles/stories/Components/Forms/form-group/group-header-in-form-grid.example.html
+++ b/packages/styles/stories/Components/Forms/form-group/group-header-in-form-grid.example.html
@@ -1,6 +1,6 @@
 <div class="fd-container fd-form-layout-grid-container">
         <div class="fd-row">
-            <div class="fd-form-group fd-col fd-col-md--6  fd-col-lg--6 fd-col-xl--6 fd-col--wrap" role="group" aria-labelledby="grid1GroupHeader">
+            <div class="fd-form-group fd-form-group--with-spacing fd-col fd-col-md--6  fd-col-lg--6 fd-col-xl--6 fd-col--wrap" role="group" aria-labelledby="grid1GroupHeader">
                 <div class="fd-form-group__header"  id="grid1GroupHeader">
                     <h1 class="fd-form-group__header-text">Group Header 1</h1>
                 </div>
@@ -29,7 +29,7 @@
                     </div>
                 </div>
             </div>
-            <div class="fd-form-group fd-col fd-col-md--6 fd-col-lg--6 fd-col-xl--6 fd-col--wrap" role="group" aria-labelledby="grid2GroupHeader">
+            <div class="fd-form-group fd-form-group--with-spacing fd-col fd-col-md--6 fd-col-lg--6 fd-col-xl--6 fd-col--wrap" role="group" aria-labelledby="grid2GroupHeader">
                 <div class="fd-form-group__header">
                     <h1 class="fd-form-group__header-text" id="grid2GroupHeader">Group Header 2</h1>
                 </div>
@@ -58,7 +58,7 @@
                     </div>
                 </div>
             </div>
-            <div class="fd-form-group fd-col fd-col-md--6 fd-col-lg--6 fd-col-xl--6 fd-col--wrap" role="group" aria-labelledby="grid3GroupHeader">
+            <div class="fd-form-group fd-form-group--with-spacing fd-col fd-col-md--6 fd-col-lg--6 fd-col-xl--6 fd-col--wrap" role="group" aria-labelledby="grid3GroupHeader">
                 <div class="fd-form-group__header">
                     <h1 class="fd-form-group__header-text" id="grid3GroupHeader">Group Header 3</h1>
                 </div>

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -202,7 +202,7 @@ exports[`Check stories > AI/Patterns/Guided Prompt > Story AIGuidedPrompt > Shou
             </div>
         </header>
    
-        <div style=\\"padding: 1rem; min-width: 500px;\\">
+        <div class=\\"fd-form-group fd-form-group--with-spacing\\" style=\\"padding: 1rem; min-width: 500px;\\">
             <div class=\\"fd-form-item\\">
                 <label class=\\"fd-form-label\\" id=\\"structureLabel\\">Structure:</label>
                 <div class=\\"fd-popover\\">
@@ -20613,7 +20613,7 @@ exports[`Check stories > Components/Forms/Form Group > Story GroupHeader > Shoul
 exports[`Check stories > Components/Forms/Form Group > Story GroupHeaderInFormGrid > Should match snapshot 1`] = `
 "<div class=\\"fd-container fd-form-layout-grid-container\\">
         <div class=\\"fd-row\\">
-            <div class=\\"fd-form-group fd-col fd-col-md--6  fd-col-lg--6 fd-col-xl--6 fd-col--wrap\\" role=\\"group\\" aria-labelledby=\\"grid1GroupHeader\\">
+            <div class=\\"fd-form-group fd-form-group--with-spacing fd-col fd-col-md--6  fd-col-lg--6 fd-col-xl--6 fd-col--wrap\\" role=\\"group\\" aria-labelledby=\\"grid1GroupHeader\\">
                 <div class=\\"fd-form-group__header\\"  id=\\"grid1GroupHeader\\">
                     <h1 class=\\"fd-form-group__header-text\\">Group Header 1</h1>
                 </div>
@@ -20642,7 +20642,7 @@ exports[`Check stories > Components/Forms/Form Group > Story GroupHeaderInFormGr
                     </div>
                 </div>
             </div>
-            <div class=\\"fd-form-group fd-col fd-col-md--6 fd-col-lg--6 fd-col-xl--6 fd-col--wrap\\" role=\\"group\\" aria-labelledby=\\"grid2GroupHeader\\">
+            <div class=\\"fd-form-group fd-form-group--with-spacing fd-col fd-col-md--6 fd-col-lg--6 fd-col-xl--6 fd-col--wrap\\" role=\\"group\\" aria-labelledby=\\"grid2GroupHeader\\">
                 <div class=\\"fd-form-group__header\\">
                     <h1 class=\\"fd-form-group__header-text\\" id=\\"grid2GroupHeader\\">Group Header 2</h1>
                 </div>
@@ -20671,7 +20671,7 @@ exports[`Check stories > Components/Forms/Form Group > Story GroupHeaderInFormGr
                     </div>
                 </div>
             </div>
-            <div class=\\"fd-form-group fd-col fd-col-md--6 fd-col-lg--6 fd-col-xl--6 fd-col--wrap\\" role=\\"group\\" aria-labelledby=\\"grid3GroupHeader\\">
+            <div class=\\"fd-form-group fd-form-group--with-spacing fd-col fd-col-md--6 fd-col-lg--6 fd-col-xl--6 fd-col--wrap\\" role=\\"group\\" aria-labelledby=\\"grid3GroupHeader\\">
                 <div class=\\"fd-form-group__header\\">
                     <h1 class=\\"fd-form-group__header-text\\" id=\\"grid3GroupHeader\\">Group Header 3</h1>
                 </div>


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/5660

## Description
The extra gap between Radio buttons and the misalignment in inline radio button group was added because form items in a form should have 0.625rem spacing. 
Added a new modifier class `fd-form-group--with-spacing` that adds spacing between the form-items only when explicitly applied. 
Removed the margin-block-start from the form-item.

**_Without spacing:_**
![Screenshot 2024-10-07 at 10 52 03 AM](https://github.com/user-attachments/assets/9a453834-41d5-49b5-9075-c847c98909a2)
![Screenshot 2024-10-07 at 10 51 40 AM](https://github.com/user-attachments/assets/4fdd1f03-4002-441c-bae6-6d20489e8fa3)

**_With spacing:_**
![Screenshot 2024-10-07 at 10 52 14 AM](https://github.com/user-attachments/assets/8da1a584-7672-453a-adab-b89a64df9731)
![Screenshot 2024-10-07 at 10 50 53 AM](https://github.com/user-attachments/assets/bff5b938-807e-4e3b-9957-7bc118ff7abe)


