### PR TITLE
feat(styles): latest updates for User Menu [ci visual]

### DIFF
--- a/packages/styles/src/list.scss
+++ b/packages/styles/src/list.scss
@@ -3,6 +3,7 @@
 @import "./mixins/list/list-base";
 @import "./mixins/list/list-dropdown";
 @import "./mixins/list/list-byline";
+@import "./mixins/list/list-subline";
 @import "./mixins/list/list-message-view";
 @import "./mixins/list/list-navigation";
 @import "./mixins/list/list-navigation-indication";

--- a/packages/styles/src/menu.scss
+++ b/packages/styles/src/menu.scss
@@ -331,6 +331,44 @@ $block: #{$fd-namespace}-menu;
       }
     }
 
+    .#{$block}__sublist {
+      --fdMenu_Item_Spacing_Left: 1rem;
+      --fdMenu_Item_Spacing_Right: 1rem;
+
+      .#{$block}__title {
+        &:first-child {
+          margin-inline-start: 0;
+        }
+  
+        &:last-child {
+          margin-inline-end: 0;
+        }
+  
+        &:only-child {
+          margin-inline: 0;
+        }
+      }
+
+      &.#{$block}__sublist--icons {
+        --fdMenu_Item_Spacing_Left: 0;
+        --fdMenu_Item_Spacing_Right: 0;
+    
+        .#{$block}__title {
+          &:first-child {
+            margin-inline-start: var(--fdMenu_Icon_Width);
+          }
+    
+          &:last-child {
+            margin-inline-end: var(--fdMenu_Text_Spacing_Right);
+          }
+    
+          &:only-child {
+            margin-inline: var(--fdMenu_Icon_Width) var(--fdMenu_Text_Spacing_Right);
+          }
+        }
+      }
+    }
+
     input,
     .#{$block}__input {
       @include fd-set-margins-x(var(--fdMenu_Text_Spacing_Right), var(--fdMenu_Text_Spacing_Right));
@@ -386,6 +424,16 @@ $block: #{$fd-namespace}-menu;
       input,
       .#{$block}__input {
         margin-inline: 0.5rem;
+      }
+
+      .#{$block}__sublist {
+        --fdMenu_Item_Spacing_Left: 0.5rem;
+        --fdMenu_Item_Spacing_Right: 0.5rem;
+
+        &.#{$block}__sublist--icons {
+          --fdMenu_Item_Spacing_Left: 0;
+          --fdMenu_Item_Spacing_Right: 0;
+        }
       }
     }
   }

--- a/packages/styles/src/mixins/list/_list-subline.scss
+++ b/packages/styles/src/mixins/list/_list-subline.scss
@@ -1,0 +1,65 @@
+@use "sass:map";
+
+@import "./list-definitions";
+
+.#{$block} {
+  &--subline {
+    .#{$block}__item {
+      @include fd-flex() {
+        gap: 0.75rem;
+        align-items: center;
+      };
+
+      min-height: 4.5rem;
+      padding-block: 0.5rem;
+      padding-inline: 1rem;
+    }
+
+    .#{$block}__content {
+      @include fd-reset();
+      
+      @include fd-flex(column) {
+        flex: 1;
+        gap: 0.25rem;
+        align-self: stretch;
+        justify-content: center;
+        align-items: flex-start;
+      };
+
+      overflow: hidden;
+    }
+
+    .#{$block}__title {
+      @include fd-ellipsis();
+
+      width: 100%;
+      max-width: 100%;
+      font-style: normal;
+      line-height: normal;
+      font-size: var(--sapFontSize);
+      color: var(--sapList_TextColor);
+      font-family: var(--sapFontBoldFamily);
+    }
+
+    .#{$block}__subline {
+      @include fd-reset();
+      @include fd-ellipsis();
+
+      width: 100%;
+      max-width: 100%;
+      font-style: normal;
+      line-height: normal;
+      font-size: var(--sapFontSize);
+      font-family: var(--sapFontFamily);
+      color: var(--sapContent_LabelColor);
+    }
+
+    .#{$block}__active-indicator {
+      color: var(--sapContent_NonInteractiveIconColor);
+    }
+
+    .#{$fd-namespace}-avatar:first-child {
+      margin-inline: 0;
+    }
+  }
+}

--- a/packages/styles/src/user-menu.scss
+++ b/packages/styles/src/user-menu.scss
@@ -20,6 +20,10 @@ $panel: #{$fd-namespace}-panel;
     --fdPanel_Header_Border_Bottom_Right_Radius: 0;
   }
 
+  .#{$block}__popover-wrapper {
+    overflow: visible;
+  }
+
   &__body {
     @include fd-reset();
 
@@ -27,11 +31,11 @@ $panel: #{$fd-namespace}-panel;
       gap: 0.5rem; 
     };
 
-    overflow: scroll;
+    overflow: visible;
     min-width: 18rem;
     max-width: 20rem;
-    padding-block: 1rem 0.5rem;
     padding-inline: 0.5rem;
+    padding-block: 2.5rem 0.5rem;
   }
 
   &__header {
@@ -71,6 +75,25 @@ $panel: #{$fd-namespace}-panel;
     color: var(--sapContent_LabelColor);
   }
 
+  .#{$block}__menu {
+    width: 100%;
+  }
+
+  .#{$block}__menu-list {
+    box-shadow: none;
+    border-radius: 0;
+
+    & > *:first-child, & > *:last-child {
+      border-radius: 0;
+    }
+  }
+
+  .#{$block}__panel {
+    & > div {
+      border-radius: 0;
+    }
+  }
+
   &__content-container {
     @include fd-reset();
 
@@ -82,10 +105,11 @@ $panel: #{$fd-namespace}-panel;
     @include fd-flex(column);
 
     height: 100%;
-    padding-block-start: 1rem;
+    padding-block-start: 0;
 
     .#{$block}__body {
       flex: 1;
+      padding-block-start: 1rem;
     }
   }
 

--- a/packages/styles/stories/Components/List/list/subline/standard.example.html
+++ b/packages/styles/stories/Components/List/list/subline/standard.example.html
@@ -1,0 +1,35 @@
+<ul class="fd-list fd-list--subline" role="list">
+    <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
+        <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_F3.png')" role="img" aria-label="Jane Doe"></span>
+        <div class="fd-list__content">
+            <div class="fd-list__title">List Item Title</div>
+            <div class="fd-list__subline">List Item Subline</div>
+            <div class="fd-list__subline">List Item Subline</div>
+        </div>
+    </li>
+    <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
+        <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" role="img" aria-label="John Doe"></span>
+        <div class="fd-list__content">
+            <div class="fd-list__title">List Item Title</div>
+            <div class="fd-list__subline">List Item Subline</div>
+            <div class="fd-list__subline">List Item Subline</div>
+        </div>
+        <span class="fd-list__active-indicator sap-icon--sys-enter-2"></span>
+    </li>
+    <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
+        <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-10" aria-role="img" aria-label="John Doe">JD</span>
+        <div class="fd-list__content">
+            <div class="fd-list__title">List Item Title Lorem, ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo? Lorem, ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo!</div>
+            <div class="fd-list__subline">List Item Subline Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus nulla aliquid soluta aperiam, amet iste sint? Explicabo dicta doloremque amet minima perferendis. Necessitatibus reiciendis voluptatum id nesciunt earum! Lorem, ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo.</div>
+            <div class="fd-list__subline">List Item Subline Lorem ipsum dolor sit amet consectetur adipisicing elit. Eaque asperiores id deleniti quae? Amet officia cum assumenda. Ab, dolores ea dignissimos, aliquid beatae magnam commodi, tenetur facere harum ex nemo? Lorem, ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo.</div>
+        </div>
+    </li>
+    <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
+        <span class="fd-avatar fd-avatar--sm fd-avatar--thumbnail" style="background-image: url('/assets/images/landscape/L1.jpg')" role="img" aria-label="John Doe"></span>
+        <div class="fd-list__content">
+            <div class="fd-list__title">List Item Title</div>
+            <div class="fd-list__subline">List Item Subline</div>
+            <div class="fd-list__subline">List Item Subline</div>
+        </div>
+    </li>
+</ul>

--- a/packages/styles/stories/Components/List/list/subline/subline-list.stories.js
+++ b/packages/styles/stories/Components/List/list/subline/subline-list.stories.js
@@ -1,0 +1,23 @@
+import standardExampleHtml from "./standard.example.html?raw";
+
+import '../../../../../src/avatar.scss';
+import '../../../../../src/list.scss';
+import '../../../../../src/icon.scss';
+import '../../../../../src/checkbox.scss';
+import '../../../../../src/link.scss';
+import '../../../../../src/button.scss';
+import '../../../../../src/info-label.scss';
+
+export default {
+  title: 'Components/List/Subline'
+};
+export const Standard = () => standardExampleHtml;
+Standard.storyName = 'Custom List Item with Subline';
+Standard.parameters = {
+  docs: {
+    description: {
+      story: `This is structure of the custom list item is being used to display the accounts in USer Menu. 
+    `
+    }
+  }
+}

