### PR TITLE
docs(styles): improve Radio button examples for a11y [ci visual]

### DIFF
--- a/packages/styles/stories/Components/Forms/radio/inline.example.html
+++ b/packages/styles/stories/Components/Forms/radio/inline.example.html
@@ -4,19 +4,19 @@
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio" id="pDidh767" name="radio4" checked>
                 <label class="fd-radio__label" for="pDidh767">
-                    <span class="fd-radio__text">Field label</span>
+                    <span class="fd-radio__text">Option 1</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio" id="pDidh7618" name="radio4" >
                 <label class="fd-radio__label" for="pDidh7618">
-                    <span class="fd-radio__text">Field label</span>
+                    <span class="fd-radio__text">Option 2</span>
                 </label>
             </div>
             <div class="fd-form-item">
                 <input type="radio" class="fd-radio" id="pDidh7619" name="radio4">
                 <label class="fd-radio__label" for="pDidh7619">
-                    <span class="fd-radio__text">Field label</span>
+                    <span class="fd-radio__text">Option 3</span>
                 </label>
             </div>
         </div>

--- a/packages/styles/stories/Components/Forms/radio/interaction-states.example.html
+++ b/packages/styles/stories/Components/Forms/radio/interaction-states.example.html
@@ -123,19 +123,19 @@
     <legend class="fd-fieldset__legend">Read-Only Interaction States</legend>
     <div class="fd-form-group">
         <div class="fd-form-item">
-            <input type="radio" class="fd-radio is-readonly" id="iSpDidh76erfg15" name="radio5f" readonly>
+            <input type="radio" class="fd-radio is-readonly" id="iSpDidh76erfg15" name="radio5f" aria-readonly="true" aria-description="This radio button is read-only and cannot be changed." onclick="return false;">
             <label class="fd-radio__label" for="iSpDidh76erfg15">
                 <span class="fd-radio__text">ReadOnly Radio Button</span>
             </label>
         </div>
         <div class="fd-form-item">
-            <input type="radio" class="fd-radio is-readonly" id="iSpDidh76erfg15cc" name="radio5f" readonly checked>
+            <input type="radio" class="fd-radio is-readonly" id="iSpDidh76erfg15cc" name="radio5f" aria-readonly="true" aria-description="This radio button is read-only and cannot be changed." onclick="return false;" checked>
             <label class="fd-radio__label" for="iSpDidh76erfg15cc">
                 <span class="fd-radio__text">ReadOnly Checked Radio Button</span>
             </label>
         </div>
         <div class="fd-form-item">
-            <input type="radio" class="fd-radio is-readonly" id="iSpDidh76erfg15hov" name="radio5f" readonly>
+            <input type="radio" class="fd-radio is-readonly" id="iSpDidh76erfg15hov" name="radio5f" aria-readonly="true" aria-description="This radio button is read-only and cannot be changed." onclick="return false;">
             <label class="fd-radio__label is-hover" for="iSpDidh76erfg15hov">
                 <span class="fd-radio__text">ReadOnly Hover Radio Button</span>
             </label>
@@ -147,31 +147,31 @@
     <legend class="fd-fieldset__legend">Disabled States</legend>
     <div class="fd-form-group">
         <div class="fd-form-item">
-            <input type="radio" class="fd-radio" id="iSpDidh7611" name="radio5g" disabled>
+            <input type="radio" class="fd-radio" id="iSpDidh7611" name="radio5g" disabled aria-disabled="true">
             <label class="fd-radio__label" for="iSpDidh7611">
                 <span class="fd-radio__text">Disabled Radio Button</span>
             </label>
         </div>
         <div class="fd-form-item">
-            <input type="radio" class="fd-radio is-success" id="iSpDidh76121" name="radio5g" disabled>
+            <input type="radio" class="fd-radio is-success" id="iSpDidh76121" name="radio5g" disabled aria-disabled="true">
             <label class="fd-radio__label" for="iSpDidh76121">
                 <span class="fd-radio__text">Success Radio Button (disabled)</span>
             </label>
         </div>
         <div class="fd-form-item">
-            <input type="radio" class="fd-radio is-error" id="iSpDidh76131" name="radio5g" disabled>
+            <input type="radio" class="fd-radio is-error" id="iSpDidh76131" name="radio5g" disabled aria-disabled="true">
             <label class="fd-radio__label" for="iSpDidh76131">
                 <span class="fd-radio__text">Error Radio Button (disabled)</span>
             </label>
         </div>
         <div class="fd-form-item">
