### PR TITLE
fix(styles): add a11y improvements for Input control [ci visual]

### DIFF
--- a/packages/styles/src/input.scss
+++ b/packages/styles/src/input.scss
@@ -36,5 +36,9 @@ $block: #{$fd-namespace}-input;
     text-align: right;
   }
 
+  &__sr-only {
+    @include fd-screen-reader-only();
+  }
+
   @include fd-input-field-states();
 }

--- a/packages/styles/stories/Components/Forms/input/input.stories.js
+++ b/packages/styles/stories/Components/Forms/input/input.stories.js
@@ -25,7 +25,7 @@ Do not use the input field if:
 - The user needs to enter long texts. In this case, use the textarea.
 - The user needs to carry out a search. In this case, use the search field.
         `,
-    tags: ['f3', 'a11y', 'theme']
+    tags: []
   }
 };
 export const Primary = () => primaryExampleHtml;

--- a/packages/styles/stories/Components/Forms/input/primary.example.html
+++ b/packages/styles/stories/Components/Forms/input/primary.example.html
@@ -1,116 +1,157 @@
-<div style="">
-    <div class="fd-form-item">
-        <label class="fd-form-label" for="input-1">Default input (regular):</label>
-        <input class="fd-input" type="text" id="input-1" placeholder="Field placeholder text">
-    </div>
-    <br>
-    <div class="fd-form-item">
-        <label class="fd-form-label" for="input-1-hover">Default input (hover):</label>
-        <input class="fd-input is-hover" type="text" id="input-1-hover" placeholder="Field placeholder text">
-    </div>
-    <br>
-    <div class="fd-form-item">
-        <label class="fd-form-label" for="input-1-focus">Default input (focus):</label>
-        <input class="fd-input is-focus" type="text" id="input-1-focus" placeholder="Field placeholder text">
-    </div>
-    <br>
-    <div class="fd-form-item">
-        <label class="fd-form-label fd-form-label--required" for="input-1c">Required Input:</label>
-        <input class="fd-input" type="text" id="input-1c" placeholder="Field placeholder text">
-    </div>
-    <br />
-    <div class="fd-form-item">
-        <label class="fd-form-label" aria-required="true" for="input-1d">Password:</label>
-        <input class="fd-input" type="password" id="input-1d">
-    </div>
-    <br />
-    <div class="fd-form-item">
-        <label class="fd-form-label" for="input-01">Error Input:</label>
-        <input class="fd-input is-error" type="text" id="input-01" placeholder="Field placeholder text">
-    </div>
-    <br />
-    <div class="fd-form-item">
-        <label class="fd-form-label" for="input-01-hover">Error Input:</label>
-        <input class="fd-input is-error is-hover" type="text" id="input-01-hover" placeholder="Field placeholder text">
-    </div>
-    <br />
-    <div class="fd-form-item">
-        <label class="fd-form-label" for="input-01-focus">Error Input:</label>
-        <input class="fd-input is-error is-focus" type="text" id="input-01-focus" placeholder="Field placeholder text">
-    </div>
-    <br />
-    <div class="fd-form-item">
-        <label class="fd-form-label" for="input-02">Success Input:</label>
-        <input class="fd-input is-success" type="text" id="input-02" placeholder="Field placeholder text">
-    </div>
-    <br />
-    <div class="fd-form-item">
-        <label class="fd-form-label" for="input-02-hover">Success Input:</label>
-        <input class="fd-input is-success is-hover" type="text" id="input-02-hover" placeholder="Field placeholder text">
-    </div>
-    <br />
-    <div class="fd-form-item">
-        <label class="fd-form-label" for="input-02-focus">Success Input:</label>
-        <input class="fd-input is-success is-focus" type="text" id="input-02-focus" placeholder="Field placeholder text">
-    </div>
-    <br />
-    <div class="fd-form-item">
-        <label class="fd-form-label" for="input-03">Warning (Alert) Input:</label>
-        <input class="fd-input is-warning" type="text" id="input-03" placeholder="Field placeholder text">
-    </div>
-    <br />
-    <div class="fd-form-item">
-        <label class="fd-form-label" for="input-03-hover">Warning (Alert) Input:</label>
-        <input class="fd-input is-warning is-hover" type="text" id="input-03-hover" placeholder="Field placeholder text">
-    </div>
-    <br />
-    <div class="fd-form-item">
-        <label class="fd-form-label" for="input-03-focus">Warning (Alert) Input:</label>
-        <input class="fd-input is-warning is-focus" type="text" id="input-03-focus" placeholder="Field placeholder text">
-    </div>
-    <br />
-    <div class="fd-form-item">
-        <label class="fd-form-label" for="input-04">Information Input:</label>
-        <input class="fd-input is-information" type="text" id="input-04" placeholder="Field placeholder text">
-    </div>
-    <br />
-    <div class="fd-form-item">
-        <label class="fd-form-label" for="input-04-hover">Information Input:</label>
-        <input class="fd-input is-information is-hover" type="text" id="input-04-hover" placeholder="Field placeholder text">
-    </div>
-    <br />
-    <div class="fd-form-item">
-        <label class="fd-form-label" for="input-04-focus">Information Input:</label>
-        <input class="fd-input is-information is-focus" type="text" id="input-04-focus" placeholder="Field placeholder text">
-    </div>
-    <br />
-    <div class="fd-form-item">
-        <label class="fd-form-label" for="input-05">Disabled Input:</label>
-        <input class="fd-input" type="text" id="input-05" disabled placeholder="Field placeholder text">
-    </div>
-    <br />
-    <div class="fd-form-item">
-        <label class="fd-form-label" for="input-06">Read-Only Input:</label>
-        <input class="fd-input" type="text" id="input-06" readonly placeholder="Field placeholder text">
-    </div>
-    <br />
-    <div class="fd-form-item fd-form-item--horizontal">
-        <label class="fd-form-label" for="input-07">Default input:</label>
-        <input class="fd-input" type="text" id="input-07" placeholder="Field placeholder text" aria-label="Image label">
-    </div>
-    <br />
-    <div class="fd-form-item fd-form-item--horizontal">
-        <label class="fd-form-label fd-form-label--required" for="input-09">Required Input:</label>
-        <input class="fd-input" type="text" id="input-09" placeholder="Field placeholder text">
-    </div>
-    <br />
-    <div class="fd-form-item fd-form-item--horizontal">
-        <label class="fd-form-label" aria-required="true" for="input-10">Password:</label>
-        <input class="fd-input" type="password" id="input-10">
-    </div>
-    <br />
-    <div class="fd-form-item fd-form-item--horizontal">
-        <label class="fd-form-label" aria-required="true" for="input-11">Input:</label>
-        <input class="fd-input" type="text" id="input-11">
-    </div>
+<div class="fd-form-item">
+    <label class="fd-form-label" for="input-default">Full Name</label>
+    <input class="fd-input" type="text" id="input-default" placeholder="e.g., Jane Doe" autocomplete="off">
 </div>
+
+<br><br>
+
+<div class="fd-form-item">
+    <label class="fd-form-label" for="input-hover">Full Name (Hover State)</label>
+    <input class="fd-input is-hover" type="text" id="input-hover" placeholder="e.g., Jane Doe" autocomplete="off">
+</div>
+
+<br><br>
+
+<div class="fd-form-item">
+    <label class="fd-form-label" for="input-focus">Full Name (Focus State)</label>
+    <input class="fd-input is-focus" type="text" id="input-focus" placeholder="e.g., Jane Doe" autocomplete="off">
+</div>
+
+<br><br>
+
+<div class="fd-form-item">
+    <label class="fd-form-label fd-form-label--required" for="input-required">Email Address</label>
+    <input class="fd-input" type="email" id="input-required" placeholder="e.g., user@example.com" autocomplete="off" required aria-required="true">
+</div>
+
+<br><br>
+
+<div class="fd-form-item">
+    <label class="fd-form-label" for="input-password">Password</label>
+    <input class="fd-input" type="password" id="input-password" autocomplete="off" required aria-required="true">
+</div>
+
+<br><br>
+
+<div class="fd-form-item">
+    <label class="fd-form-label" for="input-error">Username (Error)</label>
+    <input class="fd-input is-error" type="text" id="input-error" placeholder="Invalid username" autocomplete="off" aria-invalid="true" aria-describedby="input-error-message">
+    <div class="fd-input__sr-only" id="input-error-message">You have entered invalid username.</div>
+</div>
+
+<br><br>
+
+<div class="fd-form-item">
+    <label class="fd-form-label" for="input-error-hover">Username (Error + Hover)</label>
+    <input class="fd-input is-error is-hover" type="text" id="input-error-hover" placeholder="Invalid username" autocomplete="off" aria-invalid="true" aria-describedby="input-error-hover-message">
+    <div class="fd-input__sr-only" id="input-error-hover-message">You have entered invalid username.</div>
+</div>
+
+<br><br>
+
+<div class="fd-form-item">
+    <label class="fd-form-label" for="input-error-focus">Username (Error + Focus)</label>
+    <input class="fd-input is-error is-focus" type="text" id="input-error-focus" placeholder="Invalid username" autocomplete="off" aria-invalid="true" aria-describedby="input-error-focus-message">
+    <div class="fd-input__sr-only" id="input-error-focus-message">You have entered invalid username.</div>
+</div>
+
+<br><br>
+
+<div class="fd-form-item">
+    <label class="fd-form-label" for="input-success">Phone Number (Success)</label>
+    <input class="fd-input is-success" type="tel" id="input-success" placeholder="e.g., +1 555 123 4567" autocomplete="off" aria-describedby="input-success-message">
+    <div class="fd-input__sr-only" id="input-success-message">Entry successfully validated</div>
+</div>
+
+<br><br>
+
+<div class="fd-form-item">
+    <label class="fd-form-label" for="input-success-hover">Phone Number (Success + Hover)</label>
+    <input class="fd-input is-success is-hover" type="tel" id="input-success-hover" placeholder="e.g., +1 555 123 4567" autocomplete="off" aria-describedby="input-success-hover-message">
+    <div class="fd-input__sr-only" id="input-success-hover-message">Entry successfully validated</div>
+</div>
+
+<br><br>
+
+<div class="fd-form-item">
+    <label class="fd-form-label" for="input-success-focus">Phone Number (Success + Focus)</label>
+    <input class="fd-input is-success is-focus" type="tel" id="input-success-focus" placeholder="e.g., +1 555 123 4567" autocomplete="off" aria-describedby="input-success-focus-message">
+    <div class="fd-input__sr-only" id="input-success-focus-message">Entry successfully validated</div>
+</div>
+
+<br><br>
+
+<div class="fd-form-item">
+    <label class="fd-form-label" for="input-warning">Security Answer (Warning)</label>
+    <input class="fd-input is-warning" type="text" id="input-warning" placeholder="e.g., Your first pet's name" autocomplete="off" aria-describedby="input-warning-message">
+    <div class="fd-input__sr-only" id="input-warning-message">Warning message</div>
+</div>
+
+<br><br>
+
+<div class="fd-form-item">
+    <label class="fd-form-label" for="input-warning-hover">Security Answer (Warning + Hover)</label>
+    <input class="fd-input is-warning is-hover" type="text" id="input-warning-hover" placeholder="e.g., Your first pet's name" autocomplete="off" aria-describedby="input-warning-hover-message">
+    <div class="fd-input__sr-only" id="input-warning-hover-message">Warning message</div>
+</div>
+
+<br><br>
+
+<div class="fd-form-item">
+    <label class="fd-form-label" for="input-warning-focus">Security Answer (Warning + Focus)</label>
+    <input class="fd-input is-warning is-focus" type="text" id="input-warning-focus" placeholder="e.g., Your first pet's name" autocomplete="off" aria-describedby="input-warning-focus-message">
+    <div class="fd-input__sr-only" id="input-warning-focus-message">Warning message</div>
+</div>
+
+<br><br>
+
+<div class="fd-form-item">
+    <label class="fd-form-label" for="input-info">Notes (Info)</label>
+    <input class="fd-input is-information" type="text" id="input-info" placeholder="e.g., Optional comments" autocomplete="off" aria-describedby="input-info-message">
+    <div class="fd-input__sr-only" id="input-info-message">Informative message</div>
+</div>
+
+<br><br>
+
+<div class="fd-form-item">
+    <label class="fd-form-label" for="input-info-hover">Notes (Info + Hover)</label>
+    <input class="fd-input is-information is-hover" type="text" id="input-info-hover" placeholder="e.g., Optional comments" autocomplete="off" aria-describedby="input-info-hover-message">
+    <div class="fd-input__sr-only" id="input-info-hover-message">Informative message</div>
+</div>
+
+<br><br>
+
+<div class="fd-form-item">
+    <label class="fd-form-label" for="input-info-focus">Notes (Info + Focus)</label>
+    <input class="fd-input is-information is-focus" type="text" id="input-info-focus" placeholder="e.g., Optional comments" autocomplete="off" aria-describedby="input-info-focus-message">
+    <div class="fd-input__sr-only" id="input-info-focus-message">Informative message</div>
+</div>
+
+<br><br>
+
+<div class="fd-form-item">
+    <label class="fd-form-label fd-form-label--disabled" for="input-disabled" aria-disabled="true">Organization</label>
+    <input class="fd-input" type="text" id="input-disabled" value="SAP" disabled>
+</div>
+
+<br><br>
+
+<div class="fd-form-item">
+    <label class="fd-form-label" for="input-readonly">Country (Read-Only)</label>
+    <input class="fd-input" type="text" id="input-readonly" value="Canada" readonly>
+</div>
+
+<br><br>
+  
+<div class="fd-form-item fd-form-item--horizontal">
+    <label class="fd-form-label" for="input-horizontal">Department</label>
+    <input class="fd-input" type="text" id="input-horizontal" placeholder="e.g., Marketing">
+</div>
+
+<br><br>
+
+<div class="fd-form-item fd-form-item--horizontal">
+    <label class="fd-form-label fd-form-label--required" for="input-horizontal-required">Employee ID</label>
+    <input class="fd-input" type="text" id="input-horizontal-required" placeholder="e.g., E12345" required aria-required="true">
+</div>
+  

--- a/packages/styles/stories/Components/Forms/input/states.example.html
+++ b/packages/styles/stories/Components/Forms/input/states.example.html
@@ -1,75 +1,133 @@
-
+<!-- Default Input -->
 <div class="fd-form-item">
-    <label class="fd-form-label" for="input-1aa">Normal input:</label>
-    <input class="fd-input" type="text" id="input-1aa" placeholder="Field placeholder text" aria-label="Image label">
-</div>
-
-<br /><br />
-
-<div class="fd-form-item">
-    <label class="fd-form-label" for="input-1bb">Success input:</label>
+    <label class="fd-form-label" for="input-default-field">Full Name</label>
+    <input
+      class="fd-input"
+      type="text"
+      id="input-default-field"
+      placeholder="e.g., Jane Doe"
+      autocomplete="off"
+    >
+  </div>
+  
+  <br><br>
+  
+  <!-- Success Input with Message -->
+  <div class="fd-form-item">
+    <label class="fd-form-label" for="input-success-field">Email Address</label>
     <div class="fd-popover">
-        <div class="fd-popover__control" aria-controls="popoverB2" aria-expanded="true" aria-haspopup="true">
-            <input class="fd-input is-success" type="text" id="input-1bb" placeholder="Field placeholder text" aria-label="Image label">
-        </div>
-        <div class="fd-popover__body fd-popover__body--input-message-group fd-popover__body--no-arrow" aria-hidden="false" id="popoverB2">
-            <div class="fd-form-message fd-form-message--success">Success message</div>
-        </div>
+      <div class="fd-popover__control" aria-controls="success-message" aria-expanded="true" aria-haspopup="true">
+        <input
+          class="fd-input is-success"
+          type="email"
+          id="input-success-field"
+          placeholder="e.g., user@example.com"
+          autocomplete="off"
+          aria-describedby="success-message"
+        >
+      </div>
+      <div class="fd-popover__body fd-popover__body--input-message-group fd-popover__body--no-arrow" id="success-message">
+        <div class="fd-form-message fd-form-message--success">Email address looks good.</div>
+      </div>
     </div>
-</div>
-
-<br /><br />
-
-<div class="fd-form-item">
-    <label class="fd-form-label" for="input-1cc">Error input:</label>
+  </div>
+  
+  <br><br><br><br>
+  
+  <!-- Error Input with Message -->
+  <div class="fd-form-item">
+    <label class="fd-form-label" for="input-error-field">Username</label>
     <div class="fd-popover">
-        <div class="fd-popover__control" aria-controls="popoverB3" aria-expanded="true" aria-haspopup="true">
-            <input class="fd-input is-error" type="text" id="input-1cc" placeholder="Field placeholder text" aria-label="Image label">
-        </div>
-        <div class="fd-popover__body fd-popover__body--input-message-group fd-popover__body--no-arrow" aria-hidden="false" id="popoverB3">
-            <div class="fd-form-message fd-form-message--error">Error message</div>
-        </div>
+      <div class="fd-popover__control" aria-controls="wrong-message" aria-expanded="true" aria-haspopup="true">
+        <input
+          class="fd-input is-error"
+          type="text"
+          id="input-error-field"
+          placeholder="e.g., johndoe123"
+          autocomplete="off"
+          aria-describedby="wrong-message"
+          aria-invalid="true"
+        >
+      </div>
+      <div class="fd-popover__body fd-popover__body--input-message-group fd-popover__body--no-arrow" id="wrong-message">
+        <div class="fd-form-message fd-form-message--error">Username must be at least 6 characters.</div>
+      </div>
     </div>
-</div>
-
-<br /><br />
-
-<div class="fd-form-item">
-    <label class="fd-form-label" for="input-1dd">Warning input:</label>
+  </div>
+  
+  <br><br><br><br>
+  
+  <!-- Warning Input with Message -->
+  <div class="fd-form-item">
+    <label class="fd-form-label" for="input-warning-field">Security Answer</label>
     <div class="fd-popover">
-        <div class="fd-popover__control" aria-controls="popoverB4" aria-expanded="true" aria-haspopup="true">
-            <input class="fd-input is-warning" type="text" id="input-1dd" placeholder="Field placeholder text" aria-label="Image label">
-        </div>
-        <div class="fd-popover__body fd-popover__body--input-message-group fd-popover__body--no-arrow" aria-hidden="false" id="popoverB4">
-            <div class="fd-form-message fd-form-message--warning">Warning message</div>
-        </div>
+      <div class="fd-popover__control" aria-controls="warning-message" aria-expanded="true" aria-haspopup="true">
+        <input
+          class="fd-input is-warning"
+          type="text"
+          id="input-warning-field"
+          placeholder="e.g., Your first pet's name"
+          autocomplete="off"
+          aria-describedby="warning-message"
+        >
+      </div>
+      <div class="fd-popover__body fd-popover__body--input-message-group fd-popover__body--no-arrow" id="warning-message">
+        <div class="fd-form-message fd-form-message--warning">Make sure this is easy for you to remember.</div>
+      </div>
     </div>
-</div>
-
-<br /><br />
-
-<div class="fd-form-item">
-    <label class="fd-form-label" for="input-1ee">Information input:</label>
+  </div>
+  
+  <br><br><br><br>
+  
+  <!-- Information Input with Message -->
+  <div class="fd-form-item">
+    <label class="fd-form-label" for="input-info-field">Additional Notes</label>
     <div class="fd-popover">
-        <div class="fd-popover__control" aria-controls="popoverB5" aria-expanded="true" aria-haspopup="true">
-            <input class="fd-input is-information" type="text" id="input-1ee" placeholder="Field placeholder text" aria-label="Image label">
-        </div>
-        <div class="fd-popover__body fd-popover__body--input-message-group fd-popover__body--no-arrow" aria-hidden="false" id="popoverB5">
-            <div class="fd-form-message fd-form-message--information">Information message</div>
-        </div>
+      <div class="fd-popover__control" aria-controls="info-message" aria-expanded="true" aria-haspopup="true">
+        <input
+          class="fd-input is-information"
+          type="text"
+          id="input-info-field"
+          placeholder="Optional"
+          autocomplete="off"
+          aria-describedby="info-message"
+        >
+      </div>
+      <div class="fd-popover__body fd-popover__body--input-message-group fd-popover__body--no-arrow" id="info-message">
+        <div class="fd-form-message fd-form-message--information">You can leave this blank if not applicable.</div>
+      </div>
     </div>
-</div>
-
-<br /><br />
-
-<div class="fd-form-item">
-    <label class="fd-form-label" for="input-1ff">Disabled Input:</label>
-    <input class="fd-input" placeholder="Disabled field" type="text" id="input-1ff" value="Non editable data" disabled>
-</div>
-
-<br /><br />
-
-<div class="fd-form-item">
-    <label class="fd-form-label" for="input-1gg">Read Only Input:</label>
-    <input class="fd-input" type="text" id="input-1gg" value="Read only data" readonly>
-</div>
+  </div>
+  
+  <br><br><br><br>
+  
+  <!-- Disabled Input -->
+  <div class="fd-form-item">
+    <label class="fd-form-label fd-form-label--disabled" for="input-disabled-field" aria-disabled="true">Organization</label>
+    <input
+      class="fd-input"
+      type="text"
+      id="input-disabled-field"
+      value="SAP"
+      placeholder="Organization"
+      autocomplete="off"
+      disabled
+    >
+  </div>
+  
+  <br><br>
+  
+  <!-- Read-Only Input -->
+  <div class="fd-form-item">
+    <label class="fd-form-label" for="input-readonly-field">Country</label>
+    <input
+      class="fd-input"
+      type="text"
+      id="input-readonly-field"
+      value="Canada"
+      placeholder="Country"
+      autocomplete="off"
+      readonly
+    >
+  </div>
+  

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -20965,202 +20965,299 @@ exports[`Check stories > Components/Forms/Form Message > Story Warning > Should 
 `;
 
 exports[`Check stories > Components/Forms/Input > Story Primary > Should match snapshot 1`] = `
