### PR TITLE
fix(styles): remove max-height from Object status [ci visual]

### DIFF
--- a/packages/styles/src/object-status.scss
+++ b/packages/styles/src/object-status.scss
@@ -735,10 +735,10 @@ $inverted-color-accents-b: (
 
   max-width: 100%;
   position: relative;
+  height: fit-content;
   word-break: break-word;
-  height: var(--fdObjectStatus_Height);
   color: var(--fdObjectStatus_Text_Color);
-  max-height: var(--fdObjectStatus_Height);
+  min-height: var(--fdObjectStatus_Height);
   line-height: var(--fdObjectStatus_Height);
   text-shadow: var(--fdObjectStatus_Text_Shadow);
   font-size: var(--fdObjectStatus_Text_Font_Size);


### PR DESCRIPTION
## Related Issue
related to https://github.com/SAP/fundamental-ngx/issues/13596

## Description
Removed the max-height for Object Status which was causing hidden text on 200% zoom.
It's also addressing the min required height for WCAG 2.2
<img width="797" height="85" alt="Screenshot 2025-11-27 at 3 07 55 PM" src="https://github.com/user-attachments/assets/11630fd1-0598-4a33-b38d-72b11c359a14" />

<img width="336" height="141" alt="Screenshot 2025-11-27 at 3 09 35 PM" src="https://github.com/user-attachments/assets/1093b8b7-1592-44c9-9582-19af02ff1678" />

