### PR TITLE
fix(styles): missing checkboxes in table pop-in example, pop-in headers, text padding fix

### DIFF
--- a/packages/styles/src/mixins/table/_table-pop-in.scss
+++ b/packages/styles/src/mixins/table/_table-pop-in.scss
@@ -17,14 +17,6 @@
       }
     }
 
-    .#{$block}__cell {
-      &--checkbox {
-        + .#{$block}__cell {
-          padding-inline-start: 0;
-        }
-      }
-    }
-
     .#{$block}__body {
       .#{$block}__cell {
         height: auto;

--- a/packages/styles/stories/Components/table/responsive-table-pop-in-mode.example.html
+++ b/packages/styles/stories/Components/table/responsive-table-pop-in-mode.example.html
@@ -4,6 +4,13 @@
         <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
     </div>
     <table class="fd-table fd-table--responsive fd-table--no-horizontal-borders fd-table--no-vertical-borders fd-table--pop-in">
+        <thead class="fd-table__header">
+            <tr class="fd-table__row">
+                <th class="fd-table__cell" scope="col">Name</th>
+                <th class="fd-table__cell" scope="col">Price</th>
+                <th class="fd-table__cell" scope="col"></th>
+            </tr>
+        </thead>
         <tbody class="fd-table__body">
             <tr class="fd-table__row fd-table__row--main fd-table__row--activable fd-table__row--hoverable">
                 <td class="fd-table__cell">
@@ -67,11 +74,24 @@
         <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
     </div>
     <table class="fd-table fd-table--responsive fd-table--no-horizontal-borders fd-table--no-vertical-borders fd-table--pop-in">
+        <thead class="fd-table__header">
+            <tr class="fd-table__row">
+                <th class="fd-table__cell fd-table__cell--checkbox" scope="col">
+                    <input aria-label="checkbox" type="checkbox" class="fd-checkbox fd-table__checkbox" id="Ai4ez611b">
+                    <label class="fd-checkbox__label fd-table__checkbox-label" for="Ai4ez611b">
+                        <span class="fd-checkbox__checkmark" aria-hidden="true"></span>
+                    </label>
+                </th>
+                <th class="fd-table__cell" scope="col">Name</th>
+                <th class="fd-table__cell" scope="col">Price</th>
+                <th class="fd-table__cell" scope="col"></th>
+            </tr>
+        </thead>
         <tbody class="fd-table__body">
             <tr class="fd-table__row fd-table__row--main">
                 <td class="fd-table__cell fd-table__cell--checkbox">
-                    <input aria-label="checkbox" type="checkbox" class="fd-checkbox" id="CWkhTG">
-                    <label class="fd-checkbox__label" for="CWkhTG"></label>
+                    <input aria-label="checkbox" type="checkbox" class="fd-checkbox" id="EWuzWh">
+                    <label class="fd-checkbox__label" for="EWuzWh"><span class="fd-checkbox__checkmark" aria-hidden="true"></span></label>
                 </td>
                 <td class="fd-table__cell">
                     <p class="fd-table__text fd-table__text--title">Banana</p>
@@ -102,7 +122,7 @@
             <tr class="fd-table__row fd-table__row--main">
                 <td class="fd-table__cell fd-table__cell--checkbox">
                     <input aria-label="checkbox" type="checkbox" class="fd-checkbox" id="Yeas6w">
