### PR TITLE
fix(styles): a11y and focus improvements for Avatar Group [ci visual]

### DIFF
--- a/packages/styles/src/avatar-group.scss
+++ b/packages/styles/src/avatar-group.scss
@@ -42,7 +42,16 @@ $block-avatar: #{$fd-namespace}-avatar;
     }
   }
 
+  &__popover-control {
+    position: relative;
+
+    @include fd-focus() {
+      @include fd-fake-fiori-focus(var(--fdAvatarGroup_Focus_Outline_Offset), var(--fdAvatarGroup_Focus_Outline_Radius));
+    }
+  }
+
   &--vertical {
+    height: 100%;
     flex-direction: column;
   }
 
@@ -57,6 +66,8 @@ $block-avatar: #{$fd-namespace}-avatar;
   }
 
   &--group-type {
+    position: relative;
+
     .#{$fd-namespace}-avatar {
       pointer-events: none;
     }

--- a/packages/styles/stories/Components/avatar-group/avatar-group.stories.js
+++ b/packages/styles/stories/Components/avatar-group/avatar-group.stories.js
@@ -78,7 +78,7 @@ By default, an overview of all "overflowed" avatars is shown directly within a p
       story: {
       }
     },
-    tags: ['v1']
+    tags: []
   }
 };
 export const IndividualType = () => individualTypeExampleHtml;

--- a/packages/styles/stories/Components/avatar-group/group-type-interaction-states.example.html
+++ b/packages/styles/stories/Components/avatar-group/group-type-interaction-states.example.html
@@ -4,42 +4,37 @@
         <div class="fd-popover__control fd-avatar-group__popover-control"
             role="button"
             tabindex="0"
-            aria-label="Avatar Group">
+            aria-label="Conjoined avatars. 6 displayed, 8 hidden. Activate for complete list.">
             <div class="fd-avatar-group fd-avatar-group--group-type fd-avatar-group--md">
                 <span 
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--accent-color-1" 
                     role="img" 
-                    aria-label="Wendy Wallace" 
-                    title="Wendy Wallace">WW
+                    aria-label="Wendy Wallace">WW
                 </span>
                 
                 <span 
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--accent-color-2" 
                     role="img" 
-                    aria-label="Simon Doe" 
-                    title="Simon Doe">
+                    aria-label="Simon Doe">
                         <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
                 </span>
                 
                 <span 
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" 
                     role="img" 
-                    alt="Ben Johnson" 
-                    title="Ben Johnson">
+                    alt="Portrait of Ben Johnson">
                 </span>
                 
                 <span 
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--accent-color-3" 
                     role="img" 
-                    aria-label="Endy Wallace" 
-                    title="Endy Wallace">EW
+                    aria-label="Endy Wallace">EW
                 </span>
                 
                 <span 
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" 
                     role="img" 
-                    aria-label="Whitney Copper" 
-                    title="Whitney Copper">
+                    aria-label="Whitney Copper">
                         <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
                 </span>
                 
@@ -47,8 +42,7 @@
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" 
                     style="background-image: url('/assets/images/portraits/L_80x80_M2.png')" 
                     role="img" 
-                    alt="Brian Tracey" 
-                    title="Brian Tracey">
+                    alt="Portrait of Brian Tracey">
                 </span>
 
                 <span 
@@ -65,43 +59,38 @@
         <div class="fd-popover__control fd-avatar-group__popover-control"
             role="button"
             tabindex="0"
-            aria-label="Avatar Group">
+            aria-label="Conjoined avatars. 6 displayed, 8 hidden. Activate for complete list.">
             <div class="fd-avatar-group fd-avatar-group--group-type fd-avatar-group--md is-hover">
                
                 <span 
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--accent-color-1" 
                     role="img" 
-                    aria-label="Wendy Wallace" 
-                    title="Wendy Wallace">WW
+                    aria-label="Wendy Wallace">WW
                 </span>
         
                 <span 
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--accent-color-2" 
                     role="img" 
-                    aria-label="Simon Doe" 
-                    title="Simon Doe">
+                    aria-label="Simon Doe">
                         <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
                 </span>
                 
                 <span 
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" 
                     role="img" 
-                    alt="Ben Johnson" 
-                    title="Ben Johnson">
+                    alt="Portrait of Ben Johnson">
                 </span>
         
                 <span 
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--accent-color-3" 
                     role="img" 
-                    aria-label="Endy Wallace" 
-                    title="Endy Wallace">EW
+                    aria-label="Endy Wallace">EW
                 </span>
                 
                 <span 
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" 
                     role="img" 
-                    aria-label="Whitney Copper" 
-                    title="Whitney Copper">
+                    aria-label="Whitney Copper">
                         <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
                 </span>
         
@@ -109,8 +98,7 @@
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" 
                     style="background-image: url('/assets/images/portraits/L_80x80_M2.png')" 
                     role="img" 
-                    alt="Brian Tracey" 
-                    title="Brian Tracey">
+                    alt="Portrait of Brian Tracey">
                 </span>
 
                 <span 
@@ -127,42 +115,37 @@
         <div class="fd-popover__control fd-avatar-group__popover-control"
             role="button"
             tabindex="0"
-            aria-label="Avatar Group">
+            aria-label="Conjoined avatars. 6 displayed, 8 hidden. Activate for complete list.">
             <div class="fd-avatar-group fd-avatar-group--group-type fd-avatar-group--md is-active">
                 <span 
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--accent-color-1" 
                     role="img" 
-                    aria-label="Wendy Wallace" 
-                    title="Wendy Wallace">WW
+                    aria-label="Wendy Wallace">WW
                 </span>
         
                 <span 
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--accent-color-2" 
                     role="img" 
-                    aria-label="Simon Doe" 
-                    title="Simon Doe">
+                    aria-label="Simon Doe">
                         <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
                 </span>
         
                 <span 
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" 
                     role="img" 
-                    alt="Ben Johnson" 
-                    title="Ben Johnson">
+                    alt="Portrait of Ben Johnson">
                 </span>
                 
                 <span 
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--accent-color-3" 
                     role="img" 
-                    aria-label="Endy Wallace" 
-                    title="Endy Wallace">EW
+                    aria-label="Endy Wallace">EW
                 </span>
         
                 <span 
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" 
                     role="img" 
-                    aria-label="Whitney Copper" 
-                    title="Whitney Copper">
+                    aria-label="Whitney Copper">
                         <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
                 </span>
                 
@@ -170,8 +153,7 @@
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" 
                     style="background-image: url('/assets/images/portraits/L_80x80_M2.png')" 
                     role="img" 
-                    alt="Brian Tracey" 
-                    title="Brian Tracey">
+                    alt="Portrait of Brian Tracey">
                 </span>
 
                 <span 
@@ -187,43 +169,37 @@
     <div class="fd-popover">
         <div class="fd-popover__control fd-avatar-group__popover-control"
             role="button"
-            tabindex="0"
-            aria-label="Avatar Group">
+            aria-label="Conjoined avatars. 6 displayed, 8 hidden. Activate for complete list.">
             <div class="fd-avatar-group fd-avatar-group--group-type fd-avatar-group--md is-disabled">
                 <span 
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--accent-color-1" 
                     role="img" 
-                    aria-label="Wendy Wallace" 
-                    title="Wendy Wallace">WW
+                    aria-label="Wendy Wallace">WW
                 </span>
         
                 <span 
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--accent-color-2" 
                     role="img" 
-                    aria-label="Simon Doe" 
-                    title="Simon Doe">
+                    aria-label="Simon Doe">
                         <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
                 </span>
                 
                 <span 
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" 
                     role="img" 
-                    alt="Ben Johnson" 
-                    title="Ben Johnson">
+                    alt="Portrait of Ben Johnson">
                 </span>
         
                 <span 
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--accent-color-3" 
                     role="img" 
-                    aria-label="Endy Wallace" 
-                    title="Endy Wallace">EW
+                    aria-label="Endy Wallace">EW
                 </span>
                 
                 <span 
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" 
                     role="img" 
-                    aria-label="Whitney Copper" 
-                    title="Whitney Copper">
+                    aria-label="Whitney Copper">
                         <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
                 </span>
                 
@@ -231,8 +207,7 @@
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" 
                     style="background-image: url('/assets/images/portraits/L_80x80_M2.png')" 
                     role="img" 
-                    alt="Brian Tracey" 
-                    title="Brian Tracey">
+                    alt="Portrait of Brian Tracey">
                 </span>
 
                 <span 
@@ -249,42 +224,37 @@
         <div class="fd-popover__control fd-avatar-group__popover-control"
             role="button"
             tabindex="0"
-            aria-label="Avatar Group">
+            aria-label="Conjoined avatars. 6 displayed, 8 hidden. Activate for complete list.">
             <div class="fd-avatar-group fd-avatar-group--group-type fd-avatar-group--md is-focus">
                 <span 
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--accent-color-1" 
                     role="img" 
-                    aria-label="Wendy Wallace" 
-                    title="Wendy Wallace">WW
+                    aria-label="Wendy Wallace">WW
                 </span>
         
                 <span 
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--accent-color-2" 
                     role="img" 
-                    aria-label="Simon Doe" 
-                    title="Simon Doe">
+                    aria-label="Simon Doe">
                         <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
                 </span>
                 
                 <span 
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" 
                     role="img" 
-                    alt="Ben Johnson" 
-                    title="Ben Johnson">
+                    alt="Portrait of Ben Johnson">
                 </span>
                 
                 <span 
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--accent-color-3" 
                     role="img" 
-                    aria-label="Endy Wallace" 
-                    title="Endy Wallace">EW
+                    aria-label="Endy Wallace">EW
                 </span>
         
                 <span 
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" 
                     role="img" 
-                    aria-label="Whitney Copper" 
-                    title="Whitney Copper">
+                    aria-label="Whitney Copper">
                         <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
                 </span>
                 
@@ -292,8 +262,7 @@
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" 
                     style="background-image: url('/assets/images/portraits/L_80x80_M2.png')" 
                     role="img" 
-                    alt="Brian Tracey" 
-                    title="Brian Tracey">
+                    alt="Portrait of Brian Tracey">
                 </span>
 
                 <span 

--- a/packages/styles/stories/Components/avatar-group/group-type-vertical.example.html
+++ b/packages/styles/stories/Components/avatar-group/group-type-vertical.example.html
@@ -3,45 +3,40 @@
         <div class="fd-popover__control fd-avatar-group__popover-control"
             role="button"
             tabindex="0"
-            aria-label="Has popup type dialog Conjoined avatars, 6 avatars displayed, 8 avatars hidden, activate for complete list"
+            aria-label="Conjoined avatars, 6 avatars displayed, 8 avatars hidden, activate for complete list"
             aria-haspopup="true"
             aria-expanded="false"
             onclick="onPopoverClick('popover_avatar-group_tztuj-v');">
-            <div class="fd-avatar-group fd-avatar-group--group-type fd-avatar-group--lg fd-avatar-group--vertical ">
+            <div class="fd-avatar-group fd-avatar-group--group-type fd-avatar-group--lg fd-avatar-group--vertical">
                 <span 
                     class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border" 
                     role="img" 
-                    aria-label="Wendy Wallace" 
-                    title="Wendy Wallace">WW
+                    aria-label="Wendy Wallace">WW
                 </span>
                 
                 <span 
                     class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border" 
                     role="img" 
-                    aria-label="Simon Dane" 
-                    title="Simon Dane">
+                    aria-label="Simon Dane">
                         <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
                 </span>
                 
                 <span 
                     class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" 
                     role="img" 
-                    alt="Michael Smith" 
-                    title="Michael Smith">
+                    alt="Portrait of Michael Smith">
                 </span>
                 
                 <span 
                     class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border" 
                     role="img" 
-                    aria-label="Endy Wallace" 
-                    title="Endy Wallace">EW
+                    aria-label="Endy Wallace">EW
                 </span>
                 
                 <span 
                     class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border" 
                     role="img" 
-                    aria-label="Whitney Copper" 
-                    title="Whitney Copper">
+                    aria-label="Whitney Copper">
                         <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
                 </span>
                 
@@ -49,8 +44,7 @@
                     class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" 
                     style="background-image: url('/assets/images/portraits/L_80x80_M2.png')" 
                     role="img" 
-                    alt="James Johnson" 
-                    title="James Johnson">
+                    alt="Portrait of James Johnson">
                 </span>
 
                 <span 
@@ -66,48 +60,50 @@
                 <div class="fd-popover__body-header">
                     <div class="fd-bar fd-bar--header">
                         <div class="fd-bar__middle">
-                            <div class="fd-bar__element">Team Members (14)</div>
+                            <div class="fd-bar__element">
+                                <h1 class="fd-title fd-title--h5">Team Members (14)</h1>
+                            </div>
                         </div>
                     </div>
                 </div>
                 <div class="fd-avatar-group__overflow-body">
-                    <span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border" role="img" aria-label="Wendy Wallace" title="Wendy Wallace">WW</span>
+                    <span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border" role="img" aria-label="Wendy Wallace">WW</span>
                     
-                    <span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border" role="img" aria-label="Sarah Smith" title="Sarah Smith">
+                    <span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border" role="img" aria-label="Sarah Smith">
                         <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation"></i>
                     </span>
                     
-                    <span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" role="img" alt="William Smith" title="William Smith"></span>
+                    <span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" role="img" alt="Portrait of William Smith"></span>
 
                     <span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border" role="img" aria-label="Endy Wallace" title="Endy Wallace">EW</span>
 
-                    <span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border" role="img" aria-label="Whitney Bow" title="Whitney Bow">
+                    <span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border" role="img" aria-label="Whitney Bow">
                         <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation"></i>
                     </span>
 
-                    <span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M2.png')" role="img" alt="Mitch Walters" title="Mitch Walters"></span>
+                    <span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M2.png')" role="img" alt="Portrait of Mitch Walters"></span>
 
-                    <span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border" role="img" aria-label="Andy Wallace" title="Andy Wallace">AW</span>
+                    <span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border" role="img" aria-label="Andy Wallace">AW</span>
 
-                    <span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border" role="img" aria-label="John Carter" title="John Carter">
+                    <span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border" role="img" aria-label="John Carter">
                         <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation"></i>
                     </span>
 
-                    <span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_F3.png')" role="img" alt="Melanie Burke" title="Melanie Burke"></span>
+                    <span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_F3.png')" role="img" alt="Portrait of Melanie Burke"></span>
 
-                    <span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border" role="img" aria-label="John Moe" title="John Moe">JM</span>
+                    <span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border" role="img" aria-label="John Moe">JM</span>
 
-                    <span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border" role="img" aria-label="Ben Bloggs" title="Ben Bloggs">BB</span>
+                    <span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border" role="img" aria-label="Ben Bloggs">BB</span>
 
-                    <span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border" role="img" aria-label="Simon Swan" title="Simon Swan">
+                    <span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border" role="img" aria-label="Simon Swan">
                         <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation"></i>
                     </span>
 
