### PR TITLE
fix(styles): remove font-weight for Emphasized btn [ci visual]

### DIFF
--- a/packages/styles/src/mixins/button/_button-types.scss
+++ b/packages/styles/src/mixins/button/_button-types.scss
@@ -35,7 +35,6 @@ $button-types-config: (
     "default": map.merge(
       map.get($default-button-config, "default"),
       (
-        "fontWeight": var(--sapButton_Emphasized_FontWeight),
         "borderWidth": var(--sapButton_Emphasized_BorderWidth),
         "borderColor": var(--sapButton_Emphasized_BorderColor),
         "color": var(--sapButton_Emphasized_TextColor),
@@ -245,7 +244,6 @@ $button-types-config: (
       @include _fd-button-type($props);
 
       @if $type == "emphasized" {
-        font-weight: var(--sapButton_Emphasized_FontWeight);
         border-width: var(--sapButton_Emphasized_BorderWidth);
 
         @include fd-focus() {


### PR DESCRIPTION
## Related Issue
Closes none, reported by a user

## Description
Emphasized button needs to rely on the font-family for the boldness of the font. We currently set the font-weight additionally to the font-family.