### PR TITLE
fix(styles): a11y update for Info Label [ci visual]

### DIFF
--- a/packages/styles/src/info-label.scss
+++ b/packages/styles/src/info-label.scss
@@ -100,6 +100,10 @@ $color-accents: (
     font-family: var(--sapFontSemiboldDuplexFamily);
   }
 
+  &__sr-only {
+    @include fd-screen-reader-only();
+  }
+
   @each $set-name, $color-set in $color-accents {
     &--accent-color-#{$set-name} {
       --fdInfoLabel_Background: #{map.get($color-set, "background")};

--- a/packages/styles/stories/Components/info-label/color-flavors.example.html
+++ b/packages/styles/stories/Components/info-label/color-flavors.example.html
@@ -1,30 +1,40 @@
 <span class="fd-info-label fd-info-label--accent-color-1">
+    <span class="fd-info-label__sr-only">Info Label</span>
     <span class="fd-info-label__text">color 1</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-2">
+    <span class="fd-info-label__sr-only">Info Label</span>
     <span class="fd-info-label__text">color 2</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-3">
+    <span class="fd-info-label__sr-only">Info Label</span>
     <span class="fd-info-label__text">color 3</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-4">
+    <span class="fd-info-label__sr-only">Info Label</span>
     <span class="fd-info-label__text">color 4</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-5">
+    <span class="fd-info-label__sr-only">Info Label</span>
     <span class="fd-info-label__text">color 5</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-6">
+    <span class="fd-info-label__sr-only">Info Label</span>
     <span class="fd-info-label__text">color 6</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-7">
+    <span class="fd-info-label__sr-only">Info Label</span>
     <span class="fd-info-label__text">color 7</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-8">
+    <span class="fd-info-label__sr-only">Info Label</span>
     <span class="fd-info-label__text">color 8</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-9">
+    <span class="fd-info-label__sr-only">Info Label</span>
     <span class="fd-info-label__text">color 9</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-10">
+    <span class="fd-info-label__sr-only">Info Label</span>
     <span class="fd-info-label__text">color 10</span>
 </span>

--- a/packages/styles/stories/Components/info-label/display-only-info-label.example.html
+++ b/packages/styles/stories/Components/info-label/display-only-info-label.example.html
@@ -1,31 +1,41 @@
 <span class="fd-info-label fd-info-label--accent-color-1 fd-info-label--display">
+    <span class="fd-info-label__sr-only">Info Label</span>
     <span class="fd-info-label__text">color 1</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-2 fd-info-label--display">
+    <span class="fd-info-label__sr-only">Info Label</span>
     <span class="fd-info-label__text">color 2</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-3 fd-info-label--display">
+    <span class="fd-info-label__sr-only">Info Label</span>
     <span class="fd-info-label__text">color 3</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-4 fd-info-label--display">
+    <span class="fd-info-label__sr-only">Info Label</span>
     <span class="fd-info-label__text">color 4</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-5 fd-info-label--display">
+    <span class="fd-info-label__sr-only">Info Label</span>
     <span class="fd-info-label__text">color 5</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-6 fd-info-label--display">
+    <span class="fd-info-label__sr-only">Info Label</span>
     <span class="fd-info-label__text">color 6</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-7 fd-info-label--display">
+    <span class="fd-info-label__sr-only">Info Label</span>
     <span class="fd-info-label__text">color 7</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-8 fd-info-label--display">
+    <span class="fd-info-label__sr-only">Info Label</span>
     <span class="fd-info-label__text">color 8</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-9 fd-info-label--display">
+    <span class="fd-info-label__sr-only">Info Label</span>
     <span class="fd-info-label__text">color 9</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-10 fd-info-label--display">
+    <span class="fd-info-label__sr-only">Info Label</span>
     <span class="fd-info-label__text">color 10</span>
 </span>
 
@@ -33,41 +43,51 @@
 
 <span class="fd-info-label fd-info-label--accent-color-1 fd-info-label--display">
     <i role="presentation" class="fd-info-label__icon sap-icon--dark-mode"></i>
-    <span class="fd-info-label__text">Info Label</span>
+    <span class="fd-info-label__sr-only">Info Label</span>
+    <span class="fd-info-label__text">Color 1</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-2 fd-info-label--display">
     <i role="presentation" class="fd-info-label__icon sap-icon--dark-mode"></i>
-    <span class="fd-info-label__text">Info Label</span>
+    <span class="fd-info-label__sr-only">Info Label</span>
+    <span class="fd-info-label__text">Color 2</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-3 fd-info-label--display">
     <i role="presentation" class="fd-info-label__icon sap-icon--dark-mode"></i>
-    <span class="fd-info-label__text">Info Label</span>
+    <span class="fd-info-label__sr-only">Info Label</span>
+    <span class="fd-info-label__text">Color 3</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-4 fd-info-label--display">
     <i role="presentation" class="fd-info-label__icon sap-icon--dark-mode"></i>
-    <span class="fd-info-label__text">Info Label</span>
+    <span class="fd-info-label__sr-only">Info Label</span>
+    <span class="fd-info-label__text">Color 4</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-5 fd-info-label--display">
     <i role="presentation" class="fd-info-label__icon sap-icon--dark-mode"></i>
-    <span class="fd-info-label__text">Info Label</span>
+    <span class="fd-info-label__sr-only">Info Label</span>
+    <span class="fd-info-label__text">Color 5</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-6 fd-info-label--display">
     <i role="presentation" class="fd-info-label__icon sap-icon--dark-mode"></i>
-    <span class="fd-info-label__text">Info Label</span>
+    <span class="fd-info-label__sr-only">Info Label</span>
+    <span class="fd-info-label__text">Color 6</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-7 fd-info-label--display">
     <i role="presentation" class="fd-info-label__icon sap-icon--dark-mode"></i>
-    <span class="fd-info-label__text">Info Label</span>
+    <span class="fd-info-label__sr-only">Info Label</span>
+    <span class="fd-info-label__text">Color 7</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-8 fd-info-label--display">
     <i role="presentation" class="fd-info-label__icon sap-icon--dark-mode"></i>
-    <span class="fd-info-label__text">Info Label</span>
+    <span class="fd-info-label__sr-only">Info Label</span>
+    <span class="fd-info-label__text">Color 8</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-9 fd-info-label--display">
     <i role="presentation" class="fd-info-label__icon sap-icon--dark-mode"></i>
-    <span class="fd-info-label__text">Info Label</span>
+    <span class="fd-info-label__sr-only">Info Label</span>
+    <span class="fd-info-label__text">Color 9</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-10 fd-info-label--display">
     <i role="presentation" class="fd-info-label__icon sap-icon--dark-mode"></i>
-    <span class="fd-info-label__text">Info Label</span>
+    <span class="fd-info-label__sr-only">Info Label</span>
+    <span class="fd-info-label__text">Color 10</span>
 </span>

--- a/packages/styles/stories/Components/info-label/info-label-with-icon.example.html
+++ b/packages/styles/stories/Components/info-label/info-label-with-icon.example.html
@@ -1,40 +1,50 @@
 <span class="fd-info-label fd-info-label--accent-color-1">
-    <i role="presentation" class="fd-info-label__icon sap-icon--dark-mode"></i>
-    <span class="fd-info-label__text">Info Label</span>
+    <i role="presentation" aria-hidden="true" class="fd-info-label__icon sap-icon--dark-mode"></i>
+    <span class="fd-info-label__sr-only">Info Label</span>
+    <span class="fd-info-label__text">Color 1</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-2">
-    <i role="presentation" class="fd-info-label__icon sap-icon--dark-mode"></i>
-    <span class="fd-info-label__text">Info Label</span>
+    <i role="presentation" aria-hidden="true" class="fd-info-label__icon sap-icon--dark-mode"></i>
+    <span class="fd-info-label__sr-only">Info Label</span>
+    <span class="fd-info-label__text">Color 2</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-3">
-    <i role="presentation" class="fd-info-label__icon sap-icon--dark-mode"></i>
-    <span class="fd-info-label__text">Info Label</span>
+    <i role="presentation" aria-hidden="true" class="fd-info-label__icon sap-icon--dark-mode"></i>
+    <span class="fd-info-label__sr-only">Info Label</span>
+    <span class="fd-info-label__text">Color 3</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-4">
-    <i role="presentation" class="fd-info-label__icon sap-icon--dark-mode"></i>
-    <span class="fd-info-label__text">Info Label</span>
+    <i role="presentation" aria-hidden="true" class="fd-info-label__icon sap-icon--dark-mode"></i>
+    <span class="fd-info-label__sr-only">Info Label</span>
+    <span class="fd-info-label__text">Color 4</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-5">
-    <i role="presentation" class="fd-info-label__icon sap-icon--dark-mode"></i>
-    <span class="fd-info-label__text">Info Label</span>
+    <i role="presentation" aria-hidden="true" class="fd-info-label__icon sap-icon--dark-mode"></i>
+    <span class="fd-info-label__sr-only">Info Label</span>
+    <span class="fd-info-label__text">Color 5</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-6">
-    <i role="presentation" class="fd-info-label__icon sap-icon--dark-mode"></i>
-    <span class="fd-info-label__text">Info Label</span>
+    <i role="presentation" aria-hidden="true" class="fd-info-label__icon sap-icon--dark-mode"></i>
+    <span class="fd-info-label__sr-only">Info Label</span>
+    <span class="fd-info-label__text">Color 6</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-7">
-    <i role="presentation" class="fd-info-label__icon sap-icon--dark-mode"></i>
-    <span class="fd-info-label__text">Info Label</span>
+    <i role="presentation" aria-hidden="true" class="fd-info-label__icon sap-icon--dark-mode"></i>
+    <span class="fd-info-label__sr-only">Info Label</span>
+    <span class="fd-info-label__text">Color 7</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-8">
-    <i role="presentation" class="fd-info-label__icon sap-icon--dark-mode"></i>
-    <span class="fd-info-label__text">Info Label</span>
+    <i role="presentation" aria-hidden="true" class="fd-info-label__icon sap-icon--dark-mode"></i>
+    <span class="fd-info-label__sr-only">Info Label</span>
+    <span class="fd-info-label__text">Color 8</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-9">
-    <i role="presentation" class="fd-info-label__icon sap-icon--dark-mode"></i>
-    <span class="fd-info-label__text">Info Label</span>
+    <i role="presentation" aria-hidden="true" class="fd-info-label__icon sap-icon--dark-mode"></i>
+    <span class="fd-info-label__sr-only">Info Label</span>
+    <span class="fd-info-label__text">Color 9</span>
 </span>
 <span class="fd-info-label fd-info-label--accent-color-10">
-    <i role="presentation" class="fd-info-label__icon sap-icon--dark-mode"></i>
-    <span class="fd-info-label__text">Info Label</span>
+    <i role="presentation" aria-hidden="true" class="fd-info-label__icon sap-icon--dark-mode"></i>
+    <span class="fd-info-label__sr-only">Info Label</span>
+    <span class="fd-info-label__text">Color 10</span>
 </span>

--- a/packages/styles/stories/Components/info-label/numeric-info-label.example.html
+++ b/packages/styles/stories/Components/info-label/numeric-info-label.example.html
@@ -1,9 +1,12 @@
 <span class="fd-info-label fd-info-label--numeric fd-info-label--accent-color-1">
+    <span class="fd-info-label__sr-only">Info Label</span>
     <span class="fd-info-label__text">6</span>
 </span>
 <span class="fd-info-label fd-info-label--numeric fd-info-label--accent-color-2">
+    <span class="fd-info-label__sr-only">Info Label</span>
     <span class="fd-info-label__text">6.2</span>
 </span>
 <span class="fd-info-label fd-info-label--numeric fd-info-label--accent-color-3">
+    <span class="fd-info-label__sr-only">Info Label</span>
     <span class="fd-info-label__text">42k</span>
 </span>

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -27538,33 +27538,43 @@ exports[`Check stories > Components/Illustrated Message > Story Spot > Should ma
 
 exports[`Check stories > Components/Info Label > Story ColorFlavors > Should match snapshot 1`] = `
 "<span class=\\"fd-info-label fd-info-label--accent-color-1\\">
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
     <span class=\\"fd-info-label__text\\">color 1</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-2\\">
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
     <span class=\\"fd-info-label__text\\">color 2</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-3\\">
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
     <span class=\\"fd-info-label__text\\">color 3</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-4\\">
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
     <span class=\\"fd-info-label__text\\">color 4</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-5\\">
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
     <span class=\\"fd-info-label__text\\">color 5</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-6\\">
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
     <span class=\\"fd-info-label__text\\">color 6</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-7\\">
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
     <span class=\\"fd-info-label__text\\">color 7</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-8\\">
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
     <span class=\\"fd-info-label__text\\">color 8</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-9\\">
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
     <span class=\\"fd-info-label__text\\">color 9</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-10\\">
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
     <span class=\\"fd-info-label__text\\">color 10</span>
 </span>
 "
@@ -27572,33 +27582,43 @@ exports[`Check stories > Components/Info Label > Story ColorFlavors > Should mat
 
 exports[`Check stories > Components/Info Label > Story DisplayModeInfoLabel > Should match snapshot 1`] = `
 "<span class=\\"fd-info-label fd-info-label--accent-color-1 fd-info-label--display\\">
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
     <span class=\\"fd-info-label__text\\">color 1</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-2 fd-info-label--display\\">
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
     <span class=\\"fd-info-label__text\\">color 2</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-3 fd-info-label--display\\">
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
     <span class=\\"fd-info-label__text\\">color 3</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-4 fd-info-label--display\\">
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
     <span class=\\"fd-info-label__text\\">color 4</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-5 fd-info-label--display\\">
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
     <span class=\\"fd-info-label__text\\">color 5</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-6 fd-info-label--display\\">
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
     <span class=\\"fd-info-label__text\\">color 6</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-7 fd-info-label--display\\">
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
     <span class=\\"fd-info-label__text\\">color 7</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-8 fd-info-label--display\\">
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
     <span class=\\"fd-info-label__text\\">color 8</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-9 fd-info-label--display\\">
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
     <span class=\\"fd-info-label__text\\">color 9</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-10 fd-info-label--display\\">
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
     <span class=\\"fd-info-label__text\\">color 10</span>
 </span>
 
@@ -27606,87 +27626,107 @@ exports[`Check stories > Components/Info Label > Story DisplayModeInfoLabel > Sh
 
 <span class=\\"fd-info-label fd-info-label--accent-color-1 fd-info-label--display\\">
     <i role=\\"presentation\\" class=\\"fd-info-label__icon sap-icon--dark-mode\\"></i>
-    <span class=\\"fd-info-label__text\\">Info Label</span>
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
+    <span class=\\"fd-info-label__text\\">Color 1</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-2 fd-info-label--display\\">
     <i role=\\"presentation\\" class=\\"fd-info-label__icon sap-icon--dark-mode\\"></i>
-    <span class=\\"fd-info-label__text\\">Info Label</span>
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
+    <span class=\\"fd-info-label__text\\">Color 2</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-3 fd-info-label--display\\">
     <i role=\\"presentation\\" class=\\"fd-info-label__icon sap-icon--dark-mode\\"></i>
-    <span class=\\"fd-info-label__text\\">Info Label</span>
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
+    <span class=\\"fd-info-label__text\\">Color 3</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-4 fd-info-label--display\\">
     <i role=\\"presentation\\" class=\\"fd-info-label__icon sap-icon--dark-mode\\"></i>
-    <span class=\\"fd-info-label__text\\">Info Label</span>
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
+    <span class=\\"fd-info-label__text\\">Color 4</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-5 fd-info-label--display\\">
     <i role=\\"presentation\\" class=\\"fd-info-label__icon sap-icon--dark-mode\\"></i>
-    <span class=\\"fd-info-label__text\\">Info Label</span>
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
+    <span class=\\"fd-info-label__text\\">Color 5</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-6 fd-info-label--display\\">
     <i role=\\"presentation\\" class=\\"fd-info-label__icon sap-icon--dark-mode\\"></i>
-    <span class=\\"fd-info-label__text\\">Info Label</span>
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
+    <span class=\\"fd-info-label__text\\">Color 6</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-7 fd-info-label--display\\">
     <i role=\\"presentation\\" class=\\"fd-info-label__icon sap-icon--dark-mode\\"></i>
-    <span class=\\"fd-info-label__text\\">Info Label</span>
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
+    <span class=\\"fd-info-label__text\\">Color 7</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-8 fd-info-label--display\\">
     <i role=\\"presentation\\" class=\\"fd-info-label__icon sap-icon--dark-mode\\"></i>
-    <span class=\\"fd-info-label__text\\">Info Label</span>
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
+    <span class=\\"fd-info-label__text\\">Color 8</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-9 fd-info-label--display\\">
     <i role=\\"presentation\\" class=\\"fd-info-label__icon sap-icon--dark-mode\\"></i>
-    <span class=\\"fd-info-label__text\\">Info Label</span>
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
+    <span class=\\"fd-info-label__text\\">Color 9</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-10 fd-info-label--display\\">
     <i role=\\"presentation\\" class=\\"fd-info-label__icon sap-icon--dark-mode\\"></i>
-    <span class=\\"fd-info-label__text\\">Info Label</span>
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
+    <span class=\\"fd-info-label__text\\">Color 10</span>
 </span>
 "
 `;
 
 exports[`Check stories > Components/Info Label > Story InfoLabelWithIcon > Should match snapshot 1`] = `
 "<span class=\\"fd-info-label fd-info-label--accent-color-1\\">
-    <i role=\\"presentation\\" class=\\"fd-info-label__icon sap-icon--dark-mode\\"></i>
-    <span class=\\"fd-info-label__text\\">Info Label</span>
+    <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-info-label__icon sap-icon--dark-mode\\"></i>
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
+    <span class=\\"fd-info-label__text\\">Color 1</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-2\\">
-    <i role=\\"presentation\\" class=\\"fd-info-label__icon sap-icon--dark-mode\\"></i>
-    <span class=\\"fd-info-label__text\\">Info Label</span>
+    <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-info-label__icon sap-icon--dark-mode\\"></i>
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
+    <span class=\\"fd-info-label__text\\">Color 2</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-3\\">
-    <i role=\\"presentation\\" class=\\"fd-info-label__icon sap-icon--dark-mode\\"></i>
-    <span class=\\"fd-info-label__text\\">Info Label</span>
+    <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-info-label__icon sap-icon--dark-mode\\"></i>
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
+    <span class=\\"fd-info-label__text\\">Color 3</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-4\\">
-    <i role=\\"presentation\\" class=\\"fd-info-label__icon sap-icon--dark-mode\\"></i>
-    <span class=\\"fd-info-label__text\\">Info Label</span>
+    <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-info-label__icon sap-icon--dark-mode\\"></i>
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
+    <span class=\\"fd-info-label__text\\">Color 4</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-5\\">
-    <i role=\\"presentation\\" class=\\"fd-info-label__icon sap-icon--dark-mode\\"></i>
-    <span class=\\"fd-info-label__text\\">Info Label</span>
+    <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-info-label__icon sap-icon--dark-mode\\"></i>
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
+    <span class=\\"fd-info-label__text\\">Color 5</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-6\\">
-    <i role=\\"presentation\\" class=\\"fd-info-label__icon sap-icon--dark-mode\\"></i>
-    <span class=\\"fd-info-label__text\\">Info Label</span>
+    <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-info-label__icon sap-icon--dark-mode\\"></i>
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
+    <span class=\\"fd-info-label__text\\">Color 6</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-7\\">
-    <i role=\\"presentation\\" class=\\"fd-info-label__icon sap-icon--dark-mode\\"></i>
-    <span class=\\"fd-info-label__text\\">Info Label</span>
+    <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-info-label__icon sap-icon--dark-mode\\"></i>
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
+    <span class=\\"fd-info-label__text\\">Color 7</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-8\\">
-    <i role=\\"presentation\\" class=\\"fd-info-label__icon sap-icon--dark-mode\\"></i>
-    <span class=\\"fd-info-label__text\\">Info Label</span>
+    <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-info-label__icon sap-icon--dark-mode\\"></i>
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
+    <span class=\\"fd-info-label__text\\">Color 8</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-9\\">
-    <i role=\\"presentation\\" class=\\"fd-info-label__icon sap-icon--dark-mode\\"></i>
-    <span class=\\"fd-info-label__text\\">Info Label</span>
+    <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-info-label__icon sap-icon--dark-mode\\"></i>
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
+    <span class=\\"fd-info-label__text\\">Color 9</span>
 </span>
 <span class=\\"fd-info-label fd-info-label--accent-color-10\\">
-    <i role=\\"presentation\\" class=\\"fd-info-label__icon sap-icon--dark-mode\\"></i>
-    <span class=\\"fd-info-label__text\\">Info Label</span>
+    <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-info-label__icon sap-icon--dark-mode\\"></i>
+    <span class=\\"fd-info-label__sr-only\\">Info Label</span>
+    <span class=\\"fd-info-label__text\\">Color 10</span>
 </span>
 "
 `;


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-styles/issues/5763

## Description
BREAKING CHANGE:
Markup changes: a new visually hidden <span> element is now required for screen reader support.

Before:
```
<span class="fd-info-label fd-info-label--accent-color-1">
    <span class="fd-info-label__text">color 1</span>
</span>
```

After:
```
<span class="fd-info-label fd-info-label--accent-color-1">
    <span class="fd-info-label__sr-only">Info Label</span>
    <span class="fd-info-label__text">color 1</span>
</span>
```