### PR TITLE
fix(styles): add a11y improvements for Link [ci visual]

### DIFF
--- a/packages/styles/src/link.scss
+++ b/packages/styles/src/link.scss
@@ -10,7 +10,7 @@ $block: #{$fd-namespace}-link;
   @include fd-link();
 
   text-underline-offset: 0.125rem;
-  line-height: var(--fdLink_Line_Height, 1.125rem);
+  line-height: var(--fdLink_Line_Height, 1rem);
 
   @include fd-icon-selector() {
     color: var(--sapLinkColor);
@@ -19,11 +19,11 @@ $block: #{$fd-namespace}-link;
     @include fd-inline-flex-center();
 
     &:first-child {
-      @include fd-set-margin-right(var(--fdLink_Icon_Spacing, 0));
+      margin-inline-end: 0.125rem;
     }
 
     &:last-child {
-      @include fd-set-margin-left(var(--fdLink_Icon_Spacing, 0));
+      margin-inline-start: 0.125rem;
     }
   }
 
@@ -52,5 +52,9 @@ $block: #{$fd-namespace}-link;
     @include fd-icon-selector() {
       color: var(--sapLink_Visited_Color);
     }
+  }
+
+  &__sr-only {
+    @include fd-screen-reader-only();
   }
 }

--- a/packages/styles/src/mixins/_mixins.scss
+++ b/packages/styles/src/mixins/_mixins.scss
@@ -202,6 +202,10 @@
     font-family: var(--sapFontBoldFamily);
   }
 
+  &--touch-target {
+    --fdLink_Line_Height: 1.5rem;
+  }
+
   &:visited {
     color: var(--sapLink_Visited_Color);
   }

--- a/packages/styles/src/theming/common/link/_sap_horizon.scss
+++ b/packages/styles/src/theming/common/link/_sap_horizon.scss
@@ -19,5 +19,4 @@
   --fdLink_Hover_Outline_Color: unset;
   --fdLink_Hover_Outline_Style: none;
   --fdLink_Display: inline-flex;
-  --fdLink_Icon_Spacing: 0.125rem;
 }

--- a/packages/styles/src/theming/common/link/_sap_horizon_hc.scss
+++ b/packages/styles/src/theming/common/link/_sap_horizon_hc.scss
@@ -11,5 +11,4 @@
   --fdLink_Hover_Outline_Width: var(--sapContent_FocusWidth);
   --fdLink_Hover_Outline_Color: var(--sapContent_FocusColor);
   --fdLink_Hover_Outline_Style: var(--sapContent_FocusStyle);
-  --fdLink_Icon_Spacing: 0.125rem;
 }

--- a/packages/styles/stories/Components/link/link.stories.js
+++ b/packages/styles/stories/Components/link/link.stories.js
@@ -21,8 +21,17 @@ export default {
 ##Accessibility
 Use a meaningful link text that indicates what will happen when the user interacts with the link i.e. *Open Sales Order*.
 Avoid texts such as *Click Here* or *Link*, as these do not make it clear to the user what the purpose of the link is.
-`,
-    tags: ['f3', 'a11y', 'theme']
+
+<b>IMPORTANT</b> The modifier class <code>fd-link--touch-target</code> adds increased vertical spacing to the link to meet WCAG 2.2 minimum touch target requirements. This modifier sets the line height to 1.5rem (24px), ensuring that links placed inside actionable containers—such as table cells or list items—are easier to tap on touch devices.
+
+**When to use:**
+
+Use this modifier when a link is the primary action inside a container that also responds to click or tap events (e.g., a clickable table row or list item). This helps ensure that the interactive area of the link meets the recommended minimum size for touch targets.
+
+**When not to use:**
+
+Do not apply this modifier in inline text or in dense text areas where increasing the line height would cause visual misalignment or disrupt text flow. In such cases, the container is not typically interactive, so the minimum touch area requirement does not apply.
+`
   }
 };
 const localStyles = `
@@ -48,65 +57,163 @@ const localStyles = `
 </style>
 `;
 export const Primary = () => `${localStyles}