-            <input type="radio" class="fd-radio is-warning" id="iSpDidh76141" name="radio5g" disabled>
+            <input type="radio" class="fd-radio is-warning" id="iSpDidh76141" name="radio5g" disabled aria-disabled="true">
             <label class="fd-radio__label" for="iSpDidh76141">
                 <span class="fd-radio__text">Warning Radio Button (disabled)</span>
             </label>
         </div>
         <div class="fd-form-item">
-            <input type="radio" class="fd-radio is-information" id="iSpDidh76151" name="radio5g" disabled>
+            <input type="radio" class="fd-radio is-information" id="iSpDidh76151" name="radio5g" disabled aria-disabled="true">
             <label class="fd-radio__label" for="iSpDidh76151">
                 <span class="fd-radio__text">Information Radio Button (disabled)</span>
             </label>

--- a/packages/styles/stories/Components/Forms/radio/primary.example.html
+++ b/packages/styles/stories/Components/Forms/radio/primary.example.html
@@ -4,19 +4,19 @@
         <div class="fd-form-item">
             <input type="radio" class="fd-radio" id="pDidh761" name="radio1" checked>
             <label class="fd-radio__label" for="pDidh761">
-                <span class="fd-radio__text">Field label</span>
+                <span class="fd-radio__text">Option 1</span>
             </label>
         </div>
         <div class="fd-form-item">
             <input type="radio" class="fd-radio" id="pDidh7612" name="radio1">
             <label class="fd-radio__label" for="pDidh7612">
-                <span class="fd-radio__text">Field label</span>
+                <span class="fd-radio__text">Option 2</span>
             </label>
         </div>
         <div class="fd-form-item">
-            <input type="radio" class="fd-radio" id="pDidh764" name="radio3" disabled>
+            <input type="radio" class="fd-radio" id="pDidh764" name="radio1" disabled aria-disabled="true">
             <label class="fd-radio__label" for="pDidh764">
-                <span class="fd-radio__text">Field label (disabled)</span>
+                <span class="fd-radio__text">Option 3 (disabled)</span>
             </label>
         </div>
     </div>

