### PR TITLE
fix(styles): checkbox link in  label  is not clickable [ci visual]

### DIFF
--- a/packages/styles/src/checkbox.scss
+++ b/packages/styles/src/checkbox.scss
@@ -102,7 +102,6 @@ $blockCheckmark: #{$fd-namespace}-checkbox__checkmark;
     @include fd-ellipsis();
 
     height: 1rem;
-    pointer-events: none;
     max-width: inherit;
   }
 


### PR DESCRIPTION
fix(styles): checkbox link in  label  is not clickable [ci visual]

closes [#12577](https://github.com/SAP/fundamental-ngx/issues/12577)

## Description
Updated the checkbox component to ensure that links within custom labels are clickable and function as intended.

## Related Issue
Closes SAP/fundamental-styles#
