### PR TITLE
fix: expose component catalog

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -204,6 +204,12 @@ jobs:
             - name: Run storybook:static build
               run: npx cross-env STORYBOOK_BASE_HREF=fundamental-styles yarn run storybook:static
 
+            - name: Regenerate component catalog with release version
+              run: yarn generate:ai-docs
+
+            - name: Copy component catalog to storybook output
+              run: cp docs/component-catalog.json storybook-static/component-catalog.json
+
             - name: Publish to gh-pages
               uses: JamesIves/github-pages-deploy-action@v4.7.3
               with:

--- a/.github/workflows/on-pull.yml
+++ b/.github/workflows/on-pull.yml
@@ -33,3 +33,18 @@ jobs:
       - run: yarn run lint
       - run: yarn run build:prod
       - run: yarn run size
+
+  check-catalog-freshness:
+    runs-on: ubuntu-latest
+    name: Check component catalog is up to date
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/nodejs
+        name: Install dependencies
+      - run: yarn generate:ai-metadata
+      - name: Fail if catalog is stale
+        run: |
+          if ! git diff --exit-code docs/component-catalog.json docs/schemas/; then
+            echo "component-catalog.json or schemas are out of date. Run 'yarn generate:ai-metadata' and commit the result."
+            exit 1
+          fi

--- a/docs/component-catalog.json
+++ b/docs/component-catalog.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "version": "0.41.0",
+  "version": "0.41.7-rc.8",
   "description": "Machine-readable catalog of Fundamental Library Styles components",
   "generatedBy": "scripts/generate-ai-metadata.js",
   "relatedFiles": {
@@ -93,9 +93,7 @@
             "--fdActionBarInlinePadding"
           ],
           "tags": [
-            "non-f3",
-            "a11y",
-            "theme"
+            "non-f3"
           ],
           "examples": [
             "actions",
@@ -176,12 +174,7 @@
             "--fdActionSheet_Item_Padding_Block",
             "--fdActionSheet_Item_Padding_Inline"
           ],
-          "tags": [
-            "a11y",
-            "f3",
-            "theme",
-            "responsive"
-          ],
+          "tags": [],
           "examples": [
             "action-sheet-mobile",
             "default"
@@ -1291,11 +1284,7 @@
             "--fdBusy_Indicator_Dot_Color",
             "--fdBusy_Indicator_Dot_Contrast_Color"
           ],
-          "tags": [
-            "f3",
-            "a11y",
-            "theme"
-          ],
+          "tags": [],
           "examples": [
             "busy-dialog",
             "contrast-mode",
@@ -1540,11 +1529,7 @@
             "menu"
           ],
           "dependencies": [],
-          "tags": [
-            "f3",
-            "a11y",
-            "theme"
-          ],
+          "tags": [],
           "variables": [
             "--fdButton_Clickable_Height",
             "--fdButton_Padding_X",
@@ -2518,12 +2503,7 @@
             "--fdCarousel_Dot_Selected_Background",
             "--fdButton_Focus_Border_Radius"
           ],
-          "tags": [
-            "f3",
-            "a11y",
-            "theme",
-            "development"
-          ],
+          "tags": [],
           "examples": [
             "carousel-backgrounds",
             "carousel-bottom",
@@ -2690,12 +2670,7 @@
           ],
           "elements": [],
           "variables": [],
