### PR TITLE
fix(styles): remove local theming var for Message Toast [ci visual]

### DIFF
--- a/packages/styles/src/theming/sap_fiori_3.scss
+++ b/packages/styles/src/theming/sap_fiori_3.scss
@@ -235,10 +235,4 @@
 
   /** User Menu */
   --fdUserMenu_User_Name_Font_Family: var(--sapFontBoldFamily);
-
-  /** 
-    Message Toast
-    TO DO: remove when the theming variable is added
-  */
-  --sapContent_Lite_Shadow: none;
 }

--- a/packages/styles/src/theming/sap_fiori_3_dark.scss
+++ b/packages/styles/src/theming/sap_fiori_3_dark.scss
@@ -236,10 +236,4 @@
 
   /** User Menu */
   --fdUserMenu_User_Name_Font_Family: var(--sapFontBoldFamily);
-
-  /** 
-    Message Toast
-    TO DO: remove when the theming variable is added
-  */
-  --sapContent_Lite_Shadow: none;
 }

--- a/packages/styles/src/theming/sap_fiori_3_hcb.scss
+++ b/packages/styles/src/theming/sap_fiori_3_hcb.scss
@@ -239,10 +239,4 @@
 
   /** User Menu */
   --fdUserMenu_User_Name_Font_Family: var(--sapFontFamily);
-
-  /** 
-    Message Toast
-    TO DO: remove when the theming variable is added
-  */
-  --sapContent_Lite_Shadow: var(--sapContent_Shadow1);
 }

--- a/packages/styles/src/theming/sap_fiori_3_hcw.scss
+++ b/packages/styles/src/theming/sap_fiori_3_hcw.scss
@@ -235,10 +235,4 @@
 
   /** User Menu */
   --fdUserMenu_User_Name_Font_Family: var(--sapFontFamily);
-
-  /** 
-    Message Toast
-    TO DO: remove when the theming variable is added
-  */
-  --sapContent_Lite_Shadow: var(--sapContent_Shadow1);
 }

--- a/packages/styles/src/theming/sap_fiori_3_light_dark.scss
+++ b/packages/styles/src/theming/sap_fiori_3_light_dark.scss
@@ -257,10 +257,4 @@
 
   /** User Menu */
   --fdUserMenu_User_Name_Font_Family: var(--sapFontBoldFamily);
-
-  /** 
-    Message Toast
-    TO DO: remove when the theming variable is added
-  */
-  --sapContent_Lite_Shadow: none;
 }

--- a/packages/styles/src/theming/sap_horizon.scss
+++ b/packages/styles/src/theming/sap_horizon.scss
@@ -245,10 +245,4 @@
 
   /** User Menu */
   --fdUserMenu_User_Name_Font_Family: var(--sapFontBoldFamily);
-
-  /** 
-    Message Toast
-    TO DO: remove when the theming variable is added
-  */
-  --sapContent_Lite_Shadow: none;
 }

--- a/packages/styles/src/theming/sap_horizon_dark.scss
+++ b/packages/styles/src/theming/sap_horizon_dark.scss
@@ -252,10 +252,4 @@
 
   /** User Menu */
   --fdUserMenu_User_Name_Font_Family: var(--sapFontBoldFamily);
-
-  /** 
-    Message Toast
-    TO DO: remove when the theming variable is added
-  */
-  --sapContent_Lite_Shadow: none;
 }

--- a/packages/styles/src/theming/sap_horizon_hcb.scss
+++ b/packages/styles/src/theming/sap_horizon_hcb.scss
@@ -239,10 +239,4 @@
 
   /** User Menu */
   --fdUserMenu_User_Name_Font_Family: var(--sapFontFamily);
-
-  /** 
-    Message Toast
-    TO DO: remove when the theming variable is added
-  */
-  --sapContent_Lite_Shadow: var(--sapContent_Shadow1);
 }

--- a/packages/styles/src/theming/sap_horizon_hcw.scss
+++ b/packages/styles/src/theming/sap_horizon_hcw.scss
@@ -239,10 +239,4 @@
 
   /** User Menu */
   --fdUserMenu_User_Name_Font_Family: var(--sapFontFamily);
-
-  /** 
-    Message Toast
-    TO DO: remove when the theming variable is added
-  */
-  --sapContent_Lite_Shadow: var(--sapContent_Shadow1);
 }


### PR DESCRIPTION
## Related Issue
Closes none

## Description
with the release of version 11.22.0 theming-base-content, the `--sapContent_Lite_Shadow` variable now fund-styles consumes it directly