### PR TITLE
fix(styles): updates for context area in ShellBar [ci visual]

### DIFF
--- a/packages/styles/src/shellbar.scss
+++ b/packages/styles/src/shellbar.scss
@@ -197,16 +197,6 @@ $block: #{$fd-namespace}-shellbar;
     }
   }
 
-  &__context-area {
-    @include fd-reset();
-
-    @include fd-flex-vertical-center () {
-      gap: 1rem;
-    }
-
-    width: 100%;
-  }
-
   &__separator {
     @include fd-reset();
 
@@ -649,6 +639,12 @@ $block: #{$fd-namespace}-shellbar;
       }
     }
 
+    &--context-area {
+      flex: 1;
+      order: 2;
+      gap: 1rem;
+    }
+
     &--actions {
       justify-content: flex-end;
       order: 3;
@@ -657,11 +653,6 @@ $block: #{$fd-namespace}-shellbar;
 
     &--full-width {
       width: 100%;
-    }
-
-    & + .#{$block}__group {
-      gap: 0.5rem;
-      justify-content: flex-end;
     }
   }
 

--- a/packages/styles/stories/Components/shellbar/optional-items.example.html
+++ b/packages/styles/stories/Components/shellbar/optional-items.example.html
@@ -12,60 +12,61 @@
                     <span class="fd-shellbar__subtitle">Solution name</span>
                 </div>
             </div>
-            <span class="fd-shellbar__separator"></span>
-            <div class="fd-shellbar__context-area" role="group" aria-label="Additional info">
-                <div class="fd-popover">
-                    <div class="fd-popover__control">
-                      <button
-                        class="fd-button fd-button--transparent fd-shellbar__button fd-shellbar__button--menu fd-button--menu"
-                        onclick="onPopoverClick('9GLB269412ow2');"
-                        aria-controls="9GLB269412ow2"
-                        aria-haspopup="true"
-                        aria-expanded="false"
-                      >
-                        <span class="fd-button__text">EMEA</span>
-                        <i class="sap-icon--slim-arrow-down"></i>
-                      </button>
-                    </div>
-                    <div
-                      class="fd-popover__body fd-popover__body--no-arrow"
-                      aria-hidden="true"
-                      id="9GLB269412ow2"
-                    >
-                      <nav class="fd-menu">
-                        <ul class="fd-menu__list fd-menu__list--no-shadow">
-                          <li class="fd-menu__item">
-                            <a role="button" class="fd-menu__link">
-                              <span class="fd-menu__title">Application A</span>
-                            </a>
-                          </li>
-                          <li class="fd-menu__item">
-                            <a role="button" class="fd-menu__link">
-                              <span class="fd-menu__title">Application B</span>
-                            </a>
-                          </li>
-                          <li class="fd-menu__item">
-                            <a role="button" class="fd-menu__link">
-                              <span class="fd-menu__title">Application C</span>
-                            </a>
-                          </li>
-                          <li class="fd-menu__item">
-                            <a role="button" class="fd-menu__link">
-                              <span class="fd-menu__title">Application D</span>
-                            </a>
-                          </li>
-                        </ul>
-                      </nav>
-                    </div>
-                </div>
-                <span class="fd-object-status fd-object-status--inverted fd-object-status--indication-1b">
-                    <span class="fd-object-status__text">Environment</span>
-                </span>
-            </div>
         </div>
