### PR TITLE
fix(styles): replace outline with fake focus in Input Group [ci visual]

### DIFF
--- a/packages/styles/src/input-group.scss
+++ b/packages/styles/src/input-group.scss
@@ -29,11 +29,38 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
   --fdInput_Height: 100%;
   --fdInput_Compact_Height: 100%;
 
+  &.is-focus,
   &:has(input:is(:focus)) {
-    background: var(--sapField_Focus_Background);
-    outline: var(--fdInput_Outline_Color) var(--sapContent_FocusStyle) var(--sapContent_FocusWidth);
-    outline-offset: var(--fdInput_Outline_Offset);
+    outline: none;
     box-shadow: none;
+    position: relative;
+    background: var(--sapField_Focus_Background);
+
+    &::after {
+      content: "";
+      position: absolute;
+      pointer-events: none;
+      inset: var(--fdInputGroup_Outline_Offset);
+      border-radius: var(--fdInput_Outline_Border_Radius);
+      border: var(--fdInput_Outline_Color) var(--sapContent_FocusStyle) var(--sapContent_FocusWidth);
+    }
+
+    &.is-success {
+      --fdInput_Outline_Color: var(--fdInput_Success_Outline_Color);
+    }
+
+    &.is-alert,
+    &.is-warning {
+      --fdInput_Outline_Color: var(--fdInput_Warning_Outline_Color);
+    }
+
+    &.is-error {
+      --fdInput_Outline_Color: var(--fdInput_Error_Outline_Color);
+    }
+
+    &.is-information {
+     --fdInput_Outline_Color: var(--fdInput_Information_Outline_Color);
+    }
   }
 
   .#{$block}__input {
@@ -148,6 +175,10 @@ $fd-input-border-radius: var(--sapField_BorderCornerRadius);
   &[readonly],
   &.is-readonly {
     overflow: visible;
+    
+    .#{$block}__addon {
+      overflow: hidden;
+    }
   }
 
   &--display,

--- a/packages/styles/src/theming/common/input-group/_sap_horizon.scss
+++ b/packages/styles/src/theming/common/input-group/_sap_horizon.scss
@@ -18,5 +18,5 @@
   --fdInput_Group_Button_Information_Active_Text_Color: var(--sapButton_Selected_TextColor);
   --fdInput_Group_Button_Information_Active_Box_Shadow: var(--sapContent_Informative_Shadow);
   --fdInput_Outline_Offset_Focus_Within: -0.125rem;
-  --fdInput_Outline_Border_Radius: 0.2rem;
+  --fdInput_Outline_Border_Radius: var(--sapField_BorderCornerRadius);
 }

--- a/packages/styles/src/theming/sap_fiori_3.scss
+++ b/packages/styles/src/theming/sap_fiori_3.scss
@@ -107,6 +107,7 @@
   --fdInputGroup_Text_Shadow: none;
   --fdInputGroup_ControlButton_SideBorder: var(--sapButton_BorderWidth) solid transparent;
   --fdInputGroup_ControlButton_SideBorder_Active: solid var(--sapButton_BorderWidth) transparent;
+  --fdInputGroup_Outline_Offset: 0.0625rem;
 
   /* Input */
   --fdInput_Text_Shadow: none;

--- a/packages/styles/src/theming/sap_fiori_3_dark.scss
+++ b/packages/styles/src/theming/sap_fiori_3_dark.scss
@@ -113,6 +113,7 @@
   --fdInputGroup_Text_Shadow: none;
   --fdInputGroup_ControlButton_SideBorder: var(--sapButton_BorderWidth) solid transparent;
   --fdInputGroup_ControlButton_SideBorder_Active: solid var(--sapButton_BorderWidth) transparent;
+  --fdInputGroup_Outline_Offset: 0.0625rem;
 
   /* Input */
   --fdInput_Text_Shadow: none;

--- a/packages/styles/src/theming/sap_fiori_3_hcb.scss
+++ b/packages/styles/src/theming/sap_fiori_3_hcb.scss
@@ -119,6 +119,7 @@
   --fdInputGroup_Text_Shadow: 0 0 0.125rem #000;
   --fdInputGroup_ControlButton_SideBorder: var(--sapField_BorderWidth) solid transparent;
   --fdInputGroup_ControlButton_SideBorder_Active: solid var(--sapField_BorderWidth) var(--sapList_SelectionBorderColor);
+  --fdInputGroup_Outline_Offset: 0.0625rem;
 
   /* Input */
   --fdInput_Text_Shadow: 0 0 0.125rem #000;

--- a/packages/styles/src/theming/sap_fiori_3_hcw.scss
+++ b/packages/styles/src/theming/sap_fiori_3_hcw.scss
@@ -115,6 +115,7 @@
   --fdInputGroup_Text_Shadow: none;
   --fdInputGroup_ControlButton_SideBorder: var(--sapField_BorderWidth) solid transparent;
   --fdInputGroup_ControlButton_SideBorder_Active: solid var(--sapField_BorderWidth) var(--sapList_SelectionBorderColor);
+  --fdInputGroup_Outline_Offset: 0.0625rem;
 
   /* Input */
   --fdInput_Text_Shadow: none;

