### PR TITLE
fix(styles): remove font weight from Card title [ci visual]

### DIFF
--- a/packages/styles/src/card.scss
+++ b/packages/styles/src/card.scss
@@ -517,7 +517,6 @@ $legend-background-colors: (
 
     font-family: var(--sapFontHeaderFamily);
     font-size: var(--fdCard_Title_Font_Size);
-    font-weight: var(--fdCard_Title_Font_Weight);
     color: var(--sapTile_TitleTextColor);
     word-wrap: break-word;
     max-height: 4.2rem;

--- a/packages/styles/src/theming/common/card/_sap_fiori.scss
+++ b/packages/styles/src/theming/common/card/_sap_fiori.scss
@@ -10,6 +10,5 @@
   --fdCard_Footer_Padding: 1rem;
   --fdCard_Footer_Actions_Item_Spacing: 0.5rem;
   --fdCard_Title_Font_Size: var(--sapFontHeader5Size);
-  --fdCard_Title_Font_Weight: var(--sapFontHeaderWeight);
   --fdCard_Main_Header_Padding_Bottom: 1rem;
 }

--- a/packages/styles/src/theming/common/card/_sap_horizon.scss
+++ b/packages/styles/src/theming/common/card/_sap_horizon.scss
@@ -9,6 +9,5 @@
   --fdCard_Footer_Padding: 0.75rem;
   --fdCard_Footer_Actions_Item_Spacing: 0.5rem;
   --fdCard_Title_Font_Size: var(--sapFontHeader6Size);
-  --fdCard_Title_Font_Weight: bold;
   --fdCard_Main_Header_Padding_Bottom: 0.75rem;
 }


### PR DESCRIPTION
## Related Issue
Closes none

## Description
The boldness of the text of Card header title should be coming from the font-family, not from font-weight. Currently, this creates a visual problem in Safari, making the text looks blurry.

Before:
<img width="877" height="450" alt="Screenshot 2026-06-01 at 2 48 39 PM" src="https://github.com/user-attachments/assets/7f77eb1d-3c24-4c9c-b25f-3e8b30f88a4e" />

After:
<img width="886" height="457" alt="Screenshot 2026-06-01 at 2 48 46 PM" src="https://github.com/user-attachments/assets/f2576e2a-3414-4d8a-acac-a2a126daab8a" />
