### PR TITLE
fix(styles): add a11y updates for Object Identifier [ci visual]

### DIFF
--- a/packages/styles/src/object-identifier.scss
+++ b/packages/styles/src/object-identifier.scss
@@ -6,9 +6,6 @@
 $block: #{$fd-namespace}-object-identifier;
 
 .#{$block} {
-  $fd-object-identifier-title-font-size: var(--sapFontLargeSize);
-  $fd-object-identifier-title-font-weight: bold;
-
   .#{$block}__link {
     font-size: inherit;
     font-weight: inherit;
@@ -18,23 +15,27 @@ $block: #{$fd-namespace}-object-identifier;
     @include fd-reset();
 
     color: var(--sapList_TextColor);
-    font-size: $fd-object-identifier-title-font-size;
+    font-size: var(--fdObjectIdentifier_Font_Size, var(--sapFontLargeSize));
+    font-weight: var(--fdObjectIdentifier_Font_Weight, normal);
 
     &--bold {
-      font-weight: $fd-object-identifier-title-font-weight;
+      --fdObjectIdentifier_Font_Weight: bold;
     }
   }
 
   &__text {
     @include fd-reset();
 
-    margin-top: 0.5rem;
+    line-height: 1.5;
+    margin-block-start: 0.5rem;
     color: var(--sapContent_LabelColor);
   }
 
+  &__sr-only {
+    @include fd-screen-reader-only();
+  }
+
   &--medium {
-    .#{$block}__title {
-      font-size: var(--sapFontSize);
-    }
+    --fdObjectIdentifier_Font_Size: var(--sapFontSize);
   }
 }

--- a/packages/styles/stories/Components/object-identifier/bold-title.example.html
+++ b/packages/styles/stories/Components/object-identifier/bold-title.example.html
@@ -1,3 +1,4 @@
 <div class="fd-object-identifier">
     <p class="fd-object-identifier__title fd-object-identifier__title--bold">NoteBook Basic 15</p>
+    <span class="fd-object-identifier__sr-only">Object Identifier</span>
 </div>

--- a/packages/styles/stories/Components/object-identifier/medium-size.example.html
+++ b/packages/styles/stories/Components/object-identifier/medium-size.example.html
@@ -2,4 +2,7 @@
 <div class="fd-object-identifier fd-object-identifier--medium">
     <p class="fd-object-identifier__title">NoteBook Basic 15</p>
     <p class="fd-object-identifier__text">Notebook Basic 15 with 2,80 GHz quad core, 15" LCD, 4 GB DDR3 RAM, 500 GB Hard Disc, Windows 8 Pro</p>
+    <span class="fd-object-identifier__sr-only">Object Identifier</span>
 </div>
+
+

--- a/packages/styles/stories/Components/object-identifier/title-and-text.example.html
+++ b/packages/styles/stories/Components/object-identifier/title-and-text.example.html
@@ -2,6 +2,7 @@
 <div class="fd-object-identifier">
     <p class="fd-object-identifier__title">NoteBook Basic 15</p>
     <p class="fd-object-identifier__text">Notebook Basic 15 with 2,80 GHz quad core, 15" LCD, 4 GB DDR3 RAM, 500 GB Hard Disc, Windows 8 Pro</p>
+    <span class="fd-object-identifier__sr-only">Object Identifier</span>
 </div>
 
 <br>
@@ -9,26 +10,29 @@
 <div class="fd-object-identifier">
     <p class="fd-object-identifier__title fd-object-identifier__title--bold">NoteBook Basic 15</p>
     <p class="fd-object-identifier__text">Notebook Basic 15 with 2,80 GHz quad core, 15" LCD, 4 GB DDR3 RAM, 500 GB Hard Disc, Windows 8 Pro</p>
+    <span class="fd-object-identifier__sr-only">Object Identifier</span>
 </div>
 
 <br>
 
 <div class="fd-object-identifier">
     <p class="fd-object-identifier__title">
