### PR TITLE
fix(styles): update Feed Input component [ci visual]

### DIFF
--- a/packages/styles/src/button.scss
+++ b/packages/styles/src/button.scss
@@ -26,8 +26,8 @@ $fd-button-badge-spacing: 0.25rem;
   @include fd-button-reset();
   @include fd-inline-flex-center();
 
-  height: var(--fdButton_Height);
-  max-height: var(--fdButton_Height);
+  height: var(--fdButton_Height, var(--sapElement_Height));
+  max-height: var(--fdButton_Height, var(--sapElement_Height));
   min-width: var(--fdButton_Min_Width);
   position: relative;
   text-align: center;
@@ -43,7 +43,7 @@ $fd-button-badge-spacing: 0.25rem;
     position: absolute;
     height: auto;
     width: 100%;
-    inset: calc((var(--fdButton_Clickable_Height) - var(--fdButton_Height)) * -0.5) 0;
+    inset: calc((var(--fdButton_Clickable_Height) - var(--fdButton_Height, var(--sapElement_Height))) * -0.5) 0;
   }
 
   &__text {
@@ -115,7 +115,7 @@ $fd-button-badge-spacing: 0.25rem;
       padding-inline: calc(0.5rem - var(--sapButton_BorderWidth)) calc(0.25rem - var(--sapButton_BorderWidth));
     }
 
-    --fdButton_Height: var(--fdButton_Compact_Height);
+    --fdButton_Height: var(--fdButton_Compact_Height, var(--sapElement_Compact_Height));
     --fdButton_Clickable_Height: 2rem;
     --fdButton_Padding_X: 0.5rem;
     --fdButton_Min_Width: 2rem;

--- a/packages/styles/src/feed-input.scss
+++ b/packages/styles/src/feed-input.scss
@@ -6,16 +6,17 @@
 $block: #{$fd-namespace}-feed-input;
 
 .#{$block} {
-  $fd-feed-input-min-height: 3rem;
-  $fd-feed-input-max-height: 20rem;
-
   @include fd-reset();
 
-  display: flex;
-  flex-direction: row;
-  padding-block: 1rem;
-  padding-inline: 1rem 0.5rem;
-  background-color: var(--sapField_Background);
+  height: 100%;
+  container-name: feed-input;
+  container-type: inline-size;
+
+  
+
+
+
+
 
   @include fd-disabled() {
     cursor: not-allowed;
@@ -30,37 +31,55 @@ $block: #{$fd-namespace}-feed-input;
     }
   }
 
-  .#{$block}__thumb {
-    display: none;
-    flex: 1 0 auto;
-    margin-inline: 0 0.5rem;
+  .#{$block}__container {
+    @include fd-reset();
+    @include fd-flex() {
+      gap: 0.5rem;
+    };
+
+    margin-block: 1rem;
+    padding-block: 1rem;
+    padding-inline: 1rem 0.5rem;
+    background-color: var(--sapGroup_ContentBackground);
   }
 
   .#{$block}__textarea {
-    min-height: $fd-feed-input-min-height;
-    max-height: $fd-feed-input-max-height;
+    min-height: 3rem;
+    max-height: 20rem;
     margin-inline: 0;
     margin-block: 0;
-    padding-block: 0.3125rem;
+    padding-block: 0.375rem;
     padding-inline: 0.5rem;
   }
 
   // It's needed to have stronger selector to override fd-button styles
   .#{$block}__submit-button {
-    margin-block: auto 0.375rem;
-    margin-inline: 0.5rem 0;
+    margin-block: 0.375rem;
+    align-self: flex-end;
 
     @include fd-rtl() {
       transform: rotate(180deg);
     }
+
+    @include fd-compact-or-condensed() {
+      --fdButton_Compact_Height: var(--sapElement_Height);
+      --fdButton_Clickable_Height: 2.75rem;
+      --fdButton_Padding_X: 0.625rem;
+      --fdButton_Min_Width: 2.25rem;
+      --fdButton_Badge_Margin_Inline_Start: 0;
+      --fdButton_Badge_Size_Attention: 0.75rem;
+    }
   }
 
