### PR TITLE
feat(styles): add separator styles and a11y updates for Breadcrumb

### DIFF
--- a/packages/styles/src/breadcrumb.scss
+++ b/packages/styles/src/breadcrumb.scss
@@ -9,9 +9,12 @@ $block: #{$fd-namespace}-breadcrumb;
   // BLOCK BASE *******************************************
   @include fd-reset();
 
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
+  @include fd-flex-vertical-center() {
+    flex-wrap: wrap;
+  }
+
+  --fdLink_Line_Height: 1.5rem;
+
   list-style: none;
 
   // ELEMENTS *******************************************
@@ -21,13 +24,13 @@ $block: #{$fd-namespace}-breadcrumb;
     color: var(--sapContent_LabelColor);
 
     &::after {
-      content: "/";
       margin-inline: 0.25rem;
       color: var(--sapContent_LabelColor);
+      content: var(--fdBreadcrumb_Separator, "/");
     }
 
-    &:last-child::after {
-      content: none;
+    &:last-child:not(:has(a)) {
+      --fdBreadcrumb_Separator: none;
     }
 
     .#{$block}__popover-body {
@@ -35,5 +38,25 @@ $block: #{$fd-namespace}-breadcrumb;
       border-top-left-radius: 0.125rem;
       border-top-right-radius: 0.125rem;
     }
+  }
+
+  &--backslash {
+    --fdBreadcrumb_Separator: "\\";
+  }
+
+  &--double-slash {
+    --fdBreadcrumb_Separator: "//";
+  }
+
+  &--double-backslash {
+    --fdBreadcrumb_Separator: "\\\\";
+  }
+
+  &--greater-than {
+    --fdBreadcrumb_Separator: ">";
+  }
+
+  &--double-greater-than {
+    --fdBreadcrumb_Separator: ">>";
   }
 }

--- a/packages/styles/src/link.scss
+++ b/packages/styles/src/link.scss
@@ -9,6 +9,9 @@ $block: #{$fd-namespace}-link;
   @include fd-reset();
   @include fd-link();
 
