### PR TITLE
fix(common-css): doc examples fixes[ci visual]

### DIFF
--- a/packages/common-css/src/_common-mixins.scss
+++ b/packages/common-css/src/_common-mixins.scss
@@ -893,29 +893,17 @@
   $_border: $width $style $color;
 
   @if  $pos == "top" {
-    border-top: $_border;
+    border-block-start: $_border;
   } @else if $pos == "bottom" {
-    border-bottom: $_border;
+    border-block-end: $_border;
   } @else if $pos == "left" {
-    border-left: $_border;
-
-    @include sap-rtl() {
-      border-left: none;
-      border-right: $_border;
-    }
+    border-inline-start: $_border;
   } @else if $pos == "right" {
-    border-right: $_border;
-
-    @include sap-rtl() {
-      border-left: $_border;
-      border-right: none;
-    }
+    border-inline-end: $_border;
   } @else if $pos == "x" {
-    border-left: $_border;
-    border-right: $_border;
+    border-inline: $_border;
   } @else if $pos == "y" {
-    border-top: $_border;
-    border-bottom: $_border;
+    border-block: $_border;
   } @else if $pos == "all" {
     border: $_border;
   } @else {

--- a/packages/common-css/stories/border-radius/border-radius.example.html
+++ b/packages/common-css/stories/border-radius/border-radius.example.html
@@ -1,5 +1,5 @@
 <style>
-    div.demo {
+    .demo div {
         display: flex;
         height: 4rem;
         width: 8rem;
@@ -7,23 +7,25 @@
     }
 </style>
 
-<h3>Element</h3>
-<div class="demo sap-border-radius-element"></div>
-<br>
-<h3>Button</h3>
-<div class="demo sap-border-radius-button"></div>
-<br>
-<h3>Field</h3>
-<div class="demo sap-border-radius-field"></div>
-<br>
-<h3>Group</h3>
-<div class="demo sap-border-radius-group"></div>
-<br>
-<h3>Popover</h3>
-<div class="demo sap-border-radius-popover"></div>
-<br>
-<h3>Tile</h3>
-<div class="demo sap-border-radius-tile"></div>
-<br>
-<h3>None</h3>
-<div class="demo sap-border-radius-none"></div>
+<div class="demo">
+    <h3>Element</h3>
+    <div class="sap-border-radius-element"></div>
+    <br>
+    <h3>Button</h3>
+    <div class="sap-border-radius-button"></div>
+    <br>
+    <h3>Field</h3>
+    <div class="sap-border-radius-field"></div>
+    <br>
+    <h3>Group</h3>
+    <div class="sap-border-radius-group"></div>
+    <br>
+    <h3>Popover</h3>
+    <div class="sap-border-radius-popover"></div>
+    <br>
+    <h3>Tile</h3>
+    <div class="sap-border-radius-tile"></div>
+    <br>
+    <h3>None</h3>
+    <div class="sap-border-radius-none"></div>
+</div>

--- a/packages/common-css/stories/busy-indicator/busy-indicator.stories.js
+++ b/packages/common-css/stories/busy-indicator/busy-indicator.stories.js
@@ -21,8 +21,8 @@ export default {
 | **Size** | &nbsp;&nbsp; **rem** &nbsp;&nbsp; | **Modifier class** |
 | :------- | :-------------------------------- | -----------------: |
 | Default  | &nbsp;&nbsp; 0.5 rem                | none               |
-| M        | &nbsp;&nbsp; 1 rem                | \`--m\`   |
-| L        | &nbsp;&nbsp; 2 rem                | \`--l\`   |
+| M        | &nbsp;&nbsp; 1 rem                | \`sap-busy-indicator--m\`   |
+| L        | &nbsp;&nbsp; 2 rem                | \`sap-busy-indicator--l\`   |
 
 ##Usage
 **Use the busy indicator if:**
@@ -38,7 +38,6 @@ The ongoing operation only covers part of a screen that has multiple controls, a
 - The operation takes less than one second.
 - You need to block the screen because the user is not supposed to start another operation. In this case, use the **Busy Dialog** component.
         `,
-    tags: ['f3', 'a11y', 'theme']
   }
 };
 export const Standard = () => standardExampleHtml;

--- a/packages/common-css/stories/colors/all-colors/all-background-color.example.html
+++ b/packages/common-css/stories/colors/all-colors/all-background-color.example.html
@@ -1,37 +1,39 @@
-<h3>legendBackgroundColor1 (--sapLegendBackgroundColor1)</h3>
-<div class="demo sap-bg-color-legendBackgroundColor1"></div>
-<br>
-<h3>legendBackgroundColor2 (--sapLegendBackgroundColor2)</h3>
-<div class="demo sap-bg-color-legendBackgroundColor2"></div>
-<br>
-<h3>legendBackgroundColor3 (--sapLegendBackgroundColor3)</h3>
-<div class="demo sap-bg-color-legendBackgroundColor3"></div>
-<br>
-<h3>legendBackgroundColor4 (--sapLegendBackgroundColor4)</h3>
-<div class="demo sap-bg-color-legendBackgroundColor4"></div>
-<br>
-<h3>legendBackgroundColor5 (--sapLegendBackgroundColor5)</h3>
-<div class="demo sap-bg-color-legendBackgroundColor5"></div>
-<br>
-<h3>tile_Background (--sapTile_Background)</h3>
-<div class="demo sap-bg-color-tile_Background"></div>
+<div class="demo">
+    <h3>legendBackgroundColor1 (--sapLegendBackgroundColor1)</h3>
+    <div class="sap-bg-color-legendBackgroundColor1"></div>
+    <br>
+    <h3>legendBackgroundColor2 (--sapLegendBackgroundColor2)</h3>
+    <div class="sap-bg-color-legendBackgroundColor2"></div>
+    <br>
+    <h3>legendBackgroundColor5 (--sapLegendBackgroundColor5)</h3>
+    <div class="sap-bg-color-legendBackgroundColor5"></div>
+    <br>
+    <h3>legendBackgroundColor6 (--sapLegendBackgroundColor6)</h3>
+    <div class="sap-bg-color-legendBackgroundColor6"></div>
+    <br>
+    <h3>legendBackgroundColor8 (--sapLegendBackgroundColor8)</h3>
+    <div class="sap-bg-color-legendBackgroundColor8"></div>
+    <br>
+    <h3>tile_Background (--sapTile_Background)</h3>
+    <div class="sap-bg-color-tile_Background"></div>
 
-<br>
-<h3>pageHeader_Background (--sapPageHeader_Background)</h3>
-<div class="demo sap-bg-color-pageHeader_Background"></div>
+    <br>
+    <h3>pageHeader_Background (--sapPageHeader_Background)</h3>
+    <div class="sap-bg-color-pageHeader_Background"></div>
 
-<br>
-<h3>progress_Value_NegativeBackground (--sapProgress_Value_NegativeBackground)</h3>
-<div class="demo sap-bg-color-progress_Value_NegativeBackground"></div>
+    <br>
+    <h3>progress_Value_NegativeBackground (--sapProgress_Value_NegativeBackground)</h3>
+    <div class="sap-bg-color-progress_Value_NegativeBackground"></div>
 
-<br>
-<h3>button_Information_Background (--sapButton_Information_Background)</h3>
-<div class="demo sap-bg-color-button_Information_Background"></div>
+    <br>
+    <h3>button_Information_Background (--sapButton_Information_Background)</h3>
+    <div class="sap-bg-color-button_Information_Background"></div>
 
-<br>
-<h3>button_Critical_Background (--sapButton_Critical_Background)</h3>
-<div class="demo sap-bg-color-button_Critical_Background"></div>
+    <br>
+    <h3>button_Critical_Background (--sapButton_Critical_Background)</h3>
+    <div class="sap-bg-color-button_Critical_Background"></div>
 
-<br>
-<h3>avatar_5_Background (--sapAvatar_5_Background)</h3>
-<div class="demo sap-bg-color-avatar_5_Background"></div>
+    <br>
+    <h3>avatar_5_Background (--sapAvatar_5_Background)</h3>
+    <div class="sap-bg-color-avatar_5_Background"></div>
+</div>

--- a/packages/common-css/stories/colors/all-colors/all-colors.stories.js
+++ b/packages/common-css/stories/colors/all-colors/all-colors.stories.js
@@ -10,7 +10,7 @@ export default {
 };
 const localStyles = `
 <style>
-    div.demo {
+    .demo div {
         display: flex;
         height: 4rem;
         width: 8rem;

--- a/packages/common-css/stories/colors/main-colors/main-background-color.example.html
+++ b/packages/common-css/stories/colors/main-colors/main-background-color.example.html
@@ -1,71 +1,73 @@
-<h3>backgroundColor (--sapBackgroundColor)</h3>
-<div class="demo sap-bg-color-backgroundColor"></div>
+<div class="demo">
+    <h3>backgroundColor (--sapBackgroundColor)</h3>
+    <div class="sap-bg-color-backgroundColor"></div>
 
-<br>
-<h3>errorBackground (--sapErrorBackground)</h3>
-<div class="demo sap-bg-color-errorBackground"></div>
+    <br>
+    <h3>errorBackground (--sapErrorBackground)</h3>
+    <div class="sap-bg-color-errorBackground"></div>
 
-<br>
-<h3>warningBackground (--sapWarningBackground)</h3>
-<div class="demo sap-bg-color-warningBackground"></div>
+    <br>
+    <h3>warningBackground (--sapWarningBackground)</h3>
+    <div class="sap-bg-color-warningBackground"></div>
 
-<br>
-<h3>successBackground (--sapSuccessBackground)</h3>
-<div class="demo sap-bg-color-successBackground"></div>
+    <br>
+    <h3>successBackground (--sapSuccessBackground)</h3>
+    <div class="sap-bg-color-successBackground"></div>
 
-<br>
-<h3>informationBackground (--sapInformationBackground)</h3>
-<div class="demo sap-bg-color-informationBackground"></div>
-
-
-<br>
-<h3>neutralBackground (--sapNeutralBackground)</h3>
-<div class="demo sap-bg-color-neutralBackground"></div>
-
-<br>
-<h3>accentBackgroundColor1 (--sapAccentBackgroundColor1)</h3>
-<div class="demo sap-bg-color-accentBackgroundColor1"></div>
+    <br>
+    <h3>informationBackground (--sapInformationBackground)</h3>
+    <div class="sap-bg-color-informationBackground"></div>
 
 
-<br>
-<h3>accentBackgroundColor2 (--sapAccentBackgroundColor2)</h3>
-<div class="demo sap-bg-color-accentBackgroundColor2"></div>
+    <br>
+    <h3>neutralBackground (--sapNeutralBackground)</h3>
+    <div class="sap-bg-color-neutralBackground"></div>
+
+    <br>
+    <h3>accentBackgroundColor1 (--sapAccentBackgroundColor1)</h3>
+    <div class="sap-bg-color-accentBackgroundColor1"></div>
 
 
-<br>
-<h3>accentBackgroundColor3 (--sapAccentBackgroundColor3)</h3>
-<div class="demo sap-bg-color-accentBackgroundColor3"></div>
+    <br>
+    <h3>accentBackgroundColor2 (--sapAccentBackgroundColor2)</h3>
+    <div class="sap-bg-color-accentBackgroundColor2"></div>
 
 
-<br>
-<h3>accentBackgroundColor4 (--sapAccentBackgroundColor4)</h3>
-<div class="demo sap-bg-color-accentBackgroundColor4"></div>
+    <br>
+    <h3>accentBackgroundColor3 (--sapAccentBackgroundColor3)</h3>
+    <div class="sap-bg-color-accentBackgroundColor3"></div>
 
 
-<br>
-<h3>accentBackgroundColor5 (--sapAccentBackgroundColor5)</h3>
-<div class="demo sap-bg-color-accentBackgroundColor5"></div>
+    <br>
+    <h3>accentBackgroundColor4 (--sapAccentBackgroundColor4)</h3>
+    <div class="sap-bg-color-accentBackgroundColor4"></div>
 
 
-<br>
-<h3>accentBackgroundColor6 (--sapAccentBackgroundColor6)</h3>
-<div class="demo sap-bg-color-accentBackgroundColor6"></div>
+    <br>
+    <h3>accentBackgroundColor5 (--sapAccentBackgroundColor5)</h3>
+    <div class="sap-bg-color-accentBackgroundColor5"></div>
 
 
-<br>
-<h3>accentBackgroundColor7 (--sapAccentBackgroundColor7)</h3>
-<div class="demo sap-bg-color-accentBackgroundColor7"></div>
+    <br>
+    <h3>accentBackgroundColor6 (--sapAccentBackgroundColor6)</h3>
+    <div class="sap-bg-color-accentBackgroundColor6"></div>
 
 
-<br>
-<h3>accentBackgroundColor8 (--sapAccentBackgroundColor8)</h3>
-<div class="demo sap-bg-color-accentBackgroundColor8"></div>
-
-<br>
-<h3>accentBackgroundColor9 (--sapAccentBackgroundColor9)</h3>
-<div class="demo sap-bg-color-accentBackgroundColor9"></div>
+    <br>
+    <h3>accentBackgroundColor7 (--sapAccentBackgroundColor7)</h3>
+    <div class="sap-bg-color-accentBackgroundColor7"></div>
 
 
-<br>
-<h3>accentBackgroundColor10 (--sapAccentBackgroundColor10)</h3>
-<div class="demo sap-bg-color-accentBackgroundColor10"></div>
+    <br>
+    <h3>accentBackgroundColor8 (--sapAccentBackgroundColor8)</h3>
+    <div class="sap-bg-color-accentBackgroundColor8"></div>
+
+    <br>
+    <h3>accentBackgroundColor9 (--sapAccentBackgroundColor9)</h3>
+    <div class="sap-bg-color-accentBackgroundColor9"></div>
+
+
+    <br>
+    <h3>accentBackgroundColor10 (--sapAccentBackgroundColor10)</h3>
+    <div class="sap-bg-color-accentBackgroundColor10"></div>
+</div>

--- a/packages/common-css/stories/colors/main-colors/main-colors.stories.js
+++ b/packages/common-css/stories/colors/main-colors/main-colors.stories.js
@@ -10,7 +10,7 @@ export default {
 };
 const localStyles = `
 <style>
-    div.demo {
+    .demo div {
         display: flex;
         height: 4rem;
         width: 8rem;

--- a/packages/common-css/stories/display/display.stories.js
+++ b/packages/common-css/stories/display/display.stories.js
@@ -46,9 +46,7 @@ ScreenReaderOnly.storyName = 'Screen-reader-only elements';
 ScreenReaderOnly.parameters = {
   docs: {
     description: {
-      story: `The <code>.sap-sr-only</code> class will hide the element visually without hiding it from screen readers. <br><br>
-            <b>SCSS Mixin: </b>
-            <code>@include sap-sr-only();</code>
+      story: `The <code>.sap-sr-only</code> class will hide the element visually without hiding it from screen readers. <br><br><b>SCSS Mixin: </b><code>@include sap-sr-only();</code>
         `
     }
   }

--- a/packages/common-css/stories/focus/focus.stories.js
+++ b/packages/common-css/stories/focus/focus.stories.js
@@ -32,8 +32,7 @@ FakeFioriFocus.storyName = 'Mixin sap-fake-fiori-focus';
 FakeFioriFocus.parameters = {
   docs: {
     description: {
-      story: `Most modern browsers do not support outline radius. An alternative apporach, using <code>sap-fake-fiori-focus</code> mixin, can be applied to solve this problem. 
-            The parameters this mixin accepts are: $offset, $radius and $alternative.`
+      story: `Most modern browsers do not support outline radius. An alternative apporach, using <code>sap-fake-fiori-focus</code> mixin, can be applied to solve this problem. The parameters this mixin accepts are: $offset, $radius and $alternative.`
     }
   }
 };

--- a/packages/common-css/stories/margin/margin.stories.js
+++ b/packages/common-css/stories/margin/margin.stories.js
@@ -140,33 +140,34 @@ TopMargin.parameters = {
   docs: {
     description: {
       story: `The top margin is displayed on the top of the element.
-            <table style="width: 100%; border-collapse: collapse; margin-top: 1rem;">
-                <tr>
-                    <th style="padding: 0.25rem;">Type</th>
-                    <th style="padding: 0.25rem;">Class</th>
-                    <th style="padding: 0.25rem;">Mixin</th>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">Tiny (0.5rem)</td>
-                    <td style="padding: 0.25rem;">.sap-margin-top-tiny</td>
-                    <td style="padding: 0.25rem;">@include sap-margin(tiny, top)</td>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">Small (1rem)</td>
-                    <td style="padding: 0.25rem;">.sap-margin-top-small</td>
-                    <td style="padding: 0.25rem;">@include sap-margin(small, top)</td>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">Medium (2rem)</td>
-                    <td style="padding: 0.25rem;">.sap-margin-top-medium</td>
-                    <td style="padding: 0.25rem;">@include sap-margin(medium, top)</td>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">Large (3rem)</td>
-                    <td style="padding: 0.25rem;">.sap-margin-top-large</td>
-                    <td style="padding: 0.25rem;">@include sap-margin(large, top)</td>
-                </tr>
-            </table>`
+
+<table style="width: 100%; border-collapse: collapse; margin-top: 1rem;">
+    <tr>
+        <th style="padding: 0.25rem;">Type</th>
+        <th style="padding: 0.25rem;">Class</th>
+        <th style="padding: 0.25rem;">Mixin</th>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">Tiny (0.5rem)</td>
+        <td style="padding: 0.25rem;">.sap-margin-top-tiny</td>
+        <td style="padding: 0.25rem;">@include sap-margin(tiny, top)</td>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">Small (1rem)</td>
+        <td style="padding: 0.25rem;">.sap-margin-top-small</td>
+        <td style="padding: 0.25rem;">@include sap-margin(small, top)</td>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">Medium (2rem)</td>
+        <td style="padding: 0.25rem;">.sap-margin-top-medium</td>
+        <td style="padding: 0.25rem;">@include sap-margin(medium, top)</td>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">Large (3rem)</td>
+        <td style="padding: 0.25rem;">.sap-margin-top-large</td>
+        <td style="padding: 0.25rem;">@include sap-margin(large, top)</td>
+    </tr>
+</table>`
     }
   }
 };
@@ -176,33 +177,34 @@ BottomMargin.parameters = {
   docs: {
     description: {
       story: `The bottom margin is displayed on the bottom of the element.
-            <table style="width: 100%; border-collapse: collapse; margin-top: 1rem;">
-                <tr>
-                    <th style="padding: 0.25rem;">Type</th>
-                    <th style="padding: 0.25rem;">Class</th>
-                    <th style="padding: 0.25rem;">Mixin</th>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">Tiny (0.5rem)</td>
-                    <td style="padding: 0.25rem;">.sap-margin-bottom-tiny</td>
-                    <td style="padding: 0.25rem;">@include sap-margin(tiny, bottom)</td>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">Small (1rem)</td>
-                    <td style="padding: 0.25rem;">.sap-margin-bottom-small</td>
-                    <td style="padding: 0.25rem;">@include sap-margin(small, bottom)</td>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">Medium (2rem)</td>
-                    <td style="padding: 0.25rem;">.sap-margin-bottom-medium</td>
-                    <td style="padding: 0.25rem;">@include sap-margin(medium, bottom)</td>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">Large (3rem)</td>
-                    <td style="padding: 0.25rem;">.sap-margin-bottom-large</td>
-                    <td style="padding: 0.25rem;">@include sap-margin(large, bottom)</td>
-                </tr>
-            </table>`
+
+<table style="width: 100%; border-collapse: collapse; margin-top: 1rem;">
+    <tr>
+        <th style="padding: 0.25rem;">Type</th>
+        <th style="padding: 0.25rem;">Class</th>
+        <th style="padding: 0.25rem;">Mixin</th>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">Tiny (0.5rem)</td>
+        <td style="padding: 0.25rem;">.sap-margin-bottom-tiny</td>
+        <td style="padding: 0.25rem;">@include sap-margin(tiny, bottom)</td>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">Small (1rem)</td>
+        <td style="padding: 0.25rem;">.sap-margin-bottom-small</td>
+        <td style="padding: 0.25rem;">@include sap-margin(small, bottom)</td>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">Medium (2rem)</td>
+        <td style="padding: 0.25rem;">.sap-margin-bottom-medium</td>
+        <td style="padding: 0.25rem;">@include sap-margin(medium, bottom)</td>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">Large (3rem)</td>
+        <td style="padding: 0.25rem;">.sap-margin-bottom-large</td>
+        <td style="padding: 0.25rem;">@include sap-margin(large, bottom)</td>
+    </tr>
+</table>`
     }
   }
 };
@@ -212,33 +214,34 @@ BeginMargin.parameters = {
   docs: {
     description: {
       story: `The begin margin is displayed on the left side and in right-to-left mode on the right side of the element.
-            <table style="width: 100%; border-collapse: collapse; margin-top: 1rem;">
-                <tr>
-                    <th style="padding: 0.25rem;">Type</th>
-                    <th style="padding: 0.25rem;">Class</th>
-                    <th style="padding: 0.25rem;">Mixin</th>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">Tiny (0.5rem)</td>
-                    <td style="padding: 0.25rem;">.sap-margin-begin-tiny</td>
-                    <td style="padding: 0.25rem;">@include sap-margin(tiny, begin)</td>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">Small (1rem)</td>
-                    <td style="padding: 0.25rem;">.sap-margin-begin-small</td>
-                    <td style="padding: 0.25rem;">@include sap-margin(small, begin)</td>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">Medium (2rem)</td>
-                    <td style="padding: 0.25rem;">.sap-margin-begin-medium</td>
-                    <td style="padding: 0.25rem;">@include sap-margin(medium, begin)</td>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">Large (3rem)</td>
-                    <td style="padding: 0.25rem;">.sap-margin-begin-large</td>
-                    <td style="padding: 0.25rem;">@include sap-margin(large, begin)</td>
-                </tr>
-            </table>`
+
+<table style="width: 100%; border-collapse: collapse; margin-top: 1rem;">
+    <tr>
+        <th style="padding: 0.25rem;">Type</th>
+        <th style="padding: 0.25rem;">Class</th>
+        <th style="padding: 0.25rem;">Mixin</th>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">Tiny (0.5rem)</td>
+        <td style="padding: 0.25rem;">.sap-margin-begin-tiny</td>
+        <td style="padding: 0.25rem;">@include sap-margin(tiny, begin)</td>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">Small (1rem)</td>
+        <td style="padding: 0.25rem;">.sap-margin-begin-small</td>
+        <td style="padding: 0.25rem;">@include sap-margin(small, begin)</td>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">Medium (2rem)</td>
+        <td style="padding: 0.25rem;">.sap-margin-begin-medium</td>
+        <td style="padding: 0.25rem;">@include sap-margin(medium, begin)</td>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">Large (3rem)</td>
+        <td style="padding: 0.25rem;">.sap-margin-begin-large</td>
+        <td style="padding: 0.25rem;">@include sap-margin(large, begin)</td>
+    </tr>
+</table>`
     }
   }
 };
@@ -248,33 +251,34 @@ EndMargin.parameters = {
   docs: {
     description: {
       story: `The end margin is displayed on the right side and in right-to-left mode on the left side of the element.
-            <table style="width: 100%; border-collapse: collapse; margin-top: 1rem;">
-                <tr>
-                    <th style="padding: 0.25rem;">Type</th>
-                    <th style="padding: 0.25rem;">Class</th>
-                    <th style="padding: 0.25rem;">Mixin</th>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">Tiny (0.5rem)</td>
-                    <td style="padding: 0.25rem;">.sap-margin-end-tiny</td>
-                    <td style="padding: 0.25rem;">@include sap-margin(tiny, end)</td>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">Small (1rem)</td>
-                    <td style="padding: 0.25rem;">.sap-margin-end-small</td>
-                    <td style="padding: 0.25rem;">@include sap-margin(small, end)</td>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">Medium (2rem)</td>
-                    <td style="padding: 0.25rem;">.sap-margin-end-medium</td>
-                    <td style="padding: 0.25rem;">@include sap-margin(medium, end)</td>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">Large (3rem)</td>
-                    <td style="padding: 0.25rem;">.sap-margin-end-large</td>
-                    <td style="padding: 0.25rem;">@include sap-margin(large, end)</td>
-                </tr>
-            </table>`
+
+<table style="width: 100%; border-collapse: collapse; margin-top: 1rem;">
+    <tr>
+        <th style="padding: 0.25rem;">Type</th>
+        <th style="padding: 0.25rem;">Class</th>
+        <th style="padding: 0.25rem;">Mixin</th>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">Tiny (0.5rem)</td>
+        <td style="padding: 0.25rem;">.sap-margin-end-tiny</td>
+        <td style="padding: 0.25rem;">@include sap-margin(tiny, end)</td>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">Small (1rem)</td>
+        <td style="padding: 0.25rem;">.sap-margin-end-small</td>
+        <td style="padding: 0.25rem;">@include sap-margin(small, end)</td>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">Medium (2rem)</td>
+        <td style="padding: 0.25rem;">.sap-margin-end-medium</td>
+        <td style="padding: 0.25rem;">@include sap-margin(medium, end)</td>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">Large (3rem)</td>
+        <td style="padding: 0.25rem;">.sap-margin-end-large</td>
+        <td style="padding: 0.25rem;">@include sap-margin(large, end)</td>
+    </tr>
+</table>`
     }
   }
 };
@@ -284,33 +288,34 @@ HorizontalMargin.parameters = {
   docs: {
     description: {
       story: `The horizontal margins are displayed on left and right side of the element.
-            <table style="width: 100%; border-collapse: collapse; margin-top: 1rem;">
-                <tr>
-                    <th style="padding: 0.25rem;">Type</th>
-                    <th style="padding: 0.25rem;">Class</th>
-                    <th style="padding: 0.25rem;">Mixin</th>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">Tiny (0.5rem)</td>
-                    <td style="padding: 0.25rem;">.sap-margin-x-tiny</td>
-                    <td style="padding: 0.25rem;">@include sap-margin(tiny, x)</td>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">Small (1rem)</td>
-                    <td style="padding: 0.25rem;">.sap-margin-x-small</td>
-                    <td style="padding: 0.25rem;">@include sap-margin(small, x)</td>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">Medium (2rem)</td>
-                    <td style="padding: 0.25rem;">.sap-margin-x-medium</td>
-                    <td style="padding: 0.25rem;">@include sap-margin(medium, x)</td>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">Large (3rem)</td>
-                    <td style="padding: 0.25rem;">.sap-margin-x-large</td>
-                    <td style="padding: 0.25rem;">@include sap-margin(large, x)</td>
-                </tr>
-            </table>`
+
+<table style="width: 100%; border-collapse: collapse; margin-top: 1rem;">
+    <tr>
+        <th style="padding: 0.25rem;">Type</th>
+        <th style="padding: 0.25rem;">Class</th>
+        <th style="padding: 0.25rem;">Mixin</th>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">Tiny (0.5rem)</td>
+        <td style="padding: 0.25rem;">.sap-margin-x-tiny</td>
+        <td style="padding: 0.25rem;">@include sap-margin(tiny, x)</td>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">Small (1rem)</td>
+        <td style="padding: 0.25rem;">.sap-margin-x-small</td>
+        <td style="padding: 0.25rem;">@include sap-margin(small, x)</td>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">Medium (2rem)</td>
+        <td style="padding: 0.25rem;">.sap-margin-x-medium</td>
+        <td style="padding: 0.25rem;">@include sap-margin(medium, x)</td>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">Large (3rem)</td>
+        <td style="padding: 0.25rem;">.sap-margin-x-large</td>
+        <td style="padding: 0.25rem;">@include sap-margin(large, x)</td>
+    </tr>
+</table>`
     }
   }
 };
@@ -320,33 +325,34 @@ VerticalMargin.parameters = {
   docs: {
     description: {
       story: `The vertical margins are displayed on top and bottom of the element.
-            <table style="width: 100%; border-collapse: collapse; margin-top: 1rem;">
-                <tr>
-                    <th style="padding: 0.25rem;">Type</th>
-                    <th style="padding: 0.25rem;">Class</th>
-                    <th style="padding: 0.25rem;">Mixin</th>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">Tiny (0.5rem)</td>
-                    <td style="padding: 0.25rem;">.sap-margin-y-tiny</td>
-                    <td style="padding: 0.25rem;">@include sap-margin(tiny, y)</td>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">Small (1rem)</td>
-                    <td style="padding: 0.25rem;">.sap-margin-y-small</td>
-                    <td style="padding: 0.25rem;">@include sap-margin(small, y)</td>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">Medium (2rem)</td>
-                    <td style="padding: 0.25rem;">.sap-margin-y-medium</td>
-                    <td style="padding: 0.25rem;">@include sap-margin(medium, y)</td>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">Large (3rem)</td>
-                    <td style="padding: 0.25rem;">.sap-margin-y-large</td>
-                    <td style="padding: 0.25rem;">@include sap-margin(large, y)</td>
-                </tr>
-            </table>`
+
+<table style="width: 100%; border-collapse: collapse; margin-top: 1rem;">
+    <tr>
+        <th style="padding: 0.25rem;">Type</th>
+        <th style="padding: 0.25rem;">Class</th>
+        <th style="padding: 0.25rem;">Mixin</th>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">Tiny (0.5rem)</td>
+        <td style="padding: 0.25rem;">.sap-margin-y-tiny</td>
+        <td style="padding: 0.25rem;">@include sap-margin(tiny, y)</td>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">Small (1rem)</td>
+        <td style="padding: 0.25rem;">.sap-margin-y-small</td>
+        <td style="padding: 0.25rem;">@include sap-margin(small, y)</td>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">Medium (2rem)</td>
+        <td style="padding: 0.25rem;">.sap-margin-y-medium</td>
+        <td style="padding: 0.25rem;">@include sap-margin(medium, y)</td>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">Large (3rem)</td>
+        <td style="padding: 0.25rem;">.sap-margin-y-large</td>
+        <td style="padding: 0.25rem;">@include sap-margin(large, y)</td>
+    </tr>
+</table>`
     }
   }
 };
@@ -356,30 +362,32 @@ ResponsiveMargin.parameters = {
   docs: {
     description: {
       story: `The responsive margins class adds a margin around an element based on the width of the container the element is in. <br>
-            <b>CSS Class: </b><code>.sap-margin-responsive</code><br>
-            <b>Mixin: </b><code>@include sap-margin-responsive()</code>
-            <table style="width: 100%; border-collapse: collapse; margin-top: 1rem;">
-                <tr>
-                    <th style="padding: 0.25rem;">Screen Size</th>
-                    <th style="padding: 0.25rem;">CSS</th>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">SM</td>
-                    <td style="padding: 0.25rem;">margin: 0 0 1rem 0 !important;</td>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">MD</td>
-                    <td style="padding: 0.25rem;">margin: 1rem !important;</td>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">LG</td>
-                    <td style="padding: 0.25rem;">margin: 1rem 2rem !important;</td>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">XL</td>
-                    <td style="padding: 0.25rem;">margin: 1rem 3rem !important;</td>
-                </tr>
-            </table>`
+
+<b>CSS Class: </b><code>.sap-margin-responsive</code><br>
+<b>Mixin: </b><code>@include sap-margin-responsive()</code>
+
+<table style="width: 100%; border-collapse: collapse; margin-top: 1rem;">
+    <tr>
+        <th style="padding: 0.25rem;">Screen Size</th>
+        <th style="padding: 0.25rem;">CSS</th>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">SM</td>
+        <td style="padding: 0.25rem;">margin: 0 0 1rem 0 !important;</td>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">MD</td>
+        <td style="padding: 0.25rem;">margin: 1rem !important;</td>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">LG</td>
+        <td style="padding: 0.25rem;">margin: 1rem 2rem !important;</td>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">XL</td>
+        <td style="padding: 0.25rem;">margin: 1rem 3rem !important;</td>
+    </tr>
+</table>`
     }
   }
 };
@@ -389,33 +397,34 @@ NegativeMargin.parameters = {
   docs: {
     description: {
       story: `The negative margin class adds a double sided negative margin to an element. This is useful when aligning elements with built-in paddings.
-            <table style="width: 100%; border-collapse: collapse; margin-top: 1rem;">
-                <tr>
-                    <th style="padding: 0.25rem;">Type</th>
-                    <th style="padding: 0.25rem;">CSS</th>
-                    <th style="padding: 0.25rem;">Class</th>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">Tiny (-0.5rem)</td>
-                    <td style="padding: 0.25rem;">margin: 0 -0.5rem !important;</td>
-                    <td style="padding: 0.25rem;">.sap-margin-tiny-negative</td>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">Small (-1rem)</td>
-                    <td style="padding: 0.25rem;">margin: 0 -1rem !important;l</td>
-                    <td style="padding: 0.25rem;">.sap-margin-small-negative</td>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">Medium (-0.5rem)</td>
-                    <td style="padding: 0.25rem;">margin: 0 -2rem !important;</td>
-                    <td style="padding: 0.25rem;">.sap-margin-medium-negative</td>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">Large (-0.5rem)</td>
-                    <td style="padding: 0.25rem;">margin: 0 -3rem !important;</td>
-                    <td style="padding: 0.25rem;">.sap-margin-large-negative</td>
-                </tr>
-            </table>`
+
+<table style="width: 100%; border-collapse: collapse; margin-top: 1rem;">
+    <tr>
+        <th style="padding: 0.25rem;">Type</th>
+        <th style="padding: 0.25rem;">CSS</th>
+        <th style="padding: 0.25rem;">Class</th>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">Tiny (-0.5rem)</td>
+        <td style="padding: 0.25rem;">margin: 0 -0.5rem !important;</td>
+        <td style="padding: 0.25rem;">.sap-margin-tiny-negative</td>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">Small (-1rem)</td>
+        <td style="padding: 0.25rem;">margin: 0 -1rem !important;</td>
+        <td style="padding: 0.25rem;">.sap-margin-small-negative</td>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">Medium (-0.5rem)</td>
+        <td style="padding: 0.25rem;">margin: 0 -2rem !important;</td>
+        <td style="padding: 0.25rem;">.sap-margin-medium-negative</td>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">Large (-0.5rem)</td>
+        <td style="padding: 0.25rem;">margin: 0 -3rem !important;</td>
+        <td style="padding: 0.25rem;">.sap-margin-large-negative</td>
+    </tr>
+</table>`
     }
   }
 };

--- a/packages/common-css/stories/padding/padding.stories.js
+++ b/packages/common-css/stories/padding/padding.stories.js
@@ -32,10 +32,7 @@ AllRoundPadding.storyName = 'All-Round Padding';
 AllRoundPadding.parameters = {
   docs: {
     description: {
-      story: `All-round padding appear on all sides of the container they are applied to.<br>
-            <b>CSS class: </b> <code>.sap-padding</code><br>
-            <b>SCSS mixin: </b> <code>@include sap-padding();</code><br>
-            This will apply 1rem padding on all sides of the container.
+      story: `All-round padding appear on all sides of the container they are applied to.<br><b>CSS class: </b> <code>.sap-padding</code><br><b>SCSS mixin: </b> <code>@include sap-padding();</code><br>This will apply 1rem padding on all sides of the container.
         `
     }
   }
@@ -46,33 +43,34 @@ HorizontalPadding.parameters = {
   docs: {
     description: {
       story: `Double sided paddings appear on two opposite sides of the element. The horizontal margins are displayed on left and right side of the element.
-            <table style="width: 100%; border-collapse: collapse; margin-top: 1rem;">
-                <tr>
-                    <th style="padding: 0.25rem;">Type</th>
-                    <th style="padding: 0.25rem;">Class</th>
-                    <th style="padding: 0.25rem;">Mixin</th>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">Tiny (0.5rem)</td>
-                    <td style="padding: 0.25rem;">.sap-padding-x-tiny</td>
-                    <td style="padding: 0.25rem;">@include sap-padding(tiny, x)</td>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">Small (1rem)</td>
-                    <td style="padding: 0.25rem;">.sap-padding-x-small</td>
-                    <td style="padding: 0.25rem;">@include sap-padding(small, x)</td>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">Medium (2rem)</td>
-                    <td style="padding: 0.25rem;">.sap-padding-x-medium</td>
-                    <td style="padding: 0.25rem;">@include sap-padding(medium, x)</td>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">Large (3rem)</td>
-                    <td style="padding: 0.25rem;">.sap-padding-x-large</td>
-                    <td style="padding: 0.25rem;">@include sap-padding(large, x)</td>
-                </tr>
-            </table>`
+            
+<table style="width: 100%; border-collapse: collapse; margin-top: 1rem;">
+  <tr>
+      <th style="padding: 0.25rem;">Type</th>
+      <th style="padding: 0.25rem;">Class</th>
+      <th style="padding: 0.25rem;">Mixin</th>
+  </tr>
+  <tr>
+      <td style="padding: 0.25rem;">Tiny (0.5rem)</td>
+      <td style="padding: 0.25rem;">.sap-padding-x-tiny</td>
+      <td style="padding: 0.25rem;">@include sap-padding(tiny, x)</td>
+  </tr>
+  <tr>
+      <td style="padding: 0.25rem;">Small (1rem)</td>
+      <td style="padding: 0.25rem;">.sap-padding-x-small</td>
+      <td style="padding: 0.25rem;">@include sap-padding(small, x)</td>
+  </tr>
+  <tr>
+      <td style="padding: 0.25rem;">Medium (2rem)</td>
+      <td style="padding: 0.25rem;">.sap-padding-x-medium</td>
+      <td style="padding: 0.25rem;">@include sap-padding(medium, x)</td>
+  </tr>
+  <tr>
+      <td style="padding: 0.25rem;">Large (3rem)</td>
+      <td style="padding: 0.25rem;">.sap-padding-x-large</td>
+      <td style="padding: 0.25rem;">@include sap-padding(large, x)</td>
+  </tr>
+</table>`
     }
   }
 };
@@ -81,31 +79,30 @@ ResponsivePadding.storyName = 'Responsive Paddings';
 ResponsivePadding.parameters = {
   docs: {
     description: {
-      story: `The responsive padding class adds a double sided padding inside a container based on screen width.<br>
-            <b>CSS Class: </b><code>.sap-padding-responsive</code><br>
-            <b>Mixin: </b><code>@include sap-padding-responsive()</code>
-            <table style="width: 100%; border-collapse: collapse; margin-top: 1rem;">
-                <tr>
-                    <th style="padding: 0.25rem;">Screen Size</th>
-                    <th style="padding: 0.25rem;">CSS</th>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">SM</td>
-                    <td style="padding: 0.25rem;">padding: 0 1rem !important;</td>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">MD</td>
-                    <td style="padding: 0.25rem;">padding: 0 2rem !important;</td>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">LG</td>
-                    <td style="padding: 0.25rem;">padding: 0 2rem !important;</td>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">XL</td>
-                    <td style="padding: 0.25rem;">padding: 0 3rem !important;</td>
-                </tr>
-            </table>`
+      story: `The responsive padding class adds a double sided padding inside a container based on screen width.<br><b>CSS Class: </b><code>.sap-padding-responsive</code><br><b>Mixin: </b><code>@include sap-padding-responsive()</code>
+
+<table style="width: 100%; border-collapse: collapse; margin-top: 1rem;">
+    <tr>
+        <th style="padding: 0.25rem;">Screen Size</th>
+        <th style="padding: 0.25rem;">CSS</th>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">SM</td>
+        <td style="padding: 0.25rem;">padding: 0 1rem !important;</td>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">MD</td>
+        <td style="padding: 0.25rem;">padding: 0 2rem !important;</td>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">LG</td>
+        <td style="padding: 0.25rem;">padding: 0 2rem !important;</td>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">XL</td>
+        <td style="padding: 0.25rem;">padding: 0 3rem !important;</td>
+    </tr>
+</table>`
     }
   }
 };
@@ -114,31 +111,30 @@ ResponsivePaddingContainer.storyName = 'Responsive Container Paddings';
 ResponsivePaddingContainer.parameters = {
   docs: {
     description: {
-      story: `The responsive padding class adds a double sided padding inside a container based on its width.<br>
-            <b>CSS Class: </b><code>.sap-padding-responsive-container</code><br>
-            <b>Mixin: </b><code>@include sap-padding-container-responsive()</code>
-            <table style="width: 100%; border-collapse: collapse; margin-top: 1rem;">
-                <tr>
-                    <th style="padding: 0.25rem;">Container Size</th>
-                    <th style="padding: 0.25rem;">CSS</th>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">SM</td>
-                    <td style="padding: 0.25rem;">padding: 0 1rem !important;</td>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">MD</td>
-                    <td style="padding: 0.25rem;">padding: 0 2rem !important;</td>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">LG</td>
-                    <td style="padding: 0.25rem;">padding: 0 2rem !important;</td>
-                </tr>
-                <tr>
-                    <td style="padding: 0.25rem;">XL</td>
-                    <td style="padding: 0.25rem;">padding: 0 3rem !important;</td>
-                </tr>
-            </table>`
+      story: `The responsive padding class adds a double sided padding inside a container based on its width.<br><b>CSS Class: </b><code>.sap-padding-responsive-container</code><br><b>Mixin: </b><code>@include sap-padding-container-responsive()</code>
+
+<table style="width: 100%; border-collapse: collapse; margin-top: 1rem;">
+    <tr>
+        <th style="padding: 0.25rem;">Container Size</th>
+        <th style="padding: 0.25rem;">CSS</th>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">SM</td>
+        <td style="padding: 0.25rem;">padding: 0 1rem !important;</td>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">MD</td>
+        <td style="padding: 0.25rem;">padding: 0 2rem !important;</td>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">LG</td>
+        <td style="padding: 0.25rem;">padding: 0 2rem !important;</td>
+    </tr>
+    <tr>
+        <td style="padding: 0.25rem;">XL</td>
+        <td style="padding: 0.25rem;">padding: 0 3rem !important;</td>
+    </tr>
+</table>`
     }
   }
 };
@@ -146,9 +142,7 @@ export const NoPadding = () => `${localStyles}${noPaddingExampleHtml}`;
 NoPadding.parameters = {
   docs: {
     description: {
-      story: `No padding class removes existing container paddings. <br>
-            <b>CSS class: </b> <code>.sap-padding-none</code><br>
-            <b>SCSS mixin: </b> <code>@include sap-padding(0);</code><br>
+      story: `No padding class removes existing container paddings. <br><b>CSS class: </b> <code>.sap-padding-none</code><br><b>SCSS mixin: </b> <code>@include sap-padding(0);</code><br>
             `
     }
   }

--- a/packages/common-css/stories/page-title/title.stories.js
+++ b/packages/common-css/stories/page-title/title.stories.js
@@ -11,8 +11,7 @@ export default {
     parameters: {
         description: `Page Title, Section Title, and Subsection Title can be used as building blocks for home pages. These elements follow a responsive spacing system for horizontal padding, which can be disabled using the <code>.no-inline-padding</code> modifier class.
 
-Typically, there is only one <b>Page Title</b> (optional), displayed in the content area above the group name. The top padding of a <b>Section Title</b> varies depending on whether a <b>Page Title</b> is present. Additionally, the vertical padding of a <b>Section Title</b> depends on its position — whether it is the first <b>Section Title</b> on the page or situated between sections. <br>
-<b>Subsection Title</b> has no padding-top, but if there's no <b>Section Title</b>, than <b>Subsection Title</b> adds 1rem padding-top.`,
+Typically, there is only one <b>Page Title</b> (optional), displayed in the content area above the group name. The top padding of a <b>Section Title</b> varies depending on whether a <b>Page Title</b> is present. Additionally, the vertical padding of a <b>Section Title</b> depends on its position — whether it is the first <b>Section Title</b> on the page or situated between sections. <br><b>Subsection Title</b> has no padding-top, but if there's no <b>Section Title</b>, than <b>Subsection Title</b> adds 1rem padding-top.`,
     }
 };
 export const Home = () => withPageTitleExampleHtml;
@@ -20,8 +19,7 @@ Home.storyName = 'Page Title, Section Title and Subsection Title';
 Home.parameters = {
   docs: {
     description: {
-      story: `The first <b>Section Title</b> under the <b>Page Title</b> has a 0.5rem top padding. Between sections, the top padding is 3rem for XL, L, and M screens, and 2rem for S screens.<br><br>
-      <b style="color: red">NOTE: The background color for the titles is added for illustration purposes.</b>`
+      story: `The first <b>Section Title</b> under the <b>Page Title</b> has a 0.5rem top padding. Between sections, the top padding is 3rem for XL, L, and M screens, and 2rem for S screens.<br><br><b style="color: red">NOTE: The background color for the titles is added for illustration purposes.</b>`
     }
   }
 };
@@ -31,8 +29,7 @@ NoPageTitle.storyName = 'Section Title and Subsection Title (no Page Title)';
 NoPageTitle.parameters = {
   docs: {
     description: {
-      story: `When there is no <b>Page Title</b>, the first <b>Section Title</b> has a top padding of 1.5rem. The padding between sections remains the same: 3rem for XL, L, and M screens, and 2rem for S screens. <br><br>
-      <b style="color: red">NOTE: The background color for the titles is added for illustration purposes.</b>`
+      story: `When there is no <b>Page Title</b>, the first <b>Section Title</b> has a top padding of 1.5rem. The padding between sections remains the same: 3rem for XL, L, and M screens, and 2rem for S screens. <br><br><b style="color: red">NOTE: The background color for the titles is added for illustration purposes.</b>`
     }
   }
 };

--- a/packages/common-css/stories/position/position-classes.example.html
+++ b/packages/common-css/stories/position/position-classes.example.html
@@ -24,3 +24,5 @@
     <h4>absolute position</h4>
     <div class="sap-position-absolute">.sap-position-absolute</div>
 </div>
+
+<br><br><br><br><br><br>

--- a/packages/common-css/stories/position/position-mixins.example.html
+++ b/packages/common-css/stories/position/position-mixins.example.html
@@ -5,43 +5,43 @@
         @include sap-position(absolute, $top: 0, $bottom: 2rem);
     }
     </code>
-
+    <br><br>
     <code>
     .test-position-relative {
         @include sap-position-relative($top: 0, $bottom: 2rem);
     }
     </code>
-
+    <br><br>
     <code>
     .test-position-absolute {
         @include sap-position-absolute($top: 0, $right: 4rem, $bottom: 2rem);
     }
     </code>
-
+    <br><br>
     <code>
     .test-position-fixed {
         @include sap-position-fixed($top: 0, $right: 4rem, $bottom: 2rem, $left: 0);
     }
     </code>
-
+    <br><br>
     <code>
     .test-position-sticky {
         @include sap-position-sticky($bottom: 0);
     }
     </code>
-
+    <br><br>
     <code>
     .test-position-absolute-center {
         @include sap-position-absolute-center();
     }
     </code>
-
+    <br><br>
     <code>
     .test-position-absolute-center-horizontally {
         @include sap-position-absolute-center-x();
     }
     </code>
-
+    <br><br>
     <code>
     .test-position-absolute-center-vertically {
         @include sap-position-absolute-center-y();

--- a/packages/common-css/stories/text/text.stories.js
+++ b/packages/common-css/stories/text/text.stories.js
@@ -28,8 +28,7 @@ DefaultExample.storyName = 'Default';
 DefaultExample.parameters = {
   docs: {
     description: {
-      story: `The default text component can display lines of text that wrap to the next line
-        once they reach the end of the content container width.`
+      story: `The default text component can display lines of text that wrap to the next line once they reach the end of the content container width.`
     }
   }
 };
@@ -37,9 +36,7 @@ export const Whitespace = () => whitespaceExampleHtml;
 Whitespace.parameters = {
   docs: {
     description: {
-      story: `The text component has a property that allows browsers to render specified indents and
-        whitespace. To display indents and/or whitespace, use the
-        \`.fd-text-pre-wrap\` class or \`data-wrap\` attribute to \`.fd-text\` class.`
+      story: `The text component has a property that allows browsers to render specified indents and whitespace. To display indents and/or whitespace, use the \`.fd-text-pre-wrap\` class or \`data-wrap\` attribute to \`.fd-text\` class.`
     }
   }
 };

--- a/packages/common-css/stories/typography/common-cases.example.html
+++ b/packages/common-css/stories/typography/common-cases.example.html
@@ -1,7 +1,7 @@
 
-<span>Header Text in Size 3: </span><span class="sap-font-header-3">Used in dynamic page header, object page header</span><br><br>
-<span>Standard Text: </span><span class="sap-font-standard-text">Used in text control</span><br><br>
-<span>Small Detail Text: </span><span class="sap-font-small-detail-text">Used in time stamps, small bylines</span><br><br>
-<span>Standard Field Text: </span><span class="sap-font-standard-field-text">Used in input field, feed input, text area</span><br><br>
-<span>Labels: </span><span class="sap-font-label">Used in labels</span><br><br>
-<span>Descriptions: </span><span class="sap-font-description">Used in object attribute</span><br><br>
+<span>Header Text in Size 3: </span><span class="sap-font-header-3">Used in dynamic page header, object page header</span><br><br><br><br>
+<span>Standard Text: </span><span class="sap-font-standard-text">Used in text control</span><br><br><br><br>
+<span>Small Detail Text: </span><span class="sap-font-small-detail-text">Used in time stamps, small bylines</span><br><br><br><br>
+<span>Standard Field Text: </span><span class="sap-font-standard-field-text">Used in input field, feed input, text area</span><br><br><br><br>
+<span>Labels: </span><span class="sap-font-label">Used in labels</span><br><br><br><br>
+<span>Descriptions: </span><span class="sap-font-description">Used in object attribute</span><br><br><br><br>

--- a/packages/common-css/stories/typography/typography.stories.js
+++ b/packages/common-css/stories/typography/typography.stories.js
@@ -15,6 +15,7 @@ FontFamily.parameters = {
   docs: {
     description: {
       story: `To set the <b>font-family</b> of an element use the <code>.sap-font-family-<i style="color: red;">type</i></code>class or the <code>@include sap-font-family(<i style="color: red;">type</i>)</code> mixin with <i style="color: red;">type</i> being one of the following:<br> regular | light | bold | semibold | semibold-duplex | monospaced-regular | monospaced-bold | black | header 
+
 <table style="width: 100%; border-collapse: collapse; margin-top: 1rem;">
     <tr>
         <th style="padding: 0.25rem;">Type</th>
@@ -85,6 +86,7 @@ FontSize.parameters = {
   docs: {
     description: {
       story: `To set the <b>font-size</b> of an element use the <code>.sap-font-size-<i style="color: red;">value</i></code>class or the <code>@include sap-font-size(<i style="color: red;">value</i>)</code> mixin with <i style="color: red;">value</i> being one of the following:<br> header-6 | header-5 | header-4 | header-3 | header-2 | header-1 | small | medium | large 
+
 <table style="width: 100%; border-collapse: collapse; margin-top: 1rem;">
     <tr>
         <th style="padding: 0.25rem;">Type</th>


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-styles/issues/6116

## Description
- Code related:  border-left, border-right, border-top, border-bottom, etc. are replaced by 
border-block-start, border-block-end, ... which doesn't require RTL handling
- Documentation related: Some doc examples and descriptions were broken due to formatting. This was fixed. Simplified some examples
