### PR TITLE
fix(styles): update Illustrated message text width in L size [ci visual]

### DIFF
--- a/packages/styles/src/illustrated-message.scss
+++ b/packages/styles/src/illustrated-message.scss
@@ -19,7 +19,7 @@ $block: #{$fd-namespace}-illustrated-message;
   --illustrationDisplay: flex;
 
   // Figcaption
-  --figcaptionMaxWidth: 20rem;
+  --figcaptionMaxWidth: 40.625rem;
 
   // Title
   --titleFontSize: 2rem;


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/6295

## Description
Updates the container that holds the title and text of the Illustrated message (figcaption).