### PR TITLE
feat(styles): add header content area to User Menu

### DIFF
--- a/packages/styles/src/user-menu.scss
+++ b/packages/styles/src/user-menu.scss
@@ -69,6 +69,13 @@ $menu: #{$fd-namespace}-menu;
     margin-block-end: 0.5rem;
   }
 
+  &__header-content-area {
+    @include fd-reset();
+
+    width: 100%;
+    padding: 0.5rem;
+  }
+
   &__user-name {
     @include fd-reset();
    

--- a/packages/styles/stories/Components/user-menu/default.example.html
+++ b/packages/styles/stories/Components/user-menu/default.example.html
@@ -1,4 +1,4 @@
-<div class="fddocs-container" style="margin-bottom: 500px; flex-wrap: wrap; gap: 5rem;">
+<div class="fddocs-container" style="margin-bottom: 500px; flex-wrap: wrap; gap: 5rem">
     <div class="fd-popover fd-popover--right fd-user-menu">
         <div class="fd-popover__body fd-popover__body--right" aria-hidden="false" id="userMenu1">
             <div class="fd-popover__wrapper fd-user-menu__popover-wrapper">
@@ -7,14 +7,25 @@
                         <span
                             class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--thumbnail"
                             aria-label="Avatar"
-                            style="background-image: url('/assets/images/portraits/L_80x80_F3.png');">
-                            <i class="fd-avatar__zoom-icon sap-icon--edit" aria-label="Edit" role="presentation" aria-hidden="true"></i>
+                            style="background-image: url('/assets/images/portraits/L_80x80_F3.png')"
+                        >
+                            <i
+                                class="fd-avatar__zoom-icon sap-icon--edit"
+                                aria-label="Edit"
+                                role="presentation"
+                                aria-hidden="true"
+                            ></i>
                         </span>
                         <div class="fd-user-menu__header-container">
                             <div class="fd-user-menu__user-name">Lisa Miller</div>
                             <div class="fd-user-menu__subline">lisa.miller@test.com</div>
                             <div class="fd-user-menu__subline">User Experience Designer</div>
                             <div class="fd-user-menu__subline">Primary Employment</div>
+                        </div>
+                        <div class="fd-user-menu__header-content-area" style="background-color: aquamarine">
+                            <div style="display: flex; align-items: center; justify-content: center">
+                                Header Content Area
+                            </div>
                         </div>
                     </div>
                     <div class="fd-user-menu__content-container">
@@ -28,28 +39,36 @@
                                         <span class="fd-menu__title">Settings</span>
                                     </a>
                                 </li>
-    
+
                                 <li class="fd-menu__item" role="presentation">
                                     <span
                                         class="fd-menu__link has-child is-expanded"
                                         aria-controls="EX100M2A"
                                         aria-expanded="true"
                                         aria-haspopup="true"
-                                        role="menuitem">
-                                            <span class="fd-menu__addon-before">
-                                                <i class="sap-icon--card" role="presentation"></i>
-                                            </span>
-                                            <div class="fd-menu__content">
-                                                <span class="fd-menu__title">Menu Item</span>
-                                                <span class="fd-menu__subtitle">Sub-menu List Item</span>
-                                            </div>
-                                            <span class="fd-menu__addon-after fd-menu__addon-after--submenu"></span>
+                                        role="menuitem"
+                                    >
+                                        <span class="fd-menu__addon-before">
+                                            <i class="sap-icon--card" role="presentation"></i>
+                                        </span>
+                                        <div class="fd-menu__content">
+                                            <span class="fd-menu__title">Menu Item</span>
+                                            <span class="fd-menu__subtitle">Sub-menu List Item</span>
+                                        </div>
+                                        <span class="fd-menu__addon-after fd-menu__addon-after--submenu"></span>
                                     </span>
-                                    
-                                    <ul class="fd-menu__sublist fd-menu__sublist--icons" id="EX100M2A" aria-hidden="false" role="menu">
+
+                                    <ul
+                                        class="fd-menu__sublist fd-menu__sublist--icons"
+                                        id="EX100M2A"
+                                        aria-hidden="false"
+                                        role="menu"
+                                    >
                                         <li class="fd-menu__item" role="presentation">
                                             <a class="fd-menu__link" href="#" role="menuitem">
-                                                <span class="fd-menu__addon-before"><i class="sap-icon--card" role="presentation"></i></span>
+                                                <span class="fd-menu__addon-before"
+                                                    ><i class="sap-icon--card" role="presentation"></i
+                                                ></span>
                                                 <span class="fd-menu__title">Sub-menu Item</span>
                                             </a>
                                         </li>
@@ -69,7 +88,7 @@
                                         <span class="fd-menu__title">Legal Information</span>
                                     </a>
                                 </li>
-    
+
                                 <li class="fd-menu__item" role="presentation">
                                     <a class="fd-menu__link" href="#" role="menuitem">
                                         <span class="fd-menu__addon-before">
@@ -78,9 +97,8 @@
                                         <span class="fd-menu__title">About</span>
                                     </a>
                                 </li>
-                                
                             </ul>
-                        </nav>  
+                        </nav>
                     </div>
                 </div>
             </div>
@@ -98,7 +116,7 @@
     </div>
 </div>
 
-<div class="fddocs-container" style="margin-bottom: 900px; flex-wrap: wrap; gap: 5rem;">
+<div class="fddocs-container" style="margin-bottom: 900px; flex-wrap: wrap; gap: 5rem">
     <div class="fd-popover fd-popover--right fd-user-menu">
         <div class="fd-popover__body fd-popover__body--right" aria-hidden="false" id="userMenu1">
             <div class="fd-popover__wrapper fd-user-menu__popover-wrapper">
@@ -107,14 +125,43 @@
                         <span
                             class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--thumbnail"
                             aria-label="Avatar"
-                            style="background-image: url('/assets/images/portraits/L_80x80_F3.png');">
-                            <i class="fd-avatar__zoom-icon sap-icon--edit" aria-label="Edit" role="presentation" aria-hidden="true"></i>
+                            style="background-image: url('/assets/images/portraits/L_80x80_F3.png')"
+                        >
+                            <i
+                                class="fd-avatar__zoom-icon sap-icon--edit"
+                                aria-label="Edit"
+                                role="presentation"
+                                aria-hidden="true"
+                            ></i>
                         </span>
                         <div class="fd-user-menu__header-container">
                             <div class="fd-user-menu__user-name">Lisa Miller</div>
                             <div class="fd-user-menu__subline">lisa.miller@test.com</div>
                             <div class="fd-user-menu__subline">User Experience Designer</div>
                             <div class="fd-user-menu__subline">Primary Employment</div>
+                        </div>
+                        <div class="fd-user-menu__header-content-area">
+                            <div
+                                role="note"
+                                aria-labelledby="message-strip-hidden-text-2 message-strip-text-2"
+                                class="fd-message-strip fd-message-strip--information"
+                            >
+                                <span class="fd-message-strip__sr-only" id="message-strip-hidden-text-2"
+                                    >Information Bar Closable</span
+                                >
+
+                                <div class="fd-message-strip__icon-container" aria-hidden="true">
+                                    <span
+                                        class="sap-icon sap-icon--message-information"
+                                        role="presentation"
+                                        aria-hidden="true"
+                                    ></span>
+                                </div>
+
+                                <p class="fd-message-strip__text" id="message-strip-text-2">
+                                    This is an information massage.
+                                </p>
+                            </div>
                         </div>
                         <button aria-label="Manage Account" class="fd-button">
                             <i class="sap-icon--user-settings"></i>
@@ -125,23 +172,43 @@
                         <div class="fd-panel fd-user-menu__panel" aria-labelledby="__panel-title-8" role="form">
                             <div class="fd-panel__header">
                                 <div class="fd-panel__expand">
-                                    <button class="fd-button fd-button--transparent fd-panel__button" aria-expanded="true"
-                                        aria-haspopup="true" aria-label="expand/collapse panel" aria-controls="__panel-8">
+                                    <button
+                                        class="fd-button fd-button--transparent fd-panel__button"
+                                        aria-expanded="true"
+                                        aria-haspopup="true"
+                                        aria-label="expand/collapse panel"
+                                        aria-controls="__panel-8"
+                                    >
                                         <i class="sap-icon--slim-arrow-down"></i>
                                     </button>
                                 </div>
                                 <h4 class="fd-panel__title" id="__panel-title-8">Accounts (3)</h4>
                                 <div class="fd-toolbar fd-toolbar--clear fd-toolbar--transparent">
                                     <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"> </span>
-                                    <button class="fd-button fd-button--transparent" aria-label="Add Account" title="Add Account">
+                                    <button
+                                        class="fd-button fd-button--transparent"
+                                        aria-label="Add Account"
+                                        title="Add Account"
+                                    >
                                         <i class="sap-icon--user-edit"></i>
                                     </button>
                                 </div>
                             </div>
-                            <div role="region" aria-labelledby="__panel-title-8" class="fd-panel__content fd-panel__content--no-padding" aria-hidden="false" id="__panel-8">
+                            <div
+                                role="region"
+                                aria-labelledby="__panel-title-8"
+                                class="fd-panel__content fd-panel__content--no-padding"
+                                aria-hidden="false"
+                                id="__panel-8"
+                            >
                                 <ul class="fd-list fd-list--subline" role="list">
                                     <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
-                                        <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_F3.png')" role="img" aria-label="Jane Doe"></span>
+                                        <span
+                                            class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--thumbnail"
+                                            style="background-image: url('/assets/images/portraits/L_80x80_F3.png')"
+                                            role="img"
+                                            aria-label="Jane Doe"
+                                        ></span>
                                         <div class="fd-list__content">
                                             <div class="fd-list__title">Lisa Miller Lorem</div>
                                             <div class="fd-list__subline">lisa.miller@test.com</div>
@@ -150,16 +217,25 @@
                                         <span class="fd-list__active-indicator sap-icon--sys-enter-2"></span>
                                     </li>
                                     <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
-                                        <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" role="img" aria-label="John Doe"></span>
+                                        <span
+                                            class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--thumbnail"
+                                            style="background-image: url('/assets/images/portraits/L_80x80_M1.png')"
+                                            role="img"
+                                            aria-label="John Doe"
+                                        ></span>
                                         <div class="fd-list__content">
                                             <div class="fd-list__title">John Doe</div>
                                             <div class="fd-list__subline">john.doe@test.com</div>
                                             <div class="fd-list__subline">Project Manager</div>
                                         </div>
-                                        
                                     </li>
                                     <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
-                                        <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-10" aria-role="img" aria-label="Jane Doe">JD</span>
+                                        <span
+                                            class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-10"
+                                            aria-role="img"
+                                            aria-label="Jane Doe"
+                                            >JD</span
+                                        >
                                         <div class="fd-list__content">
                                             <div class="fd-list__title">Jane Doe</div>
                                             <div class="fd-list__subline">jane.doe@test.com</div>
@@ -167,7 +243,6 @@
                                         </div>
                                     </li>
                                 </ul>
-                                
                             </div>
                         </div>
                         <nav class="fd-menu fd-menu--icons fd-user-menu__menu">
@@ -180,37 +255,52 @@
                                         <span class="fd-menu__title">Settings</span>
                                     </a>
                                 </li>
-    
+
                                 <li class="fd-menu__item" role="presentation">
                                     <span
                                         class="fd-menu__link has-child is-expanded"
                                         aria-controls="EX100M2B"
                                         aria-expanded="true"
                                         aria-haspopup="true"
-                                        role="menuitem">
-                                            <span class="fd-menu__addon-before">
-                                                <i class="sap-icon--card" role="presentation"></i>
-                                            </span>
-                                            <div class="fd-menu__content">
-                                                <span class="fd-menu__title">Menu Item Lorem ipsum dolor sit amet consectetur, adipisicing elit.</span>
-                                                <span class="fd-menu__subtitle">Sub-menu List Item Consectetur reprehenderit, cumque iusto molestiae doloribus assumenda omnis eveniet</span>
-                                            </div>
-                                            
-                                            <span class="fd-menu__addon-after fd-menu__addon-after--submenu"></span>
+                                        role="menuitem"
+                                    >
+                                        <span class="fd-menu__addon-before">
+                                            <i class="sap-icon--card" role="presentation"></i>
+                                        </span>
+                                        <div class="fd-menu__content">
+                                            <span class="fd-menu__title"
+                                                >Menu Item Lorem ipsum dolor sit amet consectetur, adipisicing
+                                                elit.</span
+                                            >
+                                            <span class="fd-menu__subtitle"
+                                                >Sub-menu List Item Consectetur reprehenderit, cumque iusto molestiae
+                                                doloribus assumenda omnis eveniet</span
+                                            >
+                                        </div>
+
+                                        <span class="fd-menu__addon-after fd-menu__addon-after--submenu"></span>
                                     </span>
-                                    
+
                                     <ul class="fd-menu__sublist" id="EX100M2B" aria-hidden="false" role="menu">
                                         <li class="fd-menu__item" role="presentation">
                                             <a class="fd-menu__link" href="#" role="menuitem">
                                                 <div class="fd-menu__content">
-                                                    <span class="fd-menu__title">Sub-menu Item 1 Consectetur reprehenderit, cumque iusto molestiae doloribus assumenda omnis eveniet</span>
+                                                    <span class="fd-menu__title"
+                                                        >Sub-menu Item 1 Consectetur reprehenderit, cumque iusto
+                                                        molestiae doloribus assumenda omnis eveniet</span
+                                                    >
                                                 </div>
-                                                <span class="fd-menu__addon-after fd-menu__addon-after--active"><i class="sap-icon--accept" role="presentation"></i></span>
+                                                <span class="fd-menu__addon-after fd-menu__addon-after--active"
+                                                    ><i class="sap-icon--accept" role="presentation"></i
+                                                ></span>
                                             </a>
                                         </li>
                                         <li class="fd-menu__item" role="presentation">
                                             <a class="fd-menu__link" href="#" role="menuitem">
-                                                <span class="fd-menu__title fd-menu__title--truncate">Sub-menu Item 2  Consectetur reprehenderit, cumque iusto molestiae doloribus assumenda omnis eveniet</span>
+                                                <span class="fd-menu__title fd-menu__title--truncate"
+                                                    >Sub-menu Item 2 Consectetur reprehenderit, cumque iusto molestiae
+                                                    doloribus assumenda omnis eveniet</span
+                                                >
                                             </a>
                                         </li>
                                     </ul>
@@ -222,12 +312,18 @@
                                             <i class="sap-icon--official-service" role="presentation"></i>
                                         </span>
                                         <div class="fd-menu__content">
-                                                <span class="fd-menu__title fd-menu__title--truncate">Menu Item Lorem ipsum dolor sit amet consectetur, adipisicing elit.</span>
-                                                <span class="fd-menu__subtitle  fd-menu__subtitle--truncate">Sub-menu List Item Consectetur reprehenderit, cumque iusto molestiae doloribus assumenda omnis eveniet</span>
+                                            <span class="fd-menu__title fd-menu__title--truncate"
+                                                >Menu Item Lorem ipsum dolor sit amet consectetur, adipisicing
+                                                elit.</span
+                                            >
+                                            <span class="fd-menu__subtitle fd-menu__subtitle--truncate"
+                                                >Sub-menu List Item Consectetur reprehenderit, cumque iusto molestiae
+                                                doloribus assumenda omnis eveniet</span
+                                            >
                                         </div>
                                     </a>
                                 </li>
-    
+
                                 <li class="fd-menu__item" role="presentation">
                                     <a class="fd-menu__link" href="#" role="menuitem">
                                         <span class="fd-menu__addon-before">
@@ -236,9 +332,8 @@
                                         <span class="fd-menu__title">About</span>
                                     </a>
                                 </li>
-                                
                             </ul>
-                        </nav>  
+                        </nav>
                     </div>
                 </div>
             </div>
@@ -256,7 +351,7 @@
     </div>
 </div>
 
-<div class="fddocs-container" style="margin-bottom: 1000px; flex-wrap: wrap; gap: 5rem;">
+<div class="fddocs-container" style="margin-bottom: 1000px; flex-wrap: wrap; gap: 5rem">
     <div class="fd-popover fd-popover--right fd-user-menu">
         <div class="fd-popover__body fd-popover__body--right" aria-hidden="false" id="userMenu1">
             <div class="fd-popover__wrapper fd-user-menu__popover-wrapper">
@@ -265,14 +360,31 @@
                         <span
                             class="fd-avatar fd-avatar--lg fd-avatar--circle fd-avatar--thumbnail"
                             aria-label="Avatar"
-                            style="background-image: url('/assets/images/portraits/L_80x80_F3.png');">
-                            <i class="fd-avatar__zoom-icon sap-icon--edit" aria-label="Edit" role="presentation" aria-hidden="true"></i>
+                            style="background-image: url('/assets/images/portraits/L_80x80_F3.png')"
+                        >
+                            <i
+                                class="fd-avatar__zoom-icon sap-icon--edit"
+                                aria-label="Edit"
+                                role="presentation"
+                                aria-hidden="true"
+                            ></i>
                         </span>
                         <div class="fd-user-menu__header-container">
-                            <div class="fd-user-menu__user-name">Lisa Miller Lorem ipsum dolor sit amet consectetur, adipisicing elit. Culpa consequuntur cum voluptate iure tenetu!</div>
-                            <div class="fd-user-menu__subline">lisa.miller@test.com Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptatem quod accusamus quis magnam, reprehenderit anim.</div>
-                            <div class="fd-user-menu__subline">A very long subline 2 that can be displayed by wrapping behaviour in the subtitle like this.</div>
-                            <div class="fd-user-menu__subline fd-user-menu__subline--truncate">A very long subline 3 that can be truncated with ellipsis</div>
+                            <div class="fd-user-menu__user-name">
+                                Lisa Miller Lorem ipsum dolor sit amet consectetur, adipisicing elit. Culpa consequuntur
+                                cum voluptate iure tenetu!
+                            </div>
+                            <div class="fd-user-menu__subline">
+                                lisa.miller@test.com Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptatem
+                                quod accusamus quis magnam, reprehenderit anim.
+                            </div>
+                            <div class="fd-user-menu__subline">
+                                A very long subline 2 that can be displayed by wrapping behaviour in the subtitle like
+                                this.
+                            </div>
+                            <div class="fd-user-menu__subline fd-user-menu__subline--truncate">
+                                A very long subline 3 that can be truncated with ellipsis
+                            </div>
                         </div>
                         <button aria-label="Manage Account" class="fd-button">
                             <i class="sap-icon--user-settings"></i>
@@ -283,41 +395,88 @@
                         <div class="fd-panel fd-user-menu__panel" aria-labelledby="__panel-title-8" role="form">
                             <div class="fd-panel__header">
                                 <div class="fd-panel__expand">
-                                    <button class="fd-button fd-button--transparent fd-panel__button" aria-expanded="true"
-                                        aria-haspopup="true" aria-label="expand/collapse panel" aria-controls="__panel-8">
+                                    <button
+                                        class="fd-button fd-button--transparent fd-panel__button"
+                                        aria-expanded="true"
+                                        aria-haspopup="true"
+                                        aria-label="expand/collapse panel"
+                                        aria-controls="__panel-8"
+                                    >
                                         <i class="sap-icon--slim-arrow-down"></i>
                                     </button>
                                 </div>
                                 <h4 class="fd-panel__title" id="__panel-title-8">Accounts (3)</h4>
                                 <div class="fd-toolbar fd-toolbar--clear fd-toolbar--transparent">
                                     <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"> </span>
-                                    <button class="fd-button fd-button--transparent" aria-label="Add Account" title="Add Account">
+                                    <button
+                                        class="fd-button fd-button--transparent"
+                                        aria-label="Add Account"
+                                        title="Add Account"
+                                    >
                                         <i class="sap-icon--user-edit"></i>
                                     </button>
                                 </div>
                             </div>
-                            <div role="region" aria-labelledby="__panel-title-8" class="fd-panel__content fd-panel__content--no-padding" aria-hidden="false" id="__panel-8">
+                            <div
+                                role="region"
+                                aria-labelledby="__panel-title-8"
+                                class="fd-panel__content fd-panel__content--no-padding"
+                                aria-hidden="false"
+                                id="__panel-8"
+                            >
                                 <ul class="fd-list fd-list--subline" role="list">
                                     <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
-                                        <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_F3.png')" role="img" aria-label="Jane Doe"></span>
+                                        <span
+                                            class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--thumbnail"
+                                            style="background-image: url('/assets/images/portraits/L_80x80_F3.png')"
+                                            role="img"
+                                            aria-label="Jane Doe"
+                                        ></span>
                                         <div class="fd-list__content">
-                                            <div class="fd-list__title">Lisa Miller Lorem, ipsum dolor sit amet consectetur adipisicing elit. Autem minima ex distinctio dolores vitae!</div>
-                                            <div class="fd-list__subline">lisa.miller@test.com Lorem, ipsum dolor sit amet consectetur adipisicing elit.</div>
-                                            <div class="fd-list__subline">Delivery Manager Lorem ipsum dolor sit amet consectetur adipisicing elit.</div>
+                                            <div class="fd-list__title">
+                                                Lisa Miller Lorem, ipsum dolor sit amet consectetur adipisicing elit.
+                                                Autem minima ex distinctio dolores vitae!
+                                            </div>
+                                            <div class="fd-list__subline">
+                                                lisa.miller@test.com Lorem, ipsum dolor sit amet consectetur adipisicing
+                                                elit.
+                                            </div>
+                                            <div class="fd-list__subline">
+                                                Delivery Manager Lorem ipsum dolor sit amet consectetur adipisicing
+                                                elit.
+                                            </div>
                                         </div>
                                         <span class="fd-list__active-indicator sap-icon--sys-enter-2"></span>
                                     </li>
                                     <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
-                                        <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--thumbnail" style="background-image: url('/assets/images/portraits/L_80x80_M1.png')" role="img" aria-label="John Doe"></span>
+                                        <span
+                                            class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--thumbnail"
+                                            style="background-image: url('/assets/images/portraits/L_80x80_M1.png')"
+                                            role="img"
+                                            aria-label="John Doe"
+                                        ></span>
                                         <div class="fd-list__content">
-                                            <div class="fd-list__title fd-list__title--truncate">John Doe Lorem, ipsum dolor sit amet consectetur adipisicing elit. Autem minima ex distinctio dolores vitae!</div>
-                                            <div class="fd-list__subline fd-list__subline--truncate">john.doe@test.com ipsum dolor sit amet consectetur adipisicing elit. Autem minima ex distinctio dolores vitae!</div>
-                                            <div class="fd-list__subline fd-list__subline--truncate">Project Manager ipsum dolor sit amet consectetur adipisicing elit. Autem minima ex distinctio dolores vitae!</div>
+                                            <div class="fd-list__title fd-list__title--truncate">
+                                                John Doe Lorem, ipsum dolor sit amet consectetur adipisicing elit. Autem
+                                                minima ex distinctio dolores vitae!
+                                            </div>
+                                            <div class="fd-list__subline fd-list__subline--truncate">
+                                                john.doe@test.com ipsum dolor sit amet consectetur adipisicing elit.
+                                                Autem minima ex distinctio dolores vitae!
+                                            </div>
+                                            <div class="fd-list__subline fd-list__subline--truncate">
+                                                Project Manager ipsum dolor sit amet consectetur adipisicing elit. Autem
+                                                minima ex distinctio dolores vitae!
+                                            </div>
                                         </div>
-                                        
                                     </li>
                                     <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
-                                        <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-10" aria-role="img" aria-label="Jane Doe">JD</span>
+                                        <span
+                                            class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-10"
+                                            aria-role="img"
+                                            aria-label="Jane Doe"
+                                            >JD</span
+                                        >
                                         <div class="fd-list__content">
                                             <div class="fd-list__title">Jane Doe</div>
                                             <div class="fd-list__subline">jane.doe@test.com</div>
@@ -325,7 +484,6 @@
                                         </div>
                                     </li>
                                 </ul>
-                                
                             </div>
                         </div>
                         <nav class="fd-menu fd-menu--icons fd-user-menu__menu">
@@ -338,18 +496,19 @@
                                         <span class="fd-menu__title">Settings</span>
                                     </a>
                                 </li>
-    
+
                                 <li class="fd-menu__item" role="presentation">
                                     <span
                                         class="fd-menu__link has-child"
                                         aria-expanded="false"
                                         aria-haspopup="true"
-                                        role="menuitem">
-                                            <span class="fd-menu__addon-before">
-                                                <i class="sap-icon--card" role="presentation"></i>
-                                            </span>
-                                            <span class="fd-menu__title">Menu Item</span>
-                                            <span class="fd-menu__addon-after fd-menu__addon-after--submenu"></span>
+                                        role="menuitem"
+                                    >
+                                        <span class="fd-menu__addon-before">
+                                            <i class="sap-icon--card" role="presentation"></i>
+                                        </span>
+                                        <span class="fd-menu__title">Menu Item</span>
+                                        <span class="fd-menu__addon-after fd-menu__addon-after--submenu"></span>
                                     </span>
                                 </li>
 
@@ -361,7 +520,7 @@
                                         <span class="fd-menu__title">Legal Information</span>
                                     </a>
                                 </li>
-    
+
                                 <li class="fd-menu__item" role="presentation">
                                     <a class="fd-menu__link" href="#" role="menuitem">
                                         <span class="fd-menu__addon-before">
@@ -370,9 +529,8 @@
                                         <span class="fd-menu__title">About</span>
                                     </a>
                                 </li>
-                                
                             </ul>
-                        </nav>  
+                        </nav>
                     </div>
                 </div>
             </div>

--- a/packages/styles/stories/Components/user-menu/user-menu.stories.js
+++ b/packages/styles/stories/Components/user-menu/user-menu.stories.js
@@ -20,6 +20,7 @@ import '../../../src/input-group.scss';
 import '../../../src/panel.scss';
 import '../../../src/toolbar.scss';
 import '../../../src/menu.scss';
+import '../../../src/message-strip.scss';
 
 export default {
   title: 'Components/User Menu',


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/6320

## Description
- a new class for the container `fd-user-menu__header-content-area`
- updated the examples to show a default container and also an example with Message Strip

## Screenshots
<img width="715" height="1141" alt="Screenshot 2026-06-01 at 4 37 48 PM" src="https://github.com/user-attachments/assets/bdef4fb3-a0ac-4862-9192-7d3552ede827" />