-        <a href="#" class="fd-link fd-object-identifier__link">
+        <a href="#" tabindex="0" class="fd-link fd-object-identifier__link" aria-describedby="fd-object-identifier-desc-1 fd-object-identifier-text-1">
             <span class="fd-link__content">NoteBook Basic 15</span>
         </a>
     </p>
-    <p class="fd-object-identifier__text">Notebook Basic 15 with 2,80 GHz quad core, 15" LCD, 4 GB DDR3 RAM, 500 GB Hard Disc, Windows 8 Pro</p>
+    <span class="fd-object-identifier__sr-only" aria-hidden="true" id="fd-object-identifier-desc-1">Object Identifier</span>
+    <p class="fd-object-identifier__text" id="fd-object-identifier-text-1">Notebook Basic 15 with 2,80 GHz quad core, 15" LCD, 4 GB DDR3 RAM, 500 GB Hard Disc, Windows 8 Pro</p>
 </div>
 
 <br>
 
 <div class="fd-object-identifier">
     <p class="fd-object-identifier__title fd-object-identifier__title--bold">
-        <a href="#" class="fd-link fd-object-identifier__link">
+        <a href="#" tabindex="0" class="fd-link fd-object-identifier__link" aria-describedby="fd-object-identifier-desc-2 fd-object-identifier-text-2">
             <span class="fd-link__content">NoteBook Basic 15</span>
         </a>
     </p>
-    <p class="fd-object-identifier__text">Notebook Basic 15 with 2,80 GHz quad core, 15" LCD, 4 GB DDR3 RAM, 500 GB Hard Disc, Windows 8 Pro</p>
+    <span class="fd-object-identifier__sr-only" aria-hidden="true" id="fd-object-identifier-desc-2">Object Identifier</span>
+    <p class="fd-object-identifier__text" id="fd-object-identifier-text-2">Notebook Basic 15 with 2,80 GHz quad core, 15" LCD, 4 GB DDR3 RAM, 500 GB Hard Disc, Windows 8 Pro</p>
 </div>

--- a/packages/styles/stories/Components/object-identifier/title-as-link.example.html
+++ b/packages/styles/stories/Components/object-identifier/title-as-link.example.html
@@ -1,7 +1,7 @@
 
 <div class="fd-object-identifier">
     <p class="fd-object-identifier__title">
-        <a href="#" class="fd-link fd-object-identifier__link">
+        <a href="#" tabindex="0" class="fd-link fd-object-identifier__link" aria-label="Object Identifier">
             <span class="fd-link__content">NoteBook Basic 15</span>
         </a>
     </p>
@@ -9,7 +9,7 @@
 <br>
 <div class="fd-object-identifier">
     <p class="fd-object-identifier__title fd-object-identifier__title--bold">
-        <a href="#" class="fd-link fd-object-identifier__link">
+        <a href="#" tabindex="0" class="fd-link fd-object-identifier__link" aria-label="Object Identifier">
             <span class="fd-link__content">NoteBook Basic 15</span>
         </a>
     </p>

--- a/packages/styles/stories/Components/object-identifier/title-only.example.html
+++ b/packages/styles/stories/Components/object-identifier/title-only.example.html
@@ -1,3 +1,4 @@
 <div class="fd-object-identifier">
     <p class="fd-object-identifier__title">NoteBook Basic 15</p>