-        <div class="fd-shellbar__group fd-shellbar__group--actions">
+        <div class="fd-shellbar__group fd-shellbar__group--context-area" role="group" aria-label="Additional info">
+            <span class="fd-shellbar__separator"></span>
+            <div class="fd-popover">
+                <div class="fd-popover__control">
+                  <button
+                    class="fd-button fd-button--transparent fd-shellbar__button fd-shellbar__button--menu fd-button--menu"
+                    onclick="onPopoverClick('9GLB269412ow2');"
+                    aria-controls="9GLB269412ow2"
+                    aria-haspopup="true"
+                    aria-expanded="false"
+                  >
+                    <span class="fd-button__text">EMEA</span>
+                    <i class="sap-icon--slim-arrow-down"></i>
+                  </button>
+                </div>
+                <div
+                  class="fd-popover__body fd-popover__body--no-arrow"
+                  aria-hidden="true"
+                  id="9GLB269412ow2"
+                >
+                  <nav class="fd-menu">
+                    <ul class="fd-menu__list fd-menu__list--no-shadow">
+                      <li class="fd-menu__item">
+                        <a role="button" class="fd-menu__link">
+                          <span class="fd-menu__title">Application A</span>
+                        </a>
+                      </li>
+                      <li class="fd-menu__item">
+                        <a role="button" class="fd-menu__link">
+                          <span class="fd-menu__title">Application B</span>
+                        </a>
+                      </li>
+                      <li class="fd-menu__item">
+                        <a role="button" class="fd-menu__link">
+                          <span class="fd-menu__title">Application C</span>
+                        </a>
+                      </li>
+                      <li class="fd-menu__item">
+                        <a role="button" class="fd-menu__link">
+                          <span class="fd-menu__title">Application D</span>
+                        </a>
+                      </li>
+                    </ul>
+                  </nav>
+                </div>
+            </div>
+            <span class="fd-shellbar__separator"></span>
+            <span class="sap-icon sap-icon--globe sap-icon--color-information"></span>
+            <span class="fd-object-status fd-object-status--inverted fd-object-status--indication-5">
+                <span class="fd-object-status__text">Environment</span>
+            </span>
+            <span class="fd-shellbar__spacer"></span>
             <div class="fd-object-marker">
-                <span class="fd-object-marker__text">New Feature</span>
+              <span class="fd-object-marker__text">New Feature</span>
             </div>
             <label class="fd-switch">
                 <span class="fd-switch__control">
@@ -80,6 +81,8 @@
                 </span>
             </label>
             <span class="fd-shellbar__separator"></span>
+        </div>
+        <div class="fd-shellbar__group fd-shellbar__group--actions">
             <div class="fd-shellbar__action">
                 <div class="fd-popover fd-popover--right">
                     <div class="fd-popover__control">
@@ -131,53 +134,53 @@
                     <span class="fd-shellbar__subtitle">Solution name</span>
                 </div>
             </div>
-            <span class="fd-shellbar__separator"></span>
-            <div class="fd-shellbar__context-area" role="group" aria-label="Additional info">
-                <div class="fd-popover">
-                    <div class="fd-popover__control">
-                      <button
-                        class="fd-button fd-button--transparent fd-shellbar__button fd-shellbar__button--menu fd-button--menu"
-                        onclick="onPopoverClick('9GLB269412874');"
-                        aria-controls="9GLB269412874"
-                        aria-haspopup="true"
-                        aria-expanded="false"
-                      >
-                        <span class="fd-button__text">EMEA</span>
-                        <i class="sap-icon--slim-arrow-down"></i>
-                      </button>
-                    </div>
-                    <div
-                      class="fd-popover__body fd-popover__body--no-arrow"
-                      aria-hidden="true"
-                      id="9GLB269412874"
-                    >
-                      <nav class="fd-menu">
-                        <ul class="fd-menu__list fd-menu__list--no-shadow">
-                          <li class="fd-menu__item">
-                            <a role="button" class="fd-menu__link">
-                              <span class="fd-menu__title">Application A</span>
-                            </a>
-                          </li>
-                          <li class="fd-menu__item">
-                            <a role="button" class="fd-menu__link">
-                              <span class="fd-menu__title">Application B</span>
-                            </a>
-                          </li>
-                          <li class="fd-menu__item">
-                            <a role="button" class="fd-menu__link">
-                              <span class="fd-menu__title">Application C</span>
-                            </a>
-                          </li>
-                          <li class="fd-menu__item">
-                            <a role="button" class="fd-menu__link">
-                              <span class="fd-menu__title">Application D</span>
-                            </a>
-                          </li>
-                        </ul>
-                      </nav>
-                    </div>
-                </div>
-            </div>
+        </div>
+        <div class="fd-shellbar__group fd-shellbar__group--context-area" role="group" aria-label="Additional info">
+          <span class="fd-shellbar__separator"></span>
+          <div class="fd-popover">
+              <div class="fd-popover__control">
+                <button
+                  class="fd-button fd-button--transparent fd-shellbar__button fd-shellbar__button--menu fd-button--menu"
+                  onclick="onPopoverClick('9GLB269412874');"
+                  aria-controls="9GLB269412874"
+                  aria-haspopup="true"
+                  aria-expanded="false"
+                >
+                  <span class="fd-button__text">EMEA</span>
+                  <i class="sap-icon--slim-arrow-down"></i>
+                </button>
+              </div>
+              <div
+                class="fd-popover__body fd-popover__body--no-arrow"
+                aria-hidden="true"
+                id="9GLB269412874"
+              >
+                <nav class="fd-menu">
+                  <ul class="fd-menu__list fd-menu__list--no-shadow">
+                    <li class="fd-menu__item">
+                      <a role="button" class="fd-menu__link">
+                        <span class="fd-menu__title">Application A</span>
+                      </a>
+                    </li>
+                    <li class="fd-menu__item">
+                      <a role="button" class="fd-menu__link">
+                        <span class="fd-menu__title">Application B</span>
+                      </a>
+                    </li>
+                    <li class="fd-menu__item">
+                      <a role="button" class="fd-menu__link">
+                        <span class="fd-menu__title">Application C</span>
+                      </a>
+                    </li>
+                    <li class="fd-menu__item">
+                      <a role="button" class="fd-menu__link">
+                        <span class="fd-menu__title">Application D</span>
+                      </a>
+                    </li>
+                  </ul>
+                </nav>
+              </div>
+          </div>
         </div>
         <div class="fd-shellbar__group fd-shellbar__group--actions">
             <div class="fd-shellbar__action">

