### PR TITLE
fix(styles): update Action Sheet [ci visual]

### DIFF
--- a/packages/styles/src/action-sheet.scss
+++ b/packages/styles/src/action-sheet.scss
@@ -4,6 +4,7 @@
 @import "./mixins";
 
 $block: #{$fd-namespace}-action-sheet;
+$bar: #{$fd-namespace}-bar;
 
 .#{$block} {
   // OVERLAY
@@ -41,7 +42,7 @@ $block: #{$fd-namespace}-action-sheet;
     @include fd-popover-border-radius();
 
     @include fd-pseudo-expand() {
-      opacity: var(--fdOverlay_Background_Opacity);
+      opacity: var(--sapBlockLayer_Opacity);
       background-color: $fd-action-sheet-overlay-color;
 
       @include fd-popover-border-radius();
@@ -50,21 +51,29 @@ $block: #{$fd-namespace}-action-sheet;
     &--active {
       @include fd-flex(column) {
         justify-content: flex-end;
-        align-items: flex-start;
+      }
+    }
+
+    .#{$block}__bar.#{$bar} {
+      border-radius: var(--sapPopover_BorderCornerRadius) var(--sapPopover_BorderCornerRadius) 0 0;
+      box-shadow: var(--sapContent_Shadow2);
+      width: calc(100% - var(--sapGroup_BorderWidth) * 2);
+      margin-inline-start: 0.0625rem;
+
+      & + .#{$block} {
+        border-radius: 0 0 var(--sapPopover_BorderCornerRadius) var(--sapPopover_BorderCornerRadius);
       }
     }
   }
 
   &__title {
     @include fd-reset();
-    @include fd-typography(var(--sapFontHeader6Size));
     @include fd-ellipsis();
+    @include fd-typography(var(--sapFontHeader5Size));
 
-    max-width: 100%;
     z-index: 1;
-    padding-block: 0 0.5rem;
-    padding-inline: 1rem;
-    color: var(--sapContent_ContrastTextColor);
+    font-family: var(--sapFontHeaderFamily);
+    color: var(--sapPageHeader_TextColor);
   }
 
   @include fd-compact-or-condensed() {

--- a/packages/styles/src/theming/sap_horizon.scss
+++ b/packages/styles/src/theming/sap_horizon.scss
@@ -72,9 +72,6 @@
   --fdSwitch_Semantic_Error_Handle_Border_Color: var(--sapButton_Track_Negative_Background);
   --fdSwitch_Semantic_Success_Handle_Border_Color: var(--sapButton_Track_Positive_Background);
 
-  /* Action sheet */
-  --fdOverlay_Background_Opacity: 0.6;
-
   /* Dynamic Page Layout */
   --fdDynamicPage_Hover_Border_Bottom: none;
   --fdDynamicPage_Title_Header_Transparent_Background: transparent;

--- a/packages/styles/src/theming/sap_horizon_dark.scss
+++ b/packages/styles/src/theming/sap_horizon_dark.scss
@@ -81,8 +81,6 @@
   --fdSwitch_Semantic_Error_Handle_Border_Color: var(--sapButton_Track_Negative_Background);
   --fdSwitch_Semantic_Success_Handle_Border_Color: var(--sapButton_Track_Positive_Background);
 
-  /* Action sheet */
-  --fdOverlay_Background_Opacity: 0.6;
 
   /* Dynamic Page Layout */
   --fdDynamicPage_Hover_Border_Bottom: none;

--- a/packages/styles/stories/Components/action-sheet/action-sheet-mobile.example.html
+++ b/packages/styles/stories/Components/action-sheet/action-sheet-mobile.example.html
@@ -5,7 +5,14 @@
         <i class="sap-icon--settings"></i>
     </button>
     <div class="fd-action-sheet__wrapper fd-action-sheet__wrapper--active" id="actionSheetPhone">
-        <h6 class="fd-action-sheet__title">Press cancel to hide action sheet</h6>
+        <div class="fd-bar fd-action-sheet__bar" role="toolbar" aria-label="Bar">
+            <div class="fd-bar__left">
+                <div class="fd-bar__element">
+                    <h6 class="fd-action-sheet__title">Control Title</h6>
+                </div>
+            </div>
+        </div>
+        
         <ul class="fd-action-sheet fd-action-sheet--mobile" role="list" aria-label="List of contextual options">
             <li class="fd-action-sheet__item" role="listitem">
                 <button class="fd-button fd-button--full-width fd-button--transparent fd-button--text-alignment-left">

--- a/packages/styles/stories/Components/action-sheet/action-sheet.stories.js
+++ b/packages/styles/stories/Components/action-sheet/action-sheet.stories.js
@@ -5,6 +5,7 @@ import '../../../src/icon.scss';
 import '../../../src/action-sheet.scss';
 import '../../../src/popover.scss';
 import '../../../src/button.scss';
+import '../../../src/bar.scss';
 export default {
   title: 'Components/Action Sheet',
   parameters: {

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -6647,7 +6647,14 @@ exports[`Check stories > Components/Action Sheet > Story ActionSheetMobile > Sho
         <i class=\\"sap-icon--settings\\"></i>
     </button>
     <div class=\\"fd-action-sheet__wrapper fd-action-sheet__wrapper--active\\" id=\\"actionSheetPhone\\">
-        <h6 class=\\"fd-action-sheet__title\\">Press cancel to hide action sheet</h6>
+        <div class=\\"fd-bar fd-action-sheet__bar\\" role=\\"toolbar\\" aria-label=\\"Bar\\">
+            <div class=\\"fd-bar__left\\">
+                <div class=\\"fd-bar__element\\">
+                    <h6 class=\\"fd-action-sheet__title\\">Control Title</h6>
+                </div>
+            </div>
+        </div>
+        
         <ul class=\\"fd-action-sheet fd-action-sheet--mobile\\" role=\\"list\\" aria-label=\\"List of contextual options\\">
             <li class=\\"fd-action-sheet__item\\" role=\\"listitem\\">
                 <button class=\\"fd-button fd-button--full-width fd-button--transparent fd-button--text-alignment-left\\">


### PR DESCRIPTION
## Related Issue
Part of https://github.com/SAP/fundamental-styles/issues/5763

## Description
- design updates for Action Sheet
- no a11y updates needed

BREAKING CHANGES:
Action Sheet Title is now in a Bar component.

Before:
```
<div class="fd-action-sheet__wrapper fd-action-sheet__wrapper--active" id="actionSheetPhone">
    <h6 class="fd-action-sheet__title">Press cancel to hide action sheet</h6>
    <ul class="fd-action-sheet fd-action-sheet--mobile">...</ul>
</div>

```

After:
```
<div class="fd-action-sheet__wrapper fd-action-sheet__wrapper--active" id="actionSheetPhone">
    <div class="fd-bar fd-action-sheet__bar" role="toolbar" aria-label="Bar">
        <div class="fd-bar__left">
            <div class="fd-bar__element">
                <h6 class="fd-action-sheet__title">Control Title</h6>
            </div>
         </div>
    </div>
    <ul class="fd-action-sheet fd-action-sheet--mobile">...</ul>
</div>

```