-                    <span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_F4.png')" role="img" alt="Maria Caffrey" title="Maria Caffrey"></span>
+                    <span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_F4.png')" role="img" alt="Portrait of Maria Caffrey"></span>
 
-                    <span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border" role="img" aria-label="Fred Bloggs" title="Fred Bloggs">FB</span>
+                    <span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border" role="img" aria-label="Fred Bloggs">FB</span>
 
-                    <span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border" role="img" aria-label="Jan Alleman" title="Jan Alleman">JA</span>
+                    <span class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border" role="img" aria-label="Jan Alleman">JA</span>
                 </div>
             </div>
         </div>
@@ -115,41 +111,36 @@
 </div>
 
 <div style="display: flex; gap: 3rem;">
-    <div class="fd-avatar-group fd-avatar-group--group-type fd-avatar-group--xs fd-avatar-group--vertical">
+    <div class="fd-avatar-group fd-avatar-group--group-type fd-avatar-group--xs fd-avatar-group--vertical" role="button" tabindex="0" aria-label="Conjoined avatars. 6 displayed, 8 hidden. Activate for complete list.">
         <span 
             class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--border" 
             role="img" 
-            aria-label="Wendy Wallace" 
-            title="Wendy Wallace">WW
+            aria-label="Wendy Wallace">WW
         </span>
         
         <span 
             class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--border" 
             role="img" 
-            aria-label="Simon Dane" 
-            title="Simon Dane">
+            aria-label="Simon Dane">
                 <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
         </span>
         
         <span 
             class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" 
             role="img" 
-            alt="Michael Smith" 
-            title="Michael Smith">
+            alt="Portrait of Michael Smith">
         </span>
         
         <span 
             class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--border" 
             role="img" 
-            aria-label="Endy Wallace" 
-            title="Endy Wallace">EW
+            aria-label="Endy Wallace">EW
         </span>
         
         <span 
             class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--border" 
             role="img" 
-            aria-label="Whitney Copper" 
-            title="Whitney Copper">
+            aria-label="Whitney Copper">
                 <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
         </span>
         
@@ -157,8 +148,7 @@
             class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" 
             style="background-image: url('/assets/images/portraits/L_80x80_M2.png')" 
             role="img" 
-            alt="James Johnson" 
-            title="James Johnson">
+            alt="Portrait of James Johnson">
         </span>
     
         <span 
@@ -168,41 +158,36 @@
         </span>
     </div>
 
-    <div class="fd-avatar-group fd-avatar-group--group-type fd-avatar-group--sm fd-avatar-group--vertical">
+    <div class="fd-avatar-group fd-avatar-group--group-type fd-avatar-group--sm fd-avatar-group--vertical" role="button" tabindex="0" aria-label="Conjoined avatars. 6 displayed, 8 hidden. Activate for complete list.">
         <span 
             class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border" 
             role="img" 
-            aria-label="Wendy Wallace" 
-            title="Wendy Wallace">WW
+            aria-label="Wendy Wallace">WW
         </span>
         
         <span 
             class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border" 
             role="img" 
-            aria-label="Simon Dane" 
-            title="Simon Dane">
+            aria-label="Simon Dane">
                 <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
         </span>
         
         <span 
             class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" 
             role="img" 
-            alt="Michael Smith" 
-            title="Michael Smith">
+            alt="Portrait of Michael Smith">
         </span>
         
         <span 
             class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border" 
             role="img" 
-            aria-label="Endy Wallace" 
-            title="Endy Wallace">EW
+            aria-label="Endy Wallace">EW
         </span>
         
         <span 
             class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border" 
             role="img" 
-            aria-label="Whitney Copper" 
-            title="Whitney Copper">
+            aria-label="Whitney Copper">
                 <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
         </span>
         
@@ -210,8 +195,7 @@
             class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" 
             style="background-image: url('/assets/images/portraits/L_80x80_M2.png')" 
             role="img" 
-            alt="James Johnson" 
-            title="James Johnson">
+            alt="Portrait of James Johnson">
         </span>
     
         <span 
@@ -221,41 +205,36 @@
         </span>
     </div>
 
-    <div class="fd-avatar-group fd-avatar-group--group-type fd-avatar-group--md fd-avatar-group--vertical">
+    <div class="fd-avatar-group fd-avatar-group--group-type fd-avatar-group--md fd-avatar-group--vertical" role="button" tabindex="0" aria-label="Conjoined avatars. 6 displayed, 8 hidden. Activate for complete list.">
         <span 
             class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" 
             role="img" 
-            aria-label="Wendy Wallace" 
-            title="Wendy Wallace">WW
+            aria-label="Wendy Wallace">WW
         </span>
         
         <span 
             class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" 
             role="img" 
-            aria-label="Simon Dane" 
-            title="Simon Dane">
+            aria-label="Simon Dane">
                 <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
         </span>
         
         <span 
             class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" 
             role="img" 
-            alt="Michael Smith" 
-            title="Michael Smith">
+            alt="Portrait of Michael Smith">
         </span>
         
         <span 
             class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" 
             role="img" 
-            aria-label="Endy Wallace" 
-            title="Endy Wallace">EW
+            aria-label="Endy Wallace">EW
         </span>
         
         <span 
             class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" 
             role="img" 
-            aria-label="Whitney Copper" 
-            title="Whitney Copper">
+            aria-label="Whitney Copper">
                 <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
         </span>
         
@@ -263,8 +242,7 @@
             class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" 
             style="background-image: url('/assets/images/portraits/L_80x80_M2.png')" 
             role="img" 
-            alt="James Johnson" 
-            title="James Johnson">
+            alt="Portrait of James Johnson">
         </span>
     
         <span 
@@ -274,41 +252,36 @@
         </span>
     </div>
 
-    <div class="fd-avatar-group fd-avatar-group--group-type fd-avatar-group--lg fd-avatar-group--vertical">
+    <div class="fd-avatar-group fd-avatar-group--group-type fd-avatar-group--lg fd-avatar-group--vertical" role="button" tabindex="0" aria-label="Conjoined avatars. 6 displayed, 8 hidden. Activate for complete list.">
         <span 
             class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border" 
             role="img" 
-            aria-label="Wendy Wallace" 
-            title="Wendy Wallace">WW
+            aria-label="Wendy Wallace">WW
         </span>
         
         <span 
             class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border" 
             role="img" 
-            aria-label="Simon Dane" 
-            title="Simon Dane">
+            aria-label="Simon Dane">
                 <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
         </span>
         
         <span 
             class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" 
             role="img" 
-            alt="Michael Smith" 
-            title="Michael Smith">
+            alt="Portrait of Michael Smith">
         </span>
         
         <span 
             class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border" 
             role="img" 
-            aria-label="Endy Wallace" 
-            title="Endy Wallace">EW
+            aria-label="Endy Wallace">EW
         </span>
         
         <span 
             class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border" 
             role="img" 
-            aria-label="Whitney Copper" 
-            title="Whitney Copper">
+            aria-label="Whitney Copper">
                 <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
         </span>
         
@@ -316,8 +289,7 @@
             class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" 
             style="background-image: url('/assets/images/portraits/L_80x80_M2.png')" 
             role="img" 
-            alt="James Johnson" 
-            title="James Johnson">
+            alt="Portrait of James Johnson">
         </span>
     
         <span 
@@ -328,41 +300,36 @@
     </div>
 
 
-    <div class="fd-avatar-group fd-avatar-group--group-type fd-avatar-group--xl fd-avatar-group--vertical">
+    <div class="fd-avatar-group fd-avatar-group--group-type fd-avatar-group--xl fd-avatar-group--vertical" role="button" tabindex="0" aria-label="Conjoined avatars. 6 displayed, 8 hidden. Activate for complete list.">
         <span 
             class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--border" 
             role="img" 
-            aria-label="Wendy Wallace" 
-            title="Wendy Wallace">WW
+            aria-label="Wendy Wallace">WW
         </span>
         
         <span 
             class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--border" 
             role="img" 
-            aria-label="Simon Dane" 
-            title="Simon Dane">
+            aria-label="Simon Dane">
                 <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
         </span>
         
         <span 
             class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" 
             role="img" 
-            alt="Michael Smith" 
-            title="Michael Smith">
+            alt="Portrait of Michael Smith">
         </span>
         
         <span 
             class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--border" 
             role="img" 
-            aria-label="Endy Wallace" 
-            title="Endy Wallace">EW
+            aria-label="Endy Wallace">EW
         </span>
         
         <span 
             class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--border" 
             role="img" 
-            aria-label="Whitney Copper" 
-            title="Whitney Copper">
+            aria-label="Whitney Copper">
                 <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
         </span>
         
@@ -370,8 +337,7 @@
             class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" 
             style="background-image: url('/assets/images/portraits/L_80x80_M2.png')" 
             role="img" 
-            alt="James Johnson" 
-            title="James Johnson">
+            alt="Portrait of James Johnson">
         </span>
     
         <span 

--- a/packages/styles/stories/Components/avatar-group/group-type.example.html
+++ b/packages/styles/stories/Components/avatar-group/group-type.example.html
@@ -11,37 +11,32 @@
                 <span 
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" 
                     role="img" 
-                    aria-label="Wendy Wallace" 
-                    title="Wendy Wallace">WW
+                    aria-label="Wendy Wallace">WW
                 </span>
                 
                 <span 
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" 
                     role="img" 
-                    aria-label="Simon Drew" 
-                    title="Simon Drew">
+                    aria-label="Simon Drew">
                         <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
                 </span>
                 
                 <span 
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" 
                     role="img" 
-                    alt="Brad Coehn" 
-                    title="Brad Coehn">
+                    alt="Portrait of Brad Coehn">
                 </span>
                 
                 <span 
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" 
                     role="img" 
-                    aria-label="Endy Wallace" 
-                    title="Endy Wallace">EW
+                    aria-label="Endy Wallace">EW
                 </span>
                 
                 <span 
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" 
                     role="img" 
-                    aria-label="Whitney Copper" 
-                    title="Whitney Copper">
+                    aria-label="Whitney Copper">
                         <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
                 </span>
                 
@@ -49,8 +44,7 @@
                     class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" 
                     style="background-image: url('/assets/images/portraits/L_80x80_M2.png')" 
                     role="img" 
-                    alt="John Doe" 
-                    title="John Doe">
+                    alt="Portrait of John Doe">
                 </span>
 
                 <span 
@@ -66,48 +60,50 @@
                 <div class="fd-popover__body-header">
                     <div class="fd-bar fd-bar--header">
                         <div class="fd-bar__middle">
-                            <div class="fd-bar__element">Team Members (14)</div>
+                            <div class="fd-bar__element">
+                                <h1 class="fd-title fd-title--h5">Team Members (14)</h1>
+                            </div>
                         </div>
                     </div>
                 </div>
                 <div class="fd-avatar-group__overflow-body">
-                    <span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" role="img" aria-label="Wendy Wallace" title="Wendy Wallace">WW</span>
+                    <span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" role="img" aria-label="Wendy Wallace">WW</span>
                     
-                    <span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" role="img" aria-label="Sarah Smith" title="Sarah Smith">
+                    <span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" role="img" aria-label="Sarah Smith">
                         <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation"></i>
                     </span>
                     
-                    <span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" role="img" alt="Alex Cardigan" title="Alex Cardigan"></span>
+                    <span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" role="img" alt="Portrait of Alex Cardigan"></span>
 
-                    <span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" role="img" aria-label="Endy Wallace" title="Endy Wallace">EW</span>
+                    <span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" role="img" aria-label="Endy Wallace">EW</span>
 
-                    <span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" role="img" aria-label="Whitney Bow" title="Whitney Bow">
+                    <span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" role="img" aria-label="Whitney Bow">
                         <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation"></i>
                     </span>
 
-                    <span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M2.png')" role="img" alt="Maria Berrigton" title="Maria Berrigton"></span>
+                    <span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M2.png')" role="img" alt="Portrait of Maria Berrigton"></span>
 
-                    <span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" role="img" aria-label="Andy Wallace" title="Andy Wallace">AW</span>
+                    <span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" role="img" aria-label="Andy Wallace">AW</span>
 
-                    <span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" role="img" aria-label="John Carter" title="John Carter">
+                    <span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" role="img" aria-label="John Carter">
                         <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation"></i>
                     </span>
 
-                    <span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_F3.png')" role="img" alt="Brian Tracey" title="Brian Tracey"></span>
+                    <span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_F3.png')" role="img" alt="Portrait of Brian Tracey"></span>
 
-                    <span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" role="img" aria-label="Jared Moe" title="Jared Moe">JM</span>
+                    <span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" role="img" aria-label="Jared Moe">JM</span>
 
-                    <span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" role="img" aria-label="Ben Bloggs" title="Ben Bloggs">BB</span>
+                    <span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" role="img" aria-label="Ben Bloggs">BB</span>
 
-                    <span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" role="img" aria-label="Simon Swan" title="Simon Swan">
+                    <span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" role="img" aria-label="Simon Swan">
                         <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation"></i>
                     </span>
 
-                    <span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_F4.png')" role="img" alt="Mike Simons" title="Mike Simons"></span>
+                    <span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_F4.png')" role="img" alt="Portrait of Mike Simons"></span>
 
-                    <span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" role="img" aria-label="Fred Bloggs" title="Fred Bloggs">FB</span>
+                    <span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" role="img" aria-label="Fred Bloggs">FB</span>
 
-                    <span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" role="img" aria-label="Cameran Alleman" title="Cameran Alleman">CA</span>
+                    <span class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" role="img" aria-label="Cameran Alleman">CA</span>
                 </div>
             </div>
         </div>
@@ -119,37 +115,32 @@
     <span 
         class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--border" 
         role="img" 
-        aria-label="Wendy Wallace" 
-        title="Wendy Wallace">WW
+        aria-label="Wendy Wallace">WW
     </span>
     
     <span 
         class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--border" 
         role="img" 
-        aria-label="Simon Drew" 
-        title="Simon Drew">
+        aria-label="Simon Drew">
             <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
     </span>
     
     <span 
         class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" 
         role="img" 
-        alt="Brad Coehn" 
-        title="Brad Coehn">
+        alt="Portrait of Brad Coehn">
     </span>
     
     <span 
         class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--border" 
         role="img" 
-        aria-label="Endy Wallace" 
-        title="Endy Wallace">EW
+        aria-label="Endy Wallace">EW
     </span>
     
     <span 
         class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--border" 
         role="img" 
-        aria-label="Whitney Copper" 
-        title="Whitney Copper">
+        aria-label="Whitney Copper">
             <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
     </span>
     
@@ -157,8 +148,7 @@
         class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" 
         style="background-image: url('/assets/images/portraits/L_80x80_M2.png')" 
         role="img" 
-        alt="John Doe" 
-        title="John Doe">
+        alt="Portrait of John Doe">
     </span>
 
     <span 
@@ -174,37 +164,32 @@
     <span 
         class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border" 
         role="img" 
-        aria-label="Wendy Wallace" 
-        title="Wendy Wallace">WW
+        aria-label="Wendy Wallace">WW
     </span>
     
     <span 
         class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border" 
         role="img" 