--- a/packages/styles/stories/Components/shellbar/overflow-toolbar.example.html
+++ b/packages/styles/stories/Components/shellbar/overflow-toolbar.example.html
@@ -12,53 +12,53 @@
                     <span class="fd-shellbar__subtitle">Solution name</span>
                 </div>
             </div>
-            <span class="fd-shellbar__separator"></span>
-            <div class="fd-shellbar__context-area" role="group" aria-label="Additional info">
-                <div class="fd-popover">
-                    <div class="fd-popover__control">
-                      <button
-                        class="fd-button fd-button--transparent fd-shellbar__button fd-shellbar__button--menu fd-button--menu"
-                        onclick="onPopoverClick('9GLB269412');"
-                        aria-controls="9GLB269412"
-                        aria-haspopup="true"
-                        aria-expanded="false"
-                      >
-                        <span class="fd-button__text">EMEA</span>
-                        <i class="sap-icon--slim-arrow-down"></i>
-                      </button>
-                    </div>
-                    <div
-                      class="fd-popover__body fd-popover__body--no-arrow"
-                      aria-hidden="true"
-                      id="9GLB269412"
-                    >
-                      <nav class="fd-menu">
-                        <ul class="fd-menu__list fd-menu__list--no-shadow">
-                          <li class="fd-menu__item">
-                            <a role="button" class="fd-menu__link">
-                              <span class="fd-menu__title">Application A</span>
-                            </a>
-                          </li>
-                          <li class="fd-menu__item">
-                            <a role="button" class="fd-menu__link">
-                              <span class="fd-menu__title">Application B</span>
-                            </a>
-                          </li>
-                          <li class="fd-menu__item">
-                            <a role="button" class="fd-menu__link">
-                              <span class="fd-menu__title">Application C</span>
-                            </a>
-                          </li>
-                          <li class="fd-menu__item">
-                            <a role="button" class="fd-menu__link">
-                              <span class="fd-menu__title">Application D</span>
-                            </a>
-                          </li>
-                        </ul>
-                      </nav>
-                    </div>
-                </div>
-            </div>
+        </div>
+        <div class="fd-shellbar__group fd-shellbar__group--context-area" role="group" aria-label="Additional info">
+          <span class="fd-shellbar__separator"></span>
+          <div class="fd-popover">
+              <div class="fd-popover__control">
+                <button
+                  class="fd-button fd-button--transparent fd-shellbar__button fd-shellbar__button--menu fd-button--menu"
+                  onclick="onPopoverClick('9GLB269412874');"
+                  aria-controls="9GLB269412874"
+                  aria-haspopup="true"
+                  aria-expanded="false"
+                >
+                  <span class="fd-button__text">EMEA</span>
+                  <i class="sap-icon--slim-arrow-down"></i>
+                </button>
+              </div>
+              <div
+                class="fd-popover__body fd-popover__body--no-arrow"
+                aria-hidden="true"
+                id="9GLB269412874"
+              >
+                <nav class="fd-menu">
+                  <ul class="fd-menu__list fd-menu__list--no-shadow">
+                    <li class="fd-menu__item">
+                      <a role="button" class="fd-menu__link">
+                        <span class="fd-menu__title">Application A</span>
+                      </a>
+                    </li>
+                    <li class="fd-menu__item">
+                      <a role="button" class="fd-menu__link">
+                        <span class="fd-menu__title">Application B</span>
+                      </a>
+                    </li>
+                    <li class="fd-menu__item">
+                      <a role="button" class="fd-menu__link">
+                        <span class="fd-menu__title">Application C</span>
+                      </a>
+                    </li>
+                    <li class="fd-menu__item">
+                      <a role="button" class="fd-menu__link">
+                        <span class="fd-menu__title">Application D</span>
+                      </a>
+                    </li>
+                  </ul>
+                </nav>
+              </div>
+          </div>
         </div>
         <div class="fd-shellbar__group fd-shellbar__group--actions">
           <div class="fd-toolbar fd-toolbar--clear fd-toolbar--transparent fd-shellbar__toolbar" role="toolbar" aria-label="Toolbar">