+<div class="docs-link-container">
+   <span><b>Regular</b></span>
+   <span><b>Hover</b></span>
+   <span><b>Active</b></span>
+   <span><b>Focus</b></span>
+   <span><b>Disabled</b></span>
+</div>
 
 <div class="docs-link-container">
-    <a href="#" class="fd-link" tabindex="0"><span class="fd-link__content">Link</span></a>
-    <a href="#" class="fd-link is-active" tabindex="0"><span class="fd-link__content">Active</span></a>
-    <a href="#" class="fd-link is-focus" tabindex="0"><span class="fd-link__content">Focused</span></a>
-    <a href="#" class="fd-link" aria-disabled="true" tabindex="0"><span class="fd-link__content">Disabled</span></a>
+    <a href="#" class="fd-link" tabindex="0" aria-disabled="false" aria-disabled="false">
+        <span class="fd-link__content">Regular Link</span>
+    </a>
+
+    <a href="#" class="fd-link is-hover" tabindex="0" aria-disabled="false">
+        <span class="fd-link__content">Regular Link</span>
+    </a>
+
+     <a href="#" class="fd-link is-active" tabindex="0" aria-disabled="false">
+        <span class="fd-link__content">Regular Link</span>
+    </a>
+
+    <a href="#" class="fd-link is-focus" tabindex="0" aria-disabled="false">
+        <span class="fd-link__content">Regular Link</span>
+    </a>
+
+    <a href="#" class="fd-link" tabindex="-1" aria-disabled="true">
+        <span class="fd-link__content">Regular Link</span>
+    </a>
 </div>
+
 <div class="docs-link-container">
-    <a href="#" class="fd-link fd-link--emphasized" tabindex="0"><span class="fd-link__content">Emphasized link</span></a>
-    <a href="#" class="fd-link fd-link--emphasized is-active" tabindex="0"><span class="fd-link__content">Active</span></a>
-    <a href="#" class="fd-link fd-link--emphasized is-focus" tabindex="0"><span class="fd-link__content">Focused</span></a>
-    <a href="#" class="fd-link fd-link--emphasized" aria-disabled="true" tabindex="0"><span class="fd-link__content">Disabled</span></a>
+    <a href="#" class="fd-link fd-link--emphasized" tabindex="0" aria-disabled="false">
+        <span class="fd-link__content">Emphasized Link</span>
+        <span class="fd-link__sr-only">Emphasized</span>
+    </a>
+
+    <a href="#" class="fd-link fd-link--emphasized is-hover" tabindex="0" aria-disabled="false">
+        <span class="fd-link__content">Emphasized Link</span>
+        <span class="fd-link__sr-only">Emphasized</span>
+    </a>
+
+    <a href="#" class="fd-link fd-link--emphasized is-active" tabindex="0" aria-disabled="false">
+        <span class="fd-link__content">Emphasized Link</span>
+        <span class="fd-link__sr-only">Emphasized</span>
+    </a>
+
+    <a href="#" class="fd-link fd-link--emphasized is-focus" tabindex="0" aria-disabled="false">
+        <span class="fd-link__content">Emphasized Link</span>
+        <span class="fd-link__sr-only">Emphasized</span>
+    </a>
+
+    <a href="#" class="fd-link fd-link--emphasized" tabindex="-1" aria-disabled="true">
+        <span class="fd-link__content">Emphasized Link</span>
+        <span class="fd-link__sr-only">Emphasized</span>
+    </a>
 </div>
+
 <div class="docs-link-container">