-        aria-label="Simon Drew" 
-        title="Simon Drew">
+        aria-label="Simon Drew">
             <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
     </span>
     
     <span 
         class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" 
         role="img" 
-        alt="Brad Coehn" 
-        title="Brad Coehn">
+        alt="Portrait of Brad Coehn">
     </span>
     
     <span 
         class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border" 
         role="img" 
-        aria-label="Endy Wallace" 
-        title="Endy Wallace">EW
+        aria-label="Endy Wallace">EW
     </span>
     
     <span 
         class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border" 
         role="img" 
-        aria-label="Whitney Copper" 
-        title="Whitney Copper">
+        aria-label="Whitney Copper">
             <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
     </span>
     
@@ -212,8 +197,7 @@
         class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" 
         style="background-image: url('/assets/images/portraits/L_80x80_M2.png')" 
         role="img" 
-        alt="John Doe" 
-        title="John Doe">
+        alt="Portrait of John Doe">
     </span>
 
     <span 
@@ -229,37 +213,32 @@
     <span 
         class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" 
         role="img" 
-        aria-label="Wendy Wallace" 
-        title="Wendy Wallace">WW
+        aria-label="Wendy Wallace">WW
     </span>
     
     <span 
         class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" 
         role="img" 
-        aria-label="Simon Drew" 
-        title="Simon Drew">
+        aria-label="Simon Drew">
             <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
     </span>
     
     <span 
         class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" 
         role="img" 
-        alt="Brad Coehn" 
-        title="Brad Coehn">
+        alt="Portrait of Brad Coehn">
     </span>
     
     <span 
         class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" 
         role="img" 
-        aria-label="Endy Wallace" 
-        title="Endy Wallace">EW
+        aria-label="Endy Wallace">EW
     </span>
     
     <span 
         class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border" 
         role="img" 
-        aria-label="Whitney Copper" 
-        title="Whitney Copper">
+        aria-label="Whitney Copper">
             <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
     </span>
     
@@ -267,8 +246,7 @@
         class="fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" 
         style="background-image: url('/assets/images/portraits/L_80x80_M2.png')" 
         role="img" 
-        alt="John Doe" 
-        title="John Doe">
+        alt="Portrait of John Doe">
     </span>
 
     <span 
@@ -284,37 +262,32 @@
     <span 
         class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border" 
         role="img" 
-        aria-label="Wendy Wallace" 
-        title="Wendy Wallace">WW
+        aria-label="Wendy Wallace">WW
     </span>
     
     <span 
         class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border" 
         role="img" 
-        aria-label="Simon Drew" 
-        title="Simon Drew">
+        aria-label="Simon Drew">
             <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
     </span>
     
     <span 
         class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" 
         role="img" 
-        alt="Brad Coehn" 
-        title="Brad Coehn">
+        alt="Portrait of Brad Coehn">
     </span>
     
     <span 
         class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border" 
         role="img" 
-        aria-label="Endy Wallace" 
-        title="Endy Wallace">EW
+        aria-label="Endy Wallace">EW
     </span>
     
     <span 
         class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border" 
         role="img" 
-        aria-label="Whitney Copper" 
-        title="Whitney Copper">
+        aria-label="Whitney Copper">
             <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
     </span>
     
@@ -322,8 +295,7 @@
         class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" 
         style="background-image: url('/assets/images/portraits/L_80x80_M2.png')" 
         role="img" 
-        alt="John Doe" 
-        title="John Doe">
+        alt="Portrait of John Doe">
     </span>
 
     <span 
@@ -340,37 +312,32 @@
     <span 
         class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--border" 
         role="img" 
-        aria-label="Wendy Wallace" 
-        title="Wendy Wallace">WW
+        aria-label="Wendy Wallace">WW
     </span>
     
     <span 
         class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--border" 
         role="img" 
-        aria-label="Simon Drew" 
-        title="Simon Drew">
+        aria-label="Simon Drew">
             <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
     </span>
     
     <span 
         class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" 
         role="img" 
-        alt="Brad Coehn" 
-        title="Brad Coehn">
+        alt="Portrait of Brad Coehn">
     </span>
     
     <span 
         class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--border" 
         role="img" 
-        aria-label="Endy Wallace" 
-        title="Endy Wallace">EW
+        aria-label="Endy Wallace">EW
     </span>
     
     <span 
         class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--border" 
         role="img" 
-        aria-label="Whitney Copper" 
-        title="Whitney Copper">
+        aria-label="Whitney Copper">
             <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
     </span>
     
@@ -378,8 +345,7 @@
         class="fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" 
         style="background-image: url('/assets/images/portraits/L_80x80_M2.png')" 
         role="img" 
-        alt="John Doe" 
-        title="John Doe">
+        alt="Portrait of John Doe">
     </span>
 
     <span 

--- a/packages/styles/stories/Components/avatar-group/individual-type-vertical.example.html
+++ b/packages/styles/stories/Components/avatar-group/individual-type-vertical.example.html
@@ -8,7 +8,7 @@
                     <span 
                         class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border" 
                         role="button" 
-                        aria-label="Jason Smith" 
+                        aria-label="Avatar Jason Smith" 
                         title="Jason Smith" 
                         tabindex="0" 
                         aria-haspopup="true" 
@@ -20,7 +20,9 @@
                     <div class="fd-quick-view">
                         <div class="fd-bar fd-bar--header">
                             <div class="fd-bar__middle">
-                                <div class="fd-bar__element">Business Card</div>
+                                <div class="fd-bar__element">
+                                    <h1 class="fd-title fd-title--h5">Business Card</h1>
+                                </div>
                             </div>
                         </div>
     
@@ -30,18 +32,17 @@
                                     <span 
                                         class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border" 
                                         role="img" 
-                                        aria-label="Jason Smith" 
-                                        title="Jason Smith">JS
+                                        aria-label="Avatar Jason Smith">JS
                                     </span>
                                     <div class="fd-quick-view__subheader-text">
                                         <h5 class="fd-title fd-title--h5">Jason Smith</h5>
-                                        <div class="fd-quick-view__subtitle">Marketing Manager</div>
+                                        <p class="fd-quick-view__subtitle">Marketing Manager</p>
                                     </div>
                                 </div>
                             </div>
                             <div class="fd-form-group" role="group">
                                 <div class="fd-form-group__header" aria-labelledby="contactDetails_5z28edb-v">
-                                    <h1 class="fd-form-group__header-text" id="contactDetails_5z28edb-v">Contact Details</h1>
+                                    <p id="contactDetails_5z28edb-v">Contact Details</p>
                                 </div>
                                 <div class="fd-form-item">
                                     <label class="fd-form-label">Mobile</label>
@@ -65,7 +66,7 @@
                     <span 
                         class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border" 
                         role="button" 
-                        aria-label="Sarah Parker" 
+                        aria-label="Avatar Sarah Parker" 
                         title="Sarah Parker" 
                         tabindex="0" 
                         aria-haspopup="true" 
@@ -78,23 +79,25 @@
                     <div class="fd-quick-view">
                         <div class="fd-bar fd-bar--header">
                             <div class="fd-bar__middle">
-                                <div class="fd-bar__element">Business Card</div>
+                                <div class="fd-bar__element">
+                                    <h1 class="fd-title fd-title--h5">Business Card</h1>
+                                </div>
                             </div>
                         </div>
     
                         <div class="fd-quick-view__content">
                             <div class="fd-bar fd-bar--header-with-subheader">
                                 <div class="fd-bar__left">
-                                    <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border" role="img" aria-label="Sarah Parker" title="Sarah Parker">SP</span>
+                                    <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border" role="img" aria-label="Avatar Sarah Parker">SP</span>
                                     <div class="fd-quick-view__subheader-text">
                                         <h5 class="fd-title fd-title--h5">Sarah Parker</h5>
-                                        <div class="fd-quick-view__subtitle">Visual Designer</div>
+                                        <p class="fd-quick-view__subtitle">Visual Designer</p>
                                     </div>
                                 </div>
                             </div>
                             <div class="fd-form-group" role="group">
                                 <div class="fd-form-group__header" aria-labelledby="contactDetails_spbw4q-v">
-                                    <h1 class="fd-form-group__header-text" id="contactDetails_spbw4q-v">Contact Details</h1>
+                                    <p class="fd-form-group__header-text" id="contactDetails_spbw4q-v">Contact Details</p>
                                 </div>
                                 <div class="fd-form-item">
                                     <label class="fd-form-label">Mobile</label>
@@ -118,7 +121,8 @@
                     <span 
                         class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" 
                         role="button" 
-                        aria-label="Christian Bow" 
+                        alt="Portrait of Christian Bow"
+                        aria-label="Avatar Christian Bow" 
                         title="Christian Bow" 
                         tabindex="0" 
                         aria-haspopup="true" 
@@ -130,23 +134,25 @@
                     <div class="fd-quick-view">
                         <div class="fd-bar fd-bar--header">
                             <div class="fd-bar__middle">
-                                <div class="fd-bar__element">Business Card</div>
+                                <div class="fd-bar__element">
+                                <h1 class="fd-title fd-title--h5">Business Card</h1>
+                            </div>
                             </div>
                         </div>
     
                         <div class="fd-quick-view__content">
                             <div class="fd-bar fd-bar--header-with-subheader">
                                 <div class="fd-bar__left">
-                                    <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" role="img" alt="Christian Bow" title="Christian Bow"></span>
+                                    <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" role="img" alt="Portrait of Christian Bow"></span>
                                     <div class="fd-quick-view__subheader-text">
                                         <h5 class="fd-title fd-title--h5">Christian Bow</h5>
-                                        <div class="fd-quick-view__subtitle">Marketing Manager</div>
+                                        <p class="fd-quick-view__subtitle">Marketing Manager</p>
                                     </div>
                                 </div>
                             </div>
                             <div class="fd-form-group" role="group">
                                 <div class="fd-form-group__header" aria-labelledby="contactDetails_4ahzcg-v">
-                                    <h1 class="fd-form-group__header-text" id="contactDetails_4ahzcg-v">Contact Details</h1>
+                                    <p id="contactDetails_4ahzcg-v">Contact Details</p>
                                 </div>
                                 <div class="fd-form-item">
                                     <label class="fd-form-label">Mobile</label>
@@ -170,7 +176,7 @@
                     <span 
                         class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border" 
                         role="button" 
-                        aria-label="Endy Wallace" 
+                        aria-label="Avatar Endy Wallace" 
                         title="Endy Wallace" 
                         tabindex="0" 
                         aria-haspopup="true" 
@@ -182,23 +188,25 @@
                     <div class="fd-quick-view">
                         <div class="fd-bar fd-bar--header">
                             <div class="fd-bar__middle">
-                                <div class="fd-bar__element">Business Card</div>
+                                <div class="fd-bar__element">
+                                <h1 class="fd-title fd-title--h5">Business Card</h1>
+                            </div>
                             </div>
                         </div>
     
                         <div class="fd-quick-view__content">
                             <div class="fd-bar fd-bar--header-with-subheader">
                                 <div class="fd-bar__left">
-                                    <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border" role="img" aria-label="Endy Wallace" title="Endy Wallace">EW</span>
+                                    <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border" role="img" aria-label="Avatar Endy Wallace">EW</span>
                                     <div class="fd-quick-view__subheader-text">
                                         <h5 class="fd-title fd-title--h5">Endy Wallace</h5>
-                                        <div class="fd-quick-view__subtitle">Software Developer</div>
+                                        <p class="fd-quick-view__subtitle">Software Developer</p>
                                     </div>
                                 </div>
                             </div>
                             <div class="fd-form-group" role="group">
                                 <div class="fd-form-group__header" aria-labelledby="contactDetails_qc1f1jf-v">
-                                    <h1 class="fd-form-group__header-text" id="contactDetails_qc1f1jf-v">Contact Details</h1>
+                                    <p id="contactDetails_qc1f1jf-v">Contact Details</p>
                                 </div>
                                 <div class="fd-form-item">
                                     <label class="fd-form-label">Mobile</label>
@@ -235,7 +243,9 @@
                         <div class="fd-popover__body-header">
                             <div class="fd-bar fd-bar--header">
                                 <div class="fd-bar__middle">
-                                    <div class="fd-bar__element">Team Members (4)</div>
+                                    <div class="fd-bar__element">
+                                        <h1 class="fd-title fd-title--h5">Team Members (4)</h1>
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -244,7 +254,7 @@
                             <span 
                                 class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border" 
                                 role="button" 
-                                aria-label="Gordon Smith" 
+                                aria-label="Avatar Gordon Smith" 
                                 title="Gordon Smith"
                                 tabindex="0">
                                 <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
@@ -254,7 +264,7 @@
                                 class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" 
                                 style="background-image: url('/assets/images/portraits/L_80x80_M2.png')" 
                                 role="button" 
-                                alt="Adam Doe" 
+                                alt="Portrait of Adam Doe" 
                                 title="Adam Doe" 
                                 tabindex="0">
                             </span>
@@ -262,7 +272,7 @@
                             <span 
                                 class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border" 
                                 role="button" 
-                                aria-label="Mandy Moore" 
+                                aria-label="Avatar Mandy Moore" 
                                 title="Mandy Moore" 
                                 tabindex="0">JM
                             </span>
@@ -270,7 +280,7 @@
                             <span 
                                 class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border" 
                                 role="button" 
-                                aria-label="Jimi Bloggs" 
+                                aria-label="Avatar Jimi Bloggs" 
                                 title="Jimi Bloggs" 
                                 tabindex="0">JB
                             </span>

--- a/packages/styles/stories/Components/avatar-group/individual-type.example.html
+++ b/packages/styles/stories/Components/avatar-group/individual-type.example.html
@@ -4,8 +4,7 @@
             <div class="fd-popover__control">
                 <span 
                     class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border" 
-                    role="button" 
-                    aria-label="Jason Smith" 
+                    aria-label="Avatar Jason Smith" 
                     title="Jason Smith" 
                     tabindex="0" 
                     aria-haspopup="true" 
@@ -17,7 +16,9 @@
                 <div class="fd-quick-view">
                     <div class="fd-bar fd-bar--header">
                         <div class="fd-bar__middle">
-                            <div class="fd-bar__element">Business Card</div>
+                            <div class="fd-bar__element">
+                                <h1 class="fd-title fd-title--h5">Business Card</h1>
+                            </div>
                         </div>
                     </div>
 
@@ -27,18 +28,18 @@
                                 <span 
                                     class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border" 
                                     role="img" 
-                                    aria-label="Jason Smith" 
-                                    title="Jason Smith">JS
+                                    aria-label="Avatar Jason Smith">
+                                    JS
                                 </span>
                                 <div class="fd-quick-view__subheader-text">
                                     <h5 class="fd-title fd-title--h5">Jason Smith</h5>
