### PR TITLE
fix(styles): deaign and a11y updates for Busy Indicator [ci visual]

### DIFF
--- a/packages/styles/src/busy-indicator.scss
+++ b/packages/styles/src/busy-indicator.scss
@@ -8,6 +8,7 @@ $block: #{$fd-namespace}-busy-indicator;
 .#{$block} {
   --Dot_Color: var(--fdBusy_Indicator_Dot_Color);
   --Dot_Size: 0.5rem;
+  --Dot_Spacing: 0.0625rem;
 
   &--contrast {
     --Dot_Color: var(--fdBusy_Indicator_Dot_Contrast_Color);
@@ -15,10 +16,12 @@ $block: #{$fd-namespace}-busy-indicator;
 
   &--m {
     --Dot_Size: 1rem;
+    --Dot_Spacing: 0.1875rem;
   }
 
   &--l {
     --Dot_Size: 2rem;
+    --Dot_Spacing: 0.25rem;
   }
 
   @include fd-reset();
@@ -66,14 +69,17 @@ $block: #{$fd-namespace}-busy-indicator;
     display: inline-block;
     border-radius: 50%;
     background-color: currentColor;
+    margin-inline-end: var(--Dot_Spacing);
     animation: grow 1.6s infinite cubic-bezier(0.32, 0.06, 0.85, 1.11);
 
     &:nth-child(2) {
       animation-delay: 0.2s;
+      margin-inline-end: var(--Dot_Spacing);
     }
 
     &:nth-child(3) {
       animation-delay: 0.4s;
+      margin-inline-end: 0;
     }
   }
 

--- a/packages/styles/stories/Components/busy-indicator/busy-dialog.example.html
+++ b/packages/styles/stories/Components/busy-indicator/busy-dialog.example.html
@@ -15,7 +15,7 @@
                 <p class="fd-text">
                     ... now loading data from a far far away server from far far away.
                 </p>
-                <div class="fd-busy-indicator fd-busy-indicator--l" aria-hidden="false" aria-label="Loading">
+                <div class="fd-busy-indicator fd-busy-indicator--l" aria-hidden="false" tabindex="0" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuetext="Busy" title="Please wait">
                     <div class="fd-busy-indicator__circle"></div>
                     <div class="fd-busy-indicator__circle"></div>
                     <div class="fd-busy-indicator__circle"></div>

--- a/packages/styles/stories/Components/busy-indicator/contrast-mode.example.html
+++ b/packages/styles/stories/Components/busy-indicator/contrast-mode.example.html
@@ -1,5 +1,5 @@
 <div style="display:flex;justify-content:center;flex-direction:column;align-items:center;background-color:cadetblue;height:250px">
-<div class="fd-busy-indicator fd-busy-indicator--l fd-busy-indicator--contrast" aria-hidden="false" aria-label="Loading">
+<div class="fd-busy-indicator fd-busy-indicator--l fd-busy-indicator--contrast" tabindex="0" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuetext="Busy" title="Please wait">
     <div class="fd-busy-indicator__circle"></div>
     <div class="fd-busy-indicator__circle"></div>
     <div class="fd-busy-indicator__circle"></div>

--- a/packages/styles/stories/Components/busy-indicator/extended-busy-indicator-inside-message-toast.example.html
+++ b/packages/styles/stories/Components/busy-indicator/extended-busy-indicator-inside-message-toast.example.html
@@ -1,6 +1,6 @@
 
 <div class="fd-message-toast fd-busy-indicator-extended fd-busy-indicator-extended--message-toast">
-    <div class="fd-busy-indicator fd-busy-indicator--l" aria-hidden="false" aria-label="Loading">
+    <div class="fd-busy-indicator fd-busy-indicator--l" aria-hidden="false" tabindex="0" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuetext="Busy" title="Please wait">
         <div class="fd-busy-indicator__circle"></div>
         <div class="fd-busy-indicator__circle"></div>
         <div class="fd-busy-indicator__circle"></div>

--- a/packages/styles/stories/Components/busy-indicator/extended-busy-indicator.example.html
+++ b/packages/styles/stories/Components/busy-indicator/extended-busy-indicator.example.html
@@ -1,5 +1,5 @@
 <div class="fd-busy-indicator-extended">