--- a/packages/styles/stories/Components/shellbar/shellbar.stories.js
+++ b/packages/styles/stories/Components/shellbar/shellbar.stories.js
@@ -47,7 +47,7 @@ export default {
       <ul>
         <li>\`fd-shellbar__group--product\`<span>: defines a container that can hold the Side Navigation Button, Branding, and the Additional Content Area (Context Area)</span></li>
         <li>\`fd-shellbar__group--actions\`<span>: defines a container for controls like the Search Field, Notifications, User Profile, Product Switch, and more.</span></li>
-        <li>\`fd-shellbar__group--center\`</li>
+        <li>\`fd-shellbar__group--context-area\`<span>: defines a container for components that are related to whole product rather than specific application.</span></li>
         <li>\`fd-shellbar__group--full-width\`<span>: expands the container to take up the full available width.</span></li>
       </ul>
     </li>
@@ -77,14 +77,11 @@ export default {
         <li>\`fd-shellbar__button--menu\`<span>: is an override style of the Menu Button, tailored for use within the Shell Bar.</span></li>
       </ul>
     </li>
-    <li>\`fd-shellbar__context-area\`<span>: an area is intended for containers that hold additional elements defined by the product.</span></li>
-    <li>\`fd-shellbar__separator\`<span>:a span element that visually isolate actions with a vertical line.</span></li>
-    <li>\`fd-shellbar__spacer\`<span>: a span element that can be used to create space between groups of elements in Context Area.</span></li>
+    <li>\`fd-shellbar__separator\`<span>: a span element that creates a small distance between elements in additional context area. The separator should, by default, isolate the left area (hamburger menu, branding) and the right area (actions, avatar, product switcher) from the additional context area, with optional placement between elements in the additional context area for visual grouping.</span>
+    </li>
+    <li>\`fd-shellbar__spacer\`<span>: a span element that can be used to create space between groups of elements in context area. Visually separates the context area into left and right group.</span></li>
     <li>\`fd-shellbar__search-field\`<span>: an override style of the search input, designed specifically for use within the Shell Bar </span></li>
 </ul>
-
-
-
 `
   }
 };