-    <a href="#" class="fd-link fd-link--subtle"><span class="fd-link__content">Subtle link</span></a>
-    <a href="#" class="fd-link fd-link--subtle is-active"><span class="fd-link__content">Active</span></a>
-    <a href="#" class="fd-link fd-link--subtle is-focus"><span class="fd-link__content">Focused</span></a>
-    <a href="#" class="fd-link fd-link--subtle" aria-disabled="true"><span class="fd-link__content">Disabled</span></a>
+    <a href="#" class="fd-link fd-link--subtle" tabindex="0" aria-disabled="false">
+        <span class="fd-link__content">Subtle Link</span>
+        <span class="fd-link__sr-only">Subtle</span>
+    </a>
+
+    <a href="#" class="fd-link fd-link--subtle is-hover" tabindex="0" aria-disabled="false">
+        <span class="fd-link__content">Subtle Link</span>
+        <span class="fd-link__sr-only">Subtle</span>
+    </a>
+
+    <a href="#" class="fd-link fd-link--subtle is-active" tabindex="0" aria-disabled="false">
+        <span class="fd-link__content">Subtle Link</span>
+        <span class="fd-link__sr-only">Subtle</span>
+    </a>
+
+    <a href="#" class="fd-link fd-link--subtle is-focus" tabindex="0" aria-disabled="false">
+        <span class="fd-link__content">Subtle Link</span>
+        <span class="fd-link__sr-only">Subtle</span>
+    </a>
+
+    <a href="#" class="fd-link fd-link--subtle" tabindex="-1" aria-disabled="true">
+        <span class="fd-link__content">Subtle Link</span>
+        <span class="fd-link__sr-only">Subtle</span>
+    </a>
 </div>
+
 <div class="docs-link-container docs-link-container--inverted">
-    <a href="#" class="fd-link fd-link--inverted"><span class="fd-link__content">Inverted link</span></a>
-    <a href="#" class="fd-link fd-link--inverted is-active"><span class="fd-link__content">Active</span></a>
-    <a href="#" class="fd-link fd-link--inverted is-focus"><span class="fd-link__content">Focused</span></a>
-    <a href="#" class="fd-link fd-link--inverted" aria-disabled="true"><span class="fd-link__content">Disabled</span></a>
-</div>
-<div class="docs-link-container">
-    <a href="#" class="fd-link" tabindex="0">
-        <span class="fd-link__content">Right icon link</span>
-        <span class="sap-icon--delete sap-icon--s"></span>
+    <a href="#" class="fd-link fd-link--inverted" tabindex="0" aria-disabled="false">
+        <span class="fd-link__content">Inverted Link</span>
     </a>
-    <a href="#" class="fd-link is-active" tabindex="0">
-        <span class="fd-link__content">Active</span>
-        <span class="sap-icon--delete sap-icon--s"></span>
+
+    <a href="#" class="fd-link fd-link--inverted is-hover" tabindex="0" aria-disabled="false">
+        <span class="fd-link__content">Inverted Link</span>
     </a>
-    <a href="#" class="fd-link is-focus" tabindex="0">
-        <span class="fd-link__content">Focused</span>
-        <span class="sap-icon--delete sap-icon--s"></span>
+
+    <a href="#" class="fd-link fd-link--inverted is-active" tabindex="0" aria-disabled="false">
+        <span class="fd-link__content">Inverted Link</span>
     </a>
-    <a href="#" class="fd-link" aria-disabled="true" tabindex="0">
-        <span class="fd-link__content">Disabled</span>
-        <span class="sap-icon--delete sap-icon--s"></span>
+
+    <a href="#" class="fd-link fd-link--inverted is-focus" tabindex="0" aria-disabled="false">
+        <span class="fd-link__content">Inverted Link</span>
+    </a>
+
+    <a href="#" class="fd-link fd-link--inverted" tabindex="-1" aria-disabled="true">
+        <span class="fd-link__content">Inverted Link</span>
     </a>
 </div>
+
 <div class="docs-link-container">
-    <a href="#" class="fd-link" tabindex="0">
-        <span class="sap-icon--delete sap-icon--s"></span>
-        <span class="fd-link__content">Left icon link</span>
+    <a href="#" class="fd-link" tabindex="0" aria-disabled="false">
+        <span class="fd-link__content">Right Icon Link</span>
+        <span class="sap-icon--delete sap-icon--s" role="presentation" aria-hidden="true"></span>
     </a>
