### PR TITLE
feat(common-css): add additional features to Border [ci visual]

### DIFF
--- a/packages/common-css/src/_common-mixins.scss
+++ b/packages/common-css/src/_common-mixins.scss
@@ -892,17 +892,17 @@
 @mixin sap-border($width, $style, $color, $pos: all) {
   $_border: $width $style $color;
 
-  @if  $pos == "top" {
+  @if $pos == "top" or $pos == "block-start" {
     border-block-start: $_border;
-  } @else if $pos == "bottom" {
+  } @else if $pos == "bottom" or $pos == "block-end" {
     border-block-end: $_border;
-  } @else if $pos == "left" {
+  } @else if $pos == "left" or $pos == "inline-start" {
     border-inline-start: $_border;
-  } @else if $pos == "right" {
+  } @else if $pos == "right" or $pos == "inline-end" {
     border-inline-end: $_border;
-  } @else if $pos == "x" {
+  } @else if $pos == "x" or $pos == "inline" {
     border-inline: $_border;
-  } @else if $pos == "y" {
+  } @else if $pos == "y" or $pos == "block" {
     border-block: $_border;
   } @else if $pos == "all" {
     border: $_border;

--- a/packages/common-css/src/_common-variables.scss
+++ b/packages/common-css/src/_common-variables.scss
@@ -21,6 +21,48 @@ $sap-corner-border-radius-group: 'group';
 $sap-corner-border-radius-popover: 'popover';
 $sap-corner-border-radius-tile: 'tile';
 
+$sap-border-style-solid: 'solid';
+$sap-border-style-dashed: 'dashed';
+$sap-border-style-dotted: 'dotted';
+$sap-border-style-double: 'double';
+$sap-border-style-hidden: 'hidden';
+$sap-border-style-none: 'none';
+
+$sap-border-width-1: 0.0625rem;
+$sap-border-width-2: 0.125rem;
+$sap-border-width-3: 0.1875rem;
+$sap-border-width-4: 0.25rem;
+$sap-border-width-element: var(--sapElement_BorderWidth);
+$sap-border-width-group: var(--sapGroup_BorderWidth);
+$sap-border-width-content-focus: var(--sapContent_FocusWidth);
+$sap-border-width-list: var(--sapList_BorderWidth);
+$sap-border-width-button: var(--sapButton_BorderWidth);
+$sap-border-width-message: var(--sapMessage_BorderWidth);
+$sap-border-width-field: var(--sapField_BorderWidth);
+$sap-border-width-field-invalid: var(--sapField_InvalidBorderWidth);
+$sap-border-width-field-warning: var(--sapField_WarningBorderWidth);
+$sap-border-width-field-success: var(--sapField_SuccessBorderWidth);
+$sap-border-width-field-information: var(--sapField_InformationBorderWidth);
+
+$sap-border-color-error: var(--sapErrorBorderColor);
+$sap-border-color-warning: var(--sapWarningBorderColor);
+$sap-border-color-success: var(--sapSuccessBorderColor);
+$sap-border-color-information: var(--sapInformationBorderColor);
+$sap-border-color-neutral: var(--sapNeutralBorderColor);
+$sap-border-color-content-badge: var(--sapContent_BadgeBorderColor);
+$sap-border-color-content-foreground: var(--sapContent_ForegroundBorderColor);
+$sap-border-color-shell: var(--sapShell_BorderColor);
+$sap-border-color-shell-interactive: var(--sapShell_InteractiveBorderColor);
+$sap-border-color-assistant: var(--sapAssistant_BorderColor);
+$sap-border-color-button: var(--sapButton_BorderColor);
+$sap-border-color-field: var(--sapField_BorderColor);
+$sap-border-color-list: var(--sapList_BorderColor);
+$sap-border-color-tile: var(--sapTile_BorderColor);
+$sap-border-color-message-error: var(--sapMessage_ErrorBorderColor);
+$sap-border-color-message-warning: var(--sapMessage_WarningBorderColor);
+$sap-border-color-message-success: var(--sapMessage_SuccessBorderColor);
+$sap-border-color-message-information: var(--sapMessage_InformationBorderColor);
+
 $sap-container-side-top: 'top';
 $sap-container-side-bottom: 'bottom';
 $sap-container-side-begin: 'begin';
@@ -76,6 +118,57 @@ $sap-corner-border-radius: (
   "group": var(--sapGroup_BorderCornerRadius),
   "popover": var(--sapPopover_BorderCornerRadius),
   "tile": var(--sapTile_BorderCornerRadius)
+);
+
+// Border-style
+$sap-border-style: (
+  "solid": solid,
+  "dashed": dashed,
+  "dotted": dotted,
+  "double": double,
+  "hidden": hidden,
+  "none": none
+);
+
+// Border-width
+$sap-border-width: (
+  "1": 0.0625rem,
+  "2": 0.125rem,
+  "3": 0.1875rem,
+  "4": 0.25rem,
+  "element": var(--sapElement_BorderWidth),
+  "group": var(--sapGroup_BorderWidth),
+  "content-focus": var(--sapContent_FocusWidth),
+  "list": var(--sapList_BorderWidth),
+  "button": var(--sapButton_BorderWidth),
+  "message": var(--sapMessage_BorderWidth),
+  "field": var(--sapField_BorderWidth),
+  "field-invalid": var(--sapField_InvalidBorderWidth),
+  "field-warning": var(--sapField_WarningBorderWidth),
+  "field-success": var(--sapField_SuccessBorderWidth),
+  "field-information": var(--sapField_InformationBorderWidth)
+);
+
+// Border-color
+$sap-border-color: (
+  "error": var(--sapErrorBorderColor),
+  "warning": var(--sapWarningBorderColor),
+  "success": var(--sapSuccessBorderColor),
+  "information": var(--sapInformationBorderColor),
+  "neutral": var(--sapNeutralBorderColor),
+  "content-badge": var(--sapContent_BadgeBorderColor),
+  "content-foreground": var(--sapContent_ForegroundBorderColor),
+  "shell": var(--sapShell_BorderColor),
+  "shell-interactive": var(--sapShell_InteractiveBorderColor),
+  "assistant": var(--sapAssistant_BorderColor),
+  "button": var(--sapButton_BorderColor),
+  "field": var(--sapField_BorderColor),
+  "list": var(--sapList_BorderColor),
+  "tile": var(--sapTile_BorderColor),
+  "message-error": var(--sapMessage_ErrorBorderColor),
+  "message-warning": var(--sapMessage_WarningBorderColor),
+  "message-success": var(--sapMessage_SuccessBorderColor),
+  "message-information": var(--sapMessage_InformationBorderColor),
 );
 
 // Flex

--- a/packages/common-css/src/common-css.scss
+++ b/packages/common-css/src/common-css.scss
@@ -2,6 +2,7 @@
 @use './../../styles/src/layout-grid' as *;
 @use './common-settings' as *;
 @use './sap-border-radius' as *;
+@use './sap-border' as *;
 @use './sap-busy-indicator' as *;
 @use './sap-colors' as *;
 @use './sap-container-type' as *;

--- a/packages/common-css/src/sap-border.scss
+++ b/packages/common-css/src/sap-border.scss
@@ -1,0 +1,53 @@
+@use "sass:map";
+@use "common-variables" as commonvars;
+@use "common-mixins" as commonmixins;
+@use "common-settings" as commonsettings;
+
+$block: #{commonsettings.$sap-namespace}-border;
+
+.#{$block} {
+  @each $type, $value in commonvars.$sap-border-style {
+    &-style-#{$type} {
+      border-style: $value;
+    }
+  }
+
+  @each $type, $value in commonvars.$sap-border-width {
+    &-width-#{$type} {
+      border-width: $value;
+    }
+  }
+
+  @each $type, $value in commonvars.$sap-border-color {
+    &-color-#{$type} {
+      border-color: $value;
+    }
+  }
+
+  $border-directions: inline, block, block-start, block-end, inline-start, inline-end;
+
+  @each $dir in $border-directions {
+    &-#{$dir} {
+      border-#{$dir}: 1px solid; // default style — overridden by width/style/color classes
+    }
+
+    @each $type, $value in commonvars.$sap-border-style {
+      &-#{$dir}-style-#{$type} {
+        border-#{$dir}-style: #{$value};
+      }
+    }
+
+    @each $type, $value in commonvars.$sap-border-width {
+      &-#{$dir}-width-#{$type} {
+        border-#{$dir}-width: #{$value};
+      }
+    }
+
+    @each $type, $value in commonvars.$sap-border-color {
+      &-#{$dir}-color-#{$type} {
+        border-#{$dir}-color: #{$value};
+      }
+    }
+  }
+  
+}