--- a/packages/styles/stories/Components/user-menu/default.example.html
+++ b/packages/styles/stories/Components/user-menu/default.example.html
@@ -1,56 +1,74 @@
 <div class="fddocs-container" style="margin-bottom: 800px">
     <div class="fd-popover fd-popover--right fd-user-menu">
         <div class="fd-popover__body fd-popover__body--right" aria-hidden="false" id="userMenu1">
-            <div class="fd-user-menu__body">
-                <div class="fd-user-menu__header">
-                    <span
-                        class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--thumbnail"
-                        aria-label="Avatar"
-                        style="background-image: url('/assets/images/portraits/L_80x80_F3.png');">
-                        <i class="fd-avatar__zoom-icon sap-icon--edit" aria-label="Edit" role="presentation" aria-hidden="true"></i>
-                    </span>
-                    <div class="fd-user-menu__header-container">
-                        <div class="fd-user-menu__user-name">Lisa Miller</div>
-                        <div class="fd-user-menu__subline">lisa.miller@test.com</div>
-                        <div class="fd-user-menu__subline">User Experience Designer</div>
+            <div class="fd-popover__wrapper fd-user-menu__popover-wrapper">
+                <div class="fd-user-menu__body">
+                    <div class="fd-user-menu__header">
+                        <span
+                            class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--thumbnail"
+                            aria-label="Avatar"
+                            style="background-image: url('/assets/images/portraits/L_80x80_F3.png');">
+                            <i class="fd-avatar__zoom-icon sap-icon--edit" aria-label="Edit" role="presentation" aria-hidden="true"></i>
+                        </span>
+                        <div class="fd-user-menu__header-container">
+                            <div class="fd-user-menu__user-name">Lisa Miller</div>
+                            <div class="fd-user-menu__subline">lisa.miller@test.com</div>
+                            <div class="fd-user-menu__subline">User Experience Designer</div>
+                        </div>
                     </div>
-                </div>
-                <div class="fd-user-menu__content-container">
-                    <ul class="fd-navigation-list" role="list">
-                        <li class="fd-navigation-list__item" role="none">
-                            <a class="fd-navigation-list__content" role="listitem" tabindex="0">
-                                <div class="fd-navigation-list__content-container">
-                                    <span class="fd-navigation-list__icon">
-                                        <i class=" sap-icon--action-settings" role="presentation"></i>
+                    <div class="fd-user-menu__content-container">
+                        <nav class="fd-menu fd-menu--icons fd-user-menu__menu">
+                            <ul class="fd-menu__list fd-user-menu__menu-list" role="menu">
+                                <li class="fd-menu__item" role="presentation">
+                                    <a class="fd-menu__link" href="#" role="menuitem">
+                                        <span class="fd-menu__addon-before">
+                                            <i class="sap-icon--action-settings" role="presentation"></i>
+                                        </span>
+                                        <span class="fd-menu__title">Settings</span>
+                                    </a>
+                                </li>
+    
+                                <li class="fd-menu__item" role="presentation">
+                                    <span
+                                        class="fd-menu__link has-child is-expanded"
+                                        aria-controls="EX100M2A"
+                                        aria-expanded="true"
+                                        aria-haspopup="true"
+                                        role="menuitem"
+                                        onclick="onPopoverClick('EX100M2A')">
+                                            <span class="fd-menu__addon-before">
+                                                <i class="sap-icon--official-service" role="presentation"></i>
+                                            </span>
+                                            <span class="fd-menu__title">Legal Information</span>
+                                            <span class="fd-menu__addon-after fd-menu__addon-after--submenu"></span>
                                     </span>
-                                    <span class="fd-navigation-list__text">Settings</span>
-                                </div>
-                                <div class="fd-navigation-list__expander">
-                                    <i class="sap-icon--navigation-right-arrow" role="presentation"></i>
-                                </div>
-                            </a>
-                        </li>
-                        <li class="fd-navigation-list__item" role="none">
-                            <a class="fd-navigation-list__content" role="listitem" tabindex="0">
-                                <div class="fd-navigation-list__content-container">
-                                    <span class="fd-navigation-list__icon">
-                                        <i class=" sap-icon--official-service" role="presentation"></i>
-                                    </span>
-                                    <span class="fd-navigation-list__text">Legal Information</span>
-                                </div>
-                            </a>
-                        </li>
-                        <li class="fd-navigation-list__item" role="none">
-                            <a class="fd-navigation-list__content" role="listitem" tabindex="0">
-                                <div class="fd-navigation-list__content-container">
-                                    <span class="fd-navigation-list__icon">
-                                        <i class=" sap-icon--message-information" role="presentation"></i>
-                                    </span>
-                                    <span class="fd-navigation-list__text">About</span>
-                                </div>
-                            </a>
-                        </li>
-                    </ul>
+                                    
+                                    <ul class="fd-menu__sublist" id="EX100M2A" aria-hidden="false" role="menu">
+                                        <li class="fd-menu__item" role="presentation">
+                                            <a class="fd-menu__link" href="#" role="menuitem">
+                                                <span class="fd-menu__title">Privacy Policy</span>
+                                            </a>
+                                        </li>
+                                        <li class="fd-menu__item" role="presentation">
+                                            <a class="fd-menu__link" href="#" role="menuitem">
+                                                <span class="fd-menu__title">Terms of Service</span>
+                                            </a>
+                                        </li>
+                                    </ul>
+                                </li>
+    
+                                <li class="fd-menu__item" role="presentation">
+                                    <a class="fd-menu__link" href="#" role="menuitem">
+                                        <span class="fd-menu__addon-before">
+                                            <i class="sap-icon--message-information" role="presentation"></i>
+                                        </span>
+                                        <span class="fd-menu__title">About</span>
+                                    </a>
+                                </li>
+                                
+                            </ul>
+                        </nav>  
+                    </div>
                 </div>
             </div>
             <div class="fd-bar fd-bar--footer">
@@ -68,99 +86,126 @@
 
     <div class="fd-popover fd-popover--right fd-user-menu">
         <div class="fd-popover__body fd-popover__body--right" aria-hidden="false" id="userMenu1">
-            <div class="fd-user-menu__body">
-                <div class="fd-user-menu__header">
-                    <span
-                        class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--thumbnail"
-                        aria-label="Avatar"
-                        style="background-image: url('/assets/images/portraits/L_80x80_F3.png');">
-                        <i class="fd-avatar__zoom-icon fd-avatar__zoom-icon--indication-8 sap-icon--edit" aria-label="Edit" role="presentation" aria-hidden="true"></i>
-                    </span>
-                    <div class="fd-user-menu__header-container">
-                        <div class="fd-user-menu__user-name">Lisa Miller</div>
-                        <div class="fd-user-menu__subline">lisa.miller@test.com</div>
-                        <div class="fd-user-menu__subline">User Experience Designer</div>
+            <div class="fd-popover__wrapper fd-user-menu__popover-wrapper">
+                <div class="fd-user-menu__body">
+                    <div class="fd-user-menu__header">
+                        <span
+                            class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--thumbnail"
+                            aria-label="Avatar"
+                            style="background-image: url('/assets/images/portraits/L_80x80_F3.png');">
+                            <i class="fd-avatar__zoom-icon fd-avatar__zoom-icon--indication-8 sap-icon--edit" aria-label="Edit" role="presentation" aria-hidden="true"></i>
+                        </span>
+                        <div class="fd-user-menu__header-container">
+                            <div class="fd-user-menu__user-name">Lisa Miller</div>
+                            <div class="fd-user-menu__subline">lisa.miller@test.com</div>
+                            <div class="fd-user-menu__subline">User Experience Designer</div>
+                        </div>
+                        <button aria-label="Manage Accounts" class="fd-button">
+                            <i class="sap-icon--user-settings"></i>
+                            <span class="fd-button__text">Manage Accounts</span>
+                        </button>
                     </div>