-    <a href="#" class="fd-link is-active" tabindex="0">
-        <span class="sap-icon--delete sap-icon--s"></span>
-        <span class="fd-link__content">Active</span>
+
+    <a href="#" class="fd-link is-hover" tabindex="0" aria-disabled="false">
+        <span class="fd-link__content">Right Icon Link</span>
+        <span class="sap-icon--delete sap-icon--s" role="presentation" aria-hidden="true"></span>
     </a>
-    <a href="#" class="fd-link is-focus" tabindex="0">
-        <span class="sap-icon--delete sap-icon--s"></span>
-        <span class="fd-link__content">Focused</span>
+
+    <a href="#" class="fd-link is-active" tabindex="0" aria-disabled="false">
+        <span class="fd-link__content">Right Icon Link</span>
+        <span class="sap-icon--delete sap-icon--s" role="presentation" aria-hidden="true"></span>
     </a>
-    <a href="#" class="fd-link" aria-disabled="true" tabindex="0">
-        <span class="sap-icon--delete sap-icon--s"></span>
-        <span class="fd-link__content">Disabled</span>
+
+    <a href="#" class="fd-link is-focus" tabindex="0" aria-disabled="false">
+        <span class="fd-link__content">Right Icon Link</span>
+        <span class="sap-icon--delete sap-icon--s" role="presentation" aria-hidden="true"></span>
+    </a>
+
+    <a href="#" class="fd-link" tabindex="-1" aria-disabled="true">
+        <span class="fd-link__content">Right Icon Link</span>
+        <span class="sap-icon--delete sap-icon--s" role="presentation" aria-hidden="true"></span>
+    </a>
+</div>
+
+<div class="docs-link-container">
+    <a href="#" class="fd-link" tabindex="0" aria-disabled="false">
+        <span class="sap-icon--delete sap-icon--s" role="presentation" aria-hidden="true"></span>
+        <span class="fd-link__content">Left Icon Link</span>
+    </a>
+
+    <a href="#" class="fd-link is-hover" tabindex="0" aria-disabled="false">
+        <span class="sap-icon--delete sap-icon--s" role="presentation" aria-hidden="true"></span>
+        <span class="fd-link__content">Left Icon Link</span>
+    </a>
+
+    <a href="#" class="fd-link is-active" tabindex="0" aria-disabled="false">
+        <span class="sap-icon--delete sap-icon--s" role="presentation" aria-hidden="true"></span>
+        <span class="fd-link__content">Left Icon Link</span>
+    </a>
+
+    <a href="#" class="fd-link is-focus" tabindex="0" aria-disabled="false">
+        <span class="sap-icon--delete sap-icon--s" role="presentation" aria-hidden="true"></span>
+        <span class="fd-link__content">Left Icon Link</span>
+    </a>
+
+    <a href="#" class="fd-link" tabindex="-1" aria-disabled="true">
+        <span class="sap-icon--delete sap-icon--s" role="presentation" aria-hidden="true"></span>
+        <span class="fd-link__content">Left Icon Link</span>
     </a>
 </div>
 `;
@@ -117,7 +224,7 @@ Primary.parameters = {
       story: `There are different types of links for various use cases.
 
 | Types | Modifier class | Use to... |