-"<div style=\\"\\">
-    <div class=\\"fd-form-item\\">
-        <label class=\\"fd-form-label\\" for=\\"input-1\\">Default input (regular):</label>
-        <input class=\\"fd-input\\" type=\\"text\\" id=\\"input-1\\" placeholder=\\"Field placeholder text\\">
-    </div>
-    <br>
-    <div class=\\"fd-form-item\\">
-        <label class=\\"fd-form-label\\" for=\\"input-1-hover\\">Default input (hover):</label>
-        <input class=\\"fd-input is-hover\\" type=\\"text\\" id=\\"input-1-hover\\" placeholder=\\"Field placeholder text\\">
-    </div>
-    <br>
-    <div class=\\"fd-form-item\\">
-        <label class=\\"fd-form-label\\" for=\\"input-1-focus\\">Default input (focus):</label>
-        <input class=\\"fd-input is-focus\\" type=\\"text\\" id=\\"input-1-focus\\" placeholder=\\"Field placeholder text\\">
-    </div>
-    <br>
-    <div class=\\"fd-form-item\\">
-        <label class=\\"fd-form-label fd-form-label--required\\" for=\\"input-1c\\">Required Input:</label>
-        <input class=\\"fd-input\\" type=\\"text\\" id=\\"input-1c\\" placeholder=\\"Field placeholder text\\">
-    </div>
-    <br />
-    <div class=\\"fd-form-item\\">
-        <label class=\\"fd-form-label\\" aria-required=\\"true\\" for=\\"input-1d\\">Password:</label>
-        <input class=\\"fd-input\\" type=\\"password\\" id=\\"input-1d\\">
-    </div>
-    <br />
-    <div class=\\"fd-form-item\\">
-        <label class=\\"fd-form-label\\" for=\\"input-01\\">Error Input:</label>
-        <input class=\\"fd-input is-error\\" type=\\"text\\" id=\\"input-01\\" placeholder=\\"Field placeholder text\\">
-    </div>
-    <br />
-    <div class=\\"fd-form-item\\">
-        <label class=\\"fd-form-label\\" for=\\"input-01-hover\\">Error Input:</label>
-        <input class=\\"fd-input is-error is-hover\\" type=\\"text\\" id=\\"input-01-hover\\" placeholder=\\"Field placeholder text\\">
-    </div>
-    <br />
-    <div class=\\"fd-form-item\\">
-        <label class=\\"fd-form-label\\" for=\\"input-01-focus\\">Error Input:</label>
-        <input class=\\"fd-input is-error is-focus\\" type=\\"text\\" id=\\"input-01-focus\\" placeholder=\\"Field placeholder text\\">
-    </div>
-    <br />
-    <div class=\\"fd-form-item\\">
-        <label class=\\"fd-form-label\\" for=\\"input-02\\">Success Input:</label>
-        <input class=\\"fd-input is-success\\" type=\\"text\\" id=\\"input-02\\" placeholder=\\"Field placeholder text\\">
-    </div>
-    <br />
-    <div class=\\"fd-form-item\\">
-        <label class=\\"fd-form-label\\" for=\\"input-02-hover\\">Success Input:</label>
-        <input class=\\"fd-input is-success is-hover\\" type=\\"text\\" id=\\"input-02-hover\\" placeholder=\\"Field placeholder text\\">
-    </div>
-    <br />
-    <div class=\\"fd-form-item\\">
-        <label class=\\"fd-form-label\\" for=\\"input-02-focus\\">Success Input:</label>
-        <input class=\\"fd-input is-success is-focus\\" type=\\"text\\" id=\\"input-02-focus\\" placeholder=\\"Field placeholder text\\">
-    </div>
-    <br />
-    <div class=\\"fd-form-item\\">
-        <label class=\\"fd-form-label\\" for=\\"input-03\\">Warning (Alert) Input:</label>
-        <input class=\\"fd-input is-warning\\" type=\\"text\\" id=\\"input-03\\" placeholder=\\"Field placeholder text\\">
-    </div>
-    <br />
-    <div class=\\"fd-form-item\\">
-        <label class=\\"fd-form-label\\" for=\\"input-03-hover\\">Warning (Alert) Input:</label>
-        <input class=\\"fd-input is-warning is-hover\\" type=\\"text\\" id=\\"input-03-hover\\" placeholder=\\"Field placeholder text\\">
-    </div>
-    <br />
-    <div class=\\"fd-form-item\\">
-        <label class=\\"fd-form-label\\" for=\\"input-03-focus\\">Warning (Alert) Input:</label>
-        <input class=\\"fd-input is-warning is-focus\\" type=\\"text\\" id=\\"input-03-focus\\" placeholder=\\"Field placeholder text\\">
-    </div>
-    <br />
-    <div class=\\"fd-form-item\\">
-        <label class=\\"fd-form-label\\" for=\\"input-04\\">Information Input:</label>
-        <input class=\\"fd-input is-information\\" type=\\"text\\" id=\\"input-04\\" placeholder=\\"Field placeholder text\\">
-    </div>
-    <br />
-    <div class=\\"fd-form-item\\">
-        <label class=\\"fd-form-label\\" for=\\"input-04-hover\\">Information Input:</label>
-        <input class=\\"fd-input is-information is-hover\\" type=\\"text\\" id=\\"input-04-hover\\" placeholder=\\"Field placeholder text\\">
-    </div>
-    <br />
-    <div class=\\"fd-form-item\\">
-        <label class=\\"fd-form-label\\" for=\\"input-04-focus\\">Information Input:</label>
-        <input class=\\"fd-input is-information is-focus\\" type=\\"text\\" id=\\"input-04-focus\\" placeholder=\\"Field placeholder text\\">
-    </div>
-    <br />
-    <div class=\\"fd-form-item\\">
-        <label class=\\"fd-form-label\\" for=\\"input-05\\">Disabled Input:</label>
-        <input class=\\"fd-input\\" type=\\"text\\" id=\\"input-05\\" disabled placeholder=\\"Field placeholder text\\">
-    </div>
-    <br />
-    <div class=\\"fd-form-item\\">
-        <label class=\\"fd-form-label\\" for=\\"input-06\\">Read-Only Input:</label>
-        <input class=\\"fd-input\\" type=\\"text\\" id=\\"input-06\\" readonly placeholder=\\"Field placeholder text\\">
-    </div>
-    <br />
-    <div class=\\"fd-form-item fd-form-item--horizontal\\">
-        <label class=\\"fd-form-label\\" for=\\"input-07\\">Default input:</label>
-        <input class=\\"fd-input\\" type=\\"text\\" id=\\"input-07\\" placeholder=\\"Field placeholder text\\" aria-label=\\"Image label\\">
-    </div>
-    <br />
-    <div class=\\"fd-form-item fd-form-item--horizontal\\">
-        <label class=\\"fd-form-label fd-form-label--required\\" for=\\"input-09\\">Required Input:</label>
-        <input class=\\"fd-input\\" type=\\"text\\" id=\\"input-09\\" placeholder=\\"Field placeholder text\\">
-    </div>
-    <br />
-    <div class=\\"fd-form-item fd-form-item--horizontal\\">
-        <label class=\\"fd-form-label\\" aria-required=\\"true\\" for=\\"input-10\\">Password:</label>
-        <input class=\\"fd-input\\" type=\\"password\\" id=\\"input-10\\">
-    </div>
-    <br />
-    <div class=\\"fd-form-item fd-form-item--horizontal\\">
-        <label class=\\"fd-form-label\\" aria-required=\\"true\\" for=\\"input-11\\">Input:</label>
-        <input class=\\"fd-input\\" type=\\"text\\" id=\\"input-11\\">
-    </div>
+"<div class=\\"fd-form-item\\">
+    <label class=\\"fd-form-label\\" for=\\"input-default\\">Full Name</label>
+    <input class=\\"fd-input\\" type=\\"text\\" id=\\"input-default\\" placeholder=\\"e.g., Jane Doe\\" autocomplete=\\"off\\">
 </div>
