### PR TITLE
fix(styles): a11y update for Message box [ci visual]

### DIFF
--- a/packages/styles/stories/Components/message-box/message-box.stories.js
+++ b/packages/styles/stories/Components/message-box/message-box.stories.js
@@ -75,7 +75,7 @@ Types.parameters = {
       story: `
 The message box can be displayed with various semantic colors and icons, indicating the type of message being relayed.
 
-Semantic type | Modifier class | Description
+|Semantic type | Modifier class | Description
 :------------------ | :------------------- | :---------------
 Confirmation | \`fd-message-box--confirmation\` | Confirmation messages prompt users to confirm an action that they have triggered. The title of the message box already includes the action that has to be confirmed, such as an intended deletion or an approval.
 Error&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | \`fd-message-box--error\` | Error messages can be triggered after the user has entered incorrect data or a system error has occurred. They should interrupt the user by displaying a dialog. A final action such as _Submit_ cannot be carried out until the user has rectified the error.
@@ -96,7 +96,7 @@ The message box has 1rem padding all around the body, and the header and footer 
 
 **To display responsive padding, add the following modifier classes to the content container:**
 
-Modifier class | rem | Screen width
+|Modifier class | rem | Screen width
 ------------------ | ---- | ---------------------
 \`fd-message-box__content--s\` | 1rem | <= 599px
 \`fd-message-box__content--m\` | 2rem | 600px - 1023px

--- a/packages/styles/stories/Components/message-box/responsive.example.html
+++ b/packages/styles/stories/Components/message-box/responsive.example.html
@@ -1,6 +1,12 @@
 
-<div class="fd-message-box-docs-static fd-message-box fd-message-box--information fd-message-box--active" role="alertdialog" aria-modal="true" aria-labelledby="fd-message-box-title-7 fd-message-box-text-7" tabindex="-1">
-    <section class="fd-message-box__content fd-message-box__content--s">
+<div 
+    class="fd-message-box-docs-static fd-message-box fd-message-box--information fd-message-box--active" 
+    role="alertdialog" 
+    aria-modal="true" 
+    aria-labelledby="fd-message-box-title-7" 
+    aria-describedby="fd-message-box-text-7" 
+    tabindex="-1">
+    <div class="fd-message-box__content fd-message-box__content--s">
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
@@ -8,12 +14,14 @@
                 </div>
             </div>
         </header>
-        <div class="fd-message-box__body" id="fd-message-box-text-7">
+
+        <section class="fd-message-box__body" id="fd-message-box-text-7">
             Informative message box for a small screen in cozy mode (mobile) and a "Show more" link in the body.
             <div class="fd-message-box__more">
                 <a href="#" class="fd-link" tabindex="0"><span class="fd-link__content">Show more</span></a>
             </div>
-        </div>
+        </section>
+
         <footer class="fd-bar fd-bar--footer fd-message-box__footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
@@ -23,13 +31,19 @@
                 </div>
             </div>
         </footer>
-    </section>
+    </div>
 </div>
 
 <br><br><br>
 
-<div class="fd-message-box-docs-static fd-message-box fd-message-box--error fd-message-box--active" role="alertdialog" aria-modal="true" aria-labelledby="fd-message-box-title-8 fd-message-box-text-8" tabindex="-1">
-    <section class="fd-message-box__content fd-message-box__content--m">
+<div 
+    class="fd-message-box-docs-static fd-message-box fd-message-box--error fd-message-box--active" 
+    role="alertdialog" 
+    aria-modal="true" 
+    aria-labelledby="fd-message-box-title-8" 
+    aria-describedby="fd-message-box-text-8" 
+    tabindex="-1">
+    <div class="fd-message-box__content fd-message-box__content--m">
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
@@ -37,9 +51,11 @@
                 </div>
             </div>
         </header>
-        <div class="fd-message-box__body" id="fd-message-box-text-8">
+
+        <section class="fd-message-box__body" id="fd-message-box-text-8">
             Error message box for a medium-sized screen in cozy mode (mobile).
-        </div>
+        </section>
+
         <footer class="fd-bar fd-bar--footer fd-message-box__footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
@@ -49,14 +65,20 @@
                 </div>
             </div>
         </footer>
-    </section>
+    </div>
 </div>
 
 
 <br><br><br>
 
-<div class="fd-message-box-docs-static fd-message-box fd-message-box--success fd-message-box--active" role="alertdialog" aria-modal="true" aria-labelledby="fd-message-box-title-9 fd-message-box-text-9" tabindex="-1">
-    <section class="fd-message-box__content fd-message-box__content--l">
+<div 
+    class="fd-message-box-docs-static fd-message-box fd-message-box--success fd-message-box--active" 
+    role="alertdialog" 
+    aria-modal="true" 
+    aria-labelledby="fd-message-box-title-9"
+    aria-describedby="fd-message-box-text-9"  
+    tabindex="-1">
+    <div class="fd-message-box__content fd-message-box__content--l">
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
@@ -64,9 +86,11 @@
                 </div>
             </div>
         </header>
-        <div class="fd-message-box__body" id="fd-message-box-text-9">
+
+        <section class="fd-message-box__body" id="fd-message-box-text-9">
             Success message box for a large screen in compact mode (desktop).
-        </div>
+        </section>
+
         <footer class="fd-bar fd-bar--footer fd-message-box__footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
@@ -76,13 +100,19 @@
                 </div>
             </div>
         </footer>
-    </section>
+    </div>
 </div>
 
 <br><br><br>
 
-<div class="fd-message-box-docs-static fd-message-box fd-message-box--warning fd-message-box--active" role="alertdialog" aria-modal="true" aria-labelledby="fd-message-box-title-10 fd-message-box-text-10" tabindex="-1">
-    <section class="fd-message-box__content fd-message-box__content--xl">
+<div 
+    class="fd-message-box-docs-static fd-message-box fd-message-box--warning fd-message-box--active" 
+    role="alertdialog" 
+    aria-modal="true" 
+    aria-labelledby="fd-message-box-title-10" 
+    aria-describedby="fd-message-box-text-10" 
+    tabindex="-1">
+    <div class="fd-message-box__content fd-message-box__content--xl">
         <header class="fd-bar fd-bar--header fd-message-box__header">
              <div class="fd-bar__left">
                 <div class="fd-bar__element">
@@ -90,9 +120,11 @@
                 </div>
             </div>
         </header>
-        <div class="fd-message-box__body" id="fd-message-box-text-10">
+        
+        <section class="fd-message-box__body" id="fd-message-box-text-10">
            Warning message box for an extra large screen in compact mode (desktop).
-        </div>
+        </section>
+        
         <footer class="fd-bar fd-bar--footer fd-message-box__footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
@@ -102,5 +134,5 @@
                 </div>
             </div>
         </footer>
-    </section>
+    </div>
 </div>

--- a/packages/styles/stories/Components/message-box/structure.example.html
+++ b/packages/styles/stories/Components/message-box/structure.example.html
@@ -1,5 +1,11 @@
-<div class="fd-message-box-docs-static fd-message-box fd-message-box--active" role="alertdialog" aria-modal="true" aria-labelledby="fd-message-box-title-1 fd-message-box-text-1" tabindex="-1">
-    <section class="fd-message-box__content">
+<div 
+    class="fd-message-box-docs-static fd-message-box fd-message-box--active" 
+    role="alertdialog" 
+    aria-modal="true" 
+    aria-labelledby="fd-message-box-title-1" 
+    aria-describedby="fd-message-box-text-1"
+    tabindex="-1">
+    <div class="fd-message-box__content">
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
@@ -7,9 +13,11 @@
                 </div>
             </div>
         </header>
-        <div class="fd-message-box__body" id="fd-message-box-text-1">
+
+        <section class="fd-message-box__body" id="fd-message-box-text-1">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-        </div>
+        </section>
+
         <footer class="fd-bar fd-bar--footer fd-message-box__footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
@@ -24,5 +32,5 @@
                 </div>
             </div>
         </footer>
-    </section>
+    </div>
 </div>

--- a/packages/styles/stories/Components/message-box/types.example.html
+++ b/packages/styles/stories/Components/message-box/types.example.html
@@ -1,16 +1,24 @@
-<div class="fd-message-box-docs-static fd-message-box fd-message-box--confirmation fd-message-box--active"  role="alertdialog" aria-modal="true" aria-labelledby="fd-message-box-title-2 fd-message-box-text-2" tabindex="-1">
-    <section class="fd-message-box__content">
+<div 
+    class="fd-message-box-docs-static fd-message-box fd-message-box--confirmation fd-message-box--active"  
+    role="alertdialog" 
+    aria-modal="true" 
+    aria-labelledby="fd-message-box-title-2" 
+    aria-describedby="fd-message-box-text-2"
+    tabindex="-1">
+    <div class="fd-message-box__content">
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <i class="sap-icon--sys-help-2"></i>
+                    <i class="sap-icon--sys-help-2" role="presentation" aria-hidden="true"></i>
                     <h1 class="fd-title fd-title--h5" id="fd-message-box-title-2">Confirmation</h1>
                 </div>
             </div>
         </header>
-        <div class="fd-message-box__body" id="fd-message-box-text-2">
+        
+        <section class="fd-message-box__body" id="fd-message-box-text-2">
             Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-        </div>
+        </section>
+        
         <footer class="fd-bar fd-bar--footer fd-message-box__footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
@@ -25,24 +33,31 @@
                 </div>
             </div>
         </footer>
-    </section>
+    </div>
 </div>
 
 <br><br><br>
 
-<div class="fd-message-box-docs-static fd-message-box fd-message-box--error fd-message-box--active" role="alertdialog" aria-modal="true" aria-labelledby="fd-message-box-title-3 fd-message-box-text-3" tabindex="-1">
-    <section class="fd-message-box__content">
+<div 
+    class="fd-message-box-docs-static fd-message-box fd-message-box--error fd-message-box--active" role="alertdialog" 
+    aria-modal="true" 
+    aria-labelledby="fd-message-box-title-3" 
+    aria-describedby="fd-message-box-text-3"
+    tabindex="-1">
+    <div class="fd-message-box__content">
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <i class="sap-icon--error"></i>
+                    <i class="sap-icon--error" role="presentation" aria-hidden="true"></i>
                     <h1 class="fd-title fd-title--h5" id="fd-message-box-title-3">Error</h1>
                 </div>
             </div>
         </header>
-        <div class="fd-message-box__body" id="fd-message-box-text-3">
+        
+        <section class="fd-message-box__body" id="fd-message-box-text-3">
             Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-        </div>
+        </section>
+        
         <footer class="fd-bar fd-bar--footer fd-message-box__footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
@@ -52,24 +67,32 @@
                 </div>
             </div>
         </footer>
-    </section>
+    </div>
 </div>
 
 <br><br><br>
 
-<div class="fd-message-box-docs-static fd-message-box fd-message-box--success fd-message-box--active" role="alertdialog" aria-modal="true" aria-labelledby="fd-message-box-title-4 fd-message-box-text-4" tabindex="-1">
-    <section class="fd-message-box__content">
+<div 
+    class="fd-message-box-docs-static fd-message-box fd-message-box--success fd-message-box--active" 
+    role="alertdialog" 
+    aria-modal="true" 
+    aria-labelledby="fd-message-box-title-4"
+    aria-describedby="fd-message-box-text-4" 
+    tabindex="-1">
+    <div class="fd-message-box__content">
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <i class="sap-icon--sys-enter-2"></i>
+                    <i class="sap-icon--sys-enter-2" role="presentation" aria-hidden="true"></i>
                     <h1 class="fd-title fd-title--h5" id="fd-message-box-title-4">Success</h1>
                 </div>
             </div>
         </header>
-        <div class="fd-message-box__body" id="fd-message-box-text-4">
+        
+        <section class="fd-message-box__body" id="fd-message-box-text-4">
             Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et mattis erat vel aliquet in sem urna et sagittis diam in vehicula.
-        </div>
+        </section>
+        
         <footer class="fd-bar fd-bar--footer fd-message-box__footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
@@ -79,24 +102,32 @@
                 </div>
             </div>
         </footer>
-    </section>
+    </div>
 </div>
 
 <br><br><br>
 
-<div class="fd-message-box-docs-static fd-message-box fd-message-box--warning fd-message-box--active" role="alertdialog" aria-modal="true" aria-labelledby="fd-message-box-title-5 fd-message-box-text-5" tabindex="-1">
-    <section class="fd-message-box__content">
+<div 
+    class="fd-message-box-docs-static fd-message-box fd-message-box--warning fd-message-box--active" 
+    role="alertdialog" 
+    aria-modal="true" 
+    aria-labelledby="fd-message-box-title-5" 
+    aria-describedby="fd-message-box-text-5"
+    tabindex="-1">
+    <div class="fd-message-box__content">
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <i class="sap-icon--alert"></i>
+                    <i class="sap-icon--alert" role="presentation" aria-hidden="true"></i>
                     <h1 class="fd-title fd-title--h5" id="fd-message-box-title-5">Warning</h1>
                 </div>
             </div>
         </header>
-        <div class="fd-message-box__body" id="fd-message-box-text-5">
+        
+        <section class="fd-message-box__body" id="fd-message-box-text-5">
             Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
-        </div>
+        </section>
+        
         <footer class="fd-bar fd-bar--footer fd-message-box__footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
@@ -106,24 +137,32 @@
                 </div>
             </div>
         </footer>
-    </section>
+    </div>
 </div>
 
 <br><br><br>
 
-<div class="fd-message-box-docs-static fd-message-box fd-message-box--information fd-message-box--active" role="alertdialog" aria-modal="true" aria-labelledby="fd-message-box-title-6 fd-message-box-text-6" tabindex="-1">
-    <section class="fd-message-box__content">
+<div 
+    class="fd-message-box-docs-static fd-message-box fd-message-box--information fd-message-box--active" 
+    role="alertdialog" 
+    aria-modal="true" 
+    aria-labelledby="fd-message-box-title-6" 
+    aria-describedby="fd-message-box-text-6"
+    tabindex="-1">
+    <div class="fd-message-box__content">
         <header class="fd-bar fd-bar--header fd-message-box__header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <i class="sap-icon--information"></i>
+                    <i class="sap-icon--information" role="presentation" aria-hidden="true"></i>
                     <h1 class="fd-title fd-title--h5" id="fd-message-box-title-6">Information</h1>
                 </div>
             </div>
         </header>
-        <div class="fd-message-box__body" id="fd-message-box-text-6">
+        
+        <section class="fd-message-box__body" id="fd-message-box-text-6">
             Vivamus sagittis diam in vehicula lobortis.
-        </div>
+        </section>
+        
         <footer class="fd-bar fd-bar--footer fd-message-box__footer">
             <div class="fd-bar__right">
                 <div class="fd-bar__element">
@@ -133,5 +172,5 @@
                 </div>
             </div>
         </footer>
-    </section>
+    </div>
 </div>

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -29383,8 +29383,14 @@ exports[`Check stories > Components/Menu > Story WithSubmenu > Should match snap
 
 exports[`Check stories > Components/Message Box > Story Responsive > Should match snapshot 1`] = `
 "
-<div class=\\"fd-message-box-docs-static fd-message-box fd-message-box--information fd-message-box--active\\" role=\\"alertdialog\\" aria-modal=\\"true\\" aria-labelledby=\\"fd-message-box-title-7 fd-message-box-text-7\\" tabindex=\\"-1\\">
-    <section class=\\"fd-message-box__content fd-message-box__content--s\\">
+<div 
+    class=\\"fd-message-box-docs-static fd-message-box fd-message-box--information fd-message-box--active\\" 
+    role=\\"alertdialog\\" 
+    aria-modal=\\"true\\" 
+    aria-labelledby=\\"fd-message-box-title-7\\" 
+    aria-describedby=\\"fd-message-box-text-7\\" 
+    tabindex=\\"-1\\">
+    <div class=\\"fd-message-box__content fd-message-box__content--s\\">
         <header class=\\"fd-bar fd-bar--header fd-message-box__header\\">
             <div class=\\"fd-bar__left\\">
                 <div class=\\"fd-bar__element\\">
@@ -29392,12 +29398,14 @@ exports[`Check stories > Components/Message Box > Story Responsive > Should matc
                 </div>
             </div>
         </header>
-        <div class=\\"fd-message-box__body\\" id=\\"fd-message-box-text-7\\">
+
+        <section class=\\"fd-message-box__body\\" id=\\"fd-message-box-text-7\\">
             Informative message box for a small screen in cozy mode (mobile) and a \\"Show more\\" link in the body.
             <div class=\\"fd-message-box__more\\">
                 <a href=\\"#\\" class=\\"fd-link\\" tabindex=\\"0\\"><span class=\\"fd-link__content\\">Show more</span></a>
             </div>
-        </div>
+        </section>
+
         <footer class=\\"fd-bar fd-bar--footer fd-message-box__footer\\">
             <div class=\\"fd-bar__right\\">
                 <div class=\\"fd-bar__element\\">
@@ -29407,13 +29415,19 @@ exports[`Check stories > Components/Message Box > Story Responsive > Should matc
                 </div>
             </div>
         </footer>
-    </section>
+    </div>
 </div>
 
 <br><br><br>
 
-<div class=\\"fd-message-box-docs-static fd-message-box fd-message-box--error fd-message-box--active\\" role=\\"alertdialog\\" aria-modal=\\"true\\" aria-labelledby=\\"fd-message-box-title-8 fd-message-box-text-8\\" tabindex=\\"-1\\">
-    <section class=\\"fd-message-box__content fd-message-box__content--m\\">
+<div 
+    class=\\"fd-message-box-docs-static fd-message-box fd-message-box--error fd-message-box--active\\" 
+    role=\\"alertdialog\\" 
+    aria-modal=\\"true\\" 
+    aria-labelledby=\\"fd-message-box-title-8\\" 
+    aria-describedby=\\"fd-message-box-text-8\\" 
+    tabindex=\\"-1\\">
+    <div class=\\"fd-message-box__content fd-message-box__content--m\\">
         <header class=\\"fd-bar fd-bar--header fd-message-box__header\\">
             <div class=\\"fd-bar__left\\">
                 <div class=\\"fd-bar__element\\">
@@ -29421,9 +29435,11 @@ exports[`Check stories > Components/Message Box > Story Responsive > Should matc
                 </div>
             </div>
         </header>
-        <div class=\\"fd-message-box__body\\" id=\\"fd-message-box-text-8\\">
+
+        <section class=\\"fd-message-box__body\\" id=\\"fd-message-box-text-8\\">
             Error message box for a medium-sized screen in cozy mode (mobile).
-        </div>
+        </section>
+
         <footer class=\\"fd-bar fd-bar--footer fd-message-box__footer\\">
             <div class=\\"fd-bar__right\\">
                 <div class=\\"fd-bar__element\\">
@@ -29433,14 +29449,20 @@ exports[`Check stories > Components/Message Box > Story Responsive > Should matc
                 </div>
             </div>
         </footer>
-    </section>
+    </div>
 </div>
 
 
 <br><br><br>
 
-<div class=\\"fd-message-box-docs-static fd-message-box fd-message-box--success fd-message-box--active\\" role=\\"alertdialog\\" aria-modal=\\"true\\" aria-labelledby=\\"fd-message-box-title-9 fd-message-box-text-9\\" tabindex=\\"-1\\">
-    <section class=\\"fd-message-box__content fd-message-box__content--l\\">
+<div 
+    class=\\"fd-message-box-docs-static fd-message-box fd-message-box--success fd-message-box--active\\" 
+    role=\\"alertdialog\\" 
+    aria-modal=\\"true\\" 
+    aria-labelledby=\\"fd-message-box-title-9\\"
+    aria-describedby=\\"fd-message-box-text-9\\"  
+    tabindex=\\"-1\\">
+    <div class=\\"fd-message-box__content fd-message-box__content--l\\">
         <header class=\\"fd-bar fd-bar--header fd-message-box__header\\">
             <div class=\\"fd-bar__left\\">
                 <div class=\\"fd-bar__element\\">
@@ -29448,9 +29470,11 @@ exports[`Check stories > Components/Message Box > Story Responsive > Should matc
                 </div>
             </div>
         </header>
-        <div class=\\"fd-message-box__body\\" id=\\"fd-message-box-text-9\\">
+
+        <section class=\\"fd-message-box__body\\" id=\\"fd-message-box-text-9\\">
             Success message box for a large screen in compact mode (desktop).
-        </div>
+        </section>
+
         <footer class=\\"fd-bar fd-bar--footer fd-message-box__footer\\">
             <div class=\\"fd-bar__right\\">
                 <div class=\\"fd-bar__element\\">
@@ -29460,13 +29484,19 @@ exports[`Check stories > Components/Message Box > Story Responsive > Should matc
                 </div>
             </div>
         </footer>
-    </section>
+    </div>
 </div>
 
 <br><br><br>
 
-<div class=\\"fd-message-box-docs-static fd-message-box fd-message-box--warning fd-message-box--active\\" role=\\"alertdialog\\" aria-modal=\\"true\\" aria-labelledby=\\"fd-message-box-title-10 fd-message-box-text-10\\" tabindex=\\"-1\\">
-    <section class=\\"fd-message-box__content fd-message-box__content--xl\\">
+<div 
+    class=\\"fd-message-box-docs-static fd-message-box fd-message-box--warning fd-message-box--active\\" 
+    role=\\"alertdialog\\" 
+    aria-modal=\\"true\\" 
+    aria-labelledby=\\"fd-message-box-title-10\\" 
+    aria-describedby=\\"fd-message-box-text-10\\" 
+    tabindex=\\"-1\\">
+    <div class=\\"fd-message-box__content fd-message-box__content--xl\\">
         <header class=\\"fd-bar fd-bar--header fd-message-box__header\\">
              <div class=\\"fd-bar__left\\">
                 <div class=\\"fd-bar__element\\">
@@ -29474,9 +29504,11 @@ exports[`Check stories > Components/Message Box > Story Responsive > Should matc
                 </div>
             </div>
         </header>
-        <div class=\\"fd-message-box__body\\" id=\\"fd-message-box-text-10\\">
+        
+        <section class=\\"fd-message-box__body\\" id=\\"fd-message-box-text-10\\">
            Warning message box for an extra large screen in compact mode (desktop).
-        </div>
+        </section>
+        
         <footer class=\\"fd-bar fd-bar--footer fd-message-box__footer\\">
             <div class=\\"fd-bar__right\\">
                 <div class=\\"fd-bar__element\\">
@@ -29486,14 +29518,20 @@ exports[`Check stories > Components/Message Box > Story Responsive > Should matc
                 </div>
             </div>
         </footer>
-    </section>
+    </div>
 </div>
 "
 `;
 
 exports[`Check stories > Components/Message Box > Story Structure > Should match snapshot 1`] = `
-"<div class=\\"fd-message-box-docs-static fd-message-box fd-message-box--active\\" role=\\"alertdialog\\" aria-modal=\\"true\\" aria-labelledby=\\"fd-message-box-title-1 fd-message-box-text-1\\" tabindex=\\"-1\\">
-    <section class=\\"fd-message-box__content\\">
+"<div 
+    class=\\"fd-message-box-docs-static fd-message-box fd-message-box--active\\" 
+    role=\\"alertdialog\\" 
+    aria-modal=\\"true\\" 
+    aria-labelledby=\\"fd-message-box-title-1\\" 
+    aria-describedby=\\"fd-message-box-text-1\\"
+    tabindex=\\"-1\\">
+    <div class=\\"fd-message-box__content\\">
         <header class=\\"fd-bar fd-bar--header fd-message-box__header\\">
             <div class=\\"fd-bar__left\\">
                 <div class=\\"fd-bar__element\\">
@@ -29501,9 +29539,11 @@ exports[`Check stories > Components/Message Box > Story Structure > Should match
                 </div>
             </div>
         </header>
-        <div class=\\"fd-message-box__body\\" id=\\"fd-message-box-text-1\\">
+
+        <section class=\\"fd-message-box__body\\" id=\\"fd-message-box-text-1\\">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-        </div>
+        </section>
+
         <footer class=\\"fd-bar fd-bar--footer fd-message-box__footer\\">
             <div class=\\"fd-bar__right\\">
                 <div class=\\"fd-bar__element\\">
@@ -29518,25 +29558,33 @@ exports[`Check stories > Components/Message Box > Story Structure > Should match
                 </div>
             </div>
         </footer>
-    </section>
+    </div>
 </div>
 "
 `;
 
 exports[`Check stories > Components/Message Box > Story Types > Should match snapshot 1`] = `
-"<div class=\\"fd-message-box-docs-static fd-message-box fd-message-box--confirmation fd-message-box--active\\"  role=\\"alertdialog\\" aria-modal=\\"true\\" aria-labelledby=\\"fd-message-box-title-2 fd-message-box-text-2\\" tabindex=\\"-1\\">
-    <section class=\\"fd-message-box__content\\">
+"<div 
+    class=\\"fd-message-box-docs-static fd-message-box fd-message-box--confirmation fd-message-box--active\\"  
+    role=\\"alertdialog\\" 
+    aria-modal=\\"true\\" 
+    aria-labelledby=\\"fd-message-box-title-2\\" 
+    aria-describedby=\\"fd-message-box-text-2\\"
+    tabindex=\\"-1\\">
+    <div class=\\"fd-message-box__content\\">
         <header class=\\"fd-bar fd-bar--header fd-message-box__header\\">
             <div class=\\"fd-bar__left\\">
                 <div class=\\"fd-bar__element\\">
-                    <i class=\\"sap-icon--sys-help-2\\"></i>
+                    <i class=\\"sap-icon--sys-help-2\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
                     <h1 class=\\"fd-title fd-title--h5\\" id=\\"fd-message-box-title-2\\">Confirmation</h1>
                 </div>
             </div>
         </header>
-        <div class=\\"fd-message-box__body\\" id=\\"fd-message-box-text-2\\">
+        
+        <section class=\\"fd-message-box__body\\" id=\\"fd-message-box-text-2\\">
             Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-        </div>
+        </section>
+        
         <footer class=\\"fd-bar fd-bar--footer fd-message-box__footer\\">
             <div class=\\"fd-bar__right\\">
                 <div class=\\"fd-bar__element\\">
@@ -29551,24 +29599,31 @@ exports[`Check stories > Components/Message Box > Story Types > Should match sna
                 </div>
             </div>
         </footer>
-    </section>
+    </div>
 </div>
 
 <br><br><br>
 
-<div class=\\"fd-message-box-docs-static fd-message-box fd-message-box--error fd-message-box--active\\" role=\\"alertdialog\\" aria-modal=\\"true\\" aria-labelledby=\\"fd-message-box-title-3 fd-message-box-text-3\\" tabindex=\\"-1\\">
-    <section class=\\"fd-message-box__content\\">
+<div 
+    class=\\"fd-message-box-docs-static fd-message-box fd-message-box--error fd-message-box--active\\" role=\\"alertdialog\\" 
+    aria-modal=\\"true\\" 
+    aria-labelledby=\\"fd-message-box-title-3\\" 
+    aria-describedby=\\"fd-message-box-text-3\\"
+    tabindex=\\"-1\\">
+    <div class=\\"fd-message-box__content\\">
         <header class=\\"fd-bar fd-bar--header fd-message-box__header\\">
             <div class=\\"fd-bar__left\\">
                 <div class=\\"fd-bar__element\\">
-                    <i class=\\"sap-icon--error\\"></i>
+                    <i class=\\"sap-icon--error\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
                     <h1 class=\\"fd-title fd-title--h5\\" id=\\"fd-message-box-title-3\\">Error</h1>
                 </div>
             </div>
         </header>
-        <div class=\\"fd-message-box__body\\" id=\\"fd-message-box-text-3\\">
+        
+        <section class=\\"fd-message-box__body\\" id=\\"fd-message-box-text-3\\">
             Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-        </div>
+        </section>
+        
         <footer class=\\"fd-bar fd-bar--footer fd-message-box__footer\\">
             <div class=\\"fd-bar__right\\">
                 <div class=\\"fd-bar__element\\">
@@ -29578,24 +29633,32 @@ exports[`Check stories > Components/Message Box > Story Types > Should match sna
                 </div>
             </div>
         </footer>
-    </section>
+    </div>
 </div>
 
 <br><br><br>
 
-<div class=\\"fd-message-box-docs-static fd-message-box fd-message-box--success fd-message-box--active\\" role=\\"alertdialog\\" aria-modal=\\"true\\" aria-labelledby=\\"fd-message-box-title-4 fd-message-box-text-4\\" tabindex=\\"-1\\">
-    <section class=\\"fd-message-box__content\\">
+<div 
+    class=\\"fd-message-box-docs-static fd-message-box fd-message-box--success fd-message-box--active\\" 
+    role=\\"alertdialog\\" 
+    aria-modal=\\"true\\" 
+    aria-labelledby=\\"fd-message-box-title-4\\"
+    aria-describedby=\\"fd-message-box-text-4\\" 
+    tabindex=\\"-1\\">
+    <div class=\\"fd-message-box__content\\">
         <header class=\\"fd-bar fd-bar--header fd-message-box__header\\">
             <div class=\\"fd-bar__left\\">
                 <div class=\\"fd-bar__element\\">
-                    <i class=\\"sap-icon--sys-enter-2\\"></i>
+                    <i class=\\"sap-icon--sys-enter-2\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
                     <h1 class=\\"fd-title fd-title--h5\\" id=\\"fd-message-box-title-4\\">Success</h1>
                 </div>
             </div>
         </header>
-        <div class=\\"fd-message-box__body\\" id=\\"fd-message-box-text-4\\">
+        
+        <section class=\\"fd-message-box__body\\" id=\\"fd-message-box-text-4\\">
             Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et mattis erat vel aliquet in sem urna et sagittis diam in vehicula.
-        </div>
+        </section>
+        
         <footer class=\\"fd-bar fd-bar--footer fd-message-box__footer\\">
             <div class=\\"fd-bar__right\\">
                 <div class=\\"fd-bar__element\\">
@@ -29605,24 +29668,32 @@ exports[`Check stories > Components/Message Box > Story Types > Should match sna
                 </div>
             </div>
         </footer>
-    </section>
+    </div>
 </div>
 
 <br><br><br>
 
-<div class=\\"fd-message-box-docs-static fd-message-box fd-message-box--warning fd-message-box--active\\" role=\\"alertdialog\\" aria-modal=\\"true\\" aria-labelledby=\\"fd-message-box-title-5 fd-message-box-text-5\\" tabindex=\\"-1\\">
-    <section class=\\"fd-message-box__content\\">
+<div 
+    class=\\"fd-message-box-docs-static fd-message-box fd-message-box--warning fd-message-box--active\\" 
+    role=\\"alertdialog\\" 
+    aria-modal=\\"true\\" 
+    aria-labelledby=\\"fd-message-box-title-5\\" 
+    aria-describedby=\\"fd-message-box-text-5\\"
+    tabindex=\\"-1\\">
+    <div class=\\"fd-message-box__content\\">
         <header class=\\"fd-bar fd-bar--header fd-message-box__header\\">
             <div class=\\"fd-bar__left\\">
                 <div class=\\"fd-bar__element\\">
-                    <i class=\\"sap-icon--alert\\"></i>
+                    <i class=\\"sap-icon--alert\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
                     <h1 class=\\"fd-title fd-title--h5\\" id=\\"fd-message-box-title-5\\">Warning</h1>
                 </div>
             </div>
         </header>
-        <div class=\\"fd-message-box__body\\" id=\\"fd-message-box-text-5\\">
+        
+        <section class=\\"fd-message-box__body\\" id=\\"fd-message-box-text-5\\">
             Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
-        </div>
+        </section>
+        
         <footer class=\\"fd-bar fd-bar--footer fd-message-box__footer\\">
             <div class=\\"fd-bar__right\\">
                 <div class=\\"fd-bar__element\\">
@@ -29632,24 +29703,32 @@ exports[`Check stories > Components/Message Box > Story Types > Should match sna
                 </div>
             </div>
         </footer>
-    </section>
+    </div>
 </div>
 
 <br><br><br>
 
-<div class=\\"fd-message-box-docs-static fd-message-box fd-message-box--information fd-message-box--active\\" role=\\"alertdialog\\" aria-modal=\\"true\\" aria-labelledby=\\"fd-message-box-title-6 fd-message-box-text-6\\" tabindex=\\"-1\\">
-    <section class=\\"fd-message-box__content\\">
+<div 
+    class=\\"fd-message-box-docs-static fd-message-box fd-message-box--information fd-message-box--active\\" 
+    role=\\"alertdialog\\" 
+    aria-modal=\\"true\\" 
+    aria-labelledby=\\"fd-message-box-title-6\\" 
+    aria-describedby=\\"fd-message-box-text-6\\"
+    tabindex=\\"-1\\">
+    <div class=\\"fd-message-box__content\\">
         <header class=\\"fd-bar fd-bar--header fd-message-box__header\\">
             <div class=\\"fd-bar__left\\">
                 <div class=\\"fd-bar__element\\">
-                    <i class=\\"sap-icon--information\\"></i>
+                    <i class=\\"sap-icon--information\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
                     <h1 class=\\"fd-title fd-title--h5\\" id=\\"fd-message-box-title-6\\">Information</h1>
                 </div>
             </div>
         </header>
-        <div class=\\"fd-message-box__body\\" id=\\"fd-message-box-text-6\\">
+        
+        <section class=\\"fd-message-box__body\\" id=\\"fd-message-box-text-6\\">
             Vivamus sagittis diam in vehicula lobortis.
-        </div>
+        </section>
+        
         <footer class=\\"fd-bar fd-bar--footer fd-message-box__footer\\">
             <div class=\\"fd-bar__right\\">
                 <div class=\\"fd-bar__element\\">
@@ -29659,7 +29738,7 @@ exports[`Check stories > Components/Message Box > Story Types > Should match sna
                 </div>
             </div>
         </footer>
-    </section>
+    </div>
 </div>
 "
 `;


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-styles/issues/5763

## Description
- a11y update: markup and aria-describedby

BREAKING CHANGE:
markup and aria-describedby 

Before:
```
<div 
    class="fd-message-box-docs-static fd-message-box fd-message-box--active" 
    role="alertdialog" 
    aria-modal="true" 
    aria-labelledby="fd-message-box-title-1 fd-message-box-text-1">
    <section class="fd-message-box__content">
        <header class="fd-bar fd-bar--header fd-message-box__header">
           ... 
          <h1 class="fd-title fd-title--h5" id="fd-message-box-title-1">Title</h1>
        </header>
        <div class="fd-message-box__body" id="fd-message-box-text-1">...</div>
        <footer class="fd-bar fd-bar--footer fd-message-box__footer">
          ...
        </footer>
    </section>
</div>
```

After:
```
<div 
    class="fd-message-box-docs-static fd-message-box fd-message-box--active" 
    role="alertdialog" 
    aria-modal="true" 
    aria-labelledby="fd-message-box-title-1" 
    aria-describedby="fd-message-box-text-1">
    <div class="fd-message-box__content">
        <header class="fd-bar fd-bar--header fd-message-box__header">
           ... 
          <h1 class="fd-title fd-title--h5" id="fd-message-box-title-1">Title</h1>
        </header>
        <section class="fd-message-box__body" id="fd-message-box-text-1">...</section>
        <footer class="fd-bar fd-bar--footer fd-message-box__footer">
          ...
        </footer>
    </div>
</div>
```