-                    <button aria-label="Manage Accounts" class="fd-button">
-                        <i class="sap-icon--user-settings"></i>
-                        <span class="fd-button__text">Manage Accounts</span>
-                    </button>
-                </div>
-                <div class="fd-user-menu__content-container">
-                    <div class="fd-panel fd-user-menu__panel" aria-labelledby="__panel-title-8" role="form">
-                        <div class="fd-panel__header">
-                            <div class="fd-panel__expand">
-                                <button class="fd-button fd-button--transparent fd-panel__button" aria-expanded="true" onclick="toggleExpandedButton(event)"
-                                    aria-haspopup="true" aria-label="expand/collapse panel" aria-controls="__panel-8">
-                                    <i class="sap-icon--slim-arrow-down"></i>
-                                </button>
+                    <div class="fd-user-menu__content-container">
+                        <div class="fd-panel fd-user-menu__panel" aria-labelledby="__panel-title-8" role="form">
+                            <div class="fd-panel__header">
+                                <div class="fd-panel__expand">
+                                    <button class="fd-button fd-button--transparent fd-panel__button" aria-expanded="true" onclick="toggleExpandedButton(event)"
+                                        aria-haspopup="true" aria-label="expand/collapse panel" aria-controls="__panel-8">
+                                        <i class="sap-icon--slim-arrow-down"></i>
+                                    </button>
+                                </div>
+                                <h4 class="fd-panel__title" id="__panel-title-8">Other Accounts (2)</h4>
+                                <div class="fd-toolbar fd-toolbar--clear fd-toolbar--transparent">
+                                    <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"> </span>
+                                    <button class="fd-button fd-button--transparent" aria-label="Add Account" title="Add Account">
+                                        <i class="sap-icon--add-employee"></i>
+                                    </button>
+                                </div>
                             </div>
-                            <h4 class="fd-panel__title" id="__panel-title-8">Other Accounts (2)</h4>
-                            <div class="fd-toolbar fd-toolbar--clear fd-toolbar--transparent">
-                                <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"> </span>
-                                <button class="fd-button fd-button--transparent" aria-label="Add Account" title="Add Account">
-                                    <i class="sap-icon--add-employee"></i>
-                                </button>
+                            <div role="region" aria-labelledby="__panel-title-8" class="fd-panel__content fd-panel__content--no-padding" aria-hidden="false" id="__panel-8">
+                                <ul class="fd-list fd-list--subline" role="list">
+                                    <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
+                                        <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_F3.png')" role="img" aria-label="Jane Doe"></span>
+                                        <div class="fd-list__content">
+                                            <div class="fd-list__title">Lisa Miller</div>
+                                            <div class="fd-list__subline">lisa.miller@test.com</div>
+                                            <div class="fd-list__subline">Delivery Manager</div>
+                                        </div>
+                                        <span class="fd-list__active-indicator sap-icon--sys-enter-2"></span>
+                                    </li>
+                                    <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
+                                        <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" role="img" aria-label="John Doe"></span>
+                                        <div class="fd-list__content">
+                                            <div class="fd-list__title">John Doe</div>
+                                            <div class="fd-list__subline">john.doe@test.com</div>
+                                            <div class="fd-list__subline">Project Manager</div>
+                                        </div>
+                                        
+                                    </li>
+                                    <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
+                                        <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-10" aria-role="img" aria-label="Jane Doe">JD</span>
+                                        <div class="fd-list__content">
+                                            <div class="fd-list__title">Jane Doe</div>
+                                            <div class="fd-list__subline">jane.doe@test.com</div>
+                                            <div class="fd-list__subline">User Experience Designer</div>
+                                        </div>
+                                    </li>
+                                </ul>
+                                
                             </div>
                         </div>
-                        <div role="region" aria-labelledby="__panel-title-8" class="fd-panel__content fd-panel__content--no-padding" aria-hidden="false" id="__panel-8">
-                            <ul class="fd-list fd-list--byline" role="list">
-                                <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
-                                    <span class="fd-avatar fd-avatar--sm fd-avatar--circle" aria-role="img" aria-label="Lisa Miller">LM</span>
-                                    <div class="fd-list__content">
-                                        <div class="fd-list__title">Lisa Miller</div>
-                                        <div class="fd-list__byline">test.lisa.miller@test.com</div>
-                                    </div>
+                        <nav class="fd-menu fd-menu--icons fd-user-menu__menu">
+                            <ul class="fd-menu__list fd-user-menu__menu-list" role="menu">
+                                <li class="fd-menu__item" role="presentation">
+                                    <a class="fd-menu__link" href="#" role="menuitem">
+                                        <span class="fd-menu__addon-before">
+                                            <i class="sap-icon--action-settings" role="presentation"></i>
+                                        </span>
+                                        <span class="fd-menu__title">Settings</span>
+                                    </a>
                                 </li>
-                                <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
+    
+                                <li class="fd-menu__item" role="presentation">
                                     <span
-                                        class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--thumbnail"
-                                        aria-label="Avatar"
-                                        style="background-image: url('/assets/images/portraits/L_80x80_F3.png');">
+                                        class="fd-menu__link has-child is-expanded"
+                                        aria-controls="EX100M2B"
+                                        aria-expanded="true"
+                                        aria-haspopup="true"
+                                        role="menuitem"
+                                        onclick="onPopoverClick('EX100M2B')">
+                                            <span class="fd-menu__addon-before">
+                                                <i class="sap-icon--official-service" role="presentation"></i>
+                                            </span>
+                                            <span class="fd-menu__title">Legal Information</span>
+                                            <span class="fd-menu__addon-after fd-menu__addon-after--submenu"></span>
                                     </span>
-                                    <div class="fd-list__content">
-                                        <div class="fd-list__title">Lisa Miller</div>
-                                        <div class="fd-list__byline">lisa.miller@test.com</div>
-                                    </div>
+                                    
+                                    <ul class="fd-menu__sublist" id="EX100M2B" aria-hidden="false" role="menu">
+                                        <li class="fd-menu__item" role="presentation">
+                                            <a class="fd-menu__link" href="#" role="menuitem">
+                                                <span class="fd-menu__title">Privacy Policy</span>
+                                            </a>
+                                        </li>
+                                        <li class="fd-menu__item" role="presentation">
+                                            <a class="fd-menu__link" href="#" role="menuitem">
+                                                <span class="fd-menu__title">Terms of Service</span>
+                                            </a>
+                                        </li>
+                                    </ul>
                                 </li>
+    
+                                <li class="fd-menu__item" role="presentation">
+                                    <a class="fd-menu__link" href="#" role="menuitem">
+                                        <span class="fd-menu__addon-before">
+                                            <i class="sap-icon--message-information" role="presentation"></i>
+                                        </span>
+                                        <span class="fd-menu__title">About</span>
+                                    </a>
+                                </li>
+                                
                             </ul>
-                        </div>
+                        </nav>  
                     </div>
-                    <ul class="fd-navigation-list" role="list">
-                        <li class="fd-navigation-list__item" role="none">
-                            <a class="fd-navigation-list__content" role="listitem" tabindex="0">
-                                <div class="fd-navigation-list__content-container">
-                                    <span class="fd-navigation-list__icon">
-                                        <i class=" sap-icon--action-settings" role="presentation"></i>
-                                    </span>
-                                    <span class="fd-navigation-list__text">Settings</span>
-                                </div>
-                                <div class="fd-navigation-list__expander">
-                                    <i class="sap-icon--navigation-right-arrow" role="presentation"></i>
-                                </div>
-                            </a>
-                        </li>
-                        <li class="fd-navigation-list__item" role="none">
-                            <a class="fd-navigation-list__content" role="listitem" tabindex="0">
-                                <div class="fd-navigation-list__content-container">
-                                    <span class="fd-navigation-list__icon">
-                                        <i class=" sap-icon--official-service" role="presentation"></i>
-                                    </span>
-                                    <span class="fd-navigation-list__text">Legal Information</span>
-                                </div>
-                            </a>
-                        </li>
-                        <li class="fd-navigation-list__item" role="none">
-                            <a class="fd-navigation-list__content" role="listitem" tabindex="0">
-                                <div class="fd-navigation-list__content-container">
-                                    <span class="fd-navigation-list__icon">
-                                        <i class=" sap-icon--message-information" role="presentation"></i>
-                                    </span>
-                                    <span class="fd-navigation-list__text">About</span>
-                                </div>
-                            </a>
-                        </li>
-                    </ul>
                 </div>
             </div>
             <div class="fd-bar fd-bar--footer">

--- a/packages/styles/stories/Components/user-menu/mobile.example.html
+++ b/packages/styles/stories/Components/user-menu/mobile.example.html
@@ -2,12 +2,6 @@
     <div style="height: 700px;">
         <div class="fd-user-menu fd-user-menu--mobile">
             <div class="fd-bar fd-bar--header fd-user-menu__title-bar">
-                <div class="fd-bar__left" aria-hidden="true"></div>
-                <div class="fd-bar__middle">
-                    <div class="fd-bar__element">
-                        <h5 class="fd-title fd-title--h5 fd-user-menu__title" aria-label="text">Profile</h5>
-                    </div>
-                </div>
                 <div class="fd-bar__right">
                     <div class="fd-bar__element">
                         <button aria-label="button" class="fd-button fd-button--transparent">
