### PR TITLE
feat(styles): add two-month view for Calendar [ci visual]

### DIFF
--- a/packages/styles/src/calendar.scss
+++ b/packages/styles/src/calendar.scss
@@ -434,6 +434,12 @@ $fd-calendar-special-days: (
     }
   }
 
+  // To hide buttons in Two-Month View
+  &__hidden {
+    opacity: 0;
+    pointer-events: none;
+  }
+
   // CALENDAR COMPACT
   @include fd-compact-or-condensed() {
     --fdCalendar_Width:
@@ -470,6 +476,12 @@ $fd-calendar-special-days: (
     --fdCalendar_Padding: 0;
 
     padding-block-start: 1rem;
+  }
+
+  &--mobile {
+    --fdCalendar_Padding: 0;
+
+    padding-block-start: 0.5rem;
   }
 }
 
@@ -561,4 +573,33 @@ $fd-calendar-special-days: (
   @include fd-compact-or-condensed() {
     --fdCalendar_Legend_Item_Padding: 0.125rem;
   }
+}
+
+.#{$block}-container {
+  @include fd-reset();
+
+  width: fit-content;
+  padding-block: 0.5rem;
+  padding-inline: 0.5rem;
+  box-shadow: var(--sapContent_Shadow2);
+  background: var(--sapGroup_ContentBackground);
+  border-radius: var(--sapPopover_BorderCornerRadius);
+
+  &--vertical {
+    --fdCalendarContainerGap: 0.5rem;
+    --fdCalendarContainerFlexDirection: column;
+  }
+
+  .#{$block}__item--other {
+    opacity: 0;
+    pointer-events: none;
+  }
+}
+
+.#{$block}-container-inner {
+  @include fd-flex($direction: var(--fdCalendarContainerFlexDirection, row)) {
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: var(--fdCalendarContainerGap, 1rem);
+  };
 }

--- a/packages/styles/stories/Components/calendar/calendar.stories.js
+++ b/packages/styles/stories/Components/calendar/calendar.stories.js
@@ -3,6 +3,8 @@ import yearsExampleHtml from "./years.example.html?raw";
 import monthsExampleHtml from "./months.example.html?raw";
 import daysExampleHtml from "./days.example.html?raw";
 import legendExampleHtml from "./legend.example.html?raw";
+import twoMonthViewExampleHtml from "./two-month-view.example.html?raw";
+
 import '../../../src/bar.scss';
 import '../../../src/dialog.scss';
 import '../../../src/tile.scss';
