### PR TITLE
fix(styles): bring CSS for byline list from fund-ngx

### DIFF
--- a/packages/styles/src/mixins/list/_list-base.scss
+++ b/packages/styles/src/mixins/list/_list-base.scss
@@ -8,6 +8,7 @@
   position: relative;
   list-style: none;
   width: 100%;
+  max-width: 100% !important;
 
   &__item,
   &__group-header,

--- a/packages/styles/src/mixins/list/_list-byline.scss
+++ b/packages/styles/src/mixins/list/_list-byline.scss
@@ -171,6 +171,10 @@ $fd-list-byline-section-text-color: var(--sapContent_LabelColor) !default;
       }
     }
 
+    .#{$block}__group-header {
+      @include fd-set-height(var(--sapElement_LineHeight));
+    }
+
     &.#{$block}--unread-indicator {
       .#{$block}__item {
         @include fd-set-paddings-x($fd-list-unread-indicator-spacing, $fd-list-byline-item-padding-x);

--- a/packages/styles/stories/Components/List/list/byline/byline-list.stories.js
+++ b/packages/styles/stories/Components/List/list/byline/byline-list.stories.js
@@ -10,6 +10,7 @@ import buttonsExampleHtml from "./buttons.example.html?raw";
 import navigationExampleHtml from "./navigation.example.html?raw";
 import attachmentExampleHtml from "./attachment.example.html?raw";
 import standardExampleHtml from "./standard.example.html?raw";
+import groupHeaderExampleHtml from "./group-header.example.html?raw";
 import '../../../../../src/list.scss';
 import '../../../../../src/icon.scss';
 import '../../../../../src/checkbox.scss';
@@ -159,6 +160,9 @@ When more than 100 characters for small screens or 300 characters for medium to 
     }
   }
 };