-                    <label class="fd-checkbox__label" for="Yeas6w"></label>
+                    <label class="fd-checkbox__label" for="Yeas6w"><span class="fd-checkbox__checkmark" aria-hidden="true"></span></label>
                 </td>
                 <td class="fd-table__cell">
                     <p class="fd-table__text fd-table__text--title">Very long name for orange, which no one expected, forces text wrapping into another line.</p>

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -46562,6 +46562,13 @@ exports[`Check stories > Components/Table > Story ResponsiveTablePopInMode > Sho
         <span class=\\"fd-toolbar__spacer fd-toolbar__spacer--auto\\"></span>
     </div>
     <table class=\\"fd-table fd-table--responsive fd-table--no-horizontal-borders fd-table--no-vertical-borders fd-table--pop-in\\">
+        <thead class=\\"fd-table__header\\">
+            <tr class=\\"fd-table__row\\">
+                <th class=\\"fd-table__cell\\" scope=\\"col\\">Name</th>
+                <th class=\\"fd-table__cell\\" scope=\\"col\\">Price</th>
+                <th class=\\"fd-table__cell\\" scope=\\"col\\"></th>
+            </tr>
+        </thead>
         <tbody class=\\"fd-table__body\\">
             <tr class=\\"fd-table__row fd-table__row--main fd-table__row--activable fd-table__row--hoverable\\">
                 <td class=\\"fd-table__cell\\">
@@ -46625,11 +46632,24 @@ exports[`Check stories > Components/Table > Story ResponsiveTablePopInMode > Sho
         <span class=\\"fd-toolbar__spacer fd-toolbar__spacer--auto\\"></span>
     </div>
     <table class=\\"fd-table fd-table--responsive fd-table--no-horizontal-borders fd-table--no-vertical-borders fd-table--pop-in\\">
+        <thead class=\\"fd-table__header\\">
+            <tr class=\\"fd-table__row\\">
+                <th class=\\"fd-table__cell fd-table__cell--checkbox\\" scope=\\"col\\">
+                    <input aria-label=\\"checkbox\\" type=\\"checkbox\\" class=\\"fd-checkbox fd-table__checkbox\\" id=\\"Ai4ez611b\\">
+                    <label class=\\"fd-checkbox__label fd-table__checkbox-label\\" for=\\"Ai4ez611b\\">
+                        <span class=\\"fd-checkbox__checkmark\\" aria-hidden=\\"true\\"></span>
+                    </label>
+                </th>
+                <th class=\\"fd-table__cell\\" scope=\\"col\\">Name</th>
+                <th class=\\"fd-table__cell\\" scope=\\"col\\">Price</th>
+                <th class=\\"fd-table__cell\\" scope=\\"col\\"></th>
+            </tr>
+        </thead>
         <tbody class=\\"fd-table__body\\">
             <tr class=\\"fd-table__row fd-table__row--main\\">
                 <td class=\\"fd-table__cell fd-table__cell--checkbox\\">
-                    <input aria-label=\\"checkbox\\" type=\\"checkbox\\" class=\\"fd-checkbox\\" id=\\"CWkhTG\\">
-                    <label class=\\"fd-checkbox__label\\" for=\\"CWkhTG\\"></label>
+                    <input aria-label=\\"checkbox\\" type=\\"checkbox\\" class=\\"fd-checkbox\\" id=\\"EWuzWh\\">
+                    <label class=\\"fd-checkbox__label\\" for=\\"EWuzWh\\"><span class=\\"fd-checkbox__checkmark\\" aria-hidden=\\"true\\"></span></label>
                 </td>
                 <td class=\\"fd-table__cell\\">
                     <p class=\\"fd-table__text fd-table__text--title\\">Banana</p>
@@ -46660,7 +46680,7 @@ exports[`Check stories > Components/Table > Story ResponsiveTablePopInMode > Sho
             <tr class=\\"fd-table__row fd-table__row--main\\">
                 <td class=\\"fd-table__cell fd-table__cell--checkbox\\">
                     <input aria-label=\\"checkbox\\" type=\\"checkbox\\" class=\\"fd-checkbox\\" id=\\"Yeas6w\\">
-                    <label class=\\"fd-checkbox__label\\" for=\\"Yeas6w\\"></label>
+                    <label class=\\"fd-checkbox__label\\" for=\\"Yeas6w\\"><span class=\\"fd-checkbox__checkmark\\" aria-hidden=\\"true\\"></span></label>
                 </td>
                 <td class=\\"fd-table__cell\\">
                     <p class=\\"fd-table__text fd-table__text--title\\">Very long name for orange, which no one expected, forces text wrapping into another line.</p>


### PR DESCRIPTION
fixes none

Previously, checkboxes were not rendering in the pop-in examples. Also pop-in was missing headers. Lastly, fixes a bug with the padding of text in cells after the checkbox cells, though this was more noticeable in fd-ngx.

before:
<img width="470" alt="Screenshot 2025-05-12 at 1 27 26 PM" src="https://github.com/user-attachments/assets/d5886ed0-8e49-44ed-a9da-a387eccf9b1a" />

after:
<img width="478" alt="Screenshot 2025-05-12 at 2 17 00 PM" src="https://github.com/user-attachments/assets/ae4daa9e-c716-49bc-9a15-f7a7637827c7" />
