### PR TITLE
fix(styles): ACC-282.1 (Level AA) Section headers truncated at 320px viewport width

### DIFF
--- a/packages/styles/src/panel.scss
+++ b/packages/styles/src/panel.scss
@@ -31,7 +31,6 @@ $block: #{$fd-namespace}-panel;
     border-bottom: var(--sapGroup_TitleBorderWidth) solid var(--fdPanel_Header_Border_Color, var(--sapGroup_TitleBorderColor));
     width: var(--fdPanel_Header_Width);
     min-width: var(--fdPanel_Header_Width);
-    height: var(--fdPanel_Header_Height);
     min-height: var(--fdPanel_Header_Height);
     top: var(--fdPanel_Header_Position_Top, unset);
     background-color: var(--sapGroup_TitleBackground);
@@ -55,7 +54,6 @@ $block: #{$fd-namespace}-panel;
 
   &__title {
     @include fd-typography(var(--sapGroup_Title_FontSize));
-    @include fd-ellipsis();
 
     flex: 1;
     width: 100%;

--- a/packages/styles/src/panel.scss
+++ b/packages/styles/src/panel.scss
@@ -54,12 +54,17 @@ $block: #{$fd-namespace}-panel;
 
   &__title {
     @include fd-typography(var(--sapGroup_Title_FontSize));
+    @include fd-ellipsis();
 
     flex: 1;
     width: 100%;
     max-width: 100%;
     font-size: var(--fdPanel_Title_Font_Size);
     padding-inline-start: 0.25rem;
+
+    &--wrap {
+      @include fd-wrap();
+    }
   }
 
   &__content {

--- a/packages/styles/stories/Components/panel/borderless.example.html
+++ b/packages/styles/stories/Components/panel/borderless.example.html
@@ -6,7 +6,7 @@
                 <i class="sap-icon--slim-arrow-right"></i>
             </button>
         </div>
-        <h4 class="fd-panel__title" id="__panel-title-1">Panel header collapsed</h4>
+        <h4 class="fd-panel__title fd-panel__title--wrap" id="__panel-title-1">Panel header collapsed</h4>
         <div class="fd-toolbar fd-toolbar--clear fd-toolbar--transparent">
             <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"> </span>
             <div class="fd-segmented-button" role="group" aria-label="Group label">
@@ -39,7 +39,7 @@
                 <i class="sap-icon--slim-arrow-down"></i>
             </button>
         </div>
-        <h4 class="fd-panel__title" id="__panel-title-2">Panel header expanded</h4>
+        <h4 class="fd-panel__title fd-panel__title--wrap" id="__panel-title-2">Panel header expanded</h4>
     </div>
     <div role="region" aria-labelledby="__panel-title-2" class="fd-panel__content" aria-hidden="false" id="__panel-2">
         <span>
@@ -58,7 +58,7 @@
 
 <div class="fd-panel fd-panel--fixed fd-panel--borderless" aria-labelledby="__panel-title-3" role="form">
     <div class="fd-panel__header">
-        <h4 class="fd-panel__title" id="__panel-title-3">Panel header</h4>
+        <h4 class="fd-panel__title fd-panel__title--wrap" id="__panel-title-3">Panel header</h4>
         <div class="fd-toolbar fd-toolbar--clear fd-toolbar--transparent">
             <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"></span>
             <div class="fd-segmented-button" role="group" aria-label="Group label">

--- a/packages/styles/stories/Components/panel/expandable.example.html
+++ b/packages/styles/stories/Components/panel/expandable.example.html
@@ -6,7 +6,7 @@
                 <i class="sap-icon--slim-arrow-right"></i>
             </button>
         </div>
-        <h4 class="fd-panel__title" id="__panel-title-7">Panel header collapsed</h4>
+        <h4 class="fd-panel__title fd-panel__title--wrap" id="__panel-title-7">Panel header collapsed</h4>
         <div class="fd-toolbar fd-toolbar--clear fd-toolbar--transparent">
             <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"> </span>
             <div class="fd-segmented-button" role="group" aria-label="Group label">
@@ -37,7 +37,7 @@
                 <i class="sap-icon--slim-arrow-down"></i>
             </button>
         </div>
-        <h4 class="fd-panel__title" id="__panel-title-8">Panel header expanded</h4>
+        <h4 class="fd-panel__title fd-panel__title--wrap" id="__panel-title-8">Panel header expanded</h4>
     </div>
     <div role="region" aria-labelledby="__panel-title-8" class="fd-panel__content" aria-hidden="false" id="__panel-8">
         <span>

--- a/packages/styles/stories/Components/panel/fixed-height-content.example.html
+++ b/packages/styles/stories/Components/panel/fixed-height-content.example.html
@@ -6,7 +6,7 @@
                 <i class="sap-icon--slim-arrow-down"></i>
             </button>
         </div>
-        <h4 class="fd-panel__title" id="__panel-title-fixed">Panel header expanded</h4>
+        <h4 class="fd-panel__title fd-panel__title--wrap" id="__panel-title-fixed">Panel header expanded</h4>
     </div>
     <div role="region" aria-labelledby="__panel-title-fixed" class="fd-panel__content" aria-hidden="false" id="__panel-fixed" style="height: 150px;">
         <span>

--- a/packages/styles/stories/Components/panel/fixed.example.html
+++ b/packages/styles/stories/Components/panel/fixed.example.html
@@ -1,6 +1,6 @@
 <div class="fd-panel" aria-labelledby="__panel-title-6" role="form">
     <div class="fd-panel__header">
-        <h4 class="fd-panel__title" id="__panel-title-6">Panel header</h4>
+        <h4 class="fd-panel__title" id="__panel-title-6">Panel header with a long title that reflows at narrow viewports (320px)</h4>
         <div class="fd-toolbar fd-toolbar--clear fd-toolbar--transparent">
             <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"> </span>
             <div class="fd-segmented-button" role="group" aria-label="Group label">

--- a/packages/styles/stories/Components/panel/fixed.example.html
+++ b/packages/styles/stories/Components/panel/fixed.example.html
@@ -1,6 +1,6 @@
 <div class="fd-panel" aria-labelledby="__panel-title-6" role="form">
     <div class="fd-panel__header">
-        <h4 class="fd-panel__title" id="__panel-title-6">Panel header with a long title that reflows at narrow viewports (320px)</h4>
+        <h4 class="fd-panel__title fd-panel__title--wrap" id="__panel-title-6">Panel header with a long title that reflows at narrow viewports (320px)</h4>
         <div class="fd-toolbar fd-toolbar--clear fd-toolbar--transparent">
             <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"> </span>
             <div class="fd-segmented-button" role="group" aria-label="Group label">

--- a/packages/styles/stories/Components/panel/panel.stories.js
+++ b/packages/styles/stories/Components/panel/panel.stories.js
@@ -32,6 +32,9 @@ The panel is a container for grouping and displaying information. Panels are res
 ##Types
 There are two types of panels: fixed and expandable.
 
+##Title wrapping
+By default, the panel title truncates with an ellipsis when it exceeds the available width. To allow the title to wrap onto multiple lines instead — for example, to comply with WCAG 1.4.10 (Reflow) at narrow viewports — add the \`.fd-panel__title--wrap\` modifier class to the \`.fd-panel__title\` element.
+
   `
   }
 };

