### PR TITLE
fix(styles): a11y update for Message Strip [ci visual]

### DIFF
--- a/packages/styles/src/message-strip.scss
+++ b/packages/styles/src/message-strip.scss
@@ -1,4 +1,5 @@
 @use "sass:map";
+@use "sass:string";
 
 @import "./new-settings";
 @import "./mixins";
@@ -18,123 +19,83 @@ $block: #{$fd-namespace}-message-strip;
   $fd-avatar-indication-colors: (
     "1": (
       "background-color": var(--sapIndicationColor_1_Background),
-      "text-color": var(--sapIndicationColor_1_TextColor),
-      "border-color": var(--sapIndicationColor_1_BorderColor),
-      "text-shadow": none
+      "border-color": var(--sapIndicationColor_1_BorderColor)
     ),
     "2": (
       "background-color": var(--sapIndicationColor_2_Background),
-      "text-color": var(--sapIndicationColor_2_TextColor),
-      "border-color": var(--sapIndicationColor_2_BorderColor),
-      "text-shadow": none
+      "border-color": var(--sapIndicationColor_2_BorderColor)
     ),
     "3": (
       "background-color": var(--sapIndicationColor_3_Background),
-      "text-color": var(--sapIndicationColor_3_TextColor),
-      "border-color": var(--sapIndicationColor_3_BorderColor),
-      "text-shadow": none
+      "border-color": var(--sapIndicationColor_3_BorderColor)
     ),
     "4": (
       "background-color": var(--sapIndicationColor_4_Background),
-      "text-color": var(--sapIndicationColor_4_TextColor),
-      "border-color": var(--sapIndicationColor_4_BorderColor),
-      "text-shadow": none
+      "border-color": var(--sapIndicationColor_4_BorderColor)
     ),
     "5": (
       "background-color": var(--sapIndicationColor_5_Background),
-      "text-color": var(--sapIndicationColor_5_TextColor),
-      "border-color": var(--sapIndicationColor_5_BorderColor),
-      "text-shadow": none
+      "border-color": var(--sapIndicationColor_5_BorderColor)
     ),
     "6": (
       "background-color": var(--sapIndicationColor_6_Background),
-      "text-color": var(--sapIndicationColor_6_TextColor),
-      "border-color": var(--sapIndicationColor_6_BorderColor),
-      "text-shadow": none
+      "border-color": var(--sapIndicationColor_6_BorderColor)
     ),
     "7": (
       "background-color": var(--sapIndicationColor_7_Background),
-      "text-color": var(--sapIndicationColor_7_TextColor),
-      "border-color": var(--sapIndicationColor_7_BorderColor),
-      "text-shadow": none
+      "border-color": var(--sapIndicationColor_7_BorderColor)
     ),
     "8": (
       "background-color": var(--sapIndicationColor_8_Background),
-      "text-color": var(--sapIndicationColor_8_TextColor),
-      "border-color": var(--sapIndicationColor_8_BorderColor),
-      "text-shadow": none
+      "border-color": var(--sapIndicationColor_8_BorderColor)
     ),
     "9": (
       "background-color": var(--sapIndicationColor_9_Background),
-      "text-color": var(--sapIndicationColor_9_TextColor),
-      "border-color": var(--sapIndicationColor_9_BorderColor),
-      "text-shadow": none
+      "border-color": var(--sapIndicationColor_9_BorderColor)
     ),
     "10": (
       "background-color": var(--sapIndicationColor_10_Background),
-      "text-color": var(--sapIndicationColor_10_TextColor),
-      "border-color": var(--sapIndicationColor_10_BorderColor),
-      "text-shadow": none
+      "border-color": var(--sapIndicationColor_10_BorderColor)
     ),
     "1b": (
-      "background-color": var(--sapIndicationColor_1b),
-      "text-color": var(--sapIndicationColor_1),
-      "border-color": var(--sapIndicationColor_1b_BorderColor),
-      "text-shadow": var(--sapContent_TextShadow)
+      "background-color": var(--sapIndicationColor_1b_Background),
+      "border-color": var(--sapIndicationColor_1b_BorderColor)
     ),
     "2b": (
-      "background-color": var(--sapIndicationColor_2b),
-      "text-color": var(--sapIndicationColor_2),
-      "border-color": var(--sapIndicationColor_2b_BorderColor),
-      "text-shadow": var(--sapContent_TextShadow)
+      "background-color": var(--sapIndicationColor_2b_Background),
+      "border-color": var(--sapIndicationColor_2b_BorderColor)
     ),
     "3b": (
-      "background-color": var(--sapIndicationColor_3b),
-      "text-color": var(--sapIndicationColor_3),
-      "border-color": var(--sapIndicationColor_3b_BorderColor),
-      "text-shadow": var(--sapContent_TextShadow)
+      "background-color": var(--sapIndicationColor_3b_Background),
+      "border-color": var(--sapIndicationColor_3b_BorderColor)
     ),
     "4b": (
-      "background-color": var(--sapIndicationColor_4b),
-      "text-color": var(--sapIndicationColor_4),
-      "border-color": var(--sapIndicationColor_4b_BorderColor),
-      "text-shadow": var(--sapContent_TextShadow)
+      "background-color": var(--sapIndicationColor_4b_Background),
+      "border-color": var(--sapIndicationColor_4b_BorderColor)
     ),
     "5b": (
-      "background-color": var(--sapIndicationColor_5b),
-      "text-color": var(--sapIndicationColor_5),
-      "border-color": var(--sapIndicationColor_5b_BorderColor),
-      "text-shadow": var(--sapContent_TextShadow)
+      "background-color": var(--sapIndicationColor_5b_Background),
+      "border-color": var(--sapIndicationColor_5b_BorderColor)
     ),
     "6b": (
-      "background-color": var(--sapIndicationColor_6b),
-      "text-color": var(--sapIndicationColor_6),
-      "border-color": var(--sapIndicationColor_6b_BorderColor),
-      "text-shadow": var(--sapContent_TextShadow)
+      "background-color": var(--sapIndicationColor_6b_Background),
+      "border-color": var(--sapIndicationColor_6b_BorderColor)
     ),
     "7b": (
-      "background-color": var(--sapIndicationColor_7b),
-      "text-color": var(--sapIndicationColor_7),
-      "border-color": var(--sapIndicationColor_7b_BorderColor),
-      "text-shadow": var(--sapContent_TextShadow)
+      "background-color": var(--sapIndicationColor_7b_Background),
+      "border-color": var(--sapIndicationColor_7b_BorderColor)
     ),
     "8b": (
-      "background-color": var(--sapIndicationColor_8b),
-      "text-color": var(--sapIndicationColor_8),
-      "border-color": var(--sapIndicationColor_8b_BorderColor),
-      "text-shadow": var(--sapContent_TextShadow)
+      "background-color": var(--sapIndicationColor_8b_Background),
+      "border-color": var(--sapIndicationColor_8b_BorderColor)
     ),
     "9b": (
-      "background-color": var(--sapIndicationColor_9b),
-      "text-color": var(--sapIndicationColor_9),
-      "border-color": var(--sapIndicationColor_9b_BorderColor),
-      "text-shadow": var(--sapContent_TextShadow)
+      "background-color": var(--sapIndicationColor_9b_Background),
+      "border-color": var(--sapIndicationColor_9b_BorderColor)
     ),
     "10b": (
-      "background-color": var(--sapIndicationColor_10b),
-      "text-color": var(--sapIndicationColor_10),
-      "border-color": var(--sapIndicationColor_10b_BorderColor),
-      "text-shadow": var(--sapContent_TextShadow)
+      "background-color": var(--sapIndicationColor_10b_Background),
+      "border-color": var(--sapIndicationColor_10b_BorderColor)
     )
   );
 