-"
+
+<br><br>
+
+<div class=\\"fd-form-item\\">
+    <label class=\\"fd-form-label\\" for=\\"input-hover\\">Full Name (Hover State)</label>
+    <input class=\\"fd-input is-hover\\" type=\\"text\\" id=\\"input-hover\\" placeholder=\\"e.g., Jane Doe\\" autocomplete=\\"off\\">
+</div>
+
+<br><br>
+
+<div class=\\"fd-form-item\\">
+    <label class=\\"fd-form-label\\" for=\\"input-focus\\">Full Name (Focus State)</label>
+    <input class=\\"fd-input is-focus\\" type=\\"text\\" id=\\"input-focus\\" placeholder=\\"e.g., Jane Doe\\" autocomplete=\\"off\\">
+</div>
+
+<br><br>
+
+<div class=\\"fd-form-item\\">
+    <label class=\\"fd-form-label fd-form-label--required\\" for=\\"input-required\\">Email Address</label>
+    <input class=\\"fd-input\\" type=\\"email\\" id=\\"input-required\\" placeholder=\\"e.g., user@example.com\\" autocomplete=\\"off\\" required aria-required=\\"true\\">
+</div>
+
+<br><br>
+
+<div class=\\"fd-form-item\\">
+    <label class=\\"fd-form-label\\" for=\\"input-password\\">Password</label>
+    <input class=\\"fd-input\\" type=\\"password\\" id=\\"input-password\\" autocomplete=\\"off\\" required aria-required=\\"true\\">
+</div>
+
+<br><br>
+
+<div class=\\"fd-form-item\\">
+    <label class=\\"fd-form-label\\" for=\\"input-error\\">Username (Error)</label>
+    <input class=\\"fd-input is-error\\" type=\\"text\\" id=\\"input-error\\" placeholder=\\"Invalid username\\" autocomplete=\\"off\\" aria-invalid=\\"true\\" aria-describedby=\\"input-error-message\\">
+    <div class=\\"fd-input__sr-only\\" id=\\"input-error-message\\">You have entered invalid username.</div>
+</div>
+
+<br><br>
+
+<div class=\\"fd-form-item\\">
+    <label class=\\"fd-form-label\\" for=\\"input-error-hover\\">Username (Error + Hover)</label>
+    <input class=\\"fd-input is-error is-hover\\" type=\\"text\\" id=\\"input-error-hover\\" placeholder=\\"Invalid username\\" autocomplete=\\"off\\" aria-invalid=\\"true\\" aria-describedby=\\"input-error-hover-message\\">
+    <div class=\\"fd-input__sr-only\\" id=\\"input-error-hover-message\\">You have entered invalid username.</div>
+</div>
+
+<br><br>
+
+<div class=\\"fd-form-item\\">
+    <label class=\\"fd-form-label\\" for=\\"input-error-focus\\">Username (Error + Focus)</label>
+    <input class=\\"fd-input is-error is-focus\\" type=\\"text\\" id=\\"input-error-focus\\" placeholder=\\"Invalid username\\" autocomplete=\\"off\\" aria-invalid=\\"true\\" aria-describedby=\\"input-error-focus-message\\">
+    <div class=\\"fd-input__sr-only\\" id=\\"input-error-focus-message\\">You have entered invalid username.</div>
+</div>
+
+<br><br>
+
+<div class=\\"fd-form-item\\">
+    <label class=\\"fd-form-label\\" for=\\"input-success\\">Phone Number (Success)</label>
+    <input class=\\"fd-input is-success\\" type=\\"tel\\" id=\\"input-success\\" placeholder=\\"e.g., +1 555 123 4567\\" autocomplete=\\"off\\" aria-describedby=\\"input-success-message\\">
+    <div class=\\"fd-input__sr-only\\" id=\\"input-success-message\\">Entry successfully validated</div>
+</div>
+
+<br><br>
+
+<div class=\\"fd-form-item\\">
+    <label class=\\"fd-form-label\\" for=\\"input-success-hover\\">Phone Number (Success + Hover)</label>
+    <input class=\\"fd-input is-success is-hover\\" type=\\"tel\\" id=\\"input-success-hover\\" placeholder=\\"e.g., +1 555 123 4567\\" autocomplete=\\"off\\" aria-describedby=\\"input-success-hover-message\\">
+    <div class=\\"fd-input__sr-only\\" id=\\"input-success-hover-message\\">Entry successfully validated</div>
+</div>
+
+<br><br>
+
+<div class=\\"fd-form-item\\">
+    <label class=\\"fd-form-label\\" for=\\"input-success-focus\\">Phone Number (Success + Focus)</label>
+    <input class=\\"fd-input is-success is-focus\\" type=\\"tel\\" id=\\"input-success-focus\\" placeholder=\\"e.g., +1 555 123 4567\\" autocomplete=\\"off\\" aria-describedby=\\"input-success-focus-message\\">
+    <div class=\\"fd-input__sr-only\\" id=\\"input-success-focus-message\\">Entry successfully validated</div>
+</div>
+
+<br><br>
+
+<div class=\\"fd-form-item\\">
+    <label class=\\"fd-form-label\\" for=\\"input-warning\\">Security Answer (Warning)</label>
+    <input class=\\"fd-input is-warning\\" type=\\"text\\" id=\\"input-warning\\" placeholder=\\"e.g., Your first pet's name\\" autocomplete=\\"off\\" aria-describedby=\\"input-warning-message\\">
+    <div class=\\"fd-input__sr-only\\" id=\\"input-warning-message\\">Warning message</div>
+</div>
+
+<br><br>
+
+<div class=\\"fd-form-item\\">
+    <label class=\\"fd-form-label\\" for=\\"input-warning-hover\\">Security Answer (Warning + Hover)</label>
+    <input class=\\"fd-input is-warning is-hover\\" type=\\"text\\" id=\\"input-warning-hover\\" placeholder=\\"e.g., Your first pet's name\\" autocomplete=\\"off\\" aria-describedby=\\"input-warning-hover-message\\">
+    <div class=\\"fd-input__sr-only\\" id=\\"input-warning-hover-message\\">Warning message</div>
+</div>
+
+<br><br>
+
+<div class=\\"fd-form-item\\">
+    <label class=\\"fd-form-label\\" for=\\"input-warning-focus\\">Security Answer (Warning + Focus)</label>
+    <input class=\\"fd-input is-warning is-focus\\" type=\\"text\\" id=\\"input-warning-focus\\" placeholder=\\"e.g., Your first pet's name\\" autocomplete=\\"off\\" aria-describedby=\\"input-warning-focus-message\\">
+    <div class=\\"fd-input__sr-only\\" id=\\"input-warning-focus-message\\">Warning message</div>
+</div>
+
+<br><br>
+
+<div class=\\"fd-form-item\\">
+    <label class=\\"fd-form-label\\" for=\\"input-info\\">Notes (Info)</label>
+    <input class=\\"fd-input is-information\\" type=\\"text\\" id=\\"input-info\\" placeholder=\\"e.g., Optional comments\\" autocomplete=\\"off\\" aria-describedby=\\"input-info-message\\">
+    <div class=\\"fd-input__sr-only\\" id=\\"input-info-message\\">Informative message</div>
+</div>
+
+<br><br>
+
+<div class=\\"fd-form-item\\">
+    <label class=\\"fd-form-label\\" for=\\"input-info-hover\\">Notes (Info + Hover)</label>
+    <input class=\\"fd-input is-information is-hover\\" type=\\"text\\" id=\\"input-info-hover\\" placeholder=\\"e.g., Optional comments\\" autocomplete=\\"off\\" aria-describedby=\\"input-info-hover-message\\">
+    <div class=\\"fd-input__sr-only\\" id=\\"input-info-hover-message\\">Informative message</div>
+</div>
+
+<br><br>
+
+<div class=\\"fd-form-item\\">
+    <label class=\\"fd-form-label\\" for=\\"input-info-focus\\">Notes (Info + Focus)</label>
+    <input class=\\"fd-input is-information is-focus\\" type=\\"text\\" id=\\"input-info-focus\\" placeholder=\\"e.g., Optional comments\\" autocomplete=\\"off\\" aria-describedby=\\"input-info-focus-message\\">
+    <div class=\\"fd-input__sr-only\\" id=\\"input-info-focus-message\\">Informative message</div>
+</div>
+
+<br><br>
+
+<div class=\\"fd-form-item\\">
+    <label class=\\"fd-form-label fd-form-label--disabled\\" for=\\"input-disabled\\" aria-disabled=\\"true\\">Organization</label>
+    <input class=\\"fd-input\\" type=\\"text\\" id=\\"input-disabled\\" value=\\"SAP\\" disabled>
+</div>
+
+<br><br>
+
+<div class=\\"fd-form-item\\">
+    <label class=\\"fd-form-label\\" for=\\"input-readonly\\">Country (Read-Only)</label>
+    <input class=\\"fd-input\\" type=\\"text\\" id=\\"input-readonly\\" value=\\"Canada\\" readonly>
+</div>
+
+<br><br>
+  
+<div class=\\"fd-form-item fd-form-item--horizontal\\">
+    <label class=\\"fd-form-label\\" for=\\"input-horizontal\\">Department</label>
+    <input class=\\"fd-input\\" type=\\"text\\" id=\\"input-horizontal\\" placeholder=\\"e.g., Marketing\\">
+</div>
+
+<br><br>
+
+<div class=\\"fd-form-item fd-form-item--horizontal\\">
+    <label class=\\"fd-form-label fd-form-label--required\\" for=\\"input-horizontal-required\\">Employee ID</label>
+    <input class=\\"fd-input\\" type=\\"text\\" id=\\"input-horizontal-required\\" placeholder=\\"e.g., E12345\\" required aria-required=\\"true\\">
+</div>
+  "
 `;
 
 exports[`Check stories > Components/Forms/Input > Story States > Should match snapshot 1`] = `