+    <span class="fd-object-identifier__sr-only">Object Identifier</span>
 </div>

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -32391,6 +32391,7 @@ exports[`Check stories > Components/Notifications > Story Primary > Should match
 exports[`Check stories > Components/Object Identifier > Story BoldTitle > Should match snapshot 1`] = `
 "<div class=\\"fd-object-identifier\\">
     <p class=\\"fd-object-identifier__title fd-object-identifier__title--bold\\">NoteBook Basic 15</p>
+    <span class=\\"fd-object-identifier__sr-only\\">Object Identifier</span>
 </div>
 "
 `;
@@ -32400,7 +32401,10 @@ exports[`Check stories > Components/Object Identifier > Story MediumSize > Shoul
 <div class=\\"fd-object-identifier fd-object-identifier--medium\\">
     <p class=\\"fd-object-identifier__title\\">NoteBook Basic 15</p>
     <p class=\\"fd-object-identifier__text\\">Notebook Basic 15 with 2,80 GHz quad core, 15\\" LCD, 4 GB DDR3 RAM, 500 GB Hard Disc, Windows 8 Pro</p>
+    <span class=\\"fd-object-identifier__sr-only\\">Object Identifier</span>
 </div>
+
+
 "
 `;
 
@@ -32409,6 +32413,7 @@ exports[`Check stories > Components/Object Identifier > Story TitleAndText > Sho
 <div class=\\"fd-object-identifier\\">
     <p class=\\"fd-object-identifier__title\\">NoteBook Basic 15</p>
     <p class=\\"fd-object-identifier__text\\">Notebook Basic 15 with 2,80 GHz quad core, 15\\" LCD, 4 GB DDR3 RAM, 500 GB Hard Disc, Windows 8 Pro</p>
+    <span class=\\"fd-object-identifier__sr-only\\">Object Identifier</span>
 </div>
 
 <br>
@@ -32416,37 +32421,39 @@ exports[`Check stories > Components/Object Identifier > Story TitleAndText > Sho
 <div class=\\"fd-object-identifier\\">
     <p class=\\"fd-object-identifier__title fd-object-identifier__title--bold\\">NoteBook Basic 15</p>
     <p class=\\"fd-object-identifier__text\\">Notebook Basic 15 with 2,80 GHz quad core, 15\\" LCD, 4 GB DDR3 RAM, 500 GB Hard Disc, Windows 8 Pro</p>
+    <span class=\\"fd-object-identifier__sr-only\\">Object Identifier</span>
 </div>
 
 <br>
 
 <div class=\\"fd-object-identifier\\">
     <p class=\\"fd-object-identifier__title\\">
-        <a href=\\"#\\" class=\\"fd-link fd-object-identifier__link\\">
+        <a href=\\"#\\" tabindex=\\"0\\" class=\\"fd-link fd-object-identifier__link\\" aria-describedby=\\"fd-object-identifier-desc-1 fd-object-identifier-text-1\\">
             <span class=\\"fd-link__content\\">NoteBook Basic 15</span>
         </a>
     </p>
-    <p class=\\"fd-object-identifier__text\\">Notebook Basic 15 with 2,80 GHz quad core, 15\\" LCD, 4 GB DDR3 RAM, 500 GB Hard Disc, Windows 8 Pro</p>
+    <span class=\\"fd-object-identifier__sr-only\\" aria-hidden=\\"true\\" id=\\"fd-object-identifier-desc-1\\">Object Identifier</span>
+    <p class=\\"fd-object-identifier__text\\" id=\\"fd-object-identifier-text-1\\">Notebook Basic 15 with 2,80 GHz quad core, 15\\" LCD, 4 GB DDR3 RAM, 500 GB Hard Disc, Windows 8 Pro</p>
 </div>
 
 <br>
 
 <div class=\\"fd-object-identifier\\">
     <p class=\\"fd-object-identifier__title fd-object-identifier__title--bold\\">
-        <a href=\\"#\\" class=\\"fd-link fd-object-identifier__link\\">
+        <a href=\\"#\\" tabindex=\\"0\\" class=\\"fd-link fd-object-identifier__link\\" aria-describedby=\\"fd-object-identifier-desc-2 fd-object-identifier-text-2\\">
             <span class=\\"fd-link__content\\">NoteBook Basic 15</span>
         </a>
     </p>
-    <p class=\\"fd-object-identifier__text\\">Notebook Basic 15 with 2,80 GHz quad core, 15\\" LCD, 4 GB DDR3 RAM, 500 GB Hard Disc, Windows 8 Pro</p>
-</div>
-"
+    <span class=\\"fd-object-identifier__sr-only\\" aria-hidden=\\"true\\" id=\\"fd-object-identifier-desc-2\\">Object Identifier</span>
+    <p class=\\"fd-object-identifier__text\\" id=\\"fd-object-identifier-text-2\\">Notebook Basic 15 with 2,80 GHz quad core, 15\\" LCD, 4 GB DDR3 RAM, 500 GB Hard Disc, Windows 8 Pro</p>
+</div>"
 `;
 
 exports[`Check stories > Components/Object Identifier > Story TitleAsLink > Should match snapshot 1`] = `
 "
 <div class=\\"fd-object-identifier\\">
     <p class=\\"fd-object-identifier__title\\">
-        <a href=\\"#\\" class=\\"fd-link fd-object-identifier__link\\">
+        <a href=\\"#\\" tabindex=\\"0\\" class=\\"fd-link fd-object-identifier__link\\" aria-label=\\"Object Identifier\\">
             <span class=\\"fd-link__content\\">NoteBook Basic 15</span>
         </a>
     </p>
@@ -32454,7 +32461,7 @@ exports[`Check stories > Components/Object Identifier > Story TitleAsLink > Shou
 <br>
 <div class=\\"fd-object-identifier\\">
     <p class=\\"fd-object-identifier__title fd-object-identifier__title--bold\\">
-        <a href=\\"#\\" class=\\"fd-link fd-object-identifier__link\\">
+        <a href=\\"#\\" tabindex=\\"0\\" class=\\"fd-link fd-object-identifier__link\\" aria-label=\\"Object Identifier\\">
             <span class=\\"fd-link__content\\">NoteBook Basic 15</span>
         </a>
     </p>
@@ -32465,6 +32472,7 @@ exports[`Check stories > Components/Object Identifier > Story TitleAsLink > Shou
 exports[`Check stories > Components/Object Identifier > Story TitleOnly > Should match snapshot 1`] = `
 "<div class=\\"fd-object-identifier\\">
     <p class=\\"fd-object-identifier__title\\">NoteBook Basic 15</p>
+    <span class=\\"fd-object-identifier__sr-only\\">Object Identifier</span>
 </div>
 "
 `;


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-styles/issues/5763

## Description
- code refactor to use CSS variables for the modifiers
- new class to visually hide elements for the SR
- doc updates


BREAKING CHANGE:
markup update to announce the role of the element

Before:
```
<div class="fd-object-identifier">
    <p class="fd-object-identifier__title fd-object-identifier__title--bold">NoteBook Basic 15</p>\
</div>
```

After:
```
<div class="fd-object-identifier">
    <p class="fd-object-identifier__title fd-object-identifier__title--bold">NoteBook Basic 15</p>
    <span class="fd-object-identifier__sr-only">Object Identifier</span>
</div>
```

Before:
```
<div class="fd-object-identifier">
    <p class="fd-object-identifier__title fd-object-identifier__title--bold">
        <a href="#" class="fd-link fd-object-identifier__link">
            <span class="fd-link__content">...</span>
        </a>
    </p>
    <p class="fd-object-identifier__text">...</p>
</div>
```

After:
```
<div class="fd-object-identifier">
    <p class="fd-object-identifier__title fd-object-identifier__title--bold">
        <a href="#" tabindex="0" class="fd-link fd-object-identifier__link" aria-describedby="fd-object-identifier-desc-2 fd-object-identifier-text-2">
            <span class="fd-link__content">...</span>
        </a>
    </p>
    <span class="fd-object-identifier__sr-only" aria-hidden="true" id="fd-object-identifier-desc-2">Object Identifier</span>
    <p class="fd-object-identifier__text" id="fd-object-identifier-text-2">...</p>
</div>
```