-          "tags": [
-            "f3",
-            "a11y",
-            "theme",
-            "development"
-          ],
+          "tags": [],
           "examples": [
             "inline-code",
             "primary"
@@ -2739,11 +2714,7 @@
           "variables": [
             "--fdBadge_Border_Color"
           ],
-          "tags": [
-            "f3",
-            "a11y",
-            "development"
-          ],
+          "tags": [],
           "examples": [
             "notifier",
             "paragraph",
@@ -2907,11 +2878,7 @@
             "bar"
           ],
           "dependencies": [],
-          "tags": [
-            "f3",
-            "a11y",
-            "theme"
-          ],
+          "tags": [],
           "variables": [],
           "examples": [
             "default-dialog",
@@ -3305,11 +3272,7 @@
             "--fdButton_Badge_Margin_Inline_Start",
             "--fdButton_Badge_Size_Attention"
           ],
-          "tags": [
-            "f3",
-            "a11y",
-            "theme"
-          ],
+          "tags": [],
           "examples": [
             "disabled",
             "input-growth",
@@ -3436,11 +3399,7 @@
             "--fdFeed_List_Item_Border_Top",
             "--fdFeed_List_Item_Border_Bottom"
           ],
-          "tags": [
-            "f3",
-            "a11y",
-            "theme"
-          ],
+          "tags": [],
           "examples": [
             "borderless",
             "group",
@@ -3566,11 +3525,7 @@
           "variables": [
             "--fdFileUploaderButtonsSpacing"
           ],
-          "tags": [
-            "f3",
-            "a11y",
-            "theme"
-          ],
+          "tags": [],
           "examples": [
             "file-uploader-with-files",
             "primary",
@@ -3762,6 +3717,10 @@
             {
               "class": "fd-form-group--no-border",
               "description": "no-border variant"
+            },
+            {
+              "class": "fd-form-group--wrap",
+              "description": "wrap variant"
             }
           ],
           "elements": [
@@ -3909,6 +3868,10 @@
             {
               "class": "fd-form-label--disabled",
               "description": "disabled variant"
+            },
+            {
+              "class": "fd-form-label--wrap",
+              "description": "wrap variant"
             },
             {
               "class": "fd-form-label--unit-description",
@@ -4583,10 +4546,7 @@
             "--fdIconTabBar_Button_Shell_Focus_Color",
             "--fdIconTabBar_Button_Shell_Background_Color_Selected"
           ],
-          "tags": [
-            "f3",
-            "development"
-          ],
+          "tags": [],
           "examples": [
             "badge",
             "counter",
@@ -5936,12 +5896,7 @@
             "action-sheet"
           ],
           "dependencies": [],
-          "tags": [
-            "f3",
-            "a11y",
-            "theme",
-            "development"
-          ],
+          "tags": [],
           "variables": [
             "--fdButton_Menu_Border_Radius",
             "--fdMenu_Icon_Width",
@@ -6071,11 +6026,7 @@
             "--fdIcon_Font_Size",
             "--fdIcon_Color"
           ],
-          "tags": [
-            "f3",
-            "a11y",
-            "theme"
-          ],
+          "tags": [],
           "examples": [
             "responsive",
             "structure",
@@ -6171,12 +6122,7 @@
             "--fdMessage_Page_Title_Margin_Top",
             "--fdMessage_Page_Title_Margin_Bottom"
           ],
-          "tags": [
-            "f3",
-            "a11y",
-            "theme",
-            "development"
-          ],
+          "tags": [],
           "examples": [
             "buttons",
             "error",
@@ -6270,10 +6216,7 @@
             "--fdMessagePopover_Information_Focus_Outline_Color",
             "--fdMessagePopover_Active_Focus_Outline_Color"
           ],
-          "tags": [
-            "f3",
-            "theme"
-          ],
+          "tags": [],
           "examples": [
             "cozy-message-popover",
             "details-view",
@@ -6507,11 +6450,7 @@
           "modifiers": [],
           "elements": [],
           "variables": [],
-          "tags": [
-            "f3",
-            "a11y",
-            "theme"
-          ],
+          "tags": [],
           "examples": [
             "default-toast"
           ],
@@ -6644,11 +6583,7 @@
             "--fdMicro_Process_Flow_Icon_Color",
             "--fdMicro_Process_Flow_Active_Icon_Color"
           ],
-          "tags": [
-            "f3",
-            "a11y",
-            "theme"
-          ],
+          "tags": [],
           "examples": [
             "default-micro-process-flow",
             "micro-process-flow-custom-width",
@@ -7297,9 +7232,7 @@
             "--fdNotification_Popover_Max_Width",
             "--fdNotification_Title_Offset"
           ],
-          "tags": [
-            "development"
-          ],
+          "tags": [],
           "examples": [
             "banner",
             "notification-group",
@@ -7509,9 +7442,7 @@
             "--fdObjectIdentifier_Font_Size",
             "--fdObjectIdentifier_Font_Weight"
           ],
-          "tags": [
-            "f3"
-          ],
+          "tags": [],
           "examples": [
             "bold-title",
             "medium-size",
@@ -7619,12 +7550,7 @@
             "--fdObject_List_Title_Font_Size",
             "--fdObject_List_Title_Font_Weight"
           ],
-          "tags": [
-            "f3",
-            "a11y",
-            "theme",
-            "development"
-          ],
+          "tags": [],
           "examples": [
             "borderless",
             "navigation",
@@ -7682,11 +7608,7 @@
             }
           ],
           "variables": [],
-          "tags": [
-            "f3",
-            "a11y",
-            "theme"
-          ],
+          "tags": [],
           "examples": [
             "clickable-object-marker",
             "icon-and-text",
@@ -8701,11 +8623,7 @@
             "menu"
           ],
           "dependencies": [],
-          "tags": [
-            "f3",
-            "a11y",
-            "theme"
-          ],
+          "tags": [],
           "modifiers": [
             {
               "class": "fd-popover--visible",
@@ -8892,11 +8810,7 @@
             "--fdButton_Outline_Contrast",
             "--fdButtonPrioritizedBorderColor"
           ],
-          "tags": [
-            "f3",
-            "a11y",
-            "theme"
-          ],
+          "tags": [],
           "examples": [
             "large",
             "medium",
@@ -9041,12 +8955,7 @@
             "--fdProgress_Indicator_Label_Position",
             "--fdProgress_Indicator_Label_Font_Size"
           ],
-          "tags": [
-            "f3",
-            "a11y",
-            "theme",
-            "development"
-          ],
+          "tags": [],
           "examples": [
             "layout",
             "truncation",
@@ -9141,6 +9050,10 @@
             {
               "class": "fd-quick-view--header-with-subheader",
               "description": "header-with-subheader variant"
+            },
+            {
+              "class": "fd-quick-view--wrap",
+              "description": "wrap variant"
             }
           ],
           "elements": [
@@ -9176,11 +9089,7 @@
             }
           ],
           "variables": [],
-          "tags": [
-            "f3",
-            "a11y",
-            "theme"
-          ],
+          "tags": [],
           "examples": [
             "dialog",
             "no-header",
@@ -9412,11 +9321,7 @@
             "--fdRating_Indicator_Disabled_Unselected_Color",
             "--fdRating_Indicator_Display_Only_Selected_Color"
           ],
-          "tags": [
-            "f3",
-            "a11y",
-            "theme"
-          ],
+          "tags": [],
           "examples": [
             "custom-icons",
             "different-values",
@@ -9602,11 +9507,7 @@
             "--fdScrollbar_Thumb_Border_Radius",
             "--fdScrollbar_Thumb_Hover_Color"
           ],
-          "tags": [
-            "f3",
-            "theme",
-            "development"
-          ],
+          "tags": [],
           "examples": [
             "default-example"
           ],
@@ -9816,6 +9717,8 @@
             "--fdButton_Border_Radius_Left",
             "--fdButton_Border_Radius_Right",
             "--fdButton_Segmented_Border_Offset",
+            "--fdButtonBorderColor",
+            "--fdButtonBackgroundColor",
             "--fdButton_Border_Radius_Left_RTL",
             "--fdButton_Border_Radius_Right_RTL",
             "--fdButton_Vertical_Border_Radius_Left",
@@ -10181,7 +10084,6 @@
           ],
           "dependencies": [],
           "tags": [
-            "experimental",
             "uxc"
           ],
           "modifiers": [
@@ -10464,9 +10366,7 @@
           "variables": [
             "--fdSkeletonGradientMiddleColor"
           ],
-          "tags": [
-            "f3"
-          ],
+          "tags": [],
           "examples": [
             "circle",
             "complex",
@@ -10625,10 +10525,7 @@
             "--fdSlider_Range_Focus_Handle_Background",
             "--fdSlider_Range_Focus_Handle_Border"
           ],
-          "tags": [
-            "f3",
-            "theme"
-          ],
+          "tags": [],
           "examples": [
             "mobile-mode",
             "range",
@@ -10924,11 +10821,7 @@
             }
           ],
           "variables": [],
-          "tags": [
-            "f3",
-            "a11y",
-            "theme"
-          ],
+          "tags": [],
           "examples": [
             "fill-values",
             "sizes",
@@ -11889,11 +11782,7 @@
           "variables": [
             "--fdText_Selected_Background_Color"
           ],
-          "tags": [
-            "f3",
-            "a11y",
-            "theme"
-          ],
+          "tags": [],
           "examples": [
             "default-example",
             "expand",
@@ -12265,11 +12154,7 @@
             "--fdTime_Unit_Line_Height",
             "--fdTime_Text_Shadow"
           ],
-          "tags": [
-            "f3",
-            "a11y",
-            "theme"
-          ],
+          "tags": [],
           "examples": [
             "default-cozy-mode",
             "scrollable-mode",
@@ -12387,10 +12272,7 @@
             "--fdTimePickerTickMarginBlock",
             "--fdTimePickerTickMarginInline"
           ],
-          "tags": [
-            "f3",
-            "theme"
-          ],
+          "tags": [],
           "examples": [
             "hours12-cozy",
             "hours24-cozy",
@@ -12532,9 +12414,7 @@
             "--fdTitle_Color",
             "--fdTitle_Font_Family"
           ],
-          "tags": [
-            "f3"
-          ],
+          "tags": [],
           "examples": [
             "elision",
             "levels",
@@ -12627,11 +12507,7 @@
             "--fdToken_Selected_Font_Family",
             "--fdToken_Border_Color_Selected_Focus"
           ],
-          "tags": [
-            "f3",
-            "a11y",
-            "theme"
-          ],
+          "tags": [],
           "examples": [
             "primary"
           ],
@@ -12707,11 +12583,7 @@
             "--fdTokenizer_Indicator_Color",
             "--fdInput_Field_Compact_Min_Width"
           ],
-          "tags": [
-            "f3",
-            "a11y",
-            "theme"
-          ],
+          "tags": [],
           "examples": [
             "cozy-tokenizer",
             "scrollable-tokenizer"
@@ -13036,12 +12908,7 @@
             "--fdToolbar_Transparent_Background",
             "--fdToolbar_Info_Outline_Color"
           ],
-          "tags": [
-            "f3",
-            "a11y",
-            "theme",
-            "design"
-          ],
+          "tags": [],
           "examples": [
             "alignment",
             "overflow",
@@ -13182,12 +13049,7 @@
             "--fdTree_Item_Level_Spacing",
             "--fdTree_Item_Highlight_Color"
           ],
-          "tags": [
-            "f3",
-            "a11y",
-            "theme",
-            "development"
-          ],
+          "tags": [],
           "examples": [
             "borderless",
             "highlight-indicators",
@@ -13306,12 +13168,7 @@
             }
           ],
           "variables": [],