-"
+"<!-- Default Input -->
 <div class=\\"fd-form-item\\">
-    <label class=\\"fd-form-label\\" for=\\"input-1aa\\">Normal input:</label>
-    <input class=\\"fd-input\\" type=\\"text\\" id=\\"input-1aa\\" placeholder=\\"Field placeholder text\\" aria-label=\\"Image label\\">
-</div>
-
-<br /><br />
-
-<div class=\\"fd-form-item\\">
-    <label class=\\"fd-form-label\\" for=\\"input-1bb\\">Success input:</label>
+    <label class=\\"fd-form-label\\" for=\\"input-default-field\\">Full Name</label>
+    <input
+      class=\\"fd-input\\"
+      type=\\"text\\"
+      id=\\"input-default-field\\"
+      placeholder=\\"e.g., Jane Doe\\"
+      autocomplete=\\"off\\"
+    >
+  </div>
+  
+  <br><br>
+  
+  <!-- Success Input with Message -->
+  <div class=\\"fd-form-item\\">
+    <label class=\\"fd-form-label\\" for=\\"input-success-field\\">Email Address</label>
     <div class=\\"fd-popover\\">
-        <div class=\\"fd-popover__control\\" aria-controls=\\"popoverB2\\" aria-expanded=\\"true\\" aria-haspopup=\\"true\\">
-            <input class=\\"fd-input is-success\\" type=\\"text\\" id=\\"input-1bb\\" placeholder=\\"Field placeholder text\\" aria-label=\\"Image label\\">
-        </div>
-        <div class=\\"fd-popover__body fd-popover__body--input-message-group fd-popover__body--no-arrow\\" aria-hidden=\\"false\\" id=\\"popoverB2\\">
-            <div class=\\"fd-form-message fd-form-message--success\\">Success message</div>
-        </div>
+      <div class=\\"fd-popover__control\\" aria-controls=\\"success-message\\" aria-expanded=\\"true\\" aria-haspopup=\\"true\\">
+        <input
+          class=\\"fd-input is-success\\"
+          type=\\"email\\"
+          id=\\"input-success-field\\"
+          placeholder=\\"e.g., user@example.com\\"
+          autocomplete=\\"off\\"
+          aria-describedby=\\"success-message\\"
+        >
+      </div>
+      <div class=\\"fd-popover__body fd-popover__body--input-message-group fd-popover__body--no-arrow\\" id=\\"success-message\\">
+        <div class=\\"fd-form-message fd-form-message--success\\">Email address looks good.</div>
+      </div>
     </div>