@@ -149,6 +151,16 @@ The legend includes:
 
 The number of flexible columns should be configurable to prevent label truncation, though labels can also wrap to accommodate longer text. Use <code>fd-calendar-legend--auto-column</code> for auto column width.<br><br>
 Appointments are represented by circles <code>fd-calendar-legend__item--appointment</code>, while special calendar days are depicted as squares (default).`
+    }
+  }
+};
+
+export const TwoMonthView = () => twoMonthViewExampleHtml;
+TwoMonthView.storyName = 'Two-Month Calendar';
+TwoMonthView.parameters = {
+  docs: {
+   description: {
+      story: `For date range selection use cases the calendar can provide 2-month view. The adjacent month days and the inner buttons are hidden. <br><br>In cases where the width of the screen is not enough the 2-month calendar is turning into a vertical structure. Use the modifier class <code>.fd-calendar-container--vertical</code> for vertical layout. <br><br>On phone the Calendar popover turns into full screen dialog with only one month and taking back the adjacent month days.`
     }
   }
 };

--- a/packages/styles/stories/Components/calendar/two-month-view.example.html
+++ b/packages/styles/stories/Components/calendar/two-month-view.example.html
@@ -1,0 +1,2452 @@
+
+<h4>Horizontal</h4>
+<div class="fd-calendar-container">
+    <div class="fd-calendar-container-inner">
+        <section class="fd-calendar" role="group" aria-roledescription="Calendar">
+            <header class="fd-calendar__navigation">
+                <div class="fd-calendar__action fd-calendar__action--arrow-left">
+                    <button type="button" class="fd-button fd-button--transparent" aria-label="Previous" title="Previous">
+                        <i class="sap-icon--slim-arrow-left" role="presentation" aria-hidden="true"></i>
+                    </button>
+                </div>
+                <div class="fd-calendar__action">
+                    <button type="button" class="fd-button fd-button--transparent" aria-label="February">February</button>
+                </div>
+                <div class="fd-calendar__action">
+                    <button type="button" class="fd-button fd-button--transparent">2018</button>
+                </div>
+                <div class="fd-calendar__action fd-calendar__action--arrow-right fd-calendar__hidden">
+                    <button type="button" class="fd-button fd-button--transparent" aria-label="Next" title="Next" tabindex="-1">
+                        <i class="sap-icon--slim-arrow-right" role="presentation" aria-hidden="true"></i>
+                    </button>
+                </div>
+            </header>
+            <table class="fd-calendar__content" id="IO0cp341" role="grid" aria-readonly="false" aria-multiselectable="true" aria-roledescription="Gregorian calendar">
+                <thead class="fd-calendar__group" role="rowgroup">
+                    <tr class="fd-calendar__row" role="row">
+                        <th role="columnheader" class="fd-calendar__item fd-calendar__item--side-helper"></th>
+                        <th role="columnheader" aria-label="Monday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Mon</span>
+                            </div>
+                        </th>
+                        <th role="columnheader" aria-label="Tuesday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Tue</span>
+                            </div>
+                        </th>
+                        <th role="columnheader" aria-label="Wednesday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Wed</span>
+                            </div>
+                        </th>
+                        <th role="columnheader" aria-label="Thursday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Thu</span>
+                            </div>
+                        </th>
+                        <th role="columnheader" aria-label="Friday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Fri</span>
+                            </div>
+                        </th>
+                        <th role="columnheader" aria-label="Saturday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Sat</span>
+                            </div>
+                        </th>
+                        <th role="columnheader" aria-label="Sunday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Sun</span>
+                            </div>
+                        </th>
+                    </tr>
+                </thead>
+                <tbody class="fd-calendar__group" role="rowgroup">
+                    <tr role="row" class="fd-calendar__row">
+                        <th 
+                            scope="row" 
+                            role="rowheader" 
+                            aria-label="Calendar Week 5" 
+                            class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">5</span>
+                            </div>
+                        </th>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="January 30, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">30</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="January 31, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">31</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 1, 2018" 
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">1</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 2, 2018" 
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">2</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 3, 2018" 
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">3</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 4, 2018; Non-Working Day" 
+                            title="Non-Working Day"
+                            class="fd-calendar__item fd-calendar__item--weekend">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">4</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 5, 2018; Non-Working Day" 
+                            title="Non-Working Day"
+                            class="fd-calendar__item fd-calendar__item--weekend">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">5</span>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr role="row" class="fd-calendar__row">
+                        <th 
+                            scope="row" 
+                            role="rowheader" 
+                            aria-label="Calendar Week 6" 
+                            class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">6</span>
+                            </div>
+                        </th>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 6, 2018"  
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">6</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 7, 2018"  
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">7</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 8, 2018"  
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">8</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 9, 2018"  
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">9</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 10, 2018"  
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">10</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            title="Non-Working Day"
+                            aria-label="February 11, 2018; Non-Working Day"  
+                            class="fd-calendar__item fd-calendar__item--weekend">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">11</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            title="Non-Working Day"
+                            aria-label="February 12, 2018; Non-Working Day"  
+                            class="fd-calendar__item fd-calendar__item--weekend">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">12</span>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr role="row" class="fd-calendar__row">
+                        <th 
+                            scope="row" 
+                            role="rowheader" 
+                            aria-label="Calendar Week 7" 
+                            class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">7</span>
+                            </div>
+                        </th>
+                        <td 
+                            role="gridcell"
+                            aria-selected="true"
+                            aria-disabled="false"
+                            aria-label="February 13, 2018"  
+                            class="fd-calendar__item fd-calendar__item--selected">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">13</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="true"
+                            aria-disabled="false"
+                            aria-label="February 14, 2018"   
+                            class="fd-calendar__item fd-calendar__item--range">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">14</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="true"
+                            aria-disabled="false"
+                            aria-label="February 15, 2018"   
+                            class="fd-calendar__item fd-calendar__item--range">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">15</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="true"
+                            aria-disabled="false"
+                            aria-label="February 16, 2018"   
+                            class="fd-calendar__item fd-calendar__item--range">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">16</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="true"
+                            aria-disabled="false"
+                            aria-label="February 17, 2018; Special Day Type 7"  
+                            title="Special Day Type 7"   
+                            class="fd-calendar__item fd-calendar__item--range  fd-calendar__item--legend-7">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">17</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="true"
+                            aria-disabled="false"
+                            aria-label="February 18, 2018; Non-Working Day, Special Day Type 1"  
+                            title="Non-Working Day, Special Day Type 1"
+                            class="fd-calendar__item fd-calendar__item--weekend
+                                fd-calendar__item--selected fd-calendar__item--legend-1">
+                                <div class="fd-calendar__text-wrapper">
+                                    <span class="fd-calendar__text">18</span>
+                                </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 19, 2018; Non-Working Day, Special Day Type 5" 
+                            title="Non-Working Day, Special Day Type 5"  
+                            class="fd-calendar__item fd-calendar__item--weekend fd-calendar__item--legend-5">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">19</span>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr role="row" class="fd-calendar__row">
+                        <th
+                            scope="row" 
+                            role="rowheader" 
+                            aria-label="Calendar Week 8" 
+                            class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">8</span>
+                            </div>
+                        </th>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 20, 2018"   
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">20</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 21, 2018"   
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">21</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 22, 2018"   
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">22</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 23, 2018"   
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">23</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 24, 2018"  
+                            title="Special Day Type 3" 
+                            class="fd-calendar__item fd-calendar__item--legend-3">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">24</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 25, 2018" 
+                            title="Non-Working Day, Special Day Type 9"  
+                            class="fd-calendar__item fd-calendar__item--weekend fd-calendar__item--legend-9">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">25</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 26, 2018; Non-Working Day"   
+                            title="Non-Working Day"
+                            class="fd-calendar__item fd-calendar__item--weekend">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">26</span>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr role="row" class="fd-calendar__row">
+                        <th
+                            scope="row" 
+                            role="rowheader" 
+                            aria-label="Calendar Week 9" 
+                            class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">9</span>
+                            </div>
+                        </th>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 27, 2018" 
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">27</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 28, 2018" 
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">28</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 1, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">1</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 2, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">2</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 3, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">3</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 4, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">4</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 5, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">5</span>
+                            </div>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <div aria-live="polite" class="fd-calendar__content fd-calendar__content--screen-reader-only">Use arrow keys to navigate dates</div>
+        </section>
+        <section class="fd-calendar" role="group" aria-roledescription="Calendar">
+            <header class="fd-calendar__navigation">
+                <div class="fd-calendar__action fd-calendar__action--arrow-left fd-calendar__hidden">
+                    <button type="button" class="fd-button fd-button--transparent" aria-label="Previous" title="Previous" tabindex="-1">
+                        <i class="sap-icon--slim-arrow-left" role="presentation" aria-hidden="true"></i>
+                    </button>
+                </div>
+                <div class="fd-calendar__action">
+                    <button type="button" class="fd-button fd-button--transparent" aria-label="March">March</button>
+                </div>
+                <div class="fd-calendar__action">
+                    <button type="button" class="fd-button fd-button--transparent">2018</button>
+                </div>
+                <div class="fd-calendar__action fd-calendar__action--arrow-right">
+                    <button type="button" class="fd-button fd-button--transparent" aria-label="Next" title="Next">
+                        <i class="sap-icon--slim-arrow-right" role="presentation" aria-hidden="true"></i>
+                    </button>
+                </div>
+            </header>
+            <table class="fd-calendar__content" id="IO0cp341" role="grid" aria-readonly="false" aria-multiselectable="true" aria-roledescription="Gregorian calendar">
+                <thead class="fd-calendar__group" role="rowgroup">
+                    <tr class="fd-calendar__row" role="row">
+                        <th role="columnheader" class="fd-calendar__item fd-calendar__item--side-helper"></th>
+                        <th role="columnheader" aria-label="Monday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Mon</span>
+                            </div>
+                        </th>
+                        <th role="columnheader" aria-label="Tuesday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Tue</span>
+                            </div>
+                        </th>
+                        <th role="columnheader" aria-label="Wednesday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Wed</span>
+                            </div>
+                        </th>
+                        <th role="columnheader" aria-label="Thursday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Thu</span>
+                            </div>
+                        </th>
+                        <th role="columnheader" aria-label="Friday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Fri</span>
+                            </div>
+                        </th>
+                        <th role="columnheader" aria-label="Saturday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Sat</span>
+                            </div>
+                        </th>
+                        <th role="columnheader" aria-label="Sunday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Sun</span>
+                            </div>
+                        </th>
+                    </tr>
+                </thead>
+                <tbody class="fd-calendar__group" role="rowgroup">
+                    <tr role="row" class="fd-calendar__row">
+                        <th 
+                            scope="row" 
+                            role="rowheader" 
+                            aria-label="Calendar Week 10" 
+                            class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">10</span>
+                            </div>
+                        </th>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 27, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">27</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 28, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">28</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 1, 2018" 
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">1</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 2, 2018" 
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">2</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 3, 2018" 
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">3</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 4, 2018; Non-Working Day" 
+                            title="Non-Working Day"
+                            class="fd-calendar__item fd-calendar__item--weekend">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">4</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 5, 2018; Non-Working Day" 
+                            title="Non-Working Day"
+                            class="fd-calendar__item fd-calendar__item--weekend">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">5</span>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr role="row" class="fd-calendar__row">
+                        <th 
+                            scope="row" 
+                            role="rowheader" 
+                            aria-label="Calendar Week 11" 
+                            class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">11</span>
+                            </div>
+                        </th>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 6, 2018"  
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">6</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 7, 2018"  
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">7</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 8, 2018"  
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">8</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 9, 2018"  
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">9</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 10, 2018"  
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">10</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            title="Non-Working Day"
+                            aria-label="March 11, 2018; Non-Working Day"  
+                            class="fd-calendar__item fd-calendar__item--weekend">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">11</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            title="Non-Working Day"
+                            aria-label="March 12, 2018; Non-Working Day"  
+                            class="fd-calendar__item fd-calendar__item--weekend">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">12</span>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr role="row" class="fd-calendar__row">
+                        <th 
+                            scope="row" 
+                            role="rowheader" 
+                            aria-label="Calendar Week 12" 
+                            class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">12</span>
+                            </div>
+                        </th>
+                        <td 
+                            role="gridcell"
+                            aria-selected="true"
+                            aria-disabled="false"
+                            aria-label="March 13, 2018"  
+                            class="fd-calendar__item fd-calendar__item--selected">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">13</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="true"
+                            aria-disabled="false"
+                            aria-label="March 14, 2018"   
+                            class="fd-calendar__item fd-calendar__item--range">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">14</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="true"
+                            aria-disabled="false"
+                            aria-label="March 15, 2018"   
+                            class="fd-calendar__item fd-calendar__item--range">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">15</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="true"
+                            aria-disabled="false"
+                            aria-label="March 16, 2018"   
+                            class="fd-calendar__item fd-calendar__item--range">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">16</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="true"
+                            aria-disabled="false"
+                            aria-label="March 17, 2018; Special Day Type 7"  
+                            title="Special Day Type 7"   
+                            class="fd-calendar__item fd-calendar__item--range  fd-calendar__item--legend-7">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">17</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="true"
+                            aria-disabled="false"
+                            aria-label="March 18, 2018; Non-Working Day, Special Day Type 1"  
+                            title="Non-Working Day, Special Day Type 1"
+                            class="fd-calendar__item fd-calendar__item--weekend
+                                fd-calendar__item--selected fd-calendar__item--legend-1">
+                                <div class="fd-calendar__text-wrapper">
+                                    <span class="fd-calendar__text">18</span>
+                                </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 19, 2018; Non-Working Day, Special Day Type 5" 
+                            title="Non-Working Day, Special Day Type 5"  
+                            class="fd-calendar__item fd-calendar__item--weekend fd-calendar__item--legend-5">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">19</span>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr role="row" class="fd-calendar__row">
+                        <th
+                            scope="row" 
+                            role="rowheader" 
+                            aria-label="Calendar Week 13" 
+                            class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">13</span>
+                            </div>
+                        </th>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 20, 2018"   
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">20</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 21, 2018"   
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">21</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 22, 2018"   
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">22</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 23, 2018"   
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">23</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 24, 2018"  
+                            title="Special Day Type 3" 
+                            class="fd-calendar__item fd-calendar__item--legend-3">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">24</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 25, 2018" 
+                            title="Non-Working Day, Special Day Type 9"  
+                            class="fd-calendar__item fd-calendar__item--weekend fd-calendar__item--legend-9">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">25</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 26, 2018; Non-Working Day"   
+                            title="Non-Working Day"
+                            class="fd-calendar__item fd-calendar__item--weekend">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">26</span>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr role="row" class="fd-calendar__row">
+                        <th
+                            scope="row" 
+                            role="rowheader" 
+                            aria-label="Calendar Week 14" 
+                            class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">14</span>
+                            </div>
+                        </th>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 27, 2018" 
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">27</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 28, 2018" 
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">28</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 29, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">29</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 30, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">30</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 31, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">31</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="April 1, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">1</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="April 2, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">2</span>
+                            </div>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <div aria-live="polite" class="fd-calendar__content fd-calendar__content--screen-reader-only">Use arrow keys to navigate dates</div>
+        </section>
+    </div>
+</div>
+
+<br><br>
+
+<h4>Vertical</h4>
+<div class="fd-calendar-container fd-calendar-container--vertical">
+    <div class="fd-calendar-container-inner">
+        <section class="fd-calendar" role="group" aria-roledescription="Calendar">
+            <header class="fd-calendar__navigation">
+                <div class="fd-calendar__action fd-calendar__action--arrow-left">
+                    <button type="button" class="fd-button fd-button--transparent" aria-label="Previous" title="Previous">
+                        <i class="sap-icon--slim-arrow-left" role="presentation" aria-hidden="true"></i>
+                    </button>
+                </div>
+                <div class="fd-calendar__action">
+                    <button type="button" class="fd-button fd-button--transparent" aria-label="February">February</button>
+                </div>
+                <div class="fd-calendar__action">
+                    <button type="button" class="fd-button fd-button--transparent">2018</button>
+                </div>
+                <div class="fd-calendar__action fd-calendar__action--arrow-right">
+                    <button type="button" class="fd-button fd-button--transparent" aria-label="Next" title="Next">
+                        <i class="sap-icon--slim-arrow-right" role="presentation" aria-hidden="true"></i>
+                    </button>
+                </div>
+            </header>
+            <table class="fd-calendar__content" id="IO0cp341" role="grid" aria-readonly="false" aria-multiselectable="true" aria-roledescription="Gregorian calendar">
+                <thead class="fd-calendar__group" role="rowgroup">
+                    <tr class="fd-calendar__row" role="row">
+                        <th role="columnheader" class="fd-calendar__item fd-calendar__item--side-helper"></th>
+                        <th role="columnheader" aria-label="Monday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Mon</span>
+                            </div>
+                        </th>
+                        <th role="columnheader" aria-label="Tuesday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Tue</span>
+                            </div>
+                        </th>
+                        <th role="columnheader" aria-label="Wednesday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Wed</span>
+                            </div>
+                        </th>
+                        <th role="columnheader" aria-label="Thursday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Thu</span>
+                            </div>
+                        </th>
+                        <th role="columnheader" aria-label="Friday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Fri</span>
+                            </div>
+                        </th>
+                        <th role="columnheader" aria-label="Saturday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Sat</span>
+                            </div>
+                        </th>
+                        <th role="columnheader" aria-label="Sunday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Sun</span>
+                            </div>
+                        </th>
+                    </tr>
+                </thead>
+                <tbody class="fd-calendar__group" role="rowgroup">
+                    <tr role="row" class="fd-calendar__row">
+                        <th 
+                            scope="row" 
+                            role="rowheader" 
+                            aria-label="Calendar Week 5" 
+                            class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">5</span>
+                            </div>
+                        </th>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="January 30, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">30</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="January 31, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">31</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 1, 2018" 
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">1</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 2, 2018" 
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">2</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 3, 2018" 
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">3</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 4, 2018; Non-Working Day" 
+                            title="Non-Working Day"
+                            class="fd-calendar__item fd-calendar__item--weekend">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">4</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 5, 2018; Non-Working Day" 
+                            title="Non-Working Day"
+                            class="fd-calendar__item fd-calendar__item--weekend">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">5</span>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr role="row" class="fd-calendar__row">
+                        <th 
+                            scope="row" 
+                            role="rowheader" 
+                            aria-label="Calendar Week 6" 
+                            class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">6</span>
+                            </div>
+                        </th>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 6, 2018"  
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">6</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 7, 2018"  
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">7</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 8, 2018"  
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">8</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 9, 2018"  
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">9</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 10, 2018"  
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">10</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            title="Non-Working Day"
+                            aria-label="February 11, 2018; Non-Working Day"  
+                            class="fd-calendar__item fd-calendar__item--weekend">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">11</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            title="Non-Working Day"
+                            aria-label="February 12, 2018; Non-Working Day"  
+                            class="fd-calendar__item fd-calendar__item--weekend">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">12</span>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr role="row" class="fd-calendar__row">
+                        <th 
+                            scope="row" 
+                            role="rowheader" 
+                            aria-label="Calendar Week 7" 
+                            class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">7</span>
+                            </div>
+                        </th>
+                        <td 
+                            role="gridcell"
+                            aria-selected="true"
+                            aria-disabled="false"
+                            aria-label="February 13, 2018"  
+                            class="fd-calendar__item fd-calendar__item--selected">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">13</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="true"
+                            aria-disabled="false"
+                            aria-label="February 14, 2018"   
+                            class="fd-calendar__item fd-calendar__item--range">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">14</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="true"
+                            aria-disabled="false"
+                            aria-label="February 15, 2018"   
+                            class="fd-calendar__item fd-calendar__item--range">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">15</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="true"
+                            aria-disabled="false"
+                            aria-label="February 16, 2018"   
+                            class="fd-calendar__item fd-calendar__item--range">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">16</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="true"
+                            aria-disabled="false"
+                            aria-label="February 17, 2018; Special Day Type 7"  
+                            title="Special Day Type 7"   
+                            class="fd-calendar__item fd-calendar__item--range  fd-calendar__item--legend-7">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">17</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="true"
+                            aria-disabled="false"
+                            aria-label="February 18, 2018; Non-Working Day, Special Day Type 1"  
+                            title="Non-Working Day, Special Day Type 1"
+                            class="fd-calendar__item fd-calendar__item--weekend
+                                fd-calendar__item--selected fd-calendar__item--legend-1">
+                                <div class="fd-calendar__text-wrapper">
+                                    <span class="fd-calendar__text">18</span>
+                                </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 19, 2018; Non-Working Day, Special Day Type 5" 
+                            title="Non-Working Day, Special Day Type 5"  
+                            class="fd-calendar__item fd-calendar__item--weekend fd-calendar__item--legend-5">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">19</span>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr role="row" class="fd-calendar__row">
+                        <th
+                            scope="row" 
+                            role="rowheader" 
+                            aria-label="Calendar Week 8" 
+                            class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">8</span>
+                            </div>
+                        </th>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 20, 2018"   
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">20</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 21, 2018"   
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">21</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 22, 2018"   
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">22</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 23, 2018"   
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">23</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 24, 2018"  
+                            title="Special Day Type 3" 
+                            class="fd-calendar__item fd-calendar__item--legend-3">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">24</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 25, 2018" 
+                            title="Non-Working Day, Special Day Type 9"  
+                            class="fd-calendar__item fd-calendar__item--weekend fd-calendar__item--legend-9">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">25</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 26, 2018; Non-Working Day"   
+                            title="Non-Working Day"
+                            class="fd-calendar__item fd-calendar__item--weekend">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">26</span>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr role="row" class="fd-calendar__row">
+                        <th
+                            scope="row" 
+                            role="rowheader" 
+                            aria-label="Calendar Week 9" 
+                            class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">9</span>
+                            </div>
+                        </th>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 27, 2018" 
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">27</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 28, 2018" 
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">28</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 1, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">1</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 2, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">2</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 3, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">3</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 4, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">4</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 5, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">5</span>
+                            </div>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <div aria-live="polite" class="fd-calendar__content fd-calendar__content--screen-reader-only">Use arrow keys to navigate dates</div>
+        </section>
+        <section class="fd-calendar" role="group" aria-roledescription="Calendar">
+            <header class="fd-calendar__navigation">
+                <div class="fd-calendar__action fd-calendar__action--arrow-left fd-calendar__hidden">
+                    <button type="button" class="fd-button fd-button--transparent" aria-label="Previous" title="Previous" tabindex="-1">
+                        <i class="sap-icon--slim-arrow-left" role="presentation" aria-hidden="true"></i>
+                    </button>
+                </div>
+                <div class="fd-calendar__action">
+                    <button type="button" class="fd-button fd-button--transparent" aria-label="March">March</button>
+                </div>
+                <div class="fd-calendar__action">
+                    <button type="button" class="fd-button fd-button--transparent">2018</button>
+                </div>
+                <div class="fd-calendar__action fd-calendar__action--arrow-right fd-calendar__hidden">
+                    <button type="button" class="fd-button fd-button--transparent" aria-label="Next" title="Next" tabindex="-1">
+                        <i class="sap-icon--slim-arrow-right" role="presentation" aria-hidden="true"></i>
+                    </button>
+                </div>
+            </header>
+            <table class="fd-calendar__content" id="IO0cp341" role="grid" aria-readonly="false" aria-multiselectable="true" aria-roledescription="Gregorian calendar">
+                <thead class="fd-calendar__group" role="rowgroup">
+                    <tr class="fd-calendar__row" role="row">
+                        <th role="columnheader" class="fd-calendar__item fd-calendar__item--side-helper"></th>
+                        <th role="columnheader" aria-label="Monday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Mon</span>
+                            </div>
+                        </th>
+                        <th role="columnheader" aria-label="Tuesday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Tue</span>
+                            </div>
+                        </th>
+                        <th role="columnheader" aria-label="Wednesday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Wed</span>
+                            </div>
+                        </th>
+                        <th role="columnheader" aria-label="Thursday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Thu</span>
+                            </div>
+                        </th>
+                        <th role="columnheader" aria-label="Friday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Fri</span>
+                            </div>
+                        </th>
+                        <th role="columnheader" aria-label="Saturday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Sat</span>
+                            </div>
+                        </th>
+                        <th role="columnheader" aria-label="Sunday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Sun</span>
+                            </div>
+                        </th>
+                    </tr>
+                </thead>
+                <tbody class="fd-calendar__group" role="rowgroup">
+                    <tr role="row" class="fd-calendar__row">
+                        <th 
+                            scope="row" 
+                            role="rowheader" 
+                            aria-label="Calendar Week 10" 
+                            class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">10</span>
+                            </div>
+                        </th>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 27, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">27</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 28, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">28</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 1, 2018" 
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">1</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 2, 2018" 
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">2</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 3, 2018" 
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">3</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 4, 2018; Non-Working Day" 
+                            title="Non-Working Day"
+                            class="fd-calendar__item fd-calendar__item--weekend">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">4</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 5, 2018; Non-Working Day" 
+                            title="Non-Working Day"
+                            class="fd-calendar__item fd-calendar__item--weekend">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">5</span>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr role="row" class="fd-calendar__row">
+                        <th 
+                            scope="row" 
+                            role="rowheader" 
+                            aria-label="Calendar Week 11" 
+                            class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">11</span>
+                            </div>
+                        </th>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 6, 2018"  
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">6</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 7, 2018"  
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">7</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 8, 2018"  
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">8</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 9, 2018"  
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">9</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 10, 2018"  
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">10</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            title="Non-Working Day"
+                            aria-label="March 11, 2018; Non-Working Day"  
+                            class="fd-calendar__item fd-calendar__item--weekend">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">11</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            title="Non-Working Day"
+                            aria-label="March 12, 2018; Non-Working Day"  
+                            class="fd-calendar__item fd-calendar__item--weekend">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">12</span>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr role="row" class="fd-calendar__row">
+                        <th 
+                            scope="row" 
+                            role="rowheader" 
+                            aria-label="Calendar Week 12" 
+                            class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">12</span>
+                            </div>
+                        </th>
+                        <td 
+                            role="gridcell"
+                            aria-selected="true"
+                            aria-disabled="false"
+                            aria-label="March 13, 2018"  
+                            class="fd-calendar__item fd-calendar__item--selected">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">13</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="true"
+                            aria-disabled="false"
+                            aria-label="March 14, 2018"   
+                            class="fd-calendar__item fd-calendar__item--range">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">14</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="true"
+                            aria-disabled="false"
+                            aria-label="March 15, 2018"   
+                            class="fd-calendar__item fd-calendar__item--range">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">15</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="true"
+                            aria-disabled="false"
+                            aria-label="March 16, 2018"   
+                            class="fd-calendar__item fd-calendar__item--range">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">16</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="true"
+                            aria-disabled="false"
+                            aria-label="March 17, 2018; Special Day Type 7"  
+                            title="Special Day Type 7"   
+                            class="fd-calendar__item fd-calendar__item--range  fd-calendar__item--legend-7">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">17</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="true"
+                            aria-disabled="false"
+                            aria-label="March 18, 2018; Non-Working Day, Special Day Type 1"  
+                            title="Non-Working Day, Special Day Type 1"
+                            class="fd-calendar__item fd-calendar__item--weekend
+                                fd-calendar__item--selected fd-calendar__item--legend-1">
+                                <div class="fd-calendar__text-wrapper">
+                                    <span class="fd-calendar__text">18</span>
+                                </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 19, 2018; Non-Working Day, Special Day Type 5" 
+                            title="Non-Working Day, Special Day Type 5"  
+                            class="fd-calendar__item fd-calendar__item--weekend fd-calendar__item--legend-5">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">19</span>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr role="row" class="fd-calendar__row">
+                        <th
+                            scope="row" 
+                            role="rowheader" 
+                            aria-label="Calendar Week 13" 
+                            class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">13</span>
+                            </div>
+                        </th>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 20, 2018"   
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">20</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 21, 2018"   
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">21</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 22, 2018"   
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">22</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 23, 2018"   
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">23</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 24, 2018"  
+                            title="Special Day Type 3" 
+                            class="fd-calendar__item fd-calendar__item--legend-3">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">24</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 25, 2018" 
+                            title="Non-Working Day, Special Day Type 9"  
+                            class="fd-calendar__item fd-calendar__item--weekend fd-calendar__item--legend-9">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">25</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 26, 2018; Non-Working Day"   
+                            title="Non-Working Day"
+                            class="fd-calendar__item fd-calendar__item--weekend">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">26</span>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr role="row" class="fd-calendar__row">
+                        <th
+                            scope="row" 
+                            role="rowheader" 
+                            aria-label="Calendar Week 14" 
+                            class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">14</span>
+                            </div>
+                        </th>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 27, 2018" 
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">27</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 28, 2018" 
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">28</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 29, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">29</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 30, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">30</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 31, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">31</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="April 1, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">1</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="April 2, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">2</span>
+                            </div>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <div aria-live="polite" class="fd-calendar__content fd-calendar__content--screen-reader-only">Use arrow keys to navigate dates</div>
+        </section>
+    </div>
+</div>
+
+<br><br>
+
+<h4>Mobile</h4>
+<div class="fd-dialog-docs-static fd-calendar-mobile-docs-static--portrait fd-dialog fd-dialog--active" style="width: fit-content;">
+    <div class="fd-dialog__content fd-dialog__content--s fd-dialog__content--mobile" style="min-height: 600px; width: fit-content;">
+      <div class="fd-dialog__header fd-bar fd-bar--header fd-bar--cosy">
+        <div class="fd-bar__left">
+          <div class="fd-bar__element">
+            <h3 class="fd-title fd-title--h5">
+              Calendar
+            </h3>
+          </div>
+        </div>
+      </div>
+      <div class="fd-dialog__body fd-dialog__body--no-vertical-padding">
+        <section class="fd-calendar fd-calendar--mobile" role="group" aria-roledescription="Calendar">
+            <header class="fd-calendar__navigation">
+                <div class="fd-calendar__action fd-calendar__action--arrow-left">
+                    <button type="button" class="fd-button fd-button--transparent" aria-label="Previous" title="Previous">
+                        <i class="sap-icon--slim-arrow-left" role="presentation" aria-hidden="true"></i>
+                    </button>
+                </div>
+                <div class="fd-calendar__action">
+                    <button type="button" class="fd-button fd-button--transparent" aria-label="February">February</button>
+                </div>
+                <div class="fd-calendar__action">
+                    <button type="button" class="fd-button fd-button--transparent">2018</button>
+                </div>
+                <div class="fd-calendar__action fd-calendar__action--arrow-right">
+                    <button type="button" class="fd-button fd-button--transparent" aria-label="Next" title="Next">
+                        <i class="sap-icon--slim-arrow-right" role="presentation" aria-hidden="true"></i>
+                    </button>
+                </div>
+            </header>
+            <table class="fd-calendar__content" id="IO0cp341" role="grid" aria-readonly="false" aria-multiselectable="true" aria-roledescription="Gregorian calendar">
+                <thead class="fd-calendar__group" role="rowgroup">
+                    <tr class="fd-calendar__row" role="row">
+                        <th role="columnheader" class="fd-calendar__item fd-calendar__item--side-helper"></th>
+                        <th role="columnheader" aria-label="Monday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Mon</span>
+                            </div>
+                        </th>
+                        <th role="columnheader" aria-label="Tuesday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Tue</span>
+                            </div>
+                        </th>
+                        <th role="columnheader" aria-label="Wednesday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Wed</span>
+                            </div>
+                        </th>
+                        <th role="columnheader" aria-label="Thursday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Thu</span>
+                            </div>
+                        </th>
+                        <th role="columnheader" aria-label="Friday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Fri</span>
+                            </div>
+                        </th>
+                        <th role="columnheader" aria-label="Saturday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Sat</span>
+                            </div>
+                        </th>
+                        <th role="columnheader" aria-label="Sunday" class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">Sun</span>
+                            </div>
+                        </th>
+                    </tr>
+                </thead>
+                <tbody class="fd-calendar__group" role="rowgroup">
+                    <tr role="row" class="fd-calendar__row">
+                        <th 
+                            scope="row" 
+                            role="rowheader" 
+                            aria-label="Calendar Week 5" 
+                            class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">5</span>
+                            </div>
+                        </th>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="January 30, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">30</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="January 31, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">31</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 1, 2018" 
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">1</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 2, 2018" 
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">2</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 3, 2018" 
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">3</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 4, 2018; Non-Working Day" 
+                            title="Non-Working Day"
+                            class="fd-calendar__item fd-calendar__item--weekend">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">4</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 5, 2018; Non-Working Day" 
+                            title="Non-Working Day"
+                            class="fd-calendar__item fd-calendar__item--weekend">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">5</span>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr role="row" class="fd-calendar__row">
+                        <th 
+                            scope="row" 
+                            role="rowheader" 
+                            aria-label="Calendar Week 6" 
+                            class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">6</span>
+                            </div>
+                        </th>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 6, 2018"  
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">6</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 7, 2018"  
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">7</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 8, 2018"  
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">8</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 9, 2018"  
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">9</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 10, 2018"  
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">10</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            title="Non-Working Day"
+                            aria-label="February 11, 2018; Non-Working Day"  
+                            class="fd-calendar__item fd-calendar__item--weekend">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">11</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            title="Non-Working Day"
+                            aria-label="February 12, 2018; Non-Working Day"  
+                            class="fd-calendar__item fd-calendar__item--weekend">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">12</span>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr role="row" class="fd-calendar__row">
+                        <th 
+                            scope="row" 
+                            role="rowheader" 
+                            aria-label="Calendar Week 7" 
+                            class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">7</span>
+                            </div>
+                        </th>
+                        <td 
+                            role="gridcell"
+                            aria-selected="true"
+                            aria-disabled="false"
+                            aria-label="February 13, 2018"  
+                            class="fd-calendar__item fd-calendar__item--selected">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">13</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="true"
+                            aria-disabled="false"
+                            aria-label="February 14, 2018"   
+                            class="fd-calendar__item fd-calendar__item--range">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">14</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="true"
+                            aria-disabled="false"
+                            aria-label="February 15, 2018"   
+                            class="fd-calendar__item fd-calendar__item--range">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">15</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="true"
+                            aria-disabled="false"
+                            aria-label="February 16, 2018"   
+                            class="fd-calendar__item fd-calendar__item--range">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">16</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="true"
+                            aria-disabled="false"
+                            aria-label="February 17, 2018; Special Day Type 7"  
+                            title="Special Day Type 7"   
+                            class="fd-calendar__item fd-calendar__item--range  fd-calendar__item--legend-7">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">17</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="true"
+                            aria-disabled="false"
+                            aria-label="February 18, 2018; Non-Working Day, Special Day Type 1"  
+                            title="Non-Working Day, Special Day Type 1"
+                            class="fd-calendar__item fd-calendar__item--weekend
+                                fd-calendar__item--selected fd-calendar__item--legend-1">
+                                <div class="fd-calendar__text-wrapper">
+                                    <span class="fd-calendar__text">18</span>
+                                </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 19, 2018; Non-Working Day, Special Day Type 5" 
+                            title="Non-Working Day, Special Day Type 5"  
+                            class="fd-calendar__item fd-calendar__item--weekend fd-calendar__item--legend-5">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">19</span>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr role="row" class="fd-calendar__row">
+                        <th
+                            scope="row" 
+                            role="rowheader" 
+                            aria-label="Calendar Week 8" 
+                            class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">8</span>
+                            </div>
+                        </th>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 20, 2018"   
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">20</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 21, 2018"   
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">21</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 22, 2018"   
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">22</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 23, 2018"   
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">23</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 24, 2018"  
+                            title="Special Day Type 3" 
+                            class="fd-calendar__item fd-calendar__item--legend-3">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">24</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 25, 2018" 
+                            title="Non-Working Day, Special Day Type 9"  
+                            class="fd-calendar__item fd-calendar__item--weekend fd-calendar__item--legend-9">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">25</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 26, 2018; Non-Working Day"   
+                            title="Non-Working Day"
+                            class="fd-calendar__item fd-calendar__item--weekend">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">26</span>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr role="row" class="fd-calendar__row">
+                        <th
+                            scope="row" 
+                            role="rowheader" 
+                            aria-label="Calendar Week 9" 
+                            class="fd-calendar__item fd-calendar__item--side-helper">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">9</span>
+                            </div>
+                        </th>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 27, 2018" 
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">27</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="February 28, 2018" 
+                            class="fd-calendar__item">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">28</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 1, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">1</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 2, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">2</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 3, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">3</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 4, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">4</span>
+                            </div>
+                        </td>
+                        <td 
+                            role="gridcell"
+                            aria-selected="false"
+                            aria-disabled="false"
+                            aria-label="March 5, 2018" 
+                            class="fd-calendar__item fd-calendar__item--other">
+                            <div class="fd-calendar__text-wrapper">
+                                <span class="fd-calendar__text">5</span>
+                            </div>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <div aria-live="polite" class="fd-calendar__content fd-calendar__content--screen-reader-only">Use arrow keys to navigate dates</div>
+        </section>
+      </div>
+      <div class="fd-dialog__footer fd-bar fd-bar--footer fd-bar--cosy">
+        <div class="fd-bar__right">
+          <div class="fd-bar__element">
+            <button class="fd-dialog__decisive-button fd-button fd-button--emphasized">
+            OK
+            </button>
+          </div>
+          <div class="fd-bar__element">
+            <button class="fd-dialog__decisive-button fd-button">
+            Cancel
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    </div>


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/6131

## Description
- CSS: added necessary classes to the Calendar component. New classes: `fd-calendar-container`, `fd-calendar-container--vertical`, `fd-calendar-container-inner`, `fd-calendar__hidden`, `fd-calendar-container`, `fd-calendar--mobile`
- Added examples to the documentation