### PR TITLE
chore: resolve OSPO findings

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -5,13 +5,13 @@ permissions:
   contents: read
   statuses: write
 
-env:
-  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_AUTH_TOKEN }}
-
 jobs:
   chromatic-deployment:
     if: contains(github.event.head_commit.message, '[ci visual]') || contains(github.event.head_commit.message, 'chore(deps-dev)') || github.event.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    environment: ci
+    env:
+      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_AUTH_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -11,13 +11,15 @@ env:
     IS_HOTFIX: ${{ github.ref == 'refs/heads/tmp_hotfix_branch' }}
     IS_PRERELEASE: ${{ github.event_name == 'push' && github.ref != 'refs/heads/tmp_hotfix_branch' }}
     IS_MANUAL: ${{ contains(github.event.head_commit.message, 'chore(release)') }}
-    NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_AUTH_TOKEN }}
-    NX_CLOUD_AUTH_TOKEN: ${{ secrets.NX_CLOUD_AUTH_TOKEN }}
 
 jobs:
     create_release:
         name: Run release
         runs-on: ubuntu-latest
+        environment: ci
+        env:
+            NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_AUTH_TOKEN }}
+            NX_CLOUD_AUTH_TOKEN: ${{ secrets.NX_CLOUD_AUTH_TOKEN }}
         permissions:
             contents: write
             id-token: write
@@ -184,6 +186,7 @@ jobs:
     gh_pages:
         name: Github Pages deploy
         runs-on: ubuntu-latest
+        environment: ci
         permissions:
             contents: write
         needs: create_release

--- a/.github/workflows/on-pull.yml
+++ b/.github/workflows/on-pull.yml
@@ -6,9 +6,6 @@ on:
 permissions:
   contents: read
 
-env:
-  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_AUTH_TOKEN }}
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
@@ -26,6 +23,9 @@ jobs:
   install-lint-build:
     runs-on: ubuntu-latest
     name: Install, Lint, Build
+    environment: ci
+    env:
+      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/nodejs


### PR DESCRIPTION
## Related Issue

none

## Description

Make `linstall-lint-build`, `chromatic-deployment`, `gh_pages` and `create_release` jobs use `environment: ci` secrets.