--- a/packages/styles/stories/Components/Forms/radio/radio.stories.js
+++ b/packages/styles/stories/Components/Forms/radio/radio.stories.js
@@ -12,18 +12,18 @@ export default {
     description: `
 Radio buttons provide users with a set of mutually exclusive options. They allow a user to select only one option from two or more choices. Each option is represented by a radio button. Consequently, radio buttons only work in groups.
 
-Use the radio button if:
+<b>Use the radio button if:</b>
 
 - You need to help users choose quickly between at least two clearly different choices.
 
-Do not use the radio button if:
+<b>Do not use the radio button if:</b>
 
 - You need to offer the user the option of multiple selection. In this case, use checkboxes instead because radio buttons are for single-selection contexts only.
 - You need to present more than 8 options. Use a dropdown box or list view.
-In special cases, there are only two mutually exclusive options. Combine them into a single checkbox or switch. For example, use a checkbox for “I agree” (for example, to terms and conditions) instead of two radio buttons for “I agree” and “I don’t agree”.
+In special cases, there are only two mutually exclusive options. Combine them into a single checkbox or switch. For example, use a checkbox for “I agree” (for example, to terms and conditions) instead of two radio buttons for “I agree” and “I don't agree”.
 - The options are numbers with fixed steps. Use a slider control.
 `,
-    tags: ['f3', 'a11y', 'theme']
+    tags: []
   }
 };
 export const Primary = () => primaryExampleHtml;

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -22288,19 +22288,19 @@ exports[`Check stories > Components/Forms/Radio > Story Inline > Should match sn
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio\\" id=\\"pDidh767\\" name=\\"radio4\\" checked>
                 <label class=\\"fd-radio__label\\" for=\\"pDidh767\\">
-                    <span class=\\"fd-radio__text\\">Field label</span>
+                    <span class=\\"fd-radio__text\\">Option 1</span>
                 </label>
             </div>
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio\\" id=\\"pDidh7618\\" name=\\"radio4\\" >
                 <label class=\\"fd-radio__label\\" for=\\"pDidh7618\\">
-                    <span class=\\"fd-radio__text\\">Field label</span>
+                    <span class=\\"fd-radio__text\\">Option 2</span>
                 </label>
             </div>
             <div class=\\"fd-form-item\\">
                 <input type=\\"radio\\" class=\\"fd-radio\\" id=\\"pDidh7619\\" name=\\"radio4\\">
                 <label class=\\"fd-radio__label\\" for=\\"pDidh7619\\">
-                    <span class=\\"fd-radio__text\\">Field label</span>
+                    <span class=\\"fd-radio__text\\">Option 3</span>
                 </label>
             </div>
         </div>
@@ -22434,19 +22434,19 @@ exports[`Check stories > Components/Forms/Radio > Story InteractionStates > Shou
     <legend class=\\"fd-fieldset__legend\\">Read-Only Interaction States</legend>
     <div class=\\"fd-form-group\\">
         <div class=\\"fd-form-item\\">
-            <input type=\\"radio\\" class=\\"fd-radio is-readonly\\" id=\\"iSpDidh76erfg15\\" name=\\"radio5f\\" readonly>
+            <input type=\\"radio\\" class=\\"fd-radio is-readonly\\" id=\\"iSpDidh76erfg15\\" name=\\"radio5f\\" aria-readonly=\\"true\\" aria-description=\\"This radio button is read-only and cannot be changed.\\" onclick=\\"return false;\\">
             <label class=\\"fd-radio__label\\" for=\\"iSpDidh76erfg15\\">
                 <span class=\\"fd-radio__text\\">ReadOnly Radio Button</span>
             </label>
         </div>
         <div class=\\"fd-form-item\\">
-            <input type=\\"radio\\" class=\\"fd-radio is-readonly\\" id=\\"iSpDidh76erfg15cc\\" name=\\"radio5f\\" readonly checked>
+            <input type=\\"radio\\" class=\\"fd-radio is-readonly\\" id=\\"iSpDidh76erfg15cc\\" name=\\"radio5f\\" aria-readonly=\\"true\\" aria-description=\\"This radio button is read-only and cannot be changed.\\" onclick=\\"return false;\\" checked>
             <label class=\\"fd-radio__label\\" for=\\"iSpDidh76erfg15cc\\">
                 <span class=\\"fd-radio__text\\">ReadOnly Checked Radio Button</span>
             </label>
         </div>
         <div class=\\"fd-form-item\\">
-            <input type=\\"radio\\" class=\\"fd-radio is-readonly\\" id=\\"iSpDidh76erfg15hov\\" name=\\"radio5f\\" readonly>
+            <input type=\\"radio\\" class=\\"fd-radio is-readonly\\" id=\\"iSpDidh76erfg15hov\\" name=\\"radio5f\\" aria-readonly=\\"true\\" aria-description=\\"This radio button is read-only and cannot be changed.\\" onclick=\\"return false;\\">
             <label class=\\"fd-radio__label is-hover\\" for=\\"iSpDidh76erfg15hov\\">
                 <span class=\\"fd-radio__text\\">ReadOnly Hover Radio Button</span>
             </label>
@@ -22458,31 +22458,31 @@ exports[`Check stories > Components/Forms/Radio > Story InteractionStates > Shou
     <legend class=\\"fd-fieldset__legend\\">Disabled States</legend>
     <div class=\\"fd-form-group\\">
         <div class=\\"fd-form-item\\">
-            <input type=\\"radio\\" class=\\"fd-radio\\" id=\\"iSpDidh7611\\" name=\\"radio5g\\" disabled>
+            <input type=\\"radio\\" class=\\"fd-radio\\" id=\\"iSpDidh7611\\" name=\\"radio5g\\" disabled aria-disabled=\\"true\\">
             <label class=\\"fd-radio__label\\" for=\\"iSpDidh7611\\">
                 <span class=\\"fd-radio__text\\">Disabled Radio Button</span>
             </label>
         </div>
         <div class=\\"fd-form-item\\">
-            <input type=\\"radio\\" class=\\"fd-radio is-success\\" id=\\"iSpDidh76121\\" name=\\"radio5g\\" disabled>
+            <input type=\\"radio\\" class=\\"fd-radio is-success\\" id=\\"iSpDidh76121\\" name=\\"radio5g\\" disabled aria-disabled=\\"true\\">
             <label class=\\"fd-radio__label\\" for=\\"iSpDidh76121\\">
                 <span class=\\"fd-radio__text\\">Success Radio Button (disabled)</span>
             </label>
         </div>
         <div class=\\"fd-form-item\\">
-            <input type=\\"radio\\" class=\\"fd-radio is-error\\" id=\\"iSpDidh76131\\" name=\\"radio5g\\" disabled>
+            <input type=\\"radio\\" class=\\"fd-radio is-error\\" id=\\"iSpDidh76131\\" name=\\"radio5g\\" disabled aria-disabled=\\"true\\">
             <label class=\\"fd-radio__label\\" for=\\"iSpDidh76131\\">
                 <span class=\\"fd-radio__text\\">Error Radio Button (disabled)</span>
             </label>
         </div>
         <div class=\\"fd-form-item\\">
-            <input type=\\"radio\\" class=\\"fd-radio is-warning\\" id=\\"iSpDidh76141\\" name=\\"radio5g\\" disabled>
+            <input type=\\"radio\\" class=\\"fd-radio is-warning\\" id=\\"iSpDidh76141\\" name=\\"radio5g\\" disabled aria-disabled=\\"true\\">
             <label class=\\"fd-radio__label\\" for=\\"iSpDidh76141\\">
                 <span class=\\"fd-radio__text\\">Warning Radio Button (disabled)</span>
             </label>
         </div>
         <div class=\\"fd-form-item\\">
-            <input type=\\"radio\\" class=\\"fd-radio is-information\\" id=\\"iSpDidh76151\\" name=\\"radio5g\\" disabled>
+            <input type=\\"radio\\" class=\\"fd-radio is-information\\" id=\\"iSpDidh76151\\" name=\\"radio5g\\" disabled aria-disabled=\\"true\\">
             <label class=\\"fd-radio__label\\" for=\\"iSpDidh76151\\">
                 <span class=\\"fd-radio__text\\">Information Radio Button (disabled)</span>
             </label>
@@ -22499,19 +22499,19 @@ exports[`Check stories > Components/Forms/Radio > Story Primary > Should match s
         <div class=\\"fd-form-item\\">
             <input type=\\"radio\\" class=\\"fd-radio\\" id=\\"pDidh761\\" name=\\"radio1\\" checked>
             <label class=\\"fd-radio__label\\" for=\\"pDidh761\\">
-                <span class=\\"fd-radio__text\\">Field label</span>
+                <span class=\\"fd-radio__text\\">Option 1</span>
             </label>
         </div>
         <div class=\\"fd-form-item\\">
             <input type=\\"radio\\" class=\\"fd-radio\\" id=\\"pDidh7612\\" name=\\"radio1\\">
             <label class=\\"fd-radio__label\\" for=\\"pDidh7612\\">
-                <span class=\\"fd-radio__text\\">Field label</span>
+                <span class=\\"fd-radio__text\\">Option 2</span>
             </label>
         </div>
         <div class=\\"fd-form-item\\">
-            <input type=\\"radio\\" class=\\"fd-radio\\" id=\\"pDidh764\\" name=\\"radio3\\" disabled>
+            <input type=\\"radio\\" class=\\"fd-radio\\" id=\\"pDidh764\\" name=\\"radio1\\" disabled aria-disabled=\\"true\\">
             <label class=\\"fd-radio__label\\" for=\\"pDidh764\\">
-                <span class=\\"fd-radio__text\\">Field label (disabled)</span>
+                <span class=\\"fd-radio__text\\">Option 3 (disabled)</span>
             </label>
         </div>
     </div>


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/6096

## Description
- check for design changes (no changes)
- adopt the design changes (if any) (none)
- check for ACC improvements (yes)
- adopt WCAG 2.2 requirements (no specific requirements for this component)
- documentation improvements and updates (yes)

1. `disabled` attributed should be accompanied by `aria-disabled="true"`
2. `readonly` attribute is not relevant to non-textual input elements, such as radio btn. Needs additional way to communicate to the used the checkbox is readonly: added aria-description

Before:
```
<input type="radio" class="fd-radio is-readonly"  readonly>
```

After:
```
<input type="radio" class="fd-radio is-readonly" aria-readonly="true" aria-description="This radio button is read-only and cannot be changed." onclick="return false;" checked>
```