-  @media (width >= 25rem) {
-    margin-top: 1rem;
-    margin-block-end: 1rem;
-
+  @container feed-input (max-width: 20rem) {
+    .#{$block}__container {
+      margin-block: 0;
+    }
+    
+  
     .#{$block}__thumb {
-      display: inline-flex;
+      display: none;
     }
   }
 }
+

--- a/packages/styles/src/feed-input.scss
+++ b/packages/styles/src/feed-input.scss
@@ -12,12 +12,6 @@ $block: #{$fd-namespace}-feed-input;
   container-name: feed-input;
   container-type: inline-size;
 
-  
-
-
-
-
-
   @include fd-disabled() {
     cursor: not-allowed;
     pointer-events: initial;
@@ -33,6 +27,7 @@ $block: #{$fd-namespace}-feed-input;
 
   .#{$block}__container {
     @include fd-reset();
+
     @include fd-flex() {
       gap: 0.5rem;
     };
@@ -52,7 +47,6 @@ $block: #{$fd-namespace}-feed-input;
     padding-inline: 0.5rem;
   }
 
-  // It's needed to have stronger selector to override fd-button styles
   .#{$block}__submit-button {
     margin-block: 0.375rem;
     align-self: flex-end;
@@ -75,8 +69,7 @@ $block: #{$fd-namespace}-feed-input;
     .#{$block}__container {
       margin-block: 0;
     }
-    
-  
+
     .#{$block}__thumb {
       display: none;
     }

