### PR TITLE
fix(styles): prevent overflow content from pushing siblings outside container

### DIFF
--- a/docs/component-catalog.json
+++ b/docs/component-catalog.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "version": "0.41.7-rc.8",
+  "version": "0.41.7-rc.15",
   "description": "Machine-readable catalog of Fundamental Library Styles components",
   "generatedBy": "scripts/generate-ai-metadata.js",
   "relatedFiles": {
@@ -2284,7 +2284,6 @@
             "--fdCard_Footer_Border_Top",
             "--fdCard_Footer_Actions_Item_Spacing",
             "--fdCard_Title_Font_Size",
-            "--fdCard_Title_Font_Weight",
             "--fdCard_Counter_Margin",
             "--fdObjectStatus_Inverted_Border_Radius",
             "--fdObjectStatus_Inverted_Padding_Block",
@@ -13237,6 +13236,11 @@
             {
               "class": "fd-user-menu__subheader",
               "description": "subheader element",
+              "modifiers": []
+            },
+            {
+              "class": "fd-user-menu__header-content-area",
+              "description": "header-content-area element",
               "modifiers": []
             },
             {

--- a/docs/schemas/user-menu.schema.json
+++ b/docs/schemas/user-menu.schema.json
@@ -64,6 +64,16 @@
             }
           }
         },
+        "fd-user-menu__header-content-area": {
+          "type": "object",
+          "description": "header-content-area element",
+          "properties": {
+            "class": {
+              "const": "fd-user-menu__header-content-area",
+              "description": "Element class name"
+            }
+          }
+        },
         "fd-user-menu__user-name": {
           "type": "object",
           "description": "user-name element",

--- a/packages/styles/src/bar.scss
+++ b/packages/styles/src/bar.scss
@@ -55,11 +55,25 @@ $floating-footer: #{$fd-namespace}-bar--floating-footer;
       gap: 0.5rem;
     }
 
-    width: 100%;
-    max-width: 100%;
+    flex: 0 1 auto;
+    min-width: 0;
 
     &--stack-contents-vertically {
       flex-direction: column;
+    }
+
+    &:has(button, input) {
+      min-width: fit-content;
+    }
+
+    &:has(h1, h2, h3, h4, h5, h6) {
+      flex-shrink: 1;
+      min-width: 0;
+    }
+
+    &:only-child {
+      flex: 1 1 100%;
+      width: 100%;
     }
   }
 
@@ -126,7 +140,7 @@ $floating-footer: #{$fd-namespace}-bar--floating-footer;
     --fdBar_Shadow: none;
     --fdBar_Background: var(--sapPageFooter_Background);
     --fdBar_Element_Text_Color: var(--sapPageFooter_TextColor);
-    
+
     border-top: var(--sapGroup_TitleBorderWidth) solid var(--sapPageFooter_BorderColor);
   }
 

--- a/packages/styles/stories/Components/dialog/device-specifications.example.html
+++ b/packages/styles/stories/Components/dialog/device-specifications.example.html
@@ -1,22 +1,22 @@
-
 <h3>Tablet without mouse attached</h3>
 <div>Full Screen Button: visible (<code>sap-icon--full-screen</code>)</div>
 <div>Resize Handle: not visible</div>
-<br>
+<br />
 <div class="fd-dialog-docs-static fd-dialog fd-dialog--active">
-    <div 
-        class="fd-dialog__content fd-dialog__content--s" 
-        role="dialog" 
-        aria-modal="true" 
+    <div
+        class="fd-dialog__content fd-dialog__content--s"
+        role="dialog"
+        aria-modal="true"
         aria-labelledby="dialog-title-12"
         aria-describedby="dialog-description-12"
     >
-        
         <header class="fd-dialog__header fd-bar fd-bar--header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
                     <h2 class="fd-title fd-title--h5" id="dialog-title-12">
-                        Lorem ipsum
+                        Lorem ipsum lorem ipsum lorem ipsum ipsum lorem ipsum lorem ipsumipsum lorem ipsum lorem ipsum
+                        ipsum lorem ipsum lorem ipsum ipsum lorem ipsum lorem ipsum ipsum lorem ipsum lorem ipsum ipsum
+                        lorem ipsum lorem ipsum
                     </h2>
                 </div>
             </div>
@@ -44,22 +44,25 @@
             </div>
         </footer>
     </div>
-</div>  
+</div>
 