@@ -74,41 +68,38 @@
                             </ul>
                         </div>
                     </div>
-                    <ul class="fd-navigation-list" role="list">
-                        <li class="fd-navigation-list__item" role="listitem" tabindex="-1">
-                            <div class="fd-navigation-list__content" tabindex="0">
-                                <div class="fd-navigation-list__content-container">
-                                    <span class="fd-navigation-list__icon">
-                                        <i class=" sap-icon--action-settings" role="presentation"></i>
+                    <nav class="fd-menu fd-menu--icons fd-user-menu__menu">
+                        <ul class="fd-menu__list fd-user-menu__menu-list" role="menu">
+                            <li class="fd-menu__item" role="presentation">
+                                <a class="fd-menu__link" href="#" role="menuitem">
+                                    <span class="fd-menu__addon-before">
+                                        <i class="sap-icon--action-settings" role="presentation"></i>
                                     </span>
-                                    <span class="fd-navigation-list__text">Settings</span>
-                                </div>
-                                <div class="fd-navigation-list__expander">
-                                    <i class="sap-icon--navigation-right-arrow" role="presentation"></i>
-                                </div>
-                            </div>
-                        </li>
-                        <li class="fd-navigation-list__item" role="listitem" tabindex="-1">
-                            <div class="fd-navigation-list__content" tabindex="0">
-                                <div class="fd-navigation-list__content-container">
-                                    <span class="fd-navigation-list__icon">
-                                        <i class=" sap-icon--official-service" role="presentation"></i>
+                                    <span class="fd-menu__title">Settings</span>
+                                </a>
+                            </li>
+
+                            <li class="fd-menu__item" role="presentation">
+                                <div class="fd-menu__link is-selected" href="#" role="menuitem">
+                                    <span class="fd-menu__addon-before">
+                                        <i class="sap-icon--official-service" role="presentation"></i>
                                     </span>
-                                    <span class="fd-navigation-list__text">Legal Information</span>
+                                    <span class="fd-menu__title">Legal Information</span>
+                                    <span class="fd-menu__addon-after fd-menu__addon-after--submenu"></span>
                                 </div>
-                            </div>
-                        </li>
-                        <li class="fd-navigation-list__item" role="listitem" tabindex="-1">
-                            <div class="fd-navigation-list__content" tabindex="0">
-                                <div class="fd-navigation-list__content-container">
-                                    <span class="fd-navigation-list__icon">
-                                        <i class=" sap-icon--message-information" role="presentation"></i>
+                            </li>
+
+                            <li class="fd-menu__item" role="presentation">
+                                <a class="fd-menu__link" href="#" role="menuitem">
+                                    <span class="fd-menu__addon-before">
+                                        <i class="sap-icon--message-information" role="presentation"></i>
                                     </span>
-                                    <span class="fd-navigation-list__text">About</span>
-                                </div>
-                            </div>
-                        </li>
-                    </ul>
+                                    <span class="fd-menu__title">About</span>
+                                </a>
+                            </li>
+                            
+                        </ul>
+                    </nav>  
                 </div>
             </div>
             <div class="fd-bar fd-bar--footer fd-user-menu__footer">
@@ -134,93 +125,26 @@
                         </button>
                     </div>
                     <div class="fd-bar__element">
-                        <h5 class="fd-title fd-title--h5" aria-label="text">Settings</h5>
+                        <h5 class="fd-title fd-title--h5" aria-label="text">Legal Information</h5>
                     </div>
                 </div>
             </div>
             <div class="fd-user-menu__body">
-                <ul class="fd-navigation-list" role="list">
-                    <li class="fd-navigation-list__item" role="listitem" tabindex="-1">
-                        <div class="fd-navigation-list__content" tabindex="0">
-                            <div class="fd-navigation-list__content-container">
-                                <span class="fd-navigation-list__icon">
-                                    <i class=" sap-icon--action-settings" role="presentation"></i>
-                                </span>
-                                <span class="fd-navigation-list__text">Settings Item</span>
+                <nav class="fd-menu fd-user-menu__menu">
+                    <ul class="fd-menu__list fd-user-menu__menu-list" role="menu">
+                        <li class="fd-menu__item" role="presentation">
+                            <a class="fd-menu__link" href="#" role="menuitem">
+                                <span class="fd-menu__title">Privacy Policy</span>
+                            </a>
+                        </li>
+
+                        <li class="fd-menu__item" role="presentation">
+                            <div class="fd-menu__link" href="#" role="menuitem">
+                                <span class="fd-menu__title">Terms of Service</span>
                             </div>
-                        </div>
-                    </li>
-                    <li class="fd-navigation-list__item" role="listitem" tabindex="-1">
-                        <div class="fd-navigation-list__content" tabindex="0">
-                            <div class="fd-navigation-list__content-container">
-                                <span class="fd-navigation-list__icon">
-                                    <i class=" sap-icon--action-settings" role="presentation"></i>
-                                </span>
-                                <span class="fd-navigation-list__text">Settings Item</span>
-                            </div>
-                        </div>
-                    </li>
-                    <li class="fd-navigation-list__item" role="listitem" tabindex="-1">
-                        <div class="fd-navigation-list__content" tabindex="0">
-                            <div class="fd-navigation-list__content-container">
-                                <span class="fd-navigation-list__icon">
-                                    <i class=" sap-icon--action-settings" role="presentation"></i>
-                                </span>
-                                <span class="fd-navigation-list__text">Settings Item</span>
-                            </div>
-                        </div>
-                    </li>
-                    <li class="fd-navigation-list__item" role="listitem" tabindex="-1">
-                        <div class="fd-navigation-list__content" tabindex="0">
-                            <div class="fd-navigation-list__content-container">
-                                <span class="fd-navigation-list__icon">
-                                    <i class=" sap-icon--action-settings" role="presentation"></i>
-                                </span>
-                                <span class="fd-navigation-list__text">Settings Item</span>
-                            </div>
-                        </div>
-                    </li>
-                    <li class="fd-navigation-list__item" role="listitem" tabindex="-1">
-                        <div class="fd-navigation-list__content" tabindex="0">
-                            <div class="fd-navigation-list__content-container">
-                                <span class="fd-navigation-list__icon">
-                                    <i class=" sap-icon--action-settings" role="presentation"></i>
-                                </span>
-                                <span class="fd-navigation-list__text">Settings Item</span>
-                            </div>
-                        </div>
-                    </li>
-                    <li class="fd-navigation-list__item" role="listitem" tabindex="-1">
-                        <div class="fd-navigation-list__content" tabindex="0">
-                            <div class="fd-navigation-list__content-container">
-                                <span class="fd-navigation-list__icon">
-                                    <i class=" sap-icon--action-settings" role="presentation"></i>
-                                </span>
-                                <span class="fd-navigation-list__text">Settings Item</span>
-                            </div>
-                        </div>
-                    </li>
-                    <li class="fd-navigation-list__item" role="listitem" tabindex="-1">
-                        <div class="fd-navigation-list__content" tabindex="0">
-                            <div class="fd-navigation-list__content-container">
-                                <span class="fd-navigation-list__icon">
-                                    <i class=" sap-icon--action-settings" role="presentation"></i>
-                                </span>
-                                <span class="fd-navigation-list__text">Settings Item</span>
-                            </div>
-                        </div>
-                    </li>
-                    <li class="fd-navigation-list__item" role="listitem" tabindex="-1">
-                        <div class="fd-navigation-list__content" tabindex="0">
-                            <div class="fd-navigation-list__content-container">
-                                <span class="fd-navigation-list__icon">
-                                    <i class=" sap-icon--action-settings" role="presentation"></i>
-                                </span>
-                                <span class="fd-navigation-list__text">Settings Item</span>
-                            </div>
-                        </div>
-                    </li>
-                </ul>
+                        </li>
+                    </ul>
+                </nav>  
             </div>
             <div class="fd-bar fd-bar--footer fd-user-menu__footer">
                 <div class="fd-bar__right">

--- a/packages/styles/stories/Components/user-menu/user-menu.stories.js
+++ b/packages/styles/stories/Components/user-menu/user-menu.stories.js
@@ -19,6 +19,7 @@ import '../../../src/navigation-list.scss';
 import '../../../src/input-group.scss';
 import '../../../src/panel.scss';
 import '../../../src/toolbar.scss';