--- a/packages/styles/src/theming/common/button/_sap_fiori.scss
+++ b/packages/styles/src/theming/common/button/_sap_fiori.scss
@@ -1,8 +1,6 @@
 @use "sass:map";
 
 :root {
-  --fdButton_Height: 2.25rem;
-  --fdButton_Compact_Height: 1.625rem;
   --fdButton_Emphasized_Active_Outline: var(--sapContent_ContrastFocusColor);
   --fdButton_Ghost_Background: var(--sapButton_Lite_Background);
   --fdButton_Outline_Contrast: var(--sapContent_ContrastFocusColor);

--- a/packages/styles/src/theming/common/button/_sap_fiori_hc.scss
+++ b/packages/styles/src/theming/common/button/_sap_fiori_hc.scss
@@ -3,8 +3,6 @@
 @import './sap_fiori';
 
 :root {
-  --fdButton_Height: 2.25rem;
-  --fdButton_Compact_Height: 1.625rem;
   --fdButton_Outline_Offset: var(--sapButton_BorderWidth);
 
   /** Badge */

--- a/packages/styles/src/theming/common/button/_sap_horizon.scss
+++ b/packages/styles/src/theming/common/button/_sap_horizon.scss
@@ -1,8 +1,6 @@
 @use "sass:map";
 
 :root {
-  --fdButton_Height: var(--sapElement_Height);
-  --fdButton_Compact_Height: var(--sapElement_Compact_Height);
   --fdButton_Emphasized_Active_Outline: var(--sapContent_FocusColor);
   --fdButton_Ghost_Background: var(--sapButton_Background);
   --fdButton_Outline_Contrast: var(--sapContent_FocusColor);

--- a/packages/styles/src/theming/common/button/_sap_horizon_hc.scss
+++ b/packages/styles/src/theming/common/button/_sap_horizon_hc.scss
@@ -3,9 +3,6 @@
 @import './sap_horizon';
 
 :root {
-  --fdButton_Height: var(--sapElement_Height);
-  --fdButton_Compact_Height: var(--sapElement_Compact_Height);
-
   /** Menu */
   --fdButton_Menu_Separator_Display: none;
   --fdButton_Menu_Offset: calc(var(--sapButton_BorderWidth) * -1);

--- a/packages/styles/stories/Components/feed-input/disabled.example.html
+++ b/packages/styles/stories/Components/feed-input/disabled.example.html
@@ -1,23 +1,24 @@
     <div class="fd-feed-input is-disabled"
-         role="region"
-         aria-label="Feed input disabled example">
-        <div class="fd-avatar fd-avatar--s fd-avatar--thumbnail fd-feed-input__thumb"
-             style="background-image: url('assets/images/avatars/4.svg')"
-             role="img"
-             aria-label="John Doe"
-             title="John Doe"></div>
-        <textarea class="fd-textarea fd-feed-input__textarea"
-                  placeholder="Post something here"
-                  aria-label="Feed message"
-                  required
-                  rows="1"
-                  aria-disabled="true"
-                  disabled>Disabled</textarea>
-        <button class="fd-button fd-feed-input__submit-button"
-                aria-label="Send"
+        role="group"
+        aria-label="Feed input disabled example">
+        <div class="fd-feed-input__container">
+            <div class="fd-avatar fd-avatar--s fd-avatar--thumbnail fd-feed-input__thumb"
+                style="background-image: url('assets/images/avatars/4.svg')"
+                role="img"
+                aria-label="John Doe"></div>
+            <textarea class="fd-textarea fd-feed-input__textarea"
+                placeholder="Post something here"
+                required
+                rows="1"
                 aria-disabled="true"
+                disabled>Disabled</textarea>
+            <button class="fd-button fd-feed-input__submit-button"
                 disabled
-                title="Send">
-            <i role="presentation" class="sap-icon--feeder-arrow"></i>
-        </button>
+                role="button"
+                aria-label="Submit"
+                aria-disabled="true"
+                title="Submit">
+                <i role="presentation" aria-hidden="true" class="sap-icon--feeder-arrow"></i>
+            </button>
+        </div>
     </div>

--- a/packages/styles/stories/Components/feed-input/input-growth.example.html
+++ b/packages/styles/stories/Components/feed-input/input-growth.example.html
@@ -1,25 +1,26 @@
     <div class="fd-feed-input"
-         role="region"
-         aria-label="Feed input height growth">
-        <div class="fd-avatar fd-avatar--s fd-avatar--thumbnail fd-feed-input__thumb"
-             style="background-image: url('assets/images/avatars/4.svg')"
-             role="img"
-             aria-label="John Doe"
-             title="John Doe"></div>
-        <textarea class="fd-textarea fd-feed-input__textarea"
-                  placeholder="Post something here"
-                  aria-label="Feed"
-                  required
-                  rows="4">
-With every line
+        role="group"
+        aria-label="Feed input height growth">
+        <div class="fd-feed-input__container">
+            <div class="fd-avatar fd-avatar--s fd-avatar--thumbnail fd-feed-input__thumb"
+                style="background-image: url('assets/images/avatars/4.svg')"
+                role="img"
+                aria-label="John Doe">
+            </div>
+            <textarea class="fd-textarea fd-feed-input__textarea"
+                placeholder="Post something here"
+                required
+                rows="4">With every line
 "textarea" grows upward
 until it reaches
 the max height
-        </textarea>
-        <button class="fd-button fd-feed-input__submit-button"
-                aria-label="Send"
+            </textarea>
+            <button class="fd-button fd-feed-input__submit-button"
+                role="button"
                 aria-disabled="false"
-                title="Send">
-            <i role="presentation" class="sap-icon--feeder-arrow"></i>
-        </button>
+                aria-label="Submit"
+                title="Submit">
+                <i role="presentation" aria-hidden="true" class="sap-icon--feeder-arrow"></i>
+            </button>
+         </div>
     </div>

--- a/packages/styles/stories/Components/feed-input/not-empty.example.html
+++ b/packages/styles/stories/Components/feed-input/not-empty.example.html
@@ -1,21 +1,25 @@
-    <div class="fd-feed-input"
-         role="region"
-         aria-label="Feed input with one row text">
+<div class="fd-feed-input"
+    role="group"
+    aria-label="Feed input with one row text">
+    <div class="fd-feed-input__container">
         <div class="fd-avatar fd-avatar--s fd-avatar--thumbnail fd-feed-input__thumb"
-             style="background-image: url('assets/images/avatars/4.svg')"
-             role="img"
-             aria-label="John Doe"
-             title="John Doe"></div>
+            style="background-image: url('assets/images/avatars/4.svg')"
+            role="img"
+            aria-label="John Doe">
+        </div>
         <textarea class="fd-textarea fd-feed-input__textarea"
-                  placeholder="Post something here"
-                  aria-label="Feed message"
-                  required
-                  rows="1">"When there is text, the submit button becomes active.</textarea>
-        <button class="fd-button
-                fd-feed-input__submit-button"
-                aria-label="Send"
-                aria-disabled="false"
-                title="Send">
-            <i role="presentation" class="sap-icon--feeder-arrow"></i>
+            placeholder="Post something here"
+            required
+            rows="1">When there is text, the submit button becomes active.
+        </textarea>
+        <button 
+            class="fd-button fd-feed-input__submit-button"
+            aria-label="Submit"
+            aria-disabled="false"
+            title="Submit"
+            role="button"
+        >
+            <i role="presentation" aria-hidden="true" class="sap-icon--feeder-arrow"></i>
         </button>
     </div>
+</div>

--- a/packages/styles/stories/Components/feed-input/over-max-height.example.html
+++ b/packages/styles/stories/Components/feed-input/over-max-height.example.html
@@ -1,16 +1,17 @@
-    <div class="fd-feed-input"
-         role="region"
-         aria-label="Feed input over max height">
-        <div class="fd-avatar fd-avatar--s fd-avatar--thumbnail fd-feed-input__thumb"
-             style="background-image: url('assets/images/avatars/4.svg')"
-             role="img"
-             aria-label="John Doe"
-             title="John Doe"></div>
-        <textarea class="fd-textarea fd-feed-input__textarea"
-                  placeholder="Post something here"
-                  aria-label="Feed message"
-                  required
-                  rows="18">X
+<div class="fd-feed-input"
+    role="group"
+    aria-label="Feed input over max height">
+    <div class="fd-feed-input__container">
+        <div 
+            class="fd-avatar fd-avatar--s fd-avatar--thumbnail fd-feed-input__thumb"
+            style="background-image: url('assets/images/avatars/4.svg')"
+            role="img"
+            aria-label="John Doe"></div>
+        <textarea 
+            class="fd-textarea fd-feed-input__textarea"
+            placeholder="Post something here"
+            required
+            rows="18">X
 X
 X
 X
@@ -29,11 +30,14 @@ X
 X
 X
 X
-X</textarea>
+X
+        </textarea>
         <button class="fd-button fd-feed-input__submit-button"
-                aria-label="Send"
-                aria-disabled="false"
-                title="Send">
-            <i role="presentation" class="sap-icon--feeder-arrow"></i>
+            role="button"
+            aria-disabled="false"
+            aria-label="Submit"
+            title="Submit">
+            <i role="presentation" aria-hidden="true" class="sap-icon--feeder-arrow"></i>
         </button>
     </div>
+</div>

--- a/packages/styles/stories/Components/feed-input/placeholder-image.example.html
+++ b/packages/styles/stories/Components/feed-input/placeholder-image.example.html
@@ -1,20 +1,23 @@
     <div class="fd-feed-input"
-         role="region"
-         aria-label="Feed input empty example">
-        <div class="fd-avatar fd-avatar--s fd-avatar--placeholder fd-feed-input__thumb"
-             role="img"
-             aria-label="John Doe"
-             title="John Doe">
-             <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true" aria-label="Image placeholder"></i>
+        role="group"
+        aria-label="Feed input empty example">
+        <div class="fd-feed-input__container">
+            <div class="fd-avatar fd-avatar--s fd-avatar--placeholder fd-feed-input__thumb"
+                role="img"
+                aria-label="John Doe">
+                <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
+            </div>
+            <textarea class="fd-textarea fd-feed-input__textarea"
+                placeholder="Post something here"
+                required
+                rows="1">With generic user image
+            </textarea>
+            <button 
+                class="fd-button fd-feed-input__submit-button"
+                role="button"
+                aria-label="Submit"
+                title="Submit">
+                <i role="presentation" aria-hidden="true" class="sap-icon--feeder-arrow"></i>
+            </button>
         </div>
-        <textarea class="fd-textarea fd-feed-input__textarea"
-                  placeholder="Post something here"
-                  aria-label="Feed message"
-                  required
-                  rows="1">With generic user image</textarea>
-        <button class="fd-button fd-feed-input__submit-button"
-                aria-label="Send"
-                title="Send">
-            <i role="presentation" class="sap-icon--feeder-arrow"></i>
-        </button>
     </div>

--- a/packages/styles/stories/Components/feed-input/standard.example.html
+++ b/packages/styles/stories/Components/feed-input/standard.example.html
@@ -1,21 +1,22 @@
 <div class="fd-feed-input"
-         role="region"
+         role="group"
          aria-label="Feed input empty example">
-        <div class="fd-avatar fd-avatar--s fd-avatar--thumbnail fd-feed-input__thumb"
-             style="background-image: url('assets/images/avatars/4.svg')"
-             role="img"
-             aria-label="John Doe"
-             title="John Doe"></div>
-        <textarea class="fd-textarea fd-feed-input__textarea"
-                  placeholder="Post something here"
-                  aria-label="Feed message"
-                  required
-                  rows="1"></textarea>
-        <button class="fd-button fd-feed-input__submit-button"
-                aria-label="Send"
-                aria-disabled="true"
+        <div class="fd-feed-input__container">
+            <div class="fd-avatar fd-avatar--s fd-avatar--thumbnail fd-feed-input__thumb"
+                style="background-image: url('assets/images/avatars/4.svg')"
+                role="img"
+                aria-label="John Doe"></div>
+            <textarea class="fd-textarea fd-feed-input__textarea"
+                placeholder="Post something here"
+                required
+                rows="1"></textarea>
+            <button class="fd-button fd-feed-input__submit-button"
                 disabled
-                title="Send">
-            <i role="presentation" class="sap-icon--feeder-arrow"></i>
-        </button>
+                role="button"
+                aria-disabled="true"
+                aria-label="Submit"
+                title="Submit">
+                <i role="presentation" aria-hidden="true" class="sap-icon--paper-plane"></i>
+            </button>
+        </div>
     </div>

--- a/packages/styles/stories/Components/feed-input/without-user-image.example.html
+++ b/packages/styles/stories/Components/feed-input/without-user-image.example.html
@@ -1,14 +1,17 @@
-    <div class="fd-feed-input"
-         role="region"
-         aria-label="Feed input empty example">
+<div class="fd-feed-input"
+    role="group"
+    aria-label="Feed input empty example">
+    <div class="fd-feed-input__container">
         <textarea class="fd-textarea fd-feed-input__textarea"
-                  placeholder="Post something here"
-                  aria-label="Feed message"
-                  required
-                  rows="1">Without user image</textarea>
+            placeholder="Post something here"
+            required
+            rows="1">Without user image
+        </textarea>
         <button class="fd-button fd-feed-input__submit-button"
-                aria-label="Send"
-                title="Send">
-            <i role="presentation" class="sap-icon--feeder-arrow"></i>
+            role="button"
+            aria-label="Submit"
+            title="Submit">
+            <i role="presentation" aria-hidden="true" class="sap-icon--feeder-arrow"></i>
         </button>
     </div>
+</div>

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -16738,99 +16738,106 @@ exports[`Check stories > Components/Dialog > Story VerticalForm > Should match s
 
 exports[`Check stories > Components/Feed Input > Story Disabled > Should match snapshot 1`] = `
 "    <div class=\\"fd-feed-input is-disabled\\"
-         role=\\"region\\"
-         aria-label=\\"Feed input disabled example\\">
-        <div class=\\"fd-avatar fd-avatar--s fd-avatar--thumbnail fd-feed-input__thumb\\"
-             style=\\"background-image: url('assets/images/avatars/4.svg')\\"
-             role=\\"img\\"
-             aria-label=\\"John Doe\\"
-             title=\\"John Doe\\"></div>
-        <textarea class=\\"fd-textarea fd-feed-input__textarea\\"
-                  placeholder=\\"Post something here\\"
-                  aria-label=\\"Feed message\\"
-                  required
-                  rows=\\"1\\"
-                  aria-disabled=\\"true\\"
-                  disabled>Disabled</textarea>
-        <button class=\\"fd-button fd-feed-input__submit-button\\"
-                aria-label=\\"Send\\"
+        role=\\"group\\"
+        aria-label=\\"Feed input disabled example\\">
+        <div class=\\"fd-feed-input__container\\">
+            <div class=\\"fd-avatar fd-avatar--s fd-avatar--thumbnail fd-feed-input__thumb\\"
+                style=\\"background-image: url('assets/images/avatars/4.svg')\\"
+                role=\\"img\\"
+                aria-label=\\"John Doe\\"></div>
+            <textarea class=\\"fd-textarea fd-feed-input__textarea\\"
+                placeholder=\\"Post something here\\"
+                required
+                rows=\\"1\\"
                 aria-disabled=\\"true\\"
+                disabled>Disabled</textarea>
+            <button class=\\"fd-button fd-feed-input__submit-button\\"
                 disabled
-                title=\\"Send\\">
-            <i role=\\"presentation\\" class=\\"sap-icon--feeder-arrow\\"></i>
-        </button>
+                role=\\"button\\"
+                aria-label=\\"Submit\\"
+                aria-disabled=\\"true\\"
+                title=\\"Submit\\">
+                <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"sap-icon--feeder-arrow\\"></i>
+            </button>
+        </div>
     </div>
 "
 `;
 
 exports[`Check stories > Components/Feed Input > Story InputGrowth > Should match snapshot 1`] = `
 "    <div class=\\"fd-feed-input\\"
-         role=\\"region\\"
-         aria-label=\\"Feed input height growth\\">
-        <div class=\\"fd-avatar fd-avatar--s fd-avatar--thumbnail fd-feed-input__thumb\\"
-             style=\\"background-image: url('assets/images/avatars/4.svg')\\"
-             role=\\"img\\"
-             aria-label=\\"John Doe\\"
-             title=\\"John Doe\\"></div>
-        <textarea class=\\"fd-textarea fd-feed-input__textarea\\"
-                  placeholder=\\"Post something here\\"
-                  aria-label=\\"Feed\\"
-                  required
-                  rows=\\"4\\">
-With every line
+        role=\\"group\\"
+        aria-label=\\"Feed input height growth\\">
+        <div class=\\"fd-feed-input__container\\">
+            <div class=\\"fd-avatar fd-avatar--s fd-avatar--thumbnail fd-feed-input__thumb\\"
+                style=\\"background-image: url('assets/images/avatars/4.svg')\\"
+                role=\\"img\\"
+                aria-label=\\"John Doe\\">
+            </div>
+            <textarea class=\\"fd-textarea fd-feed-input__textarea\\"
+                placeholder=\\"Post something here\\"
+                required
+                rows=\\"4\\">With every line
 \\"textarea\\" grows upward
 until it reaches
 the max height
-        </textarea>
-        <button class=\\"fd-button fd-feed-input__submit-button\\"
-                aria-label=\\"Send\\"
+            </textarea>
+            <button class=\\"fd-button fd-feed-input__submit-button\\"
+                role=\\"button\\"
                 aria-disabled=\\"false\\"
-                title=\\"Send\\">
-            <i role=\\"presentation\\" class=\\"sap-icon--feeder-arrow\\"></i>
-        </button>
+                aria-label=\\"Submit\\"
+                title=\\"Submit\\">
+                <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"sap-icon--feeder-arrow\\"></i>
+            </button>
+         </div>
     </div>
 "
 `;
 
 exports[`Check stories > Components/Feed Input > Story NotEmpty > Should match snapshot 1`] = `
-"    <div class=\\"fd-feed-input\\"
-         role=\\"region\\"
-         aria-label=\\"Feed input with one row text\\">
+"<div class=\\"fd-feed-input\\"
+    role=\\"group\\"
+    aria-label=\\"Feed input with one row text\\">
+    <div class=\\"fd-feed-input__container\\">
         <div class=\\"fd-avatar fd-avatar--s fd-avatar--thumbnail fd-feed-input__thumb\\"
-             style=\\"background-image: url('assets/images/avatars/4.svg')\\"
-             role=\\"img\\"
-             aria-label=\\"John Doe\\"
-             title=\\"John Doe\\"></div>
+            style=\\"background-image: url('assets/images/avatars/4.svg')\\"
+            role=\\"img\\"
+            aria-label=\\"John Doe\\">
+        </div>
         <textarea class=\\"fd-textarea fd-feed-input__textarea\\"
-                  placeholder=\\"Post something here\\"
-                  aria-label=\\"Feed message\\"
-                  required
-                  rows=\\"1\\">\\"When there is text, the submit button becomes active.</textarea>
-        <button class=\\"fd-button
-                fd-feed-input__submit-button\\"
-                aria-label=\\"Send\\"
-                aria-disabled=\\"false\\"
-                title=\\"Send\\">
-            <i role=\\"presentation\\" class=\\"sap-icon--feeder-arrow\\"></i>
+            placeholder=\\"Post something here\\"
+            required
+            rows=\\"1\\">When there is text, the submit button becomes active.
+        </textarea>
+        <button 
+            class=\\"fd-button fd-feed-input__submit-button\\"
+            aria-label=\\"Submit\\"
+            aria-disabled=\\"false\\"
+            title=\\"Submit\\"
+            role=\\"button\\"
+        >
+            <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"sap-icon--feeder-arrow\\"></i>
         </button>
     </div>
+</div>
 "
 `;
 
 exports[`Check stories > Components/Feed Input > Story OverMaxHeight > Should match snapshot 1`] = `
-"    <div class=\\"fd-feed-input\\"
-         role=\\"region\\"
-         aria-label=\\"Feed input over max height\\">
-        <div class=\\"fd-avatar fd-avatar--s fd-avatar--thumbnail fd-feed-input__thumb\\"
-             style=\\"background-image: url('assets/images/avatars/4.svg')\\"
-             role=\\"img\\"
-             aria-label=\\"John Doe\\"
-             title=\\"John Doe\\"></div>
-        <textarea class=\\"fd-textarea fd-feed-input__textarea\\"
-                  placeholder=\\"Post something here\\"
-                  aria-label=\\"Feed message\\"
-                  required
-                  rows=\\"18\\">X
+"<div class=\\"fd-feed-input\\"
+    role=\\"group\\"
+    aria-label=\\"Feed input over max height\\">
+    <div class=\\"fd-feed-input__container\\">
+        <div 
+            class=\\"fd-avatar fd-avatar--s fd-avatar--thumbnail fd-feed-input__thumb\\"
+            style=\\"background-image: url('assets/images/avatars/4.svg')\\"
+            role=\\"img\\"
+            aria-label=\\"John Doe\\"></div>
+        <textarea 
+            class=\\"fd-textarea fd-feed-input__textarea\\"
+            placeholder=\\"Post something here\\"
+            required
+            rows=\\"18\\">X
 X
 X
 X
@@ -16849,81 +16856,91 @@ X
 X
 X
 X
-X</textarea>
+X
+        </textarea>
         <button class=\\"fd-button fd-feed-input__submit-button\\"
-                aria-label=\\"Send\\"
-                aria-disabled=\\"false\\"
-                title=\\"Send\\">
-            <i role=\\"presentation\\" class=\\"sap-icon--feeder-arrow\\"></i>
+            role=\\"button\\"
+            aria-disabled=\\"false\\"
+            aria-label=\\"Submit\\"
+            title=\\"Submit\\">
+            <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"sap-icon--feeder-arrow\\"></i>
         </button>
     </div>
+</div>
 "
 `;
 
 exports[`Check stories > Components/Feed Input > Story PlaceholderImage > Should match snapshot 1`] = `
 "    <div class=\\"fd-feed-input\\"
-         role=\\"region\\"
-         aria-label=\\"Feed input empty example\\">
-        <div class=\\"fd-avatar fd-avatar--s fd-avatar--placeholder fd-feed-input__thumb\\"
-             role=\\"img\\"
-             aria-label=\\"John Doe\\"
-             title=\\"John Doe\\">
-             <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\" aria-label=\\"Image placeholder\\"></i>
+        role=\\"group\\"
+        aria-label=\\"Feed input empty example\\">
+        <div class=\\"fd-feed-input__container\\">
+            <div class=\\"fd-avatar fd-avatar--s fd-avatar--placeholder fd-feed-input__thumb\\"
+                role=\\"img\\"
+                aria-label=\\"John Doe\\">
+                <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
+            </div>
+            <textarea class=\\"fd-textarea fd-feed-input__textarea\\"
+                placeholder=\\"Post something here\\"
+                required
+                rows=\\"1\\">With generic user image
+            </textarea>
+            <button 
+                class=\\"fd-button fd-feed-input__submit-button\\"
+                role=\\"button\\"
+                aria-label=\\"Submit\\"
+                title=\\"Submit\\">
+                <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"sap-icon--feeder-arrow\\"></i>
+            </button>
         </div>
-        <textarea class=\\"fd-textarea fd-feed-input__textarea\\"
-                  placeholder=\\"Post something here\\"
-                  aria-label=\\"Feed message\\"
-                  required
-                  rows=\\"1\\">With generic user image</textarea>
-        <button class=\\"fd-button fd-feed-input__submit-button\\"
-                aria-label=\\"Send\\"
-                title=\\"Send\\">
-            <i role=\\"presentation\\" class=\\"sap-icon--feeder-arrow\\"></i>
-        </button>
     </div>
 "
 `;
 
 exports[`Check stories > Components/Feed Input > Story Standard > Should match snapshot 1`] = `
 "<div class=\\"fd-feed-input\\"
-         role=\\"region\\"
+         role=\\"group\\"
          aria-label=\\"Feed input empty example\\">
-        <div class=\\"fd-avatar fd-avatar--s fd-avatar--thumbnail fd-feed-input__thumb\\"
-             style=\\"background-image: url('assets/images/avatars/4.svg')\\"
-             role=\\"img\\"
-             aria-label=\\"John Doe\\"
-             title=\\"John Doe\\"></div>
-        <textarea class=\\"fd-textarea fd-feed-input__textarea\\"
-                  placeholder=\\"Post something here\\"
-                  aria-label=\\"Feed message\\"
-                  required
-                  rows=\\"1\\"></textarea>
-        <button class=\\"fd-button fd-feed-input__submit-button\\"
-                aria-label=\\"Send\\"
-                aria-disabled=\\"true\\"
+        <div class=\\"fd-feed-input__container\\">
+            <div class=\\"fd-avatar fd-avatar--s fd-avatar--thumbnail fd-feed-input__thumb\\"
+                style=\\"background-image: url('assets/images/avatars/4.svg')\\"
+                role=\\"img\\"
+                aria-label=\\"John Doe\\"></div>
+            <textarea class=\\"fd-textarea fd-feed-input__textarea\\"
+                placeholder=\\"Post something here\\"
+                required
+                rows=\\"1\\"></textarea>
+            <button class=\\"fd-button fd-feed-input__submit-button\\"
                 disabled
-                title=\\"Send\\">
-            <i role=\\"presentation\\" class=\\"sap-icon--feeder-arrow\\"></i>
-        </button>
+                role=\\"button\\"
+                aria-disabled=\\"true\\"
+                aria-label=\\"Submit\\"
+                title=\\"Submit\\">
+                <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"sap-icon--paper-plane\\"></i>
+            </button>
+        </div>
     </div>
 "
 `;
 
 exports[`Check stories > Components/Feed Input > Story WithoutUserImage > Should match snapshot 1`] = `
-"    <div class=\\"fd-feed-input\\"
-         role=\\"region\\"
-         aria-label=\\"Feed input empty example\\">
+"<div class=\\"fd-feed-input\\"
+    role=\\"group\\"
+    aria-label=\\"Feed input empty example\\">
+    <div class=\\"fd-feed-input__container\\">
         <textarea class=\\"fd-textarea fd-feed-input__textarea\\"
-                  placeholder=\\"Post something here\\"
-                  aria-label=\\"Feed message\\"
-                  required
-                  rows=\\"1\\">Without user image</textarea>
+            placeholder=\\"Post something here\\"
+            required
+            rows=\\"1\\">Without user image
+        </textarea>
         <button class=\\"fd-button fd-feed-input__submit-button\\"
-                aria-label=\\"Send\\"
-                title=\\"Send\\">
-            <i role=\\"presentation\\" class=\\"sap-icon--feeder-arrow\\"></i>
+            role=\\"button\\"
+            aria-label=\\"Submit\\"
+            title=\\"Submit\\">
+            <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"sap-icon--feeder-arrow\\"></i>
         </button>
     </div>
+</div>
 "
 `;
 


### PR DESCRIPTION
## Related Issue
Part of https://github.com/SAP/fundamental-styles/issues/5763

## Description
- design updates: paddings, dimensions, the Submit button should have the same size in cozy and compact modes, an additional div element with class `fd-feed-input__container` is added to handle to component responsiveness (breaking change). The vertical margin and the thumbnail should be hidden when the element reaches max 20rem. It has to use container query, not media query.
- a11y updates: the parent should have role `group`, thumbnail doesn't need title, textarea does't need aria-label, etc.

BREAKING CHANGE:
an additional div element with class `fd-feed-input__container` is added, aria attributes and roles are updated.