-<br><br>
+<br /><br />
 <h3>Tablet with mouse attached</h3>
 <div>Full Screen Button: visible (<code>sap-icon--full-screen</code>)</div>
 <div>Resize Handle: visible</div>
-<br>
+<br />
 <section class="fd-dialog-docs-static fd-dialog fd-dialog--active">
-    <div class="fd-dialog__content fd-dialog__content--s" role="dialog" aria-modal="true" aria-labelledby="dialog-title-6">
+    <div
+        class="fd-dialog__content fd-dialog__content--s"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="dialog-title-6"
+    >
         <span class="fd-dialog__resize-handle"></span>
         <header class="fd-dialog__header fd-bar fd-bar--header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5" id="dialog-title-6">
-                        Lorem ipsum
-                    </h2>
+                    <h2 class="fd-title fd-title--h5" id="dialog-title-6">Lorem ipsum</h2>
                 </div>
             </div>
             <div class="fd-bar__right">
@@ -84,22 +87,25 @@
             </div>
         </footer>
     </div>
-</section>    
+</section>
 
-<br><br>
+<br /><br />
 <h3>Hybrid device</h3>
 <div>Full Screen Button: visible (<code>sap-icon--full-screen</code>)</div>
 <div>Resize Handle: visible</div>
-<br>
+<br />
 <section class="fd-dialog-docs-static fd-dialog fd-dialog--active">
-    <div class="fd-dialog__content fd-dialog__content--s" role="dialog" aria-modal="true" aria-labelledby="dialog-title-6">
+    <div
+        class="fd-dialog__content fd-dialog__content--s"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="dialog-title-6"
+    >
         <span class="fd-dialog__resize-handle"></span>
         <header class="fd-dialog__header fd-bar fd-bar--header fd-bar--compact">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5" id="dialog-title-6">
-                        Lorem ipsum
-                    </h2>
+                    <h2 class="fd-title fd-title--h5" id="dialog-title-6">Lorem ipsum</h2>
                 </div>
             </div>
             <div class="fd-bar__right">
@@ -124,21 +130,24 @@
             </div>
         </footer>
     </div>
-</section>  
+</section>
 
-<br><br>
+<br /><br />
 <h3>Full screen</h3>
 <div>Full Screen Button: visible (<code>sap-icon--exitfullscreen</code>)</div>
 <div>Resize Handle: not visible</div>
-<br>
+<br />
 <section class="fd-dialog-docs-static fd-dialog fd-dialog--active">
-    <div class="fd-dialog__content fd-dialog__content--s  fd-dialog__content--mobile" role="dialog" aria-modal="true" aria-labelledby="dialog-title-6">
+    <div
+        class="fd-dialog__content fd-dialog__content--s fd-dialog__content--mobile"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="dialog-title-6"
+    >
         <header class="fd-dialog__header fd-bar fd-bar--header">
             <div class="fd-bar__left">
                 <div class="fd-bar__element">
-                    <h2 class="fd-title fd-title--h5" id="dialog-title-6">
-                        Lorem ipsum
-                    </h2>
+                    <h2 class="fd-title fd-title--h5" id="dialog-title-6">Lorem ipsum</h2>
                 </div>
             </div>
             <div class="fd-bar__right">
@@ -163,4 +172,4 @@
             </div>
         </footer>
     </div>
-</section>  
+</section>


### PR DESCRIPTION
## Related Issue
Closes none

## Description
### Problem
- When `fd-bar__left` or `fd-bar__right` contained long text, the flex layout would push the other section out of view
- Previous implementation used `width: 100%` on all sections, causing each to demand full container width
- Buttons and icons would overlap with padding or disappear entirely

### Solution
- Changed sections to use `flex: 0 1 auto` (don't grow by default, can shrink, start at content size)
- Removed `flex-grow: 1` from all sections to prevent equal distribution
- Added `min-width: 0` to allow proper shrinking and text overflow
- Elements containing headings (`h1-h6`) can shrink with `flex-shrink: 1` and `min-width: 0`
- Buttons have min-width set to the button height

## Screenshots
In dialog component

### Before:
<img width="597" height="181" alt="Screenshot 2026-06-02 at 2 04 04 PM" src="https://github.com/user-attachments/assets/7cc6c384-e503-4ee4-bff7-bbbe6ff550e4" />

### After:
<img width="467" height="167" alt="Screenshot 2026-06-02 at 1 48 06 PM" src="https://github.com/user-attachments/assets/8474fd60-4f3e-4a00-a0f6-6d8520901806" />