-</div>
-
-<br /><br />
-
-<div class=\\"fd-form-item\\">
-    <label class=\\"fd-form-label\\" for=\\"input-1cc\\">Error input:</label>
+  </div>
+  
+  <br><br><br><br>
+  
+  <!-- Error Input with Message -->
+  <div class=\\"fd-form-item\\">
+    <label class=\\"fd-form-label\\" for=\\"input-error-field\\">Username</label>
     <div class=\\"fd-popover\\">
-        <div class=\\"fd-popover__control\\" aria-controls=\\"popoverB3\\" aria-expanded=\\"true\\" aria-haspopup=\\"true\\">
-            <input class=\\"fd-input is-error\\" type=\\"text\\" id=\\"input-1cc\\" placeholder=\\"Field placeholder text\\" aria-label=\\"Image label\\">
-        </div>
-        <div class=\\"fd-popover__body fd-popover__body--input-message-group fd-popover__body--no-arrow\\" aria-hidden=\\"false\\" id=\\"popoverB3\\">
-            <div class=\\"fd-form-message fd-form-message--error\\">Error message</div>
-        </div>
+      <div class=\\"fd-popover__control\\" aria-controls=\\"wrong-message\\" aria-expanded=\\"true\\" aria-haspopup=\\"true\\">
+        <input
+          class=\\"fd-input is-error\\"
+          type=\\"text\\"
+          id=\\"input-error-field\\"
+          placeholder=\\"e.g., johndoe123\\"
+          autocomplete=\\"off\\"
+          aria-describedby=\\"wrong-message\\"
+          aria-invalid=\\"true\\"
+        >
+      </div>
+      <div class=\\"fd-popover__body fd-popover__body--input-message-group fd-popover__body--no-arrow\\" id=\\"wrong-message\\">
+        <div class=\\"fd-form-message fd-form-message--error\\">Username must be at least 6 characters.</div>
+      </div>
     </div>
