### PR TITLE
fix(styles): add a11y updates for textarea [ci visual]

### DIFF
--- a/packages/styles/src/textarea.scss
+++ b/packages/styles/src/textarea.scss
@@ -49,6 +49,10 @@ $block: #{$fd-namespace}-textarea;
     border-radius: 0 var(--sapField_BorderCornerRadius) var(--sapField_BorderCornerRadius) 0 !important;
   }
 
+  &__sr-only {
+    @include fd-screen-reader-only();
+  }
+
   &[aria-expanded="false"] {
     z-index: 0;
   }

--- a/packages/styles/stories/Components/Forms/textarea/counter.example.html
+++ b/packages/styles/stories/Components/Forms/textarea/counter.example.html
@@ -1,5 +1,18 @@
 <div class="fd-form-item">
-    <label class="fd-form-label" for="textarea-2">Counter text area:</label>
-    <textarea class="fd-textarea" id="textarea-2">Pellentesque metus lacus commodo eget justo ut rutrum varius nunc.</textarea>
-    <div class="fd-textarea-counter">150 characters left</div>
-</div>
+    <label class="fd-form-label" for="textarea-2">Message</label>
+  
+    <textarea
+      class="fd-textarea"
+      id="textarea-2"
+      name="message"
+      rows="4"
+      maxlength="200"
+      aria-required="false"
+      placeholder="Write something here"
+      aria-labelledby="textarea-2-counter"
+    ></textarea>
+  
+    <div class="fd-textarea-counter" id="textarea-2-counter">
+      200 characters left
+    </div>
+  </div>

--- a/packages/styles/stories/Components/Forms/textarea/disabled-and-read-only.example.html
+++ b/packages/styles/stories/Components/Forms/textarea/disabled-and-read-only.example.html
@@ -1,12 +1,42 @@
 <div class="fd-form-item">
-    <label class="fd-form-label" for="textarea-7">Text area:</label>
-    <textarea class="fd-textarea" id="textarea-7" disabled>Disabled textarea</textarea>
+    <label class="fd-form-label" for="textarea-7" aria-disabled="true">Message (Disabled)</label>
+    <textarea
+      class="fd-textarea"
+      rows="2"
+      id="textarea-7"
+      name="message-disabled"
+      aria-required="false"
+      disabled
+      aria-disabled="true">Disabled textarea
+    </textarea>
 </div>
+
+<br><br>
+
 <div class="fd-form-item">
-    <label class="fd-form-label" for="textarea-8">Text area:</label>
-    <textarea class="fd-textarea" id="textarea-8" readonly>Read Only textarea</textarea>
+    <label class="fd-form-label" for="textarea-8">Message (Read-Only)</label>
+    <textarea
+      class="fd-textarea"
+      rows="2"
+      id="textarea-8"
+      name="message-readonly"
+      aria-required="false"
+      readonly
+      aria-readonly="true">Read Only textarea
+    </textarea>
 </div>
+
+<br><br>
+
 <div class="fd-form-item">
-    <label class="fd-form-label" for="textarea-9">Text area:</label>
-    <textarea class="fd-textarea is-focus" id="textarea-9" readonly>Focussed Read Only textarea</textarea>
-</div>
+    <label class="fd-form-label" for="textarea-9">Message (Read-Only & Focused)</label>
+    <textarea
+      class="fd-textarea is-focus"
+      rows="2"
+      id="textarea-9"
+      name="message-readonly-focus"
+      aria-required="false"
+      readonly
+      aria-readonly="true"
+    >Focused Read Only textarea</textarea>
+  </div>

--- a/packages/styles/stories/Components/Forms/textarea/primary.example.html
+++ b/packages/styles/stories/Components/Forms/textarea/primary.example.html
@@ -1,4 +1,4 @@
 <div class="fd-form-item">
-    <label class="fd-form-label" for="textarea-1">Text area:</label>
-    <textarea class="fd-textarea" id="textarea-1" placeholder="Write something here"></textarea>
+    <label class="fd-form-label" for="textarea-1">Message:</label>
+    <textarea class="fd-textarea" id="textarea-1" placeholder="Write something here" rows="4" aria-required="false"></textarea>
 </div>