--- a/packages/styles/stories/Components/panel/sticky-header.example.html
+++ b/packages/styles/stories/Components/panel/sticky-header.example.html
@@ -7,7 +7,7 @@
                     <i class="sap-icon--slim-arrow-down"></i>
                 </button>
             </div>
-            <h4 class="fd-panel__title" id="__panel-title-sticky">Panel sticky header</h4>
+            <h4 class="fd-panel__title fd-panel__title--wrap" id="__panel-title-sticky">Panel sticky header</h4>
         </div>
         <div role="region" aria-labelledby="__panel-title-sticky" class="fd-panel__content" aria-hidden="false" id="__panel-sticky">
             <span>

--- a/packages/styles/stories/Components/panel/transparent.example.html
+++ b/packages/styles/stories/Components/panel/transparent.example.html
@@ -6,7 +6,7 @@
                 <i class="sap-icon--slim-arrow-down"></i>
             </button>
         </div>
-        <h4 class="fd-panel__title" id="__panel-title-4">Panel header expanded</h4>
+        <h4 class="fd-panel__title fd-panel__title--wrap" id="__panel-title-4">Panel header expanded</h4>
     </div>
     <div role="region" aria-labelledby="__panel-title-4" class="fd-panel__content" aria-hidden="false" id="__panel-4">
         <span>
@@ -25,7 +25,7 @@
 
 <div class="fd-panel fd-panel--transparent" aria-labelledby="__panel-title-5" role="form">
     <div class="fd-panel__header">
-        <h4 class="fd-panel__title" id="__panel-title-5">Panel header</h4>
+        <h4 class="fd-panel__title fd-panel__title--wrap" id="__panel-title-5">Panel header</h4>
         <div class="fd-toolbar fd-toolbar--clear fd-toolbar--transparent">
             <span class="fd-toolbar__spacer fd-toolbar__spacer--auto"> </span>
             <div class="fd-segmented-button" role="group" aria-label="Group label">


### PR DESCRIPTION
## Related Issue
Closes [SAP/fundamental-styles#](https://github.com/SAP/fundamental-styles/issues/6348)

## Description
**panel.scss** 
- removed `height: var(--fdPanel_Header_Height)`, keeping only `min-height` so the header can grow taller when the title wraps.
-  Added title wrapping
By default, the panel title truncates with an ellipsis when it exceeds the available width. To allow the title to wrap onto multiple lines instead — for example, to comply with WCAG 1.4.10 (Reflow) at narrow viewports — add the `fd-panel__title--wrap` modifier class to the `fd-panel__title` element.

**fixed.example.html**
- updated the story title to a longer string so the reflow behavior is visible at 320px without needing to modify the HTML manually.

## Screenshots
<img width="418" height="548" alt="Screenshot 2026-07-01 at 15 52 36" src="https://github.com/user-attachments/assets/e2438592-e0d1-4fb1-a8c1-7ee74649a372" />