-    <div class="fd-busy-indicator fd-busy-indicator--l" aria-hidden="false" aria-label="Loading">
+    <div class="fd-busy-indicator fd-busy-indicator--l" aria-hidden="false" tabindex="0" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuetext="Busy" title="Please wait">
         <div class="fd-busy-indicator__circle"></div>
         <div class="fd-busy-indicator__circle"></div>
         <div class="fd-busy-indicator__circle"></div>

--- a/packages/styles/stories/Components/busy-indicator/standard.example.html
+++ b/packages/styles/stories/Components/busy-indicator/standard.example.html
@@ -1,15 +1,15 @@
 <div style="text-align: center">
-    <div class="fd-busy-indicator fd-busy-indicator--l" aria-hidden="false" aria-label="Loading">
+    <div class="fd-busy-indicator fd-busy-indicator--l" tabindex="0" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuetext="Busy" title="Please wait">
         <div class="fd-busy-indicator__circle"></div>
         <div class="fd-busy-indicator__circle"></div>
         <div class="fd-busy-indicator__circle"></div>
     </div><br /><br />
-    <div class="fd-busy-indicator fd-busy-indicator--m" aria-hidden="false" aria-label="Loading">
+    <div class="fd-busy-indicator fd-busy-indicator--m" tabindex="0" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuetext="Busy" title="Please wait">
         <div class="fd-busy-indicator__circle"></div>
         <div class="fd-busy-indicator__circle"></div>
         <div class="fd-busy-indicator__circle"></div>
     </div><br /><br />