-| ----:| :--------------- | :--------------|
+| :----| :--------------- | :--------------|
 | Default | *n/a* | Display a simple link. |
 | Subtle | \`fd-link--subtle\` | Distinguish between important (default) and less important (subtle) links in tables with large data lists. |
 | Disabled | \`fd-link--disabled\` | Display a link that a user cannot interactive with. |
@@ -127,9 +234,16 @@ Primary.parameters = {
 You can display a link with an icon placed on either side of the link text.
 
 | Icon style | Modifier class |
-| ----------: | :-------------|
+| :---------- | :-------------|
 | Left Arrow | \`sap-icon--slim-arrow-left sap-icon--s\` |
 | Right Arrow | \`sap-icon--slim-arrow-right sap-icon--s\` |
+
+###Accessibility
+In case of interactive containers, applies increased line height (1.5rem / 24px) to ensure the link meets WCAG 2.2 minimum touch target requirements.
+
+| Type | Modifier class |
+| :---------- | :-------------|
+| Touch Target | \`fd-link--touch-target\` |
 `
     }
   }

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -27714,65 +27714,163 @@ exports[`Check stories > Components/Link > Story Primary > Should match snapshot
     }
 </style>
 
+<div class=\\"docs-link-container\\">
+   <span><b>Regular</b></span>
+   <span><b>Hover</b></span>
+   <span><b>Active</b></span>
+   <span><b>Focus</b></span>
+   <span><b>Disabled</b></span>
+</div>
 
 <div class=\\"docs-link-container\\">
-    <a href=\\"#\\" class=\\"fd-link\\" tabindex=\\"0\\"><span class=\\"fd-link__content\\">Link</span></a>
-    <a href=\\"#\\" class=\\"fd-link is-active\\" tabindex=\\"0\\"><span class=\\"fd-link__content\\">Active</span></a>
-    <a href=\\"#\\" class=\\"fd-link is-focus\\" tabindex=\\"0\\"><span class=\\"fd-link__content\\">Focused</span></a>
-    <a href=\\"#\\" class=\\"fd-link\\" aria-disabled=\\"true\\" tabindex=\\"0\\"><span class=\\"fd-link__content\\">Disabled</span></a>
+    <a href=\\"#\\" class=\\"fd-link\\" tabindex=\\"0\\" aria-disabled=\\"false\\" aria-disabled=\\"false\\">
+        <span class=\\"fd-link__content\\">Regular Link</span>
+    </a>
+
+    <a href=\\"#\\" class=\\"fd-link is-hover\\" tabindex=\\"0\\" aria-disabled=\\"false\\">
+        <span class=\\"fd-link__content\\">Regular Link</span>
+    </a>
+
+     <a href=\\"#\\" class=\\"fd-link is-active\\" tabindex=\\"0\\" aria-disabled=\\"false\\">
+        <span class=\\"fd-link__content\\">Regular Link</span>
+    </a>
+
+    <a href=\\"#\\" class=\\"fd-link is-focus\\" tabindex=\\"0\\" aria-disabled=\\"false\\">
+        <span class=\\"fd-link__content\\">Regular Link</span>
+    </a>
+
+    <a href=\\"#\\" class=\\"fd-link\\" tabindex=\\"-1\\" aria-disabled=\\"true\\">
+        <span class=\\"fd-link__content\\">Regular Link</span>
+    </a>
 </div>
+
 <div class=\\"docs-link-container\\">
-    <a href=\\"#\\" class=\\"fd-link fd-link--emphasized\\" tabindex=\\"0\\"><span class=\\"fd-link__content\\">Emphasized link</span></a>
-    <a href=\\"#\\" class=\\"fd-link fd-link--emphasized is-active\\" tabindex=\\"0\\"><span class=\\"fd-link__content\\">Active</span></a>
-    <a href=\\"#\\" class=\\"fd-link fd-link--emphasized is-focus\\" tabindex=\\"0\\"><span class=\\"fd-link__content\\">Focused</span></a>
-    <a href=\\"#\\" class=\\"fd-link fd-link--emphasized\\" aria-disabled=\\"true\\" tabindex=\\"0\\"><span class=\\"fd-link__content\\">Disabled</span></a>
+    <a href=\\"#\\" class=\\"fd-link fd-link--emphasized\\" tabindex=\\"0\\" aria-disabled=\\"false\\">
+        <span class=\\"fd-link__content\\">Emphasized Link</span>
+        <span class=\\"fd-link__sr-only\\">Emphasized</span>
+    </a>
+
+    <a href=\\"#\\" class=\\"fd-link fd-link--emphasized is-hover\\" tabindex=\\"0\\" aria-disabled=\\"false\\">
+        <span class=\\"fd-link__content\\">Emphasized Link</span>
+        <span class=\\"fd-link__sr-only\\">Emphasized</span>
+    </a>
+
+    <a href=\\"#\\" class=\\"fd-link fd-link--emphasized is-active\\" tabindex=\\"0\\" aria-disabled=\\"false\\">
+        <span class=\\"fd-link__content\\">Emphasized Link</span>
+        <span class=\\"fd-link__sr-only\\">Emphasized</span>
+    </a>
+
+    <a href=\\"#\\" class=\\"fd-link fd-link--emphasized is-focus\\" tabindex=\\"0\\" aria-disabled=\\"false\\">
+        <span class=\\"fd-link__content\\">Emphasized Link</span>
+        <span class=\\"fd-link__sr-only\\">Emphasized</span>
+    </a>
+
+    <a href=\\"#\\" class=\\"fd-link fd-link--emphasized\\" tabindex=\\"-1\\" aria-disabled=\\"true\\">
+        <span class=\\"fd-link__content\\">Emphasized Link</span>
+        <span class=\\"fd-link__sr-only\\">Emphasized</span>
+    </a>
 </div>
+
 <div class=\\"docs-link-container\\">
-    <a href=\\"#\\" class=\\"fd-link fd-link--subtle\\"><span class=\\"fd-link__content\\">Subtle link</span></a>
-    <a href=\\"#\\" class=\\"fd-link fd-link--subtle is-active\\"><span class=\\"fd-link__content\\">Active</span></a>
-    <a href=\\"#\\" class=\\"fd-link fd-link--subtle is-focus\\"><span class=\\"fd-link__content\\">Focused</span></a>
-    <a href=\\"#\\" class=\\"fd-link fd-link--subtle\\" aria-disabled=\\"true\\"><span class=\\"fd-link__content\\">Disabled</span></a>
+    <a href=\\"#\\" class=\\"fd-link fd-link--subtle\\" tabindex=\\"0\\" aria-disabled=\\"false\\">
+        <span class=\\"fd-link__content\\">Subtle Link</span>
+        <span class=\\"fd-link__sr-only\\">Subtle</span>
+    </a>
+
+    <a href=\\"#\\" class=\\"fd-link fd-link--subtle is-hover\\" tabindex=\\"0\\" aria-disabled=\\"false\\">
+        <span class=\\"fd-link__content\\">Subtle Link</span>
+        <span class=\\"fd-link__sr-only\\">Subtle</span>
+    </a>
+
+    <a href=\\"#\\" class=\\"fd-link fd-link--subtle is-active\\" tabindex=\\"0\\" aria-disabled=\\"false\\">
+        <span class=\\"fd-link__content\\">Subtle Link</span>
+        <span class=\\"fd-link__sr-only\\">Subtle</span>
+    </a>
+
+    <a href=\\"#\\" class=\\"fd-link fd-link--subtle is-focus\\" tabindex=\\"0\\" aria-disabled=\\"false\\">
+        <span class=\\"fd-link__content\\">Subtle Link</span>
+        <span class=\\"fd-link__sr-only\\">Subtle</span>
+    </a>
+
+    <a href=\\"#\\" class=\\"fd-link fd-link--subtle\\" tabindex=\\"-1\\" aria-disabled=\\"true\\">
+        <span class=\\"fd-link__content\\">Subtle Link</span>
+        <span class=\\"fd-link__sr-only\\">Subtle</span>
+    </a>
 </div>
+
 <div class=\\"docs-link-container docs-link-container--inverted\\">
-    <a href=\\"#\\" class=\\"fd-link fd-link--inverted\\"><span class=\\"fd-link__content\\">Inverted link</span></a>
-    <a href=\\"#\\" class=\\"fd-link fd-link--inverted is-active\\"><span class=\\"fd-link__content\\">Active</span></a>
-    <a href=\\"#\\" class=\\"fd-link fd-link--inverted is-focus\\"><span class=\\"fd-link__content\\">Focused</span></a>
-    <a href=\\"#\\" class=\\"fd-link fd-link--inverted\\" aria-disabled=\\"true\\"><span class=\\"fd-link__content\\">Disabled</span></a>
-</div>
-<div class=\\"docs-link-container\\">
-    <a href=\\"#\\" class=\\"fd-link\\" tabindex=\\"0\\">
-        <span class=\\"fd-link__content\\">Right icon link</span>
-        <span class=\\"sap-icon--delete sap-icon--s\\"></span>
+    <a href=\\"#\\" class=\\"fd-link fd-link--inverted\\" tabindex=\\"0\\" aria-disabled=\\"false\\">
+        <span class=\\"fd-link__content\\">Inverted Link</span>
     </a>
-    <a href=\\"#\\" class=\\"fd-link is-active\\" tabindex=\\"0\\">
-        <span class=\\"fd-link__content\\">Active</span>
-        <span class=\\"sap-icon--delete sap-icon--s\\"></span>
+
+    <a href=\\"#\\" class=\\"fd-link fd-link--inverted is-hover\\" tabindex=\\"0\\" aria-disabled=\\"false\\">
+        <span class=\\"fd-link__content\\">Inverted Link</span>
     </a>
-    <a href=\\"#\\" class=\\"fd-link is-focus\\" tabindex=\\"0\\">
-        <span class=\\"fd-link__content\\">Focused</span>
-        <span class=\\"sap-icon--delete sap-icon--s\\"></span>
+
+    <a href=\\"#\\" class=\\"fd-link fd-link--inverted is-active\\" tabindex=\\"0\\" aria-disabled=\\"false\\">
+        <span class=\\"fd-link__content\\">Inverted Link</span>
     </a>
-    <a href=\\"#\\" class=\\"fd-link\\" aria-disabled=\\"true\\" tabindex=\\"0\\">
-        <span class=\\"fd-link__content\\">Disabled</span>
-        <span class=\\"sap-icon--delete sap-icon--s\\"></span>
+
+    <a href=\\"#\\" class=\\"fd-link fd-link--inverted is-focus\\" tabindex=\\"0\\" aria-disabled=\\"false\\">
+        <span class=\\"fd-link__content\\">Inverted Link</span>
+    </a>
+
+    <a href=\\"#\\" class=\\"fd-link fd-link--inverted\\" tabindex=\\"-1\\" aria-disabled=\\"true\\">
+        <span class=\\"fd-link__content\\">Inverted Link</span>
     </a>
 </div>
+
 <div class=\\"docs-link-container\\">
-    <a href=\\"#\\" class=\\"fd-link\\" tabindex=\\"0\\">
-        <span class=\\"sap-icon--delete sap-icon--s\\"></span>
-        <span class=\\"fd-link__content\\">Left icon link</span>
+    <a href=\\"#\\" class=\\"fd-link\\" tabindex=\\"0\\" aria-disabled=\\"false\\">
+        <span class=\\"fd-link__content\\">Right Icon Link</span>
+        <span class=\\"sap-icon--delete sap-icon--s\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
     </a>
-    <a href=\\"#\\" class=\\"fd-link is-active\\" tabindex=\\"0\\">
-        <span class=\\"sap-icon--delete sap-icon--s\\"></span>
-        <span class=\\"fd-link__content\\">Active</span>
+
+    <a href=\\"#\\" class=\\"fd-link is-hover\\" tabindex=\\"0\\" aria-disabled=\\"false\\">
+        <span class=\\"fd-link__content\\">Right Icon Link</span>
+        <span class=\\"sap-icon--delete sap-icon--s\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
     </a>
-    <a href=\\"#\\" class=\\"fd-link is-focus\\" tabindex=\\"0\\">
-        <span class=\\"sap-icon--delete sap-icon--s\\"></span>
-        <span class=\\"fd-link__content\\">Focused</span>
+
+    <a href=\\"#\\" class=\\"fd-link is-active\\" tabindex=\\"0\\" aria-disabled=\\"false\\">
+        <span class=\\"fd-link__content\\">Right Icon Link</span>
+        <span class=\\"sap-icon--delete sap-icon--s\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
     </a>
-    <a href=\\"#\\" class=\\"fd-link\\" aria-disabled=\\"true\\" tabindex=\\"0\\">
-        <span class=\\"sap-icon--delete sap-icon--s\\"></span>
-        <span class=\\"fd-link__content\\">Disabled</span>
+
+    <a href=\\"#\\" class=\\"fd-link is-focus\\" tabindex=\\"0\\" aria-disabled=\\"false\\">
+        <span class=\\"fd-link__content\\">Right Icon Link</span>
+        <span class=\\"sap-icon--delete sap-icon--s\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+    </a>
+
+    <a href=\\"#\\" class=\\"fd-link\\" tabindex=\\"-1\\" aria-disabled=\\"true\\">
+        <span class=\\"fd-link__content\\">Right Icon Link</span>
+        <span class=\\"sap-icon--delete sap-icon--s\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+    </a>
+</div>
+
+<div class=\\"docs-link-container\\">
+    <a href=\\"#\\" class=\\"fd-link\\" tabindex=\\"0\\" aria-disabled=\\"false\\">
+        <span class=\\"sap-icon--delete sap-icon--s\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+        <span class=\\"fd-link__content\\">Left Icon Link</span>
+    </a>
+
+    <a href=\\"#\\" class=\\"fd-link is-hover\\" tabindex=\\"0\\" aria-disabled=\\"false\\">
+        <span class=\\"sap-icon--delete sap-icon--s\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+        <span class=\\"fd-link__content\\">Left Icon Link</span>
+    </a>
+
+    <a href=\\"#\\" class=\\"fd-link is-active\\" tabindex=\\"0\\" aria-disabled=\\"false\\">
+        <span class=\\"sap-icon--delete sap-icon--s\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+        <span class=\\"fd-link__content\\">Left Icon Link</span>
+    </a>
+
+    <a href=\\"#\\" class=\\"fd-link is-focus\\" tabindex=\\"0\\" aria-disabled=\\"false\\">
+        <span class=\\"sap-icon--delete sap-icon--s\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+        <span class=\\"fd-link__content\\">Left Icon Link</span>
+    </a>
+
+    <a href=\\"#\\" class=\\"fd-link\\" tabindex=\\"-1\\" aria-disabled=\\"true\\">
+        <span class=\\"sap-icon--delete sap-icon--s\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+        <span class=\\"fd-link__content\\">Left Icon Link</span>
     </a>
 </div>
 "


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-styles/issues/5763

## Description
- the default line-height of the Link is 1rem
- for interactive containers added a modifier class `fd-link--touch-target` to ensure touchable area of 1.5rem (new feature)
- updated documentation and examples
- added a visually hidden span element to describe emphasized and subtle links (breaking change)
- the icons have role and aria-hidden

BREAKING CHANGE:
added a visually hidden span element to describe emphasized and subtle links


Before:
```
<a href="#" class="fd-link fd-link--emphasized" tabindex="0" aria-disabled="false">
    <span class="fd-link__content">Emphasized Link</span>
</a>
```

After:
```
<a href="#" class="fd-link fd-link--emphasized" tabindex="0" aria-disabled="false">
    <span class="fd-link__content">Emphasized Link</span>
    <span class="fd-link__sr-only">Emphasized</span>
</a>
```

Before:
```
<a href="#" class="fd-link is-focus" tabindex="0" aria-disabled="false">
    <span class="sap-icon--delete sap-icon--s"></span>
    <span class="fd-link__content">Left Icon Link</span>
</a>
```

After:
```
<a href="#" class="fd-link is-focus" tabindex="0" aria-disabled="false">
    <span class="sap-icon--delete sap-icon--s" role="presentation" aria-hidden="true"></span>
    <span class="fd-link__content">Left Icon Link</span>
</a>
```