### PR TITLE
fix(styles): restyle scrollbar for BTP vertical nav [ci visual]

### DIFF
--- a/packages/styles/src/navigation.scss
+++ b/packages/styles/src/navigation.scss
@@ -167,9 +167,30 @@ $navExternalLinkIndicator: #{$block}__external-link-indicator;
       @include fd-set-paddings-x-equal(var(--fdNavigation_Padding_X));
 
       height: 100%;
-      overflow: scroll;
+      overflow: hidden scroll;
       position: relative;
       padding-block-end: 0.25rem;
+
+      // Scrollbar styling
+      scrollbar-width: thin;
+      scrollbar-color: var(--sapScrollBar_FaceColor) var(--sapScrollBar_TrackColor);
+
+      &::-webkit-scrollbar {
+        width: 0.75rem;
+      }
+
+      &::-webkit-scrollbar-track {
+        background: var(--sapScrollBar_TrackColor);
+      }
+
+      &::-webkit-scrollbar-thumb {
+        background: var(--sapScrollBar_FaceColor);
+        border-radius: 0.375rem;
+
+        &:hover {
+          background: var(--sapScrollBar_Hover_FaceColor);
+        }
+      }
     }
 
     &--bottom {

--- a/packages/styles/stories/Components/switch/basic.example.html
+++ b/packages/styles/stories/Components/switch/basic.example.html
@@ -1,10 +1,16 @@
-
 <div class="fd-form-group">
     <div class="fd-form-item">
         <div class="fd-form-label" id="label1">Default Switch</div>
         <label class="fd-switch">
             <span class="fd-switch__control">
-                <input class="fd-switch__input" type="checkbox" name="" value="" aria-labelledby="label1" id="y21YO3251">
+                <input
+                    class="fd-switch__input"
+                    type="checkbox"
+                    name=""
+                    value=""
+                    aria-labelledby="label1"
+                    id="y21YO3251"
+                />
                 <div class="fd-switch__slider">
                     <div class="fd-switch__track">
                         <i role="presentation" class="fd-switch__icon fd-switch__icon--on sap-icon--accept"></i>
@@ -19,7 +25,14 @@
         <div class="fd-form-label" id="label7">Disabled Switch</div>
         <label class="fd-switch is-disabled">
             <span class="fd-switch__control">
-                <input class="fd-switch__input" type="checkbox" name="" value="" aria-labelledby="label7" id="y21Y13431">
+                <input
+                    class="fd-switch__input"
+                    type="checkbox"
+                    name=""
+                    value=""
+                    aria-labelledby="label7"
+                    id="y21Y13431"
+                />
                 <div class="fd-switch__slider">
                     <div class="fd-switch__track">
                         <i role="presentation" class="fd-switch__icon fd-switch__icon--on sap-icon--accept"></i>


### PR DESCRIPTION
## Related Issue
related to FIORITECHP1-35301

## Description
Problem description:
Side Nav - ScrollBar doesn't change theme. When the theme is changed to evening horizon, the scrollbar still appears in light mode as shown.

Fix:
- removed the horizontal scroll, now have only vertical for the top container
- restyled the vertical scroll using theming variables so that colors change with the theme.

## Screenshots
### Before:
<img width="590" height="1005" alt="Screenshot 2026-05-11 at 12 49 25 PM" src="https://github.com/user-attachments/assets/cf2ad996-bffe-4a30-858b-4ef59a89c10a" />


### After:
<img width="769" height="983" alt="Screenshot 2026-05-11 at 12 45 13 PM" src="https://github.com/user-attachments/assets/9231053a-9b6a-4ae7-b1c0-bb454cb40ee4" />