-</div>
-
-<br /><br />
-
-<div class=\\"fd-form-item\\">
-    <label class=\\"fd-form-label\\" for=\\"input-1dd\\">Warning input:</label>
+  </div>
+  
+  <br><br><br><br>
+  
+  <!-- Warning Input with Message -->
+  <div class=\\"fd-form-item\\">
+    <label class=\\"fd-form-label\\" for=\\"input-warning-field\\">Security Answer</label>
     <div class=\\"fd-popover\\">
-        <div class=\\"fd-popover__control\\" aria-controls=\\"popoverB4\\" aria-expanded=\\"true\\" aria-haspopup=\\"true\\">
-            <input class=\\"fd-input is-warning\\" type=\\"text\\" id=\\"input-1dd\\" placeholder=\\"Field placeholder text\\" aria-label=\\"Image label\\">
-        </div>
-        <div class=\\"fd-popover__body fd-popover__body--input-message-group fd-popover__body--no-arrow\\" aria-hidden=\\"false\\" id=\\"popoverB4\\">
-            <div class=\\"fd-form-message fd-form-message--warning\\">Warning message</div>
-        </div>
+      <div class=\\"fd-popover__control\\" aria-controls=\\"warning-message\\" aria-expanded=\\"true\\" aria-haspopup=\\"true\\">
+        <input
+          class=\\"fd-input is-warning\\"
+          type=\\"text\\"
+          id=\\"input-warning-field\\"
+          placeholder=\\"e.g., Your first pet's name\\"
+          autocomplete=\\"off\\"
+          aria-describedby=\\"warning-message\\"
+        >
+      </div>
+      <div class=\\"fd-popover__body fd-popover__body--input-message-group fd-popover__body--no-arrow\\" id=\\"warning-message\\">
+        <div class=\\"fd-form-message fd-form-message--warning\\">Make sure this is easy for you to remember.</div>
+      </div>
     </div>
