### PR TITLE
fix(styles): add option to make individual Table cells non-interactive

### DIFF
--- a/packages/styles/src/table.scss
+++ b/packages/styles/src/table.scss
@@ -81,6 +81,18 @@ $table-z-index: (
         background-color: var(--fdTable_Header_Cell_Active_Background);
         color: var(--fdTable_Header_Cell_Hover_Active_Color);
       }
+
+      &.#{$block}__cell--non-interactive {
+        @include fd-hover() {
+          background-color: var(--sapList_HeaderBackground);
+          color: var(--sapList_HeaderTextColor);
+        }
+  
+        @include fd-active() {
+          background-color: var(--sapList_HeaderBackground);
+          color: var(--sapList_HeaderTextColor);
+        }
+      }
     }
 
     &--non-interactive {

--- a/packages/styles/stories/Components/table/primary.example.html
+++ b/packages/styles/stories/Components/table/primary.example.html
@@ -54,6 +54,63 @@
 </table>
 
 <br><br>
+<h4>Individual non-interactive header cells</h4>
+<div class="fd-toolbar fd-toolbar--title fd-toolbar-active">
+    <h4 class="fd-title fd-title--h4 fd-toolbar__title">Default Table</h4>
+    <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
+</div>
+<table class="fd-table">
+    <thead class="fd-table__header">
+        <tr class="fd-table__row">
+            <th class="fd-table__cell fd-table__cell--non-interactive" scope="col">Non-interactive Column Header</th>
+            <th class="fd-table__cell" scope="col">Column Header</th>
+            <th class="fd-table__cell" scope="col">Column Header</th>
+            <th class="fd-table__cell" scope="col">Column Header</th>
+            <th class="fd-table__cell fd-table__cell--non-interactive" scope="col">Non-interactive Column Header</th>
+        </tr>
+    </thead>
+    <tbody class="fd-table__body">
+        <tr class="fd-table__row">
+            <td class="fd-table__cell"><a class="fd-link"><span class="fd-link__content">user.name@email.com</span></a></td>
+            <td class="fd-table__cell">
+                <div class="fd-table__text fd-table__text--no-wrap" style="max-width: 250px">
+                    Very long Text Not Wrapped, limited by max-width
+                    Very long Text Not Wrapped, limited by max-width
+                    Very long Text Not Wrapped, limited by max-width
+                    Very long Text Not Wrapped, limited by max-width
+                    Very long Text Not Wrapped, limited by max-width
+                    Very long Text Not Wrapped, limited by max-width
+                </div>
+            </td>
+            <td class="fd-table__cell">Middle Name</td>
+            <td class="fd-table__cell">Last Name</td>
+            <td class="fd-table__cell">01/26/17</td>
+        </tr>
+        <tr class="fd-table__row">
+            <td class="fd-table__cell"><a class="fd-link"><span class="fd-link__content">user.name@email.com</span></a></td>
+            <td class="fd-table__cell">
+                <div class="fd-table__text" style="max-width: 250px">
+                    Very long Text Wrapped, limited by max-width
+                    Very long Text Wrapped, limited by max-width
+                    Very long Text Wrapped, limited by max-width
+                    Very long Text Wrapped, limited by max-width
+                </div>
+            </td>
+            <td class="fd-table__cell">Middle Name</td>
+            <td class="fd-table__cell">Last Name</td>
+            <td class="fd-table__cell">01/26/17</td>
+        </tr>
+        <tr class="fd-table__row">
+            <td class="fd-table__cell"><a class="fd-link"><span class="fd-link__content">user.name@email.com</span></a></td>
+            <td class="fd-table__cell">First Name</td>
+            <td class="fd-table__cell">Middle Name</td>
+            <td class="fd-table__cell">Last Name</td>
+            <td class="fd-table__cell">01/26/17</td>
+        </tr>
+    </tbody>
+</table>
+
+<br><br>
 <h4>Non-interactive header cells</h4>
 <div class="fd-toolbar fd-toolbar--title fd-toolbar-active">
     <h4 class="fd-title fd-title--h4 fd-toolbar__title">Default Table</h4>

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -45151,6 +45151,63 @@ exports[`Check stories > Components/Table > Story Primary > Should match snapsho
 </table>
 
 <br><br>
+<h4>Individual non-interactive header cells</h4>
+<div class=\\"fd-toolbar fd-toolbar--title fd-toolbar-active\\">
+    <h4 class=\\"fd-title fd-title--h4 fd-toolbar__title\\">Default Table</h4>
+    <span class=\\"fd-toolbar__spacer fd-toolbar__spacer--auto\\"></span>
+</div>
+<table class=\\"fd-table\\">
+    <thead class=\\"fd-table__header\\">
+        <tr class=\\"fd-table__row\\">
+            <th class=\\"fd-table__cell fd-table__cell--non-interactive\\" scope=\\"col\\">Non-interactive Column Header</th>
+            <th class=\\"fd-table__cell\\" scope=\\"col\\">Column Header</th>
+            <th class=\\"fd-table__cell\\" scope=\\"col\\">Column Header</th>
+            <th class=\\"fd-table__cell\\" scope=\\"col\\">Column Header</th>
+            <th class=\\"fd-table__cell fd-table__cell--non-interactive\\" scope=\\"col\\">Non-interactive Column Header</th>
+        </tr>
+    </thead>
+    <tbody class=\\"fd-table__body\\">
+        <tr class=\\"fd-table__row\\">
+            <td class=\\"fd-table__cell\\"><a class=\\"fd-link\\"><span class=\\"fd-link__content\\">user.name@email.com</span></a></td>
+            <td class=\\"fd-table__cell\\">
+                <div class=\\"fd-table__text fd-table__text--no-wrap\\" style=\\"max-width: 250px\\">
+                    Very long Text Not Wrapped, limited by max-width
+                    Very long Text Not Wrapped, limited by max-width
+                    Very long Text Not Wrapped, limited by max-width
+                    Very long Text Not Wrapped, limited by max-width
+                    Very long Text Not Wrapped, limited by max-width
+                    Very long Text Not Wrapped, limited by max-width
+                </div>
+            </td>
+            <td class=\\"fd-table__cell\\">Middle Name</td>
+            <td class=\\"fd-table__cell\\">Last Name</td>
+            <td class=\\"fd-table__cell\\">01/26/17</td>
+        </tr>
+        <tr class=\\"fd-table__row\\">
+            <td class=\\"fd-table__cell\\"><a class=\\"fd-link\\"><span class=\\"fd-link__content\\">user.name@email.com</span></a></td>
+            <td class=\\"fd-table__cell\\">
+                <div class=\\"fd-table__text\\" style=\\"max-width: 250px\\">
+                    Very long Text Wrapped, limited by max-width
+                    Very long Text Wrapped, limited by max-width
+                    Very long Text Wrapped, limited by max-width
+                    Very long Text Wrapped, limited by max-width
+                </div>
+            </td>
+            <td class=\\"fd-table__cell\\">Middle Name</td>
+            <td class=\\"fd-table__cell\\">Last Name</td>
+            <td class=\\"fd-table__cell\\">01/26/17</td>
+        </tr>
+        <tr class=\\"fd-table__row\\">
+            <td class=\\"fd-table__cell\\"><a class=\\"fd-link\\"><span class=\\"fd-link__content\\">user.name@email.com</span></a></td>
+            <td class=\\"fd-table__cell\\">First Name</td>
+            <td class=\\"fd-table__cell\\">Middle Name</td>
+            <td class=\\"fd-table__cell\\">Last Name</td>
+            <td class=\\"fd-table__cell\\">01/26/17</td>
+        </tr>
+    </tbody>
+</table>
+
+<br><br>
 <h4>Non-interactive header cells</h4>
 <div class=\\"fd-toolbar fd-toolbar--title fd-toolbar-active\\">
     <h4 class=\\"fd-title fd-title--h4 fd-toolbar__title\\">Default Table</h4>


### PR DESCRIPTION


## Related Issue
Closes none
related to https://github.com/SAP/fundamental-ngx/issues/11919
## Description
adds `fd-table__cell--non-interactive` modifier class to `fd-table__cell` so that individual header cells can be non-interactive
