### PR TITLE
fix(styles): dialog design and a11y updates [ci visual]

### DIFF
--- a/packages/styles/src/_dialog-placeholders.scss
+++ b/packages/styles/src/_dialog-placeholders.scss
@@ -30,7 +30,7 @@ $fd-dialog-loader-margin-y: 1.5rem;
     width: 100%;
     height: 100%;
     background-color: var(--sapBlockLayer_Background);
-    opacity: var(--fdDialog_Background_Opacity);
+    opacity: var(--sapBlockLayer_Opacity);
   }
 }
 

--- a/packages/styles/src/dialog.scss
+++ b/packages/styles/src/dialog.scss
@@ -151,6 +151,7 @@ $menu: #{$fd-namespace}-menu;
     cursor: se-resize;
     line-height: 1rem;
     position: absolute;
+    z-index: 2;
 
     @include fd-rtl() {
       cursor: sw-resize;

--- a/packages/styles/src/theming/sap_fiori_3.scss
+++ b/packages/styles/src/theming/sap_fiori_3.scss
@@ -139,9 +139,6 @@
   /* Badge */
   --fdBadge_Border_Color: transparent;
 
-  /** Dialog */
-  --fdDialog_Background_Opacity: 0.6;
-
   /* Message Strip */
   --fdMessageStrip_Border_Width: 0.0625rem;
   --fdMessageStrip_Border_Radius: var(--sapElement_BorderCornerRadius);

--- a/packages/styles/src/theming/sap_fiori_3_dark.scss
+++ b/packages/styles/src/theming/sap_fiori_3_dark.scss
@@ -148,9 +148,6 @@
   /* Badge */
   --fdBadge_Border_Color: transparent;
 
-  /** Dialog */
-  --fdDialog_Background_Opacity: 0.6;
-
   /* Message Strip */
   --fdMessageStrip_Border_Width: 0.0625rem;
   --fdMessageStrip_Border_Radius: var(--sapElement_BorderCornerRadius);

--- a/packages/styles/src/theming/sap_fiori_3_hcb.scss
+++ b/packages/styles/src/theming/sap_fiori_3_hcb.scss
@@ -151,9 +151,6 @@
   /* Badge */
   --fdBadge_Border_Color: var(--sapGroup_ContentBorderColor);
 
-  /** Dialog */
-  --fdDialog_Background_Opacity: 0.8;
-
   /* Message Strip */
   --fdMessageStrip_Border_Width: 0.125rem;
   --fdMessageStrip_Border_Radius: var(--sapElement_BorderCornerRadius);

--- a/packages/styles/src/theming/sap_fiori_3_hcw.scss
+++ b/packages/styles/src/theming/sap_fiori_3_hcw.scss
@@ -147,9 +147,6 @@
   /* Badge */
   --fdBadge_Border_Color: var(--sapGroup_ContentBorderColor);
 
-  /** Dialog */
-  --fdDialog_Background_Opacity: 0.8;
-
   /* Message Strip */
   --fdMessageStrip_Border_Width: 0.125rem;
   --fdMessageStrip_Border_Radius: var(--sapElement_BorderCornerRadius);

--- a/packages/styles/src/theming/sap_fiori_3_light_dark.scss
+++ b/packages/styles/src/theming/sap_fiori_3_light_dark.scss
@@ -146,9 +146,6 @@
   /* Badge */
   --fdBadge_Border_Color: transparent;
 
-  /** Dialog */
-  --fdDialog_Background_Opacity: 0.6;
-
   /* Message Strip */
   --fdMessageStrip_Border_Width: 0.0625rem;
   --fdMessageStrip_Border_Radius: var(--sapElement_BorderCornerRadius);

--- a/packages/styles/src/theming/sap_horizon.scss
+++ b/packages/styles/src/theming/sap_horizon.scss
@@ -146,9 +146,6 @@
   /* Badge */
   --fdBadge_Border_Color: transparent;
 
-  /** Dialog */
-  --fdDialog_Background_Opacity: 0.6;
-
   /* Message Strip */
   --fdMessageStrip_Border_Width: 0.0625rem;
   --fdMessageStrip_Border_Radius: var(--sapPopover_BorderCornerRadius);

--- a/packages/styles/src/theming/sap_horizon_dark.scss
+++ b/packages/styles/src/theming/sap_horizon_dark.scss
@@ -159,9 +159,6 @@
   /* Badge */
   --fdBadge_Border_Color: var(--sapGroup_ContentBorderColor);
 
-  /** Dialog */
-  --fdDialog_Background_Opacity: 0.6;
-
   /* Message Strip */
   --fdMessageStrip_Border_Width: 0.0625rem;
   --fdMessageStrip_Border_Radius: var(--sapPopover_BorderCornerRadius);

--- a/packages/styles/src/theming/sap_horizon_hcb.scss
+++ b/packages/styles/src/theming/sap_horizon_hcb.scss
@@ -147,10 +147,6 @@
   /* Badge */
   --fdBadge_Border_Color: var(--sapGroup_ContentBorderColor);
 
-  /** Dialog */
-  --fdDialog_Background_Opacity: 0.6;
-  --fdDialog_Content_Border_Radius: var(--sapPopover_BorderCornerRadius);
-
   /* Message Strip */
   --fdMessageStrip_Border_Width: 0.125rem;
   --fdMessageStrip_Border_Radius: var(--sapPopover_BorderCornerRadius);

--- a/packages/styles/src/theming/sap_horizon_hcw.scss
+++ b/packages/styles/src/theming/sap_horizon_hcw.scss
@@ -148,9 +148,6 @@
   /* Badge */
   --fdBadge_Border_Color: var(--sapGroup_ContentBorderColor);
 
-  /** Dialog */
-  --fdDialog_Background_Opacity: 0.6;
-
   /* Message Strip */
   --fdMessageStrip_Border_Width: 0.125rem;
   --fdMessageStrip_Border_Radius: var(--sapPopover_BorderCornerRadius);

--- a/packages/styles/stories/Components/dialog/default-dialog.example.html
+++ b/packages/styles/stories/Components/dialog/default-dialog.example.html
@@ -1,6 +1,11 @@
 
-<section class="fd-dialog-docs-static fd-dialog fd-dialog--active">
-    <div class="fd-dialog__content fd-dialog__content--s" role="dialog" aria-modal="true" aria-labelledby="dialog-title-1">
+<div class="fd-dialog-docs-static fd-dialog fd-dialog--active">
+    <div 
+        class="fd-dialog__content fd-dialog__content--s" 
+        role="dialog" 
+        aria-modal="true" 
+        aria-labelledby="dialog-title-1"
+        aria-describedby="dialog-description-1">
         <span class="fd-dialog__resize-handle"></span>
         <header class="fd-dialog__header fd-bar">
             <div class="fd-bar__left">
@@ -11,8 +16,10 @@
                 </div>
             </div>
         </header>
-        <div class="fd-dialog__body">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat...
+        <section class="fd-dialog__body">
+            <span id="dialog-description-1">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat...
+            </span>
             <div class="fd-dialog__loader">
                 <div class="fd-busy-indicator fd-busy-indicator--m" aria-hidden="false" aria-label="Loading">
                     <div class="fd-busy-indicator__circle"></div>
@@ -20,7 +27,7 @@
                     <div class="fd-busy-indicator__circle"></div>
                 </div><br /><br />
             </div>
-        </div>
+        </section>
         <footer class="fd-dialog__footer fd-bar fd-bar--footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
@@ -36,4 +43,4 @@
             </div>
         </footer>
     </div>
-</section>
+</div>

--- a/packages/styles/stories/Components/dialog/device-specifications.example.html
+++ b/packages/styles/stories/Components/dialog/device-specifications.example.html
@@ -3,12 +3,19 @@
 <div>Full Screen Button: visible (<code>sap-icon--full-screen</code>)</div>
 <div>Resize Handle: not visible</div>
 <br>
-<section class="fd-dialog-docs-static fd-dialog fd-dialog--active">
-    <div class="fd-dialog__content fd-dialog__content--s" role="dialog" aria-modal="true" aria-labelledby="dialog-title-6">
+<div class="fd-dialog-docs-static fd-dialog fd-dialog--active">
+    <div 
+        class="fd-dialog__content fd-dialog__content--s" 
+        role="dialog" 
+        aria-modal="true" 
+        aria-labelledby="dialog-title-12"
+        aria-describedby="dialog-description-12"
+    >
+        
         <header class="fd-dialog__header fd-bar fd-bar--header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5" id="dialog-title-6">
+                    <h2 class="fd-title fd-title--h5" id="dialog-title-12">
                         Lorem ipsum
                     </h2>
                 </div>
@@ -21,9 +28,11 @@
                 </div>
             </div>
         </header>
-        <div class="fd-dialog__body">
+
+        <section class="fd-dialog__body" id="dialog-description-12">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
-        </div>
+        </section>
+
         <footer class="fd-dialog__footer fd-bar fd-bar--footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
@@ -35,7 +44,7 @@
             </div>
         </footer>
     </div>
-</section>  
+</div>  
 
 <br><br>
 <h3>Tablet with mouse attached</h3>

--- a/packages/styles/stories/Components/dialog/draggable.example.html
+++ b/packages/styles/stories/Components/dialog/draggable.example.html
@@ -1,6 +1,12 @@
 
-<section class="fd-dialog-docs-static fd-dialog fd-dialog--active">
-    <div class="fd-dialog__content fd-dialog__content--draggable-grab fd-dialog__content--s" role="dialog" aria-modal="true" aria-labelledby="dialog-title-7">
+<div class="fd-dialog-docs-static fd-dialog fd-dialog--active">
+    <div 
+        class="fd-dialog__content fd-dialog__content--draggable-grab fd-dialog__content--s" 
+        role="dialog" 
+        aria-modal="true" 
+        aria-labelledby="dialog-title-7"
+        aria-describedby="dialog-description-7"
+    >
         <header class="fd-dialog__header fd-bar fd-bar--header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
@@ -10,9 +16,11 @@
                 </div>
             </div>
         </header>
-        <div class="fd-dialog__body">
+
+        <section class="fd-dialog__body" id="dialog-description-7">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
-        </div>
+        </section>
+        
         <footer class="fd-dialog__footer fd-bar fd-bar--footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
@@ -24,4 +32,4 @@
             </div>
         </footer>
     </div>
-</section>
+</div>

--- a/packages/styles/stories/Components/dialog/horizontal-form-in-dialog.example.html
+++ b/packages/styles/stories/Components/dialog/horizontal-form-in-dialog.example.html
@@ -1,6 +1,12 @@
 
-<section class="fd-dialog-docs-static fd-dialog fd-dialog--active">
-    <div class="fd-dialog__content fd-dialog__content--s" role="dialog" aria-modal="true" aria-labelledby="dialog-title-2">
+<div class="fd-dialog-docs-static fd-dialog fd-dialog--active">
+    <div 
+        class="fd-dialog__content fd-dialog__content--s" 
+        role="dialog" 
+        aria-modal="true" 
+        aria-labelledby="dialog-title-2"
+    >
+        
         <header class="fd-dialog__header fd-bar fd-bar--header">
             <div class="fd-bar__left">
             <div class="fd-bar__element">
@@ -10,7 +16,8 @@
             </div>
             </div>
         </header>
-        <div class="fd-dialog__body">
+        
+        <section class="fd-dialog__body">
             <div class="fd-container fd-form-layout-grid-container fd-form-group">
                 <div class="fd-row fd-form-item">
                     <div class="fd-col fd-col-md--2 fd-col-lg--4">
@@ -81,7 +88,8 @@
                     </div>
                 </div>
             </div>
-        </div>
+        </section>
+        
         <footer class="fd-dialog__footer fd-bar fd-bar--footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
@@ -93,4 +101,4 @@
             </div>
         </footer>
     </div>
-</section>
+</div>

--- a/packages/styles/stories/Components/dialog/loading.example.html
+++ b/packages/styles/stories/Components/dialog/loading.example.html
@@ -1,6 +1,13 @@
 
-<section class="fd-dialog-docs-static fd-dialog fd-dialog--active" id="loading-dialog-example">
-    <div class="fd-dialog__content fd-dialog__content--s" role="dialog" aria-modal="true" aria-labelledby="dialog-title-9">
+<div class="fd-dialog-docs-static fd-dialog fd-dialog--active" id="loading-dialog-example">
+    <div 
+        class="fd-dialog__content fd-dialog__content--s" 
+        role="dialog" 
+        aria-modal="true" 
+        aria-labelledby="dialog-title-9"
+        aria-describedby="dialog-description-9"
+    >
+        
         <header class="fd-dialog__header fd-bar fd-bar--header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
@@ -10,14 +17,16 @@
                 </div>
             </div>
         </header>
-        <div class="fd-dialog__body">
+
+        <section class="fd-dialog__body" id="dialog-description-8">
             <strong>Status:</strong> Connecting 127.0.0.1
             <div class="fd-dialog__loader fd-busy-indicator--l" aria-hidden="false" aria-label="Loading">
                 <div class="fd-busy-indicator--circle-0"></div>
                 <div class="fd-busy-indicator--circle-1"></div>
                 <div class="fd-busy-indicator--circle-2"></div>
             </div>
-        </div>
+        </section>
+
         <footer class="fd-dialog__footer fd-bar fd-bar--footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
@@ -26,4 +35,4 @@
             </div>
         </footer>
     </div>
-</section>
+</div>

--- a/packages/styles/stories/Components/dialog/resizable.example.html
+++ b/packages/styles/stories/Components/dialog/resizable.example.html
@@ -1,7 +1,14 @@
 
-<section class="fd-dialog-docs-static fd-dialog fd-dialog--active">
-    <div class="fd-dialog__content fd-dialog__content--s" role="dialog" aria-modal="true" aria-labelledby="dialog-title-6">
-        <span class="fd-dialog__resize-handle"></span>
+<div class="fd-dialog-docs-static fd-dialog fd-dialog--active">
+    <div 
+        class="fd-dialog__content fd-dialog__content--s" 
+        role="dialog" 
+        aria-modal="true" 
+        aria-labelledby="dialog-title-6"
+        aria-describedby="dialog-description-6"
+    >
+        <span class="fd-dialog__resize-handle" role="presentation" aria-hidden="true"></span>
+        
         <header class="fd-dialog__header fd-bar fd-bar--header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
@@ -11,9 +18,11 @@
                 </div>
             </div>
         </header>
-        <div class="fd-dialog__body">
+        
+        <section class="fd-dialog__body" id="dialog-description-6">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
-        </div>
+        </section>
+        
         <footer class="fd-dialog__footer fd-bar fd-bar--footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
@@ -25,4 +34,4 @@
             </div>
         </footer>
     </div>
-</section>
+</div>

--- a/packages/styles/stories/Components/dialog/selectable.example.html
+++ b/packages/styles/stories/Components/dialog/selectable.example.html
@@ -1,6 +1,11 @@
 
-<section class="fd-dialog-docs-static fd-dialog fd-dialog--active" id="select-dialog-example">
-    <div class="fd-dialog__content" role="dialog" aria-modal="true" aria-labelledby="dialog-title-8">
+<div class="fd-dialog-docs-static fd-dialog fd-dialog--active" id="select-dialog-example">
+    <div 
+        class="fd-dialog__content" 
+        role="dialog" 
+        aria-modal="true" 
+        aria-labelledby="dialog-title-8"
+    >
         <header class="fd-dialog__header fd-bar fd-bar--header-with-subheader">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
@@ -15,7 +20,8 @@
                 </div>
             </div>
         </header>
-        <div class="fd-dialog__subheader fd-bar fd-bar--subheader">
+
+        <section class="fd-dialog__subheader fd-bar fd-bar--subheader">
             <div class="fd-bar__middle">
                 <div class="fd-input-group">
                     <input class="fd-input fd-input-group__input" type="text" aria-label="search" placeholder="Search...">
@@ -26,8 +32,9 @@
                     </span>
                 </div>
             </div>
-        </div>
-        <div class="fd-dialog__body fd-dialog__body--no-vertical-padding">
+        </section>
+
+        <section class="fd-dialog__body fd-dialog__body--no-vertical-padding">
             <ul class="fd-list fd-list--selection fd-list--no-border" aria-label="selection list" role="listbox">
                 <li role="option" tabindex="0" class="fd-list__item">
                     <div class="fd-form-item fd-list__form-item">
@@ -87,7 +94,8 @@
             <span class="fd-list__footer">
                 2 items selected
             </span>
-        </div>
+        </section>
+
         <footer class="fd-dialog__footer fd-bar fd-bar--footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
@@ -99,4 +107,4 @@
             </div>
         </footer>
     </div>
-</section>
+</div>

--- a/packages/styles/stories/Components/dialog/sizes.example.html
+++ b/packages/styles/stories/Components/dialog/sizes.example.html
@@ -1,6 +1,13 @@
 
-<section class="fd-dialog-docs-static fd-dialog fd-dialog--active">
-    <div class="fd-dialog__content fd-dialog__content--s" role="dialog" aria-modal="true" aria-labelledby="dialog-title-2">
+<div class="fd-dialog-docs-static fd-dialog fd-dialog--active">
+    <div 
+        class="fd-dialog__content fd-dialog__content--s" 
+        role="dialog" 
+        aria-modal="true" 
+        aria-labelledby="dialog-title-2"
+        aria-describedby="dialog-description-2"
+    >
+        
         <header class="fd-dialog__header fd-bar fd-bar--header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
@@ -10,9 +17,11 @@
                 </div>
             </div>
         </header>
-        <div class="fd-dialog__body">
+        
+        <section class="fd-dialog__body" id="dialog-description-2">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
-        </div>
+        </section>
+        
         <footer class="fd-dialog__footer fd-bar fd-bar--footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
@@ -24,10 +33,17 @@
             </div>
         </footer>
     </div>
-</section>
+</div>
 <br />
-<section class="fd-dialog-docs-static fd-dialog fd-dialog--active">
-    <div class="fd-dialog__content fd-dialog__content--m" role="dialog" aria-modal="true" aria-labelledby="dialog-title-3">
+<div class="fd-dialog-docs-static fd-dialog fd-dialog--active">
+    <div 
+        class="fd-dialog__content fd-dialog__content--m" 
+        role="dialog" 
+        aria-modal="true" 
+        aria-labelledby="dialog-title-3" 
+        aria-describedby="dialog-description-3"
+    >
+        
         <header class="fd-dialog__header fd-bar fd-bar--header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
@@ -37,9 +53,11 @@
                 </div>
             </div>
         </header>
-        <div class="fd-dialog__body">
+        
+        <section class="fd-dialog__body" id="dialog-description-3">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
-        </div>
+        </section>
+        
         <footer class="fd-dialog__footer fd-bar fd-bar--footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
@@ -51,10 +69,17 @@
             </div>
         </footer>
     </div>
-</section>
+</div>
 <br />
-<section class="fd-dialog-docs-static fd-dialog fd-dialog--active">
-    <div class="fd-dialog__content fd-dialog__content--l" role="dialog" aria-modal="true" aria-labelledby="dialog-title-4">
+<div class="fd-dialog-docs-static fd-dialog fd-dialog--active">
+    <div 
+        class="fd-dialog__content fd-dialog__content--l" 
+        role="dialog" 
+        aria-modal="true" 
+        aria-labelledby="dialog-title-4"
+        aria-describedby="dialog-description-4"
+    >
+        
         <header class="fd-dialog__header fd-bar fd-bar--header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
@@ -64,9 +89,11 @@
                 </div>
             </div>
         </header>
-        <div class="fd-dialog__body">
+        
+        <section class="fd-dialog__body" id="dialog-description-4">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
-        </div>
+        </section>
+        
         <footer class="fd-dialog__footer fd-bar fd-bar--footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
@@ -78,10 +105,19 @@
             </div>
         </footer>
     </div>
-</section>
+</div>
+
 <br />
-<section class="fd-dialog-docs-static fd-dialog fd-dialog--active">
-    <div class="fd-dialog__content fd-dialog__content--xl" role="dialog" aria-modal="true" aria-labelledby="dialog-title-5">
+
+<div class="fd-dialog-docs-static fd-dialog fd-dialog--active">
+    <div 
+        class="fd-dialog__content fd-dialog__content--xl" 
+        role="dialog" 
+        aria-modal="true" 
+        aria-labelledby="dialog-title-5"
+        aria-describedby="dialog-description-5"
+    >
+        
         <header class="fd-dialog__header fd-bar fd-bar--header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
@@ -91,9 +127,11 @@
                 </div>
             </div>
         </header>
-        <div class="fd-dialog__body">
+        
+        <section class="fd-dialog__body" id="dialog-description-5">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
-        </div>
+        </section>
+        
         <footer class="fd-dialog__footer fd-bar fd-bar--footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
@@ -105,4 +143,4 @@
             </div>
         </footer>
     </div>
-</section>
+</div>

--- a/packages/styles/stories/Components/dialog/vertical-form-in-dialog.example.html
+++ b/packages/styles/stories/Components/dialog/vertical-form-in-dialog.example.html
@@ -1,5 +1,10 @@
-<section class="fd-dialog-docs-static fd-dialog fd-dialog--active">
-    <div class="fd-dialog__content fd-dialog__content--s" role="dialog" aria-modal="true" aria-labelledby="dialog-title-2">
+<div class="fd-dialog-docs-static fd-dialog fd-dialog--active">
+    <div 
+        class="fd-dialog__content fd-dialog__content--s" 
+        role="dialog" 
+        aria-modal="true" 
+        aria-labelledby="dialog-title-2">
+        
         <header class="fd-dialog__header fd-bar fd-bar--header">
             <div class="fd-bar__left">
             <div class="fd-bar__element">
@@ -9,7 +14,8 @@
             </div>
             </div>
         </header>
-        <div class="fd-dialog__body">
+
+        <section class="fd-dialog__body">
             <div class="fd-container fd-form-layout-grid-container fd-form-layout-grid-container--vertical fd-form-group">
                 <div class="fd-row fd-form-item">
                     <div class="fd-col">
@@ -80,7 +86,8 @@
                     </div>
                 </div>
             </div>
-        </div>
+        </section>
+        
         <footer class="fd-dialog__footer fd-bar fd-bar--footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
@@ -92,4 +99,4 @@
             </div>
         </footer>
     </div>
-</section>
+</div>

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -15921,8 +15921,13 @@ exports[`Check stories > Components/Counter > Story Tabs > Should match snapshot
 
 exports[`Check stories > Components/Dialog > Story DefaultDialog > Should match snapshot 1`] = `
 "
-<section class=\\"fd-dialog-docs-static fd-dialog fd-dialog--active\\">
-    <div class=\\"fd-dialog__content fd-dialog__content--s\\" role=\\"dialog\\" aria-modal=\\"true\\" aria-labelledby=\\"dialog-title-1\\">
+<div class=\\"fd-dialog-docs-static fd-dialog fd-dialog--active\\">
+    <div 
+        class=\\"fd-dialog__content fd-dialog__content--s\\" 
+        role=\\"dialog\\" 
+        aria-modal=\\"true\\" 
+        aria-labelledby=\\"dialog-title-1\\"
+        aria-describedby=\\"dialog-description-1\\">
         <span class=\\"fd-dialog__resize-handle\\"></span>
         <header class=\\"fd-dialog__header fd-bar\\">
             <div class=\\"fd-bar__left\\">
@@ -15933,8 +15938,10 @@ exports[`Check stories > Components/Dialog > Story DefaultDialog > Should match 
                 </div>
             </div>
         </header>
-        <div class=\\"fd-dialog__body\\">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat...
+        <section class=\\"fd-dialog__body\\">
+            <span id=\\"dialog-description-1\\">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat...
+            </span>
             <div class=\\"fd-dialog__loader\\">
                 <div class=\\"fd-busy-indicator fd-busy-indicator--m\\" aria-hidden=\\"false\\" aria-label=\\"Loading\\">
                     <div class=\\"fd-busy-indicator__circle\\"></div>
@@ -15942,7 +15949,7 @@ exports[`Check stories > Components/Dialog > Story DefaultDialog > Should match 
                     <div class=\\"fd-busy-indicator__circle\\"></div>
                 </div><br /><br />
             </div>
-        </div>
+        </section>
         <footer class=\\"fd-dialog__footer fd-bar fd-bar--footer\\">
             <div class=\\"fd-bar__right\\">
                 <div class=\\"fd-bar__element\\">
@@ -15958,14 +15965,20 @@ exports[`Check stories > Components/Dialog > Story DefaultDialog > Should match 
             </div>
         </footer>
     </div>
-</section>
+</div>
 "
 `;
 
 exports[`Check stories > Components/Dialog > Story Draggable > Should match snapshot 1`] = `
 "
-<section class=\\"fd-dialog-docs-static fd-dialog fd-dialog--active\\">
-    <div class=\\"fd-dialog__content fd-dialog__content--draggable-grab fd-dialog__content--s\\" role=\\"dialog\\" aria-modal=\\"true\\" aria-labelledby=\\"dialog-title-7\\">
+<div class=\\"fd-dialog-docs-static fd-dialog fd-dialog--active\\">
+    <div 
+        class=\\"fd-dialog__content fd-dialog__content--draggable-grab fd-dialog__content--s\\" 
+        role=\\"dialog\\" 
+        aria-modal=\\"true\\" 
+        aria-labelledby=\\"dialog-title-7\\"
+        aria-describedby=\\"dialog-description-7\\"
+    >
         <header class=\\"fd-dialog__header fd-bar fd-bar--header\\">
             <div class=\\"fd-bar__left\\">
                 <div class=\\"fd-bar__element\\">
@@ -15975,9 +15988,11 @@ exports[`Check stories > Components/Dialog > Story Draggable > Should match snap
                 </div>
             </div>
         </header>
-        <div class=\\"fd-dialog__body\\">
+
+        <section class=\\"fd-dialog__body\\" id=\\"dialog-description-7\\">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
-        </div>
+        </section>
+        
         <footer class=\\"fd-dialog__footer fd-bar fd-bar--footer\\">
             <div class=\\"fd-bar__right\\">
                 <div class=\\"fd-bar__element\\">
@@ -15989,14 +16004,20 @@ exports[`Check stories > Components/Dialog > Story Draggable > Should match snap
             </div>
         </footer>
     </div>
-</section>
+</div>
 "
 `;
 
 exports[`Check stories > Components/Dialog > Story HorizontalForm > Should match snapshot 1`] = `
 "
-<section class=\\"fd-dialog-docs-static fd-dialog fd-dialog--active\\">
-    <div class=\\"fd-dialog__content fd-dialog__content--s\\" role=\\"dialog\\" aria-modal=\\"true\\" aria-labelledby=\\"dialog-title-2\\">
+<div class=\\"fd-dialog-docs-static fd-dialog fd-dialog--active\\">
+    <div 
+        class=\\"fd-dialog__content fd-dialog__content--s\\" 
+        role=\\"dialog\\" 
+        aria-modal=\\"true\\" 
+        aria-labelledby=\\"dialog-title-2\\"
+    >
+        
         <header class=\\"fd-dialog__header fd-bar fd-bar--header\\">
             <div class=\\"fd-bar__left\\">
             <div class=\\"fd-bar__element\\">
@@ -16006,7 +16027,8 @@ exports[`Check stories > Components/Dialog > Story HorizontalForm > Should match
             </div>
             </div>
         </header>
-        <div class=\\"fd-dialog__body\\">
+        
+        <section class=\\"fd-dialog__body\\">
             <div class=\\"fd-container fd-form-layout-grid-container fd-form-group\\">
                 <div class=\\"fd-row fd-form-item\\">
                     <div class=\\"fd-col fd-col-md--2 fd-col-lg--4\\">
@@ -16077,7 +16099,8 @@ exports[`Check stories > Components/Dialog > Story HorizontalForm > Should match
                     </div>
                 </div>
             </div>
-        </div>
+        </section>
+        
         <footer class=\\"fd-dialog__footer fd-bar fd-bar--footer\\">
             <div class=\\"fd-bar__right\\">
                 <div class=\\"fd-bar__element\\">
@@ -16089,14 +16112,21 @@ exports[`Check stories > Components/Dialog > Story HorizontalForm > Should match
             </div>
         </footer>
     </div>
-</section>
+</div>
 "
 `;
 
 exports[`Check stories > Components/Dialog > Story Loading > Should match snapshot 1`] = `
 "
-<section class=\\"fd-dialog-docs-static fd-dialog fd-dialog--active\\" id=\\"loading-dialog-example\\">
-    <div class=\\"fd-dialog__content fd-dialog__content--s\\" role=\\"dialog\\" aria-modal=\\"true\\" aria-labelledby=\\"dialog-title-9\\">
+<div class=\\"fd-dialog-docs-static fd-dialog fd-dialog--active\\" id=\\"loading-dialog-example\\">
+    <div 
+        class=\\"fd-dialog__content fd-dialog__content--s\\" 
+        role=\\"dialog\\" 
+        aria-modal=\\"true\\" 
+        aria-labelledby=\\"dialog-title-9\\"
+        aria-describedby=\\"dialog-description-9\\"
+    >
+        
         <header class=\\"fd-dialog__header fd-bar fd-bar--header\\">
             <div class=\\"fd-bar__left\\">
                 <div class=\\"fd-bar__element\\">
@@ -16106,14 +16136,16 @@ exports[`Check stories > Components/Dialog > Story Loading > Should match snapsh
                 </div>
             </div>
         </header>
-        <div class=\\"fd-dialog__body\\">
+
+        <section class=\\"fd-dialog__body\\" id=\\"dialog-description-8\\">
             <strong>Status:</strong> Connecting 127.0.0.1
             <div class=\\"fd-dialog__loader fd-busy-indicator--l\\" aria-hidden=\\"false\\" aria-label=\\"Loading\\">
                 <div class=\\"fd-busy-indicator--circle-0\\"></div>
                 <div class=\\"fd-busy-indicator--circle-1\\"></div>
                 <div class=\\"fd-busy-indicator--circle-2\\"></div>
             </div>
-        </div>
+        </section>
+
         <footer class=\\"fd-dialog__footer fd-bar fd-bar--footer\\">
             <div class=\\"fd-bar__right\\">
                 <div class=\\"fd-bar__element\\">
@@ -16122,14 +16154,21 @@ exports[`Check stories > Components/Dialog > Story Loading > Should match snapsh
             </div>
         </footer>
     </div>
-</section>"
+</div>"
 `;
 
 exports[`Check stories > Components/Dialog > Story Resizable > Should match snapshot 1`] = `
 "
-<section class=\\"fd-dialog-docs-static fd-dialog fd-dialog--active\\">
-    <div class=\\"fd-dialog__content fd-dialog__content--s\\" role=\\"dialog\\" aria-modal=\\"true\\" aria-labelledby=\\"dialog-title-6\\">
-        <span class=\\"fd-dialog__resize-handle\\"></span>
+<div class=\\"fd-dialog-docs-static fd-dialog fd-dialog--active\\">
+    <div 
+        class=\\"fd-dialog__content fd-dialog__content--s\\" 
+        role=\\"dialog\\" 
+        aria-modal=\\"true\\" 
+        aria-labelledby=\\"dialog-title-6\\"
+        aria-describedby=\\"dialog-description-6\\"
+    >
+        <span class=\\"fd-dialog__resize-handle\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+        
         <header class=\\"fd-dialog__header fd-bar fd-bar--header\\">
             <div class=\\"fd-bar__left\\">
                 <div class=\\"fd-bar__element\\">
@@ -16139,9 +16178,11 @@ exports[`Check stories > Components/Dialog > Story Resizable > Should match snap
                 </div>
             </div>
         </header>
-        <div class=\\"fd-dialog__body\\">
+        
+        <section class=\\"fd-dialog__body\\" id=\\"dialog-description-6\\">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
-        </div>
+        </section>
+        
         <footer class=\\"fd-dialog__footer fd-bar fd-bar--footer\\">
             <div class=\\"fd-bar__right\\">
                 <div class=\\"fd-bar__element\\">
@@ -16153,14 +16194,19 @@ exports[`Check stories > Components/Dialog > Story Resizable > Should match snap
             </div>
         </footer>
     </div>
-</section>
+</div>
 "
 `;
 
 exports[`Check stories > Components/Dialog > Story Selectable > Should match snapshot 1`] = `
 "
-<section class=\\"fd-dialog-docs-static fd-dialog fd-dialog--active\\" id=\\"select-dialog-example\\">
-    <div class=\\"fd-dialog__content\\" role=\\"dialog\\" aria-modal=\\"true\\" aria-labelledby=\\"dialog-title-8\\">
+<div class=\\"fd-dialog-docs-static fd-dialog fd-dialog--active\\" id=\\"select-dialog-example\\">
+    <div 
+        class=\\"fd-dialog__content\\" 
+        role=\\"dialog\\" 
+        aria-modal=\\"true\\" 
+        aria-labelledby=\\"dialog-title-8\\"
+    >
         <header class=\\"fd-dialog__header fd-bar fd-bar--header-with-subheader\\">
             <div class=\\"fd-bar__left\\">
                 <div class=\\"fd-bar__element\\">
@@ -16175,7 +16221,8 @@ exports[`Check stories > Components/Dialog > Story Selectable > Should match sna
                 </div>
             </div>
         </header>
-        <div class=\\"fd-dialog__subheader fd-bar fd-bar--subheader\\">
+
+        <section class=\\"fd-dialog__subheader fd-bar fd-bar--subheader\\">
             <div class=\\"fd-bar__middle\\">
                 <div class=\\"fd-input-group\\">
                     <input class=\\"fd-input fd-input-group__input\\" type=\\"text\\" aria-label=\\"search\\" placeholder=\\"Search...\\">
@@ -16186,8 +16233,9 @@ exports[`Check stories > Components/Dialog > Story Selectable > Should match sna
                     </span>
                 </div>
             </div>
-        </div>
-        <div class=\\"fd-dialog__body fd-dialog__body--no-vertical-padding\\">
+        </section>
+
+        <section class=\\"fd-dialog__body fd-dialog__body--no-vertical-padding\\">
             <ul class=\\"fd-list fd-list--selection fd-list--no-border\\" aria-label=\\"selection list\\" role=\\"listbox\\">
                 <li role=\\"option\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
                     <div class=\\"fd-form-item fd-list__form-item\\">
@@ -16247,7 +16295,8 @@ exports[`Check stories > Components/Dialog > Story Selectable > Should match sna
             <span class=\\"fd-list__footer\\">
                 2 items selected
             </span>
-        </div>
+        </section>
+
         <footer class=\\"fd-dialog__footer fd-bar fd-bar--footer\\">
             <div class=\\"fd-bar__right\\">
                 <div class=\\"fd-bar__element\\">
@@ -16259,13 +16308,20 @@ exports[`Check stories > Components/Dialog > Story Selectable > Should match sna
             </div>
         </footer>
     </div>
-</section>"
+</div>"
 `;
 
 exports[`Check stories > Components/Dialog > Story Sizes > Should match snapshot 1`] = `
 "
-<section class=\\"fd-dialog-docs-static fd-dialog fd-dialog--active\\">
-    <div class=\\"fd-dialog__content fd-dialog__content--s\\" role=\\"dialog\\" aria-modal=\\"true\\" aria-labelledby=\\"dialog-title-2\\">
+<div class=\\"fd-dialog-docs-static fd-dialog fd-dialog--active\\">
+    <div 
+        class=\\"fd-dialog__content fd-dialog__content--s\\" 
+        role=\\"dialog\\" 
+        aria-modal=\\"true\\" 
+        aria-labelledby=\\"dialog-title-2\\"
+        aria-describedby=\\"dialog-description-2\\"
+    >
+        
         <header class=\\"fd-dialog__header fd-bar fd-bar--header\\">
             <div class=\\"fd-bar__left\\">
                 <div class=\\"fd-bar__element\\">
@@ -16275,9 +16331,11 @@ exports[`Check stories > Components/Dialog > Story Sizes > Should match snapshot
                 </div>
             </div>
         </header>
-        <div class=\\"fd-dialog__body\\">
+        
+        <section class=\\"fd-dialog__body\\" id=\\"dialog-description-2\\">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
-        </div>
+        </section>
+        
         <footer class=\\"fd-dialog__footer fd-bar fd-bar--footer\\">
             <div class=\\"fd-bar__right\\">
                 <div class=\\"fd-bar__element\\">
@@ -16289,10 +16347,17 @@ exports[`Check stories > Components/Dialog > Story Sizes > Should match snapshot
             </div>
         </footer>
     </div>
-</section>
+</div>
 <br />
-<section class=\\"fd-dialog-docs-static fd-dialog fd-dialog--active\\">
-    <div class=\\"fd-dialog__content fd-dialog__content--m\\" role=\\"dialog\\" aria-modal=\\"true\\" aria-labelledby=\\"dialog-title-3\\">
+<div class=\\"fd-dialog-docs-static fd-dialog fd-dialog--active\\">
+    <div 
+        class=\\"fd-dialog__content fd-dialog__content--m\\" 
+        role=\\"dialog\\" 
+        aria-modal=\\"true\\" 
+        aria-labelledby=\\"dialog-title-3\\" 
+        aria-describedby=\\"dialog-description-3\\"
+    >
+        
         <header class=\\"fd-dialog__header fd-bar fd-bar--header\\">
             <div class=\\"fd-bar__left\\">
                 <div class=\\"fd-bar__element\\">
@@ -16302,9 +16367,11 @@ exports[`Check stories > Components/Dialog > Story Sizes > Should match snapshot
                 </div>
             </div>
         </header>
-        <div class=\\"fd-dialog__body\\">
+        
+        <section class=\\"fd-dialog__body\\" id=\\"dialog-description-3\\">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
-        </div>
+        </section>
+        
         <footer class=\\"fd-dialog__footer fd-bar fd-bar--footer\\">
             <div class=\\"fd-bar__right\\">
                 <div class=\\"fd-bar__element\\">
@@ -16316,10 +16383,17 @@ exports[`Check stories > Components/Dialog > Story Sizes > Should match snapshot
             </div>
         </footer>
     </div>
-</section>
+</div>
 <br />
-<section class=\\"fd-dialog-docs-static fd-dialog fd-dialog--active\\">
-    <div class=\\"fd-dialog__content fd-dialog__content--l\\" role=\\"dialog\\" aria-modal=\\"true\\" aria-labelledby=\\"dialog-title-4\\">
+<div class=\\"fd-dialog-docs-static fd-dialog fd-dialog--active\\">
+    <div 
+        class=\\"fd-dialog__content fd-dialog__content--l\\" 
+        role=\\"dialog\\" 
+        aria-modal=\\"true\\" 
+        aria-labelledby=\\"dialog-title-4\\"
+        aria-describedby=\\"dialog-description-4\\"
+    >
+        
         <header class=\\"fd-dialog__header fd-bar fd-bar--header\\">
             <div class=\\"fd-bar__left\\">
                 <div class=\\"fd-bar__element\\">
@@ -16329,9 +16403,11 @@ exports[`Check stories > Components/Dialog > Story Sizes > Should match snapshot
                 </div>
             </div>
         </header>
-        <div class=\\"fd-dialog__body\\">
+        
+        <section class=\\"fd-dialog__body\\" id=\\"dialog-description-4\\">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
-        </div>
+        </section>
+        
         <footer class=\\"fd-dialog__footer fd-bar fd-bar--footer\\">
             <div class=\\"fd-bar__right\\">
                 <div class=\\"fd-bar__element\\">
@@ -16343,10 +16419,19 @@ exports[`Check stories > Components/Dialog > Story Sizes > Should match snapshot
             </div>
         </footer>
     </div>
-</section>
+</div>
+
 <br />
-<section class=\\"fd-dialog-docs-static fd-dialog fd-dialog--active\\">
-    <div class=\\"fd-dialog__content fd-dialog__content--xl\\" role=\\"dialog\\" aria-modal=\\"true\\" aria-labelledby=\\"dialog-title-5\\">
+
+<div class=\\"fd-dialog-docs-static fd-dialog fd-dialog--active\\">
+    <div 
+        class=\\"fd-dialog__content fd-dialog__content--xl\\" 
+        role=\\"dialog\\" 
+        aria-modal=\\"true\\" 
+        aria-labelledby=\\"dialog-title-5\\"
+        aria-describedby=\\"dialog-description-5\\"
+    >
+        
         <header class=\\"fd-dialog__header fd-bar fd-bar--header\\">
             <div class=\\"fd-bar__left\\">
                 <div class=\\"fd-bar__element\\">
@@ -16356,9 +16441,11 @@ exports[`Check stories > Components/Dialog > Story Sizes > Should match snapshot
                 </div>
             </div>
         </header>
-        <div class=\\"fd-dialog__body\\">
+        
+        <section class=\\"fd-dialog__body\\" id=\\"dialog-description-5\\">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
-        </div>
+        </section>
+        
         <footer class=\\"fd-dialog__footer fd-bar fd-bar--footer\\">
             <div class=\\"fd-bar__right\\">
                 <div class=\\"fd-bar__element\\">
@@ -16370,7 +16457,7 @@ exports[`Check stories > Components/Dialog > Story Sizes > Should match snapshot
             </div>
         </footer>
     </div>
-</section>
+</div>
 "
 `;
 
@@ -16380,12 +16467,19 @@ exports[`Check stories > Components/Dialog > Story TabletAndHybridDeviceSpecific
 <div>Full Screen Button: visible (<code>sap-icon--full-screen</code>)</div>
 <div>Resize Handle: not visible</div>
 <br>
-<section class=\\"fd-dialog-docs-static fd-dialog fd-dialog--active\\">
-    <div class=\\"fd-dialog__content fd-dialog__content--s\\" role=\\"dialog\\" aria-modal=\\"true\\" aria-labelledby=\\"dialog-title-6\\">
+<div class=\\"fd-dialog-docs-static fd-dialog fd-dialog--active\\">
+    <div 
+        class=\\"fd-dialog__content fd-dialog__content--s\\" 
+        role=\\"dialog\\" 
+        aria-modal=\\"true\\" 
+        aria-labelledby=\\"dialog-title-12\\"
+        aria-describedby=\\"dialog-description-12\\"
+    >
+        
         <header class=\\"fd-dialog__header fd-bar fd-bar--header\\">
             <div class=\\"fd-bar__left\\">
                 <div class=\\"fd-bar__element\\">
-                    <h2 class=\\"fd-title fd-title--h5\\" id=\\"dialog-title-6\\">
+                    <h2 class=\\"fd-title fd-title--h5\\" id=\\"dialog-title-12\\">
                         Lorem ipsum
                     </h2>
                 </div>
@@ -16398,9 +16492,11 @@ exports[`Check stories > Components/Dialog > Story TabletAndHybridDeviceSpecific
                 </div>
             </div>
         </header>
-        <div class=\\"fd-dialog__body\\">
+
+        <section class=\\"fd-dialog__body\\" id=\\"dialog-description-12\\">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
-        </div>
+        </section>
+
         <footer class=\\"fd-dialog__footer fd-bar fd-bar--footer\\">
             <div class=\\"fd-bar__right\\">
                 <div class=\\"fd-bar__element\\">
@@ -16412,7 +16508,7 @@ exports[`Check stories > Components/Dialog > Story TabletAndHybridDeviceSpecific
             </div>
         </footer>
     </div>
-</section>  
+</div>  
 
 <br><br>
 <h3>Tablet with mouse attached</h3>
@@ -16535,8 +16631,13 @@ exports[`Check stories > Components/Dialog > Story TabletAndHybridDeviceSpecific
 `;
 
 exports[`Check stories > Components/Dialog > Story VerticalForm > Should match snapshot 1`] = `
-"<section class=\\"fd-dialog-docs-static fd-dialog fd-dialog--active\\">
-    <div class=\\"fd-dialog__content fd-dialog__content--s\\" role=\\"dialog\\" aria-modal=\\"true\\" aria-labelledby=\\"dialog-title-2\\">
+"<div class=\\"fd-dialog-docs-static fd-dialog fd-dialog--active\\">
+    <div 
+        class=\\"fd-dialog__content fd-dialog__content--s\\" 
+        role=\\"dialog\\" 
+        aria-modal=\\"true\\" 
+        aria-labelledby=\\"dialog-title-2\\">
+        
         <header class=\\"fd-dialog__header fd-bar fd-bar--header\\">
             <div class=\\"fd-bar__left\\">
             <div class=\\"fd-bar__element\\">
@@ -16546,7 +16647,8 @@ exports[`Check stories > Components/Dialog > Story VerticalForm > Should match s
             </div>
             </div>
         </header>
-        <div class=\\"fd-dialog__body\\">
+
+        <section class=\\"fd-dialog__body\\">
             <div class=\\"fd-container fd-form-layout-grid-container fd-form-layout-grid-container--vertical fd-form-group\\">
                 <div class=\\"fd-row fd-form-item\\">
                     <div class=\\"fd-col\\">
@@ -16617,7 +16719,8 @@ exports[`Check stories > Components/Dialog > Story VerticalForm > Should match s
                     </div>
                 </div>
             </div>
-        </div>
+        </section>
+        
         <footer class=\\"fd-dialog__footer fd-bar fd-bar--footer\\">
             <div class=\\"fd-bar__right\\">
                 <div class=\\"fd-bar__element\\">
@@ -16629,7 +16732,7 @@ exports[`Check stories > Components/Dialog > Story VerticalForm > Should match s
             </div>
         </footer>
     </div>
-</section>
+</div>
 "
 `;
 


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-styles/issues/5763

## Description
- design update: opacity of the backdrop, cleanup
- bug fix: missing resize handle
- a11y: markup update

BREAKING CHANGE:
updated markup and aria

Before:
```
<section class="fd-dialog">
    <div class="fd-dialog__content" role="dialog" aria-modal="true" aria-labelledby="dialog-title-1">
        <header class="fd-dialog__header fd-bar fd-bar--header">
            ...
           <h2 class="fd-title fd-title--h5" id="dialog-title-1">...</h2>
            ...
        </header>
        <div class="fd-dialog__body">
           ....
        </div>
        <footer class="fd-dialog__footer fd-bar fd-bar--footer">
           ...
        </footer>
    </div>
</section>
```

After:
```
<div class="fd-dialog">
    <div class="fd-dialog__content" role="dialog" aria-modal="true" aria-labelledby="dialog-title-2" aria-describedby="dialog-title-2">
        <header class="fd-dialog__header fd-bar fd-bar--header">
            ...
           <h2 class="fd-title fd-title--h5" id="dialog-title-2">...</h2>
            ...
        </header>
        <section class="fd-dialog__body" id="dialog-body-2">
           ....
        </div>
        <footer class="fd-dialog__footer fd-bar fd-bar--footer">
           ...
        </footer>
    </div>
</section>
```