-                                    <div class="fd-quick-view__subtitle">Marketing Manager</div>
+                                    <p class="fd-quick-view__subtitle">Marketing Manager</p>
                                 </div>
                             </div>
                         </div>
                         <div class="fd-form-group" role="group">
                             <div class="fd-form-group__header" aria-labelledby="contactDetails_5z28edb">
-                                <h1 class="fd-form-group__header-text" id="contactDetails_5z28edb">Contact Details</h1>
+                                <p class="fd-form-group__header-text" id="contactDetails_5z28edb">Contact Details</p>
                             </div>
                             <div class="fd-form-item">
                                 <label class="fd-form-label">Mobile</label>
@@ -62,7 +63,7 @@
                 <span 
                     class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border" 
                     role="button" 
-                    aria-label="Sarah Parker" 
+                    aria-label="Avatar Sarah Parker" 
                     title="Sarah Parker" 
                     tabindex="0" 
                     aria-haspopup="true" 
@@ -75,23 +76,25 @@
                 <div class="fd-quick-view">
                     <div class="fd-bar fd-bar--header">
                         <div class="fd-bar__middle">
-                            <div class="fd-bar__element">Business Card</div>
+                            <div class="fd-bar__element">
+                                <h1 class="fd-title fd-title--h5">Business Card</h1>
+                            </div>
                         </div>
                     </div>
 
                     <div class="fd-quick-view__content">
                         <div class="fd-bar fd-bar--header-with-subheader">
                             <div class="fd-bar__left">
-                                <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border" role="img" aria-label="Wendy Wallace" title="Wendy Wallace">WW</span>
+                                <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border" role="img" aria-label="Avatar Wendy Wallace" title="Wendy Wallace">WW</span>
                                 <div class="fd-quick-view__subheader-text">
                                     <h5 class="fd-title fd-title--h5">Sarah Parker</h5>
-                                    <div class="fd-quick-view__subtitle">Visual Designer</div>
+                                    <p class="fd-quick-view__subtitle">Visual Designer</p>
                                 </div>
                             </div>
                         </div>
                         <div class="fd-form-group" role="group">
                             <div class="fd-form-group__header" aria-labelledby="contactDetails_spbw4q">
-                                <h1 class="fd-form-group__header-text" id="contactDetails_spbw4q">Contact Details</h1>
+                                <p class="fd-form-group__header-text" id="contactDetails_spbw4q">Contact Details</p>
                             </div>
                             <div class="fd-form-item">
                                 <label class="fd-form-label">Mobile</label>
@@ -115,7 +118,7 @@
                 <span 
                     class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" 
                     role="button" 
-                    aria-label="Christian Bow" 
+                    aria-label="Avatar Christian Bow" 
                     title="Christian Bow" 
                     tabindex="0" 
                     aria-haspopup="true" 
@@ -127,7 +130,9 @@
                 <div class="fd-quick-view">
                     <div class="fd-bar fd-bar--header">
                         <div class="fd-bar__middle">
-                            <div class="fd-bar__element">Business Card</div>
+                            <div class="fd-bar__element">
+                                <h1 class="fd-title fd-title--h5">Business Card</h1>
+                            </div>
                         </div>
                     </div>
 
@@ -137,13 +142,13 @@
                                 <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" role="img" alt="Christian Bow" title="Christian Bow"></span>
                                 <div class="fd-quick-view__subheader-text">
                                     <h5 class="fd-title fd-title--h5">Christian Bow</h5>
-                                    <div class="fd-quick-view__subtitle">Marketing Manager</div>
+                                    <p class="fd-quick-view__subtitle">Marketing Manager</p>
                                 </div>
                             </div>
                         </div>
                         <div class="fd-form-group" role="group">
                             <div class="fd-form-group__header" aria-labelledby="contactDetails_4ahzcg">
-                                <h1 class="fd-form-group__header-text" id="contactDetails_4ahzcg">Contact Details</h1>
+                                <p class="fd-form-group__header-text" id="contactDetails_4ahzcg">Contact Details</p>
                             </div>
                             <div class="fd-form-item">
                                 <label class="fd-form-label">Mobile</label>
@@ -167,7 +172,7 @@
                 <span 
                     class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border" 
                     role="button" 
-                    aria-label="Endy Wallace" 
+                    aria-label="Avatar Endy Wallace" 
                     title="Endy Wallace" 
                     tabindex="0" 
                     aria-haspopup="true" 
@@ -179,23 +184,25 @@
                 <div class="fd-quick-view">
                     <div class="fd-bar fd-bar--header">
                         <div class="fd-bar__middle">
-                            <div class="fd-bar__element">Business Card</div>
+                            <div class="fd-bar__element">
+                                <h1 class="fd-title fd-title--h5">Business Card</h1>
+                            </div>
                         </div>
                     </div>
 
                     <div class="fd-quick-view__content">
                         <div class="fd-bar fd-bar--header-with-subheader">
                             <div class="fd-bar__left">
-                                <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border" role="img" aria-label="Endy Wallace" title="Endy Wallace">EW</span>
+                                <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border" role="img" aria-label="Avatar Endy Wallace" title="Endy Wallace">EW</span>
                                 <div class="fd-quick-view__subheader-text">
                                     <h5 class="fd-title fd-title--h5">Endy Wallace</h5>
-                                    <div class="fd-quick-view__subtitle">Software Developer</div>
+                                    <p class="fd-quick-view__subtitle">Software Developer</p>
                                 </div>
                             </div>
                         </div>
                         <div class="fd-form-group" role="group">
                             <div class="fd-form-group__header" aria-labelledby="contactDetails_qc1f1jf">
-                                <h1 class="fd-form-group__header-text" id="contactDetails_qc1f1jf">Contact Details</h1>
+                                <p class="fd-form-group__header-text" id="contactDetails_qc1f1jf">Contact Details</p>
                             </div>
                             <div class="fd-form-item">
                                 <label class="fd-form-label">Mobile</label>
@@ -232,7 +239,9 @@
                     <div class="fd-popover__body-header">
                         <div class="fd-bar fd-bar--header">
                             <div class="fd-bar__middle">
-                                <div class="fd-bar__element">Team Members (4)</div>
+                                <div class="fd-bar__element">
+                                    <h1 class="fd-title fd-title--h5">Team Members (4)</h1>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -241,7 +250,7 @@
                         <span 
                             class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border" 
                             role="button" 
-                            aria-label="Gordon Smith" 
+                            aria-label="Avatar Gordon Smith" 
                             title="Gordon Smith"
                             tabindex="0">
                             <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
@@ -259,7 +268,7 @@
                         <span 
                             class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border" 
                             role="button" 
-                            aria-label="John Moe" 
+                            aria-label="Avatar John Moe" 
                             title="John Moe" 
                             tabindex="0">JM
                         </span>
@@ -267,7 +276,7 @@
                         <span 
                             class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border" 
                             role="button" 
-                            aria-label="Joe Bloggs" 
+                            aria-label="Avatar Joe Bloggs" 
                             title="Joe Bloggs" 
                             tabindex="0">JB
                         </span>

--- a/packages/styles/stories/Components/avatar-group/overflow.example.html
+++ b/packages/styles/stories/Components/avatar-group/overflow.example.html
@@ -28,7 +28,7 @@
                 <span 
                     class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" 
                     role="button" 
-                    alt="Christian Bow" 
+                    alt="Portrait of Christian Bow" 
                     title="Christian Bow"
                     tabindex="0">
                 </span>
@@ -85,7 +85,7 @@
                 <span 
                     class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" 
                     role="button" 
-                    alt="Christian Bow" 
+                    alt="Portrait of Christian Bow" 
                     title="Christian Bow"
                     tabindex="0">
                 </span>
@@ -141,7 +141,7 @@
                 <span 
                     class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" 
                     role="button" 
-                    alt="Christian Bow" 
+                    alt="Portrait of Christian Bow" 
                     title="Christian Bow"
                     tabindex="0">
                 </span>
@@ -197,7 +197,7 @@
                 <span 
                     class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" 
                     role="button" 