--- a/packages/styles/stories/Components/Forms/textarea/states.example.html
+++ b/packages/styles/stories/Components/Forms/textarea/states.example.html
@@ -1,49 +1,84 @@
-
 <div class="fd-form-item">
-    <label class="fd-form-label" for="textarea-3">Success text area:</label>
+    <label class="fd-form-label" for="textarea-3">Success message:</label>
     <div class="fd-popover">
         <div class="fd-popover__control" aria-controls="popoverT51" aria-expanded="true" aria-haspopup="true">
-            <textarea class="fd-textarea is-success" id="textarea-3" placeholder="Write something here"></textarea>
+            <textarea 
+                class="fd-textarea is-success" 
+                rows="2"
+                id="textarea-3"
+                placeholder="Enter your message here"
+                aria-required="false"
+                aria-labelledby="textarea-3-count"
+                aria-describedby="textarea-3-message popoverT51"></textarea>
+            <div class="fd-textarea__sr-only" id="textarea-3-message">Value State Success</div>
         </div>
         <div class="fd-popover__body fd-popover__body--input-message-group fd-popover__body--no-arrow" aria-hidden="false" id="popoverT51">
-            <div class="fd-form-message fd-form-message--success">Success message</div>
+            <div class="fd-form-message fd-form-message--success">Your input was successfully saved.</div>
         </div>
     </div>
-    <div class="fd-textarea-counter">150 characters left</div>
+    <div class="fd-textarea-counter" id="textarea-3-count">150 characters remaining</div>
 </div>
-<br/>
+
+<br><br>
+
 <div class="fd-form-item">
-    <label class="fd-form-label" for="textarea-4">Error text area:</label>
+    <label class="fd-form-label" for="textarea-4">Error message:</label>
     <div class="fd-popover">
         <div class="fd-popover__control" aria-controls="popoverT52" aria-expanded="true" aria-haspopup="true">
-            <textarea class="fd-textarea is-error" id="textarea-4" placeholder="Write something here"></textarea>
+            <textarea 
+                class="fd-textarea is-error" 
+                rows="2"
+                id="textarea-4" 
+                placeholder="Enter your message here"
+                aria-required="false"
+                aria-invalid="true"
+                aria-describedby="textarea-4-message popoverT52"></textarea>
+            <div class="fd-textarea__sr-only" id="textarea-4-message">Value State Error</div>
         </div>
         <div class="fd-popover__body fd-popover__body--input-message-group fd-popover__body--no-arrow" aria-hidden="false" id="popoverT52">
-            <div class="fd-form-message fd-form-message--error">Error message</div>
+            <div class="fd-form-message fd-form-message--error">Please correct the highlighted error.</div>
         </div>
     </div>
 </div>
-<br/>
+
+<br><br><br><br>
+
 <div class="fd-form-item">
-    <label class="fd-form-label" for="textarea-5">Warning text area:</label>
+    <label class="fd-form-label" for="textarea-5">Warning message:</label>
     <div class="fd-popover">
         <div class="fd-popover__control" aria-controls="popoverT53" aria-expanded="true" aria-haspopup="true">
-            <textarea class="fd-textarea is-warning" id="textarea-5" placeholder="Write something here"></textarea>
+            <textarea 
+                class="fd-textarea is-warning" 
+                rows="2"
+                id="textarea-5" 
+                placeholder="Enter your message here"
+                aria-required="false"
+                aria-describedby="textarea-5-message popoverT53"></textarea>
+            <div class="fd-textarea__sr-only" id="textarea-5-message">Value State Warning</div>
         </div>
         <div class="fd-popover__body fd-popover__body--input-message-group fd-popover__body--no-arrow" aria-hidden="false" id="popoverT53">
-            <div class="fd-form-message fd-form-message--warning">Warning message</div>
+            <div class="fd-form-message fd-form-message--warning">Please review your input for potential issues.</div>
         </div>
     </div>
 </div>
-<br/>
+
+<br><br><br><br>
+
 <div class="fd-form-item">
-    <label class="fd-form-label" for="textarea-6">Information text area:</label>
+    <label class="fd-form-label" for="textarea-6">Information message:</label>
     <div class="fd-popover">
         <div class="fd-popover__control" aria-controls="popoverT54" aria-expanded="true" aria-haspopup="true">
