### PR TITLE
fix(styles): add design and a11y updates for Breadcrumb [ci visual]

### DIFF
--- a/packages/styles/src/breadcrumb.scss
+++ b/packages/styles/src/breadcrumb.scss
@@ -6,7 +6,6 @@
 $block: #{$fd-namespace}-breadcrumb;
 
 .#{$block} {
-  // BLOCK BASE *******************************************
   @include fd-reset();
 
   @include fd-flex-vertical-center() {
@@ -16,16 +15,17 @@ $block: #{$fd-namespace}-breadcrumb;
   --fdLink_Line_Height: 1.5rem;
 
   list-style: none;
+  margin-block-end: 0.5rem;
 
-  // ELEMENTS *******************************************
   &__item {
     @include fd-reset();
 
+    padding-block: 0.0625rem;
     color: var(--sapContent_LabelColor);
 
     &::after {
       margin-inline: 0.25rem;
-      color: var(--sapContent_LabelColor);
+      color: var(--sapTextColor);
       content: var(--fdBreadcrumb_Separator, "/");
     }
 

--- a/packages/styles/stories/Components/breadcrumb/current-item.example.html
+++ b/packages/styles/stories/Components/breadcrumb/current-item.example.html
@@ -1,23 +1,51 @@
 <nav aria-label="Breadcrumb Trail">
     <ol class="fd-breadcrumb">
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Products</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Suppliers</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Titanium</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Ultra Portable</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">12 inch</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Super portable deluxe</span></a></li>
-        <li aria-current="page" class="fd-breadcrumb__item">Laptop</li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Root Page 1 of 7"><span class="fd-link__content">Products</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 2 of 7"><span class="fd-link__content">Suppliers</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 3 of 7"><span class="fd-link__content">Titanium</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 4 of 7"><span class="fd-link__content">Ultra Portable</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 5 of 7"><span class="fd-link__content">12 inch</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 6 of 7"><span class="fd-link__content">Super portable deluxe</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <span role="link" aria-current="page" aria-label="Current page 7 of 7">Laptop</span>
+        </li>
     </ol>
 </nav>
 <br>
 <nav aria-label="Breadcrumb Trail">
     <ol class="fd-breadcrumb">
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Products</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Suppliers</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Titanium</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Ultra Portable</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">12 inch</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Super portable deluxe</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Laptop</span></a></li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Root Page 1 of 7"><span class="fd-link__content">Products</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 2 of 7"><span class="fd-link__content">Suppliers</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 3 of 7"><span class="fd-link__content">Titanium</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 4 of 7"><span class="fd-link__content">Ultra Portable</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 5 of 7"><span class="fd-link__content">12 inch</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 6 of 7"><span class="fd-link__content">Super portable deluxe</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="page" aria-label="Current page 7 of 7"><span class="fd-link__content">Laptop</span></a>
+        </li>
     </ol>
 </nav>

--- a/packages/styles/stories/Components/breadcrumb/overflow.example.html
+++ b/packages/styles/stories/Components/breadcrumb/overflow.example.html
@@ -21,28 +21,30 @@
                 <div class="fd-popover__wrapper">
                     <ul class="fd-list fd-list--navigation" role="menu">
                         <li tabindex="-1" role="menuitem" class="fd-list__item fd-list__item--link">
-                            <a tabindex="0" class="fd-list__link" href="#">
-                                <span class="fd-list__title">Products</span>
-                            </a>
+                            <a class="fd-list__link" tabindex="0" href="#" aria-current="false" aria-label="Root Page 1 of 7"><span class="fd-list__title">Products</span></a>
                         </li>
                         <li tabindex="-1" role="menuitem" class="fd-list__item fd-list__item--link">
-                            <a tabindex="0" class="fd-list__link" href="#">
-                                <span class="fd-list__title">Suppliers</span>
-                            </a>
+                            <a class="fd-list__link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 2 of 7"><span class="fd-list__title">Suppliers</span></a>
                         </li>
                         <li tabindex="-1" role="menuitem" class="fd-list__item fd-list__item--link">
-                            <a tabindex="0" class="fd-list__link" href="#">
-                                <span class="fd-list__title">Titanium</span>
-                            </a>
+                            <a class="fd-list__link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 3 of 7"><span class="fd-list__title">Titanium</span></a>
                         </li>
                     </ul>
                 </div>
             </div>
         </div></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Ultra Portable</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">12 inch</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Super portable deluxe</span></a></li>
-        <li aria-current="page" class="fd-breadcrumb__item">Laptop</li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 4 of 7"><span class="fd-link__content">Ultra Portable</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 5 of 7"><span class="fd-link__content">12 inch</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 6 of 7"><span class="fd-link__content">Super portable deluxe</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <span role="link" aria-current="page" aria-label="Current page 7 of 7">Laptop</span>
+        </li>
     </ol>
 </nav>
 <div style="height: 150px"></div>

--- a/packages/styles/stories/Components/breadcrumb/standard.example.html
+++ b/packages/styles/stories/Components/breadcrumb/standard.example.html
@@ -1,11 +1,25 @@
 <nav aria-label="Breadcrumb Trail">
     <ol class="fd-breadcrumb">
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Products</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Suppliers</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Titanium</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Ultra Portable</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">12 inch</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Super portable deluxe</span></a></li>
-        <li aria-current="page" class="fd-breadcrumb__item">Laptop</li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Root Page 1 of 7"><span class="fd-link__content">Products</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 2 of 7"><span class="fd-link__content">Suppliers</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 3 of 7"><span class="fd-link__content">Titanium</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 4 of 7"><span class="fd-link__content">Ultra Portable</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 5 of 7"><span class="fd-link__content">12 inch</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 6 of 7"><span class="fd-link__content">Super portable deluxe</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <span role="link" aria-current="page" aria-label="Current page 7 of 7">Laptop</span>
+        </li>
     </ol>
 </nav>

--- a/packages/styles/stories/Components/breadcrumb/styles.example.html
+++ b/packages/styles/stories/Components/breadcrumb/styles.example.html
@@ -1,77 +1,161 @@
 <h4>Slash (default)</h4>
 <nav aria-label="Breadcrumb Trail">
     <ol class="fd-breadcrumb">
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Products</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Suppliers</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Titanium</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Ultra Portable</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">12 inch</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Super portable deluxe</span></a></li>
-        <li aria-current="page" class="fd-breadcrumb__item">Laptop</li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Root Page 1 of 7"><span class="fd-link__content">Products</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 2 of 7"><span class="fd-link__content">Suppliers</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 3 of 7"><span class="fd-link__content">Titanium</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 4 of 7"><span class="fd-link__content">Ultra Portable</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 5 of 7"><span class="fd-link__content">12 inch</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 6 of 7"><span class="fd-link__content">Super portable deluxe</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <span role="link" aria-current="page" aria-label="Current page 7 of 7">Laptop</span>
+        </li>
     </ol>
 </nav>
 
 <h4>Backslash</h4>
 <nav aria-label="Breadcrumb Trail">
     <ol class="fd-breadcrumb fd-breadcrumb--backslash">
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Products</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Suppliers</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Titanium</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Ultra Portable</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">12 inch</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Super portable deluxe</span></a></li>
-        <li aria-current="page" class="fd-breadcrumb__item">Laptop</li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Root Page 1 of 7"><span class="fd-link__content">Products</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 2 of 7"><span class="fd-link__content">Suppliers</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 3 of 7"><span class="fd-link__content">Titanium</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 4 of 7"><span class="fd-link__content">Ultra Portable</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 5 of 7"><span class="fd-link__content">12 inch</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 6 of 7"><span class="fd-link__content">Super portable deluxe</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <span role="link" aria-current="page" aria-label="Current page 7 of 7">Laptop</span>
+        </li>
     </ol>
 </nav>
 
 <h4>Double slash</h4>
 <nav aria-label="Breadcrumb Trail">
     <ol class="fd-breadcrumb fd-breadcrumb--double-slash">
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Products</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Suppliers</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Titanium</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Ultra Portable</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">12 inch</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Super portable deluxe</span></a></li>
-        <li aria-current="page" class="fd-breadcrumb__item">Laptop</li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Root Page 1 of 7"><span class="fd-link__content">Products</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 2 of 7"><span class="fd-link__content">Suppliers</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 3 of 7"><span class="fd-link__content">Titanium</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 4 of 7"><span class="fd-link__content">Ultra Portable</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 5 of 7"><span class="fd-link__content">12 inch</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 6 of 7"><span class="fd-link__content">Super portable deluxe</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <span role="link" aria-current="page" aria-label="Current page 7 of 7">Laptop</span>
+        </li>
     </ol>
 </nav>
 
 <h4>Double backslash</h4>
 <nav aria-label="Breadcrumb Trail">
     <ol class="fd-breadcrumb fd-breadcrumb--double-backslash">
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Products</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Suppliers</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Titanium</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Ultra Portable</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">12 inch</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Super portable deluxe</span></a></li>
-        <li aria-current="page" class="fd-breadcrumb__item">Laptop</li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Root Page 1 of 7"><span class="fd-link__content">Products</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 2 of 7"><span class="fd-link__content">Suppliers</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 3 of 7"><span class="fd-link__content">Titanium</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 4 of 7"><span class="fd-link__content">Ultra Portable</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 5 of 7"><span class="fd-link__content">12 inch</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 6 of 7"><span class="fd-link__content">Super portable deluxe</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <span role="link" aria-current="page" aria-label="Current page 7 of 7">Laptop</span>
+        </li>
     </ol>
 </nav>
 
 <h4>Greater than</h4>
 <nav aria-label="Breadcrumb Trail">
     <ol class="fd-breadcrumb fd-breadcrumb--greater-than">
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Products</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Suppliers</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Titanium</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Ultra Portable</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">12 inch</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Super portable deluxe</span></a></li>
-        <li aria-current="page" class="fd-breadcrumb__item">Laptop</li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Root Page 1 of 7"><span class="fd-link__content">Products</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 2 of 7"><span class="fd-link__content">Suppliers</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 3 of 7"><span class="fd-link__content">Titanium</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 4 of 7"><span class="fd-link__content">Ultra Portable</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 5 of 7"><span class="fd-link__content">12 inch</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 6 of 7"><span class="fd-link__content">Super portable deluxe</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <span role="link" aria-current="page" aria-label="Current page 7 of 7">Laptop</span>
+        </li>
     </ol>
 </nav>
 
 <h4>Double greater than</h4>
 <nav aria-label="Breadcrumb Trail">
     <ol class="fd-breadcrumb fd-breadcrumb--double-greater-than">
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Products</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Suppliers</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Titanium</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Ultra Portable</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">12 inch</span></a></li>
-        <li class="fd-breadcrumb__item"><a class="fd-link" tabindex="0" href="#"><span class="fd-link__content">Super portable deluxe</span></a></li>
-        <li aria-current="page" class="fd-breadcrumb__item">Laptop</li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Root Page 1 of 7"><span class="fd-link__content">Products</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 2 of 7"><span class="fd-link__content">Suppliers</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 3 of 7"><span class="fd-link__content">Titanium</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 4 of 7"><span class="fd-link__content">Ultra Portable</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 5 of 7"><span class="fd-link__content">12 inch</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <a class="fd-link" tabindex="0" href="#" aria-current="false" aria-label="Parent Page 6 of 7"><span class="fd-link__content">Super portable deluxe</span></a>
+        </li>
+        <li class="fd-breadcrumb__item">
+            <span role="link" aria-current="page" aria-label="Current page 7 of 7">Laptop</span>
+        </li>
     </ol>
 </nav>

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -9778,25 +9778,53 @@ exports[`Check stories > Components/Bar > Story Subheader > Should match snapsho
 exports[`Check stories > Components/Breadcrumb > Story CurrentItem > Should match snapshot 1`] = `
 "<nav aria-label=\\"Breadcrumb Trail\\">
     <ol class=\\"fd-breadcrumb\\">
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Products</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Suppliers</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Titanium</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Ultra Portable</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">12 inch</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Super portable deluxe</span></a></li>
-        <li aria-current=\\"page\\" class=\\"fd-breadcrumb__item\\">Laptop</li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Root Page 1 of 7\\"><span class=\\"fd-link__content\\">Products</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 2 of 7\\"><span class=\\"fd-link__content\\">Suppliers</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 3 of 7\\"><span class=\\"fd-link__content\\">Titanium</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 4 of 7\\"><span class=\\"fd-link__content\\">Ultra Portable</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 5 of 7\\"><span class=\\"fd-link__content\\">12 inch</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 6 of 7\\"><span class=\\"fd-link__content\\">Super portable deluxe</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <span role=\\"link\\" aria-current=\\"page\\" aria-label=\\"Current page 7 of 7\\">Laptop</span>
+        </li>
     </ol>
 </nav>
 <br>
 <nav aria-label=\\"Breadcrumb Trail\\">
     <ol class=\\"fd-breadcrumb\\">
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Products</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Suppliers</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Titanium</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Ultra Portable</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">12 inch</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Super portable deluxe</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Laptop</span></a></li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Root Page 1 of 7\\"><span class=\\"fd-link__content\\">Products</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 2 of 7\\"><span class=\\"fd-link__content\\">Suppliers</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 3 of 7\\"><span class=\\"fd-link__content\\">Titanium</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 4 of 7\\"><span class=\\"fd-link__content\\">Ultra Portable</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 5 of 7\\"><span class=\\"fd-link__content\\">12 inch</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 6 of 7\\"><span class=\\"fd-link__content\\">Super portable deluxe</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"page\\" aria-label=\\"Current page 7 of 7\\"><span class=\\"fd-link__content\\">Laptop</span></a>
+        </li>
     </ol>
 </nav>
 "
@@ -9826,28 +9854,30 @@ exports[`Check stories > Components/Breadcrumb > Story Overflow > Should match s
                 <div class=\\"fd-popover__wrapper\\">
                     <ul class=\\"fd-list fd-list--navigation\\" role=\\"menu\\">
                         <li tabindex=\\"-1\\" role=\\"menuitem\\" class=\\"fd-list__item fd-list__item--link\\">
-                            <a tabindex=\\"0\\" class=\\"fd-list__link\\" href=\\"#\\">
-                                <span class=\\"fd-list__title\\">Products</span>
-                            </a>
+                            <a class=\\"fd-list__link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Root Page 1 of 7\\"><span class=\\"fd-list__title\\">Products</span></a>
                         </li>
                         <li tabindex=\\"-1\\" role=\\"menuitem\\" class=\\"fd-list__item fd-list__item--link\\">
-                            <a tabindex=\\"0\\" class=\\"fd-list__link\\" href=\\"#\\">
-                                <span class=\\"fd-list__title\\">Suppliers</span>
-                            </a>
+                            <a class=\\"fd-list__link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 2 of 7\\"><span class=\\"fd-list__title\\">Suppliers</span></a>
                         </li>
                         <li tabindex=\\"-1\\" role=\\"menuitem\\" class=\\"fd-list__item fd-list__item--link\\">
-                            <a tabindex=\\"0\\" class=\\"fd-list__link\\" href=\\"#\\">
-                                <span class=\\"fd-list__title\\">Titanium</span>
-                            </a>
+                            <a class=\\"fd-list__link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 3 of 7\\"><span class=\\"fd-list__title\\">Titanium</span></a>
                         </li>
                     </ul>
                 </div>
             </div>
         </div></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Ultra Portable</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">12 inch</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Super portable deluxe</span></a></li>
-        <li aria-current=\\"page\\" class=\\"fd-breadcrumb__item\\">Laptop</li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 4 of 7\\"><span class=\\"fd-link__content\\">Ultra Portable</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 5 of 7\\"><span class=\\"fd-link__content\\">12 inch</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 6 of 7\\"><span class=\\"fd-link__content\\">Super portable deluxe</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <span role=\\"link\\" aria-current=\\"page\\" aria-label=\\"Current page 7 of 7\\">Laptop</span>
+        </li>
     </ol>
 </nav>
 <div style=\\"height: 150px\\"></div>
@@ -9857,13 +9887,27 @@ exports[`Check stories > Components/Breadcrumb > Story Overflow > Should match s
 exports[`Check stories > Components/Breadcrumb > Story Standard > Should match snapshot 1`] = `
 "<nav aria-label=\\"Breadcrumb Trail\\">
     <ol class=\\"fd-breadcrumb\\">
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Products</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Suppliers</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Titanium</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Ultra Portable</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">12 inch</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Super portable deluxe</span></a></li>
-        <li aria-current=\\"page\\" class=\\"fd-breadcrumb__item\\">Laptop</li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Root Page 1 of 7\\"><span class=\\"fd-link__content\\">Products</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 2 of 7\\"><span class=\\"fd-link__content\\">Suppliers</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 3 of 7\\"><span class=\\"fd-link__content\\">Titanium</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 4 of 7\\"><span class=\\"fd-link__content\\">Ultra Portable</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 5 of 7\\"><span class=\\"fd-link__content\\">12 inch</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 6 of 7\\"><span class=\\"fd-link__content\\">Super portable deluxe</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <span role=\\"link\\" aria-current=\\"page\\" aria-label=\\"Current page 7 of 7\\">Laptop</span>
+        </li>
     </ol>
 </nav>
 "
@@ -9873,78 +9917,162 @@ exports[`Check stories > Components/Breadcrumb > Story Styles > Should match sna
 "<h4>Slash (default)</h4>
 <nav aria-label=\\"Breadcrumb Trail\\">
     <ol class=\\"fd-breadcrumb\\">
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Products</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Suppliers</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Titanium</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Ultra Portable</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">12 inch</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Super portable deluxe</span></a></li>
-        <li aria-current=\\"page\\" class=\\"fd-breadcrumb__item\\">Laptop</li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Root Page 1 of 7\\"><span class=\\"fd-link__content\\">Products</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 2 of 7\\"><span class=\\"fd-link__content\\">Suppliers</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 3 of 7\\"><span class=\\"fd-link__content\\">Titanium</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 4 of 7\\"><span class=\\"fd-link__content\\">Ultra Portable</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 5 of 7\\"><span class=\\"fd-link__content\\">12 inch</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 6 of 7\\"><span class=\\"fd-link__content\\">Super portable deluxe</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <span role=\\"link\\" aria-current=\\"page\\" aria-label=\\"Current page 7 of 7\\">Laptop</span>
+        </li>
     </ol>
 </nav>
 
 <h4>Backslash</h4>
 <nav aria-label=\\"Breadcrumb Trail\\">
     <ol class=\\"fd-breadcrumb fd-breadcrumb--backslash\\">
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Products</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Suppliers</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Titanium</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Ultra Portable</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">12 inch</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Super portable deluxe</span></a></li>
-        <li aria-current=\\"page\\" class=\\"fd-breadcrumb__item\\">Laptop</li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Root Page 1 of 7\\"><span class=\\"fd-link__content\\">Products</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 2 of 7\\"><span class=\\"fd-link__content\\">Suppliers</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 3 of 7\\"><span class=\\"fd-link__content\\">Titanium</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 4 of 7\\"><span class=\\"fd-link__content\\">Ultra Portable</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 5 of 7\\"><span class=\\"fd-link__content\\">12 inch</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 6 of 7\\"><span class=\\"fd-link__content\\">Super portable deluxe</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <span role=\\"link\\" aria-current=\\"page\\" aria-label=\\"Current page 7 of 7\\">Laptop</span>
+        </li>
     </ol>
 </nav>
 
 <h4>Double slash</h4>
 <nav aria-label=\\"Breadcrumb Trail\\">
     <ol class=\\"fd-breadcrumb fd-breadcrumb--double-slash\\">
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Products</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Suppliers</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Titanium</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Ultra Portable</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">12 inch</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Super portable deluxe</span></a></li>
-        <li aria-current=\\"page\\" class=\\"fd-breadcrumb__item\\">Laptop</li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Root Page 1 of 7\\"><span class=\\"fd-link__content\\">Products</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 2 of 7\\"><span class=\\"fd-link__content\\">Suppliers</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 3 of 7\\"><span class=\\"fd-link__content\\">Titanium</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 4 of 7\\"><span class=\\"fd-link__content\\">Ultra Portable</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 5 of 7\\"><span class=\\"fd-link__content\\">12 inch</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 6 of 7\\"><span class=\\"fd-link__content\\">Super portable deluxe</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <span role=\\"link\\" aria-current=\\"page\\" aria-label=\\"Current page 7 of 7\\">Laptop</span>
+        </li>
     </ol>
 </nav>
 
 <h4>Double backslash</h4>
 <nav aria-label=\\"Breadcrumb Trail\\">
     <ol class=\\"fd-breadcrumb fd-breadcrumb--double-backslash\\">
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Products</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Suppliers</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Titanium</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Ultra Portable</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">12 inch</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Super portable deluxe</span></a></li>
-        <li aria-current=\\"page\\" class=\\"fd-breadcrumb__item\\">Laptop</li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Root Page 1 of 7\\"><span class=\\"fd-link__content\\">Products</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 2 of 7\\"><span class=\\"fd-link__content\\">Suppliers</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 3 of 7\\"><span class=\\"fd-link__content\\">Titanium</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 4 of 7\\"><span class=\\"fd-link__content\\">Ultra Portable</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 5 of 7\\"><span class=\\"fd-link__content\\">12 inch</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 6 of 7\\"><span class=\\"fd-link__content\\">Super portable deluxe</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <span role=\\"link\\" aria-current=\\"page\\" aria-label=\\"Current page 7 of 7\\">Laptop</span>
+        </li>
     </ol>
 </nav>
 
 <h4>Greater than</h4>
 <nav aria-label=\\"Breadcrumb Trail\\">
     <ol class=\\"fd-breadcrumb fd-breadcrumb--greater-than\\">
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Products</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Suppliers</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Titanium</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Ultra Portable</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">12 inch</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Super portable deluxe</span></a></li>
-        <li aria-current=\\"page\\" class=\\"fd-breadcrumb__item\\">Laptop</li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Root Page 1 of 7\\"><span class=\\"fd-link__content\\">Products</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 2 of 7\\"><span class=\\"fd-link__content\\">Suppliers</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 3 of 7\\"><span class=\\"fd-link__content\\">Titanium</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 4 of 7\\"><span class=\\"fd-link__content\\">Ultra Portable</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 5 of 7\\"><span class=\\"fd-link__content\\">12 inch</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 6 of 7\\"><span class=\\"fd-link__content\\">Super portable deluxe</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <span role=\\"link\\" aria-current=\\"page\\" aria-label=\\"Current page 7 of 7\\">Laptop</span>
+        </li>
     </ol>
 </nav>
 
 <h4>Double greater than</h4>
 <nav aria-label=\\"Breadcrumb Trail\\">
     <ol class=\\"fd-breadcrumb fd-breadcrumb--double-greater-than\\">
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Products</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Suppliers</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Titanium</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Ultra Portable</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">12 inch</span></a></li>
-        <li class=\\"fd-breadcrumb__item\\"><a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\"><span class=\\"fd-link__content\\">Super portable deluxe</span></a></li>
-        <li aria-current=\\"page\\" class=\\"fd-breadcrumb__item\\">Laptop</li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Root Page 1 of 7\\"><span class=\\"fd-link__content\\">Products</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 2 of 7\\"><span class=\\"fd-link__content\\">Suppliers</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 3 of 7\\"><span class=\\"fd-link__content\\">Titanium</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 4 of 7\\"><span class=\\"fd-link__content\\">Ultra Portable</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 5 of 7\\"><span class=\\"fd-link__content\\">12 inch</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <a class=\\"fd-link\\" tabindex=\\"0\\" href=\\"#\\" aria-current=\\"false\\" aria-label=\\"Parent Page 6 of 7\\"><span class=\\"fd-link__content\\">Super portable deluxe</span></a>
+        </li>
+        <li class=\\"fd-breadcrumb__item\\">
+            <span role=\\"link\\" aria-current=\\"page\\" aria-label=\\"Current page 7 of 7\\">Laptop</span>
+        </li>
     </ol>
 </nav>"
 `;


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-styles/issues/5763

## Description
- design updates: spacings and color for the separators
- a11y: aria-label, aria-current for the links

BREAKING CHANGES:
The last item (current), the text should be wrapped in a span with the necessary aria attributes.

Before:
```
<li aria-current="page" class="fd-breadcrumb__item">Laptop</li>
```

After:
```
<li class="fd-breadcrumb__item">
    <span role="link" aria-current="page" aria-label="Current page 7 of 7">Laptop</span>
</li>
```