### PR TITLE
feat(styles): add wrapping modifier classes for multiple elements 

### DIFF
--- a/packages/styles/src/bar.scss
+++ b/packages/styles/src/bar.scss
@@ -32,7 +32,7 @@ $floating-footer: #{$fd-namespace}-bar--floating-footer;
     justify-content: space-between;
   }
 
-  height: var(--fdBar_Height);
+  min-height: var(--fdBar_Height);
   z-index: var(--fdBar_Z_Index);
   box-shadow: var(--fdBar_Shadow);
   background: var(--fdBar_Background);
@@ -77,6 +77,7 @@ $floating-footer: #{$fd-namespace}-bar--floating-footer;
 
     max-width: 100%;
     max-height: 100%;
+    text-wrap: auto;
     color: var(--fdBar_Element_Text_Color, var(--sapTextColor));
     font-family: var(--fdBar_Element_Text_Font_Family, var(--sapFontFamily));
     font-size: var(--fdBar_Element_Text_Font_Size, var(--sapFontSize));

--- a/packages/styles/src/form-group.scss
+++ b/packages/styles/src/form-group.scss
@@ -25,7 +25,7 @@ $block: #{$fd-namespace}-form-group;
     width: 100%;
     padding-inline: var(--fdFormGroupPaddingInline, 1rem);
     box-sizing: border-box;
-    height: var(--sapElement_LineHeight);
+    min-height: var(--sapElement_LineHeight);
     background-color: var(--sapGroup_TitleBackground);
     border-bottom: var(--sapGroup_TitleBorderWidth) solid var(--sapGroup_TitleBorderColor);
 
@@ -46,5 +46,9 @@ $block: #{$fd-namespace}-form-group;
     font-size: var(--sapGroup_Title_FontSize);
     font-weight: bold;
     color: var(--sapGroup_TitleTextColor);
+
+    &--wrap {
+      @include fd-wrap();
+    }
   }
 }

--- a/packages/styles/src/form-label.scss
+++ b/packages/styles/src/form-label.scss
@@ -15,6 +15,10 @@ $block: #{$fd-namespace}-form-label;
     pointer-events: none;
   }
 
