### PR TITLE
fix: update ConventionalChangelog to use new class-based API

### DIFF
--- a/.github/actions/generate-conventional-release-notes/index.mjs
+++ b/.github/actions/generate-conventional-release-notes/index.mjs
@@ -1,4 +1,4 @@
-import conventionalChangelog from 'conventional-changelog';
+import { ConventionalChangelog } from 'conventional-changelog';
 import * as core from '@actions/core';
 import through from 'through2';
 import closestVersion from './closest-version.mjs';
@@ -11,10 +11,13 @@ const deleteTags = (tags) => {
 const generateChangelog = (fromVersion) => {
     return new Promise((resolve, reject) => {
         let generatedReleaseNotes = '';
-        conventionalChangelog({
-            preset: 'angular',
-            releaseCount: 1
-        }, null, { from: fromVersion }, null, { headerPartial: '' })
+        const changelog = new ConventionalChangelog()
+            .loadPreset('angular')
+            .options({ releaseCount: 1 })
+            .context({ from: fromVersion })
+            .writer({ headerPartial: '' });
+            
+        changelog.writeStream()
             .pipe(through(function(chunk, _enc, callback) {
                 this.push(chunk);
                 generatedReleaseNotes += chunk.toString();


### PR DESCRIPTION
- Replace default import with named import { ConventionalChangelog }
- Update generateChangelog function to use new class methods:
  - .loadPreset() for preset configuration
  - .options() for release options
  - .context() for version context
  - .writer() for writer options
  - .writeStream() to get the readable stream
- Resolves SyntaxError: does not provide an export named 'default'