--- a/packages/styles/src/theming/sap_fiori_3_light_dark.scss
+++ b/packages/styles/src/theming/sap_fiori_3_light_dark.scss
@@ -111,6 +111,7 @@
   --fdInputGroup_Text_Shadow: none;
   --fdInputGroup_ControlButton_SideBorder: var(--sapButton_BorderWidth) solid transparent;
   --fdInputGroup_ControlButton_SideBorder_Active: solid var(--sapButton_BorderWidth) transparent;
+  --fdInputGroup_Outline_Offset: 0.0625rem;
 
   /* Input */
   --fdInput_Text_Shadow: none;

--- a/packages/styles/src/theming/sap_horizon.scss
+++ b/packages/styles/src/theming/sap_horizon.scss
@@ -112,6 +112,7 @@
   --fdInputGroup_Text_Shadow: none;
   --fdInputGroup_ControlButton_SideBorder: var(--sapButton_BorderWidth) solid transparent;
   --fdInputGroup_ControlButton_SideBorder_Active: solid var(--sapButton_BorderWidth) transparent;
+  --fdInputGroup_Outline_Offset: 0;
 
   /* Input */
   --fdInput_Text_Shadow: none;

--- a/packages/styles/src/theming/sap_horizon_dark.scss
+++ b/packages/styles/src/theming/sap_horizon_dark.scss
@@ -125,6 +125,7 @@
   --fdInputGroup_Text_Shadow: none;
   --fdInputGroup_ControlButton_SideBorder: var(--sapButton_BorderWidth) solid transparent;
   --fdInputGroup_ControlButton_SideBorder_Active: solid var(--sapButton_BorderWidth) transparent;
+   --fdInputGroup_Outline_Offset: 0;
 
   /* Input */
   --fdInput_Text_Shadow: none;

--- a/packages/styles/src/theming/sap_horizon_hcb.scss
+++ b/packages/styles/src/theming/sap_horizon_hcb.scss
@@ -113,6 +113,7 @@
   --fdInputGroup_Text_Shadow: none;
   --fdInputGroup_ControlButton_SideBorder: var(--sapField_BorderWidth) solid transparent;
   --fdInputGroup_ControlButton_SideBorder_Active: solid var(--sapField_BorderWidth) var(--sapList_SelectionBorderColor);
+  --fdInputGroup_Outline_Offset: 0.0625rem;
 
   /* Input */
   --fdInput_Text_Shadow: none;

--- a/packages/styles/src/theming/sap_horizon_hcw.scss
+++ b/packages/styles/src/theming/sap_horizon_hcw.scss
@@ -114,6 +114,7 @@
   --fdInputGroup_Text_Shadow: none;
   --fdInputGroup_ControlButton_SideBorder: var(--sapField_BorderWidth) solid transparent;
   --fdInputGroup_ControlButton_SideBorder_Active: solid var(--sapField_BorderWidth) var(--sapList_SelectionBorderColor);
+  --fdInputGroup_Outline_Offset: 0.0625rem;
 
   /* Input */
   --fdInput_Text_Shadow: none;


### PR DESCRIPTION
## Related Issue
Closes https://github.com/SAP/fundamental-styles/issues/6346

## Description
The focus outline in Input Group was hidden under the addon buttons which created a11y concerns. There is no way to add z-index on the outline and the solution was to create a fake focus with `::after`, a practice we used in the past to deal with focus border radius. 
While testing in HC themes noticed a bug in read-only mode and fixed that as well.

## Screenshots
### Before:
<img width="1029" height="92" alt="Screenshot 2026-06-26 at 12 52 54 PM" src="https://github.com/user-attachments/assets/1621d838-d1ef-4b62-99cb-e7c31768f2be" />
<img width="1028" height="73" alt="Screenshot 2026-06-26 at 12 52 59 PM" src="https://github.com/user-attachments/assets/830d04f3-ca38-4658-abd7-437d1ab16157" />


### After:

<img width="1134" height="500" alt="Screenshot 2026-06-26 at 12 47 47 PM" src="https://github.com/user-attachments/assets/80aaaf2b-bcd9-490a-aae9-bd65fed57055" />
<img width="1093" height="478" alt="Screenshot 2026-06-26 at 12 47 52 PM" src="https://github.com/user-attachments/assets/57a8c002-e92c-4898-9bd6-772ed12c3982" />

### Before:
<img width="1092" height="671" alt="Screenshot 2026-06-26 at 12 55 07 PM" src="https://github.com/user-attachments/assets/65c9a395-4a44-45a6-a1a7-8bcdfe1d401d" />


### After:

<img width="1127" height="679" alt="Screenshot 2026-06-26 at 12 47 59 PM" src="https://github.com/user-attachments/assets/f4ef6ce7-d723-4759-ab6d-9f02b722b67d" />

### Before:
We were relying on `is-focus` class to apply the correct focus color and type, but for the states, when you click on the input the wrong focus was applied (all fields get blue focus. See the example bellow called "Focus" for the correct ones)
<img width="1091" height="685" alt="Screenshot 2026-06-26 at 12 56 18 PM" src="https://github.com/user-attachments/assets/fa65b916-6f40-47d8-9266-315c592e40e9" />


### After:
<img width="1116" height="679" alt="Screenshot 2026-06-26 at 1 03 34 PM" src="https://github.com/user-attachments/assets/4d447f03-bd0a-4a66-8d53-ad942e431db6" />

