### PR TITLE
fix(styles): add bigger outline offset for Link focus [ci visual]

### DIFF
--- a/packages/styles/src/theming/common/link/_sap_fiori.scss
+++ b/packages/styles/src/theming/common/link/_sap_fiori.scss
@@ -14,7 +14,7 @@
   --fdLink_Focus_Background: transparent;
   --fdLink_Focus_Border_Radius: 0;
   --fdLink_Focus_Text_Shadow: none;
-  --fdLink_Hover_Outline_Offset: -0.0625rem;
+  --fdLink_Hover_Outline_Offset: 0.0625rem;
   --fdLink_Hover_Outline_Width: var(--sapContent_FocusWidth);
   --fdLink_Hover_Outline_Color: var(--sapContent_FocusColor);
   --fdLink_Hover_Outline_Style: var(--sapContent_FocusStyle);

--- a/packages/styles/src/theming/common/link/_sap_fiori_hc.scss
+++ b/packages/styles/src/theming/common/link/_sap_fiori_hc.scss
@@ -13,7 +13,7 @@
   --fdLink_Focus_Background: transparent;
   --fdLink_Focus_Border_Radius: 0;
   --fdLink_Focus_Text_Shadow: none;
-  --fdLink_Hover_Outline_Offset: -0.0625rem;
+  --fdLink_Hover_Outline_Offset: 0.0625rem;
   --fdLink_Hover_Outline_Width: var(--sapContent_FocusWidth);
   --fdLink_Hover_Outline_Color: var(--sapContent_FocusColor);
   --fdLink_Hover_Outline_Style: var(--sapContent_FocusStyle);

--- a/packages/styles/src/theming/common/link/_sap_horizon_hc.scss
+++ b/packages/styles/src/theming/common/link/_sap_horizon_hc.scss
@@ -7,7 +7,7 @@
   --fdLink_Focus_Background: transparent;
   --fdLink_Focus_Border_Radius: 0;
   --fdLink_Focus_Text_Shadow: none;
-  --fdLink_Hover_Outline_Offset: -0.0625rem;
+  --fdLink_Hover_Outline_Offset: 0.125rem;
   --fdLink_Hover_Outline_Width: var(--sapContent_FocusWidth);
   --fdLink_Hover_Outline_Color: var(--sapContent_FocusColor);
   --fdLink_Hover_Outline_Style: var(--sapContent_FocusStyle);


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/6162

## Description
Added bigger offset for focus outline so it gives a bit more space around the text, esp in high contrast themes.
Before:
<img width="383" height="761" alt="Screenshot 2025-09-03 at 1 26 10 PM" src="https://github.com/user-attachments/assets/0e7c0892-195d-41f5-9378-906d1a2fbd3c" />


After:
<img width="528" height="693" alt="Screenshot 2025-09-03 at 1 25 43 PM" src="https://github.com/user-attachments/assets/6b48ed43-0312-4c41-ad24-ddcb22626c2b" />