-</div>
-
-<br /><br />
-
-<div class=\\"fd-form-item\\">
-    <label class=\\"fd-form-label\\" for=\\"input-1ee\\">Information input:</label>
+  </div>
+  
+  <br><br><br><br>
+  
+  <!-- Information Input with Message -->
+  <div class=\\"fd-form-item\\">
+    <label class=\\"fd-form-label\\" for=\\"input-info-field\\">Additional Notes</label>
     <div class=\\"fd-popover\\">
-        <div class=\\"fd-popover__control\\" aria-controls=\\"popoverB5\\" aria-expanded=\\"true\\" aria-haspopup=\\"true\\">
-            <input class=\\"fd-input is-information\\" type=\\"text\\" id=\\"input-1ee\\" placeholder=\\"Field placeholder text\\" aria-label=\\"Image label\\">
-        </div>
-        <div class=\\"fd-popover__body fd-popover__body--input-message-group fd-popover__body--no-arrow\\" aria-hidden=\\"false\\" id=\\"popoverB5\\">
-            <div class=\\"fd-form-message fd-form-message--information\\">Information message</div>
-        </div>
+      <div class=\\"fd-popover__control\\" aria-controls=\\"info-message\\" aria-expanded=\\"true\\" aria-haspopup=\\"true\\">
+        <input
+          class=\\"fd-input is-information\\"
+          type=\\"text\\"
+          id=\\"input-info-field\\"
+          placeholder=\\"Optional\\"
+          autocomplete=\\"off\\"
+          aria-describedby=\\"info-message\\"
+        >
+      </div>
+      <div class=\\"fd-popover__body fd-popover__body--input-message-group fd-popover__body--no-arrow\\" id=\\"info-message\\">
+        <div class=\\"fd-form-message fd-form-message--information\\">You can leave this blank if not applicable.</div>
+      </div>
     </div>