+import '../../../src/menu.scss';
 
 export default {
   title: 'Components/User Menu',

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -30037,6 +30037,45 @@ exports[`Check stories > Components/List/Standard > Story Unread > Should match 
 "
 `;
 
+exports[`Check stories > Components/List/Subline > Story Standard > Should match snapshot 1`] = `
+"<ul class=\\"fd-list fd-list--subline\\" role=\\"list\\">
+    <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-list__item--interractive\\">
+        <span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_F3.png')\\" role=\\"img\\" aria-label=\\"Jane Doe\\"></span>
+        <div class=\\"fd-list__content\\">
+            <div class=\\"fd-list__title\\">List Item Title</div>
+            <div class=\\"fd-list__subline\\">List Item Subline</div>
+            <div class=\\"fd-list__subline\\">List Item Subline</div>
+        </div>
+    </li>
+    <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-list__item--interractive\\">
+        <span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" role=\\"img\\" aria-label=\\"John Doe\\"></span>
+        <div class=\\"fd-list__content\\">
+            <div class=\\"fd-list__title\\">List Item Title</div>
+            <div class=\\"fd-list__subline\\">List Item Subline</div>
+            <div class=\\"fd-list__subline\\">List Item Subline</div>
+        </div>
+        <span class=\\"fd-list__active-indicator sap-icon--sys-enter-2\\"></span>
+    </li>
+    <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-list__item--interractive\\">
+        <span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-10\\" aria-role=\\"img\\" aria-label=\\"John Doe\\">JD</span>
+        <div class=\\"fd-list__content\\">
+            <div class=\\"fd-list__title\\">List Item Title Lorem, ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo? Lorem, ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo!</div>
+            <div class=\\"fd-list__subline\\">List Item Subline Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus nulla aliquid soluta aperiam, amet iste sint? Explicabo dicta doloremque amet minima perferendis. Necessitatibus reiciendis voluptatum id nesciunt earum! Lorem, ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo.</div>
+            <div class=\\"fd-list__subline\\">List Item Subline Lorem ipsum dolor sit amet consectetur adipisicing elit. Eaque asperiores id deleniti quae? Amet officia cum assumenda. Ab, dolores ea dignissimos, aliquid beatae magnam commodi, tenetur facere harum ex nemo? Lorem, ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo.</div>
+        </div>
+    </li>
+    <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-list__item--interractive\\">
+        <span class=\\"fd-avatar fd-avatar--sm fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/landscape/L1.jpg')\\" role=\\"img\\" aria-label=\\"John Doe\\"></span>
+        <div class=\\"fd-list__content\\">
+            <div class=\\"fd-list__title\\">List Item Title</div>
+            <div class=\\"fd-list__subline\\">List Item Subline</div>
+            <div class=\\"fd-list__subline\\">List Item Subline</div>
+        </div>
+    </li>
+</ul>
+"
+`;
+
 exports[`Check stories > Components/Menu > Story Buttons > Should match snapshot 1`] = `
 "<div style=\\"display: flex; gap: 3rem; flex-wrap:wrap;\\">
     <nav class=\\"fd-menu fd-menu--icons\\">
@@ -51692,56 +51731,74 @@ exports[`Check stories > Components/User Menu > Story Default > Should match sna
 "<div class=\\"fddocs-container\\" style=\\"margin-bottom: 800px\\">
     <div class=\\"fd-popover fd-popover--right fd-user-menu\\">
         <div class=\\"fd-popover__body fd-popover__body--right\\" aria-hidden=\\"false\\" id=\\"userMenu1\\">
-            <div class=\\"fd-user-menu__body\\">
-                <div class=\\"fd-user-menu__header\\">
-                    <span
-                        class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--thumbnail\\"
-                        aria-label=\\"Avatar\\"
-                        style=\\"background-image: url('/assets/images/portraits/L_80x80_F3.png');\\">
-                        <i class=\\"fd-avatar__zoom-icon sap-icon--edit\\" aria-label=\\"Edit\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
-                    </span>
-                    <div class=\\"fd-user-menu__header-container\\">
-                        <div class=\\"fd-user-menu__user-name\\">Lisa Miller</div>
-                        <div class=\\"fd-user-menu__subline\\">lisa.miller@test.com</div>
-                        <div class=\\"fd-user-menu__subline\\">User Experience Designer</div>
+            <div class=\\"fd-popover__wrapper fd-user-menu__popover-wrapper\\">
+                <div class=\\"fd-user-menu__body\\">
+                    <div class=\\"fd-user-menu__header\\">
+                        <span
+                            class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--thumbnail\\"
+                            aria-label=\\"Avatar\\"
+                            style=\\"background-image: url('/assets/images/portraits/L_80x80_F3.png');\\">
+                            <i class=\\"fd-avatar__zoom-icon sap-icon--edit\\" aria-label=\\"Edit\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
+                        </span>
+                        <div class=\\"fd-user-menu__header-container\\">
+                            <div class=\\"fd-user-menu__user-name\\">Lisa Miller</div>
+                            <div class=\\"fd-user-menu__subline\\">lisa.miller@test.com</div>
+                            <div class=\\"fd-user-menu__subline\\">User Experience Designer</div>
+                        </div>
                     </div>
-                </div>
-                <div class=\\"fd-user-menu__content-container\\">
-                    <ul class=\\"fd-navigation-list\\" role=\\"list\\">
-                        <li class=\\"fd-navigation-list__item\\" role=\\"none\\">
-                            <a class=\\"fd-navigation-list__content\\" role=\\"listitem\\" tabindex=\\"0\\">
-                                <div class=\\"fd-navigation-list__content-container\\">
-                                    <span class=\\"fd-navigation-list__icon\\">
-                                        <i class=\\" sap-icon--action-settings\\" role=\\"presentation\\"></i>
+                    <div class=\\"fd-user-menu__content-container\\">
+                        <nav class=\\"fd-menu fd-menu--icons fd-user-menu__menu\\">
+                            <ul class=\\"fd-menu__list fd-user-menu__menu-list\\" role=\\"menu\\">
+                                <li class=\\"fd-menu__item\\" role=\\"presentation\\">
+                                    <a class=\\"fd-menu__link\\" href=\\"#\\" role=\\"menuitem\\">
+                                        <span class=\\"fd-menu__addon-before\\">
+                                            <i class=\\"sap-icon--action-settings\\" role=\\"presentation\\"></i>
+                                        </span>
+                                        <span class=\\"fd-menu__title\\">Settings</span>
+                                    </a>
+                                </li>
+    
+                                <li class=\\"fd-menu__item\\" role=\\"presentation\\">
+                                    <span
+                                        class=\\"fd-menu__link has-child is-expanded\\"
+                                        aria-controls=\\"EX100M2A\\"
+                                        aria-expanded=\\"true\\"
+                                        aria-haspopup=\\"true\\"
+                                        role=\\"menuitem\\"
+                                        onclick=\\"onPopoverClick('EX100M2A')\\">
+                                            <span class=\\"fd-menu__addon-before\\">
+                                                <i class=\\"sap-icon--official-service\\" role=\\"presentation\\"></i>
+                                            </span>
+                                            <span class=\\"fd-menu__title\\">Legal Information</span>
+                                            <span class=\\"fd-menu__addon-after fd-menu__addon-after--submenu\\"></span>
                                     </span>
-                                    <span class=\\"fd-navigation-list__text\\">Settings</span>
-                                </div>
-                                <div class=\\"fd-navigation-list__expander\\">
-                                    <i class=\\"sap-icon--navigation-right-arrow\\" role=\\"presentation\\"></i>
-                                </div>
-                            </a>
-                        </li>
-                        <li class=\\"fd-navigation-list__item\\" role=\\"none\\">
-                            <a class=\\"fd-navigation-list__content\\" role=\\"listitem\\" tabindex=\\"0\\">
-                                <div class=\\"fd-navigation-list__content-container\\">
-                                    <span class=\\"fd-navigation-list__icon\\">
-                                        <i class=\\" sap-icon--official-service\\" role=\\"presentation\\"></i>
-                                    </span>
-                                    <span class=\\"fd-navigation-list__text\\">Legal Information</span>
-                                </div>
-                            </a>
-                        </li>
-                        <li class=\\"fd-navigation-list__item\\" role=\\"none\\">
-                            <a class=\\"fd-navigation-list__content\\" role=\\"listitem\\" tabindex=\\"0\\">
-                                <div class=\\"fd-navigation-list__content-container\\">
-                                    <span class=\\"fd-navigation-list__icon\\">
-                                        <i class=\\" sap-icon--message-information\\" role=\\"presentation\\"></i>
-                                    </span>
-                                    <span class=\\"fd-navigation-list__text\\">About</span>
-                                </div>
-                            </a>
-                        </li>
-                    </ul>
+                                    
+                                    <ul class=\\"fd-menu__sublist\\" id=\\"EX100M2A\\" aria-hidden=\\"false\\" role=\\"menu\\">
+                                        <li class=\\"fd-menu__item\\" role=\\"presentation\\">
+                                            <a class=\\"fd-menu__link\\" href=\\"#\\" role=\\"menuitem\\">
+                                                <span class=\\"fd-menu__title\\">Privacy Policy</span>
+                                            </a>
+                                        </li>
+                                        <li class=\\"fd-menu__item\\" role=\\"presentation\\">
+                                            <a class=\\"fd-menu__link\\" href=\\"#\\" role=\\"menuitem\\">
+                                                <span class=\\"fd-menu__title\\">Terms of Service</span>
+                                            </a>
+                                        </li>
+                                    </ul>
+                                </li>
+    
+                                <li class=\\"fd-menu__item\\" role=\\"presentation\\">
+                                    <a class=\\"fd-menu__link\\" href=\\"#\\" role=\\"menuitem\\">
+                                        <span class=\\"fd-menu__addon-before\\">
+                                            <i class=\\"sap-icon--message-information\\" role=\\"presentation\\"></i>
+                                        </span>
+                                        <span class=\\"fd-menu__title\\">About</span>
+                                    </a>
+                                </li>
+                                
+                            </ul>
+                        </nav>  
+                    </div>
                 </div>
             </div>
             <div class=\\"fd-bar fd-bar--footer\\">
@@ -51759,99 +51816,126 @@ exports[`Check stories > Components/User Menu > Story Default > Should match sna
 
     <div class=\\"fd-popover fd-popover--right fd-user-menu\\">
         <div class=\\"fd-popover__body fd-popover__body--right\\" aria-hidden=\\"false\\" id=\\"userMenu1\\">
-            <div class=\\"fd-user-menu__body\\">
-                <div class=\\"fd-user-menu__header\\">
-                    <span
-                        class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--thumbnail\\"
-                        aria-label=\\"Avatar\\"
-                        style=\\"background-image: url('/assets/images/portraits/L_80x80_F3.png');\\">
-                        <i class=\\"fd-avatar__zoom-icon fd-avatar__zoom-icon--indication-8 sap-icon--edit\\" aria-label=\\"Edit\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
-                    </span>
-                    <div class=\\"fd-user-menu__header-container\\">
-                        <div class=\\"fd-user-menu__user-name\\">Lisa Miller</div>
-                        <div class=\\"fd-user-menu__subline\\">lisa.miller@test.com</div>
-                        <div class=\\"fd-user-menu__subline\\">User Experience Designer</div>
+            <div class=\\"fd-popover__wrapper fd-user-menu__popover-wrapper\\">
+                <div class=\\"fd-user-menu__body\\">
+                    <div class=\\"fd-user-menu__header\\">
+                        <span
+                            class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--thumbnail\\"
+                            aria-label=\\"Avatar\\"
+                            style=\\"background-image: url('/assets/images/portraits/L_80x80_F3.png');\\">
+                            <i class=\\"fd-avatar__zoom-icon fd-avatar__zoom-icon--indication-8 sap-icon--edit\\" aria-label=\\"Edit\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
+                        </span>
+                        <div class=\\"fd-user-menu__header-container\\">
+                            <div class=\\"fd-user-menu__user-name\\">Lisa Miller</div>
+                            <div class=\\"fd-user-menu__subline\\">lisa.miller@test.com</div>
+                            <div class=\\"fd-user-menu__subline\\">User Experience Designer</div>
+                        </div>
+                        <button aria-label=\\"Manage Accounts\\" class=\\"fd-button\\">
+                            <i class=\\"sap-icon--user-settings\\"></i>
+                            <span class=\\"fd-button__text\\">Manage Accounts</span>
+                        </button>
                     </div>
-                    <button aria-label=\\"Manage Accounts\\" class=\\"fd-button\\">
-                        <i class=\\"sap-icon--user-settings\\"></i>
-                        <span class=\\"fd-button__text\\">Manage Accounts</span>
-                    </button>
-                </div>
-                <div class=\\"fd-user-menu__content-container\\">
-                    <div class=\\"fd-panel fd-user-menu__panel\\" aria-labelledby=\\"__panel-title-8\\" role=\\"form\\">
-                        <div class=\\"fd-panel__header\\">
-                            <div class=\\"fd-panel__expand\\">
-                                <button class=\\"fd-button fd-button--transparent fd-panel__button\\" aria-expanded=\\"true\\" onclick=\\"toggleExpandedButton(event)\\"
-                                    aria-haspopup=\\"true\\" aria-label=\\"expand/collapse panel\\" aria-controls=\\"__panel-8\\">
-                                    <i class=\\"sap-icon--slim-arrow-down\\"></i>
-                                </button>
+                    <div class=\\"fd-user-menu__content-container\\">
+                        <div class=\\"fd-panel fd-user-menu__panel\\" aria-labelledby=\\"__panel-title-8\\" role=\\"form\\">
+                            <div class=\\"fd-panel__header\\">
+                                <div class=\\"fd-panel__expand\\">
+                                    <button class=\\"fd-button fd-button--transparent fd-panel__button\\" aria-expanded=\\"true\\" onclick=\\"toggleExpandedButton(event)\\"
+                                        aria-haspopup=\\"true\\" aria-label=\\"expand/collapse panel\\" aria-controls=\\"__panel-8\\">
+                                        <i class=\\"sap-icon--slim-arrow-down\\"></i>
+                                    </button>
+                                </div>
+                                <h4 class=\\"fd-panel__title\\" id=\\"__panel-title-8\\">Other Accounts (2)</h4>
+                                <div class=\\"fd-toolbar fd-toolbar--clear fd-toolbar--transparent\\">
+                                    <span class=\\"fd-toolbar__spacer fd-toolbar__spacer--auto\\"> </span>
+                                    <button class=\\"fd-button fd-button--transparent\\" aria-label=\\"Add Account\\" title=\\"Add Account\\">
+                                        <i class=\\"sap-icon--add-employee\\"></i>
+                                    </button>
+                                </div>
                             </div>
-                            <h4 class=\\"fd-panel__title\\" id=\\"__panel-title-8\\">Other Accounts (2)</h4>
-                            <div class=\\"fd-toolbar fd-toolbar--clear fd-toolbar--transparent\\">
-                                <span class=\\"fd-toolbar__spacer fd-toolbar__spacer--auto\\"> </span>
-                                <button class=\\"fd-button fd-button--transparent\\" aria-label=\\"Add Account\\" title=\\"Add Account\\">
-                                    <i class=\\"sap-icon--add-employee\\"></i>
-                                </button>
+                            <div role=\\"region\\" aria-labelledby=\\"__panel-title-8\\" class=\\"fd-panel__content fd-panel__content--no-padding\\" aria-hidden=\\"false\\" id=\\"__panel-8\\">
+                                <ul class=\\"fd-list fd-list--subline\\" role=\\"list\\">
+                                    <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-list__item--interractive\\">
+                                        <span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_F3.png')\\" role=\\"img\\" aria-label=\\"Jane Doe\\"></span>
+                                        <div class=\\"fd-list__content\\">
+                                            <div class=\\"fd-list__title\\">Lisa Miller</div>
+                                            <div class=\\"fd-list__subline\\">lisa.miller@test.com</div>
+                                            <div class=\\"fd-list__subline\\">Delivery Manager</div>
+                                        </div>
+                                        <span class=\\"fd-list__active-indicator sap-icon--sys-enter-2\\"></span>
+                                    </li>
+                                    <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-list__item--interractive\\">
+                                        <span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" role=\\"img\\" aria-label=\\"John Doe\\"></span>
+                                        <div class=\\"fd-list__content\\">
+                                            <div class=\\"fd-list__title\\">John Doe</div>
+                                            <div class=\\"fd-list__subline\\">john.doe@test.com</div>
+                                            <div class=\\"fd-list__subline\\">Project Manager</div>
+                                        </div>
+                                        
+                                    </li>
+                                    <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-list__item--interractive\\">
+                                        <span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-10\\" aria-role=\\"img\\" aria-label=\\"Jane Doe\\">JD</span>
+                                        <div class=\\"fd-list__content\\">
+                                            <div class=\\"fd-list__title\\">Jane Doe</div>
+                                            <div class=\\"fd-list__subline\\">jane.doe@test.com</div>
+                                            <div class=\\"fd-list__subline\\">User Experience Designer</div>
+                                        </div>
+                                    </li>
+                                </ul>
+                                
                             </div>
                         </div>
-                        <div role=\\"region\\" aria-labelledby=\\"__panel-title-8\\" class=\\"fd-panel__content fd-panel__content--no-padding\\" aria-hidden=\\"false\\" id=\\"__panel-8\\">
-                            <ul class=\\"fd-list fd-list--byline\\" role=\\"list\\">
-                                <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-list__item--interractive\\">
-                                    <span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle\\" aria-role=\\"img\\" aria-label=\\"Lisa Miller\\">LM</span>
-                                    <div class=\\"fd-list__content\\">
-                                        <div class=\\"fd-list__title\\">Lisa Miller</div>
-                                        <div class=\\"fd-list__byline\\">test.lisa.miller@test.com</div>
-                                    </div>
+                        <nav class=\\"fd-menu fd-menu--icons fd-user-menu__menu\\">
+                            <ul class=\\"fd-menu__list fd-user-menu__menu-list\\" role=\\"menu\\">
+                                <li class=\\"fd-menu__item\\" role=\\"presentation\\">
+                                    <a class=\\"fd-menu__link\\" href=\\"#\\" role=\\"menuitem\\">
+                                        <span class=\\"fd-menu__addon-before\\">
+                                            <i class=\\"sap-icon--action-settings\\" role=\\"presentation\\"></i>
+                                        </span>
+                                        <span class=\\"fd-menu__title\\">Settings</span>
+                                    </a>
                                 </li>
-                                <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-list__item--interractive\\">
+    
+                                <li class=\\"fd-menu__item\\" role=\\"presentation\\">
                                     <span
-                                        class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--thumbnail\\"
-                                        aria-label=\\"Avatar\\"
-                                        style=\\"background-image: url('/assets/images/portraits/L_80x80_F3.png');\\">
+                                        class=\\"fd-menu__link has-child is-expanded\\"
+                                        aria-controls=\\"EX100M2B\\"
+                                        aria-expanded=\\"true\\"
+                                        aria-haspopup=\\"true\\"
+                                        role=\\"menuitem\\"
+                                        onclick=\\"onPopoverClick('EX100M2B')\\">
+                                            <span class=\\"fd-menu__addon-before\\">
+                                                <i class=\\"sap-icon--official-service\\" role=\\"presentation\\"></i>
+                                            </span>
+                                            <span class=\\"fd-menu__title\\">Legal Information</span>
+                                            <span class=\\"fd-menu__addon-after fd-menu__addon-after--submenu\\"></span>
                                     </span>
-                                    <div class=\\"fd-list__content\\">
-                                        <div class=\\"fd-list__title\\">Lisa Miller</div>
-                                        <div class=\\"fd-list__byline\\">lisa.miller@test.com</div>
-                                    </div>
+                                    
+                                    <ul class=\\"fd-menu__sublist\\" id=\\"EX100M2B\\" aria-hidden=\\"false\\" role=\\"menu\\">
+                                        <li class=\\"fd-menu__item\\" role=\\"presentation\\">
+                                            <a class=\\"fd-menu__link\\" href=\\"#\\" role=\\"menuitem\\">
+                                                <span class=\\"fd-menu__title\\">Privacy Policy</span>
+                                            </a>
+                                        </li>
+                                        <li class=\\"fd-menu__item\\" role=\\"presentation\\">
+                                            <a class=\\"fd-menu__link\\" href=\\"#\\" role=\\"menuitem\\">
+                                                <span class=\\"fd-menu__title\\">Terms of Service</span>
+                                            </a>
+                                        </li>
+                                    </ul>
                                 </li>
+    
+                                <li class=\\"fd-menu__item\\" role=\\"presentation\\">
+                                    <a class=\\"fd-menu__link\\" href=\\"#\\" role=\\"menuitem\\">
+                                        <span class=\\"fd-menu__addon-before\\">
+                                            <i class=\\"sap-icon--message-information\\" role=\\"presentation\\"></i>
+                                        </span>
+                                        <span class=\\"fd-menu__title\\">About</span>
+                                    </a>
+                                </li>
+                                
                             </ul>
-                        </div>
+                        </nav>  
                     </div>
-                    <ul class=\\"fd-navigation-list\\" role=\\"list\\">
-                        <li class=\\"fd-navigation-list__item\\" role=\\"none\\">
-                            <a class=\\"fd-navigation-list__content\\" role=\\"listitem\\" tabindex=\\"0\\">
-                                <div class=\\"fd-navigation-list__content-container\\">
-                                    <span class=\\"fd-navigation-list__icon\\">
-                                        <i class=\\" sap-icon--action-settings\\" role=\\"presentation\\"></i>
-                                    </span>
-                                    <span class=\\"fd-navigation-list__text\\">Settings</span>
-                                </div>
-                                <div class=\\"fd-navigation-list__expander\\">
-                                    <i class=\\"sap-icon--navigation-right-arrow\\" role=\\"presentation\\"></i>
-                                </div>
-                            </a>
-                        </li>
-                        <li class=\\"fd-navigation-list__item\\" role=\\"none\\">
-                            <a class=\\"fd-navigation-list__content\\" role=\\"listitem\\" tabindex=\\"0\\">
-                                <div class=\\"fd-navigation-list__content-container\\">
-                                    <span class=\\"fd-navigation-list__icon\\">
-                                        <i class=\\" sap-icon--official-service\\" role=\\"presentation\\"></i>
-                                    </span>
-                                    <span class=\\"fd-navigation-list__text\\">Legal Information</span>
-                                </div>
-                            </a>
-                        </li>
-                        <li class=\\"fd-navigation-list__item\\" role=\\"none\\">
-                            <a class=\\"fd-navigation-list__content\\" role=\\"listitem\\" tabindex=\\"0\\">
-                                <div class=\\"fd-navigation-list__content-container\\">
-                                    <span class=\\"fd-navigation-list__icon\\">
-                                        <i class=\\" sap-icon--message-information\\" role=\\"presentation\\"></i>
-                                    </span>
-                                    <span class=\\"fd-navigation-list__text\\">About</span>
-                                </div>
-                            </a>
-                        </li>
-                    </ul>
                 </div>
             </div>
             <div class=\\"fd-bar fd-bar--footer\\">
@@ -51875,12 +51959,6 @@ exports[`Check stories > Components/User Menu > Story Mobile > Should match snap
     <div style=\\"height: 700px;\\">
         <div class=\\"fd-user-menu fd-user-menu--mobile\\">
             <div class=\\"fd-bar fd-bar--header fd-user-menu__title-bar\\">
-                <div class=\\"fd-bar__left\\" aria-hidden=\\"true\\"></div>
-                <div class=\\"fd-bar__middle\\">
-                    <div class=\\"fd-bar__element\\">
-                        <h5 class=\\"fd-title fd-title--h5 fd-user-menu__title\\" aria-label=\\"text\\">Profile</h5>
-                    </div>
-                </div>
                 <div class=\\"fd-bar__right\\">
                     <div class=\\"fd-bar__element\\">
                         <button aria-label=\\"button\\" class=\\"fd-button fd-button--transparent\\">
@@ -51947,41 +52025,38 @@ exports[`Check stories > Components/User Menu > Story Mobile > Should match snap
                             </ul>
                         </div>
                     </div>
-                    <ul class=\\"fd-navigation-list\\" role=\\"list\\">
-                        <li class=\\"fd-navigation-list__item\\" role=\\"listitem\\" tabindex=\\"-1\\">
-                            <div class=\\"fd-navigation-list__content\\" tabindex=\\"0\\">
-                                <div class=\\"fd-navigation-list__content-container\\">
-                                    <span class=\\"fd-navigation-list__icon\\">
-                                        <i class=\\" sap-icon--action-settings\\" role=\\"presentation\\"></i>
+                    <nav class=\\"fd-menu fd-menu--icons fd-user-menu__menu\\">
+                        <ul class=\\"fd-menu__list fd-user-menu__menu-list\\" role=\\"menu\\">
+                            <li class=\\"fd-menu__item\\" role=\\"presentation\\">
+                                <a class=\\"fd-menu__link\\" href=\\"#\\" role=\\"menuitem\\">
+                                    <span class=\\"fd-menu__addon-before\\">
+                                        <i class=\\"sap-icon--action-settings\\" role=\\"presentation\\"></i>
                                     </span>
-                                    <span class=\\"fd-navigation-list__text\\">Settings</span>
-                                </div>
-                                <div class=\\"fd-navigation-list__expander\\">
-                                    <i class=\\"sap-icon--navigation-right-arrow\\" role=\\"presentation\\"></i>
-                                </div>
-                            </div>
-                        </li>
-                        <li class=\\"fd-navigation-list__item\\" role=\\"listitem\\" tabindex=\\"-1\\">
-                            <div class=\\"fd-navigation-list__content\\" tabindex=\\"0\\">
-                                <div class=\\"fd-navigation-list__content-container\\">
-                                    <span class=\\"fd-navigation-list__icon\\">
-                                        <i class=\\" sap-icon--official-service\\" role=\\"presentation\\"></i>
+                                    <span class=\\"fd-menu__title\\">Settings</span>
+                                </a>
+                            </li>
+
+                            <li class=\\"fd-menu__item\\" role=\\"presentation\\">
+                                <div class=\\"fd-menu__link is-selected\\" href=\\"#\\" role=\\"menuitem\\">
+                                    <span class=\\"fd-menu__addon-before\\">
+                                        <i class=\\"sap-icon--official-service\\" role=\\"presentation\\"></i>
                                     </span>
-                                    <span class=\\"fd-navigation-list__text\\">Legal Information</span>
+                                    <span class=\\"fd-menu__title\\">Legal Information</span>
+                                    <span class=\\"fd-menu__addon-after fd-menu__addon-after--submenu\\"></span>
                                 </div>
-                            </div>
-                        </li>
-                        <li class=\\"fd-navigation-list__item\\" role=\\"listitem\\" tabindex=\\"-1\\">
-                            <div class=\\"fd-navigation-list__content\\" tabindex=\\"0\\">
-                                <div class=\\"fd-navigation-list__content-container\\">
-                                    <span class=\\"fd-navigation-list__icon\\">
-                                        <i class=\\" sap-icon--message-information\\" role=\\"presentation\\"></i>
+                            </li>
+
+                            <li class=\\"fd-menu__item\\" role=\\"presentation\\">
+                                <a class=\\"fd-menu__link\\" href=\\"#\\" role=\\"menuitem\\">
+                                    <span class=\\"fd-menu__addon-before\\">
+                                        <i class=\\"sap-icon--message-information\\" role=\\"presentation\\"></i>
                                     </span>
-                                    <span class=\\"fd-navigation-list__text\\">About</span>
-                                </div>
-                            </div>
-                        </li>
-                    </ul>
+                                    <span class=\\"fd-menu__title\\">About</span>
+                                </a>
+                            </li>
+                            
+                        </ul>
+                    </nav>  
                 </div>
             </div>
             <div class=\\"fd-bar fd-bar--footer fd-user-menu__footer\\">
@@ -52007,93 +52082,26 @@ exports[`Check stories > Components/User Menu > Story Mobile > Should match snap
                         </button>
                     </div>
                     <div class=\\"fd-bar__element\\">
-                        <h5 class=\\"fd-title fd-title--h5\\" aria-label=\\"text\\">Settings</h5>
+                        <h5 class=\\"fd-title fd-title--h5\\" aria-label=\\"text\\">Legal Information</h5>
                     </div>
                 </div>
             </div>
             <div class=\\"fd-user-menu__body\\">
-                <ul class=\\"fd-navigation-list\\" role=\\"list\\">
-                    <li class=\\"fd-navigation-list__item\\" role=\\"listitem\\" tabindex=\\"-1\\">
-                        <div class=\\"fd-navigation-list__content\\" tabindex=\\"0\\">
-                            <div class=\\"fd-navigation-list__content-container\\">
-                                <span class=\\"fd-navigation-list__icon\\">
-                                    <i class=\\" sap-icon--action-settings\\" role=\\"presentation\\"></i>
-                                </span>
-                                <span class=\\"fd-navigation-list__text\\">Settings Item</span>
+                <nav class=\\"fd-menu fd-user-menu__menu\\">
+                    <ul class=\\"fd-menu__list fd-user-menu__menu-list\\" role=\\"menu\\">
+                        <li class=\\"fd-menu__item\\" role=\\"presentation\\">
+                            <a class=\\"fd-menu__link\\" href=\\"#\\" role=\\"menuitem\\">
+                                <span class=\\"fd-menu__title\\">Privacy Policy</span>
+                            </a>
+                        </li>
+
+                        <li class=\\"fd-menu__item\\" role=\\"presentation\\">
+                            <div class=\\"fd-menu__link\\" href=\\"#\\" role=\\"menuitem\\">
+                                <span class=\\"fd-menu__title\\">Terms of Service</span>
                             </div>
-                        </div>
-                    </li>
-                    <li class=\\"fd-navigation-list__item\\" role=\\"listitem\\" tabindex=\\"-1\\">
-                        <div class=\\"fd-navigation-list__content\\" tabindex=\\"0\\">
-                            <div class=\\"fd-navigation-list__content-container\\">
-                                <span class=\\"fd-navigation-list__icon\\">
-                                    <i class=\\" sap-icon--action-settings\\" role=\\"presentation\\"></i>
-                                </span>
-                                <span class=\\"fd-navigation-list__text\\">Settings Item</span>
-                            </div>
-                        </div>
-                    </li>
-                    <li class=\\"fd-navigation-list__item\\" role=\\"listitem\\" tabindex=\\"-1\\">
-                        <div class=\\"fd-navigation-list__content\\" tabindex=\\"0\\">
-                            <div class=\\"fd-navigation-list__content-container\\">
-                                <span class=\\"fd-navigation-list__icon\\">
-                                    <i class=\\" sap-icon--action-settings\\" role=\\"presentation\\"></i>
-                                </span>
-                                <span class=\\"fd-navigation-list__text\\">Settings Item</span>
-                            </div>
-                        </div>
-                    </li>
-                    <li class=\\"fd-navigation-list__item\\" role=\\"listitem\\" tabindex=\\"-1\\">
-                        <div class=\\"fd-navigation-list__content\\" tabindex=\\"0\\">
-                            <div class=\\"fd-navigation-list__content-container\\">
-                                <span class=\\"fd-navigation-list__icon\\">
-                                    <i class=\\" sap-icon--action-settings\\" role=\\"presentation\\"></i>
-                                </span>
-                                <span class=\\"fd-navigation-list__text\\">Settings Item</span>
-                            </div>
-                        </div>
-                    </li>
-                    <li class=\\"fd-navigation-list__item\\" role=\\"listitem\\" tabindex=\\"-1\\">
-                        <div class=\\"fd-navigation-list__content\\" tabindex=\\"0\\">
-                            <div class=\\"fd-navigation-list__content-container\\">
-                                <span class=\\"fd-navigation-list__icon\\">
-                                    <i class=\\" sap-icon--action-settings\\" role=\\"presentation\\"></i>
-                                </span>
-                                <span class=\\"fd-navigation-list__text\\">Settings Item</span>
-                            </div>
-                        </div>
-                    </li>
-                    <li class=\\"fd-navigation-list__item\\" role=\\"listitem\\" tabindex=\\"-1\\">
-                        <div class=\\"fd-navigation-list__content\\" tabindex=\\"0\\">
-                            <div class=\\"fd-navigation-list__content-container\\">
-                                <span class=\\"fd-navigation-list__icon\\">
-                                    <i class=\\" sap-icon--action-settings\\" role=\\"presentation\\"></i>
-                                </span>
-                                <span class=\\"fd-navigation-list__text\\">Settings Item</span>
-                            </div>
-                        </div>
-                    </li>
-                    <li class=\\"fd-navigation-list__item\\" role=\\"listitem\\" tabindex=\\"-1\\">
-                        <div class=\\"fd-navigation-list__content\\" tabindex=\\"0\\">
-                            <div class=\\"fd-navigation-list__content-container\\">
-                                <span class=\\"fd-navigation-list__icon\\">
-                                    <i class=\\" sap-icon--action-settings\\" role=\\"presentation\\"></i>
-                                </span>
-                                <span class=\\"fd-navigation-list__text\\">Settings Item</span>
-                            </div>
-                        </div>
-                    </li>
-                    <li class=\\"fd-navigation-list__item\\" role=\\"listitem\\" tabindex=\\"-1\\">
-                        <div class=\\"fd-navigation-list__content\\" tabindex=\\"0\\">
-                            <div class=\\"fd-navigation-list__content-container\\">
-                                <span class=\\"fd-navigation-list__icon\\">
-                                    <i class=\\" sap-icon--action-settings\\" role=\\"presentation\\"></i>
-                                </span>
-                                <span class=\\"fd-navigation-list__text\\">Settings Item</span>
-                            </div>
-                        </div>
-                    </li>
-                </ul>
+                        </li>
+                    </ul>
+                </nav>  
             </div>
             <div class=\\"fd-bar fd-bar--footer fd-user-menu__footer\\">
                 <div class=\\"fd-bar__right\\">


### PR DESCRIPTION
## Related Issue
Closes none

## Description
- added new type of List called "subline" that is used in User Menu panel to display account information

<img width="1187" alt="Screenshot 2025-02-17 at 4 50 57 PM" src="https://github.com/user-attachments/assets/7ba5e975-cd3d-49a3-a33d-6e2b7e115b4b" />

- User menu is refactored to use Menu and not Navigation List (this is a Breaking change)
- Menu component sublist needed some small fixes for the paddings when is used in Menu with icons
- New modifier classes for the User Menu: `.fd-user-menu__menu` and `.fd-user-menu__menu-list` for style overwrite of Menu elements.


BREAKING CHANGES:
- User Menu is now using Menu, not Navigation List
- User Menu is wrapped in `.fd-popover__wrapper` element
- New classes: `.fd-user-menu__menu` and `.fd-user-menu__menu-list`