### PR TITLE
fix(styles): add fix for missing btn focus in input group [ci visual]

### DIFF
--- a/packages/styles/src/input-group.scss
+++ b/packages/styles/src/input-group.scss
@@ -29,8 +29,7 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
   --fdInput_Height: 100%;
   --fdInput_Compact_Height: 100%;
 
-  &:has(input:is(:focus)),
-  &:has(button:is(:focus)) {
+  &:has(input:is(:focus)) {
     background: var(--sapField_Focus_Background);
     outline: var(--fdInput_Outline_Color) var(--sapContent_FocusStyle) var(--sapContent_FocusWidth);
     outline-offset: var(--fdInput_Outline_Offset);
@@ -113,14 +112,6 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
       padding-block: 0;
       padding-inline: 0;
       overflow: visible;
-
-      button {
-        @include fd-focus() {
-          &::after {
-            border: none;
-          }
-        }
-      }
     }
   }
 


### PR DESCRIPTION
## Related Issue
related to https://github.com/SAP/fundamental-ngx/issues/13350

## Description
apply focus only when the input is focussed, show the btn outline if the btn is focussed