-</div>
-
-<br /><br />
-
-<div class=\\"fd-form-item\\">
-    <label class=\\"fd-form-label\\" for=\\"input-1ff\\">Disabled Input:</label>
-    <input class=\\"fd-input\\" placeholder=\\"Disabled field\\" type=\\"text\\" id=\\"input-1ff\\" value=\\"Non editable data\\" disabled>
-</div>
-
-<br /><br />
-
-<div class=\\"fd-form-item\\">
-    <label class=\\"fd-form-label\\" for=\\"input-1gg\\">Read Only Input:</label>
-    <input class=\\"fd-input\\" type=\\"text\\" id=\\"input-1gg\\" value=\\"Read only data\\" readonly>
-</div>
-"
+  </div>
+  
+  <br><br><br><br>
+  
+  <!-- Disabled Input -->
+  <div class=\\"fd-form-item\\">
+    <label class=\\"fd-form-label fd-form-label--disabled\\" for=\\"input-disabled-field\\" aria-disabled=\\"true\\">Organization</label>
+    <input
+      class=\\"fd-input\\"
+      type=\\"text\\"
+      id=\\"input-disabled-field\\"
+      value=\\"SAP\\"
+      placeholder=\\"Organization\\"
+      autocomplete=\\"off\\"
+      disabled
+    >
+  </div>
+  
+  <br><br>
+  
+  <!-- Read-Only Input -->
+  <div class=\\"fd-form-item\\">
+    <label class=\\"fd-form-label\\" for=\\"input-readonly-field\\">Country</label>
+    <input
+      class=\\"fd-input\\"
+      type=\\"text\\"
+      id=\\"input-readonly-field\\"
+      value=\\"Canada\\"
+      placeholder=\\"Country\\"
+      autocomplete=\\"off\\"
+      readonly
+    >
+  </div>
+  "
 `;
 
 exports[`Check stories > Components/Forms/Input Group > Story Default > Should match snapshot 1`] = `


### PR DESCRIPTION
## Related Issue
par of https://github.com/SAP/fundamental-styles/issues/5763

## Description
- updated the examples
- added necessary aria attributes
- added a new visually hidden element to describe input states

BREAKING CHANGES:
 added a new visually hidden element to describe input states with class `fd-input__sr-only`