### PR TITLE
fix: Build Failure: `Maximum call stack size exceeded` in `yarn run build:visual-stories`

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -34,7 +34,7 @@
             "fundamental-styles/storybook": ["packages/storybook/src/index.ts"],
             "fundamental-styles/storybook/current-package": ["packages/storybook/src/lib/addons/current-package"],
             "fundamental-styles/utils": ["packages/utils/src/index.ts"],
-            "styles": ["packages/styles", "packages/styles/index.ts"],
+            "styles": ["packages/styles/index.ts"],
             "theming-preview": ["packages/theming-preview/src/index.js"],
             "workspace-plugins": ["packages/workspace-plugins/src/index.ts"],
             "@fundamental-styles/mcp": ["packages/mcp/src/index.ts"]
@@ -46,7 +46,8 @@
         "compilerOptions": {
             "module": "CommonJS"
         },
-        "transpileOnly": true
+        "transpileOnly": true,
+        "ignore": ["(?:^|/)node_modules/", "(?:^|/)\\.nx/"]
     },
     "exclude": ["node_modules", "tmp"]
 }


### PR DESCRIPTION
## Related Issue
none

## Description
Running `yarn start` (or `yarn run build:visual-stories` directly) failed with:

```
RangeError: Maximum call stack size exceeded
    at visitor (typescript.js:98493:19)
    at visitEachChildOfBinaryExpression (typescript.js:95999:26)
    at visitEachChild (typescript.js:95515:33)
    at visitTypeScript (typescript.js:98761:16)
    ...
```

## Root Cause

Two separate issues combined to produce the error.

### Issue 1 — ts-node compiles the nx cloud update bundle

nx downloads a versioned cloud client bundle to `.nx/cache/cloud/<version>/index.js` and `require()`s it at runtime. This bundle is **5 MB of obfuscated JavaScript**.

When ts-node is registered as a global `require()` hook (which nx does for local TypeScript plugins), it intercepts all file loads — including `.js` files — because `tsconfig.base.json` has `"allowJs": true`. Feeding 5 MB of deeply nested minified code through TypeScript's transformation pipeline causes the recursive `visitEachChildOfBinaryExpression` visitor to overflow the call stack.

The bundle path `.nx/cache/cloud/` is not covered by ts-node's default ignore pattern (`node_modules/` only), so ts-node attempts to compile it.

**This problem surfaced in early August 2026** when nx downloaded a new cloud client bundle (`2608.07.0038`). It is unrelated to any project source changes.

### Issue 2 — `tsconfig.base.json` has a malformed SWC path alias

```json
"styles": ["packages/styles", "packages/styles/index.ts"]
```

SWC requires non-wildcard path aliases to have **exactly one** entry. Having two entries causes a Rust-level panic:

```
thread '<unnamed>' panicked at swc_ecma_loader/src/resolvers/tsc.rs:82:21:
assertion `left == right` failed: value of `paths.styles` should be an array
with one element because the src path does not contains * (wildcard)
  left: 2
 right: 1
```

This was hit during investigation when `@swc-node/register` was temporarily installed. That package was reverted, so the panic is not currently reachable. The path alias entry was corrected anyway since the configuration was malformed.

## Fix

Two changes to `tsconfig.base.json`, no new dependencies required.

### 1. Add `.nx/` to ts-node's ignore list

```json
"ts-node": {
    "require": ["tsconfig-paths/register"],
    "compilerOptions": {
        "module": "CommonJS"
    },
    "transpileOnly": true,
    "ignore": ["(?:^|/)node_modules/", "(?:^|/)\\.nx/"]
}
```

This tells ts-node to skip any file under `.nx/`, letting Node load the cloud bundle with its default JS handler as intended.

### 2. Fix the `styles` path alias to a single entry

```json
"styles": ["packages/styles/index.ts"]
```

`packages/styles/index.ts` is the correct canonical entry point. The redundant `packages/styles` directory entry was removed.

## Why the project appeared to work before August 2026

- The nx cloud bundle at `.nx/cache/cloud/` was only downloaded in early August 2026. Before that file existed, there was nothing in `.nx/` for ts-node to intercept.
- The `styles` path alias issue was always latent but only triggered when SWC is the active transpiler.