-    <div class="fd-busy-indicator" aria-hidden="false" aria-label="Loading">
+    <div class="fd-busy-indicator" tabindex="0" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuetext="Busy" title="Please wait">
         <div class="fd-busy-indicator__circle"></div>
         <div class="fd-busy-indicator__circle"></div>
         <div class="fd-busy-indicator__circle"></div>

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -9970,7 +9970,7 @@ exports[`Check stories > Components/Busy Indicator > Story BusyDialog > Should m
                 <p class=\\"fd-text\\">
                     ... now loading data from a far far away server from far far away.
                 </p>
-                <div class=\\"fd-busy-indicator fd-busy-indicator--l\\" aria-hidden=\\"false\\" aria-label=\\"Loading\\">
+                <div class=\\"fd-busy-indicator fd-busy-indicator--l\\" aria-hidden=\\"false\\" tabindex=\\"0\\" role=\\"progressbar\\" aria-valuemin=\\"0\\" aria-valuemax=\\"100\\" aria-valuetext=\\"Busy\\" title=\\"Please wait\\">
                     <div class=\\"fd-busy-indicator__circle\\"></div>
                     <div class=\\"fd-busy-indicator__circle\\"></div>
                     <div class=\\"fd-busy-indicator__circle\\"></div>
@@ -9991,7 +9991,7 @@ exports[`Check stories > Components/Busy Indicator > Story BusyDialog > Should m
 
 exports[`Check stories > Components/Busy Indicator > Story ContrastMode > Should match snapshot 1`] = `
 "<div style=\\"display:flex;justify-content:center;flex-direction:column;align-items:center;background-color:cadetblue;height:250px\\">
-<div class=\\"fd-busy-indicator fd-busy-indicator--l fd-busy-indicator--contrast\\" aria-hidden=\\"false\\" aria-label=\\"Loading\\">
+<div class=\\"fd-busy-indicator fd-busy-indicator--l fd-busy-indicator--contrast\\" tabindex=\\"0\\" role=\\"progressbar\\" aria-valuemin=\\"0\\" aria-valuemax=\\"100\\" aria-valuetext=\\"Busy\\" title=\\"Please wait\\">
     <div class=\\"fd-busy-indicator__circle\\"></div>
     <div class=\\"fd-busy-indicator__circle\\"></div>
     <div class=\\"fd-busy-indicator__circle\\"></div>
@@ -10002,7 +10002,7 @@ exports[`Check stories > Components/Busy Indicator > Story ContrastMode > Should
 
 exports[`Check stories > Components/Busy Indicator > Story ExtendedBusyIndicator > Should match snapshot 1`] = `
 "<div class=\\"fd-busy-indicator-extended\\">
-    <div class=\\"fd-busy-indicator fd-busy-indicator--l\\" aria-hidden=\\"false\\" aria-label=\\"Loading\\">
+    <div class=\\"fd-busy-indicator fd-busy-indicator--l\\" aria-hidden=\\"false\\" tabindex=\\"0\\" role=\\"progressbar\\" aria-valuemin=\\"0\\" aria-valuemax=\\"100\\" aria-valuetext=\\"Busy\\" title=\\"Please wait\\">
         <div class=\\"fd-busy-indicator__circle\\"></div>
         <div class=\\"fd-busy-indicator__circle\\"></div>
         <div class=\\"fd-busy-indicator__circle\\"></div>
@@ -10014,7 +10014,7 @@ exports[`Check stories > Components/Busy Indicator > Story ExtendedBusyIndicator
 exports[`Check stories > Components/Busy Indicator > Story ExtendedBusyIndicatorInsideMessageToast > Should match snapshot 1`] = `
 "
 <div class=\\"fd-message-toast fd-busy-indicator-extended fd-busy-indicator-extended--message-toast\\">
-    <div class=\\"fd-busy-indicator fd-busy-indicator--l\\" aria-hidden=\\"false\\" aria-label=\\"Loading\\">
+    <div class=\\"fd-busy-indicator fd-busy-indicator--l\\" aria-hidden=\\"false\\" tabindex=\\"0\\" role=\\"progressbar\\" aria-valuemin=\\"0\\" aria-valuemax=\\"100\\" aria-valuetext=\\"Busy\\" title=\\"Please wait\\">
         <div class=\\"fd-busy-indicator__circle\\"></div>
         <div class=\\"fd-busy-indicator__circle\\"></div>
         <div class=\\"fd-busy-indicator__circle\\"></div>
@@ -10025,17 +10025,17 @@ exports[`Check stories > Components/Busy Indicator > Story ExtendedBusyIndicator
 
 exports[`Check stories > Components/Busy Indicator > Story Standard > Should match snapshot 1`] = `
 "<div style=\\"text-align: center\\">
-    <div class=\\"fd-busy-indicator fd-busy-indicator--l\\" aria-hidden=\\"false\\" aria-label=\\"Loading\\">
+    <div class=\\"fd-busy-indicator fd-busy-indicator--l\\" tabindex=\\"0\\" role=\\"progressbar\\" aria-valuemin=\\"0\\" aria-valuemax=\\"100\\" aria-valuetext=\\"Busy\\" title=\\"Please wait\\">
         <div class=\\"fd-busy-indicator__circle\\"></div>
         <div class=\\"fd-busy-indicator__circle\\"></div>
         <div class=\\"fd-busy-indicator__circle\\"></div>
     </div><br /><br />
-    <div class=\\"fd-busy-indicator fd-busy-indicator--m\\" aria-hidden=\\"false\\" aria-label=\\"Loading\\">
+    <div class=\\"fd-busy-indicator fd-busy-indicator--m\\" tabindex=\\"0\\" role=\\"progressbar\\" aria-valuemin=\\"0\\" aria-valuemax=\\"100\\" aria-valuetext=\\"Busy\\" title=\\"Please wait\\">
         <div class=\\"fd-busy-indicator__circle\\"></div>
         <div class=\\"fd-busy-indicator__circle\\"></div>
         <div class=\\"fd-busy-indicator__circle\\"></div>
     </div><br /><br />
-    <div class=\\"fd-busy-indicator\\" aria-hidden=\\"false\\" aria-label=\\"Loading\\">
+    <div class=\\"fd-busy-indicator\\" tabindex=\\"0\\" role=\\"progressbar\\" aria-valuemin=\\"0\\" aria-valuemax=\\"100\\" aria-valuetext=\\"Busy\\" title=\\"Please wait\\">
         <div class=\\"fd-busy-indicator__circle\\"></div>
         <div class=\\"fd-busy-indicator__circle\\"></div>
         <div class=\\"fd-busy-indicator__circle\\"></div>


### PR DESCRIPTION
## Related Issue
Part of https://github.com/SAP/fundamental-styles/issues/5763

## Description
- design update: spacing between the dots, margin-bottom
- a11y: role and aria attributes (breaking change)

BREAKING CHANGES:
new a11y role and aria attributes

Before:
```
<div class="fd-busy-indicator fd-busy-indicator--l" aria-hidden="false" aria-label="Loading">...</div>
```

After:
```
<div class="fd-busy-indicator fd-busy-indicator--l" aria-hidden="false" tabindex="0" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuetext="Busy" title="Please wait">...</div>
```