--- a/packages/common-css/stories/border/border-mixin.example.html
+++ b/packages/common-css/stories/border/border-mixin.example.html
@@ -1,0 +1,31 @@
+<div>
+1. <b>All</b>
+
+<pre>@include sap-border(0.125rem, solid, #000);</pre>
+<br>
+
+2. <b>Border Top</b>
+<pre>@include sap-border(0.125rem, solid, #000, top);</pre> or <pre>@include sap-border(0.125rem, solid, #000, block-start);</pre>
+<br>
+
+3. <b>Border Bottom</b>
+<pre>@include sap-border(0.125rem, solid, #000, bottom);</pre> or <pre>@include sap-border(0.125rem, solid, #000, block-end);</pre>
+<br>
+
+4. <b>Border Left</b>
+<pre>@include sap-border(0.125rem, solid, #000, left);</pre> or <pre>@include sap-border(0.125rem, solid, #000, inline-start);</pre>
+<br>
+
+6. <b>Border Right</b>
+<pre>@include sap-border(0.125rem, solid, #000, right);</pre> or <pre>@include sap-border(0.125rem, solid, #000, inline-end);</pre>
+<br>
+
+7. <b>Border Top and Bottom (y)</b>
+<pre>@include sap-border(0.125rem, solid, #000, y);</pre> or <pre>@include sap-border(0.125rem, solid, #000, block);</pre>
+<br>
+
+8. <b>Border Left and Right (x)</b>
+<pre>@include sap-border(0.125rem, solid, #000, x);</pre> or <pre>@include sap-border(0.125rem, solid, #000, inline);</pre>
+<br>
+
+</div>

--- a/packages/common-css/stories/border/border.example.html
+++ b/packages/common-css/stories/border/border.example.html
@@ -1,31 +1,34 @@
-<div>
-1. All
+<style>
+    .demo {
+        gap: 2rem;
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+    }
+    .demo div {
+        display: flex;
+        height: 4rem;
+        width: 8rem;
+        background: #fff;
+    }
+</style>
 
-<pre>@include sap-border(0.125rem, solid, #000);</pre>
-<br>
+<div class="demo">
+    <div class="sap-border-style-solid sap-border-width-1 sap-border-color-error"></div>
+    <div class="sap-border-style-dashed sap-border-width-2 sap-border-color-warning"></div>
+    <div class="sap-border-style-dotted sap-border-width-3 sap-border-color-success"></div>
+    <div class="sap-border-style-double sap-border-width-4 sap-border-color-information"></div>
+    <div class="sap-border-style-solid sap-border-width-4 sap-border-color-button"></div>
+    <div class="sap-border-style-dashed sap-border-width-4 sap-border-color-assistant"></div>
+</div>
 
-2. Top Border
-<pre>@include sap-border(0.125rem, solid, #000, top);</pre>
-<br>
+<br><br>
 
-3. Bottom Border
-<pre>@include sap-border(0.125rem, solid, #000, bottom);</pre>
-<br>
-
-4. Left Border
-<pre>@include sap-border(0.125rem, solid, #000, left);</pre>
-<br>
-
-6. Right Border
-<pre>@include sap-border(0.125rem, solid, #000, right);</pre>
-<br>
-
-7. Top and Bottom Border (y)
-<pre>@include sap-border(0.125rem, solid, #000, y);</pre>
-<br>
-
-8. Left and Right Border (x)
-<pre>@include sap-border(0.125rem, solid, #000, x);</pre>
-<br>
-
+<div class="demo">
+    <div class="sap-border-inline-style-solid sap-border-inline-width-4 sap-border-inline-color-error"></div>
+    <div class="sap-border-block-style-dashed sap-border-block-width-4 sap-border-block-color-warning"></div>
+    <div class="sap-border-inline-start-style-dotted sap-border-inline-start-width-4 sap-border-inline-start-color-success"></div>
+    <div class="sap-border-inline-end-style-double sap-border-inline-end-width-4 sap-border-inline-end-color-information"></div>
+    <div class="sap-border-block-start-style-solid sap-border-block-start-width-4 sap-border-block-start-color-button"></div>
+    <div class="sap-border-block-end-style-dashed sap-border-block-end-width-4 sap-border-block-end-color-assistant"></div>
 </div>

--- a/packages/common-css/stories/border/border.stories.js
+++ b/packages/common-css/stories/border/border.stories.js
@@ -1,17 +1,272 @@
+import '../../src/sap-border.scss';
 import borderExampleHtml from "./border.example.html?raw";
+import borderMixinExampleHtml from "./border-mixin.example.html?raw";
 export default {
     title: 'Border',
     parameters: {
-        description: `
-      `,
+        description: `Border utilities provide ready-to-use classes for commonly used border parameters—style, width, and color. In addition to these predefined classes, SCSS mixins are available for applying the same styles in custom classes, allowing flexibility while ensuring design consistency.
+<br><br><h3>Border Style Classes</h3><table>
+  <thead>
+    <tr>
+      <th>Style</th>
+      <th>CSS Class</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>solid</td>
+      <td><code>.sap-border-style-solid</code></td>
+    </tr>
+    <tr>
+      <td>dashed</td>
+      <td><code>.sap-border-style-dashed</code></td>
+    </tr>
+    <tr>
+      <td>dotted</td>
+      <td><code>.sap-border-style-dotted</code></td>
+    </tr>
+    <tr>
+      <td>double</td>
+      <td><code>.sap-border-style-double</code></td>
+    </tr>
+    <tr>
+      <td>hidden</td>
+      <td><code>.sap-border-style-hidden</code></td>
+    </tr>
+    <tr>
+      <td>none</td>
+      <td><code>.sap-border-style-none</code></td>
+    </tr>
+  </tbody>
+</table>
+<br><h3>Border Width Classes</h3>
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>CSS Class</th>
+      <th>Value</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>1</td>
+      <td><code>.sap-border-width-1</code></td>
+      <td>0.0625rem</td>
+    </tr>
+    <tr>
+      <td>2</td>
+      <td><code>.sap-border-width-2</code></td>
+      <td>0.125rem</td>
+    </tr>
+    <tr>
+      <td>3</td>
+      <td><code>.sap-border-width-3</code></td>
+      <td>0.1875rem</td>
+    </tr>
+    <tr>
+      <td>4</td>
+      <td><code>.sap-border-width-4</code></td>
+      <td>0.25rem</td>
+    </tr>
+    <tr>
+      <td>element</td>
+      <td><code>.sap-border-width-element</code></td>
+      <td>var(--sapElement_BorderWidth)</td>
+    </tr>
+    <tr>
+      <td>group</td>
+      <td><code>.sap-border-width-group</code></td>
+      <td>var(--sapGroup_BorderWidth)</td>
+    </tr>
+    <tr>
+      <td>content-focus</td>
+      <td><code>.sap-border-width-content-focus</code></td>
+      <td>var(--sapContent_FocusWidth)</td>
+    </tr>
+    <tr>
+      <td>list</td>
+      <td><code>.sap-border-width-list</code></td>
+      <td>var(--sapList_BorderWidth)</td>
+    </tr>
+    <tr>
+      <td>button</td>
+      <td><code>.sap-border-width-button</code></td>
+      <td>var(--sapButton_BorderWidth)</td>
+    </tr>
+    <tr>
+      <td>message</td>
+      <td><code>.sap-border-width-message</code></td>
+      <td>var(--sapMessage_BorderWidth)</td>
+    </tr>
+    <tr>
+      <td>field</td>
+      <td><code>.sap-border-width-field</code></td>
+      <td>var(--sapField_BorderWidth)</td>
+    </tr>
+    <tr>
+      <td>field-invalid</td>
+      <td><code>.sap-border-width-field-invalid</code></td>
+      <td>var(--sapField_InvalidBorderWidth)</td>
+    </tr>
+    <tr>
+      <td>field-warning</td>
+      <td><code>.sap-border-width-field-warning</code></td>
+      <td>var(--sapField_WarningBorderWidth)</td>
+    </tr>
+    <tr>
+      <td>field-success</td>
+      <td><code>.sap-border-width-field-success</code></td>
+      <td>var(--sapField_SuccessBorderWidth)</td>
+    </tr>
+    <tr>
+      <td>field-information</td>
+      <td><code>.sap-border-width-field-information</code></td>
+      <td>var(--sapField_InformationBorderWidth)</td>
+    </tr>
+  </tbody>
+</table>
+<br><h3>Border Color Classes</h3>
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>CSS Class</th>
+      <th>Value</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td>error</td><td><code>.sap-border-color-error</code></td><td>var(--sapErrorBorderColor)</td></tr>
+    <tr><td>warning</td><td><code>.sap-border-color-warning</code></td><td>var(--sapWarningBorderColor)</td></tr>
+    <tr><td>success</td><td><code>.sap-border-color-success</code></td><td>var(--sapSuccessBorderColor)</td></tr>
+    <tr><td>information</td><td><code>.sap-border-color-information</code></td><td>var(--sapInformationBorderColor)</td></tr>
+    <tr><td>neutral</td><td><code>.sap-border-color-neutral</code></td><td>var(--sapNeutralBorderColor)</td></tr>
+    <tr><td>content-badge</td><td><code>.sap-border-color-content-badge</code></td><td>var(--sapContent_BadgeBorderColor)</td></tr>
+    <tr><td>content-foreground</td><td><code>.sap-border-color-content-foreground</code></td><td>var(--sapContent_ForegroundBorderColor)</td></tr>
+    <tr><td>shell</td><td><code>.sap-border-color-shell</code></td><td>var(--sapShell_BorderColor)</td></tr>
+    <tr><td>shell-interactive</td><td><code>.sap-border-color-shell-interactive</code></td><td>var(--sapShell_InteractiveBorderColor)</td></tr>
+    <tr><td>assistant</td><td><code>.sap-border-color-assistant</code></td><td>var(--sapAssistant_BorderColor)</td></tr>
+    <tr><td>button</td><td><code>.sap-border-color-button</code></td><td>var(--sapButton_BorderColor)</td></tr>
+    <tr><td>field</td><td><code>.sap-border-color-field</code></td><td>var(--sapField_BorderColor)</td></tr>
+    <tr><td>list</td><td><code>.sap-border-color-list</code></td><td>var(--sapList_BorderColor)</td></tr>
+    <tr><td>tile</td><td><code>.sap-border-color-tile</code></td><td>var(--sapTile_BorderColor)</td></tr>
+    <tr><td>message-error</td><td><code>.sap-border-color-message-error</code></td><td>var(--sapMessage_ErrorBorderColor)</td></tr>
+    <tr><td>message-warning</td><td><code>.sap-border-color-message-warning</code></td><td>var(--sapMessage_WarningBorderColor)</td></tr>
+    <tr><td>message-success</td><td><code>.sap-border-color-message-success</code></td><td>var(--sapMessage_SuccessBorderColor)</td></tr>
+    <tr><td>message-information</td><td><code>.sap-border-color-message-information</code></td><td>var(--sapMessage_InformationBorderColor)</td></tr>
+  </tbody>
+</table>
+<br><br>
+
+<p>
+  The classes listed above apply borders on <strong>all four sides</strong> of an element.
+  Similar variations are available for applying borders to specific directions:
+</p>
+
+<ul>
+  <li>
+    **Inline**: applies border along the inline (text) direction
+    (left/right in LTR, right/left in RTL)
+    <ul>
+      <li><code>sap-border-inline-style-*</code></li>
+      <li><code>sap-border-inline-width-*</code></li>
+      <li><code>sap-border-inline-color-*</code></li>
+    </ul>
+  </li>
+
+  <li>
+    **Block**: applies border along the block (vertical) direction (top/bottom)
+    <ul>
+      <li><code>sap-border-block-style-*</code></li>
+      <li><code>sap-border-block-width-*</code></li>
+      <li><code>sap-border-block-color-*</code></li>
+    </ul>
+  </li>
+
+  <li>
+    **Block Start**: applies border to the start edge of the block direction
+    (top in horizontal writing modes)
+    <ul>
+      <li><code>sap-border-block-start-style-*</code></li>
+      <li><code>sap-border-block-start-width-*</code></li>
+      <li><code>sap-border-block-start-color-*</code></li>
+    </ul>
+  </li>
+
+  <li>
+    **Block End**: applies border to the end edge of the block direction
+    (bottom in horizontal writing modes)
+    <ul>
+      <li><code>sap-border-block-end-style-*</code></li>
+      <li><code>sap-border-block-end-width-*</code></li>
+      <li><code>sap-border-block-end-color-*</code></li>
+    </ul>
+  </li>
+
+  <li>
+    **Inline Start**: applies border to the start edge of the inline direction
+    (left in LTR, right in RTL)
+    <ul>
+      <li><code>sap-border-inline-start-style-*</code></li>
+      <li><code>sap-border-inline-start-width-*</code></li>
+      <li><code>sap-border-inline-start-color-*</code></li>
+    </ul>
+  </li>
+
+  <li>
+    **Inline End**: applies border to the end edge of the inline direction
+    (right in LTR, left in RTL)
+    <ul>
+      <li><code>sap-border-inline-end-style-*</code></li>
+      <li><code>sap-border-inline-end-width-*</code></li>
+      <li><code>sap-border-inline-end-color-*</code></li>
+    </ul>
+  </li>
+</ul>`,
     }
 };
 export const Border = () => borderExampleHtml;
-Border.storyName = 'Mixin sap-border';
+Border.storyName = '';
 Border.parameters = {
   docs: {
     description: {
-      story: 'The <code>sap-border</code> helper mixin allows you to specify the width, style, and color of an element\'s border. This is achieved by providing values to the <code>sap-border</code> parameters: <code>$width</code>, <code>$style</code>, <code>$color</code>, and <code>$pos</code>.<br><br> The <code>$pos</code> value can be one of the following: <code>all | top | bottom | left | right | x | y</code>. The default value is <code>all</code>, which will apply borders on all sides. <code>x</code> will set borders on left and right of the element, and <code>y</code> on top and bottom of the element.'
+      story: ''
     }
   }
 };
+
+export const BorderMixin = () => borderMixinExampleHtml;
+BorderMixin.storyName = 'SCSS mixin sap-border';
+BorderMixin.parameters = {
+  docs: {
+    description: {
+      story: `<p>
+  The <code>sap-border</code> helper mixin allows you to specify the width, style, and color of an element's border. 
+  This is achieved by providing values to the <code>sap-border</code> parameters: 
+  <code>$width</code>, <code>$style</code>, <code>$color</code>, and <code>$pos</code>.
+</p>
+
+<p>
+  The <code>$pos</code> parameter defines where the border will be applied and can be one of the following:
+</p>
+
+<ul>
+  <li>**all**: applies borders to all sides (default).</li>
+  <li>**top**: applies the border to the top side (<code>border-block-start</code>).</li>
+  <li>**bottom**: applies the border to the bottom side (<code>border-block-end</code>).</li>
+  <li>**left**: applies the border to the left side (<code>border-inline-start</code>).</li>
+  <li>**right**: applies the border to the right side (<code>border-inline-end</code>).</li>
+  <li>**x**: applies the border to left and right sides (<code>border-inline</code>).</li>
+  <li>**y**: applies the border to top and bottom sides (<code>border-block</code>).</li>
+  <li>**inline**: applies the border to both inline sides (<code>border-inline</code>).</li>
+  <li>**block**: applies the border to both block sides (<code>border-block</code>).</li>
+  <li>**inline-start**: applies the border to the start of the inline axis (<code>border-inline-start</code>).</li>
+  <li>**inline-end**: applies the border to the end of the inline axis (<code>border-inline-end</code>).</li>
+  <li>**block-start**: applies the border to the start of the block axis (<code>border-block-start</code>).</li>
+  <li>**block-end**: applies the border to the end of the block axis (<code>border-block-end</code>).</li>
+</ul>
+`
+    }
+  }
+};
+


### PR DESCRIPTION
## Related Issue
part of https://github.com/SAP/fundamental-styles/issues/6145

## Description
- Added CSS utility classes for the most commonly used border parameters (style, width, and color).
- Updated documentation and examples to reflect new border utilities and usage patterns.
- Enhanced SCSS mixin to support directional border properties, including block, inline, block-start, block-end, inline-start, and inline-end.