@@ -119,8 +116,8 @@ OptionalItems.parameters = {
         <li><b>Help:</b> used to trigger the help functionality within products.</li>
         <li><b>Feedback:</b> used to trigger the "Leave Feedback" functionality within products.</li>
         <li><b>Product Switch:</b> used for global navigation, allowing users to switch between different SAP products and services.</li>
-        <li><b>Separator:</b> can be used to isolate actions.</li>
-        <li><b>Spacer:</b> can be used to create space between groups of elements.</li>
+        <li><b>Separator:</b> creates a small distance between elements in additional context area.</li>
+        <li><b>Spacer:</b> creates space between groups of elements in context area. Visually separates the context area into left and right group.</li>
       </ul>`
     }
   }

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -40243,60 +40243,61 @@ exports[`Check stories > Components/Shellbar > Story OptionalItems > Should matc
                     <span class=\\"fd-shellbar__subtitle\\">Solution name</span>
                 </div>
             </div>
-            <span class=\\"fd-shellbar__separator\\"></span>
-            <div class=\\"fd-shellbar__context-area\\" role=\\"group\\" aria-label=\\"Additional info\\">
-                <div class=\\"fd-popover\\">
-                    <div class=\\"fd-popover__control\\">
-                      <button
-                        class=\\"fd-button fd-button--transparent fd-shellbar__button fd-shellbar__button--menu fd-button--menu\\"
-                        onclick=\\"onPopoverClick('9GLB269412ow2');\\"
-                        aria-controls=\\"9GLB269412ow2\\"
-                        aria-haspopup=\\"true\\"
-                        aria-expanded=\\"false\\"
-                      >
-                        <span class=\\"fd-button__text\\">EMEA</span>
-                        <i class=\\"sap-icon--slim-arrow-down\\"></i>
-                      </button>
-                    </div>
-                    <div
-                      class=\\"fd-popover__body fd-popover__body--no-arrow\\"
-                      aria-hidden=\\"true\\"
-                      id=\\"9GLB269412ow2\\"
-                    >
-                      <nav class=\\"fd-menu\\">
-                        <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                          <li class=\\"fd-menu__item\\">
-                            <a role=\\"button\\" class=\\"fd-menu__link\\">
-                              <span class=\\"fd-menu__title\\">Application A</span>
-                            </a>
-                          </li>
-                          <li class=\\"fd-menu__item\\">
-                            <a role=\\"button\\" class=\\"fd-menu__link\\">
-                              <span class=\\"fd-menu__title\\">Application B</span>
-                            </a>
-                          </li>
-                          <li class=\\"fd-menu__item\\">
-                            <a role=\\"button\\" class=\\"fd-menu__link\\">
-                              <span class=\\"fd-menu__title\\">Application C</span>
-                            </a>
-                          </li>
-                          <li class=\\"fd-menu__item\\">
-                            <a role=\\"button\\" class=\\"fd-menu__link\\">
-                              <span class=\\"fd-menu__title\\">Application D</span>
-                            </a>
-                          </li>
-                        </ul>
-                      </nav>
-                    </div>
-                </div>
-                <span class=\\"fd-object-status fd-object-status--inverted fd-object-status--indication-1b\\">
-                    <span class=\\"fd-object-status__text\\">Environment</span>
-                </span>
-            </div>
         </div>
-        <div class=\\"fd-shellbar__group fd-shellbar__group--actions\\">
+        <div class=\\"fd-shellbar__group fd-shellbar__group--context-area\\" role=\\"group\\" aria-label=\\"Additional info\\">
+            <span class=\\"fd-shellbar__separator\\"></span>
+            <div class=\\"fd-popover\\">
+                <div class=\\"fd-popover__control\\">
+                  <button
+                    class=\\"fd-button fd-button--transparent fd-shellbar__button fd-shellbar__button--menu fd-button--menu\\"
+                    onclick=\\"onPopoverClick('9GLB269412ow2');\\"
+                    aria-controls=\\"9GLB269412ow2\\"
+                    aria-haspopup=\\"true\\"
+                    aria-expanded=\\"false\\"
+                  >
+                    <span class=\\"fd-button__text\\">EMEA</span>
+                    <i class=\\"sap-icon--slim-arrow-down\\"></i>
+                  </button>
+                </div>
+                <div
+                  class=\\"fd-popover__body fd-popover__body--no-arrow\\"
+                  aria-hidden=\\"true\\"
+                  id=\\"9GLB269412ow2\\"
+                >
+                  <nav class=\\"fd-menu\\">
+                    <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
+                      <li class=\\"fd-menu__item\\">
+                        <a role=\\"button\\" class=\\"fd-menu__link\\">
+                          <span class=\\"fd-menu__title\\">Application A</span>
+                        </a>
+                      </li>
+                      <li class=\\"fd-menu__item\\">
+                        <a role=\\"button\\" class=\\"fd-menu__link\\">
+                          <span class=\\"fd-menu__title\\">Application B</span>
+                        </a>
+                      </li>
+                      <li class=\\"fd-menu__item\\">
+                        <a role=\\"button\\" class=\\"fd-menu__link\\">
+                          <span class=\\"fd-menu__title\\">Application C</span>
+                        </a>
+                      </li>
+                      <li class=\\"fd-menu__item\\">
+                        <a role=\\"button\\" class=\\"fd-menu__link\\">
+                          <span class=\\"fd-menu__title\\">Application D</span>
+                        </a>
+                      </li>
+                    </ul>
+                  </nav>
+                </div>
+            </div>
+            <span class=\\"fd-shellbar__separator\\"></span>
+            <span class=\\"sap-icon sap-icon--globe sap-icon--color-information\\"></span>
+            <span class=\\"fd-object-status fd-object-status--inverted fd-object-status--indication-5\\">
+                <span class=\\"fd-object-status__text\\">Environment</span>
+            </span>
+            <span class=\\"fd-shellbar__spacer\\"></span>
             <div class=\\"fd-object-marker\\">
-                <span class=\\"fd-object-marker__text\\">New Feature</span>
+              <span class=\\"fd-object-marker__text\\">New Feature</span>
             </div>
             <label class=\\"fd-switch\\">
                 <span class=\\"fd-switch__control\\">
@@ -40311,6 +40312,8 @@ exports[`Check stories > Components/Shellbar > Story OptionalItems > Should matc
                 </span>
             </label>
             <span class=\\"fd-shellbar__separator\\"></span>
+        </div>
+        <div class=\\"fd-shellbar__group fd-shellbar__group--actions\\">
             <div class=\\"fd-shellbar__action\\">
                 <div class=\\"fd-popover fd-popover--right\\">
                     <div class=\\"fd-popover__control\\">
@@ -40362,53 +40365,53 @@ exports[`Check stories > Components/Shellbar > Story OptionalItems > Should matc
                     <span class=\\"fd-shellbar__subtitle\\">Solution name</span>
                 </div>
             </div>
-            <span class=\\"fd-shellbar__separator\\"></span>
-            <div class=\\"fd-shellbar__context-area\\" role=\\"group\\" aria-label=\\"Additional info\\">
-                <div class=\\"fd-popover\\">
-                    <div class=\\"fd-popover__control\\">
-                      <button
-                        class=\\"fd-button fd-button--transparent fd-shellbar__button fd-shellbar__button--menu fd-button--menu\\"
-                        onclick=\\"onPopoverClick('9GLB269412874');\\"
-                        aria-controls=\\"9GLB269412874\\"
-                        aria-haspopup=\\"true\\"
-                        aria-expanded=\\"false\\"
-                      >
-                        <span class=\\"fd-button__text\\">EMEA</span>
-                        <i class=\\"sap-icon--slim-arrow-down\\"></i>
-                      </button>
-                    </div>
-                    <div
-                      class=\\"fd-popover__body fd-popover__body--no-arrow\\"
-                      aria-hidden=\\"true\\"
-                      id=\\"9GLB269412874\\"
-                    >
-                      <nav class=\\"fd-menu\\">
-                        <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                          <li class=\\"fd-menu__item\\">
-                            <a role=\\"button\\" class=\\"fd-menu__link\\">
-                              <span class=\\"fd-menu__title\\">Application A</span>
-                            </a>
-                          </li>
-                          <li class=\\"fd-menu__item\\">
-                            <a role=\\"button\\" class=\\"fd-menu__link\\">
-                              <span class=\\"fd-menu__title\\">Application B</span>
-                            </a>
-                          </li>
-                          <li class=\\"fd-menu__item\\">
-                            <a role=\\"button\\" class=\\"fd-menu__link\\">
-                              <span class=\\"fd-menu__title\\">Application C</span>
-                            </a>
-                          </li>
-                          <li class=\\"fd-menu__item\\">
-                            <a role=\\"button\\" class=\\"fd-menu__link\\">
-                              <span class=\\"fd-menu__title\\">Application D</span>
-                            </a>
-                          </li>
-                        </ul>
-                      </nav>
-                    </div>
-                </div>
-            </div>
+        </div>
+        <div class=\\"fd-shellbar__group fd-shellbar__group--context-area\\" role=\\"group\\" aria-label=\\"Additional info\\">
+          <span class=\\"fd-shellbar__separator\\"></span>
+          <div class=\\"fd-popover\\">
+              <div class=\\"fd-popover__control\\">
+                <button
+                  class=\\"fd-button fd-button--transparent fd-shellbar__button fd-shellbar__button--menu fd-button--menu\\"
+                  onclick=\\"onPopoverClick('9GLB269412874');\\"
+                  aria-controls=\\"9GLB269412874\\"
+                  aria-haspopup=\\"true\\"
+                  aria-expanded=\\"false\\"
+                >
+                  <span class=\\"fd-button__text\\">EMEA</span>
+                  <i class=\\"sap-icon--slim-arrow-down\\"></i>
+                </button>
+              </div>
+              <div
+                class=\\"fd-popover__body fd-popover__body--no-arrow\\"
+                aria-hidden=\\"true\\"
+                id=\\"9GLB269412874\\"
+              >
+                <nav class=\\"fd-menu\\">
+                  <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
+                    <li class=\\"fd-menu__item\\">
+                      <a role=\\"button\\" class=\\"fd-menu__link\\">
+                        <span class=\\"fd-menu__title\\">Application A</span>
+                      </a>
+                    </li>
+                    <li class=\\"fd-menu__item\\">
+                      <a role=\\"button\\" class=\\"fd-menu__link\\">
+                        <span class=\\"fd-menu__title\\">Application B</span>
+                      </a>
+                    </li>
+                    <li class=\\"fd-menu__item\\">
+                      <a role=\\"button\\" class=\\"fd-menu__link\\">
+                        <span class=\\"fd-menu__title\\">Application C</span>
+                      </a>
+                    </li>
+                    <li class=\\"fd-menu__item\\">
+                      <a role=\\"button\\" class=\\"fd-menu__link\\">
+                        <span class=\\"fd-menu__title\\">Application D</span>
+                      </a>
+                    </li>
+                  </ul>
+                </nav>
+              </div>
+          </div>
         </div>
         <div class=\\"fd-shellbar__group fd-shellbar__group--actions\\">
             <div class=\\"fd-shellbar__action\\">
@@ -40581,53 +40584,53 @@ exports[`Check stories > Components/Shellbar > Story OverflowToolbar > Should ma
                     <span class=\\"fd-shellbar__subtitle\\">Solution name</span>
                 </div>
             </div>
-            <span class=\\"fd-shellbar__separator\\"></span>
-            <div class=\\"fd-shellbar__context-area\\" role=\\"group\\" aria-label=\\"Additional info\\">
-                <div class=\\"fd-popover\\">
-                    <div class=\\"fd-popover__control\\">
-                      <button
-                        class=\\"fd-button fd-button--transparent fd-shellbar__button fd-shellbar__button--menu fd-button--menu\\"
-                        onclick=\\"onPopoverClick('9GLB269412');\\"
-                        aria-controls=\\"9GLB269412\\"
-                        aria-haspopup=\\"true\\"
-                        aria-expanded=\\"false\\"
-                      >
-                        <span class=\\"fd-button__text\\">EMEA</span>
-                        <i class=\\"sap-icon--slim-arrow-down\\"></i>
-                      </button>
-                    </div>
-                    <div
-                      class=\\"fd-popover__body fd-popover__body--no-arrow\\"
-                      aria-hidden=\\"true\\"
-                      id=\\"9GLB269412\\"
-                    >
-                      <nav class=\\"fd-menu\\">
-                        <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
-                          <li class=\\"fd-menu__item\\">
-                            <a role=\\"button\\" class=\\"fd-menu__link\\">
-                              <span class=\\"fd-menu__title\\">Application A</span>
-                            </a>
-                          </li>
-                          <li class=\\"fd-menu__item\\">
-                            <a role=\\"button\\" class=\\"fd-menu__link\\">
-                              <span class=\\"fd-menu__title\\">Application B</span>
-                            </a>
-                          </li>
-                          <li class=\\"fd-menu__item\\">
-                            <a role=\\"button\\" class=\\"fd-menu__link\\">
-                              <span class=\\"fd-menu__title\\">Application C</span>
-                            </a>
-                          </li>
-                          <li class=\\"fd-menu__item\\">
-                            <a role=\\"button\\" class=\\"fd-menu__link\\">
-                              <span class=\\"fd-menu__title\\">Application D</span>
-                            </a>
-                          </li>
-                        </ul>
-                      </nav>
-                    </div>
-                </div>
-            </div>
+        </div>
+        <div class=\\"fd-shellbar__group fd-shellbar__group--context-area\\" role=\\"group\\" aria-label=\\"Additional info\\">
+          <span class=\\"fd-shellbar__separator\\"></span>
+          <div class=\\"fd-popover\\">
+              <div class=\\"fd-popover__control\\">
+                <button
+                  class=\\"fd-button fd-button--transparent fd-shellbar__button fd-shellbar__button--menu fd-button--menu\\"
+                  onclick=\\"onPopoverClick('9GLB269412874');\\"
+                  aria-controls=\\"9GLB269412874\\"
+                  aria-haspopup=\\"true\\"
+                  aria-expanded=\\"false\\"
+                >
+                  <span class=\\"fd-button__text\\">EMEA</span>
+                  <i class=\\"sap-icon--slim-arrow-down\\"></i>
+                </button>
+              </div>
+              <div
+                class=\\"fd-popover__body fd-popover__body--no-arrow\\"
+                aria-hidden=\\"true\\"
+                id=\\"9GLB269412874\\"
+              >
+                <nav class=\\"fd-menu\\">
+                  <ul class=\\"fd-menu__list fd-menu__list--no-shadow\\">
+                    <li class=\\"fd-menu__item\\">
+                      <a role=\\"button\\" class=\\"fd-menu__link\\">
+                        <span class=\\"fd-menu__title\\">Application A</span>
+                      </a>
+                    </li>
+                    <li class=\\"fd-menu__item\\">
+                      <a role=\\"button\\" class=\\"fd-menu__link\\">
+                        <span class=\\"fd-menu__title\\">Application B</span>
+                      </a>
+                    </li>
+                    <li class=\\"fd-menu__item\\">
+                      <a role=\\"button\\" class=\\"fd-menu__link\\">
+                        <span class=\\"fd-menu__title\\">Application C</span>
+                      </a>
+                    </li>
+                    <li class=\\"fd-menu__item\\">
+                      <a role=\\"button\\" class=\\"fd-menu__link\\">
+                        <span class=\\"fd-menu__title\\">Application D</span>
+                      </a>
+                    </li>
+                  </ul>
+                </nav>
+              </div>
+          </div>
         </div>
         <div class=\\"fd-shellbar__group fd-shellbar__group--actions\\">
           <div class=\\"fd-toolbar fd-toolbar--clear fd-toolbar--transparent fd-shellbar__toolbar\\" role=\\"toolbar\\" aria-label=\\"Toolbar\\">


### PR DESCRIPTION
## Related Issue
Closes none

## Description
Context area is a separate ShellBar group
- removed class `fd-shellbar__context-area`
- added a modifier class for `fd-shellbar__group` to represent context area `fd-shellbar__group--context-area`
- updated the examples markup

Before:
```
<div class="fd-shellbar__context-area" role="group" aria-label="Additional info">...</div>
```

After:
```
<div class="fd-shellbar__group fd-shellbar__group--context-area" role="group" aria-label="Additional info">...</div>
```