### PR TITLE
fix: remove shellbar subtitle from examples

### DIFF
--- a/packages/styles/stories/Components/shellbar/shellbar.stories.js
+++ b/packages/styles/stories/Components/shellbar/shellbar.stories.js
@@ -62,7 +62,6 @@ export default {
       </ul>
     </li>
     <li>\`fd-shellbar__title\`<span>: the Product name</span></li>
-    <li>\`fd-shellbar__subtitle\`<span>: the Solution name</span></li>
     <li>\`fd-shellbar__action\`<span>: is a container for controls in the actions group, with modifier classes that control the visibility of the element based on the screen size. </span>
       <ul>
         <li>\`fd-shellbar__action--grow\`</li>

--- a/packages/styles/stories/Components/shellbar/shellbar.stories.js
+++ b/packages/styles/stories/Components/shellbar/shellbar.stories.js
@@ -70,7 +70,6 @@ export default {
         <li>\`fd-shellbar__action--desktop\`</li>
       </ul>
     </li>
-    <li>\`fd-shellbar__product\`<span>: a container for Product name and Solution name</span></li>
     <li>\`fd-shellbar__button\`<span>: is an override style of \`fd-button\`, tailored for use within the Shell Bar.</span>
       <ul>
         <li>\`fd-shellbar__button--menu\`<span>: is an override style of the Menu Button, tailored for use within the Shell Bar.</span></li>

--- a/packages/theming-preview/src/shell-tile-card.html
+++ b/packages/theming-preview/src/shell-tile-card.html
@@ -85,7 +85,6 @@
                                         </nav>
                                     </div>
                                 </div>
-                                <div class="fd-shellbar__subtitle">Subtitle</div>
                             </div>
                             <div class="fd-shellbar__group fd-shellbar__group--actions">
                                 <div class="fd-shellbar__action fd-shellbar__action--grow">


### PR DESCRIPTION
fixes none