+  text-underline-offset: 0.125rem;
+  line-height: var(--fdLink_Line_Height, 1.125rem);
+
   @include fd-icon-selector() {
     color: var(--sapLinkColor);
     line-height: 1;

--- a/packages/styles/stories/Components/breadcrumb/breadcrumb.stories.js
+++ b/packages/styles/stories/Components/breadcrumb/breadcrumb.stories.js
@@ -1,5 +1,8 @@
 import overflowExampleHtml from "./overflow.example.html?raw";
 import standardExampleHtml from "./standard.example.html?raw";
+import stylesExampleHtml from "./styles.example.html?raw";
+import currentItemExampleHtml from "./current-item.example.html?raw";
+
 import '../../../src/popover.scss';
 import '../../../src/list.scss';
 import '../../../src/breadcrumb.scss';
@@ -37,6 +40,31 @@ Standard.parameters = {
   docs: {
     description: {
       story: 'The standard breadcrumb component displays several pages in text format separated by dividers, indicating a navigation path. Each page can be specifically selected to navigate to its corresponding page. It can be displayed by using the `fd-breadcrumb` class.'
+    }
+  }
+};
+export const Styles = () => stylesExampleHtml;
+Styles.parameters = {
+  docs: {
+    description: {
+      story: `Separator between the links can be configured with modifier classes added to the main \`fd-breadcrumb\` class. For example: \`fd-breadcrumb--backslash\` or \`fd-breadcrumb--double-greater-than\`.
+
+| **Separator style**      | **Modifier class**                 |
+| :------------------ | :-------------------------------------- |
+| Slash               | default (no modiier class)              |
+| Backslash           | \`fd-breadcrumb--backslash\`            |
+| Double slash        | \`fd-breadcrumb--double-slash\`         |
+| Double backslash	  | \`fd-breadcrumb--double-backslash\`     |
+| Greater than        | \`fd-breadcrumb--greater-than\`         |
+| Double greater than	| \`fd-breadcrumb--double-greater-than\`  |`
+    }
+  }
+};
+export const CurrentItem = () => currentItemExampleHtml;
+CurrentItem.parameters = {
+  docs: {
+    description: {
+      story: 'The Breadcrumbs component offers two visual styles for the last item: as a "current page" (non-interactive and without a separator) or as a regular link with a following separator.'
     }
   }
 };

--- a/packages/styles/stories/Components/breadcrumb/current-item.example.html
+++ b/packages/styles/stories/Components/breadcrumb/current-item.example.html
@@ -1,0 +1,23 @@
+<nav aria-label="Breadcrumb Trail">
+    <ol class="fd-breadcrumb">
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Products</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Suppliers</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Titanium</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Ultra Portable</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">12 inch</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Super portable deluxe</span></a></li>
+        <li aria-current="page" class="fd-breadcrumb__item">Laptop</li>
+    </ol>
+</nav>
+<br>
+<nav aria-label="Breadcrumb Trail">
+    <ol class="fd-breadcrumb">
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Products</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Suppliers</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Titanium</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Ultra Portable</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">12 inch</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Super portable deluxe</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Laptop</span></a></li>
+    </ol>
+</nav>

--- a/packages/styles/stories/Components/breadcrumb/overflow.example.html
+++ b/packages/styles/stories/Components/breadcrumb/overflow.example.html
@@ -1,6 +1,6 @@
 
 <nav aria-label="overflowing product breadcrumbs">
-    <ul class="fd-breadcrumb">
+    <ol class="fd-breadcrumb">
         <li class="fd-breadcrumb__item"><div class="fd-popover">
             <div class="fd-popover__control">
                 <div
@@ -43,6 +43,6 @@
         <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">12 inch</span></a></li>
         <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Super portable deluxe</span></a></li>
         <li aria-current="page" class="fd-breadcrumb__item">Laptop</li>
-    </ul>
+    </ol>
 </nav>
 <div style="height: 150px"></div>

--- a/packages/styles/stories/Components/breadcrumb/standard.example.html
+++ b/packages/styles/stories/Components/breadcrumb/standard.example.html
@@ -1,5 +1,5 @@
-<nav aria-label="products breadcrumbs">
-    <ul class="fd-breadcrumb">
+<nav aria-label="Breadcrumb Trail">
+    <ol class="fd-breadcrumb">
         <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Products</span></a></li>
         <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Suppliers</span></a></li>
         <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Titanium</span></a></li>
@@ -7,5 +7,5 @@
         <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">12 inch</span></a></li>
         <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Super portable deluxe</span></a></li>
         <li aria-current="page" class="fd-breadcrumb__item">Laptop</li>
-    </ul>
+    </ol>
 </nav>

--- a/packages/styles/stories/Components/breadcrumb/styles.example.html
+++ b/packages/styles/stories/Components/breadcrumb/styles.example.html
@@ -1,0 +1,77 @@
+<h4>Slash (default)</h4>
+<nav aria-label="Breadcrumb Trail">
+    <ol class="fd-breadcrumb">
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Products</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Suppliers</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Titanium</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Ultra Portable</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">12 inch</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Super portable deluxe</span></a></li>
+        <li aria-current="page" class="fd-breadcrumb__item">Laptop</li>
+    </ol>
+</nav>
+
+<h4>Backslash</h4>
+<nav aria-label="Breadcrumb Trail">
+    <ol class="fd-breadcrumb fd-breadcrumb--backslash">
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Products</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Suppliers</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Titanium</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Ultra Portable</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">12 inch</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Super portable deluxe</span></a></li>
+        <li aria-current="page" class="fd-breadcrumb__item">Laptop</li>
+    </ol>
+</nav>
+
+<h4>Double slash</h4>
+<nav aria-label="Breadcrumb Trail">
+    <ol class="fd-breadcrumb fd-breadcrumb--double-slash">
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Products</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Suppliers</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Titanium</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Ultra Portable</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">12 inch</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Super portable deluxe</span></a></li>
+        <li aria-current="page" class="fd-breadcrumb__item">Laptop</li>
+    </ol>
+</nav>
+
+<h4>Double backslash</h4>
+<nav aria-label="Breadcrumb Trail">
+    <ol class="fd-breadcrumb fd-breadcrumb--double-backslash">
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Products</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Suppliers</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Titanium</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Ultra Portable</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">12 inch</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Super portable deluxe</span></a></li>
+        <li aria-current="page" class="fd-breadcrumb__item">Laptop</li>
+    </ol>
+</nav>
+
+<h4>Greater than</h4>
+<nav aria-label="Breadcrumb Trail">
+    <ol class="fd-breadcrumb fd-breadcrumb--greater-than">
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Products</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Suppliers</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Titanium</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Ultra Portable</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">12 inch</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Super portable deluxe</span></a></li>
+        <li aria-current="page" class="fd-breadcrumb__item">Laptop</li>
+    </ol>
+</nav>
+
+<h4>Double greater than</h4>
+<nav aria-label="Breadcrumb Trail">
+    <ol class="fd-breadcrumb fd-breadcrumb--double-greater-than">
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Products</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Suppliers</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Titanium</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Ultra Portable</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">12 inch</span></a></li>
+        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Super portable deluxe</span></a></li>
+        <li aria-current="page" class="fd-breadcrumb__item">Laptop</li>
+    </ol>
+</nav>

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -11457,10 +11457,37 @@ exports[`Check stories > Components/Bar > Story Subheader > Should match snapsho
 "
 `;
 
+exports[`Check stories > Components/Breadcrumb > Story CurrentItem > Should match snapshot 1`] = `
+"<nav aria-label=\\"Breadcrumb Trail\\">
+    <ol class=\\"fd-breadcrumb\\">
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Products</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Suppliers</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Titanium</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Ultra Portable</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">12 inch</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Super portable deluxe</span></a></li>
+        <li aria-current=\\"page\\" class=\\"fd-breadcrumb__item\\">Laptop</li>
+    </ol>
+</nav>
+<br>
+<nav aria-label=\\"Breadcrumb Trail\\">
+    <ol class=\\"fd-breadcrumb\\">
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Products</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Suppliers</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Titanium</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Ultra Portable</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">12 inch</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Super portable deluxe</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Laptop</span></a></li>
+    </ol>
+</nav>
+"
+`;
+
 exports[`Check stories > Components/Breadcrumb > Story Overflow > Should match snapshot 1`] = `
 "
 <nav aria-label=\\"overflowing product breadcrumbs\\">
-    <ul class=\\"fd-breadcrumb\\">
+    <ol class=\\"fd-breadcrumb\\">
         <li class=\\"fd-breadcrumb__item\\"><div class=\\"fd-popover\\">
             <div class=\\"fd-popover__control\\">
                 <div
@@ -11503,15 +11530,15 @@ exports[`Check stories > Components/Breadcrumb > Story Overflow > Should match s
         <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">12 inch</span></a></li>
         <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Super portable deluxe</span></a></li>
         <li aria-current=\\"page\\" class=\\"fd-breadcrumb__item\\">Laptop</li>
-    </ul>
+    </ol>
 </nav>
 <div style=\\"height: 150px\\"></div>
 "
 `;
 
 exports[`Check stories > Components/Breadcrumb > Story Standard > Should match snapshot 1`] = `
-"<nav aria-label=\\"products breadcrumbs\\">
-    <ul class=\\"fd-breadcrumb\\">
+"<nav aria-label=\\"Breadcrumb Trail\\">
+    <ol class=\\"fd-breadcrumb\\">
         <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Products</span></a></li>
         <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Suppliers</span></a></li>
         <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Titanium</span></a></li>
@@ -11519,9 +11546,89 @@ exports[`Check stories > Components/Breadcrumb > Story Standard > Should match s
         <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">12 inch</span></a></li>
         <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Super portable deluxe</span></a></li>
         <li aria-current=\\"page\\" class=\\"fd-breadcrumb__item\\">Laptop</li>
-    </ul>
+    </ol>
 </nav>
 "
+`;
+
+exports[`Check stories > Components/Breadcrumb > Story Styles > Should match snapshot 1`] = `
+"<h4>Slash (default)</h4>
+<nav aria-label=\\"Breadcrumb Trail\\">
+    <ol class=\\"fd-breadcrumb\\">
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Products</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Suppliers</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Titanium</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Ultra Portable</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">12 inch</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Super portable deluxe</span></a></li>
+        <li aria-current=\\"page\\" class=\\"fd-breadcrumb__item\\">Laptop</li>
+    </ol>
+</nav>
+
+<h4>Backslash</h4>
+<nav aria-label=\\"Breadcrumb Trail\\">
+    <ol class=\\"fd-breadcrumb fd-breadcrumb--backslash\\">
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Products</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Suppliers</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Titanium</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Ultra Portable</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">12 inch</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Super portable deluxe</span></a></li>
+        <li aria-current=\\"page\\" class=\\"fd-breadcrumb__item\\">Laptop</li>
+    </ol>
+</nav>
+
+<h4>Double slash</h4>
+<nav aria-label=\\"Breadcrumb Trail\\">
+    <ol class=\\"fd-breadcrumb fd-breadcrumb--double-slash\\">
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Products</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Suppliers</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Titanium</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Ultra Portable</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">12 inch</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Super portable deluxe</span></a></li>
+        <li aria-current=\\"page\\" class=\\"fd-breadcrumb__item\\">Laptop</li>
+    </ol>
+</nav>
+
+<h4>Double backslash</h4>
+<nav aria-label=\\"Breadcrumb Trail\\">
+    <ol class=\\"fd-breadcrumb fd-breadcrumb--double-backslash\\">
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Products</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Suppliers</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Titanium</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Ultra Portable</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">12 inch</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Super portable deluxe</span></a></li>
+        <li aria-current=\\"page\\" class=\\"fd-breadcrumb__item\\">Laptop</li>
+    </ol>
+</nav>
+
+<h4>Greater than</h4>
+<nav aria-label=\\"Breadcrumb Trail\\">
+    <ol class=\\"fd-breadcrumb fd-breadcrumb--greater-than\\">
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Products</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Suppliers</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Titanium</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Ultra Portable</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">12 inch</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Super portable deluxe</span></a></li>
+        <li aria-current=\\"page\\" class=\\"fd-breadcrumb__item\\">Laptop</li>
+    </ol>
+</nav>
+
+<h4>Double greater than</h4>
+<nav aria-label=\\"Breadcrumb Trail\\">
+    <ol class=\\"fd-breadcrumb fd-breadcrumb--double-greater-than\\">
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Products</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Suppliers</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Titanium</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Ultra Portable</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">12 inch</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Super portable deluxe</span></a></li>
+        <li aria-current=\\"page\\" class=\\"fd-breadcrumb__item\\">Laptop</li>
+    </ol>
+</nav>"
 `;
 
 exports[`Check stories > Components/Busy Indicator > Story BusyDialog > Should match snapshot 1`] = `


### PR DESCRIPTION
## Related Issue
Closes none

## Description
- add separator styles
- two options for current page appearance
- updated examples
- updated height of the link for a11y requirements

## Screenshots
<img width="1163" alt="Screenshot 2024-11-26 at 11 53 30 AM" src="https://github.com/user-attachments/assets/2e43449c-28ea-4214-a54e-9a56ca9af37d">
<img width="849" alt="Screenshot 2024-11-26 at 11 53 24 AM" src="https://github.com/user-attachments/assets/37afb3c3-c1a6-4a13-90fb-1dc3ecbfacfa">