+  &--wrap {
+    @include fd-wrap();
+  }
+
   &--unit-description {
     color: var(--sapField_TextColor);
     margin-block: 0;

--- a/packages/styles/src/mixins/_mixins.scss
+++ b/packages/styles/src/mixins/_mixins.scss
@@ -195,6 +195,9 @@
   align-items: center;
   transition: all $fd-animation-speed ease-in;
   line-height: inherit;
+  white-space: normal;
+  overflow-wrap: break-word;
+  word-break: break-word;
 
   @include fd-link-underline();
 
@@ -300,6 +303,12 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+@mixin fd-wrap {
+  white-space: normal;
+  overflow: visible;
+  text-overflow: clip;
 }
 
 @mixin fd-flex-center {

--- a/packages/styles/src/popover.scss
+++ b/packages/styles/src/popover.scss
@@ -65,6 +65,10 @@ body.fd-overlay-active::before {
     @include fd-disabled() {
       pointer-events: none;
     }
+
+    & > a {
+      white-space: nowrap;
+    }
   }
 
   &__wrapper {

--- a/packages/styles/src/quick-view.scss
+++ b/packages/styles/src/quick-view.scss
@@ -63,6 +63,10 @@ $fd-quick-view-group-item-indent: 0.75rem;
     @include fd-ellipsis();
 
     color: var(--sapTile_TextColor);
+
+    &--wrap {
+      @include fd-wrap();
+    }
   }
 
   .#{$fd-namespace}-input:not(input) {

--- a/packages/styles/stories/Components/avatar-group/avatar-group.stories.js
+++ b/packages/styles/stories/Components/avatar-group/avatar-group.stories.js
@@ -87,8 +87,7 @@ IndividualType.parameters = {
     story: {
     },
     description: {
-      story: `The Avatar Individual Type component features avatars and an overflow shape, each with its own click area, catering to scenarios where users prioritize detailed information about specific group members. Avatars are displayed adjacent to each other without overlap, making it ideal for smaller groups like project teams.<br>
-      For Individual type add the \`fd-avatar-group--individual-type\` modifier class to the \`fd-avatar-group\` base class.`
+      story: `The Avatar Individual Type component features avatars and an overflow shape, each with its own click area, catering to scenarios where users prioritize detailed information about specific group members. Avatars are displayed adjacent to each other without overlap, making it ideal for smaller groups like project teams.<br>For Individual type add the \`fd-avatar-group--individual-type\` modifier class to the \`fd-avatar-group\` base class.`
     }
   }
 };

--- a/packages/styles/stories/Components/avatar-group/individual-type.example.html
+++ b/packages/styles/stories/Components/avatar-group/individual-type.example.html
@@ -1,4 +1,4 @@
-<div style="min-height: 400px;">
+<div style="min-height: 1000px;">
     <div class="fd-avatar-group fd-avatar-group--individual-type fd-avatar-group--sm">
         <div class="fd-popover">
             <div class="fd-popover__control">
@@ -72,12 +72,12 @@
                         <i class="fd-avatar__icon sap-icon--person-placeholder" role="presentation" aria-hidden="true"></i>
                 </span>
             </div>
-            <div class="fd-popover__body" aria-hidden="true" id="popover_avatar_spbw4q">
+            <div class="fd-popover__body" aria-hidden="true" id="popover_avatar_spbw4q" style="max-width: 400px;">
                 <div class="fd-quick-view">
                     <div class="fd-bar fd-bar--header">
                         <div class="fd-bar__middle">
                             <div class="fd-bar__element">
-                                <h1 class="fd-title fd-title--h5">Business Card</h1>
+                                <h1 class="fd-title fd-title--h5 fd-title--wrap">Business Card Lorem ipsum, dolor sit amet consectetur adipisicing elit. Architecto perferendis sapiente velit excepturi rerum eligendi, nihil impedit exercitationem temporibus ex autem illo. Inventore, commodi molestias hic at quod saepe aut.</h1>
                             </div>
                         </div>
                     </div>
@@ -87,26 +87,36 @@
                             <div class="fd-bar__left">
                                 <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--border" role="img" aria-label="Avatar Wendy Wallace" title="Wendy Wallace">WW</span>
                                 <div class="fd-quick-view__subheader-text">
-                                    <h5 class="fd-title fd-title--h5">Sarah Parker</h5>
-                                    <p class="fd-quick-view__subtitle">Visual Designer</p>
+                                    <h5 class="fd-title fd-title--h5 fd-title--wrap">Sarah Parker Lorem ipsum dolor sit amet consectetur adipisicing elit. Ullam pariatur ratione vitae doloremque numquam!</h5>
+                                    <p class="fd-quick-view__subtitle fd-quick-view__subtitle--wrap">Visual Designer Lorem ipsum dolor sit, amet consectetur adipisicing elit. Inventore officiis sunt, nostrum et adipisci excepturi accusamus odit ea doloribus ducimus sapiente culpa maxime sit aliquam! Mollitia qui ducimus porro unde?</p>
                                 </div>
                             </div>
                         </div>
                         <div class="fd-form-group" role="group">
                             <div class="fd-form-group__header" aria-labelledby="contactDetails_spbw4q">
-                                <p class="fd-form-group__header-text" id="contactDetails_spbw4q">Contact Details</p>
+                                <p class="fd-form-group__header-text fd-form-group__header-text--wrap" id="contactDetails_spbw4q">Contact Details Lorem ipsum, dolor sit amet consectetur adipisicing elit. Porro beatae veritatis eum ratione, cumque rerum libero fugiat consequuntur totam fuga, assumenda quisquam vero earum excepturi, eius ullam in similique! Laborum.</p>
                             </div>
                             <div class="fd-form-item">
                                 <label class="fd-form-label">Mobile</label>
-                                <a class="fd-link" href="tel:+89181818181">+89181818181</a>
+                                <a class="fd-link" href="tel:+89181818181">
+                                     <span class="fd-link__content">+89181818181</span>
+                                </a>
                             </div>
                             <div class="fd-form-item">
-                                <label class="fd-form-label">Phone</label>
-                                <a class="fd-link" href="tel:+2828282828">+2828282828</a>
+                                <label class="fd-form-label fd-form-label--wrap">Phone Lorem ipsum dolor sit amet consectetur adipisicing elit. Nisi totam doloremque ipsa natus magnam rerum repudiandae autem, beatae reprehenderit aspernatur, cupiditate aliquam doloribus quaerat maiores dolores! Rerum amet expedita vitae.</label>
+                                <a class="fd-link" href="tel:+2828282828">
+                                    <span class="fd-link__content">
+                                        +28282828283745873657816578265782456784568256834567384563845637845637845637485387453
+                                    </span>
+                                </a>
                             </div>
                             <div class="fd-form-item">
-                                <label class="fd-form-label">Email</label>
-                                <a class="fd-link" href="mailto:hello@fundamental.com">hello@fundamental.com</a>
+                                <label class="fd-form-label fd-form-label--wrap">Email Lorem ipsum dolor sit amet consectetur adipisicing elit. Nemo aperiam ipsa, odit similique modi accusamus! Architecto, voluptatum voluptatibus temporibus dolor aspernatur repellendus, voluptas enim nobis libero vel, exercitationem tempora iure.</label>
+                                <a class="fd-link" href="mailto:hello@fundamental.com">
+                                    <span class="fd-link__content">
+                                        helloloremvoluptatumvoluptatibustemporibus_doloraspernaturrepellendus_remvoluptatumvoluptatibus@fundamental.com
+                                    </span>
+                                </a>
                             </div>
                         </div>
                     </div>

--- a/packages/styles/stories/Components/popover/popover.stories.js
+++ b/packages/styles/stories/Components/popover/popover.stories.js
@@ -129,9 +129,7 @@ ControlExamplesBtp.storyName = 'BTP Popover';
 ControlExamplesBtp.parameters = {
   docs: {
     description: {
-      story: `This extension of Popover is used by components and patterns in the BTP area. Apply the <code>.fd-popover--btp</code> modifier class to <code>.fd-popover</code> base class. <br>
-      To add padding to the Popover body use the <code>.fd-popover__body--padding</code> modifier class together with <code>.fd-popover__body</code> base class. <br>
-      The content of the footer can be centered by using the <code>.fd-popover__body-footer--center</code> modifier. 
+      story: `This extension of Popover is used by components and patterns in the BTP area. Apply the <code>.fd-popover--btp</code> modifier class to <code>.fd-popover</code> base class. <br>To add padding to the Popover body use the <code>.fd-popover__body--padding</code> modifier class together with <code>.fd-popover__body</code> base class. <br>The content of the footer can be centered by using the <code>.fd-popover__body-footer--center</code> modifier. 
         `
     }
   }

--- a/packages/styles/stories/Components/popover/variants.example.html
+++ b/packages/styles/stories/Components/popover/variants.example.html
@@ -1,4 +1,4 @@
-<div class="fddocs-container" style="margin-bottom: 275px">
+<div class="fddocs-container" style="margin-bottom: 400px">
     <div class="fd-popover">
         <div class="fd-popover__control">
             <button
@@ -106,7 +106,6 @@
                 class="fd-button"
                 onclick="onPopoverClick('popoverHSF3');"
                 role="button">
-                    <!- role is needed to override the combobox role due to aria-haspopup -->
                     Header, subheader and footer
             </button>
         </div>
@@ -147,6 +146,155 @@
                                     </button>
                                 </div>
                             </div>
+                        </div>
+                    </div>
+                </div>
+            </header>
+            <nav class="fd-menu" aria-label="options with header, subheader and footer">
+                <ul class="fd-menu__list fd-menu__list--no-shadow">
+                    <li class="fd-menu__item">
+                        <a class="fd-menu__link" href="#">
+                            <span class="fd-menu__title">Option 1</span>
+                        </a>
+                    </li>
+                    <li class="fd-menu__item">
+                        <a class="fd-menu__link" href="#">
+                            <span class="fd-menu__title">Option 2</span>
+                        </a>
+                    </li>
+                    <li class="fd-menu__item">
+                        <a class="fd-menu__link" href="#">
+                            <span class="fd-menu__title">Option 3</span>
+                        </a>
+                    </li>
+                </ul>
+            </nav>
+            <footer class="fd-popover__body-footer">
+                <div class="fd-bar is-compact fd-bar--footer">
+                    <div class="fd-bar__right">
+                        <div class="fd-bar__element">
+                            <button class="fd-button fd-button--emphasized">Save</button>
+                        </div>
+                        <div class="fd-bar__element">
+                            <button class="fd-button fd-button--transparent">Cancel</button>
+                        </div>
+                    </div>
+                </div>
+            </footer>
+        </section>
+    </div>
+</div>
+
+<div class="fddocs-container" style="margin-bottom: 400px">
+    <div class="fd-popover">
+        <div class="fd-popover__control">
+            <button
+                aria-controls="popoverHSF3wee"
+                aria-expanded="true"
+                aria-haspopup="dialog"
+                class="fd-button"
+                onclick="onPopoverClick('popoverHSF3wee');"
+                role="button">
+                    Long text (title)
+            </button>
+        </div>
+        <section
+            aria-hidden="false"
+            class="fd-popover__body"
+            id="popoverHSF3wee"
+            style="width: 300px;"
+            aria-label="Dialog Data 1"
+            role="dialog">
+            <header class="fd-popover__body-header">
+                <div class="fd-bar fd-bar--header-with-subheader">
+                    <div class="fd-bar__left">
+                        <div id="popoverHeaderHSF3wee" class="fd-bar__element">
+                            <h5 class="fd-title fd-title--h5 fd-title--wrap" aria-label="text">Header Lorem ipsum dolor sit amet consectetur adipisicing elit. Sint repellendus exercitationem debitis, ipsum quaerat quo excepturi.</h5>
+                        </div>
+                    </div>
+                </div>
+                <div class="fd-bar is-compact fd-bar--subheader">
+                    <div class="fd-bar__middle">
+                        <div class="fd-bar__element">
+                            Lorem ipsum dolor sit amet consectetur adipisicing elit. Sint repellendus exercitationem debitis, ipsum quaerat quo excepturi.
+                        </div>
+                    </div>
+                </div>
+            </header>
+            <nav class="fd-menu" aria-label="options with header, subheader and footer">
+                <ul class="fd-menu__list fd-menu__list--no-shadow">
+                    <li class="fd-menu__item">
+                        <a class="fd-menu__link" href="#">
+                            <span class="fd-menu__title">Option 1</span>
+                        </a>
+                    </li>
+                    <li class="fd-menu__item">
+                        <a class="fd-menu__link" href="#">
+                            <span class="fd-menu__title">Option 2</span>
+                        </a>
+                    </li>
+                    <li class="fd-menu__item">
+                        <a class="fd-menu__link" href="#">
+                            <span class="fd-menu__title">Option 3</span>
+                        </a>
+                    </li>
+                </ul>
+            </nav>
+            <footer class="fd-popover__body-footer">
+                <div class="fd-bar is-compact fd-bar--footer">
+                    <div class="fd-bar__right">
+                        <div class="fd-bar__element">
+                            <button class="fd-button fd-button--emphasized">Save</button>
+                        </div>
+                        <div class="fd-bar__element">
+                            <button class="fd-button fd-button--transparent">Cancel</button>
+                        </div>
+                    </div>
+                </div>
+            </footer>
+        </section>
+    </div>
+
+    <div class="fd-popover">
+        <div class="fd-popover__control">
+            <button
+                aria-controls="popoverHSF3rq"
+                aria-expanded="true"
+                aria-haspopup="dialog"
+                class="fd-button"
+                onclick="onPopoverClick('popoverHSF3rq');"
+                role="button">
+                    Long text
+            </button>
+        </div>
+        <section
+            aria-hidden="false"
+            class="fd-popover__body"
+            id="popoverHSF3rq"
+            style="width: 300px;"
+            aria-label="Dialog Data 1"
+            role="dialog">
+            <header class="fd-popover__body-header">
+                <div class="fd-bar fd-bar--header-with-subheader">
+                    <div class="fd-bar__left">
+                        <div class="fd-bar__element">
+                            <button
+                                aria-label="back button"
+                                class="fd-button fd-button--transparent">
+                                <i class="sap-icon--navigation-left-arrow"></i>
+                            </button>
+                        </div>
+                        <div id="popoverHeaderHSF3rq" class="fd-bar__element">
+                           <span>
+                                Header Lorem ipsum dolor sit amet consectetur adipisicing elit. Sint repellendus exercitationem debitis, ipsum quaerat quo excepturi enim.
+                           </span>
+                        </div>
+                    </div>
+                </div>
+                <div class="fd-bar is-compact fd-bar--subheader">
+                    <div class="fd-bar__middle">
+                        <div class="fd-bar__element">
+                            Lorem ipsum dolor sit amet consectetur adipisicing elit. Sint repellendus exercitationem debitis, ipsum quaerat quo excepturi enim.
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION


## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/6267

## Description
**New modifier classes:**
-  `fd-form-group__header-text--wrap` for Form Header component
-  `fd-form-label--wrap` for Form Label component
-  `fd-quick-view__subtitle--wrap` for Quick View component

**Updated Avatar Group and Popover examples**

## Screenshots
### Avatar Group
<img width="1260" height="1270" alt="Screenshot 2026-04-01 at 3 19 23 PM" src="https://github.com/user-attachments/assets/f5ddb423-cfcb-4036-aba5-ee75e2e336db" />

### Popover
<img width="1571" height="1245" alt="Screenshot 2026-04-01 at 2 55 42 PM" src="https://github.com/user-attachments/assets/15cff1d6-226e-47a9-b71e-092f4769d5a9" />
