### PR TITLE
fix(styles): update touch area size for Switch [ci visual]

### DIFF
--- a/packages/styles/src/switch.scss
+++ b/packages/styles/src/switch.scss
@@ -90,7 +90,7 @@ $block: #{$fd-namespace}-switch;
   align-items: center;
   cursor: pointer;
   padding-block: var(--fdSwitch_Padding, 0.625rem);
-  padding-inline: 0;
+  padding-inline: 0.3125rem;
   margin-inline: 0;
 
   @include fd-disabled() {


### PR DESCRIPTION
## Related Issue
Closes none

## Description
The specs for Switch have been updated and the touch area size has been changed.

## Screenshots
Default Switch:
<img width="949" height="333" alt="Screenshot 2026-05-08 at 10 37 47 AM" src="https://github.com/user-attachments/assets/d2948ca3-fd75-46b5-b65f-eaeeca323c94" />


Text Switch:
<img width="968" height="366" alt="Screenshot 2026-05-08 at 10 38 02 AM" src="https://github.com/user-attachments/assets/459ec9ff-30ba-45e0-8d6c-8c8b1e9148ba" />