@@ -241,10 +202,113 @@ $block: #{$fd-namespace}-message-strip;
 
   @each $set-name, $color-set in $fd-avatar-indication-colors {
     &--indication-color-#{$set-name} {
-      --fdMessageStrip_Icon_Color: #{map.get($color-set, "text-color")};
-      --fdMessageStrip_Text_Color: #{map.get($color-set, "text-color")};
       --fdMessageStrip_Border_Color: #{map.get($color-set, "border-color")};
       --fdMessageStrip_Background_Color: #{map.get($color-set, "background-color")};
+
+      // Second set of Indication Colors (the indication color ends with the letter b)
+      @if string.slice($set-name, -1) == "b" {
+        --fdMessageStrip_Icon_Color: var(--sapContent_IconColor);
+        --fdMessageStrip_Text_Color: var(--sapTextColor);
+
+        text-shadow: none;
+
+        &.#{$block}--link a {
+          color: var(--sapLink_SubtleColor);
+          text-shadow: none;
+
+          // TO BE SPECIFIED
+          @include fd-focus() {
+            background-color: var(--sapContent_ContrastTextColor);
+          }
+        }
+
+        .#{$block}__close {
+          --fdButtonColor: var(--sapContent_IconColor);
+    
+          @include fd-hover() {
+            --fdButtonColor: var(--sapContent_IconColor);
+            --fdButtonBackgroundColor: var(--sapMessage_Button_Hover_Background);
+            --fdButtonBorderColor: var(--sapContent_IconColor);
+          }
+    
+          @include fd-active() {
+            --fdButtonColor: var(--sapContent_IconColor);
+            --fdButtonBackgroundColor: var(--sapMessage_Button_Hover_Background);
+            --fdButtonBorderColor: var(--sapContent_IconColor);
+          }
+    
+          @include fd-focus() {
+            --fdButtonColor: var(--sapContent_IconColor);
+            --fdButtonBackgroundColor: none;
+            --fdButtonBorderColor: transparent;
+    
+            &::after {
+              border-color: var(--sapContent_FocusColor);
+            }
+
+            @include fd-hover() {
+              --fdButtonColor: var(--sapContent_IconColor);
+              --fdButtonBackgroundColor: var(--sapMessage_Button_Hover_Background);
+              --fdButtonBorderColor: var(--sapContent_IconColor);
+
+              &::after {
+                border-color: var(--sapContent_FocusColor);
+              }
+            }
+          }
+        }
+      } @else {
+        --fdMessageStrip_Icon_Color: var(--sapContent_ContrastTextColor);
+        --fdMessageStrip_Text_Color: var(--sapContent_ContrastTextColor);
+
+        text-shadow: var(--sapContent_ContrastTextShadow);
+
+        &.#{$block}--link a {
+          color: var(--sapContent_ContrastTextColor);
+          text-shadow: var(--sapContent_ContrastTextShadow);
+
+          // TO BE SPECIFIED
+          @include fd-focus() {
+            background-color: var(--sapTextColor);
+          }
+        }
+    
+        .#{$block}__close {
+          --fdButtonColor: var(--sapContent_ContrastIconColor);
+    
+          @include fd-hover() {
+            --fdButtonColor: var(--sapContent_ContrastIconColor);
+            --fdButtonBackgroundColor: var(--sapMessage_Button_Hover_Background);
+            --fdButtonBorderColor: var(--sapContent_ContrastIconColor);
+          }
+    
+          @include fd-active() {
+            --fdButtonColor: var(--sapContent_ContrastIconColor);
+            --fdButtonBackgroundColor: var(--sapMessage_Button_Hover_Background);
+            --fdButtonBorderColor: var(--sapContent_ContrastIconColor);
+          }
+    
+          @include fd-focus() {
+            --fdButtonColor: var(--sapContent_ContrastIconColor);
+            --fdButtonBackgroundColor: none;
+            --fdButtonBorderColor: transparent;
+    
+            &::after {
+              border-color: var(--sapContent_ContrastFocusColor);
+            }
+
+            @include fd-hover() {
+              --fdButtonColor: var(--sapContent_ContrastIconColor);
+              --fdButtonBackgroundColor: var(--sapMessage_Button_Hover_Background);
+              --fdButtonBorderColor: var(--sapContent_ContrastIconColor);
+
+              &::after {
+                border-color: var(--sapContent_ContrastFocusColor);
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/packages/styles/src/message-strip.scss
+++ b/packages/styles/src/message-strip.scss
@@ -147,8 +147,8 @@ $block: #{$fd-namespace}-message-strip;
   position: relative;
   border-style: solid;
   font-size: var(--sapFontSize);
-  border-width: var(--fdMessageStrip_Border_Width);
-  border-radius: var(--fdMessageStrip_Border_Radius);
+  border-width: var(--sapMessage_BorderWidth);
+  border-radius: var(--sapPopover_BorderCornerRadius);
   background: var(--fdMessageStrip_Background_Color);
   border-color: var(--fdMessageStrip_Border_Color);
 
@@ -188,6 +188,10 @@ $block: #{$fd-namespace}-message-strip;
       line-height: 1;
       color: var(--fdMessageStrip_Icon_Color);
     }
+  }
+
+  &__sr-only {
+    @include fd-screen-reader-only();
   }
 
   &--warning {
@@ -231,6 +235,8 @@ $block: #{$fd-namespace}-message-strip;
 
   &--link a {
     text-shadow: var(--sapContent_TextShadow);
+    margin-inline-start: 0.25rem;
+    padding-inline: 0.25rem;
   }
 
   @each $set-name, $color-set in $fd-avatar-indication-colors {

--- a/packages/styles/src/theming/sap_fiori_3.scss
+++ b/packages/styles/src/theming/sap_fiori_3.scss
@@ -140,8 +140,6 @@
   --fdBadge_Border_Color: transparent;
 
   /* Message Strip */
-  --fdMessageStrip_Border_Width: 0.0625rem;
-  --fdMessageStrip_Border_Radius: var(--sapElement_BorderCornerRadius);
   --fdMessageStrip_Border_Color_Success: var(--sapSuccessBorderColor);
   --fdMessageStrip_Border_Color_Error: var(--sapErrorBorderColor);
   --fdMessageStrip_Border_Color_Warning: var(--sapWarningBorderColor);

--- a/packages/styles/src/theming/sap_fiori_3_dark.scss
+++ b/packages/styles/src/theming/sap_fiori_3_dark.scss
@@ -149,8 +149,6 @@
   --fdBadge_Border_Color: transparent;
 
   /* Message Strip */
-  --fdMessageStrip_Border_Width: 0.0625rem;
-  --fdMessageStrip_Border_Radius: var(--sapElement_BorderCornerRadius);
   --fdMessageStrip_Border_Color_Success: var(--sapSuccessBorderColor);
   --fdMessageStrip_Border_Color_Error: var(--sapErrorBorderColor);
   --fdMessageStrip_Border_Color_Warning: var(--sapWarningBorderColor);

--- a/packages/styles/src/theming/sap_fiori_3_hcb.scss
+++ b/packages/styles/src/theming/sap_fiori_3_hcb.scss
@@ -152,8 +152,6 @@
   --fdBadge_Border_Color: var(--sapGroup_ContentBorderColor);
 
   /* Message Strip */
-  --fdMessageStrip_Border_Width: 0.125rem;
-  --fdMessageStrip_Border_Radius: var(--sapElement_BorderCornerRadius);
   --fdMessageStrip_Border_Color_Success: var(--sapSuccessBorderColor);
   --fdMessageStrip_Border_Color_Error: var(--sapErrorBorderColor);
   --fdMessageStrip_Border_Color_Warning: var(--sapWarningBorderColor);

--- a/packages/styles/src/theming/sap_fiori_3_hcw.scss
+++ b/packages/styles/src/theming/sap_fiori_3_hcw.scss
@@ -148,8 +148,6 @@
   --fdBadge_Border_Color: var(--sapGroup_ContentBorderColor);
 
   /* Message Strip */
-  --fdMessageStrip_Border_Width: 0.125rem;
-  --fdMessageStrip_Border_Radius: var(--sapElement_BorderCornerRadius);
   --fdMessageStrip_Border_Color_Success: var(--sapSuccessBorderColor);
   --fdMessageStrip_Border_Color_Error: var(--sapErrorBorderColor);
   --fdMessageStrip_Border_Color_Warning: var(--sapWarningBorderColor);

--- a/packages/styles/src/theming/sap_fiori_3_light_dark.scss
+++ b/packages/styles/src/theming/sap_fiori_3_light_dark.scss
@@ -147,8 +147,6 @@
   --fdBadge_Border_Color: transparent;
 
   /* Message Strip */
-  --fdMessageStrip_Border_Width: 0.0625rem;
-  --fdMessageStrip_Border_Radius: var(--sapElement_BorderCornerRadius);
   --fdMessageStrip_Border_Color_Success: var(--sapSuccessBorderColor);
   --fdMessageStrip_Border_Color_Error: var(--sapErrorBorderColor);
   --fdMessageStrip_Border_Color_Warning: var(--sapWarningBorderColor);

--- a/packages/styles/src/theming/sap_horizon.scss
+++ b/packages/styles/src/theming/sap_horizon.scss
@@ -147,8 +147,6 @@
   --fdBadge_Border_Color: transparent;
 
   /* Message Strip */
-  --fdMessageStrip_Border_Width: 0.0625rem;
-  --fdMessageStrip_Border_Radius: var(--sapPopover_BorderCornerRadius);
   --fdMessageStrip_Border_Color_Success: var(--sapMessage_SuccessBorderColor);
   --fdMessageStrip_Border_Color_Error: var(--sapMessage_ErrorBorderColor);
   --fdMessageStrip_Border_Color_Warning: var(--sapMessage_WarningBorderColor);

--- a/packages/styles/src/theming/sap_horizon_dark.scss
+++ b/packages/styles/src/theming/sap_horizon_dark.scss
@@ -160,8 +160,6 @@
   --fdBadge_Border_Color: var(--sapGroup_ContentBorderColor);
 
   /* Message Strip */
-  --fdMessageStrip_Border_Width: 0.0625rem;
-  --fdMessageStrip_Border_Radius: var(--sapPopover_BorderCornerRadius);
   --fdMessageStrip_Border_Color_Success: var(--sapMessage_SuccessBorderColor);
   --fdMessageStrip_Border_Color_Error: var(--sapMessage_ErrorBorderColor);
   --fdMessageStrip_Border_Color_Warning: var(--sapMessage_WarningBorderColor);

--- a/packages/styles/src/theming/sap_horizon_hcb.scss
+++ b/packages/styles/src/theming/sap_horizon_hcb.scss
@@ -148,8 +148,6 @@
   --fdBadge_Border_Color: var(--sapGroup_ContentBorderColor);
 
   /* Message Strip */
-  --fdMessageStrip_Border_Width: 0.125rem;
-  --fdMessageStrip_Border_Radius: var(--sapPopover_BorderCornerRadius);
   --fdMessageStrip_Border_Color_Success: var(--sapMessage_SuccessBorderColor);
   --fdMessageStrip_Border_Color_Error: var(--sapMessage_ErrorBorderColor);
   --fdMessageStrip_Border_Color_Warning: var(--sapMessage_WarningBorderColor);

--- a/packages/styles/src/theming/sap_horizon_hcw.scss
+++ b/packages/styles/src/theming/sap_horizon_hcw.scss
@@ -149,8 +149,6 @@
   --fdBadge_Border_Color: var(--sapGroup_ContentBorderColor);
 
   /* Message Strip */
-  --fdMessageStrip_Border_Width: 0.125rem;
-  --fdMessageStrip_Border_Radius: var(--sapPopover_BorderCornerRadius);
   --fdMessageStrip_Border_Color_Success: var(--sapMessage_SuccessBorderColor);
   --fdMessageStrip_Border_Color_Error: var(--sapMessage_ErrorBorderColor);
   --fdMessageStrip_Border_Color_Warning: var(--sapMessage_WarningBorderColor);

--- a/packages/styles/stories/Components/message-strip/default-strip.example.html
+++ b/packages/styles/stories/Components/message-strip/default-strip.example.html
@@ -1,5 +1,9 @@
-<div class="fd-message-strip fd-message-strip--no-icon" role="note" aria-live="assertive" id="message-strip-1" aria-labelledby="message-strip-1">
-  <p class="fd-message-strip__text">
-    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
+<div 
+  class="fd-message-strip fd-message-strip--no-icon" 
+  role="note"
+  aria-labelledby="message-strip-hidden-text-1 message-strip-text-1">
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-1">Information Bar</span>
+  <p class="fd-message-strip__text" id="message-strip-text-1">
+    This is a message.
   </p>
 </div>

--- a/packages/styles/stories/Components/message-strip/error.example.html
+++ b/packages/styles/stories/Components/message-strip/error.example.html
@@ -1,11 +1,22 @@
-<div class="fd-message-strip fd-message-strip--error fd-message-strip--dismissible" role="note" aria-live="assertive" id="message-strip-5" aria-labelledby="message-strip-5">
+<div 
+  role="note" 
+  aria-labelledby="message-strip-hidden-text-5 message-strip-text-5"
+  class="fd-message-strip fd-message-strip--error fd-message-strip--dismissible">
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-5">Error Information Bar Closable</span>
+  
   <div class="fd-message-strip__icon-container" aria-hidden="true">
-    <span class="sap-icon sap-icon--message-error" focusable="false" role="presentation" aria-hidden="true"></span>
+    <span class="sap-icon sap-icon--message-error" role="presentation" aria-hidden="true"></span>
   </div>
-  <p class="fd-message-strip__text">
-    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
+
+  <p class="fd-message-strip__text" id="message-strip-text-5">
+    Error Message Strip
   </p>
-  <button class="fd-button fd-button--transparent is-compact fd-message-strip__close" aria-controls="message-strip-5" aria-label="Close" title="Close">
-    <i class="sap-icon--decline"></i>
+
+  <button 
+    role="button"
+    class="fd-button fd-button--transparent is-compact fd-message-strip__close" 
+    aria-label="Error Information Bar Close" 
+    title="Error Information Bar Close">
+    <i class="sap-icon--decline" role="presentation" aria-hidden="true"></i>
   </button>
 </div>

--- a/packages/styles/stories/Components/message-strip/information.example.html
+++ b/packages/styles/stories/Components/message-strip/information.example.html
@@ -1,11 +1,22 @@
-<div class="fd-message-strip fd-message-strip--information fd-message-strip--dismissible" role="note" aria-live="assertive" id="message-strip-2" aria-labelledby="message-strip-2">
+<div 
+  role="note" 
+  aria-labelledby="message-strip-hidden-text-2 message-strip-text-2"
+  class="fd-message-strip fd-message-strip--information fd-message-strip--dismissible">
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-2">Information Bar Closable</span>
+  
   <div class="fd-message-strip__icon-container" aria-hidden="true">
-    <span class="sap-icon sap-icon--message-information" focusable="false" role="presentation" aria-hidden="true"></span>
+    <span class="sap-icon sap-icon--message-information" role="presentation" aria-hidden="true"></span>
   </div>
-  <p class="fd-message-strip__text">
-    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
+
+  <p class="fd-message-strip__text" id="message-strip-text-2">
+    Information Message Strip
   </p>
-  <button class="fd-button fd-button--transparent is-compact fd-message-strip__close" aria-controls="message-strip-2" aria-label="Close" title="Close">
-    <i class="sap-icon--decline"></i>
+
+  <button 
+    role="button"
+    class="fd-button fd-button--transparent is-compact fd-message-strip__close" 
+    aria-label="Information Bar Close" 
+    title="Information Bar Close">
+    <i class="sap-icon--decline" role="presentation" aria-hidden="true"></i>
   </button>
 </div>

--- a/packages/styles/stories/Components/message-strip/message-strip-with-accent-colors.example.html
+++ b/packages/styles/stories/Components/message-strip/message-strip-with-accent-colors.example.html
@@ -1,9 +1,9 @@
 <div 
-  class="fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-1" 
+  class="fd-message-strip fd-message-strip--dismissible fd-message-strip--link fd-message-strip--indication-color-1" 
   role="note"  
   aria-labelledby="message-strip-hidden-text-19 message-strip-text-19">
   
-  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-19">Custom Information Bar</span>
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-19">Custom Information Bar Closable</span>
 
   <div class="fd-message-strip__icon-container" aria-hidden="true">
     <span class="sap-icon sap-icon--master-task-triangle-2" role="presentation" aria-hidden="true"></span>
@@ -11,17 +11,26 @@
 
   <p class="fd-message-strip__text" id="message-strip-text-19">
     Message Strip with indication color 1 (Dark Red)
+    <a href="#" class="fd-link fd-link--subtle" tabindex="0"><span class="fd-link__content">Link</span></a>
   </p>
+
+  <button 
+    role="button"
+    class="fd-button fd-button--transparent is-compact fd-message-strip__close" 
+    aria-label="Custom Information Bar Close" 
+    title="Custom Information Bar Close">
+    <i class="sap-icon--decline" role="presentation" aria-hidden="true"></i>
+  </button>
 </div>
 
 <br>
 
 <div 
-  class="fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-1b" 
+  class="fd-message-strip fd-message-strip--dismissible fd-message-strip--link fd-message-strip--indication-color-1b" 
   role="note" 
   aria-labelledby="message-strip-hidden-text-20 message-strip-text-20">
   
-  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-20">Custom Information Bar</span>
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-20">Custom Information Bar Closable</span>
 
   <div class="fd-message-strip__icon-container" aria-hidden="true">
     <span class="sap-icon sap-icon--master-task-triangle-2" role="presentation" aria-hidden="true"></span>
@@ -29,53 +38,80 @@
   
   <p class="fd-message-strip__text" id="message-strip-text-20">
     Message Strip with indication color 1b (Dark Red)
+    <a href="#" class="fd-link fd-link--subtle" tabindex="0"><span class="fd-link__content">Link</span></a>
   </p>
+
+  <button 
+    role="button"
+    class="fd-button fd-button--transparent is-compact fd-message-strip__close" 
+    aria-label="Custom Information Bar Close" 
+    title="Custom Information Bar Close">
+    <i class="sap-icon--decline" role="presentation" aria-hidden="true"></i>
+  </button>
 </div>
 
 <br>
 
 <div 
-  class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-2" 
+  class="fd-message-strip fd-message-strip--dismissible fd-message-strip--link  fd-message-strip--indication-color-2" 
   role="note" 
   aria-labelledby="message-strip-hidden-text-21 message-strip-text-21">
   
-  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-21">Custom Information Bar</span>
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-21">Custom Information Bar Closable</span>
 
   <div class="fd-message-strip__icon-container" aria-hidden="true">
     <span class="sap-icon sap-icon--cloud" role="presentation" aria-hidden="true"></span>
   </div>
   
   <p class="fd-message-strip__text" id="message-strip-text-21">
-    Message Strip with indication color 2  (Red)
+    Message Strip with indication color 2 (Red)
+    <a href="#" class="fd-link fd-link--subtle" tabindex="0"><span class="fd-link__content">Link</span></a>
   </p>
+
+  <button 
+    role="button"
+    class="fd-button fd-button--transparent is-compact fd-message-strip__close" 
+    aria-label="Custom Information Bar Close" 
+    title="Custom Information Bar Close">
+    <i class="sap-icon--decline" role="presentation" aria-hidden="true"></i>
+  </button>
 </div>
 
 <br>
 
 <div 
-  class="fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-2b" 
+  class="fd-message-strip fd-message-strip--dismissible fd-message-strip--link fd-message-strip--indication-color-2b" 
   role="note" 
   aria-labelledby="message-strip-hidden-text-22 message-strip-text-22">
   
-  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-22">Custom Information Bar</span>
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-22">Custom Information Bar Closable</span>
 
   <div class="fd-message-strip__icon-container" aria-hidden="true">
     <span class="sap-icon sap-icon--cloud" role="presentation" aria-hidden="true"></span>
   </div>
   
   <p class="fd-message-strip__text" id="message-strip-text-22">
-    Message Strip with indication color 2b (Red) 
+    Message Strip with indication color 2b (Red)
+    <a href="#" class="fd-link fd-link--subtle" tabindex="0"><span class="fd-link__content">Link</span></a>
   </p>
+
+  <button 
+    role="button"
+    class="fd-button fd-button--transparent is-compact fd-message-strip__close" 
+    aria-label="Custom Information Bar Close" 
+    title="Custom Information Bar Close">
+    <i class="sap-icon--decline" role="presentation" aria-hidden="true"></i>
+  </button>
 </div>
 
 <br>
 
 <div 
-  class="fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-3" 
+  class="fd-message-strip fd-message-strip--dismissible fd-message-strip--link fd-message-strip--indication-color-3" 
   role="note" 
   aria-labelledby="message-strip-hidden-text-23 message-strip-text-23">
 
-  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-23">Custom Information Bar</span>
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-23">Custom Information Bar Closable</span>
 
   <div class="fd-message-strip__icon-container" aria-hidden="true">
     <span class="sap-icon sap-icon--heart-2" role="presentation" aria-hidden="true"></span>
@@ -83,7 +119,16 @@
 
   <p class="fd-message-strip__text" id="message-strip-text-23">
     Message Strip with indication color 3 (Yellow)
+    <a href="#" class="fd-link fd-link--subtle" tabindex="0"><span class="fd-link__content">Link</span></a>
   </p>
+
+  <button 
+    role="button"
+    class="fd-button fd-button--transparent is-compact fd-message-strip__close" 
+    aria-label="Custom Information Bar Close" 
+    title="Custom Information Bar Close">
+    <i class="sap-icon--decline" role="presentation" aria-hidden="true"></i>
+  </button>
 </div>
 
 <br>
@@ -93,7 +138,7 @@
   role="note" 
   aria-labelledby="message-strip-hidden-text-24 message-strip-text-24">
   
-  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-24">Custom Information Bar</span>
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-24">Custom Information Bar Closable</span>
 
   <div class="fd-message-strip__icon-container" aria-hidden="true">
     <span class="sap-icon sap-icon--heart-2" role="presentation" aria-hidden="true"></span>
@@ -102,6 +147,14 @@
   <p class="fd-message-strip__text" id="message-strip-text-24">
     Message Strip with indication color 3b (Yellow) 
   </p>
+
+  <button 
+    role="button"
+    class="fd-button fd-button--transparent is-compact fd-message-strip__close" 
+    aria-label="Custom Information Bar Close" 
+    title="Custom Information Bar Close">
+    <i class="sap-icon--decline" role="presentation" aria-hidden="true"></i>
+  </button>
 </div>
 
 <br>
@@ -111,7 +164,7 @@
   role="note"
   aria-labelledby="message-strip-hidden-text-25 message-strip-text-25">
   
-  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-25">Custom Information Bar</span>
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-25">Custom Information Bar Closable</span>
 
   <div class="fd-message-strip__icon-container" aria-hidden="true">
     <span class="sap-icon sap-icon--circle-task" role="presentation" aria-hidden="true"></span>
@@ -120,6 +173,14 @@
   <p class="fd-message-strip__text" id="message-strip-text-25">
     Message Strip with indication color 4 (Green)
   </p>
+
+  <button 
+    role="button"
+    class="fd-button fd-button--transparent is-compact fd-message-strip__close" 
+    aria-label="Custom Information Bar Close" 
+    title="Custom Information Bar Close">
+    <i class="sap-icon--decline" role="presentation" aria-hidden="true"></i>
+  </button>
 </div>
 
 <br>
@@ -129,7 +190,7 @@
   role="note" 
   aria-labelledby="message-strip-hidden-text-26 message-strip-text-26">
 
-  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-26">Custom Information Bar</span>
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-26">Custom Information Bar Closable</span>
 
   <div class="fd-message-strip__icon-container" aria-hidden="true">
     <span class="sap-icon sap-icon--circle-task" role="presentation" aria-hidden="true"></span>
@@ -138,6 +199,14 @@
   <p class="fd-message-strip__text" id="message-strip-text-26">
     Message Strip with indication color 4b (Green)
   </p>
+
+  <button 
+    role="button"
+    class="fd-button fd-button--transparent is-compact fd-message-strip__close" 
+    aria-label="Custom Information Bar Close" 
+    title="Custom Information Bar Close">
+    <i class="sap-icon--decline" role="presentation" aria-hidden="true"></i>
+  </button>
 </div>
 
 <br>
@@ -147,7 +216,7 @@
   role="note"
   aria-labelledby="message-strip-hidden-text-27 message-strip-text-27">
   
-  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-27">Custom Information Bar</span>
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-27">Custom Information Bar Closable</span>
 
   <div class="fd-message-strip__icon-container" aria-hidden="true">
     <span class="sap-icon sap-icon--feedback" role="presentation" aria-hidden="true"></span>
@@ -156,6 +225,14 @@
   <p class="fd-message-strip__text" id="message-strip-text-27">
     Message Strip with indication color 5 (Blue)
   </p>
+
+  <button 
+    role="button"
+    class="fd-button fd-button--transparent is-compact fd-message-strip__close" 
+    aria-label="Custom Information Bar Close" 
+    title="Custom Information Bar Close">
+    <i class="sap-icon--decline" role="presentation" aria-hidden="true"></i>
+  </button>
 </div>
 
 
@@ -166,7 +243,7 @@
   role="note" 
   aria-labelledby="message-strip-hidden-text-28 message-strip-text-28">
   
-  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-28">Custom Information Bar</span>
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-28">Custom Information Bar Closable</span>
 
   <div class="fd-message-strip__icon-container" aria-hidden="true">
     <span class="sap-icon sap-icon--feedback" role="presentation" aria-hidden="true"></span>
@@ -175,6 +252,14 @@
   <p class="fd-message-strip__text" id="message-strip-text-28">
     Message Strip with indication color 5b (Blue)
   </p>
+
+  <button 
+    role="button"
+    class="fd-button fd-button--transparent is-compact fd-message-strip__close" 
+    aria-label="Custom Information Bar Close" 
+    title="Custom Information Bar Close">
+    <i class="sap-icon--decline" role="presentation" aria-hidden="true"></i>
+  </button>
 </div>
 
 <br>
@@ -184,7 +269,7 @@
   role="note" 
   aria-labelledby="message-strip-hidden-text-29 message-strip-text-29">
   
-  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-29">Custom Information Bar</span>
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-29">Custom Information Bar Closable</span>
 
   <div class="fd-message-strip__icon-container" aria-hidden="true">
     <span class="sap-icon sap-icon--text-color" role="presentation" aria-hidden="true"></span>
@@ -193,6 +278,14 @@
   <p class="fd-message-strip__text" id="message-strip-text-29">
     Message Strip with indication color 6 (Teal)
   </p>
+
+  <button 
+    role="button"
+    class="fd-button fd-button--transparent is-compact fd-message-strip__close" 
+    aria-label="Custom Information Bar Close" 
+    title="Custom Information Bar Close">
+    <i class="sap-icon--decline" role="presentation" aria-hidden="true"></i>
+  </button>
 </div>
 
 <br>
@@ -202,7 +295,7 @@
   role="note"
   aria-labelledby="message-strip-hidden-text-30 message-strip-text-30">
   
-  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-30">Custom Information Bar</span>
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-30">Custom Information Bar Closable</span>
 
   <div class="fd-message-strip__icon-container" aria-hidden="true">
     <span class="sap-icon sap-icon--text-color" role="presentation" aria-hidden="true"></span>
@@ -211,6 +304,14 @@
   <p class="fd-message-strip__text" id="message-strip-text-30">
     Message Strip with indication color 6b (Teal)
   </p>
+
+  <button 
+    role="button"
+    class="fd-button fd-button--transparent is-compact fd-message-strip__close" 
+    aria-label="Custom Information Bar Close" 
+    title="Custom Information Bar Close">
+    <i class="sap-icon--decline" role="presentation" aria-hidden="true"></i>
+  </button>
 </div>
 
 <br>
@@ -220,7 +321,7 @@
   role="note" 
   aria-labelledby="message-strip-hidden-text-31 message-strip-text-31">
   
-  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-31">Custom Information Bar</span>
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-31">Custom Information Bar Closable</span>
 
   <div class="fd-message-strip__icon-container" aria-hidden="true">
     <span class="sap-icon sap-icon--away" role="presentation" aria-hidden="true"></span>
@@ -229,6 +330,14 @@
   <p class="fd-message-strip__text" id="message-strip-text-31">
     Message Strip with indication color 7 (Purple)
   </p>
+
+  <button 
+    role="button"
+    class="fd-button fd-button--transparent is-compact fd-message-strip__close" 
+    aria-label="Custom Information Bar Close" 
+    title="Custom Information Bar Close">
+    <i class="sap-icon--decline" role="presentation" aria-hidden="true"></i>
+  </button>
 </div>
 
 <br>
@@ -238,7 +347,7 @@
   role="note"
   aria-labelledby="message-strip-hidden-text-32 message-strip-text-32">
   
-  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-32">Custom Information Bar</span>
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-32">Custom Information Bar Closable</span>
 
   <div class="fd-message-strip__icon-container" aria-hidden="true">
     <span class="sap-icon sap-icon--away" role="presentation" aria-hidden="true"></span>
@@ -247,6 +356,14 @@
   <p class="fd-message-strip__text" id="message-strip-text-32">
     Message Strip with indication color 7b (Purple)
   </p>
+
+  <button 
+    role="button"
+    class="fd-button fd-button--transparent is-compact fd-message-strip__close" 
+    aria-label="Custom Information Bar Close" 
+    title="Custom Information Bar Close">
+    <i class="sap-icon--decline" role="presentation" aria-hidden="true"></i>
+  </button>
 </div>
 
 <br>
@@ -256,7 +373,7 @@
   role="note" 
   aria-labelledby="message-strip-hidden-text-33 message-strip-text-33">
   
-  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-33">Custom Information Bar</span>
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-33">Custom Information Bar Closable</span>
 
   <div class="fd-message-strip__icon-container" aria-hidden="true">
     <span class="sap-icon sap-icon--cursor" role="presentation" aria-hidden="true"></span>
@@ -265,6 +382,14 @@
   <p class="fd-message-strip__text" id="message-strip-text-33">
     Message Strip with indication color 8 (Pink)
   </p>
+
+  <button 
+    role="button"
+    class="fd-button fd-button--transparent is-compact fd-message-strip__close" 
+    aria-label="Custom Information Bar Close" 
+    title="Custom Information Bar Close">
+    <i class="sap-icon--decline" role="presentation" aria-hidden="true"></i>
+  </button>
 </div>
 
 <br>
@@ -274,7 +399,7 @@
   role="note"  
   aria-labelledby="message-strip-hidden-text-34 message-strip-text-34">
   
-  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-34">Custom Information Bar</span>
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-34">Custom Information Bar Closable</span>
 
   <div class="fd-message-strip__icon-container" aria-hidden="true">
     <span class="sap-icon sap-icon--cursor" role="presentation" aria-hidden="true"></span>
@@ -283,6 +408,14 @@
   <p class="fd-message-strip__text" id="message-strip-text-34">
     Message Strip with indication color 8b (Pink)
   </p>
+
+  <button 
+    role="button"
+    class="fd-button fd-button--transparent is-compact fd-message-strip__close" 
+    aria-label="Custom Information Bar Close" 
+    title="Custom Information Bar Close">
+    <i class="sap-icon--decline" role="presentation" aria-hidden="true"></i>
+  </button>
 </div>
 
 <br>
@@ -292,7 +425,7 @@
   role="note" 
   aria-labelledby="message-strip-hidden-text-35 message-strip-text-35">
   
-  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-35">Custom Information Bar</span>
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-35">Custom Information Bar Closable</span>
 
   <div class="fd-message-strip__icon-container" aria-hidden="true">
     <span class="sap-icon sap-icon--copy" role="presentation" aria-hidden="true"></span>
@@ -301,6 +434,14 @@
   <p class="fd-message-strip__text" id="message-strip-text-35">
     Message Strip with indication color 9 (Black/White)
   </p>
+
+  <button 
+    role="button"
+    class="fd-button fd-button--transparent is-compact fd-message-strip__close" 
+    aria-label="Custom Information Bar Close" 
+    title="Custom Information Bar Close">
+    <i class="sap-icon--decline" role="presentation" aria-hidden="true"></i>
+  </button>
 </div>
 
 <br>
@@ -310,7 +451,7 @@
   role="note"
   aria-labelledby="message-strip-hidden-text-36 message-strip-text-36">
   
-  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-36">Custom Information Bar</span>
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-36">Custom Information Bar Closable</span>
 
   <div class="fd-message-strip__icon-container" aria-hidden="true">
     <span class="sap-icon sap-icon--copy" role="presentation" aria-hidden="true"></span>
@@ -319,6 +460,14 @@
   <p class="fd-message-strip__text" id="message-strip-text-36">
     Message Strip with indication color 9b (Black/White)
   </p>
+
+  <button 
+    role="button"
+    class="fd-button fd-button--transparent is-compact fd-message-strip__close" 
+    aria-label="Custom Information Bar Close" 
+    title="Custom Information Bar Close">
+    <i class="sap-icon--decline" role="presentation" aria-hidden="true"></i>
+  </button>
 </div>
 
 <br>
@@ -328,7 +477,7 @@
   role="note" 
   aria-labelledby="message-strip-hidden-text-37 message-strip-text-37">
   
-  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-37">Custom Information Bar</span>
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-37">Custom Information Bar Closable</span>
 
   <div class="fd-message-strip__icon-container" aria-hidden="true">
     <span class="sap-icon sap-icon--reset" role="presentation" aria-hidden="true"></span>
@@ -337,6 +486,14 @@
   <p class="fd-message-strip__text" id="message-strip-text-37">
     Message Strip with indication color 10 (Grey)
   </p>
+
+  <button 
+    role="button"
+    class="fd-button fd-button--transparent is-compact fd-message-strip__close" 
+    aria-label="Custom Information Bar Close" 
+    title="Custom Information Bar Close">
+    <i class="sap-icon--decline" role="presentation" aria-hidden="true"></i>
+  </button>
 </div>
 
 <br>
@@ -346,7 +503,7 @@
   role="note"
   aria-labelledby="message-strip-hidden-text-38 message-strip-text-38">
   
-  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-38">Custom Information Bar</span>
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-38">Custom Information Bar Closable</span>
 
   <div class="fd-message-strip__icon-container" aria-hidden="true">
     <span class="sap-icon sap-icon--reset" role="presentation" aria-hidden="true"></span>
@@ -355,4 +512,12 @@
   <p class="fd-message-strip__text" id="message-strip-text-38">
     Message Strip with indication color 10b (Grey)
   </p>
+
+  <button 
+    role="button"
+    class="fd-button fd-button--transparent is-compact fd-message-strip__close" 
+    aria-label="Custom Information Bar Close" 
+    title="Custom Information Bar Close">
+    <i class="sap-icon--decline" role="presentation" aria-hidden="true"></i>
+  </button>
 </div>

--- a/packages/styles/stories/Components/message-strip/message-strip-with-accent-colors.example.html
+++ b/packages/styles/stories/Components/message-strip/message-strip-with-accent-colors.example.html
@@ -1,97 +1,159 @@
-<div class="fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-1" role="note" aria-live="assertive" id="message-strip-17" aria-labelledby="message-strip-17">
+<div 
+  class="fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-1" 
+  role="note"  
+  aria-labelledby="message-strip-hidden-text-19 message-strip-text-19">
+  
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-19">Custom Information Bar</span>
+
   <div class="fd-message-strip__icon-container" aria-hidden="true">
-    <span class="sap-icon sap-icon--master-task-triangle-2" focusable="false" role="presentation" aria-hidden="true"></span>
+    <span class="sap-icon sap-icon--master-task-triangle-2" role="presentation" aria-hidden="true"></span>
   </div>
-  <p class="fd-message-strip__text">
+
+  <p class="fd-message-strip__text" id="message-strip-text-19">
     Message Strip with indication color 1 (Dark Red)
   </p>
 </div>
 
 <br>
 
-<div class="fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-1b" role="note" aria-live="assertive" id="message-strip-27" aria-labelledby="message-strip-27">
+<div 
+  class="fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-1b" 
+  role="note" 
+  aria-labelledby="message-strip-hidden-text-20 message-strip-text-20">
+  
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-20">Custom Information Bar</span>
+
   <div class="fd-message-strip__icon-container" aria-hidden="true">
-    <span class="sap-icon sap-icon--master-task-triangle-2" focusable="false" role="presentation" aria-hidden="true"></span>
+    <span class="sap-icon sap-icon--master-task-triangle-2" role="presentation" aria-hidden="true"></span>
   </div>
-  <p class="fd-message-strip__text">
+  
+  <p class="fd-message-strip__text" id="message-strip-text-20">
     Message Strip with indication color 1b (Dark Red)
   </p>
 </div>
 
 <br>
 
-<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-2" role="note" aria-live="assertive" id="message-strip-18" aria-labelledby="message-strip-18">
+<div 
+  class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-2" 
+  role="note" 
+  aria-labelledby="message-strip-hidden-text-21 message-strip-text-21">
+  
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-21">Custom Information Bar</span>
+
   <div class="fd-message-strip__icon-container" aria-hidden="true">
-    <span class="sap-icon sap-icon--cloud" focusable="false" role="presentation" aria-hidden="true"></span>
+    <span class="sap-icon sap-icon--cloud" role="presentation" aria-hidden="true"></span>
   </div>
-  <p class="fd-message-strip__text">
+  
+  <p class="fd-message-strip__text" id="message-strip-text-21">
     Message Strip with indication color 2  (Red)
   </p>
 </div>
 
-
 <br>
 
-<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-2b" role="note" aria-live="assertive" id="message-strip-28" aria-labelledby="message-strip-28">
+<div 
+  class="fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-2b" 
+  role="note" 
+  aria-labelledby="message-strip-hidden-text-22 message-strip-text-22">
+  
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-22">Custom Information Bar</span>
+
   <div class="fd-message-strip__icon-container" aria-hidden="true">
-    <span class="sap-icon sap-icon--cloud" focusable="false" role="presentation" aria-hidden="true"></span>
+    <span class="sap-icon sap-icon--cloud" role="presentation" aria-hidden="true"></span>
   </div>
-  <p class="fd-message-strip__text">
+  
+  <p class="fd-message-strip__text" id="message-strip-text-22">
     Message Strip with indication color 2b (Red) 
   </p>
 </div>
 
 <br>
 
-<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-3" role="note" aria-live="assertive" id="message-strip-19" aria-labelledby="message-strip-19">
+<div 
+  class="fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-3" 
+  role="note" 
+  aria-labelledby="message-strip-hidden-text-23 message-strip-text-23">
+
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-23">Custom Information Bar</span>
+
   <div class="fd-message-strip__icon-container" aria-hidden="true">
-    <span class="sap-icon sap-icon--heart-2" focusable="false" role="presentation" aria-hidden="true"></span>
+    <span class="sap-icon sap-icon--heart-2" role="presentation" aria-hidden="true"></span>
   </div>
-  <p class="fd-message-strip__text">
+
+  <p class="fd-message-strip__text" id="message-strip-text-23">
     Message Strip with indication color 3 (Yellow)
   </p>
 </div>
 
 <br>
 
-<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-3b" role="note" aria-live="assertive" id="message-strip-29" aria-labelledby="message-strip-29">
+<div 
+  class="fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-3b" 
+  role="note" 
+  aria-labelledby="message-strip-hidden-text-24 message-strip-text-24">
+  
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-24">Custom Information Bar</span>
+
   <div class="fd-message-strip__icon-container" aria-hidden="true">
-    <span class="sap-icon sap-icon--heart-2" focusable="false" role="presentation" aria-hidden="true"></span>
+    <span class="sap-icon sap-icon--heart-2" role="presentation" aria-hidden="true"></span>
   </div>
-  <p class="fd-message-strip__text">
+  
+  <p class="fd-message-strip__text" id="message-strip-text-24">
     Message Strip with indication color 3b (Yellow) 
   </p>
 </div>
 
 <br>
 
-<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-4" role="note" aria-live="assertive" id="message-strip-20" aria-labelledby="message-strip-20">
+<div 
+  class="fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-4" 
+  role="note"
+  aria-labelledby="message-strip-hidden-text-25 message-strip-text-25">
+  
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-25">Custom Information Bar</span>
+
   <div class="fd-message-strip__icon-container" aria-hidden="true">
-    <span class="sap-icon sap-icon--circle-task" focusable="false" role="presentation" aria-hidden="true"></span>
+    <span class="sap-icon sap-icon--circle-task" role="presentation" aria-hidden="true"></span>
   </div>
-  <p class="fd-message-strip__text">
+  
+  <p class="fd-message-strip__text" id="message-strip-text-25">
     Message Strip with indication color 4 (Green)
   </p>
 </div>
 
 <br>
 
-<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-4b" role="note" aria-live="assertive" id="message-strip-30" aria-labelledby="message-strip-30">
+<div 
+  class="fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-4b" 
+  role="note" 
+  aria-labelledby="message-strip-hidden-text-26 message-strip-text-26">
+
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-26">Custom Information Bar</span>
+
   <div class="fd-message-strip__icon-container" aria-hidden="true">
-    <span class="sap-icon sap-icon--circle-task" focusable="false" role="presentation" aria-hidden="true"></span>
+    <span class="sap-icon sap-icon--circle-task" role="presentation" aria-hidden="true"></span>
   </div>
-  <p class="fd-message-strip__text">
+
+  <p class="fd-message-strip__text" id="message-strip-text-26">
     Message Strip with indication color 4b (Green)
   </p>
 </div>
 
 <br>
 
-<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-5" role="note" aria-live="assertive" id="message-strip-21" aria-labelledby="message-strip-21">
+<div 
+  class="fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-5" 
+  role="note"
+  aria-labelledby="message-strip-hidden-text-27 message-strip-text-27">
+  
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-27">Custom Information Bar</span>
+
   <div class="fd-message-strip__icon-container" aria-hidden="true">
-    <span class="sap-icon sap-icon--feedback" focusable="false" role="presentation" aria-hidden="true"></span>
+    <span class="sap-icon sap-icon--feedback" role="presentation" aria-hidden="true"></span>
   </div>
-  <p class="fd-message-strip__text">
+ 
+  <p class="fd-message-strip__text" id="message-strip-text-27">
     Message Strip with indication color 5 (Blue)
   </p>
 </div>
@@ -99,121 +161,198 @@
 
 <br>
 
-<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-5b" role="note" aria-live="assertive" id="message-strip-31" aria-labelledby="message-strip-31">
+<div 
+  class="fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-5b" 
+  role="note" 
+  aria-labelledby="message-strip-hidden-text-28 message-strip-text-28">
+  
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-28">Custom Information Bar</span>
+
   <div class="fd-message-strip__icon-container" aria-hidden="true">
-    <span class="sap-icon sap-icon--feedback" focusable="false" role="presentation" aria-hidden="true"></span>
+    <span class="sap-icon sap-icon--feedback" role="presentation" aria-hidden="true"></span>
   </div>
-  <p class="fd-message-strip__text">
+  
+  <p class="fd-message-strip__text" id="message-strip-text-28">
     Message Strip with indication color 5b (Blue)
   </p>
 </div>
 
 <br>
 
-<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-6" role="note" aria-live="assertive" id="message-strip-22" aria-labelledby="message-strip-22">
+<div 
+  class="fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-6" 
+  role="note" 
+  aria-labelledby="message-strip-hidden-text-29 message-strip-text-29">
+  
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-29">Custom Information Bar</span>
+
   <div class="fd-message-strip__icon-container" aria-hidden="true">
-    <span class="sap-icon sap-icon--text-color" focusable="false" role="presentation" aria-hidden="true"></span>
+    <span class="sap-icon sap-icon--text-color" role="presentation" aria-hidden="true"></span>
   </div>
-  <p class="fd-message-strip__text">
+  
+  <p class="fd-message-strip__text" id="message-strip-text-29">
     Message Strip with indication color 6 (Teal)
   </p>
 </div>
 
 <br>
 
-<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-6b" role="note" aria-live="assertive" id="message-strip-32" aria-labelledby="message-strip-32">
+<div 
+  class="fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-6b" 
+  role="note"
+  aria-labelledby="message-strip-hidden-text-30 message-strip-text-30">
+  
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-30">Custom Information Bar</span>
+
   <div class="fd-message-strip__icon-container" aria-hidden="true">
-    <span class="sap-icon sap-icon--text-color" focusable="false" role="presentation" aria-hidden="true"></span>
+    <span class="sap-icon sap-icon--text-color" role="presentation" aria-hidden="true"></span>
   </div>
-  <p class="fd-message-strip__text">
+  
+  <p class="fd-message-strip__text" id="message-strip-text-30">
     Message Strip with indication color 6b (Teal)
   </p>
 </div>
 
 <br>
 
-<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-7" role="note" aria-live="assertive" id="message-strip-23" aria-labelledby="message-strip-23">
+<div 
+  class="fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-7" 
+  role="note" 
+  aria-labelledby="message-strip-hidden-text-31 message-strip-text-31">
+  
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-31">Custom Information Bar</span>
+
   <div class="fd-message-strip__icon-container" aria-hidden="true">
-    <span class="sap-icon sap-icon--away" focusable="false" role="presentation" aria-hidden="true"></span>
+    <span class="sap-icon sap-icon--away" role="presentation" aria-hidden="true"></span>
   </div>
-  <p class="fd-message-strip__text">
+ 
+  <p class="fd-message-strip__text" id="message-strip-text-31">
     Message Strip with indication color 7 (Purple)
   </p>
 </div>
 
 <br>
 
-<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-7b" role="note" aria-live="assertive" id="message-strip-33" aria-labelledby="message-strip-33">
+<div 
+  class="fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-7b" 
+  role="note"
+  aria-labelledby="message-strip-hidden-text-32 message-strip-text-32">
+  
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-32">Custom Information Bar</span>
+
   <div class="fd-message-strip__icon-container" aria-hidden="true">
-    <span class="sap-icon sap-icon--away" focusable="false" role="presentation" aria-hidden="true"></span>
+    <span class="sap-icon sap-icon--away" role="presentation" aria-hidden="true"></span>
   </div>
-  <p class="fd-message-strip__text">
+  
+  <p class="fd-message-strip__text" id="message-strip-text-32">
     Message Strip with indication color 7b (Purple)
   </p>
 </div>
 
 <br>
 
-<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-8" role="note" aria-live="assertive" id="message-strip-24" aria-labelledby="message-strip-24">
+<div 
+  class="fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-8" 
+  role="note" 
+  aria-labelledby="message-strip-hidden-text-33 message-strip-text-33">
+  
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-33">Custom Information Bar</span>
+
   <div class="fd-message-strip__icon-container" aria-hidden="true">
-    <span class="sap-icon sap-icon--cursor" focusable="false" role="presentation" aria-hidden="true"></span>
+    <span class="sap-icon sap-icon--cursor" role="presentation" aria-hidden="true"></span>
   </div>
-  <p class="fd-message-strip__text">
+  
+  <p class="fd-message-strip__text" id="message-strip-text-33">
     Message Strip with indication color 8 (Pink)
   </p>
 </div>
 
 <br>
 
-<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-8b" role="note" aria-live="assertive" id="message-strip-34" aria-labelledby="message-strip-34">
+<div 
+  class="fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-8b" 
+  role="note"  
+  aria-labelledby="message-strip-hidden-text-34 message-strip-text-34">
+  
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-34">Custom Information Bar</span>
+
   <div class="fd-message-strip__icon-container" aria-hidden="true">
-    <span class="sap-icon sap-icon--cursor" focusable="false" role="presentation" aria-hidden="true"></span>
+    <span class="sap-icon sap-icon--cursor" role="presentation" aria-hidden="true"></span>
   </div>
-  <p class="fd-message-strip__text">
+  
+  <p class="fd-message-strip__text" id="message-strip-text-34">
     Message Strip with indication color 8b (Pink)
   </p>
 </div>
 
 <br>
 
-<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-9" role="note" aria-live="assertive" id="message-strip-25" aria-labelledby="message-strip-25">
+<div 
+  class="fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-9" 
+  role="note" 
+  aria-labelledby="message-strip-hidden-text-35 message-strip-text-35">
+  
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-35">Custom Information Bar</span>
+
   <div class="fd-message-strip__icon-container" aria-hidden="true">
-    <span class="sap-icon sap-icon--copy" focusable="false" role="presentation" aria-hidden="true"></span>
+    <span class="sap-icon sap-icon--copy" role="presentation" aria-hidden="true"></span>
   </div>
-  <p class="fd-message-strip__text">
+  
+  <p class="fd-message-strip__text" id="message-strip-text-35">
     Message Strip with indication color 9 (Black/White)
   </p>
 </div>
 
 <br>
 
-<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-9b" role="note" aria-live="assertive" id="message-strip-35" aria-labelledby="message-strip-35">
+<div 
+  class="fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-9b" 
+  role="note"
+  aria-labelledby="message-strip-hidden-text-36 message-strip-text-36">
+  
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-36">Custom Information Bar</span>
+
   <div class="fd-message-strip__icon-container" aria-hidden="true">
-    <span class="sap-icon sap-icon--copy" focusable="false" role="presentation" aria-hidden="true"></span>
+    <span class="sap-icon sap-icon--copy" role="presentation" aria-hidden="true"></span>
   </div>
-  <p class="fd-message-strip__text">
+  
+  <p class="fd-message-strip__text" id="message-strip-text-36">
     Message Strip with indication color 9b (Black/White)
   </p>
 </div>
 
 <br>
 
-<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-10" role="note" aria-live="assertive" id="message-strip-26" aria-labelledby="message-strip-26">
+<div 
+  class="fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-10" 
+  role="note" 
+  aria-labelledby="message-strip-hidden-text-37 message-strip-text-37">
+  
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-37">Custom Information Bar</span>
+
   <div class="fd-message-strip__icon-container" aria-hidden="true">
-    <span class="sap-icon sap-icon--reset" focusable="false" role="presentation" aria-hidden="true"></span>
+    <span class="sap-icon sap-icon--reset" role="presentation" aria-hidden="true"></span>
   </div>
-  <p class="fd-message-strip__text">
+  
+  <p class="fd-message-strip__text" id="message-strip-text-37">
     Message Strip with indication color 10 (Grey)
   </p>
 </div>
 
 <br>
 
-<div class="fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-10b" role="note" aria-live="assertive" id="message-strip-36" aria-labelledby="message-strip-36">
+<div 
+  class="fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-10b" 
+  role="note"
+  aria-labelledby="message-strip-hidden-text-38 message-strip-text-38">
+  
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-38">Custom Information Bar</span>
+
   <div class="fd-message-strip__icon-container" aria-hidden="true">
-    <span class="sap-icon sap-icon--reset" focusable="false" role="presentation" aria-hidden="true"></span>
+    <span class="sap-icon sap-icon--reset" role="presentation" aria-hidden="true"></span>
   </div>
-  <p class="fd-message-strip__text">
+  
+  <p class="fd-message-strip__text" id="message-strip-text-38">
     Message Strip with indication color 10b (Grey)
   </p>
 </div>

--- a/packages/styles/stories/Components/message-strip/message-strip-with-custom-icon.example.html
+++ b/packages/styles/stories/Components/message-strip/message-strip-with-custom-icon.example.html
@@ -1,23 +1,37 @@
-<div class="fd-message-strip fd-message-strip--dismissible" role="note" aria-live="assertive" id="message-strip-15" aria-labelledby="message-strip-15">
+<div 
+  class="fd-message-strip" 
+  role="note"
+  aria-labelledby="message-strip-hidden-text-17 message-strip-text-17">
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-17">Information Bar</span>
   <div class="fd-message-strip__icon-container" aria-hidden="true">
-    <span class="sap-icon sap-icon--master-task-triangle-2" focusable="false" role="presentation" aria-hidden="true"></span>
+    <span class="sap-icon sap-icon--master-task-triangle-2" role="presentation" aria-hidden="true"></span>
   </div>
-  <p class="fd-message-strip__text">
-    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna. 
+  <p class="fd-message-strip__text" id="message-strip-text-17">
+    Message with a custom icon
   </p>
-  <button class="fd-button fd-button--transparent is-compact fd-message-strip__close" aria-controls="message-strip-15" aria-label="Close" title="Close">
-    <i class="sap-icon--decline"></i>
-  </button>
 </div>
-<br>
-<div class="fd-message-strip fd-message-strip--dismissible fd-message-strip--error" role="note" aria-live="assertive" id="message-strip-16" aria-labelledby="message-strip-16">
+
+<br />
+
+<div 
+  role="note" 
+  aria-labelledby="message-strip-hidden-text-18 message-strip-text-18"
+  class="fd-message-strip fd-message-strip--error fd-message-strip--dismissible">
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-18">Error Information Bar Closable</span>
+  
   <div class="fd-message-strip__icon-container" aria-hidden="true">
-    <span class="sap-icon sap-icon--not-editable" focusable="false" role="presentation" aria-hidden="true"></span>
+    <span class="sap-icon sap-icon--not-editable" role="presentation" aria-hidden="true"></span>
   </div>
-  <p class="fd-message-strip__text">
-    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna. 
+
+  <p class="fd-message-strip__text" id="message-strip-text-18">
+    Error Message Strip
   </p>
-  <button class="fd-button fd-button--transparent is-compact fd-message-strip__close" aria-controls="message-strip-16" aria-label="Close" title="Close">
-    <i class="sap-icon--decline"></i>
+
+  <button 
+    role="button"
+    class="fd-button fd-button--transparent is-compact fd-message-strip__close" 
+    aria-label="Error Information Bar Close" 
+    title="Error Information Bar Close">
+    <i class="sap-icon--decline" role="presentation" aria-hidden="true"></i>
   </button>
 </div>

--- a/packages/styles/stories/Components/message-strip/message-strip-with-link.example.html
+++ b/packages/styles/stories/Components/message-strip/message-strip-with-link.example.html
@@ -1,12 +1,52 @@
-<div class="fd-message-strip fd-message-strip--error fd-message-strip--dismissible fd-message-strip--link" role="note" aria-live="assertive" id="message-strip-14" aria-labelledby="message-strip-14">
-  <div class="fd-message-strip__icon-container" aria-hidden="true">
-    <span class="sap-icon sap-icon--message-error" focusable="false" role="presentation" aria-hidden="true"></span>
-  </div>
-  <p class="fd-message-strip__text">
-    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
-    <a href="#" class="fd-link fd-link--emphasized" tabindex="0"><span class="fd-link__content">Default link</span></a>
+<div 
+  role="note" 
+  aria-labelledby="message-strip-hidden-text-14 message-strip-text-14"
+  class="fd-message-strip fd-message-strip--information fd-message-strip--no-icon fd-message-strip--link">
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-14">Information Bar</span>
+  <p class="fd-message-strip__text" id="message-strip-text-14">
+    Information Message Strip
+    <a href="#" class="fd-link fd-link--emphasized" tabindex="0"><span class="fd-link__content">Link</span></a>
   </p>
-  <button class="fd-button fd-button--transparent is-compact fd-message-strip__close" aria-controls="message-strip-14" aria-label="Close" title="Close">
-    <i class="sap-icon--decline"></i>
+</div>
+
+<br />
+
+<div 
+  role="note" 
+  aria-labelledby="message-strip-hidden-text-15 message-strip-text-15"
+  class="fd-message-strip fd-message-strip--success fd-message-strip--no-icon fd-message-strip--link">
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-15">Success Information Bar</span>
+  <p class="fd-message-strip__text" id="message-strip-text-15">
+    Success Message Strip
+    <a href="#" class="fd-link fd-link--emphasized" tabindex="0"><span class="fd-link__content">Link1</span></a>
+    <a href="#" class="fd-link fd-link--emphasized" tabindex="0"><span class="fd-link__content">Link2</span></a>
+  </p>
+</div>
+
+<br />
+
+<div 
+  role="note" 
+  aria-labelledby="message-strip-hidden-text-16 message-strip-text-16"
+  class="fd-message-strip fd-message-strip--error fd-message-strip--dismissible fd-message-strip--link">
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-16">Error Information Bar Closable</span>
+  
+  <div class="fd-message-strip__icon-container" aria-hidden="true">
+    <span class="sap-icon sap-icon--message-error" role="presentation" aria-hidden="true"></span>
+  </div>
+
+  <p class="fd-message-strip__text" id="message-strip-text-16">
+    Error Message Strip
+    <a href="#" class="fd-link fd-link--emphasized" tabindex="0"><span class="fd-link__content">Link1</span></a>
+    and
+    <a href="#" class="fd-link fd-link--emphasized" tabindex="0"><span class="fd-link__content">Link2</span></a>
+  </p>
+
+  <button 
+    role="button"
+    class="fd-button fd-button--transparent is-compact fd-message-strip__close" 
+    aria-label="Error Information Bar Close" 
+    title="Error Information Bar Close">
+    <i class="sap-icon--decline" role="presentation" aria-hidden="true"></i>
   </button>
 </div>

--- a/packages/styles/stories/Components/message-strip/message-strip.stories.js
+++ b/packages/styles/stories/Components/message-strip/message-strip.stories.js
@@ -129,7 +129,11 @@ MessageStripWithAccentColors.storyName = 'Custom Message Strip';
 MessageStripWithAccentColors.parameters = {
   docs: {
     description: {
-      story: `If the application needs a custom Message Strip, other than the semantic variations, then the colours from Inverted Object Status/Tag control should be used. Use the modifier classes \`.fd-message-strip--indication-color-*\`, where \`*\` is a number from 1 to 10 for the first set, and 1b to 10b for the second set. `
+      story: `If the application needs a custom Message Strip, other than the semantic variations, then the colours from Inverted Object Status/Tag control should be used. Use the modifier classes \`.fd-message-strip--indication-color-*\`, where \`*\` is a number from 1 to 10 for the first set, and 1b to 10b for the second set. <br />
+      <b>Disclaimer</b> <br />
+Please note that accessibility features, including contrast ratios, are verified only for centrally defined standard values in Light, Dark, HCB, and HCW themes. Customization of components – whether internal or external – may impact compliance, and accessibility cannot be guaranteed.
+
+`
     }
   }
 };

--- a/packages/styles/stories/Components/message-strip/message-strip.stories.js
+++ b/packages/styles/stories/Components/message-strip/message-strip.stories.js
@@ -35,8 +35,7 @@ export default {
       - <b>Text with Link </b>- add the \`.fd-message-strip--link\` modifier class if the text message contains a link element.
 - <b>Close button (optional) </b>- each message can have a Close button so it can be removed from the UI, if needed. Add the \`.fd-message-strip--dismissible\` modifier class for a dismissible message strip.
 
-        `,
-    tags: ['f3', 'theme']
+        `
   }
 };
 
@@ -105,7 +104,14 @@ MessageStripWithLink.storyName = 'Text with link';
 MessageStripWithLink.parameters = {
   docs: {
     description: {
-      story: 'The Link inside Message Strip has additional styling. Add the `fd-message-strip--link` modifier class if the message contains a link element.'
+      story: `The Link inside Message Strip has additional styling. Add the <code>fd-message-strip--link</code> modifier class if the message contains a link element. <br>
+      The MessageStrip can include multiple links—not just one. This allows applications to provide additional context or actions related to the message, such as links to:
+      <ul>
+        <li>Other apps where the issue originated</li>
+        <li>Apps where the issue can be resolved</li>
+        <li>Related objects or specific sections</li>
+        <li>Help documentation</li>
+      </ul>`
     }
   }
 };

--- a/packages/styles/stories/Components/message-strip/no-icons-not-dismissible.example.html
+++ b/packages/styles/stories/Components/message-strip/no-icons-not-dismissible.example.html
@@ -1,33 +1,45 @@
-<div class="fd-message-strip fd-message-strip--information fd-message-strip--no-icon"
-     role="note" aria-live="assertive" id="message-strip-10" aria-labelledby="message-strip-10">
-  <p class="fd-message-strip__text">
-    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
+<div 
+  role="note" 
+  aria-labelledby="message-strip-hidden-text-10 message-strip-text-10"
+  class="fd-message-strip fd-message-strip--information fd-message-strip--no-icon" >
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-10">Information Bar</span>
+  <p class="fd-message-strip__text" id="message-strip-text-10">
+    Information Message Strip
   </p>
 </div>
 
 <br />
 
-<div class="fd-message-strip fd-message-strip--success fd-message-strip--no-icon"
-     role="note" aria-live="assertive" id="message-strip-11" aria-labelledby="message-strip-11">
-  <p class="fd-message-strip__text">
-    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
+<div 
+  role="note" 
+  aria-labelledby="message-strip-hidden-text-11 message-strip-text-11"
+  class="fd-message-strip fd-message-strip--success fd-message-strip--no-icon">
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-11">Success Information Bar</span>
+  <p class="fd-message-strip__text" id="message-strip-text-11">
+    Success Message Strip
   </p>
 </div>
 
 <br />
 
-<div class="fd-message-strip fd-message-strip--warning fd-message-strip--no-icon"
-     role="note" aria-live="assertive" id="message-strip-12" aria-labelledby="message-strip-12">
-  <p class="fd-message-strip__text">
-    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
+<div 
+  role="note" 
+  aria-labelledby="message-strip-hidden-text-12 message-strip-text-12"
+  class="fd-message-strip fd-message-strip--warning fd-message-strip--no-icon">
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-12">Warning Information Bar</span>
+  <p class="fd-message-strip__text" id="message-strip-text-12">
+    Warning Message Strip
   </p>
 </div>
 
 <br />
 
-<div class="fd-message-strip fd-message-strip--error fd-message-strip--no-icon"
-     role="note" aria-live="assertive" id="message-strip-13" aria-labelledby="message-strip-13">
-  <p class="fd-message-strip__text">
-    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
+<div 
+  role="note" 
+  aria-labelledby="message-strip-hidden-text-13 message-strip-text-13"
+  class="fd-message-strip fd-message-strip--error fd-message-strip--no-icon">
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-13">Error Information Bar</span>
+  <p class="fd-message-strip__text" id="message-strip-text-13">
+    Error Message Strip
   </p>
 </div>

--- a/packages/styles/stories/Components/message-strip/no-icons.example.html
+++ b/packages/styles/stories/Components/message-strip/no-icons.example.html
@@ -1,45 +1,84 @@
-<div class="fd-message-strip fd-message-strip--information fd-message-strip--no-icon fd-message-strip--dismissible"
-     role="note" aria-live="assertive" id="message-strip-6" aria-labelledby="message-strip-6">
-  <p class="fd-message-strip__text">
-    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
+<div 
+  role="note" 
+  aria-labelledby="message-strip-hidden-text-6 message-strip-text-6"
+  class="fd-message-strip fd-message-strip--information fd-message-strip--dismissible fd-message-strip--no-icon" >
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-6">Information Bar Closable</span>
+
+  <p class="fd-message-strip__text" id="message-strip-text-6">
+    Information Message Strip
   </p>
-  <button class="fd-button fd-button--transparent is-compact fd-message-strip__close" aria-controls="message-strip-6" aria-label="Close" title="Close">
-    <i class="sap-icon--decline"></i>
+
+  <button 
+    role="button"
+    class="fd-button fd-button--transparent is-compact fd-message-strip__close" 
+    aria-label="Information Bar Close" 
+    title="Information Bar Close">
+    <i class="sap-icon--decline" role="presentation" aria-hidden="true"></i>
   </button>
 </div>
 
 <br />
 
-<div class="fd-message-strip fd-message-strip--success fd-message-strip--no-icon fd-message-strip--dismissible"
-     role="note" aria-live="assertive" id="message-strip-7" aria-labelledby="message-strip-7">
-  <p class="fd-message-strip__text">
-    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
+<div 
+  role="note" 
+  aria-labelledby="message-strip-hidden-text-7 message-strip-text-7"
+  class="fd-message-strip fd-message-strip--success fd-message-strip--dismissible fd-message-strip--no-icon">
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-7">Success Information Bar Closable</span>
+
+  <p class="fd-message-strip__text" id="message-strip-text-7">
+    Success Message Strip
   </p>
-  <button class="fd-button fd-button--transparent is-compact fd-message-strip__close" aria-controls="message-strip-7" aria-label="Close" title="Close">
-    <i class="sap-icon--decline"></i>
+
+  <button 
+    role="button"
+    class="fd-button fd-button--transparent is-compact fd-message-strip__close" 
+    aria-label="Success Information Bar Close" 
+    title="Success Information Bar Close">
+    <i class="sap-icon--decline" role="presentation" aria-hidden="true"></i>
+  </button>
+</div>
+
+
+<br />
+
+<div 
+  role="note" 
+  aria-labelledby="message-strip-hidden-text-8 message-strip-text-8"
+  class="fd-message-strip fd-message-strip--warning fd-message-strip--dismissible fd-message-strip--no-icon">
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-8">Warning Information Bar Closable</span>
+  
+  <p class="fd-message-strip__text" id="message-strip-text-8">
+    Warning Message Strip
+  </p>
+
+  <button 
+    role="button"
+    class="fd-button fd-button--transparent is-compact fd-message-strip__close" 
+    aria-label="Warning Information Bar Close" 
+    title="Warning Information Bar Close">
+    <i class="sap-icon--decline" role="presentation" aria-hidden="true"></i>
   </button>
 </div>
 
 <br />
 
-<div class="fd-message-strip fd-message-strip--warning fd-message-strip--no-icon fd-message-strip--dismissible"
-     role="note" aria-live="assertive" id="message-strip-8" aria-labelledby="message-strip-8">
-  <p class="fd-message-strip__text">
-    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
+<div 
+  role="note" 
+  aria-labelledby="message-strip-hidden-text-9 message-strip-text-9"
+  class="fd-message-strip fd-message-strip--error fd-message-strip--dismissible fd-message-strip--no-icon">
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-9">Error Information Bar Closable</span>
+  
+  <p class="fd-message-strip__text" id="message-strip-text-9">
+    Error Message Strip
   </p>
-  <button class="fd-button fd-button--transparent is-compact fd-message-strip__close" aria-controls="message-strip-8" aria-label="Close" title="Close">
-    <i class="sap-icon--decline"></i>
+
+  <button 
+    role="button"
+    class="fd-button fd-button--transparent is-compact fd-message-strip__close" 
+    aria-label="Error Information Bar Close" 
+    title="Error Information Bar Close">
+    <i class="sap-icon--decline" role="presentation" aria-hidden="true"></i>
   </button>
 </div>
 
-<br />
 
-<div class="fd-message-strip fd-message-strip--error fd-message-strip--no-icon fd-message-strip--dismissible"
-     role="note" aria-live="assertive" id="message-strip-9" aria-labelledby="message-strip-9">
-  <p class="fd-message-strip__text">
-    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
-  </p>
-  <button class="fd-button fd-button--transparent is-compact fd-message-strip__close" aria-controls="message-strip-9" aria-label="Close" title="Close">
-    <i class="sap-icon--decline"></i>
-  </button>
-</div>

--- a/packages/styles/stories/Components/message-strip/success.example.html
+++ b/packages/styles/stories/Components/message-strip/success.example.html
@@ -1,11 +1,22 @@
-<div class="fd-message-strip fd-message-strip--success fd-message-strip--dismissible" role="note" aria-live="assertive" id="message-strip-3" aria-labelledby="message-strip-3">
+<div 
+  role="note" 
+  aria-labelledby="message-strip-hidden-text-3 message-strip-text-3"
+  class="fd-message-strip fd-message-strip--success fd-message-strip--dismissible">
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-3">Success Information Bar Closable</span>
+  
   <div class="fd-message-strip__icon-container" aria-hidden="true">
-    <span class="sap-icon sap-icon--message-success" focusable="false" role="presentation" aria-hidden="true"></span>
+    <span class="sap-icon sap-icon--message-success" role="presentation" aria-hidden="true"></span>
   </div>
-  <p class="fd-message-strip__text">
-    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
+
+  <p class="fd-message-strip__text" id="message-strip-text-3">
+    Success Message Strip
   </p>
-  <button class="fd-button fd-button--transparent is-compact fd-message-strip__close" aria-controls="message-strip-3" aria-label="Close" title="Close">
-    <i class="sap-icon--decline"></i>
+
+  <button 
+    role="button"
+    class="fd-button fd-button--transparent is-compact fd-message-strip__close" 
+    aria-label="Success Information Bar Close" 
+    title="Success Information Bar Close">
+    <i class="sap-icon--decline" role="presentation" aria-hidden="true"></i>
   </button>
 </div>

--- a/packages/styles/stories/Components/message-strip/warning.example.html
+++ b/packages/styles/stories/Components/message-strip/warning.example.html
@@ -1,11 +1,22 @@
-<div class="fd-message-strip fd-message-strip--warning fd-message-strip--dismissible" role="note" aria-live="assertive" id="message-strip-4" aria-labelledby="message-strip-4">
+<div 
+  role="note" 
+  aria-labelledby="message-strip-hidden-text-4 message-strip-text-4"
+  class="fd-message-strip fd-message-strip--warning fd-message-strip--dismissible">
+  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-4">Warning Information Bar Closable</span>
+  
   <div class="fd-message-strip__icon-container" aria-hidden="true">
-    <span class="sap-icon sap-icon--message-warning" focusable="false" role="presentation" aria-hidden="true"></span>
+    <span class="sap-icon sap-icon--message-warning" role="presentation" aria-hidden="true"></span>
   </div>
-  <p class="fd-message-strip__text">
-    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
+
+  <p class="fd-message-strip__text" id="message-strip-text-4">
+    Warning Message Strip
   </p>
-  <button class="fd-button fd-button--transparent is-compact fd-message-strip__close" aria-controls="message-strip-4" aria-label="Close" title="Close">
-    <i class="sap-icon--decline"></i>
+
+  <button 
+    role="button"
+    class="fd-button fd-button--transparent is-compact fd-message-strip__close" 
+    aria-label="Warning Information Bar Close" 
+    title="Warning Information Bar Close">
+    <i class="sap-icon--decline" role="presentation" aria-hidden="true"></i>
   </button>
 </div>

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -30833,11 +30833,11 @@ exports[`Check stories > Components/Message Strip > Story Information > Should m
 
 exports[`Check stories > Components/Message Strip > Story MessageStripWithAccentColors > Should match snapshot 1`] = `
 "<div 
-  class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-1\\" 
+  class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--link fd-message-strip--indication-color-1\\" 
   role=\\"note\\"  
   aria-labelledby=\\"message-strip-hidden-text-19 message-strip-text-19\\">
   
-  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-19\\">Custom Information Bar</span>
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-19\\">Custom Information Bar Closable</span>
 
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
     <span class=\\"sap-icon sap-icon--master-task-triangle-2\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
@@ -30845,17 +30845,26 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
 
   <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-19\\">
     Message Strip with indication color 1 (Dark Red)
+    <a href=\\"#\\" class=\\"fd-link fd-link--subtle\\" tabindex=\\"0\\"><span class=\\"fd-link__content\\">Link</span></a>
   </p>
+
+  <button 
+    role=\\"button\\"
+    class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" 
+    aria-label=\\"Custom Information Bar Close\\" 
+    title=\\"Custom Information Bar Close\\">
+    <i class=\\"sap-icon--decline\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
+  </button>
 </div>
 
 <br>
 
 <div 
-  class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-1b\\" 
+  class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--link fd-message-strip--indication-color-1b\\" 
   role=\\"note\\" 
   aria-labelledby=\\"message-strip-hidden-text-20 message-strip-text-20\\">
   
-  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-20\\">Custom Information Bar</span>
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-20\\">Custom Information Bar Closable</span>
 
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
     <span class=\\"sap-icon sap-icon--master-task-triangle-2\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
@@ -30863,53 +30872,80 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
   
   <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-20\\">
     Message Strip with indication color 1b (Dark Red)
+    <a href=\\"#\\" class=\\"fd-link fd-link--subtle\\" tabindex=\\"0\\"><span class=\\"fd-link__content\\">Link</span></a>
   </p>
+
+  <button 
+    role=\\"button\\"
+    class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" 
+    aria-label=\\"Custom Information Bar Close\\" 
+    title=\\"Custom Information Bar Close\\">
+    <i class=\\"sap-icon--decline\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
+  </button>
 </div>
 
 <br>
 
 <div 
-  class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-2\\" 
+  class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--link  fd-message-strip--indication-color-2\\" 
   role=\\"note\\" 
   aria-labelledby=\\"message-strip-hidden-text-21 message-strip-text-21\\">
   
-  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-21\\">Custom Information Bar</span>
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-21\\">Custom Information Bar Closable</span>
 
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
     <span class=\\"sap-icon sap-icon--cloud\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
   
   <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-21\\">
-    Message Strip with indication color 2  (Red)
+    Message Strip with indication color 2 (Red)
+    <a href=\\"#\\" class=\\"fd-link fd-link--subtle\\" tabindex=\\"0\\"><span class=\\"fd-link__content\\">Link</span></a>
   </p>
+
+  <button 
+    role=\\"button\\"
+    class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" 
+    aria-label=\\"Custom Information Bar Close\\" 
+    title=\\"Custom Information Bar Close\\">
+    <i class=\\"sap-icon--decline\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
+  </button>
 </div>
 
 <br>
 
 <div 
-  class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-2b\\" 
+  class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--link fd-message-strip--indication-color-2b\\" 
   role=\\"note\\" 
   aria-labelledby=\\"message-strip-hidden-text-22 message-strip-text-22\\">
   
-  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-22\\">Custom Information Bar</span>
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-22\\">Custom Information Bar Closable</span>
 
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
     <span class=\\"sap-icon sap-icon--cloud\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
   
   <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-22\\">
-    Message Strip with indication color 2b (Red) 
+    Message Strip with indication color 2b (Red)
+    <a href=\\"#\\" class=\\"fd-link fd-link--subtle\\" tabindex=\\"0\\"><span class=\\"fd-link__content\\">Link</span></a>
   </p>
+
+  <button 
+    role=\\"button\\"
+    class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" 
+    aria-label=\\"Custom Information Bar Close\\" 
+    title=\\"Custom Information Bar Close\\">
+    <i class=\\"sap-icon--decline\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
+  </button>
 </div>
 
 <br>
 
 <div 
-  class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-3\\" 
+  class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--link fd-message-strip--indication-color-3\\" 
   role=\\"note\\" 
   aria-labelledby=\\"message-strip-hidden-text-23 message-strip-text-23\\">
 
-  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-23\\">Custom Information Bar</span>
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-23\\">Custom Information Bar Closable</span>
 
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
     <span class=\\"sap-icon sap-icon--heart-2\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
@@ -30917,7 +30953,16 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
 
   <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-23\\">
     Message Strip with indication color 3 (Yellow)
+    <a href=\\"#\\" class=\\"fd-link fd-link--subtle\\" tabindex=\\"0\\"><span class=\\"fd-link__content\\">Link</span></a>
   </p>
+
+  <button 
+    role=\\"button\\"
+    class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" 
+    aria-label=\\"Custom Information Bar Close\\" 
+    title=\\"Custom Information Bar Close\\">
+    <i class=\\"sap-icon--decline\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
+  </button>
 </div>
 
 <br>
@@ -30927,7 +30972,7 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
   role=\\"note\\" 
   aria-labelledby=\\"message-strip-hidden-text-24 message-strip-text-24\\">
   
-  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-24\\">Custom Information Bar</span>
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-24\\">Custom Information Bar Closable</span>
 
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
     <span class=\\"sap-icon sap-icon--heart-2\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
@@ -30936,6 +30981,14 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
   <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-24\\">
     Message Strip with indication color 3b (Yellow) 
   </p>
+
+  <button 
+    role=\\"button\\"
+    class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" 
+    aria-label=\\"Custom Information Bar Close\\" 
+    title=\\"Custom Information Bar Close\\">
+    <i class=\\"sap-icon--decline\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
+  </button>
 </div>
 
 <br>
@@ -30945,7 +30998,7 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
   role=\\"note\\"
   aria-labelledby=\\"message-strip-hidden-text-25 message-strip-text-25\\">
   
-  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-25\\">Custom Information Bar</span>
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-25\\">Custom Information Bar Closable</span>
 
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
     <span class=\\"sap-icon sap-icon--circle-task\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
@@ -30954,6 +31007,14 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
   <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-25\\">
     Message Strip with indication color 4 (Green)
   </p>
+
+  <button 
+    role=\\"button\\"
+    class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" 
+    aria-label=\\"Custom Information Bar Close\\" 
+    title=\\"Custom Information Bar Close\\">
+    <i class=\\"sap-icon--decline\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
+  </button>
 </div>
 
 <br>
@@ -30963,7 +31024,7 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
   role=\\"note\\" 
   aria-labelledby=\\"message-strip-hidden-text-26 message-strip-text-26\\">
 
-  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-26\\">Custom Information Bar</span>
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-26\\">Custom Information Bar Closable</span>
 
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
     <span class=\\"sap-icon sap-icon--circle-task\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
@@ -30972,6 +31033,14 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
   <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-26\\">
     Message Strip with indication color 4b (Green)
   </p>
+
+  <button 
+    role=\\"button\\"
+    class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" 
+    aria-label=\\"Custom Information Bar Close\\" 
+    title=\\"Custom Information Bar Close\\">
+    <i class=\\"sap-icon--decline\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
+  </button>
 </div>
 
 <br>
@@ -30981,7 +31050,7 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
   role=\\"note\\"
   aria-labelledby=\\"message-strip-hidden-text-27 message-strip-text-27\\">
   
-  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-27\\">Custom Information Bar</span>
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-27\\">Custom Information Bar Closable</span>
 
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
     <span class=\\"sap-icon sap-icon--feedback\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
@@ -30990,6 +31059,14 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
   <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-27\\">
     Message Strip with indication color 5 (Blue)
   </p>
+
+  <button 
+    role=\\"button\\"
+    class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" 
+    aria-label=\\"Custom Information Bar Close\\" 
+    title=\\"Custom Information Bar Close\\">
+    <i class=\\"sap-icon--decline\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
+  </button>
 </div>
 
 
@@ -31000,7 +31077,7 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
   role=\\"note\\" 
   aria-labelledby=\\"message-strip-hidden-text-28 message-strip-text-28\\">
   
-  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-28\\">Custom Information Bar</span>
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-28\\">Custom Information Bar Closable</span>
 
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
     <span class=\\"sap-icon sap-icon--feedback\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
@@ -31009,6 +31086,14 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
   <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-28\\">
     Message Strip with indication color 5b (Blue)
   </p>
+
+  <button 
+    role=\\"button\\"
+    class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" 
+    aria-label=\\"Custom Information Bar Close\\" 
+    title=\\"Custom Information Bar Close\\">
+    <i class=\\"sap-icon--decline\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
+  </button>
 </div>
 
 <br>
@@ -31018,7 +31103,7 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
   role=\\"note\\" 
   aria-labelledby=\\"message-strip-hidden-text-29 message-strip-text-29\\">
   
-  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-29\\">Custom Information Bar</span>
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-29\\">Custom Information Bar Closable</span>
 
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
     <span class=\\"sap-icon sap-icon--text-color\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
@@ -31027,6 +31112,14 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
   <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-29\\">
     Message Strip with indication color 6 (Teal)
   </p>
+
+  <button 
+    role=\\"button\\"
+    class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" 
+    aria-label=\\"Custom Information Bar Close\\" 
+    title=\\"Custom Information Bar Close\\">
+    <i class=\\"sap-icon--decline\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
+  </button>
 </div>
 
 <br>
@@ -31036,7 +31129,7 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
   role=\\"note\\"
   aria-labelledby=\\"message-strip-hidden-text-30 message-strip-text-30\\">
   
-  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-30\\">Custom Information Bar</span>
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-30\\">Custom Information Bar Closable</span>
 
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
     <span class=\\"sap-icon sap-icon--text-color\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
@@ -31045,6 +31138,14 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
   <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-30\\">
     Message Strip with indication color 6b (Teal)
   </p>
+
+  <button 
+    role=\\"button\\"
+    class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" 
+    aria-label=\\"Custom Information Bar Close\\" 
+    title=\\"Custom Information Bar Close\\">
+    <i class=\\"sap-icon--decline\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
+  </button>
 </div>
 
 <br>
@@ -31054,7 +31155,7 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
   role=\\"note\\" 
   aria-labelledby=\\"message-strip-hidden-text-31 message-strip-text-31\\">
   
-  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-31\\">Custom Information Bar</span>
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-31\\">Custom Information Bar Closable</span>
 
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
     <span class=\\"sap-icon sap-icon--away\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
@@ -31063,6 +31164,14 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
   <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-31\\">
     Message Strip with indication color 7 (Purple)
   </p>
+
+  <button 
+    role=\\"button\\"
+    class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" 
+    aria-label=\\"Custom Information Bar Close\\" 
+    title=\\"Custom Information Bar Close\\">
+    <i class=\\"sap-icon--decline\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
+  </button>
 </div>
 
 <br>
@@ -31072,7 +31181,7 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
   role=\\"note\\"
   aria-labelledby=\\"message-strip-hidden-text-32 message-strip-text-32\\">
   
-  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-32\\">Custom Information Bar</span>
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-32\\">Custom Information Bar Closable</span>
 
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
     <span class=\\"sap-icon sap-icon--away\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
@@ -31081,6 +31190,14 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
   <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-32\\">
     Message Strip with indication color 7b (Purple)
   </p>
+
+  <button 
+    role=\\"button\\"
+    class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" 
+    aria-label=\\"Custom Information Bar Close\\" 
+    title=\\"Custom Information Bar Close\\">
+    <i class=\\"sap-icon--decline\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
+  </button>
 </div>
 
 <br>
@@ -31090,7 +31207,7 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
   role=\\"note\\" 
   aria-labelledby=\\"message-strip-hidden-text-33 message-strip-text-33\\">
   
-  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-33\\">Custom Information Bar</span>
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-33\\">Custom Information Bar Closable</span>
 
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
     <span class=\\"sap-icon sap-icon--cursor\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
@@ -31099,6 +31216,14 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
   <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-33\\">
     Message Strip with indication color 8 (Pink)
   </p>
+
+  <button 
+    role=\\"button\\"
+    class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" 
+    aria-label=\\"Custom Information Bar Close\\" 
+    title=\\"Custom Information Bar Close\\">
+    <i class=\\"sap-icon--decline\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
+  </button>
 </div>
 
 <br>
@@ -31108,7 +31233,7 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
   role=\\"note\\"  
   aria-labelledby=\\"message-strip-hidden-text-34 message-strip-text-34\\">
   
-  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-34\\">Custom Information Bar</span>
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-34\\">Custom Information Bar Closable</span>
 
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
     <span class=\\"sap-icon sap-icon--cursor\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
@@ -31117,6 +31242,14 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
   <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-34\\">
     Message Strip with indication color 8b (Pink)
   </p>
+
+  <button 
+    role=\\"button\\"
+    class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" 
+    aria-label=\\"Custom Information Bar Close\\" 
+    title=\\"Custom Information Bar Close\\">
+    <i class=\\"sap-icon--decline\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
+  </button>
 </div>
 
 <br>
@@ -31126,7 +31259,7 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
   role=\\"note\\" 
   aria-labelledby=\\"message-strip-hidden-text-35 message-strip-text-35\\">
   
-  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-35\\">Custom Information Bar</span>
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-35\\">Custom Information Bar Closable</span>
 
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
     <span class=\\"sap-icon sap-icon--copy\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
@@ -31135,6 +31268,14 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
   <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-35\\">
     Message Strip with indication color 9 (Black/White)
   </p>
+
+  <button 
+    role=\\"button\\"
+    class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" 
+    aria-label=\\"Custom Information Bar Close\\" 
+    title=\\"Custom Information Bar Close\\">
+    <i class=\\"sap-icon--decline\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
+  </button>
 </div>
 
 <br>
@@ -31144,7 +31285,7 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
   role=\\"note\\"
   aria-labelledby=\\"message-strip-hidden-text-36 message-strip-text-36\\">
   
-  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-36\\">Custom Information Bar</span>
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-36\\">Custom Information Bar Closable</span>
 
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
     <span class=\\"sap-icon sap-icon--copy\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
@@ -31153,6 +31294,14 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
   <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-36\\">
     Message Strip with indication color 9b (Black/White)
   </p>
+
+  <button 
+    role=\\"button\\"
+    class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" 
+    aria-label=\\"Custom Information Bar Close\\" 
+    title=\\"Custom Information Bar Close\\">
+    <i class=\\"sap-icon--decline\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
+  </button>
 </div>
 
 <br>
@@ -31162,7 +31311,7 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
   role=\\"note\\" 
   aria-labelledby=\\"message-strip-hidden-text-37 message-strip-text-37\\">
   
-  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-37\\">Custom Information Bar</span>
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-37\\">Custom Information Bar Closable</span>
 
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
     <span class=\\"sap-icon sap-icon--reset\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
@@ -31171,6 +31320,14 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
   <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-37\\">
     Message Strip with indication color 10 (Grey)
   </p>
+
+  <button 
+    role=\\"button\\"
+    class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" 
+    aria-label=\\"Custom Information Bar Close\\" 
+    title=\\"Custom Information Bar Close\\">
+    <i class=\\"sap-icon--decline\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
+  </button>
 </div>
 
 <br>
@@ -31180,7 +31337,7 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
   role=\\"note\\"
   aria-labelledby=\\"message-strip-hidden-text-38 message-strip-text-38\\">
   
-  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-38\\">Custom Information Bar</span>
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-38\\">Custom Information Bar Closable</span>
 
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
     <span class=\\"sap-icon sap-icon--reset\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
@@ -31189,6 +31346,14 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
   <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-38\\">
     Message Strip with indication color 10b (Grey)
   </p>
+
+  <button 
+    role=\\"button\\"
+    class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" 
+    aria-label=\\"Custom Information Bar Close\\" 
+    title=\\"Custom Information Bar Close\\">
+    <i class=\\"sap-icon--decline\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
+  </button>
 </div>
 "
 `;

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -30768,139 +30768,226 @@ exports[`Check stories > Components/Message Popover > Story MessageTrigger > Sho
 `;
 
 exports[`Check stories > Components/Message Strip > Story DefaultStrip > Should match snapshot 1`] = `
-"<div class=\\"fd-message-strip fd-message-strip--no-icon\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-1\\" aria-labelledby=\\"message-strip-1\\">
-  <p class=\\"fd-message-strip__text\\">
-    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
+"<div 
+  class=\\"fd-message-strip fd-message-strip--no-icon\\" 
+  role=\\"note\\"
+  aria-labelledby=\\"message-strip-hidden-text-1 message-strip-text-1\\">
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-1\\">Information Bar</span>
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-1\\">
+    This is a message.
   </p>
 </div>
 "
 `;
 
 exports[`Check stories > Components/Message Strip > Story Error > Should match snapshot 1`] = `
-"<div class=\\"fd-message-strip fd-message-strip--error fd-message-strip--dismissible\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-5\\" aria-labelledby=\\"message-strip-5\\">
+"<div 
+  role=\\"note\\" 
+  aria-labelledby=\\"message-strip-hidden-text-5 message-strip-text-5\\"
+  class=\\"fd-message-strip fd-message-strip--error fd-message-strip--dismissible\\">
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-5\\">Error Information Bar Closable</span>
+  
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
-    <span class=\\"sap-icon sap-icon--message-error\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+    <span class=\\"sap-icon sap-icon--message-error\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
-  <p class=\\"fd-message-strip__text\\">
-    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
+
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-5\\">
+    Error Message Strip
   </p>
-  <button class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" aria-controls=\\"message-strip-5\\" aria-label=\\"Close\\" title=\\"Close\\">
-    <i class=\\"sap-icon--decline\\"></i>
+
+  <button 
+    role=\\"button\\"
+    class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" 
+    aria-label=\\"Error Information Bar Close\\" 
+    title=\\"Error Information Bar Close\\">
+    <i class=\\"sap-icon--decline\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
   </button>
-</div>
-"
+</div>"
 `;
 
 exports[`Check stories > Components/Message Strip > Story Information > Should match snapshot 1`] = `
-"<div class=\\"fd-message-strip fd-message-strip--information fd-message-strip--dismissible\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-2\\" aria-labelledby=\\"message-strip-2\\">
+"<div 
+  role=\\"note\\" 
+  aria-labelledby=\\"message-strip-hidden-text-2 message-strip-text-2\\"
+  class=\\"fd-message-strip fd-message-strip--information fd-message-strip--dismissible\\">
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-2\\">Information Bar Closable</span>
+  
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
-    <span class=\\"sap-icon sap-icon--message-information\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+    <span class=\\"sap-icon sap-icon--message-information\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
-  <p class=\\"fd-message-strip__text\\">
-    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
+
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-2\\">
+    Information Message Strip
   </p>
-  <button class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" aria-controls=\\"message-strip-2\\" aria-label=\\"Close\\" title=\\"Close\\">
-    <i class=\\"sap-icon--decline\\"></i>
+
+  <button 
+    role=\\"button\\"
+    class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" 
+    aria-label=\\"Information Bar Close\\" 
+    title=\\"Information Bar Close\\">
+    <i class=\\"sap-icon--decline\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
   </button>
 </div>
 "
 `;
 
 exports[`Check stories > Components/Message Strip > Story MessageStripWithAccentColors > Should match snapshot 1`] = `
-"<div class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-1\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-17\\" aria-labelledby=\\"message-strip-17\\">
+"<div 
+  class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-1\\" 
+  role=\\"note\\"  
+  aria-labelledby=\\"message-strip-hidden-text-19 message-strip-text-19\\">
+  
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-19\\">Custom Information Bar</span>
+
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
-    <span class=\\"sap-icon sap-icon--master-task-triangle-2\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+    <span class=\\"sap-icon sap-icon--master-task-triangle-2\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
-  <p class=\\"fd-message-strip__text\\">
+
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-19\\">
     Message Strip with indication color 1 (Dark Red)
   </p>
 </div>
 
 <br>
 
-<div class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-1b\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-27\\" aria-labelledby=\\"message-strip-27\\">
+<div 
+  class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-1b\\" 
+  role=\\"note\\" 
+  aria-labelledby=\\"message-strip-hidden-text-20 message-strip-text-20\\">
+  
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-20\\">Custom Information Bar</span>
+
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
-    <span class=\\"sap-icon sap-icon--master-task-triangle-2\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+    <span class=\\"sap-icon sap-icon--master-task-triangle-2\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
-  <p class=\\"fd-message-strip__text\\">
+  
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-20\\">
     Message Strip with indication color 1b (Dark Red)
   </p>
 </div>
 
 <br>
 
-<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-2\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-18\\" aria-labelledby=\\"message-strip-18\\">
+<div 
+  class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-2\\" 
+  role=\\"note\\" 
+  aria-labelledby=\\"message-strip-hidden-text-21 message-strip-text-21\\">
+  
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-21\\">Custom Information Bar</span>
+
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
-    <span class=\\"sap-icon sap-icon--cloud\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+    <span class=\\"sap-icon sap-icon--cloud\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
-  <p class=\\"fd-message-strip__text\\">
+  
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-21\\">
     Message Strip with indication color 2  (Red)
   </p>
 </div>
 
-
 <br>
 
-<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-2b\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-28\\" aria-labelledby=\\"message-strip-28\\">
+<div 
+  class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-2b\\" 
+  role=\\"note\\" 
+  aria-labelledby=\\"message-strip-hidden-text-22 message-strip-text-22\\">
+  
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-22\\">Custom Information Bar</span>
+
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
-    <span class=\\"sap-icon sap-icon--cloud\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+    <span class=\\"sap-icon sap-icon--cloud\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
-  <p class=\\"fd-message-strip__text\\">
+  
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-22\\">
     Message Strip with indication color 2b (Red) 
   </p>
 </div>
 
 <br>
 
-<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-3\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-19\\" aria-labelledby=\\"message-strip-19\\">
+<div 
+  class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-3\\" 
+  role=\\"note\\" 
+  aria-labelledby=\\"message-strip-hidden-text-23 message-strip-text-23\\">
+
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-23\\">Custom Information Bar</span>
+
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
-    <span class=\\"sap-icon sap-icon--heart-2\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+    <span class=\\"sap-icon sap-icon--heart-2\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
-  <p class=\\"fd-message-strip__text\\">
+
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-23\\">
     Message Strip with indication color 3 (Yellow)
   </p>
 </div>
 
 <br>
 
-<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-3b\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-29\\" aria-labelledby=\\"message-strip-29\\">
+<div 
+  class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-3b\\" 
+  role=\\"note\\" 
+  aria-labelledby=\\"message-strip-hidden-text-24 message-strip-text-24\\">
+  
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-24\\">Custom Information Bar</span>
+
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
-    <span class=\\"sap-icon sap-icon--heart-2\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+    <span class=\\"sap-icon sap-icon--heart-2\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
-  <p class=\\"fd-message-strip__text\\">
+  
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-24\\">
     Message Strip with indication color 3b (Yellow) 
   </p>
 </div>
 
 <br>
 
-<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-4\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-20\\" aria-labelledby=\\"message-strip-20\\">
+<div 
+  class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-4\\" 
+  role=\\"note\\"
+  aria-labelledby=\\"message-strip-hidden-text-25 message-strip-text-25\\">
+  
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-25\\">Custom Information Bar</span>
+
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
-    <span class=\\"sap-icon sap-icon--circle-task\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+    <span class=\\"sap-icon sap-icon--circle-task\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
-  <p class=\\"fd-message-strip__text\\">
+  
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-25\\">
     Message Strip with indication color 4 (Green)
   </p>
 </div>
 
 <br>
 
-<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-4b\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-30\\" aria-labelledby=\\"message-strip-30\\">
+<div 
+  class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-4b\\" 
+  role=\\"note\\" 
+  aria-labelledby=\\"message-strip-hidden-text-26 message-strip-text-26\\">
+
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-26\\">Custom Information Bar</span>
+
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
-    <span class=\\"sap-icon sap-icon--circle-task\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+    <span class=\\"sap-icon sap-icon--circle-task\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
-  <p class=\\"fd-message-strip__text\\">
+
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-26\\">
     Message Strip with indication color 4b (Green)
   </p>
 </div>
 
 <br>
 
-<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-5\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-21\\" aria-labelledby=\\"message-strip-21\\">
+<div 
+  class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-5\\" 
+  role=\\"note\\"
+  aria-labelledby=\\"message-strip-hidden-text-27 message-strip-text-27\\">
+  
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-27\\">Custom Information Bar</span>
+
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
-    <span class=\\"sap-icon sap-icon--feedback\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+    <span class=\\"sap-icon sap-icon--feedback\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
-  <p class=\\"fd-message-strip__text\\">
+ 
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-27\\">
     Message Strip with indication color 5 (Blue)
   </p>
 </div>
@@ -30908,121 +30995,198 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
 
 <br>
 
-<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-5b\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-31\\" aria-labelledby=\\"message-strip-31\\">
+<div 
+  class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-5b\\" 
+  role=\\"note\\" 
+  aria-labelledby=\\"message-strip-hidden-text-28 message-strip-text-28\\">
+  
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-28\\">Custom Information Bar</span>
+
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
-    <span class=\\"sap-icon sap-icon--feedback\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+    <span class=\\"sap-icon sap-icon--feedback\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
-  <p class=\\"fd-message-strip__text\\">
+  
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-28\\">
     Message Strip with indication color 5b (Blue)
   </p>
 </div>
 
 <br>
 
-<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-6\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-22\\" aria-labelledby=\\"message-strip-22\\">
+<div 
+  class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-6\\" 
+  role=\\"note\\" 
+  aria-labelledby=\\"message-strip-hidden-text-29 message-strip-text-29\\">
+  
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-29\\">Custom Information Bar</span>
+
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
-    <span class=\\"sap-icon sap-icon--text-color\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+    <span class=\\"sap-icon sap-icon--text-color\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
-  <p class=\\"fd-message-strip__text\\">
+  
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-29\\">
     Message Strip with indication color 6 (Teal)
   </p>
 </div>
 
 <br>
 
-<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-6b\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-32\\" aria-labelledby=\\"message-strip-32\\">
+<div 
+  class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-6b\\" 
+  role=\\"note\\"
+  aria-labelledby=\\"message-strip-hidden-text-30 message-strip-text-30\\">
+  
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-30\\">Custom Information Bar</span>
+
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
-    <span class=\\"sap-icon sap-icon--text-color\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+    <span class=\\"sap-icon sap-icon--text-color\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
-  <p class=\\"fd-message-strip__text\\">
+  
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-30\\">
     Message Strip with indication color 6b (Teal)
   </p>
 </div>
 
 <br>
 
-<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-7\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-23\\" aria-labelledby=\\"message-strip-23\\">
+<div 
+  class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-7\\" 
+  role=\\"note\\" 
+  aria-labelledby=\\"message-strip-hidden-text-31 message-strip-text-31\\">
+  
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-31\\">Custom Information Bar</span>
+
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
-    <span class=\\"sap-icon sap-icon--away\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+    <span class=\\"sap-icon sap-icon--away\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
-  <p class=\\"fd-message-strip__text\\">
+ 
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-31\\">
     Message Strip with indication color 7 (Purple)
   </p>
 </div>
 
 <br>
 
-<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-7b\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-33\\" aria-labelledby=\\"message-strip-33\\">
+<div 
+  class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-7b\\" 
+  role=\\"note\\"
+  aria-labelledby=\\"message-strip-hidden-text-32 message-strip-text-32\\">
+  
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-32\\">Custom Information Bar</span>
+
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
-    <span class=\\"sap-icon sap-icon--away\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+    <span class=\\"sap-icon sap-icon--away\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
-  <p class=\\"fd-message-strip__text\\">
+  
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-32\\">
     Message Strip with indication color 7b (Purple)
   </p>
 </div>
 
 <br>
 
-<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-8\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-24\\" aria-labelledby=\\"message-strip-24\\">
+<div 
+  class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-8\\" 
+  role=\\"note\\" 
+  aria-labelledby=\\"message-strip-hidden-text-33 message-strip-text-33\\">
+  
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-33\\">Custom Information Bar</span>
+
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
-    <span class=\\"sap-icon sap-icon--cursor\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+    <span class=\\"sap-icon sap-icon--cursor\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
-  <p class=\\"fd-message-strip__text\\">
+  
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-33\\">
     Message Strip with indication color 8 (Pink)
   </p>
 </div>
 
 <br>
 
-<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-8b\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-34\\" aria-labelledby=\\"message-strip-34\\">
+<div 
+  class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-8b\\" 
+  role=\\"note\\"  
+  aria-labelledby=\\"message-strip-hidden-text-34 message-strip-text-34\\">
+  
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-34\\">Custom Information Bar</span>
+
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
-    <span class=\\"sap-icon sap-icon--cursor\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+    <span class=\\"sap-icon sap-icon--cursor\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
-  <p class=\\"fd-message-strip__text\\">
+  
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-34\\">
     Message Strip with indication color 8b (Pink)
   </p>
 </div>
 
 <br>
 
-<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-9\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-25\\" aria-labelledby=\\"message-strip-25\\">
+<div 
+  class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-9\\" 
+  role=\\"note\\" 
+  aria-labelledby=\\"message-strip-hidden-text-35 message-strip-text-35\\">
+  
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-35\\">Custom Information Bar</span>
+
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
-    <span class=\\"sap-icon sap-icon--copy\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+    <span class=\\"sap-icon sap-icon--copy\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
-  <p class=\\"fd-message-strip__text\\">
+  
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-35\\">
     Message Strip with indication color 9 (Black/White)
   </p>
 </div>
 
 <br>
 
-<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-9b\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-35\\" aria-labelledby=\\"message-strip-35\\">
+<div 
+  class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-9b\\" 
+  role=\\"note\\"
+  aria-labelledby=\\"message-strip-hidden-text-36 message-strip-text-36\\">
+  
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-36\\">Custom Information Bar</span>
+
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
-    <span class=\\"sap-icon sap-icon--copy\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+    <span class=\\"sap-icon sap-icon--copy\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
-  <p class=\\"fd-message-strip__text\\">
+  
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-36\\">
     Message Strip with indication color 9b (Black/White)
   </p>
 </div>
 
 <br>
 
-<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-10\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-26\\" aria-labelledby=\\"message-strip-26\\">
+<div 
+  class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-10\\" 
+  role=\\"note\\" 
+  aria-labelledby=\\"message-strip-hidden-text-37 message-strip-text-37\\">
+  
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-37\\">Custom Information Bar</span>
+
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
-    <span class=\\"sap-icon sap-icon--reset\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+    <span class=\\"sap-icon sap-icon--reset\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
-  <p class=\\"fd-message-strip__text\\">
+  
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-37\\">
     Message Strip with indication color 10 (Grey)
   </p>
 </div>
 
 <br>
 
-<div class=\\"fd-message-strip fd-message-strip--dismissible  fd-message-strip--indication-color-10b\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-36\\" aria-labelledby=\\"message-strip-36\\">
+<div 
+  class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--indication-color-10b\\" 
+  role=\\"note\\"
+  aria-labelledby=\\"message-strip-hidden-text-38 message-strip-text-38\\">
+  
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-38\\">Custom Information Bar</span>
+
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
-    <span class=\\"sap-icon sap-icon--reset\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+    <span class=\\"sap-icon sap-icon--reset\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
-  <p class=\\"fd-message-strip__text\\">
+  
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-38\\">
     Message Strip with indication color 10b (Grey)
   </p>
 </div>
@@ -31030,162 +31194,286 @@ exports[`Check stories > Components/Message Strip > Story MessageStripWithAccent
 `;
 
 exports[`Check stories > Components/Message Strip > Story MessageStripWithCustomIcon > Should match snapshot 1`] = `
-"<div class=\\"fd-message-strip fd-message-strip--dismissible\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-15\\" aria-labelledby=\\"message-strip-15\\">
+"<div 
+  class=\\"fd-message-strip\\" 
+  role=\\"note\\"
+  aria-labelledby=\\"message-strip-hidden-text-17 message-strip-text-17\\">
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-17\\">Information Bar</span>
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
-    <span class=\\"sap-icon sap-icon--master-task-triangle-2\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+    <span class=\\"sap-icon sap-icon--master-task-triangle-2\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
-  <p class=\\"fd-message-strip__text\\">
-    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna. 
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-17\\">
+    Message with a custom icon
   </p>
-  <button class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" aria-controls=\\"message-strip-15\\" aria-label=\\"Close\\" title=\\"Close\\">
-    <i class=\\"sap-icon--decline\\"></i>
-  </button>
 </div>
-<br>
-<div class=\\"fd-message-strip fd-message-strip--dismissible fd-message-strip--error\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-16\\" aria-labelledby=\\"message-strip-16\\">
+
+<br />
+
+<div 
+  role=\\"note\\" 
+  aria-labelledby=\\"message-strip-hidden-text-18 message-strip-text-18\\"
+  class=\\"fd-message-strip fd-message-strip--error fd-message-strip--dismissible\\">
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-18\\">Error Information Bar Closable</span>
+  
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
-    <span class=\\"sap-icon sap-icon--not-editable\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+    <span class=\\"sap-icon sap-icon--not-editable\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
-  <p class=\\"fd-message-strip__text\\">
-    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna. 
+
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-18\\">
+    Error Message Strip
   </p>
-  <button class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" aria-controls=\\"message-strip-16\\" aria-label=\\"Close\\" title=\\"Close\\">
-    <i class=\\"sap-icon--decline\\"></i>
+
+  <button 
+    role=\\"button\\"
+    class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" 
+    aria-label=\\"Error Information Bar Close\\" 
+    title=\\"Error Information Bar Close\\">
+    <i class=\\"sap-icon--decline\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
   </button>
-</div>
-"
+</div>"
 `;
 
 exports[`Check stories > Components/Message Strip > Story MessageStripWithLink > Should match snapshot 1`] = `
-"<div class=\\"fd-message-strip fd-message-strip--error fd-message-strip--dismissible fd-message-strip--link\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-14\\" aria-labelledby=\\"message-strip-14\\">
-  <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
-    <span class=\\"sap-icon sap-icon--message-error\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
-  </div>
-  <p class=\\"fd-message-strip__text\\">
-    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
-    <a href=\\"#\\" class=\\"fd-link fd-link--emphasized\\" tabindex=\\"0\\"><span class=\\"fd-link__content\\">Default link</span></a>
+"<div 
+  role=\\"note\\" 
+  aria-labelledby=\\"message-strip-hidden-text-14 message-strip-text-14\\"
+  class=\\"fd-message-strip fd-message-strip--information fd-message-strip--no-icon fd-message-strip--link\\">
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-14\\">Information Bar</span>
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-14\\">
+    Information Message Strip
+    <a href=\\"#\\" class=\\"fd-link fd-link--emphasized\\" tabindex=\\"0\\"><span class=\\"fd-link__content\\">Link</span></a>
   </p>
-  <button class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" aria-controls=\\"message-strip-14\\" aria-label=\\"Close\\" title=\\"Close\\">
-    <i class=\\"sap-icon--decline\\"></i>
-  </button>
 </div>
-"
+
+<br />
+
+<div 
+  role=\\"note\\" 
+  aria-labelledby=\\"message-strip-hidden-text-15 message-strip-text-15\\"
+  class=\\"fd-message-strip fd-message-strip--success fd-message-strip--no-icon fd-message-strip--link\\">
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-15\\">Success Information Bar</span>
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-15\\">
+    Success Message Strip
+    <a href=\\"#\\" class=\\"fd-link fd-link--emphasized\\" tabindex=\\"0\\"><span class=\\"fd-link__content\\">Link1</span></a>
+    <a href=\\"#\\" class=\\"fd-link fd-link--emphasized\\" tabindex=\\"0\\"><span class=\\"fd-link__content\\">Link2</span></a>
+  </p>
+</div>
+
+<br />
+
+<div 
+  role=\\"note\\" 
+  aria-labelledby=\\"message-strip-hidden-text-16 message-strip-text-16\\"
+  class=\\"fd-message-strip fd-message-strip--error fd-message-strip--dismissible fd-message-strip--link\\">
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-16\\">Error Information Bar Closable</span>
+  
+  <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
+    <span class=\\"sap-icon sap-icon--message-error\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+  </div>
+
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-16\\">
+    Error Message Strip
+    <a href=\\"#\\" class=\\"fd-link fd-link--emphasized\\" tabindex=\\"0\\"><span class=\\"fd-link__content\\">Link1</span></a>
+    and
+    <a href=\\"#\\" class=\\"fd-link fd-link--emphasized\\" tabindex=\\"0\\"><span class=\\"fd-link__content\\">Link2</span></a>
+  </p>
+
+  <button 
+    role=\\"button\\"
+    class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" 
+    aria-label=\\"Error Information Bar Close\\" 
+    title=\\"Error Information Bar Close\\">
+    <i class=\\"sap-icon--decline\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
+  </button>
+</div>"
 `;
 
 exports[`Check stories > Components/Message Strip > Story NoIcons > Should match snapshot 1`] = `
-"<div class=\\"fd-message-strip fd-message-strip--information fd-message-strip--no-icon fd-message-strip--dismissible\\"
-     role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-6\\" aria-labelledby=\\"message-strip-6\\">
-  <p class=\\"fd-message-strip__text\\">
-    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
+"<div 
+  role=\\"note\\" 
+  aria-labelledby=\\"message-strip-hidden-text-6 message-strip-text-6\\"
+  class=\\"fd-message-strip fd-message-strip--information fd-message-strip--dismissible fd-message-strip--no-icon\\" >
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-6\\">Information Bar Closable</span>
+
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-6\\">
+    Information Message Strip
   </p>
-  <button class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" aria-controls=\\"message-strip-6\\" aria-label=\\"Close\\" title=\\"Close\\">
-    <i class=\\"sap-icon--decline\\"></i>
+
+  <button 
+    role=\\"button\\"
+    class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" 
+    aria-label=\\"Information Bar Close\\" 
+    title=\\"Information Bar Close\\">
+    <i class=\\"sap-icon--decline\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
   </button>
 </div>
 
 <br />
 
-<div class=\\"fd-message-strip fd-message-strip--success fd-message-strip--no-icon fd-message-strip--dismissible\\"
-     role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-7\\" aria-labelledby=\\"message-strip-7\\">
-  <p class=\\"fd-message-strip__text\\">
-    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
+<div 
+  role=\\"note\\" 
+  aria-labelledby=\\"message-strip-hidden-text-7 message-strip-text-7\\"
+  class=\\"fd-message-strip fd-message-strip--success fd-message-strip--dismissible fd-message-strip--no-icon\\">
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-7\\">Success Information Bar Closable</span>
+
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-7\\">
+    Success Message Strip
   </p>
-  <button class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" aria-controls=\\"message-strip-7\\" aria-label=\\"Close\\" title=\\"Close\\">
-    <i class=\\"sap-icon--decline\\"></i>
+
+  <button 
+    role=\\"button\\"
+    class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" 
+    aria-label=\\"Success Information Bar Close\\" 
+    title=\\"Success Information Bar Close\\">
+    <i class=\\"sap-icon--decline\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
+  </button>
+</div>
+
+
+<br />
+
+<div 
+  role=\\"note\\" 
+  aria-labelledby=\\"message-strip-hidden-text-8 message-strip-text-8\\"
+  class=\\"fd-message-strip fd-message-strip--warning fd-message-strip--dismissible fd-message-strip--no-icon\\">
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-8\\">Warning Information Bar Closable</span>
+  
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-8\\">
+    Warning Message Strip
+  </p>
+
+  <button 
+    role=\\"button\\"
+    class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" 
+    aria-label=\\"Warning Information Bar Close\\" 
+    title=\\"Warning Information Bar Close\\">
+    <i class=\\"sap-icon--decline\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
   </button>
 </div>
 
 <br />
 
-<div class=\\"fd-message-strip fd-message-strip--warning fd-message-strip--no-icon fd-message-strip--dismissible\\"
-     role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-8\\" aria-labelledby=\\"message-strip-8\\">
-  <p class=\\"fd-message-strip__text\\">
-    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
+<div 
+  role=\\"note\\" 
+  aria-labelledby=\\"message-strip-hidden-text-9 message-strip-text-9\\"
+  class=\\"fd-message-strip fd-message-strip--error fd-message-strip--dismissible fd-message-strip--no-icon\\">
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-9\\">Error Information Bar Closable</span>
+  
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-9\\">
+    Error Message Strip
   </p>
-  <button class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" aria-controls=\\"message-strip-8\\" aria-label=\\"Close\\" title=\\"Close\\">
-    <i class=\\"sap-icon--decline\\"></i>
+
+  <button 
+    role=\\"button\\"
+    class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" 
+    aria-label=\\"Error Information Bar Close\\" 
+    title=\\"Error Information Bar Close\\">
+    <i class=\\"sap-icon--decline\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
   </button>
 </div>
 
-<br />
 
-<div class=\\"fd-message-strip fd-message-strip--error fd-message-strip--no-icon fd-message-strip--dismissible\\"
-     role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-9\\" aria-labelledby=\\"message-strip-9\\">
-  <p class=\\"fd-message-strip__text\\">
-    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
-  </p>
-  <button class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" aria-controls=\\"message-strip-9\\" aria-label=\\"Close\\" title=\\"Close\\">
-    <i class=\\"sap-icon--decline\\"></i>
-  </button>
-</div>
 "
 `;
 
 exports[`Check stories > Components/Message Strip > Story NoIconsNotDismissible > Should match snapshot 1`] = `
-"<div class=\\"fd-message-strip fd-message-strip--information fd-message-strip--no-icon\\"
-     role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-10\\" aria-labelledby=\\"message-strip-10\\">
-  <p class=\\"fd-message-strip__text\\">
-    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
+"<div 
+  role=\\"note\\" 
+  aria-labelledby=\\"message-strip-hidden-text-10 message-strip-text-10\\"
+  class=\\"fd-message-strip fd-message-strip--information fd-message-strip--no-icon\\" >
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-10\\">Information Bar</span>
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-10\\">
+    Information Message Strip
   </p>
 </div>
 
 <br />
 
-<div class=\\"fd-message-strip fd-message-strip--success fd-message-strip--no-icon\\"
-     role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-11\\" aria-labelledby=\\"message-strip-11\\">
-  <p class=\\"fd-message-strip__text\\">
-    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
+<div 
+  role=\\"note\\" 
+  aria-labelledby=\\"message-strip-hidden-text-11 message-strip-text-11\\"
+  class=\\"fd-message-strip fd-message-strip--success fd-message-strip--no-icon\\">
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-11\\">Success Information Bar</span>
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-11\\">
+    Success Message Strip
   </p>
 </div>
 
 <br />
 
-<div class=\\"fd-message-strip fd-message-strip--warning fd-message-strip--no-icon\\"
-     role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-12\\" aria-labelledby=\\"message-strip-12\\">
-  <p class=\\"fd-message-strip__text\\">
-    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
+<div 
+  role=\\"note\\" 
+  aria-labelledby=\\"message-strip-hidden-text-12 message-strip-text-12\\"
+  class=\\"fd-message-strip fd-message-strip--warning fd-message-strip--no-icon\\">
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-12\\">Warning Information Bar</span>
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-12\\">
+    Warning Message Strip
   </p>
 </div>
 
 <br />
 
-<div class=\\"fd-message-strip fd-message-strip--error fd-message-strip--no-icon\\"
-     role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-13\\" aria-labelledby=\\"message-strip-13\\">
-  <p class=\\"fd-message-strip__text\\">
-    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
+<div 
+  role=\\"note\\" 
+  aria-labelledby=\\"message-strip-hidden-text-13 message-strip-text-13\\"
+  class=\\"fd-message-strip fd-message-strip--error fd-message-strip--no-icon\\">
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-13\\">Error Information Bar</span>
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-13\\">
+    Error Message Strip
   </p>
 </div>
 "
 `;
 
 exports[`Check stories > Components/Message Strip > Story Success > Should match snapshot 1`] = `
-"<div class=\\"fd-message-strip fd-message-strip--success fd-message-strip--dismissible\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-3\\" aria-labelledby=\\"message-strip-3\\">
+"<div 
+  role=\\"note\\" 
+  aria-labelledby=\\"message-strip-hidden-text-3 message-strip-text-3\\"
+  class=\\"fd-message-strip fd-message-strip--success fd-message-strip--dismissible\\">
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-3\\">Success Information Bar Closable</span>
+  
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
-    <span class=\\"sap-icon sap-icon--message-success\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+    <span class=\\"sap-icon sap-icon--message-success\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
-  <p class=\\"fd-message-strip__text\\">
-    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
+
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-3\\">
+    Success Message Strip
   </p>
-  <button class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" aria-controls=\\"message-strip-3\\" aria-label=\\"Close\\" title=\\"Close\\">
-    <i class=\\"sap-icon--decline\\"></i>
+
+  <button 
+    role=\\"button\\"
+    class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" 
+    aria-label=\\"Success Information Bar Close\\" 
+    title=\\"Success Information Bar Close\\">
+    <i class=\\"sap-icon--decline\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
   </button>
 </div>
 "
 `;
 
 exports[`Check stories > Components/Message Strip > Story Warning > Should match snapshot 1`] = `
-"<div class=\\"fd-message-strip fd-message-strip--warning fd-message-strip--dismissible\\" role=\\"note\\" aria-live=\\"assertive\\" id=\\"message-strip-4\\" aria-labelledby=\\"message-strip-4\\">
+"<div 
+  role=\\"note\\" 
+  aria-labelledby=\\"message-strip-hidden-text-4 message-strip-text-4\\"
+  class=\\"fd-message-strip fd-message-strip--warning fd-message-strip--dismissible\\">
+  <span class=\\"fd-message-strip__sr-only\\" id=\\"message-strip-hidden-text-4\\">Warning Information Bar Closable</span>
+  
   <div class=\\"fd-message-strip__icon-container\\" aria-hidden=\\"true\\">
-    <span class=\\"sap-icon sap-icon--message-warning\\" focusable=\\"false\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
+    <span class=\\"sap-icon sap-icon--message-warning\\" role=\\"presentation\\" aria-hidden=\\"true\\"></span>
   </div>
-  <p class=\\"fd-message-strip__text\\">
-    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
+
+  <p class=\\"fd-message-strip__text\\" id=\\"message-strip-text-4\\">
+    Warning Message Strip
   </p>
-  <button class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" aria-controls=\\"message-strip-4\\" aria-label=\\"Close\\" title=\\"Close\\">
-    <i class=\\"sap-icon--decline\\"></i>
+
+  <button 
+    role=\\"button\\"
+    class=\\"fd-button fd-button--transparent is-compact fd-message-strip__close\\" 
+    aria-label=\\"Warning Information Bar Close\\" 
+    title=\\"Warning Information Bar Close\\">
+    <i class=\\"sap-icon--decline\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
   </button>
-</div>
-"
+</div>"
 `;
 
 exports[`Check stories > Components/Message Toast > Story DefaultToast > Should match snapshot 1`] = `


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-styles/issues/5763

## Description
IMPORTANT:
We received this from the designer:
<img width="862" alt="Screenshot 2025-06-02 at 11 40 45 AM" src="https://github.com/user-attachments/assets/af0a03d5-8e2e-45bf-8a2b-564b06733cdc" />


- code cleanup
- added option for multiple links in the text element
- added a sr only span to describe the message strip
- markup update, roles, aria attributes, etc.

BREAKING CHANGE:
added a visually hidden span to add description to the message strip

Before:
```
<div class="fd-message-strip fd-message-strip--no-icon" role="note" aria-live="assertive" id="message-strip-1" aria-labelledby="message-strip-1">
  <p class="fd-message-strip__text">
    Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et.
  </p>
</div>
```

After:
```
<div 
  class="fd-message-strip fd-message-strip--no-icon" 
  role="note"
  aria-labelledby="message-strip-hidden-text-1 message-strip-text-1">
  <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-1">Information Bar</span>
  <p class="fd-message-strip__text" id="message-strip-text-1">
    This is a message.
  </p>
</div>
```