+export const GroupHeader = () => groupHeaderExampleHtml;
+GroupHeader.storyName = 'With Group Header';
+
 export const UnreadNotification = () => unreadNotificationExampleHtml;
 UnreadNotification.parameters = {
   docs: {

--- a/packages/styles/stories/Components/List/list/byline/group-header.example.html
+++ b/packages/styles/stories/Components/List/list/byline/group-header.example.html
@@ -1,0 +1,56 @@
+<h4>Standard size</h4>
+<ul class="fd-list fd-list--byline" role="list">
+    <li role="listitem" class="fd-list__group-header">
+        <span class="fd-list__title">Group header 1</span>
+    </li>
+    <li role="listitem" tabindex="0" class="fd-list__item">
+        <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
+        <div class="fd-list__content">
+            <div class="fd-list__title">List Item Title</div>
+            <div class="fd-list__byline">Byline (description)</div>
+        </div>
+    </li>
+    <li role="listitem" tabindex="0" class="fd-list__item">
+        <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--employee"></i></span>
+        <div class="fd-list__content">
+            <div class="fd-list__title">List item with no byline</div>
+        </div>
+    </li>
+    <li role="listitem" tabindex="0" class="fd-list__item">
+        <span class="fd-image--s fd-list__thumbnail" aria-label="Godafoss waterfall in northern Iceland"
+              style="background-image: url('assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg'); background-size:cover;"></span>
+        <div class="fd-list__content">
+            <div class="fd-list__title">List item with 2-column byline</div>
+            <div class="fd-list__byline fd-list__byline--2-col">
+                <div class="fd-list__byline-left">First text item in byline (standard text)</div>
+                <div class="fd-list__byline-right">Second text item in byline (can be semantic)</div>
+            </div>
+        </div>
+    </li>
+    <li role="listitem" class="fd-list__group-header">
+        <span class="fd-list__title">Group header 2</span>
+      </li>
+    <li role="listitem" tabindex="0" class="fd-list__item">
+        <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--employee"></i></span>
+        <div class="fd-list__content">
+            <div class="fd-list__title">List item with no byline</div>
+        </div>
+    </li>
+    <li role="listitem" tabindex="0" class="fd-list__item">
+    <span class="fd-image--s fd-list__thumbnail" aria-label="Godafoss waterfall in northern Iceland"
+          style="background-image: url('assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg'); background-size:cover;"></span>
+        <div class="fd-list__content">
+            <div class="fd-list__title">List item with 2-column byline</div>
+            <div class="fd-list__byline fd-list__byline--2-col">
+                <div class="fd-list__byline-left">First text item in byline (standard text)</div>
+                <div class="fd-list__byline-right">Second text item in byline (can be semantic)</div>
+            </div>
+        </div>
+    </li>
+    <li role="listitem" tabindex="0" class="fd-list__item">
+        <div class="fd-list__content">
+            <div class="fd-list__title">Text-only list item</div>
+            <div class="fd-list__byline">Byline (description)</div>
+        </div>
+    </li>
+</ul>

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -27297,6 +27297,66 @@ style=\\"background-image: url('assets/images/backgrounds/Godafoss_waterfall_in_
 "
 `;
 
+exports[`Check stories > Components/List/Byline > Story GroupHeader > Should match snapshot 1`] = `
+"<h4>Standard size</h4>
+<ul class=\\"fd-list fd-list--byline\\" role=\\"list\\">
+    <li role=\\"listitem\\" class=\\"fd-list__group-header\\">
+        <span class=\\"fd-list__title\\">Group header 1</span>
+    </li>
+    <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
+        <span class=\\"fd-list__thumbnail\\"><i role=\\"presentation\\" class=\\"sap-icon--activate\\"></i></span>
+        <div class=\\"fd-list__content\\">
+            <div class=\\"fd-list__title\\">List Item Title</div>
+            <div class=\\"fd-list__byline\\">Byline (description)</div>
+        </div>
+    </li>
+    <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
+        <span class=\\"fd-list__thumbnail\\"><i role=\\"presentation\\" class=\\"sap-icon--employee\\"></i></span>
+        <div class=\\"fd-list__content\\">
+            <div class=\\"fd-list__title\\">List item with no byline</div>
+        </div>
+    </li>
+    <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
+        <span class=\\"fd-image--s fd-list__thumbnail\\" aria-label=\\"Godafoss waterfall in northern Iceland\\"
+              style=\\"background-image: url('assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg'); background-size:cover;\\"></span>
+        <div class=\\"fd-list__content\\">
+            <div class=\\"fd-list__title\\">List item with 2-column byline</div>
+            <div class=\\"fd-list__byline fd-list__byline--2-col\\">
+                <div class=\\"fd-list__byline-left\\">First text item in byline (standard text)</div>
+                <div class=\\"fd-list__byline-right\\">Second text item in byline (can be semantic)</div>
+            </div>
+        </div>
+    </li>
+    <li role=\\"listitem\\" class=\\"fd-list__group-header\\">
+        <span class=\\"fd-list__title\\">Group header 2</span>
+      </li>
+    <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
+        <span class=\\"fd-list__thumbnail\\"><i role=\\"presentation\\" class=\\"sap-icon--employee\\"></i></span>
+        <div class=\\"fd-list__content\\">
+            <div class=\\"fd-list__title\\">List item with no byline</div>
+        </div>
+    </li>
+    <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
+    <span class=\\"fd-image--s fd-list__thumbnail\\" aria-label=\\"Godafoss waterfall in northern Iceland\\"
+          style=\\"background-image: url('assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg'); background-size:cover;\\"></span>
+        <div class=\\"fd-list__content\\">
+            <div class=\\"fd-list__title\\">List item with 2-column byline</div>
+            <div class=\\"fd-list__byline fd-list__byline--2-col\\">
+                <div class=\\"fd-list__byline-left\\">First text item in byline (standard text)</div>
+                <div class=\\"fd-list__byline-right\\">Second text item in byline (can be semantic)</div>
+            </div>
+        </div>
+    </li>
+    <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
+        <div class=\\"fd-list__content\\">
+            <div class=\\"fd-list__title\\">Text-only list item</div>
+            <div class=\\"fd-list__byline\\">Byline (description)</div>
+        </div>
+    </li>
+</ul>
+"
+`;
+
 exports[`Check stories > Components/List/Byline > Story Interractive > Should match snapshot 1`] = `
 "<ul class=\\"fd-list fd-list--byline\\" role=\\"list\\">
     <li role=\\"listitem\\" tabindex=\\"-1\\" class=\\"fd-list__item fd-list__item--interractive\\">


### PR DESCRIPTION
## Related Issue
related to https://github.com/SAP/fundamental-ngx/issues/13107

## Description
- brings CSS from fund-ngx 
- ensures the height of the li element with group header stays consistent in byline
- updates the example to catch problems with visual tests