### PR TITLE
fix(styles): show outline on focus for input group [ci visual]

### DIFF
--- a/packages/styles/src/input-group.scss
+++ b/packages/styles/src/input-group.scss
@@ -29,6 +29,14 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
   --fdInput_Height: 100%;
   --fdInput_Compact_Height: 100%;
 
+  &:has(input:is(:focus)),
+  &:has(button:is(:focus)) {
+    background: var(--sapField_Focus_Background);
+    outline: var(--fdInput_Outline_Color) var(--sapContent_FocusStyle) var(--sapContent_FocusWidth);
+    outline-offset: var(--fdInput_Outline_Offset);
+    box-shadow: none;
+  }
+
   .#{$block}__input {
     @include fd-reset-child-spacing();
 
@@ -105,6 +113,14 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
       padding-block: 0;
       padding-inline: 0;
       overflow: visible;
+
+      button {
+        @include fd-focus() {
+          &::after {
+            border: none;
+          }
+        }
+      }
     }
   }
 

--- a/packages/styles/src/mixins/_forms.scss
+++ b/packages/styles/src/mixins/_forms.scss
@@ -100,6 +100,7 @@ $fd-input-field-height--compact: 1.625rem;
 @mixin fd-input-readonly() {
   --fdInput_Outline_Offset: -0.25rem;
 
+  z-index: -1;
   box-shadow: none;
   border-color: var(--sapField_ReadOnly_BorderColor);
   background: var(--sapField_ReadOnly_BackgroundStyle);


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/5951

## Description
Input Group is a composite component consisting of an input and a button. The current CSS allows us to detect focus on either element and apply a focus outline to the parent. Previously, this was possible in Fundamental-ngx but required JavaScript in Fundamental-styles.