### PR TITLE
fix(styles): make screenreader not announce asterisk on required fields [ci visual]

### DIFF
--- a/packages/styles/src/form-label.scss
+++ b/packages/styles/src/form-label.scss
@@ -25,7 +25,7 @@ $block: #{$fd-namespace}-form-label;
     padding-inline-end: 0.5rem;
 
     &::after {
-      content: '*';
+      content: '*' / '';
       font-size: var(--sapFontLargeSize);
       font-weight: bold;
       color: var(--sapField_RequiredColor);

--- a/packages/styles/src/mixins/_forms.scss
+++ b/packages/styles/src/mixins/_forms.scss
@@ -456,7 +456,7 @@ $fd-input-field-height--compact: 1.625rem;
   padding-inline-end: 0.5rem;
 
   &::after {
-    content: '*';
+    content: '*' / '';
     font-size: var(--sapFontSize);
     font-weight: bold;
     color: var(--sapField_RequiredColor);


### PR DESCRIPTION
fixes #5692 

fixes https://github.com/SAP/fundamental-ngx/issues/11284