-          "tags": [
-            "f3",
-            "a11y",
-            "theme",
-            "development"
-          ],
+          "tags": [],
           "examples": [
             "edit",
             "no-data",
@@ -13568,11 +13425,7 @@
             "--fdTitle_Font_Size",
             "--fdTitle_Font_Family"
           ],
-          "tags": [
-            "f3",
-            "theme",
-            "development"
-          ],
+          "tags": [],
           "examples": [
             "dirty-label",
             "sizes"
@@ -13950,11 +13803,7 @@
             "--fdWizard_Step_Content_Container_Spacing",
             "--fdWizard_Step_Content_Container_Background_Color"
           ],
-          "tags": [
-            "f3",
-            "theme",
-            "development"
-          ],
+          "tags": [],
           "examples": [
             "customized",
             "default-example",

--- a/docs/schemas/badge.schema.json
+++ b/docs/schemas/badge.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://sap.github.io/fundamental-styles/schemas/badge.json",
   "title": "Badge Component",
-  "description": "Badge component",
+  "description": "Badges display small amounts of color-coded meta information. Use to highlight entity states, notifications, or counts (e.g., \"3 pending items\"). Can be filled or outlined, with semantic colors for status indication.",
   "type": "object",
   "properties": {
     "baseClass": {

--- a/docs/schemas/button-split.schema.json
+++ b/docs/schemas/button-split.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://sap.github.io/fundamental-styles/schemas/button-split.json",
   "title": "Button Split Component",
-  "description": "Button Split component",
+  "description": "Split buttons combine a primary action with a dropdown menu of related secondary actions. The primary action executes immediately when clicked, while the arrow reveals additional options. Use when one option is used more frequently than others.",
   "type": "object",
   "properties": {
     "baseClass": {

--- a/docs/schemas/counter.schema.json
+++ b/docs/schemas/counter.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://sap.github.io/fundamental-styles/schemas/counter.json",
   "title": "Counter Component",
-  "description": "Counter component",
+  "description": "Counters display numerical values with optional indicators (e.g., \"5 new messages\"). Typically used in navigation items, cards, or list headers to show counts, notifications, or status summaries.",
   "type": "object",
   "properties": {
     "baseClass": {

--- a/docs/schemas/dynamic-page.schema.json
+++ b/docs/schemas/dynamic-page.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://sap.github.io/fundamental-styles/schemas/dynamic-page.json",
   "title": "Dynamic Page Component",
-  "description": "Dynamic Page component",
+  "description": "Dynamic Page is foundation for all SAP pages. Generic layout supporting various use cases with variable header and page content. Header is collapsible to help users focus on content while keeping important header info and actions readily available. Uses foundation layout components (dynamic page header, footer toolbar).",
   "type": "object",
   "properties": {
     "baseClass": {

--- a/docs/schemas/dynamic-side-content.schema.json
+++ b/docs/schemas/dynamic-side-content.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://sap.github.io/fundamental-styles/schemas/dynamic-side-content.json",
   "title": "Dynamic Side Content Component",
-  "description": "Dynamic Side Content component",
+  "description": "Dynamic Side Content is layout control displaying supplemental content in separate area to support understanding of main content. Two elements: side content section (`.fd-dynamic-side__side`) and main content section (`.fd-dynamic-side__main`). Screen width ratio varies based on available space - side displays left/right or bottom if space limited.",
   "type": "object",
   "properties": {
     "baseClass": {

--- a/docs/schemas/facet.schema.json
+++ b/docs/schemas/facet.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://sap.github.io/fundamental-styles/schemas/facet.json",
   "title": "Facet Component",
-  "description": "Facet component",
+  "description": "Facets display key-value pairs in a compact, scannable format. Use in object headers or cards to show essential information like status, date, owner, or metrics. Supports icons and semantic colors.",
   "type": "object",
   "properties": {
     "baseClass": {

--- a/docs/schemas/fieldset.schema.json
+++ b/docs/schemas/fieldset.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://sap.github.io/fundamental-styles/schemas/fieldset.json",
   "title": "Fieldset Component",
-  "description": "Fieldset component",
+  "description": "A fieldset gives semantic meaning to a group of elements inside a form (e.g., Billing or Shipping Address). Grouping fields provides styling and accessibility benefits, and is especially important for checkbox groups and radio button groups.",
   "type": "object",
   "properties": {
     "baseClass": {

--- a/docs/schemas/flexible-column-layout.schema.json
+++ b/docs/schemas/flexible-column-layout.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://sap.github.io/fundamental-styles/schemas/flexible-column-layout.json",
   "title": "Flexible Column Layout Component",
-  "description": "Flexible Column Layout component",
+  "description": "Flexible Column Layout is layout control displaying multiple floorplans on single page. Enables faster, more fluid navigation between floorplans than page-by-page. Offers layouts with up to 3 columns (1, 2, 3). Users can resize columns, switch layouts, view rightmost column in full screen. Responsive for desktop and mobile.",
   "type": "object",
   "properties": {
     "baseClass": {

--- a/docs/schemas/form-group.schema.json
+++ b/docs/schemas/form-group.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://sap.github.io/fundamental-styles/schemas/form-group.json",
   "title": "Form Group Component",
-  "description": "Form Group component",
+  "description": "Form groups assemble form elements with labels, messages, and help containers. Components like `fd-form__item` with label and control can be used independently when error messages aren't needed.",
   "type": "object",
   "properties": {
     "baseClass": {
@@ -16,7 +16,8 @@
           "fd-form-group--inline",
           "fd-form-group--with-spacing",
           "fd-form-group--no-padding",
-          "fd-form-group--no-border"
+          "fd-form-group--no-border",
+          "fd-form-group--wrap"
         ]
       },
       "description": "Optional modifier classes"

--- a/docs/schemas/form-header.schema.json
+++ b/docs/schemas/form-header.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://sap.github.io/fundamental-styles/schemas/form-header.json",
   "title": "Form Header Component",
-  "description": "Form Header component",
+  "description": "Form headers are titles that provide context about a group of input fields. For example, \"Personal Information\" would categorize fields like Name, Address, etc.",
   "type": "object",
   "properties": {
     "baseClass": {

--- a/docs/schemas/form-label.schema.json
+++ b/docs/schemas/form-label.schema.json
@@ -14,6 +14,7 @@
       "items": {
         "enum": [
           "fd-form-label--disabled",
+          "fd-form-label--wrap",
           "fd-form-label--unit-description",
           "fd-form-label--required",
           "fd-form-label--colon",

--- a/docs/schemas/form-message.schema.json
+++ b/docs/schemas/form-message.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://sap.github.io/fundamental-styles/schemas/form-message.json",
   "title": "Form Message Component",
-  "description": "Form Message component",
+  "description": "Form messages display value state text (success, error, warning, information) shown when focus is on the input field. They work with input control value states to provide feedback to users.",
   "type": "object",
   "properties": {
     "baseClass": {

--- a/docs/schemas/grid-list.schema.json
+++ b/docs/schemas/grid-list.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://sap.github.io/fundamental-styles/schemas/grid-list.json",
   "title": "Grid List Component",
-  "description": "Grid List component",
+  "description": "Grid list displays items in a grid format (not rows), ideal for visual content like images, charts, and object cards that benefit from more height. Usually used as an alternative view for lists or tables, focusing on complete items rather than cells.",
   "type": "object",
   "properties": {
     "baseClass": {

--- a/docs/schemas/input-group.schema.json
+++ b/docs/schemas/input-group.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://sap.github.io/fundamental-styles/schemas/input-group.json",
   "title": "Input Group Component",
-  "description": "Input Group component",
+  "description": "Input Group combines form inputs with add-ons (text, icons, or buttons) to help users understand the information being entered. Add-ons can be positioned before, after, or on both sides of the input field. Supports validation states (success, error, warning, information).",
   "type": "object",
   "properties": {
     "baseClass": {

--- a/docs/schemas/layout-panel.schema.json
+++ b/docs/schemas/layout-panel.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://sap.github.io/fundamental-styles/schemas/layout-panel.json",
   "title": "Layout Panel Component",
-  "description": "Layout Panel component",
+  "description": "Layout Panels encapsulate part of content, form elements, lists, collections on a page. Place patterns and interactions within panels to achieve focus and separation for tasks with information displayed inside panel. Organizes content into distinct sections.",
   "type": "object",
   "properties": {
     "baseClass": {

--- a/docs/schemas/page.schema.json
+++ b/docs/schemas/page.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://sap.github.io/fundamental-styles/schemas/page.json",
   "title": "Page Component",
-  "description": "Page component",
+  "description": "Page is the foundation wrapper for all application pages. Provides consistent structure with optional header, footer, and content areas. Use as the outermost container for every page in your application.",
   "type": "object",
   "properties": {
     "baseClass": {

--- a/docs/schemas/quick-view.schema.json
+++ b/docs/schemas/quick-view.schema.json
@@ -13,7 +13,8 @@
       "type": "array",
       "items": {
         "enum": [
-          "fd-quick-view--header-with-subheader"
+          "fd-quick-view--header-with-subheader",
+          "fd-quick-view--wrap"
         ]
       },
       "description": "Optional modifier classes"

--- a/docs/schemas/section.schema.json
+++ b/docs/schemas/section.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://sap.github.io/fundamental-styles/schemas/section.json",
   "title": "Section Component",
-  "description": "Section component",
+  "description": "Sections group related content on a page with optional headers and visual separation. Use to organize page content into logical, scannable blocks. Can be collapsible to help users focus on relevant information.",
   "type": "object",
   "properties": {
     "baseClass": {

--- a/docs/schemas/side-nav.schema.json
+++ b/docs/schemas/side-nav.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://sap.github.io/fundamental-styles/schemas/side-nav.json",
   "title": "Side Nav Component",
-  "description": "Side Nav component",
+  "description": "Side Navigation provides hierarchical navigation for applications. Displays a collapsible sidebar with navigation items, icons, and nested submenus. Use for primary app navigation in the Shellbar or as dedicated sidebar.",
   "type": "object",
   "properties": {
     "baseClass": {

--- a/docs/schemas/splitter.schema.json
+++ b/docs/schemas/splitter.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://sap.github.io/fundamental-styles/schemas/splitter.json",
   "title": "Splitter Component",
-  "description": "Splitter component",
+  "description": "Splitter divides screen into resizable panes separated by a draggable divider. Users can adjust pane sizes by dragging the separator. Use for master-detail layouts or comparing content side-by-side.",
   "type": "object",
   "properties": {
     "baseClass": {

--- a/docs/schemas/tabs.schema.json
+++ b/docs/schemas/tabs.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://sap.github.io/fundamental-styles/schemas/tabs.json",
   "title": "Tabs Component",
-  "description": "Tabs component",
+  "description": "Tabs organize content into separate views, allowing users to switch between different sections without leaving the page. Use for dividing content into meaningful categories that users can explore one at a time.",
   "type": "object",
   "properties": {
     "baseClass": {

--- a/docs/schemas/tile.schema.json
+++ b/docs/schemas/tile.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://sap.github.io/fundamental-styles/schemas/tile.json",
   "title": "Tile Component",
-  "description": "Tile component",
+  "description": "Tiles display summarized information or entry points to applications, pages, or actions. Use in home pages, launchpads, or dashboards to present options in a grid layout. Can include icons, titles, subtitles, and quick actions.",
   "type": "object",
   "properties": {
     "baseClass": {

--- a/docs/schemas/tool-layout.schema.json
+++ b/docs/schemas/tool-layout.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://sap.github.io/fundamental-styles/schemas/tool-layout.json",
   "title": "Tool Layout Component",
-  "description": "Tool Layout component",
+  "description": "Tool Layout consists of three main areas: Tool Header (always present, top-aligned with global actions and navigation controls), Navigation (side navigation in expanded/snapped variants), and Content (empty container for any content). Complete layout structure for tool-based applications.",
   "type": "object",
   "properties": {
     "baseClass": {

--- a/docs/schemas/wizard.schema.json
+++ b/docs/schemas/wizard.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://sap.github.io/fundamental-styles/schemas/wizard.json",
   "title": "Wizard Component",
-  "description": "Wizard component",
+  "description": "Wizard guides user through long or unfamiliar task by dividing into sections, revealing information in digestible way. Consists of walkthrough screen (input required info) and summary page (read-only review before submission). Two types: standard (linear, known steps) and branching (non-linear, variable steps). Supports 3-8 steps, optional steps allowed.",
   "type": "object",
   "properties": {
     "baseClass": {

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,7 +8,7 @@
 [build]
   ignore = 'git log -1 --pretty=%B | grep dependabot'
   publish = "storybook-static"
-  command = "yarn run storybook:static"
+  command = "yarn run storybook:static && cp docs/component-catalog.json storybook-static/component-catalog.json"
 
 [build.environment]
   NODE_VERSION = "24.11.1"

--- a/scripts/generate-ai-metadata.js
+++ b/scripts/generate-ai-metadata.js
@@ -33,7 +33,11 @@ const CONFIG = {
   catalogFile: path.join(__dirname, '../docs/component-catalog.json'),
   schemasDir: path.join(__dirname, '../docs/schemas'),
   verbose: process.argv.includes('--verbose'),
+  packageJsonPath: path.join(__dirname, '../packages/styles/package.json'),
 };
+
+const packageJson = JSON.parse(fs.readFileSync(CONFIG.packageJsonPath, 'utf8'));
+const LIBRARY_VERSION = packageJson.version;
 
 // Logging utility
 const log = {
@@ -674,7 +678,7 @@ function updateCatalog(components) {
 
   const catalog = {
     $schema: 'https://json-schema.org/draft/2020-12/schema',
-    version: '0.41.0',
+    version: LIBRARY_VERSION,
     description: 'Machine-readable catalog of Fundamental Library Styles components',
     generatedBy: 'scripts/generate-ai-metadata.js',
     relatedFiles: {

--- a/scripts/generate-ai-metadata.js
+++ b/scripts/generate-ai-metadata.js
@@ -370,14 +370,29 @@ function extractModifiersFromSassMaps(content, baseClass) {
 }
 
 /**
+ * Find the actual stories directory for a component, case-insensitively.
+ * Needed because directory names may be capitalized (e.g. "List") while
+ * component IDs are always lowercase (e.g. "list").
+ */
+function findStoriesDir(componentName) {
+  try {
+    const entries = fs.readdirSync(CONFIG.storiesDir);
+    const match = entries.find(e => e.toLowerCase() === componentName.toLowerCase());
+    return match ? path.join(CONFIG.storiesDir, match) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Extract modifiers from story HTML files
  */
 function extractModifiersFromStories(componentName, baseClass) {
   const modifiers = new Set();
 
-  // Check component-specific stories folder
-  const storiesPath = path.join(CONFIG.storiesDir, componentName);
-  if (fs.existsSync(storiesPath)) {
+  // Check component-specific stories folder (case-insensitive lookup)
+  const storiesPath = findStoriesDir(componentName);
+  if (storiesPath) {
     extractModifiersFromDirectory(storiesPath, baseClass, modifiers);
   }
 
@@ -429,8 +444,8 @@ function extractModifiersFromDirectory(dirPath, baseClass, modifiers) {
 function extractElementModifiersFromStories(componentName, baseClass) {
   const elementModifiers = new Map(); // element name -> Set of modifier classes
 
-  const storiesPath = path.join(CONFIG.storiesDir, componentName);
-  if (fs.existsSync(storiesPath)) {
+  const storiesPath = findStoriesDir(componentName);
+  if (storiesPath) {
     extractElementModifiersFromDirectory(storiesPath, baseClass, elementModifiers);
   }
 


### PR DESCRIPTION
## Related Issue

Closes https://github.com/SAP/fundamental-styles/issues/6311

## Description

Changes:

1. **scripts/generate-ai-metadata.js**

- Added packageJsonPath to CONFIG
- Reads LIBRARY_VERSION dynamically from packages/styles/package.json instead of using the hardcoded '0.41.0' string — so the catalog version is always in sync with the library release version

2. **.github/workflows/create-release.yml**

- two new steps in the gh_pages job after the storybook build:
- yarn generate:ai-docs — regenerates the catalog with the correct release version (runs after lerna version has already bumped packages/styles/package.json)
- cp docs/component-catalog.json storybook-static/component-catalog.json — places the file in the storybook output folder, which is then published to GitHub Pages by the existing deploy action

This means https://sap.github.io/fundamental-styles/component-catalog.json will serve the catalog on every stable release, and the catalog version will always match the published npm package version.

3. **netlify.toml**
- copies the `component-catalog.json` so that it's present on all Netlify deploys as well - check out https://deploy-preview-6316--fundamental-styles.netlify.app/component-catalog.json

4. **.github/workflows/on-pull.yml**
- Check if `component-catalog.json` has been updated or if out of sync with source changes. If our of sync, make job exit with a non-zero exit code.

5. Updates the component docs