-            <textarea class="fd-textarea is-information" id="textarea-6" placeholder="Write something here"></textarea>
+            <textarea 
+                class="fd-textarea is-information" 
+                rows="2"
+                id="textarea-6" 
+                placeholder="Enter your message here"
+                aria-required="false"
+                aria-describedby="textarea-6-message popoverT54"></textarea>
+            <div class="fd-textarea__sr-only" id="textarea-6-message">Value State Information</div>
         </div>
         <div class="fd-popover__body fd-popover__body--input-message-group fd-popover__body--no-arrow" aria-hidden="false" id="popoverT54">
-            <div class="fd-form-message fd-form-message--information">Information message</div>
+            <div class="fd-form-message fd-form-message--information">This is additional information about your input.</div>
         </div>
     </div>
 </div>

--- a/packages/styles/stories/Components/Forms/textarea/textarea.stories.js
+++ b/packages/styles/stories/Components/Forms/textarea/textarea.stories.js
@@ -26,7 +26,7 @@ Do not use the text area if
 - You only want them to enter a single line of text, use the input component instead.
 - Users need to enter formatted text. Use the rich text editor instead.
 `,
-    tags: ['f3', 'a11y', 'theme']
+    tags: []
   }
 };
 export const Primary = () => primaryExampleHtml;
@@ -50,7 +50,6 @@ DisabledAndReadOnly.parameters = {
   }
 };
 export const States = () => statesExampleHtml;
-States.storyName = 'Responsiveness';
 States.parameters = {
   docs: {
     description: {

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -22749,84 +22749,160 @@ exports[`Check stories > Components/Forms/Radio > Story TextTruncation > Should 
 
 exports[`Check stories > Components/Forms/Textarea > Story Counter > Should match snapshot 1`] = `
 "<div class=\\"fd-form-item\\">
-    <label class=\\"fd-form-label\\" for=\\"textarea-2\\">Counter text area:</label>
-    <textarea class=\\"fd-textarea\\" id=\\"textarea-2\\">Pellentesque metus lacus commodo eget justo ut rutrum varius nunc.</textarea>
-    <div class=\\"fd-textarea-counter\\">150 characters left</div>
-</div>
-"
+    <label class=\\"fd-form-label\\" for=\\"textarea-2\\">Message</label>
+  
+    <textarea
+      class=\\"fd-textarea\\"
+      id=\\"textarea-2\\"
+      name=\\"message\\"
+      rows=\\"4\\"
+      maxlength=\\"200\\"
+      aria-required=\\"false\\"
+      placeholder=\\"Write something here\\"
+      aria-labelledby=\\"textarea-2-counter\\"
+    ></textarea>
+  
+    <div class=\\"fd-textarea-counter\\" id=\\"textarea-2-counter\\">
+      200 characters left
+    </div>
+  </div>"
 `;
 
 exports[`Check stories > Components/Forms/Textarea > Story DisabledAndReadOnly > Should match snapshot 1`] = `
 "<div class=\\"fd-form-item\\">
-    <label class=\\"fd-form-label\\" for=\\"textarea-7\\">Text area:</label>
-    <textarea class=\\"fd-textarea\\" id=\\"textarea-7\\" disabled>Disabled textarea</textarea>
+    <label class=\\"fd-form-label\\" for=\\"textarea-7\\" aria-disabled=\\"true\\">Message (Disabled)</label>
+    <textarea
+      class=\\"fd-textarea\\"
+      rows=\\"2\\"
+      id=\\"textarea-7\\"
+      name=\\"message-disabled\\"
+      aria-required=\\"false\\"
+      disabled
+      aria-disabled=\\"true\\">Disabled textarea
+    </textarea>
 </div>
+
+<br><br>
+
 <div class=\\"fd-form-item\\">
-    <label class=\\"fd-form-label\\" for=\\"textarea-8\\">Text area:</label>
-    <textarea class=\\"fd-textarea\\" id=\\"textarea-8\\" readonly>Read Only textarea</textarea>
+    <label class=\\"fd-form-label\\" for=\\"textarea-8\\">Message (Read-Only)</label>
+    <textarea
+      class=\\"fd-textarea\\"
+      rows=\\"2\\"
+      id=\\"textarea-8\\"
+      name=\\"message-readonly\\"
+      aria-required=\\"false\\"
+      readonly
+      aria-readonly=\\"true\\">Read Only textarea
+    </textarea>
 </div>
+
+<br><br>
+
 <div class=\\"fd-form-item\\">
-    <label class=\\"fd-form-label\\" for=\\"textarea-9\\">Text area:</label>
-    <textarea class=\\"fd-textarea is-focus\\" id=\\"textarea-9\\" readonly>Focussed Read Only textarea</textarea>
-</div>
-"
+    <label class=\\"fd-form-label\\" for=\\"textarea-9\\">Message (Read-Only & Focused)</label>
+    <textarea
+      class=\\"fd-textarea is-focus\\"
+      rows=\\"2\\"
+      id=\\"textarea-9\\"
+      name=\\"message-readonly-focus\\"
+      aria-required=\\"false\\"
+      readonly
+      aria-readonly=\\"true\\"
+    >Focused Read Only textarea</textarea>
+  </div>"
 `;
 
 exports[`Check stories > Components/Forms/Textarea > Story Primary > Should match snapshot 1`] = `
 "<div class=\\"fd-form-item\\">
-    <label class=\\"fd-form-label\\" for=\\"textarea-1\\">Text area:</label>
-    <textarea class=\\"fd-textarea\\" id=\\"textarea-1\\" placeholder=\\"Write something here\\"></textarea>
+    <label class=\\"fd-form-label\\" for=\\"textarea-1\\">Message:</label>
+    <textarea class=\\"fd-textarea\\" id=\\"textarea-1\\" placeholder=\\"Write something here\\" rows=\\"4\\" aria-required=\\"false\\"></textarea>
 </div>
 "
 `;
 
 exports[`Check stories > Components/Forms/Textarea > Story States > Should match snapshot 1`] = `
-"
-<div class=\\"fd-form-item\\">
-    <label class=\\"fd-form-label\\" for=\\"textarea-3\\">Success text area:</label>
+"<div class=\\"fd-form-item\\">
+    <label class=\\"fd-form-label\\" for=\\"textarea-3\\">Success message:</label>
     <div class=\\"fd-popover\\">
         <div class=\\"fd-popover__control\\" aria-controls=\\"popoverT51\\" aria-expanded=\\"true\\" aria-haspopup=\\"true\\">
-            <textarea class=\\"fd-textarea is-success\\" id=\\"textarea-3\\" placeholder=\\"Write something here\\"></textarea>
+            <textarea 
+                class=\\"fd-textarea is-success\\" 
+                rows=\\"2\\"
+                id=\\"textarea-3\\"
+                placeholder=\\"Enter your message here\\"
+                aria-required=\\"false\\"
+                aria-labelledby=\\"textarea-3-count\\"
+                aria-describedby=\\"textarea-3-message popoverT51\\"></textarea>
+            <div class=\\"fd-textarea__sr-only\\" id=\\"textarea-3-message\\">Value State Success</div>
         </div>
         <div class=\\"fd-popover__body fd-popover__body--input-message-group fd-popover__body--no-arrow\\" aria-hidden=\\"false\\" id=\\"popoverT51\\">
-            <div class=\\"fd-form-message fd-form-message--success\\">Success message</div>
+            <div class=\\"fd-form-message fd-form-message--success\\">Your input was successfully saved.</div>
         </div>
     </div>
-    <div class=\\"fd-textarea-counter\\">150 characters left</div>
+    <div class=\\"fd-textarea-counter\\" id=\\"textarea-3-count\\">150 characters remaining</div>
 </div>
-<br/>
+
+<br><br>
+
 <div class=\\"fd-form-item\\">
-    <label class=\\"fd-form-label\\" for=\\"textarea-4\\">Error text area:</label>
+    <label class=\\"fd-form-label\\" for=\\"textarea-4\\">Error message:</label>
     <div class=\\"fd-popover\\">
         <div class=\\"fd-popover__control\\" aria-controls=\\"popoverT52\\" aria-expanded=\\"true\\" aria-haspopup=\\"true\\">
-            <textarea class=\\"fd-textarea is-error\\" id=\\"textarea-4\\" placeholder=\\"Write something here\\"></textarea>
+            <textarea 
+                class=\\"fd-textarea is-error\\" 
+                rows=\\"2\\"
+                id=\\"textarea-4\\" 
+                placeholder=\\"Enter your message here\\"
+                aria-required=\\"false\\"
+                aria-invalid=\\"true\\"
+                aria-describedby=\\"textarea-4-message popoverT52\\"></textarea>
+            <div class=\\"fd-textarea__sr-only\\" id=\\"textarea-4-message\\">Value State Error</div>
         </div>
         <div class=\\"fd-popover__body fd-popover__body--input-message-group fd-popover__body--no-arrow\\" aria-hidden=\\"false\\" id=\\"popoverT52\\">
-            <div class=\\"fd-form-message fd-form-message--error\\">Error message</div>
+            <div class=\\"fd-form-message fd-form-message--error\\">Please correct the highlighted error.</div>
         </div>
     </div>
 </div>
-<br/>
+
+<br><br><br><br>
+
 <div class=\\"fd-form-item\\">
-    <label class=\\"fd-form-label\\" for=\\"textarea-5\\">Warning text area:</label>
+    <label class=\\"fd-form-label\\" for=\\"textarea-5\\">Warning message:</label>
     <div class=\\"fd-popover\\">
         <div class=\\"fd-popover__control\\" aria-controls=\\"popoverT53\\" aria-expanded=\\"true\\" aria-haspopup=\\"true\\">
-            <textarea class=\\"fd-textarea is-warning\\" id=\\"textarea-5\\" placeholder=\\"Write something here\\"></textarea>
+            <textarea 
+                class=\\"fd-textarea is-warning\\" 
+                rows=\\"2\\"
+                id=\\"textarea-5\\" 
+                placeholder=\\"Enter your message here\\"
+                aria-required=\\"false\\"
+                aria-describedby=\\"textarea-5-message popoverT53\\"></textarea>
+            <div class=\\"fd-textarea__sr-only\\" id=\\"textarea-5-message\\">Value State Warning</div>
         </div>
         <div class=\\"fd-popover__body fd-popover__body--input-message-group fd-popover__body--no-arrow\\" aria-hidden=\\"false\\" id=\\"popoverT53\\">
-            <div class=\\"fd-form-message fd-form-message--warning\\">Warning message</div>
+            <div class=\\"fd-form-message fd-form-message--warning\\">Please review your input for potential issues.</div>
         </div>
     </div>
 </div>
-<br/>
+
+<br><br><br><br>
+
 <div class=\\"fd-form-item\\">
-    <label class=\\"fd-form-label\\" for=\\"textarea-6\\">Information text area:</label>
+    <label class=\\"fd-form-label\\" for=\\"textarea-6\\">Information message:</label>
     <div class=\\"fd-popover\\">
         <div class=\\"fd-popover__control\\" aria-controls=\\"popoverT54\\" aria-expanded=\\"true\\" aria-haspopup=\\"true\\">
-            <textarea class=\\"fd-textarea is-information\\" id=\\"textarea-6\\" placeholder=\\"Write something here\\"></textarea>
+            <textarea 
+                class=\\"fd-textarea is-information\\" 
+                rows=\\"2\\"
+                id=\\"textarea-6\\" 
+                placeholder=\\"Enter your message here\\"
+                aria-required=\\"false\\"
+                aria-describedby=\\"textarea-6-message popoverT54\\"></textarea>
+            <div class=\\"fd-textarea__sr-only\\" id=\\"textarea-6-message\\">Value State Information</div>
         </div>
         <div class=\\"fd-popover__body fd-popover__body--input-message-group fd-popover__body--no-arrow\\" aria-hidden=\\"false\\" id=\\"popoverT54\\">
-            <div class=\\"fd-form-message fd-form-message--information\\">Information message</div>
+            <div class=\\"fd-form-message fd-form-message--information\\">This is additional information about your input.</div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-styles/issues/5763

## Description
- no design updates
- added a new visually hidden element with class `fd-textarea__sr-only` to provide additional info about the state of the textarea.
- updated the examples with necessary attributes for a11y

BREAKING CHANGES:
added a new visually hidden element with class `fd-textarea__sr-only` to provide additional info about the state of the textarea.