-                    alt="Christian Bow" 
+                    alt="Portrait of Christian Bow" 
                     title="Christian Bow"
                     tabindex="0">
                 </span>

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -7614,37 +7614,32 @@ exports[`Check stories > Components/Avatar Group > Story GroupType > Should matc
                 <span 
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" 
                     role=\\"img\\" 
-                    aria-label=\\"Wendy Wallace\\" 
-                    title=\\"Wendy Wallace\\">WW
+                    aria-label=\\"Wendy Wallace\\">WW
                 </span>
                 
                 <span 
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" 
                     role=\\"img\\" 
-                    aria-label=\\"Simon Drew\\" 
-                    title=\\"Simon Drew\\">
+                    aria-label=\\"Simon Drew\\">
                         <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
                 </span>
                 
                 <span 
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" 
                     role=\\"img\\" 
-                    alt=\\"Brad Coehn\\" 
-                    title=\\"Brad Coehn\\">
+                    alt=\\"Portrait of Brad Coehn\\">
                 </span>
                 
                 <span 
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" 
                     role=\\"img\\" 
-                    aria-label=\\"Endy Wallace\\" 
-                    title=\\"Endy Wallace\\">EW
+                    aria-label=\\"Endy Wallace\\">EW
                 </span>
                 
                 <span 
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" 
                     role=\\"img\\" 
-                    aria-label=\\"Whitney Copper\\" 
-                    title=\\"Whitney Copper\\">
+                    aria-label=\\"Whitney Copper\\">
                         <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
                 </span>
                 
@@ -7652,8 +7647,7 @@ exports[`Check stories > Components/Avatar Group > Story GroupType > Should matc
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" 
                     style=\\"background-image: url('/assets/images/portraits/L_80x80_M2.png')\\" 
                     role=\\"img\\" 
-                    alt=\\"John Doe\\" 
-                    title=\\"John Doe\\">
+                    alt=\\"Portrait of John Doe\\">
                 </span>
 
                 <span 
@@ -7669,48 +7663,50 @@ exports[`Check stories > Components/Avatar Group > Story GroupType > Should matc
                 <div class=\\"fd-popover__body-header\\">
                     <div class=\\"fd-bar fd-bar--header\\">
                         <div class=\\"fd-bar__middle\\">
-                            <div class=\\"fd-bar__element\\">Team Members (14)</div>
+                            <div class=\\"fd-bar__element\\">
+                                <h1 class=\\"fd-title fd-title--h5\\">Team Members (14)</h1>
+                            </div>
                         </div>
                     </div>
                 </div>
                 <div class=\\"fd-avatar-group__overflow-body\\">
-                    <span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Wendy Wallace\\" title=\\"Wendy Wallace\\">WW</span>
+                    <span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Wendy Wallace\\">WW</span>
                     
-                    <span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Sarah Smith\\" title=\\"Sarah Smith\\">
+                    <span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Sarah Smith\\">
                         <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\"></i>
                     </span>
                     
-                    <span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" role=\\"img\\" alt=\\"Alex Cardigan\\" title=\\"Alex Cardigan\\"></span>
+                    <span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" role=\\"img\\" alt=\\"Portrait of Alex Cardigan\\"></span>
 
-                    <span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Endy Wallace\\" title=\\"Endy Wallace\\">EW</span>
+                    <span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Endy Wallace\\">EW</span>
 
-                    <span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Whitney Bow\\" title=\\"Whitney Bow\\">
+                    <span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Whitney Bow\\">
                         <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\"></i>
                     </span>
 
-                    <span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M2.png')\\" role=\\"img\\" alt=\\"Maria Berrigton\\" title=\\"Maria Berrigton\\"></span>
+                    <span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M2.png')\\" role=\\"img\\" alt=\\"Portrait of Maria Berrigton\\"></span>
 
-                    <span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Andy Wallace\\" title=\\"Andy Wallace\\">AW</span>
+                    <span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Andy Wallace\\">AW</span>
 
-                    <span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"John Carter\\" title=\\"John Carter\\">
+                    <span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"John Carter\\">
                         <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\"></i>
                     </span>
 
-                    <span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_F3.png')\\" role=\\"img\\" alt=\\"Brian Tracey\\" title=\\"Brian Tracey\\"></span>
+                    <span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_F3.png')\\" role=\\"img\\" alt=\\"Portrait of Brian Tracey\\"></span>
 
-                    <span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Jared Moe\\" title=\\"Jared Moe\\">JM</span>
+                    <span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Jared Moe\\">JM</span>
 
-                    <span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Ben Bloggs\\" title=\\"Ben Bloggs\\">BB</span>
+                    <span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Ben Bloggs\\">BB</span>
 
-                    <span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Simon Swan\\" title=\\"Simon Swan\\">
+                    <span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Simon Swan\\">
                         <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\"></i>
                     </span>
 
-                    <span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_F4.png')\\" role=\\"img\\" alt=\\"Mike Simons\\" title=\\"Mike Simons\\"></span>
+                    <span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_F4.png')\\" role=\\"img\\" alt=\\"Portrait of Mike Simons\\"></span>
 
-                    <span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Fred Bloggs\\" title=\\"Fred Bloggs\\">FB</span>
+                    <span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Fred Bloggs\\">FB</span>
 
-                    <span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Cameran Alleman\\" title=\\"Cameran Alleman\\">CA</span>
+                    <span class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Cameran Alleman\\">CA</span>
                 </div>
             </div>
         </div>
@@ -7722,37 +7718,32 @@ exports[`Check stories > Components/Avatar Group > Story GroupType > Should matc
     <span 
         class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--border\\" 
         role=\\"img\\" 
-        aria-label=\\"Wendy Wallace\\" 
-        title=\\"Wendy Wallace\\">WW
+        aria-label=\\"Wendy Wallace\\">WW
     </span>
     
     <span 
         class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--border\\" 
         role=\\"img\\" 
-        aria-label=\\"Simon Drew\\" 
-        title=\\"Simon Drew\\">
+        aria-label=\\"Simon Drew\\">
             <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
     </span>
     
     <span 
         class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" 
         role=\\"img\\" 
-        alt=\\"Brad Coehn\\" 
-        title=\\"Brad Coehn\\">
+        alt=\\"Portrait of Brad Coehn\\">
     </span>
     
     <span 
         class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--border\\" 
         role=\\"img\\" 
-        aria-label=\\"Endy Wallace\\" 
-        title=\\"Endy Wallace\\">EW
+        aria-label=\\"Endy Wallace\\">EW
     </span>
     
     <span 
         class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--border\\" 
         role=\\"img\\" 
-        aria-label=\\"Whitney Copper\\" 
-        title=\\"Whitney Copper\\">
+        aria-label=\\"Whitney Copper\\">
             <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
     </span>
     
@@ -7760,8 +7751,7 @@ exports[`Check stories > Components/Avatar Group > Story GroupType > Should matc
         class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" 
         style=\\"background-image: url('/assets/images/portraits/L_80x80_M2.png')\\" 
         role=\\"img\\" 
-        alt=\\"John Doe\\" 
-        title=\\"John Doe\\">
+        alt=\\"Portrait of John Doe\\">
     </span>
 
     <span 
@@ -7777,37 +7767,32 @@ exports[`Check stories > Components/Avatar Group > Story GroupType > Should matc
     <span 
         class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border\\" 
         role=\\"img\\" 
-        aria-label=\\"Wendy Wallace\\" 
-        title=\\"Wendy Wallace\\">WW
+        aria-label=\\"Wendy Wallace\\">WW
     </span>
     
     <span 
         class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border\\" 
         role=\\"img\\" 
-        aria-label=\\"Simon Drew\\" 
-        title=\\"Simon Drew\\">
+        aria-label=\\"Simon Drew\\">
             <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
     </span>
     
     <span 
         class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" 
         role=\\"img\\" 
-        alt=\\"Brad Coehn\\" 
-        title=\\"Brad Coehn\\">
+        alt=\\"Portrait of Brad Coehn\\">
     </span>
     
     <span 
         class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border\\" 
         role=\\"img\\" 
-        aria-label=\\"Endy Wallace\\" 
-        title=\\"Endy Wallace\\">EW
+        aria-label=\\"Endy Wallace\\">EW
     </span>
     
     <span 
         class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border\\" 
         role=\\"img\\" 
-        aria-label=\\"Whitney Copper\\" 
-        title=\\"Whitney Copper\\">
+        aria-label=\\"Whitney Copper\\">
             <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
     </span>
     
@@ -7815,8 +7800,7 @@ exports[`Check stories > Components/Avatar Group > Story GroupType > Should matc
         class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" 
         style=\\"background-image: url('/assets/images/portraits/L_80x80_M2.png')\\" 
         role=\\"img\\" 
-        alt=\\"John Doe\\" 
-        title=\\"John Doe\\">
+        alt=\\"Portrait of John Doe\\">
     </span>
 
     <span 
@@ -7832,37 +7816,32 @@ exports[`Check stories > Components/Avatar Group > Story GroupType > Should matc
     <span 
         class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" 
         role=\\"img\\" 
-        aria-label=\\"Wendy Wallace\\" 
-        title=\\"Wendy Wallace\\">WW
+        aria-label=\\"Wendy Wallace\\">WW
     </span>
     
     <span 
         class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" 
         role=\\"img\\" 
-        aria-label=\\"Simon Drew\\" 
-        title=\\"Simon Drew\\">
+        aria-label=\\"Simon Drew\\">
             <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
     </span>
     
     <span 
         class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" 
         role=\\"img\\" 
-        alt=\\"Brad Coehn\\" 
-        title=\\"Brad Coehn\\">
+        alt=\\"Portrait of Brad Coehn\\">
     </span>
     
     <span 
         class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" 
         role=\\"img\\" 
-        aria-label=\\"Endy Wallace\\" 
-        title=\\"Endy Wallace\\">EW
+        aria-label=\\"Endy Wallace\\">EW
     </span>
     
     <span 
         class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" 
         role=\\"img\\" 
-        aria-label=\\"Whitney Copper\\" 
-        title=\\"Whitney Copper\\">
+        aria-label=\\"Whitney Copper\\">
             <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
     </span>
     
@@ -7870,8 +7849,7 @@ exports[`Check stories > Components/Avatar Group > Story GroupType > Should matc
         class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" 
         style=\\"background-image: url('/assets/images/portraits/L_80x80_M2.png')\\" 
         role=\\"img\\" 
-        alt=\\"John Doe\\" 
-        title=\\"John Doe\\">
+        alt=\\"Portrait of John Doe\\">
     </span>
 
     <span 
@@ -7887,37 +7865,32 @@ exports[`Check stories > Components/Avatar Group > Story GroupType > Should matc
     <span 
         class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border\\" 
         role=\\"img\\" 
-        aria-label=\\"Wendy Wallace\\" 
-        title=\\"Wendy Wallace\\">WW
+        aria-label=\\"Wendy Wallace\\">WW
     </span>
     
     <span 
         class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border\\" 
         role=\\"img\\" 
-        aria-label=\\"Simon Drew\\" 
-        title=\\"Simon Drew\\">
+        aria-label=\\"Simon Drew\\">
             <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
     </span>
     
     <span 
         class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" 
         role=\\"img\\" 
-        alt=\\"Brad Coehn\\" 
-        title=\\"Brad Coehn\\">
+        alt=\\"Portrait of Brad Coehn\\">
     </span>
     
     <span 
         class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border\\" 
         role=\\"img\\" 
-        aria-label=\\"Endy Wallace\\" 
-        title=\\"Endy Wallace\\">EW
+        aria-label=\\"Endy Wallace\\">EW
     </span>
     
     <span 
         class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border\\" 
         role=\\"img\\" 
-        aria-label=\\"Whitney Copper\\" 
-        title=\\"Whitney Copper\\">
+        aria-label=\\"Whitney Copper\\">
             <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
     </span>
     
@@ -7925,8 +7898,7 @@ exports[`Check stories > Components/Avatar Group > Story GroupType > Should matc
         class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" 
         style=\\"background-image: url('/assets/images/portraits/L_80x80_M2.png')\\" 
         role=\\"img\\" 
-        alt=\\"John Doe\\" 
-        title=\\"John Doe\\">
+        alt=\\"Portrait of John Doe\\">
     </span>
 
     <span 
@@ -7943,37 +7915,32 @@ exports[`Check stories > Components/Avatar Group > Story GroupType > Should matc
     <span 
         class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--border\\" 
         role=\\"img\\" 
-        aria-label=\\"Wendy Wallace\\" 
-        title=\\"Wendy Wallace\\">WW
+        aria-label=\\"Wendy Wallace\\">WW
     </span>
     
     <span 
         class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--border\\" 
         role=\\"img\\" 
-        aria-label=\\"Simon Drew\\" 
-        title=\\"Simon Drew\\">
+        aria-label=\\"Simon Drew\\">
             <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
     </span>
     
     <span 
         class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" 
         role=\\"img\\" 
-        alt=\\"Brad Coehn\\" 
-        title=\\"Brad Coehn\\">
+        alt=\\"Portrait of Brad Coehn\\">
     </span>
     
     <span 
         class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--border\\" 
         role=\\"img\\" 
-        aria-label=\\"Endy Wallace\\" 
-        title=\\"Endy Wallace\\">EW
+        aria-label=\\"Endy Wallace\\">EW
     </span>
     
     <span 
         class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--border\\" 
         role=\\"img\\" 
-        aria-label=\\"Whitney Copper\\" 
-        title=\\"Whitney Copper\\">
+        aria-label=\\"Whitney Copper\\">
             <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
     </span>
     
@@ -7981,8 +7948,7 @@ exports[`Check stories > Components/Avatar Group > Story GroupType > Should matc
         class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" 
         style=\\"background-image: url('/assets/images/portraits/L_80x80_M2.png')\\" 
         role=\\"img\\" 
-        alt=\\"John Doe\\" 
-        title=\\"John Doe\\">
+        alt=\\"Portrait of John Doe\\">
     </span>
 
     <span 
@@ -8000,42 +7966,37 @@ exports[`Check stories > Components/Avatar Group > Story GroupTypeInteractionSta
         <div class=\\"fd-popover__control fd-avatar-group__popover-control\\"
             role=\\"button\\"
             tabindex=\\"0\\"
-            aria-label=\\"Avatar Group\\">
+            aria-label=\\"Conjoined avatars. 6 displayed, 8 hidden. Activate for complete list.\\">
             <div class=\\"fd-avatar-group fd-avatar-group--group-type fd-avatar-group--md\\">
                 <span 
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--accent-color-1\\" 
                     role=\\"img\\" 
-                    aria-label=\\"Wendy Wallace\\" 
-                    title=\\"Wendy Wallace\\">WW
+                    aria-label=\\"Wendy Wallace\\">WW
                 </span>
                 
                 <span 
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--accent-color-2\\" 
                     role=\\"img\\" 
-                    aria-label=\\"Simon Doe\\" 
-                    title=\\"Simon Doe\\">
+                    aria-label=\\"Simon Doe\\">
                         <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
                 </span>
                 
                 <span 
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" 
                     role=\\"img\\" 
-                    alt=\\"Ben Johnson\\" 
-                    title=\\"Ben Johnson\\">
+                    alt=\\"Portrait of Ben Johnson\\">
                 </span>
                 
                 <span 
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--accent-color-3\\" 
                     role=\\"img\\" 
-                    aria-label=\\"Endy Wallace\\" 
-                    title=\\"Endy Wallace\\">EW
+                    aria-label=\\"Endy Wallace\\">EW
                 </span>
                 
                 <span 
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" 
                     role=\\"img\\" 
-                    aria-label=\\"Whitney Copper\\" 
-                    title=\\"Whitney Copper\\">
+                    aria-label=\\"Whitney Copper\\">
                         <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
                 </span>
                 
@@ -8043,8 +8004,7 @@ exports[`Check stories > Components/Avatar Group > Story GroupTypeInteractionSta
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" 
                     style=\\"background-image: url('/assets/images/portraits/L_80x80_M2.png')\\" 
                     role=\\"img\\" 
-                    alt=\\"Brian Tracey\\" 
-                    title=\\"Brian Tracey\\">
+                    alt=\\"Portrait of Brian Tracey\\">
                 </span>
 
                 <span 
@@ -8061,43 +8021,38 @@ exports[`Check stories > Components/Avatar Group > Story GroupTypeInteractionSta
         <div class=\\"fd-popover__control fd-avatar-group__popover-control\\"
             role=\\"button\\"
             tabindex=\\"0\\"
-            aria-label=\\"Avatar Group\\">
+            aria-label=\\"Conjoined avatars. 6 displayed, 8 hidden. Activate for complete list.\\">
             <div class=\\"fd-avatar-group fd-avatar-group--group-type fd-avatar-group--md is-hover\\">
                
                 <span 
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--accent-color-1\\" 
                     role=\\"img\\" 
-                    aria-label=\\"Wendy Wallace\\" 
-                    title=\\"Wendy Wallace\\">WW
+                    aria-label=\\"Wendy Wallace\\">WW
                 </span>
         
                 <span 
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--accent-color-2\\" 
                     role=\\"img\\" 
-                    aria-label=\\"Simon Doe\\" 
-                    title=\\"Simon Doe\\">
+                    aria-label=\\"Simon Doe\\">
                         <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
                 </span>
                 
                 <span 
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" 
                     role=\\"img\\" 
-                    alt=\\"Ben Johnson\\" 
-                    title=\\"Ben Johnson\\">
+                    alt=\\"Portrait of Ben Johnson\\">
                 </span>
         
                 <span 
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--accent-color-3\\" 
                     role=\\"img\\" 
-                    aria-label=\\"Endy Wallace\\" 
-                    title=\\"Endy Wallace\\">EW
+                    aria-label=\\"Endy Wallace\\">EW
                 </span>
                 
                 <span 
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" 
                     role=\\"img\\" 
-                    aria-label=\\"Whitney Copper\\" 
-                    title=\\"Whitney Copper\\">
+                    aria-label=\\"Whitney Copper\\">
                         <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
                 </span>
         
@@ -8105,8 +8060,7 @@ exports[`Check stories > Components/Avatar Group > Story GroupTypeInteractionSta
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" 
                     style=\\"background-image: url('/assets/images/portraits/L_80x80_M2.png')\\" 
                     role=\\"img\\" 
-                    alt=\\"Brian Tracey\\" 
-                    title=\\"Brian Tracey\\">
+                    alt=\\"Portrait of Brian Tracey\\">
                 </span>
 
                 <span 
@@ -8123,42 +8077,37 @@ exports[`Check stories > Components/Avatar Group > Story GroupTypeInteractionSta
         <div class=\\"fd-popover__control fd-avatar-group__popover-control\\"
             role=\\"button\\"
             tabindex=\\"0\\"
-            aria-label=\\"Avatar Group\\">
+            aria-label=\\"Conjoined avatars. 6 displayed, 8 hidden. Activate for complete list.\\">
             <div class=\\"fd-avatar-group fd-avatar-group--group-type fd-avatar-group--md is-active\\">
                 <span 
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--accent-color-1\\" 
                     role=\\"img\\" 
-                    aria-label=\\"Wendy Wallace\\" 
-                    title=\\"Wendy Wallace\\">WW
+                    aria-label=\\"Wendy Wallace\\">WW
                 </span>
         
                 <span 
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--accent-color-2\\" 
                     role=\\"img\\" 
-                    aria-label=\\"Simon Doe\\" 
-                    title=\\"Simon Doe\\">
+                    aria-label=\\"Simon Doe\\">
                         <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
                 </span>
         
                 <span 
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" 
                     role=\\"img\\" 
-                    alt=\\"Ben Johnson\\" 
-                    title=\\"Ben Johnson\\">
+                    alt=\\"Portrait of Ben Johnson\\">
                 </span>
                 
                 <span 
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--accent-color-3\\" 
                     role=\\"img\\" 
-                    aria-label=\\"Endy Wallace\\" 
-                    title=\\"Endy Wallace\\">EW
+                    aria-label=\\"Endy Wallace\\">EW
                 </span>
         
                 <span 
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" 
                     role=\\"img\\" 
-                    aria-label=\\"Whitney Copper\\" 
-                    title=\\"Whitney Copper\\">
+                    aria-label=\\"Whitney Copper\\">
                         <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
                 </span>
                 
@@ -8166,8 +8115,7 @@ exports[`Check stories > Components/Avatar Group > Story GroupTypeInteractionSta
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" 
                     style=\\"background-image: url('/assets/images/portraits/L_80x80_M2.png')\\" 
                     role=\\"img\\" 
-                    alt=\\"Brian Tracey\\" 
-                    title=\\"Brian Tracey\\">
+                    alt=\\"Portrait of Brian Tracey\\">
                 </span>
 
                 <span 
@@ -8183,43 +8131,37 @@ exports[`Check stories > Components/Avatar Group > Story GroupTypeInteractionSta
     <div class=\\"fd-popover\\">
         <div class=\\"fd-popover__control fd-avatar-group__popover-control\\"
             role=\\"button\\"
-            tabindex=\\"0\\"
-            aria-label=\\"Avatar Group\\">
+            aria-label=\\"Conjoined avatars. 6 displayed, 8 hidden. Activate for complete list.\\">
             <div class=\\"fd-avatar-group fd-avatar-group--group-type fd-avatar-group--md is-disabled\\">
                 <span 
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--accent-color-1\\" 
                     role=\\"img\\" 
-                    aria-label=\\"Wendy Wallace\\" 
-                    title=\\"Wendy Wallace\\">WW
+                    aria-label=\\"Wendy Wallace\\">WW
                 </span>
         
                 <span 
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--accent-color-2\\" 
                     role=\\"img\\" 
-                    aria-label=\\"Simon Doe\\" 
-                    title=\\"Simon Doe\\">
+                    aria-label=\\"Simon Doe\\">
                         <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
                 </span>
                 
                 <span 
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" 
                     role=\\"img\\" 
-                    alt=\\"Ben Johnson\\" 
-                    title=\\"Ben Johnson\\">
+                    alt=\\"Portrait of Ben Johnson\\">
                 </span>
         
                 <span 
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--accent-color-3\\" 
                     role=\\"img\\" 
-                    aria-label=\\"Endy Wallace\\" 
-                    title=\\"Endy Wallace\\">EW
+                    aria-label=\\"Endy Wallace\\">EW
                 </span>
                 
                 <span 
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" 
                     role=\\"img\\" 
-                    aria-label=\\"Whitney Copper\\" 
-                    title=\\"Whitney Copper\\">
+                    aria-label=\\"Whitney Copper\\">
                         <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
                 </span>
                 
@@ -8227,8 +8169,7 @@ exports[`Check stories > Components/Avatar Group > Story GroupTypeInteractionSta
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" 
                     style=\\"background-image: url('/assets/images/portraits/L_80x80_M2.png')\\" 
                     role=\\"img\\" 
-                    alt=\\"Brian Tracey\\" 
-                    title=\\"Brian Tracey\\">
+                    alt=\\"Portrait of Brian Tracey\\">
                 </span>
 
                 <span 
@@ -8245,42 +8186,37 @@ exports[`Check stories > Components/Avatar Group > Story GroupTypeInteractionSta
         <div class=\\"fd-popover__control fd-avatar-group__popover-control\\"
             role=\\"button\\"
             tabindex=\\"0\\"
-            aria-label=\\"Avatar Group\\">
+            aria-label=\\"Conjoined avatars. 6 displayed, 8 hidden. Activate for complete list.\\">
             <div class=\\"fd-avatar-group fd-avatar-group--group-type fd-avatar-group--md is-focus\\">
                 <span 
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--accent-color-1\\" 
                     role=\\"img\\" 
-                    aria-label=\\"Wendy Wallace\\" 
-                    title=\\"Wendy Wallace\\">WW
+                    aria-label=\\"Wendy Wallace\\">WW
                 </span>
         
                 <span 
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--accent-color-2\\" 
                     role=\\"img\\" 
-                    aria-label=\\"Simon Doe\\" 
-                    title=\\"Simon Doe\\">
+                    aria-label=\\"Simon Doe\\">
                         <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
                 </span>
                 
                 <span 
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" 
                     role=\\"img\\" 
-                    alt=\\"Ben Johnson\\" 
-                    title=\\"Ben Johnson\\">
+                    alt=\\"Portrait of Ben Johnson\\">
                 </span>
                 
                 <span 
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--accent-color-3\\" 
                     role=\\"img\\" 
-                    aria-label=\\"Endy Wallace\\" 
-                    title=\\"Endy Wallace\\">EW
+                    aria-label=\\"Endy Wallace\\">EW
                 </span>
         
                 <span 
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" 
                     role=\\"img\\" 
-                    aria-label=\\"Whitney Copper\\" 
-                    title=\\"Whitney Copper\\">
+                    aria-label=\\"Whitney Copper\\">
                         <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
                 </span>
                 
@@ -8288,8 +8224,7 @@ exports[`Check stories > Components/Avatar Group > Story GroupTypeInteractionSta
                     class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" 
                     style=\\"background-image: url('/assets/images/portraits/L_80x80_M2.png')\\" 
                     role=\\"img\\" 
-                    alt=\\"Brian Tracey\\" 
-                    title=\\"Brian Tracey\\">
+                    alt=\\"Portrait of Brian Tracey\\">
                 </span>
 
                 <span 
@@ -8309,45 +8244,40 @@ exports[`Check stories > Components/Avatar Group > Story GroupTypeVertical > Sho
         <div class=\\"fd-popover__control fd-avatar-group__popover-control\\"
             role=\\"button\\"
             tabindex=\\"0\\"
-            aria-label=\\"Has popup type dialog Conjoined avatars, 6 avatars displayed, 8 avatars hidden, activate for complete list\\"
+            aria-label=\\"Conjoined avatars, 6 avatars displayed, 8 avatars hidden, activate for complete list\\"
             aria-haspopup=\\"true\\"
             aria-expanded=\\"false\\"
             onclick=\\"onPopoverClick('popover_avatar-group_tztuj-v');\\">
-            <div class=\\"fd-avatar-group fd-avatar-group--group-type fd-avatar-group--lg fd-avatar-group--vertical \\">
+            <div class=\\"fd-avatar-group fd-avatar-group--group-type fd-avatar-group--lg fd-avatar-group--vertical\\">
                 <span 
                     class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border\\" 
                     role=\\"img\\" 
-                    aria-label=\\"Wendy Wallace\\" 
-                    title=\\"Wendy Wallace\\">WW
+                    aria-label=\\"Wendy Wallace\\">WW
                 </span>
                 
                 <span 
                     class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border\\" 
                     role=\\"img\\" 
-                    aria-label=\\"Simon Dane\\" 
-                    title=\\"Simon Dane\\">
+                    aria-label=\\"Simon Dane\\">
                         <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
                 </span>
                 
                 <span 
                     class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" 
                     role=\\"img\\" 
-                    alt=\\"Michael Smith\\" 
-                    title=\\"Michael Smith\\">
+                    alt=\\"Portrait of Michael Smith\\">
                 </span>
                 
                 <span 
                     class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border\\" 
                     role=\\"img\\" 
-                    aria-label=\\"Endy Wallace\\" 
-                    title=\\"Endy Wallace\\">EW
+                    aria-label=\\"Endy Wallace\\">EW
                 </span>
                 
                 <span 
                     class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border\\" 
                     role=\\"img\\" 
-                    aria-label=\\"Whitney Copper\\" 
-                    title=\\"Whitney Copper\\">
+                    aria-label=\\"Whitney Copper\\">
                         <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
                 </span>
                 
@@ -8355,8 +8285,7 @@ exports[`Check stories > Components/Avatar Group > Story GroupTypeVertical > Sho
                     class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" 
                     style=\\"background-image: url('/assets/images/portraits/L_80x80_M2.png')\\" 
                     role=\\"img\\" 
-                    alt=\\"James Johnson\\" 
-                    title=\\"James Johnson\\">
+                    alt=\\"Portrait of James Johnson\\">
                 </span>
 
                 <span 
@@ -8372,48 +8301,50 @@ exports[`Check stories > Components/Avatar Group > Story GroupTypeVertical > Sho
                 <div class=\\"fd-popover__body-header\\">
                     <div class=\\"fd-bar fd-bar--header\\">
                         <div class=\\"fd-bar__middle\\">
-                            <div class=\\"fd-bar__element\\">Team Members (14)</div>
+                            <div class=\\"fd-bar__element\\">
+                                <h1 class=\\"fd-title fd-title--h5\\">Team Members (14)</h1>
+                            </div>
                         </div>
                     </div>
                 </div>
                 <div class=\\"fd-avatar-group__overflow-body\\">
-                    <span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Wendy Wallace\\" title=\\"Wendy Wallace\\">WW</span>
+                    <span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Wendy Wallace\\">WW</span>
                     
-                    <span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Sarah Smith\\" title=\\"Sarah Smith\\">
+                    <span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Sarah Smith\\">
                         <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\"></i>
                     </span>
                     
-                    <span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" role=\\"img\\" alt=\\"William Smith\\" title=\\"William Smith\\"></span>
+                    <span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" role=\\"img\\" alt=\\"Portrait of William Smith\\"></span>
 
                     <span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Endy Wallace\\" title=\\"Endy Wallace\\">EW</span>
 
-                    <span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Whitney Bow\\" title=\\"Whitney Bow\\">
+                    <span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Whitney Bow\\">
                         <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\"></i>
                     </span>
 
-                    <span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M2.png')\\" role=\\"img\\" alt=\\"Mitch Walters\\" title=\\"Mitch Walters\\"></span>
+                    <span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M2.png')\\" role=\\"img\\" alt=\\"Portrait of Mitch Walters\\"></span>
 
-                    <span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Andy Wallace\\" title=\\"Andy Wallace\\">AW</span>
+                    <span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Andy Wallace\\">AW</span>
 
-                    <span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"John Carter\\" title=\\"John Carter\\">
+                    <span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"John Carter\\">
                         <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\"></i>
                     </span>
 
-                    <span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_F3.png')\\" role=\\"img\\" alt=\\"Melanie Burke\\" title=\\"Melanie Burke\\"></span>
+                    <span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_F3.png')\\" role=\\"img\\" alt=\\"Portrait of Melanie Burke\\"></span>
 
-                    <span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"John Moe\\" title=\\"John Moe\\">JM</span>
+                    <span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"John Moe\\">JM</span>
 
-                    <span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Ben Bloggs\\" title=\\"Ben Bloggs\\">BB</span>
+                    <span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Ben Bloggs\\">BB</span>
 
-                    <span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Simon Swan\\" title=\\"Simon Swan\\">
+                    <span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Simon Swan\\">
                         <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\"></i>
                     </span>
 
-                    <span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_F4.png')\\" role=\\"img\\" alt=\\"Maria Caffrey\\" title=\\"Maria Caffrey\\"></span>
+                    <span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_F4.png')\\" role=\\"img\\" alt=\\"Portrait of Maria Caffrey\\"></span>
 
-                    <span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Fred Bloggs\\" title=\\"Fred Bloggs\\">FB</span>
+                    <span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Fred Bloggs\\">FB</span>
 
-                    <span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Jan Alleman\\" title=\\"Jan Alleman\\">JA</span>
+                    <span class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Jan Alleman\\">JA</span>
                 </div>
             </div>
         </div>
@@ -8421,41 +8352,36 @@ exports[`Check stories > Components/Avatar Group > Story GroupTypeVertical > Sho
 </div>
 
 <div style=\\"display: flex; gap: 3rem;\\">
-    <div class=\\"fd-avatar-group fd-avatar-group--group-type fd-avatar-group--xs fd-avatar-group--vertical\\">
+    <div class=\\"fd-avatar-group fd-avatar-group--group-type fd-avatar-group--xs fd-avatar-group--vertical\\" role=\\"button\\" tabindex=\\"0\\" aria-label=\\"Conjoined avatars. 6 displayed, 8 hidden. Activate for complete list.\\">
         <span 
             class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--border\\" 
             role=\\"img\\" 
-            aria-label=\\"Wendy Wallace\\" 
-            title=\\"Wendy Wallace\\">WW
+            aria-label=\\"Wendy Wallace\\">WW
         </span>
         
         <span 
             class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--border\\" 
             role=\\"img\\" 
-            aria-label=\\"Simon Dane\\" 
-            title=\\"Simon Dane\\">
+            aria-label=\\"Simon Dane\\">
                 <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
         </span>
         
         <span 
             class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" 
             role=\\"img\\" 
-            alt=\\"Michael Smith\\" 
-            title=\\"Michael Smith\\">
+            alt=\\"Portrait of Michael Smith\\">
         </span>
         
         <span 
             class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--border\\" 
             role=\\"img\\" 
-            aria-label=\\"Endy Wallace\\" 
-            title=\\"Endy Wallace\\">EW
+            aria-label=\\"Endy Wallace\\">EW
         </span>
         
         <span 
             class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--border\\" 
             role=\\"img\\" 
-            aria-label=\\"Whitney Copper\\" 
-            title=\\"Whitney Copper\\">
+            aria-label=\\"Whitney Copper\\">
                 <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
         </span>
         
@@ -8463,8 +8389,7 @@ exports[`Check stories > Components/Avatar Group > Story GroupTypeVertical > Sho
             class=\\"fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" 
             style=\\"background-image: url('/assets/images/portraits/L_80x80_M2.png')\\" 
             role=\\"img\\" 
-            alt=\\"James Johnson\\" 
-            title=\\"James Johnson\\">
+            alt=\\"Portrait of James Johnson\\">
         </span>
     
         <span 
@@ -8474,41 +8399,36 @@ exports[`Check stories > Components/Avatar Group > Story GroupTypeVertical > Sho
         </span>
     </div>
 
-    <div class=\\"fd-avatar-group fd-avatar-group--group-type fd-avatar-group--sm fd-avatar-group--vertical\\">
+    <div class=\\"fd-avatar-group fd-avatar-group--group-type fd-avatar-group--sm fd-avatar-group--vertical\\" role=\\"button\\" tabindex=\\"0\\" aria-label=\\"Conjoined avatars. 6 displayed, 8 hidden. Activate for complete list.\\">
         <span 
             class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border\\" 
             role=\\"img\\" 
-            aria-label=\\"Wendy Wallace\\" 
-            title=\\"Wendy Wallace\\">WW
+            aria-label=\\"Wendy Wallace\\">WW
         </span>
         
         <span 
             class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border\\" 
             role=\\"img\\" 
-            aria-label=\\"Simon Dane\\" 
-            title=\\"Simon Dane\\">
+            aria-label=\\"Simon Dane\\">
                 <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
         </span>
         
         <span 
             class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" 
             role=\\"img\\" 
-            alt=\\"Michael Smith\\" 
-            title=\\"Michael Smith\\">
+            alt=\\"Portrait of Michael Smith\\">
         </span>
         
         <span 
             class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border\\" 
             role=\\"img\\" 
-            aria-label=\\"Endy Wallace\\" 
-            title=\\"Endy Wallace\\">EW
+            aria-label=\\"Endy Wallace\\">EW
         </span>
         
         <span 
             class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border\\" 
             role=\\"img\\" 
-            aria-label=\\"Whitney Copper\\" 
-            title=\\"Whitney Copper\\">
+            aria-label=\\"Whitney Copper\\">
                 <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
         </span>
         
@@ -8516,8 +8436,7 @@ exports[`Check stories > Components/Avatar Group > Story GroupTypeVertical > Sho
             class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" 
             style=\\"background-image: url('/assets/images/portraits/L_80x80_M2.png')\\" 
             role=\\"img\\" 
-            alt=\\"James Johnson\\" 
-            title=\\"James Johnson\\">
+            alt=\\"Portrait of James Johnson\\">
         </span>
     
         <span 
@@ -8527,41 +8446,36 @@ exports[`Check stories > Components/Avatar Group > Story GroupTypeVertical > Sho
         </span>
     </div>
 
-    <div class=\\"fd-avatar-group fd-avatar-group--group-type fd-avatar-group--md fd-avatar-group--vertical\\">
+    <div class=\\"fd-avatar-group fd-avatar-group--group-type fd-avatar-group--md fd-avatar-group--vertical\\" role=\\"button\\" tabindex=\\"0\\" aria-label=\\"Conjoined avatars. 6 displayed, 8 hidden. Activate for complete list.\\">
         <span 
             class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" 
             role=\\"img\\" 
-            aria-label=\\"Wendy Wallace\\" 
-            title=\\"Wendy Wallace\\">WW
+            aria-label=\\"Wendy Wallace\\">WW
         </span>
         
         <span 
             class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" 
             role=\\"img\\" 
-            aria-label=\\"Simon Dane\\" 
-            title=\\"Simon Dane\\">
+            aria-label=\\"Simon Dane\\">
                 <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
         </span>
         
         <span 
             class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" 
             role=\\"img\\" 
-            alt=\\"Michael Smith\\" 
-            title=\\"Michael Smith\\">
+            alt=\\"Portrait of Michael Smith\\">
         </span>
         
         <span 
             class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" 
             role=\\"img\\" 
-            aria-label=\\"Endy Wallace\\" 
-            title=\\"Endy Wallace\\">EW
+            aria-label=\\"Endy Wallace\\">EW
         </span>
         
         <span 
             class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border\\" 
             role=\\"img\\" 
-            aria-label=\\"Whitney Copper\\" 
-            title=\\"Whitney Copper\\">
+            aria-label=\\"Whitney Copper\\">
                 <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
         </span>
         
@@ -8569,8 +8483,7 @@ exports[`Check stories > Components/Avatar Group > Story GroupTypeVertical > Sho
             class=\\"fd-avatar fd-avatar--md fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" 
             style=\\"background-image: url('/assets/images/portraits/L_80x80_M2.png')\\" 
             role=\\"img\\" 
-            alt=\\"James Johnson\\" 
-            title=\\"James Johnson\\">
+            alt=\\"Portrait of James Johnson\\">
         </span>
     
         <span 
@@ -8580,41 +8493,36 @@ exports[`Check stories > Components/Avatar Group > Story GroupTypeVertical > Sho
         </span>
     </div>
 
-    <div class=\\"fd-avatar-group fd-avatar-group--group-type fd-avatar-group--lg fd-avatar-group--vertical\\">
+    <div class=\\"fd-avatar-group fd-avatar-group--group-type fd-avatar-group--lg fd-avatar-group--vertical\\" role=\\"button\\" tabindex=\\"0\\" aria-label=\\"Conjoined avatars. 6 displayed, 8 hidden. Activate for complete list.\\">
         <span 
             class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border\\" 
             role=\\"img\\" 
-            aria-label=\\"Wendy Wallace\\" 
-            title=\\"Wendy Wallace\\">WW
+            aria-label=\\"Wendy Wallace\\">WW
         </span>
         
         <span 
             class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border\\" 
             role=\\"img\\" 
-            aria-label=\\"Simon Dane\\" 
-            title=\\"Simon Dane\\">
+            aria-label=\\"Simon Dane\\">
                 <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
         </span>
         
         <span 
             class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" 
             role=\\"img\\" 
-            alt=\\"Michael Smith\\" 
-            title=\\"Michael Smith\\">
+            alt=\\"Portrait of Michael Smith\\">
         </span>
         
         <span 
             class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border\\" 
             role=\\"img\\" 
-            aria-label=\\"Endy Wallace\\" 
-            title=\\"Endy Wallace\\">EW
+            aria-label=\\"Endy Wallace\\">EW
         </span>
         
         <span 
             class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border\\" 
             role=\\"img\\" 
-            aria-label=\\"Whitney Copper\\" 
-            title=\\"Whitney Copper\\">
+            aria-label=\\"Whitney Copper\\">
                 <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
         </span>
         
@@ -8622,8 +8530,7 @@ exports[`Check stories > Components/Avatar Group > Story GroupTypeVertical > Sho
             class=\\"fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" 
             style=\\"background-image: url('/assets/images/portraits/L_80x80_M2.png')\\" 
             role=\\"img\\" 
-            alt=\\"James Johnson\\" 
-            title=\\"James Johnson\\">
+            alt=\\"Portrait of James Johnson\\">
         </span>
     
         <span 
@@ -8634,41 +8541,36 @@ exports[`Check stories > Components/Avatar Group > Story GroupTypeVertical > Sho
     </div>
 
 
-    <div class=\\"fd-avatar-group fd-avatar-group--group-type fd-avatar-group--xl fd-avatar-group--vertical\\">
+    <div class=\\"fd-avatar-group fd-avatar-group--group-type fd-avatar-group--xl fd-avatar-group--vertical\\" role=\\"button\\" tabindex=\\"0\\" aria-label=\\"Conjoined avatars. 6 displayed, 8 hidden. Activate for complete list.\\">
         <span 
             class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--border\\" 
             role=\\"img\\" 
-            aria-label=\\"Wendy Wallace\\" 
-            title=\\"Wendy Wallace\\">WW
+            aria-label=\\"Wendy Wallace\\">WW
         </span>
         
         <span 
             class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--border\\" 
             role=\\"img\\" 
-            aria-label=\\"Simon Dane\\" 
-            title=\\"Simon Dane\\">
+            aria-label=\\"Simon Dane\\">
                 <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
         </span>
         
         <span 
             class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" 
             role=\\"img\\" 
-            alt=\\"Michael Smith\\" 
-            title=\\"Michael Smith\\">
+            alt=\\"Portrait of Michael Smith\\">
         </span>
         
         <span 
             class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--border\\" 
             role=\\"img\\" 
-            aria-label=\\"Endy Wallace\\" 
-            title=\\"Endy Wallace\\">EW
+            aria-label=\\"Endy Wallace\\">EW
         </span>
         
         <span 
             class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--border\\" 
             role=\\"img\\" 
-            aria-label=\\"Whitney Copper\\" 
-            title=\\"Whitney Copper\\">
+            aria-label=\\"Whitney Copper\\">
                 <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
         </span>
         
@@ -8676,8 +8578,7 @@ exports[`Check stories > Components/Avatar Group > Story GroupTypeVertical > Sho
             class=\\"fd-avatar fd-avatar--xl fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" 
             style=\\"background-image: url('/assets/images/portraits/L_80x80_M2.png')\\" 
             role=\\"img\\" 
-            alt=\\"James Johnson\\" 
-            title=\\"James Johnson\\">
+            alt=\\"Portrait of James Johnson\\">
         </span>
     
         <span 
@@ -8696,8 +8597,7 @@ exports[`Check stories > Components/Avatar Group > Story IndividualType > Should
             <div class=\\"fd-popover__control\\">
                 <span 
                     class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border\\" 
-                    role=\\"button\\" 
-                    aria-label=\\"Jason Smith\\" 
+                    aria-label=\\"Avatar Jason Smith\\" 
                     title=\\"Jason Smith\\" 
                     tabindex=\\"0\\" 
                     aria-haspopup=\\"true\\" 
@@ -8709,7 +8609,9 @@ exports[`Check stories > Components/Avatar Group > Story IndividualType > Should
                 <div class=\\"fd-quick-view\\">
                     <div class=\\"fd-bar fd-bar--header\\">
                         <div class=\\"fd-bar__middle\\">
-                            <div class=\\"fd-bar__element\\">Business Card</div>
+                            <div class=\\"fd-bar__element\\">
+                                <h1 class=\\"fd-title fd-title--h5\\">Business Card</h1>
+                            </div>
                         </div>
                     </div>
 
@@ -8719,18 +8621,18 @@ exports[`Check stories > Components/Avatar Group > Story IndividualType > Should
                                 <span 
                                     class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border\\" 
                                     role=\\"img\\" 
-                                    aria-label=\\"Jason Smith\\" 
-                                    title=\\"Jason Smith\\">JS
+                                    aria-label=\\"Avatar Jason Smith\\">
+                                    JS
                                 </span>
                                 <div class=\\"fd-quick-view__subheader-text\\">
                                     <h5 class=\\"fd-title fd-title--h5\\">Jason Smith</h5>
-                                    <div class=\\"fd-quick-view__subtitle\\">Marketing Manager</div>
+                                    <p class=\\"fd-quick-view__subtitle\\">Marketing Manager</p>
                                 </div>
                             </div>
                         </div>
                         <div class=\\"fd-form-group\\" role=\\"group\\">
                             <div class=\\"fd-form-group__header\\" aria-labelledby=\\"contactDetails_5z28edb\\">
-                                <h1 class=\\"fd-form-group__header-text\\" id=\\"contactDetails_5z28edb\\">Contact Details</h1>
+                                <p class=\\"fd-form-group__header-text\\" id=\\"contactDetails_5z28edb\\">Contact Details</p>
                             </div>
                             <div class=\\"fd-form-item\\">
                                 <label class=\\"fd-form-label\\">Mobile</label>
@@ -8754,7 +8656,7 @@ exports[`Check stories > Components/Avatar Group > Story IndividualType > Should
                 <span 
                     class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border\\" 
                     role=\\"button\\" 
-                    aria-label=\\"Sarah Parker\\" 
+                    aria-label=\\"Avatar Sarah Parker\\" 
                     title=\\"Sarah Parker\\" 
                     tabindex=\\"0\\" 
                     aria-haspopup=\\"true\\" 
@@ -8767,23 +8669,25 @@ exports[`Check stories > Components/Avatar Group > Story IndividualType > Should
                 <div class=\\"fd-quick-view\\">
                     <div class=\\"fd-bar fd-bar--header\\">
                         <div class=\\"fd-bar__middle\\">
-                            <div class=\\"fd-bar__element\\">Business Card</div>
+                            <div class=\\"fd-bar__element\\">
+                                <h1 class=\\"fd-title fd-title--h5\\">Business Card</h1>
+                            </div>
                         </div>
                     </div>
 
                     <div class=\\"fd-quick-view__content\\">
                         <div class=\\"fd-bar fd-bar--header-with-subheader\\">
                             <div class=\\"fd-bar__left\\">
-                                <span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Wendy Wallace\\" title=\\"Wendy Wallace\\">WW</span>
+                                <span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Avatar Wendy Wallace\\" title=\\"Wendy Wallace\\">WW</span>
                                 <div class=\\"fd-quick-view__subheader-text\\">
                                     <h5 class=\\"fd-title fd-title--h5\\">Sarah Parker</h5>
-                                    <div class=\\"fd-quick-view__subtitle\\">Visual Designer</div>
+                                    <p class=\\"fd-quick-view__subtitle\\">Visual Designer</p>
                                 </div>
                             </div>
                         </div>
                         <div class=\\"fd-form-group\\" role=\\"group\\">
                             <div class=\\"fd-form-group__header\\" aria-labelledby=\\"contactDetails_spbw4q\\">
-                                <h1 class=\\"fd-form-group__header-text\\" id=\\"contactDetails_spbw4q\\">Contact Details</h1>
+                                <p class=\\"fd-form-group__header-text\\" id=\\"contactDetails_spbw4q\\">Contact Details</p>
                             </div>
                             <div class=\\"fd-form-item\\">
                                 <label class=\\"fd-form-label\\">Mobile</label>
@@ -8807,7 +8711,7 @@ exports[`Check stories > Components/Avatar Group > Story IndividualType > Should
                 <span 
                     class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" 
                     role=\\"button\\" 
-                    aria-label=\\"Christian Bow\\" 
+                    aria-label=\\"Avatar Christian Bow\\" 
                     title=\\"Christian Bow\\" 
                     tabindex=\\"0\\" 
                     aria-haspopup=\\"true\\" 
@@ -8819,7 +8723,9 @@ exports[`Check stories > Components/Avatar Group > Story IndividualType > Should
                 <div class=\\"fd-quick-view\\">
                     <div class=\\"fd-bar fd-bar--header\\">
                         <div class=\\"fd-bar__middle\\">
-                            <div class=\\"fd-bar__element\\">Business Card</div>
+                            <div class=\\"fd-bar__element\\">
+                                <h1 class=\\"fd-title fd-title--h5\\">Business Card</h1>
+                            </div>
                         </div>
                     </div>
 
@@ -8829,13 +8735,13 @@ exports[`Check stories > Components/Avatar Group > Story IndividualType > Should
                                 <span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" role=\\"img\\" alt=\\"Christian Bow\\" title=\\"Christian Bow\\"></span>
                                 <div class=\\"fd-quick-view__subheader-text\\">
                                     <h5 class=\\"fd-title fd-title--h5\\">Christian Bow</h5>
-                                    <div class=\\"fd-quick-view__subtitle\\">Marketing Manager</div>
+                                    <p class=\\"fd-quick-view__subtitle\\">Marketing Manager</p>
                                 </div>
                             </div>
                         </div>
                         <div class=\\"fd-form-group\\" role=\\"group\\">
                             <div class=\\"fd-form-group__header\\" aria-labelledby=\\"contactDetails_4ahzcg\\">
-                                <h1 class=\\"fd-form-group__header-text\\" id=\\"contactDetails_4ahzcg\\">Contact Details</h1>
+                                <p class=\\"fd-form-group__header-text\\" id=\\"contactDetails_4ahzcg\\">Contact Details</p>
                             </div>
                             <div class=\\"fd-form-item\\">
                                 <label class=\\"fd-form-label\\">Mobile</label>
@@ -8859,7 +8765,7 @@ exports[`Check stories > Components/Avatar Group > Story IndividualType > Should
                 <span 
                     class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border\\" 
                     role=\\"button\\" 
-                    aria-label=\\"Endy Wallace\\" 
+                    aria-label=\\"Avatar Endy Wallace\\" 
                     title=\\"Endy Wallace\\" 
                     tabindex=\\"0\\" 
                     aria-haspopup=\\"true\\" 
@@ -8871,23 +8777,25 @@ exports[`Check stories > Components/Avatar Group > Story IndividualType > Should
                 <div class=\\"fd-quick-view\\">
                     <div class=\\"fd-bar fd-bar--header\\">
                         <div class=\\"fd-bar__middle\\">
-                            <div class=\\"fd-bar__element\\">Business Card</div>
+                            <div class=\\"fd-bar__element\\">
+                                <h1 class=\\"fd-title fd-title--h5\\">Business Card</h1>
+                            </div>
                         </div>
                     </div>
 
                     <div class=\\"fd-quick-view__content\\">
                         <div class=\\"fd-bar fd-bar--header-with-subheader\\">
                             <div class=\\"fd-bar__left\\">
-                                <span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Endy Wallace\\" title=\\"Endy Wallace\\">EW</span>
+                                <span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Avatar Endy Wallace\\" title=\\"Endy Wallace\\">EW</span>
                                 <div class=\\"fd-quick-view__subheader-text\\">
                                     <h5 class=\\"fd-title fd-title--h5\\">Endy Wallace</h5>
-                                    <div class=\\"fd-quick-view__subtitle\\">Software Developer</div>
+                                    <p class=\\"fd-quick-view__subtitle\\">Software Developer</p>
                                 </div>
                             </div>
                         </div>
                         <div class=\\"fd-form-group\\" role=\\"group\\">
                             <div class=\\"fd-form-group__header\\" aria-labelledby=\\"contactDetails_qc1f1jf\\">
-                                <h1 class=\\"fd-form-group__header-text\\" id=\\"contactDetails_qc1f1jf\\">Contact Details</h1>
+                                <p class=\\"fd-form-group__header-text\\" id=\\"contactDetails_qc1f1jf\\">Contact Details</p>
                             </div>
                             <div class=\\"fd-form-item\\">
                                 <label class=\\"fd-form-label\\">Mobile</label>
@@ -8924,7 +8832,9 @@ exports[`Check stories > Components/Avatar Group > Story IndividualType > Should
                     <div class=\\"fd-popover__body-header\\">
                         <div class=\\"fd-bar fd-bar--header\\">
                             <div class=\\"fd-bar__middle\\">
-                                <div class=\\"fd-bar__element\\">Team Members (4)</div>
+                                <div class=\\"fd-bar__element\\">
+                                    <h1 class=\\"fd-title fd-title--h5\\">Team Members (4)</h1>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -8933,7 +8843,7 @@ exports[`Check stories > Components/Avatar Group > Story IndividualType > Should
                         <span 
                             class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border\\" 
                             role=\\"button\\" 
-                            aria-label=\\"Gordon Smith\\" 
+                            aria-label=\\"Avatar Gordon Smith\\" 
                             title=\\"Gordon Smith\\"
                             tabindex=\\"0\\">
                             <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
@@ -8951,7 +8861,7 @@ exports[`Check stories > Components/Avatar Group > Story IndividualType > Should
                         <span 
                             class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border\\" 
                             role=\\"button\\" 
-                            aria-label=\\"John Moe\\" 
+                            aria-label=\\"Avatar John Moe\\" 
                             title=\\"John Moe\\" 
                             tabindex=\\"0\\">JM
                         </span>
@@ -8959,7 +8869,7 @@ exports[`Check stories > Components/Avatar Group > Story IndividualType > Should
                         <span 
                             class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border\\" 
                             role=\\"button\\" 
-                            aria-label=\\"Joe Bloggs\\" 
+                            aria-label=\\"Avatar Joe Bloggs\\" 
                             title=\\"Joe Bloggs\\" 
                             tabindex=\\"0\\">JB
                         </span>
@@ -8983,7 +8893,7 @@ exports[`Check stories > Components/Avatar Group > Story IndividualTypeVertical 
                     <span 
                         class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border\\" 
                         role=\\"button\\" 
-                        aria-label=\\"Jason Smith\\" 
+                        aria-label=\\"Avatar Jason Smith\\" 
                         title=\\"Jason Smith\\" 
                         tabindex=\\"0\\" 
                         aria-haspopup=\\"true\\" 
@@ -8995,7 +8905,9 @@ exports[`Check stories > Components/Avatar Group > Story IndividualTypeVertical 
                     <div class=\\"fd-quick-view\\">
                         <div class=\\"fd-bar fd-bar--header\\">
                             <div class=\\"fd-bar__middle\\">
-                                <div class=\\"fd-bar__element\\">Business Card</div>
+                                <div class=\\"fd-bar__element\\">
+                                    <h1 class=\\"fd-title fd-title--h5\\">Business Card</h1>
+                                </div>
                             </div>
                         </div>
     
@@ -9005,18 +8917,17 @@ exports[`Check stories > Components/Avatar Group > Story IndividualTypeVertical 
                                     <span 
                                         class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border\\" 
                                         role=\\"img\\" 
-                                        aria-label=\\"Jason Smith\\" 
-                                        title=\\"Jason Smith\\">JS
+                                        aria-label=\\"Avatar Jason Smith\\">JS
                                     </span>
                                     <div class=\\"fd-quick-view__subheader-text\\">
                                         <h5 class=\\"fd-title fd-title--h5\\">Jason Smith</h5>
-                                        <div class=\\"fd-quick-view__subtitle\\">Marketing Manager</div>
+                                        <p class=\\"fd-quick-view__subtitle\\">Marketing Manager</p>
                                     </div>
                                 </div>
                             </div>
                             <div class=\\"fd-form-group\\" role=\\"group\\">
                                 <div class=\\"fd-form-group__header\\" aria-labelledby=\\"contactDetails_5z28edb-v\\">
-                                    <h1 class=\\"fd-form-group__header-text\\" id=\\"contactDetails_5z28edb-v\\">Contact Details</h1>
+                                    <p id=\\"contactDetails_5z28edb-v\\">Contact Details</p>
                                 </div>
                                 <div class=\\"fd-form-item\\">
                                     <label class=\\"fd-form-label\\">Mobile</label>
@@ -9040,7 +8951,7 @@ exports[`Check stories > Components/Avatar Group > Story IndividualTypeVertical 
                     <span 
                         class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border\\" 
                         role=\\"button\\" 
-                        aria-label=\\"Sarah Parker\\" 
+                        aria-label=\\"Avatar Sarah Parker\\" 
                         title=\\"Sarah Parker\\" 
                         tabindex=\\"0\\" 
                         aria-haspopup=\\"true\\" 
@@ -9053,23 +8964,25 @@ exports[`Check stories > Components/Avatar Group > Story IndividualTypeVertical 
                     <div class=\\"fd-quick-view\\">
                         <div class=\\"fd-bar fd-bar--header\\">
                             <div class=\\"fd-bar__middle\\">
-                                <div class=\\"fd-bar__element\\">Business Card</div>
+                                <div class=\\"fd-bar__element\\">
+                                    <h1 class=\\"fd-title fd-title--h5\\">Business Card</h1>
+                                </div>
                             </div>
                         </div>
     
                         <div class=\\"fd-quick-view__content\\">
                             <div class=\\"fd-bar fd-bar--header-with-subheader\\">
                                 <div class=\\"fd-bar__left\\">
-                                    <span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Sarah Parker\\" title=\\"Sarah Parker\\">SP</span>
+                                    <span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Avatar Sarah Parker\\">SP</span>
                                     <div class=\\"fd-quick-view__subheader-text\\">
                                         <h5 class=\\"fd-title fd-title--h5\\">Sarah Parker</h5>
-                                        <div class=\\"fd-quick-view__subtitle\\">Visual Designer</div>
+                                        <p class=\\"fd-quick-view__subtitle\\">Visual Designer</p>
                                     </div>
                                 </div>
                             </div>
                             <div class=\\"fd-form-group\\" role=\\"group\\">
                                 <div class=\\"fd-form-group__header\\" aria-labelledby=\\"contactDetails_spbw4q-v\\">
-                                    <h1 class=\\"fd-form-group__header-text\\" id=\\"contactDetails_spbw4q-v\\">Contact Details</h1>
+                                    <p class=\\"fd-form-group__header-text\\" id=\\"contactDetails_spbw4q-v\\">Contact Details</p>
                                 </div>
                                 <div class=\\"fd-form-item\\">
                                     <label class=\\"fd-form-label\\">Mobile</label>
@@ -9093,7 +9006,8 @@ exports[`Check stories > Components/Avatar Group > Story IndividualTypeVertical 
                     <span 
                         class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" 
                         role=\\"button\\" 
-                        aria-label=\\"Christian Bow\\" 
+                        alt=\\"Portrait of Christian Bow\\"
+                        aria-label=\\"Avatar Christian Bow\\" 
                         title=\\"Christian Bow\\" 
                         tabindex=\\"0\\" 
                         aria-haspopup=\\"true\\" 
@@ -9105,23 +9019,25 @@ exports[`Check stories > Components/Avatar Group > Story IndividualTypeVertical 
                     <div class=\\"fd-quick-view\\">
                         <div class=\\"fd-bar fd-bar--header\\">
                             <div class=\\"fd-bar__middle\\">
-                                <div class=\\"fd-bar__element\\">Business Card</div>
+                                <div class=\\"fd-bar__element\\">
+                                <h1 class=\\"fd-title fd-title--h5\\">Business Card</h1>
+                            </div>
                             </div>
                         </div>
     
                         <div class=\\"fd-quick-view__content\\">
                             <div class=\\"fd-bar fd-bar--header-with-subheader\\">
                                 <div class=\\"fd-bar__left\\">
-                                    <span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" role=\\"img\\" alt=\\"Christian Bow\\" title=\\"Christian Bow\\"></span>
+                                    <span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" role=\\"img\\" alt=\\"Portrait of Christian Bow\\"></span>
                                     <div class=\\"fd-quick-view__subheader-text\\">
                                         <h5 class=\\"fd-title fd-title--h5\\">Christian Bow</h5>
-                                        <div class=\\"fd-quick-view__subtitle\\">Marketing Manager</div>
+                                        <p class=\\"fd-quick-view__subtitle\\">Marketing Manager</p>
                                     </div>
                                 </div>
                             </div>
                             <div class=\\"fd-form-group\\" role=\\"group\\">
                                 <div class=\\"fd-form-group__header\\" aria-labelledby=\\"contactDetails_4ahzcg-v\\">
-                                    <h1 class=\\"fd-form-group__header-text\\" id=\\"contactDetails_4ahzcg-v\\">Contact Details</h1>
+                                    <p id=\\"contactDetails_4ahzcg-v\\">Contact Details</p>
                                 </div>
                                 <div class=\\"fd-form-item\\">
                                     <label class=\\"fd-form-label\\">Mobile</label>
@@ -9145,7 +9061,7 @@ exports[`Check stories > Components/Avatar Group > Story IndividualTypeVertical 
                     <span 
                         class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border\\" 
                         role=\\"button\\" 
-                        aria-label=\\"Endy Wallace\\" 
+                        aria-label=\\"Avatar Endy Wallace\\" 
                         title=\\"Endy Wallace\\" 
                         tabindex=\\"0\\" 
                         aria-haspopup=\\"true\\" 
@@ -9157,23 +9073,25 @@ exports[`Check stories > Components/Avatar Group > Story IndividualTypeVertical 
                     <div class=\\"fd-quick-view\\">
                         <div class=\\"fd-bar fd-bar--header\\">
                             <div class=\\"fd-bar__middle\\">
-                                <div class=\\"fd-bar__element\\">Business Card</div>
+                                <div class=\\"fd-bar__element\\">
+                                <h1 class=\\"fd-title fd-title--h5\\">Business Card</h1>
+                            </div>
                             </div>
                         </div>
     
                         <div class=\\"fd-quick-view__content\\">
                             <div class=\\"fd-bar fd-bar--header-with-subheader\\">
                                 <div class=\\"fd-bar__left\\">
-                                    <span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Endy Wallace\\" title=\\"Endy Wallace\\">EW</span>
+                                    <span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border\\" role=\\"img\\" aria-label=\\"Avatar Endy Wallace\\">EW</span>
                                     <div class=\\"fd-quick-view__subheader-text\\">
                                         <h5 class=\\"fd-title fd-title--h5\\">Endy Wallace</h5>
-                                        <div class=\\"fd-quick-view__subtitle\\">Software Developer</div>
+                                        <p class=\\"fd-quick-view__subtitle\\">Software Developer</p>
                                     </div>
                                 </div>
                             </div>
                             <div class=\\"fd-form-group\\" role=\\"group\\">
                                 <div class=\\"fd-form-group__header\\" aria-labelledby=\\"contactDetails_qc1f1jf-v\\">
-                                    <h1 class=\\"fd-form-group__header-text\\" id=\\"contactDetails_qc1f1jf-v\\">Contact Details</h1>
+                                    <p id=\\"contactDetails_qc1f1jf-v\\">Contact Details</p>
                                 </div>
                                 <div class=\\"fd-form-item\\">
                                     <label class=\\"fd-form-label\\">Mobile</label>
@@ -9210,7 +9128,9 @@ exports[`Check stories > Components/Avatar Group > Story IndividualTypeVertical 
                         <div class=\\"fd-popover__body-header\\">
                             <div class=\\"fd-bar fd-bar--header\\">
                                 <div class=\\"fd-bar__middle\\">
-                                    <div class=\\"fd-bar__element\\">Team Members (4)</div>
+                                    <div class=\\"fd-bar__element\\">
+                                        <h1 class=\\"fd-title fd-title--h5\\">Team Members (4)</h1>
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -9219,7 +9139,7 @@ exports[`Check stories > Components/Avatar Group > Story IndividualTypeVertical 
                             <span 
                                 class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border\\" 
                                 role=\\"button\\" 
-                                aria-label=\\"Gordon Smith\\" 
+                                aria-label=\\"Avatar Gordon Smith\\" 
                                 title=\\"Gordon Smith\\"
                                 tabindex=\\"0\\">
                                 <i class=\\"fd-avatar__icon sap-icon--person-placeholder\\" role=\\"presentation\\" aria-hidden=\\"true\\"></i>
@@ -9229,7 +9149,7 @@ exports[`Check stories > Components/Avatar Group > Story IndividualTypeVertical 
                                 class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" 
                                 style=\\"background-image: url('/assets/images/portraits/L_80x80_M2.png')\\" 
                                 role=\\"button\\" 
-                                alt=\\"Adam Doe\\" 
+                                alt=\\"Portrait of Adam Doe\\" 
                                 title=\\"Adam Doe\\" 
                                 tabindex=\\"0\\">
                             </span>
@@ -9237,7 +9157,7 @@ exports[`Check stories > Components/Avatar Group > Story IndividualTypeVertical 
                             <span 
                                 class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border\\" 
                                 role=\\"button\\" 
-                                aria-label=\\"Mandy Moore\\" 
+                                aria-label=\\"Avatar Mandy Moore\\" 
                                 title=\\"Mandy Moore\\" 
                                 tabindex=\\"0\\">JM
                             </span>
@@ -9245,7 +9165,7 @@ exports[`Check stories > Components/Avatar Group > Story IndividualTypeVertical 
                             <span 
                                 class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border\\" 
                                 role=\\"button\\" 
-                                aria-label=\\"Jimi Bloggs\\" 
+                                aria-label=\\"Avatar Jimi Bloggs\\" 
                                 title=\\"Jimi Bloggs\\" 
                                 tabindex=\\"0\\">JB
                             </span>
@@ -9291,7 +9211,7 @@ exports[`Check stories > Components/Avatar Group > Story Overflow > Should match
                 <span 
                     class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" 
                     role=\\"button\\" 
-                    alt=\\"Christian Bow\\" 
+                    alt=\\"Portrait of Christian Bow\\" 
                     title=\\"Christian Bow\\"
                     tabindex=\\"0\\">
                 </span>
@@ -9348,7 +9268,7 @@ exports[`Check stories > Components/Avatar Group > Story Overflow > Should match
                 <span 
                     class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" 
                     role=\\"button\\" 
-                    alt=\\"Christian Bow\\" 
+                    alt=\\"Portrait of Christian Bow\\" 
                     title=\\"Christian Bow\\"
                     tabindex=\\"0\\">
                 </span>
@@ -9404,7 +9324,7 @@ exports[`Check stories > Components/Avatar Group > Story Overflow > Should match
                 <span 
                     class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" 
                     role=\\"button\\" 
-                    alt=\\"Christian Bow\\" 
+                    alt=\\"Portrait of Christian Bow\\" 
                     title=\\"Christian Bow\\"
                     tabindex=\\"0\\">
                 </span>
@@ -9460,7 +9380,7 @@ exports[`Check stories > Components/Avatar Group > Story Overflow > Should match
                 <span 
                     class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/portraits/L_80x80_M1.png')\\" 
                     role=\\"button\\" 
-                    alt=\\"Christian Bow\\" 
+                    alt=\\"Portrait of Christian Bow\\" 
                     title=\\"Christian Bow\\"
                     tabindex=\\"0\\">
                 </span>


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-styles/issues/5763

## Description
- focus for Avatar group (Group type) when alone and with Popover
- Avatar with `role="img"` doesn't need title property. `aria-label` is enough in this case.
- updated the doc examples