### PR TITLE
feat(styles): new truncation rules for standard and byline lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,19 +271,20 @@ git clone https://github.com/SAP/fundamental-styles.git
 cd fundamental-styles
 
 # Install dependencies
-npm install
+yarn install
 
 # Start development server
-npm start
+yarn start
 
 # Start with production build
-npm run start:prod
+yarn run start:prod
 ```
 
 ### ⚙️ Prerequisites
 
 - Git
-- [Node.js LTS](https://nodejs.org/)
+- [Node.js](https://nodejs.org/) v24.11.1 (see `.nvmrc` — run `nvm use` to switch automatically)
+- [Yarn](https://yarnpkg.com/)
 
 ### 🤝 Contributing
 

--- a/packages/styles/src/mixins/list/_list-base.scss
+++ b/packages/styles/src/mixins/list/_list-base.scss
@@ -326,17 +326,12 @@
     .#{$block}__item {
       height: auto;
       min-height: var(--fdList_Item_Height);
-      align-items: flex-start;
-      padding-block: 0.75rem;
+      align-items: center;
     }
 
-    // __link is the visual content container (height: 100%; padding-block: 0 by default);
-    // padding set on the item is not visible — reset it and move it onto __link instead.
+    // __link has height: 100% by default; override to let it grow with content.
     .#{$block}__item--link {
-      padding-block: 0;
-
       .#{$block}__link {
-        padding-block: 0.75rem;
         height: auto;
       }
     }
@@ -346,9 +341,10 @@
       @include fd-wrap();
     }
 
-    // Counter and icon never wrap; keep them centered so they don't sit at the top of a tall item.
+    // Counter, icon and button never wrap; keep them centered so they don't sit at the top of a tall item.
     .#{$block}__item-counter,
-    .#{$block}__icon {
+    .#{$block}__icon,
+    .#{$block}__button {
       align-self: center;
     }
   }
@@ -356,27 +352,23 @@
   &__item--wrap {
     height: auto;
     min-height: var(--fdList_Item_Height);
-    align-items: flex-start;
-    padding-block: 0.75rem;
+    align-items: center;
 
     .#{$block}__title,
     .#{$block}__secondary {
       @include fd-wrap();
     }
 
-    // Counter and icon never wrap; keep them centered so they don't sit at the top of a tall item.
+    // Counter, icon and button never wrap; keep them centered so they don't sit at the top of a tall item.
     .#{$block}__item-counter,
-    .#{$block}__icon {
+    .#{$block}__icon,
+    .#{$block}__button {
       align-self: center;
     }
 
-    // __link is the visual content container (height: 100%; padding-block: 0 by default);
-    // padding set on the item is not visible — reset it and move it onto __link instead.
+    // __link has height: 100% by default; override to let it grow with content.
     &.#{$block}__item--link {
-      padding-block: 0;
-
       .#{$block}__link {
-        padding-block: 0.75rem;
         height: auto;
       }
     }
@@ -385,8 +377,7 @@
   &__item:has(.#{$block}__title--wrap, .#{$block}__secondary--wrap) {
     height: auto;
     min-height: var(--fdList_Item_Height);
-    align-items: flex-start;
-    padding-block: 0.75rem;
+    align-items: center;
 
     // Secondary without --wrap is a short fixed-height label; keep it centered
     // rather than top-aligned so it visually aligns with the content, not just the first line.
@@ -394,20 +385,43 @@
       align-self: center;
     }
 
-    // Counter and icon never wrap; keep them centered so they don't sit at the top of a tall item.
+    // Counter, icon and button never wrap; keep them centered so they don't sit at the top of a tall item.
     .#{$block}__item-counter,
-    .#{$block}__icon {
+    .#{$block}__icon,
+    .#{$block}__button {
       align-self: center;
     }
 
-    // __link is the visual content container (height: 100%; padding-block: 0 by default);
-    // padding set on the item is not visible — reset it and move it onto __link instead.
+    // __link has height: 100% by default; override to let it grow with content.
     &.#{$block}__item--link {
-      padding-block: 0;
-
       .#{$block}__link {
-        padding-block: 0.75rem;
         height: auto;
+      }
+    }
+  }
+
+  // Vertical breathing room for wrapped text in standard (non-byline) lists. In byline lists
+  // __title lives inside __content (a flex column), so margin-block would shift the title
+  // down within that column and break alignment with the sibling icon.
+  &--wrap:not(.#{$block}--byline) {
+    .#{$block}__title,
+    .#{$block}__secondary {
+      margin-block: 0.75rem;
+    }
+  }
+
+  &:not(.#{$block}--byline) {
+    .#{$block}__item--wrap {
+      .#{$block}__title,
+      .#{$block}__secondary {
+        margin-block: 0.75rem;
+      }
+    }
+
+    .#{$block}__item:has(.#{$block}__title--wrap, .#{$block}__secondary--wrap) {
+      .#{$block}__title--wrap,
+      .#{$block}__secondary--wrap {
+        margin-block: 0.75rem;
       }
     }
   }

--- a/packages/styles/src/mixins/list/_list-base.scss
+++ b/packages/styles/src/mixins/list/_list-base.scss
@@ -143,6 +143,11 @@
     font-size: var(--fdList_Item_Text_Font_Size);
     min-height: var(--fdList_Item_Text_Font_Size);
 
+    &--wrap {
+      white-space: normal;
+      overflow: visible;
+    }
+
     &:last-child:first-child {
       flex-basis: auto;
     }
@@ -162,6 +167,11 @@
     font-size: var(--sapFontSize);
     color: var(--fdList_Status_Text_Color);
     padding-inline-start: 1rem;
+
+    &--wrap {
+      white-space: normal;
+      overflow: visible;
+    }
 
     &--positive {
       --fdList_Status_Text_Color: var(--sapPositiveTextColor);
@@ -232,6 +242,11 @@
       font-size: var(--sapFontHeader6Size);
       font-family: var(--sapFontHeaderFamily);
       color: var(--sapList_TableGroupHeaderTextColor);
+
+      &--wrap {
+        white-space: normal;
+        overflow: visible;
+      }
     }
   }
 
@@ -307,6 +322,35 @@
           height: var(--fdList_Item_Action_Button_Size_Compact);
         }
       }
+    }
+  }
+
+  &--wrap {
+    .#{$block}__item {
+      height: auto;
+      min-height: var(--fdList_Item_Height);
+      align-items: flex-start;
+      padding-block: 0.75rem;
+    }
+
+    .#{$block}__title,
+    .#{$block}__secondary {
+      white-space: normal;
+      overflow: visible;
+    }
+  }
+
+  &__item--wrap,
+  &__item:has(.#{$block}__title--wrap, .#{$block}__secondary--wrap) {
+    height: auto;
+    min-height: var(--fdList_Item_Height);
+    align-items: flex-start;
+    padding-block: 0.75rem;
+
+    .#{$block}__title,
+    .#{$block}__secondary {
+      white-space: normal;
+      overflow: visible;
     }
   }
 

--- a/packages/styles/src/mixins/list/_list-base.scss
+++ b/packages/styles/src/mixins/list/_list-base.scss
@@ -144,8 +144,7 @@
     min-height: var(--fdList_Item_Text_Font_Size);
 
     &--wrap {
-      white-space: normal;
-      overflow: visible;
+      @include fd-wrap();
     }
 
     &:last-child:first-child {
@@ -169,8 +168,7 @@
     padding-inline-start: 1rem;
 
     &--wrap {
-      white-space: normal;
-      overflow: visible;
+      @include fd-wrap();
     }
 
     &--positive {
@@ -244,8 +242,7 @@
       color: var(--sapList_TableGroupHeaderTextColor);
 
       &--wrap {
-        white-space: normal;
-        overflow: visible;
+        @include fd-wrap();
       }
     }
   }
@@ -335,13 +332,11 @@
 
     .#{$block}__title,
     .#{$block}__secondary {
-      white-space: normal;
-      overflow: visible;
+      @include fd-wrap();
     }
   }
 
-  &__item--wrap,
-  &__item:has(.#{$block}__title--wrap, .#{$block}__secondary--wrap) {
+  &__item--wrap {
     height: auto;
     min-height: var(--fdList_Item_Height);
     align-items: flex-start;
@@ -349,9 +344,15 @@
 
     .#{$block}__title,
     .#{$block}__secondary {
-      white-space: normal;
-      overflow: visible;
+      @include fd-wrap();
     }
+  }
+
+  &__item:has(.#{$block}__title--wrap, .#{$block}__secondary--wrap) {
+    height: auto;
+    min-height: var(--fdList_Item_Height);
+    align-items: flex-start;
+    padding-block: 0.75rem;
   }
 
   &--no-border {

--- a/packages/styles/src/mixins/list/_list-base.scss
+++ b/packages/styles/src/mixins/list/_list-base.scss
@@ -330,9 +330,26 @@
       padding-block: 0.75rem;
     }
 
+    // __link is the visual content container (height: 100%; padding-block: 0 by default);
+    // padding set on the item is not visible — reset it and move it onto __link instead.
+    .#{$block}__item--link {
+      padding-block: 0;
+
+      .#{$block}__link {
+        padding-block: 0.75rem;
+        height: auto;
+      }
+    }
+
     .#{$block}__title,
     .#{$block}__secondary {
       @include fd-wrap();
+    }
+
+    // Counter and icon never wrap; keep them centered so they don't sit at the top of a tall item.
+    .#{$block}__item-counter,
+    .#{$block}__icon {
+      align-self: center;
     }
   }
 
@@ -346,6 +363,23 @@
     .#{$block}__secondary {
       @include fd-wrap();
     }
+
+    // Counter and icon never wrap; keep them centered so they don't sit at the top of a tall item.
+    .#{$block}__item-counter,
+    .#{$block}__icon {
+      align-self: center;
+    }
+
+    // __link is the visual content container (height: 100%; padding-block: 0 by default);
+    // padding set on the item is not visible — reset it and move it onto __link instead.
+    &.#{$block}__item--link {
+      padding-block: 0;
+
+      .#{$block}__link {
+        padding-block: 0.75rem;
+        height: auto;
+      }
+    }
   }
 
   &__item:has(.#{$block}__title--wrap, .#{$block}__secondary--wrap) {
@@ -353,6 +387,29 @@
     min-height: var(--fdList_Item_Height);
     align-items: flex-start;
     padding-block: 0.75rem;
+
+    // Secondary without --wrap is a short fixed-height label; keep it centered
+    // rather than top-aligned so it visually aligns with the content, not just the first line.
+    .#{$block}__secondary:not(.#{$block}__secondary--wrap) {
+      align-self: center;
+    }
+
+    // Counter and icon never wrap; keep them centered so they don't sit at the top of a tall item.
+    .#{$block}__item-counter,
+    .#{$block}__icon {
+      align-self: center;
+    }
+
+    // __link is the visual content container (height: 100%; padding-block: 0 by default);
+    // padding set on the item is not visible — reset it and move it onto __link instead.
+    &.#{$block}__item--link {
+      padding-block: 0;
+
+      .#{$block}__link {
+        padding-block: 0.75rem;
+        height: auto;
+      }
+    }
   }
 
   &--no-border {

--- a/packages/styles/src/mixins/list/_list-base.scss
+++ b/packages/styles/src/mixins/list/_list-base.scss
@@ -224,6 +224,11 @@
     border-bottom: var(--sapList_BorderWidth) solid var(--fdList_Item_Border_Color);
     background: var(--fdList_Item_Background_Color);
     cursor: pointer;
+
+    &--more {
+      text-transform: capitalize;
+      pointer-events: all;
+    }
   }
 
   &__group-header {

--- a/packages/styles/src/mixins/list/_list-byline.scss
+++ b/packages/styles/src/mixins/list/_list-byline.scss
@@ -105,7 +105,7 @@ $fd-list-byline-section-text-color: var(--sapContent_LabelColor) !default;
       font-size: $fd-list-normal-font-size;
       color: $fd-list-byline-section-text-color;
       line-height: $fd-list-byline-text-line-height;
-      padding-block-start: 0.5rem;
+      padding-block-start: 0.75rem;
 
       &--2-col {
         display: flex;

--- a/packages/styles/src/mixins/list/_list-byline.scss
+++ b/packages/styles/src/mixins/list/_list-byline.scss
@@ -94,8 +94,7 @@ $fd-list-byline-section-text-color: var(--sapContent_LabelColor) !default;
       min-height: $fd-list-byline-text-line-height;
 
       &--wrap {
-        white-space: normal;
-        overflow: visible;
+        @include fd-wrap();
       }
     }
 
@@ -114,8 +113,7 @@ $fd-list-byline-section-text-color: var(--sapContent_LabelColor) !default;
       }
 
       &--wrap {
-        white-space: normal;
-        overflow: visible;
+        @include fd-wrap();
 
         .#{$block}__byline-right,
         .#{$block}__byline-left {
@@ -136,16 +134,14 @@ $fd-list-byline-section-text-color: var(--sapContent_LabelColor) !default;
     &.#{$block}--wrap {
       .#{$block}__title,
       .#{$block}__byline {
-        white-space: normal;
-        overflow: visible;
+        @include fd-wrap();
       }
     }
 
     .#{$block}__item--wrap {
       .#{$block}__title,
       .#{$block}__byline {
-        white-space: normal;
-        overflow: visible;
+        @include fd-wrap();
       }
     }
 

--- a/packages/styles/src/mixins/list/_list-byline.scss
+++ b/packages/styles/src/mixins/list/_list-byline.scss
@@ -136,12 +136,46 @@ $fd-list-byline-section-text-color: var(--sapContent_LabelColor) !default;
       .#{$block}__byline {
         @include fd-wrap();
       }
+
+      // In byline link items __thumbnail and __icon are children of __link (not __item).
+      // __link uses fd-flex-vertical-center() which sets align-items: center; override to
+      // top-align the thumbnail/icon with the content when text wraps.
+      .#{$block}__link {
+        align-items: flex-start;
+
+        // The navigation arrow is a decorative ::after with height: 100%, but height: 100%
+        // does not resolve on a flex item inside an auto-height container, so the arrow
+        // collapses to icon size and sits at the top. Keep it centered instead.
+        &--navigation-indicator::after {
+          align-self: center;
+        }
+      }
     }
 
     .#{$block}__item--wrap {
       .#{$block}__title,
       .#{$block}__byline {
         @include fd-wrap();
+      }
+
+      // Same __link / ::after alignment fix as &--wrap above.
+      .#{$block}__link {
+        align-items: flex-start;
+
+        &--navigation-indicator::after {
+          align-self: center;
+        }
+      }
+    }
+
+    .#{$block}__item:has(.#{$block}__title--wrap, .#{$block}__byline--wrap) {
+      // Same __link / ::after alignment fix as &--wrap above.
+      .#{$block}__link {
+        align-items: flex-start;
+
+        &--navigation-indicator::after {
+          align-self: center;
+        }
       }
     }
 

--- a/packages/styles/src/mixins/list/_list-byline.scss
+++ b/packages/styles/src/mixins/list/_list-byline.scss
@@ -92,6 +92,11 @@ $fd-list-byline-section-text-color: var(--sapContent_LabelColor) !default;
 
       font-size: $fd-list-large-font-size;
       min-height: $fd-list-byline-text-line-height;
+
+      &--wrap {
+        white-space: normal;
+        overflow: visible;
+      }
     }
 
     .#{$block}__byline {
@@ -109,6 +114,9 @@ $fd-list-byline-section-text-color: var(--sapContent_LabelColor) !default;
       }
 
       &--wrap {
+        white-space: normal;
+        overflow: visible;
+
         .#{$block}__byline-right,
         .#{$block}__byline-left {
           padding-inline: 0;
@@ -125,16 +133,26 @@ $fd-list-byline-section-text-color: var(--sapContent_LabelColor) !default;
       }
     }
 
+    &.#{$block}--wrap {
+      .#{$block}__title,
+      .#{$block}__byline {
+        white-space: normal;
+        overflow: visible;
+      }
+    }
+
+    .#{$block}__item--wrap {
+      .#{$block}__title,
+      .#{$block}__byline {
+        white-space: normal;
+        overflow: visible;
+      }
+    }
+
     .#{$block}__link {
       &--more {
         text-transform: capitalize;
         pointer-events: all;
-      }
-    }
-
-    .#{$block}__title, .#{$block}__byline {
-      &--wrap {
-        white-space: normal;
       }
     }
 
@@ -190,9 +208,6 @@ $fd-list-byline-section-text-color: var(--sapContent_LabelColor) !default;
     &.#{$block}--no-border {
       .#{$block}__item {
         @include fd-set-paddings-y-equal($fd-list-byline-borderless-item-padding-y);
-
-        max-height: $fd-list-byline-item-height;
-        height: 100%;
       }
 
       .#{$block}__item:first-child {

--- a/packages/styles/src/mixins/list/_list-selection.scss
+++ b/packages/styles/src/mixins/list/_list-selection.scss
@@ -34,8 +34,19 @@
 
     .#{$block}__item--wrap,
     .#{$block}__item:has(.#{$block}__title--wrap, .#{$block}__secondary--wrap) {
+      // Centered by default; excluded when --wrap-top-aligned is present so there is no specificity conflict.
+      &:not(.#{$block}__item--wrap-top-aligned) {
+        .#{$block}__form-item {
+          top: 50%;
+          transform: translateY(-50%);
+        }
+      }
+    }
+
+    .#{$block}__item--wrap-top-aligned {
       .#{$block}__form-item {
-        top: 0.75rem;
+        top: 0;
+        transform: none;
       }
     }
 
@@ -52,7 +63,8 @@
       .#{$block}__item--wrap,
       .#{$block}__item:has(.#{$block}__title--wrap, .#{$block}__byline--wrap) {
         .#{$block}__form-item {
-          top: $fd-list-byline-item-padding-y;
+          top: 0.3125rem;
+          transform: none;
         }
       }
 

--- a/packages/styles/src/mixins/list/_list-selection.scss
+++ b/packages/styles/src/mixins/list/_list-selection.scss
@@ -32,6 +32,13 @@
       }
     }
 
+    .#{$block}__item--wrap,
+    .#{$block}__item:has(.#{$block}__title--wrap, .#{$block}__secondary--wrap) {
+      .#{$block}__form-item {
+        top: 0.75rem;
+      }
+    }
+
     // SELECTION + Byline
     &.#{$block}--byline {
       .#{$block}__item {
@@ -40,6 +47,13 @@
 
       .#{$block}__form-item {
         top: 0.3125rem;
+      }
+
+      .#{$block}__item--wrap,
+      .#{$block}__item:has(.#{$block}__title--wrap, .#{$block}__byline--wrap) {
+        .#{$block}__form-item {
+          top: $fd-list-byline-item-padding-y;
+        }
       }
 
       @include fd-compact-or-condensed() {

--- a/packages/styles/src/mixins/list/_list-subline.scss
+++ b/packages/styles/src/mixins/list/_list-subline.scss
@@ -75,7 +75,7 @@
 
     &.#{$block}--wrap {
       .#{$block}__item {
-        align-items: flex-start;
+        align-items: center;
       }
 
       .#{$block}__content {
@@ -89,7 +89,7 @@
     }
 
     .#{$block}__item--wrap {
-      align-items: flex-start;
+      align-items: center;
 
       .#{$block}__content {
         overflow: visible;
@@ -102,7 +102,7 @@
     }
 
     .#{$block}__item:has(.#{$block}__title--wrap, .#{$block}__subline--wrap) {
-      align-items: flex-start;
+      align-items: center;
     }
 
     .#{$block}__active-indicator {

--- a/packages/styles/src/mixins/list/_list-subline.scss
+++ b/packages/styles/src/mixins/list/_list-subline.scss
@@ -27,10 +27,6 @@
       };
 
       overflow: hidden;
-
-      &:has(.#{$block}__title--wrap, .#{$block}__subline--wrap) {
-        overflow: visible;
-      }
     }
 
     .#{$block}__title {
@@ -45,8 +41,7 @@
       @include fd-ellipsis();
 
       &--wrap {
-        white-space: normal;
-        overflow: visible;
+        @include fd-wrap();
       }
 
       // @deprecated: --truncate is a no-op since truncation is now the default
@@ -69,8 +64,7 @@
       @include fd-ellipsis();
 
       &--wrap {
-        white-space: normal;
-        overflow: visible;
+        @include fd-wrap();
       }
 
       // @deprecated: --truncate is a no-op since truncation is now the default
@@ -90,13 +84,11 @@
 
       .#{$block}__title,
       .#{$block}__subline {
-        white-space: normal;
-        overflow: visible;
+        @include fd-wrap();
       }
     }
 
-    .#{$block}__item--wrap,
-    .#{$block}__item:has(.#{$block}__title--wrap, .#{$block}__subline--wrap) {
+    .#{$block}__item--wrap {
       align-items: flex-start;
 
       .#{$block}__content {
@@ -105,9 +97,12 @@
 
       .#{$block}__title,
       .#{$block}__subline {
-        white-space: normal;
-        overflow: visible;
+        @include fd-wrap();
       }
+    }
+
+    .#{$block}__item:has(.#{$block}__title--wrap, .#{$block}__subline--wrap) {
+      align-items: flex-start;
     }
 
     .#{$block}__active-indicator {

--- a/packages/styles/src/mixins/list/_list-subline.scss
+++ b/packages/styles/src/mixins/list/_list-subline.scss
@@ -18,7 +18,7 @@
 
     .#{$block}__content {
       @include fd-reset();
-      
+
       @include fd-flex(column) {
         flex: 1;
         gap: 0.25rem;
@@ -27,6 +27,10 @@
       };
 
       overflow: hidden;
+
+      &:has(.#{$block}__title--wrap, .#{$block}__subline--wrap) {
+        overflow: visible;
+      }
     }
 
     .#{$block}__title {
@@ -34,11 +38,18 @@
       max-width: 100%;
       font-style: normal;
       line-height: normal;
-      white-space: normal;
       font-size: var(--sapFontSize);
       color: var(--sapList_TextColor);
       font-family: var(--sapFontSemiboldDuplexFamily);
 
+      @include fd-ellipsis();
+
+      &--wrap {
+        white-space: normal;
+        overflow: visible;
+      }
+
+      // @deprecated: --truncate is a no-op since truncation is now the default
       &--truncate {
         @include fd-ellipsis();
       }
@@ -51,13 +62,51 @@
       max-width: 100%;
       font-style: normal;
       line-height: normal;
-      white-space: normal;
       font-size: var(--sapFontSize);
       font-family: var(--sapFontFamily);
       color: var(--sapContent_LabelColor);
 
+      @include fd-ellipsis();
+
+      &--wrap {
+        white-space: normal;
+        overflow: visible;
+      }
+
+      // @deprecated: --truncate is a no-op since truncation is now the default
       &--truncate {
         @include fd-ellipsis();
+      }
+    }
+
+    &.#{$block}--wrap {
+      .#{$block}__item {
+        align-items: flex-start;
+      }
+
+      .#{$block}__content {
+        overflow: visible;
+      }
+
+      .#{$block}__title,
+      .#{$block}__subline {
+        white-space: normal;
+        overflow: visible;
+      }
+    }
+
+    .#{$block}__item--wrap,
+    .#{$block}__item:has(.#{$block}__title--wrap, .#{$block}__subline--wrap) {
+      align-items: flex-start;
+
+      .#{$block}__content {
+        overflow: visible;
+      }
+
+      .#{$block}__title,
+      .#{$block}__subline {
+        white-space: normal;
+        overflow: visible;
       }
     }
 

--- a/packages/styles/src/user-menu.scss
+++ b/packages/styles/src/user-menu.scss
@@ -91,8 +91,6 @@ $menu: #{$fd-namespace}-menu;
 
     &--wrap {
       display: block;
-      -webkit-line-clamp: unset;
-      -webkit-box-orient: unset;
       overflow: visible;
       max-height: none;
     }

--- a/packages/styles/src/user-menu.scss
+++ b/packages/styles/src/user-menu.scss
@@ -78,33 +78,47 @@ $menu: #{$fd-namespace}-menu;
 
   &__user-name {
     @include fd-reset();
-   
+
     max-width: 100%;
     line-height: 1.4rem;
-    white-space: normal;
     color: var(--sapTextColor);
     font-size: var(--sapFontLargeSize);
     font-family: var(--fdUserMenu_User_Name_Font_Family);
 
-    &--truncate {
-      @include fd-line-clamp(2);
+    @include fd-line-clamp(2);
 
-      max-height: 2.8rem;
+    max-height: 2.8rem;
+
+    &--wrap {
+      display: block;
+      -webkit-line-clamp: unset;
+      -webkit-box-orient: unset;
+      overflow: visible;
+      max-height: none;
     }
-  }  
+
+    &--truncate {
+      // deprecated no-op: truncation is now the default
+    }
+  }
 
   &__user-info,
   &__user-role,
   &__subline {
     @include fd-reset();
-    
+
     width: 100%;
     max-width: 100%;
-    white-space: normal;
     color: var(--sapContent_LabelColor);
 
+    @include fd-ellipsis();
+
+    &--wrap {
+      @include fd-wrap();
+    }
+
     &--truncate {
-      @include fd-ellipsis();
+      // deprecated no-op: truncation is now the default
     }
   }
 

--- a/packages/styles/stories/Components/List/list/byline/borderless.example.html
+++ b/packages/styles/stories/Components/List/list/byline/borderless.example.html
@@ -26,7 +26,7 @@ style="background-image: url('assets/images/backgrounds/Godafoss_waterfall_in_no
 <li role="listitem" tabindex="0" class="fd-list__item">
     <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--world"></i></span>
   <div class="fd-list__content">
-      <div class="fd-list__title fd-list__title--wrap">List item with 2-column byline (with an additional semantic byline) List item with 2-column byline (with an additional semantic byline) List item with 2-column byline (with an additional semantic byline) List item with 2-column byline (with an additional semantic byline)</div>
+      <div class="fd-list__title fd-list__title--wrap">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua, ut enim ad minim veniam</div>
       <div class="fd-list__byline fd-list__byline--2-col">
           <div class="fd-list__byline-left">First text item in byline (standard text)</div>
           <div class="fd-list__byline-right fd-list__byline-right--informative">Second text item in byline (information)</div>

--- a/packages/styles/stories/Components/List/list/byline/borderless.example.html
+++ b/packages/styles/stories/Components/List/list/byline/borderless.example.html
@@ -26,7 +26,7 @@ style="background-image: url('assets/images/backgrounds/Godafoss_waterfall_in_no
 <li role="listitem" tabindex="0" class="fd-list__item">
     <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--world"></i></span>
   <div class="fd-list__content">
-      <div class="fd-list__title fd-list__title--wrap">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua, ut enim ad minim veniam</div>
+      <div class="fd-list__title fd-list__title--wrap">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur</div>
       <div class="fd-list__byline fd-list__byline--2-col">
           <div class="fd-list__byline-left">First text item in byline (standard text)</div>
           <div class="fd-list__byline-right fd-list__byline-right--informative">Second text item in byline (information)</div>

--- a/packages/styles/stories/Components/List/list/byline/borderless.example.html
+++ b/packages/styles/stories/Components/List/list/byline/borderless.example.html
@@ -26,7 +26,7 @@ style="background-image: url('assets/images/backgrounds/Godafoss_waterfall_in_no
 <li role="listitem" tabindex="0" class="fd-list__item">
     <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--world"></i></span>
   <div class="fd-list__content">
-      <div class="fd-list__title">List item with 2-column byline (with an additional semantic byline)</div>
+      <div class="fd-list__title fd-list__title--wrap">List item with 2-column byline (with an additional semantic byline) List item with 2-column byline (with an additional semantic byline) List item with 2-column byline (with an additional semantic byline) List item with 2-column byline (with an additional semantic byline)</div>
       <div class="fd-list__byline fd-list__byline--2-col">
           <div class="fd-list__byline-left">First text item in byline (standard text)</div>
           <div class="fd-list__byline-right fd-list__byline-right--informative">Second text item in byline (information)</div>

--- a/packages/styles/stories/Components/List/list/byline/buttons.example.html
+++ b/packages/styles/stories/Components/List/list/byline/buttons.example.html
@@ -3,7 +3,8 @@
     <li role="listitem" class="fd-list__item">
         <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
         <div class="fd-list__content">
-            <span class="fd-list__title">List item 1</span>
+            <span class="fd-list__title fd-list__title--wrap">List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</span>
+            <span class="fd-list__byline">Byline (description) List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</span>
         </div>
         <button class="fd-button fd-button--transparent fd-list__button">
             <i class="sap-icon--edit"></i>

--- a/packages/styles/stories/Components/List/list/byline/buttons.example.html
+++ b/packages/styles/stories/Components/List/list/byline/buttons.example.html
@@ -17,11 +17,13 @@
         <div class="fd-list__content">
             <span class="fd-list__title fd-list__title--wrap"
                 >Title that wraps. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
-                dolore magna aliqua</span
+                dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur</span
             >
             <span class="fd-list__byline fd-list__byline--wrap"
                 >Byline that wraps. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Donec velit
-                neque, auctor sit amet aliquam vel</span
+                neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula. Proin elementum sapien vel enim facilisis, at faucibus
+                nibh ornare. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas</span
             >
         </div>
         <button class="fd-button fd-button--transparent fd-list__button">

--- a/packages/styles/stories/Components/List/list/byline/buttons.example.html
+++ b/packages/styles/stories/Components/List/list/byline/buttons.example.html
@@ -5,10 +5,10 @@
             <span class="fd-list__title fd-list__title--wrap">List item 1</span>
             <span class="fd-list__byline">Byline (description) List item 1 </span>
         </div>
-        <button class="fd-button fd-button--transparent fd-list__button">
+        <button class="fd-button fd-button--transparent fd-list__button" aria-label="Edit>
             <i class="sap-icon--edit"></i>
         </button>
-        <button class="fd-button fd-button--transparent fd-list__button">
+        <button class="fd-button fd-button--transparent fd-list__button" aria-label="Decline">
             <i class="sap-icon--decline"></i>
         </button>
     </li>
@@ -26,10 +26,10 @@
                 nibh ornare. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas</span
             >
         </div>
-        <button class="fd-button fd-button--transparent fd-list__button">
+        <button class="fd-button fd-button--transparent fd-list__button" aria-label="Edit">
             <i class="sap-icon--edit"></i>
         </button>
-        <button class="fd-button fd-button--transparent fd-list__button">
+        <button class="fd-button fd-button--transparent fd-list__button" aria-label="Decline">
             <i class="sap-icon--decline"></i>
         </button>
     </li>

--- a/packages/styles/stories/Components/List/list/byline/buttons.example.html
+++ b/packages/styles/stories/Components/List/list/byline/buttons.example.html
@@ -1,10 +1,28 @@
-
 <ul class="fd-list fd-list--byline" role="list">
     <li role="listitem" class="fd-list__item">
         <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
         <div class="fd-list__content">
-            <span class="fd-list__title fd-list__title--wrap">List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</span>
-            <span class="fd-list__byline">Byline (description) List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</span>
+            <span class="fd-list__title fd-list__title--wrap">List item 1</span>
+            <span class="fd-list__byline">Byline (description) List item 1 </span>
+        </div>
+        <button class="fd-button fd-button--transparent fd-list__button">
+            <i class="sap-icon--edit"></i>
+        </button>
+        <button class="fd-button fd-button--transparent fd-list__button">
+            <i class="sap-icon--decline"></i>
+        </button>
+    </li>
+    <li role="listitem" class="fd-list__item">
+        <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
+        <div class="fd-list__content">
+            <span class="fd-list__title fd-list__title--wrap"
+                >Title that wraps. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+                dolore magna aliqua</span
+            >
+            <span class="fd-list__byline fd-list__byline--wrap"
+                >Byline that wraps. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Donec velit
+                neque, auctor sit amet aliquam vel</span
+            >
         </div>
         <button class="fd-button fd-button--transparent fd-list__button">
             <i class="sap-icon--edit"></i>

--- a/packages/styles/stories/Components/List/list/byline/byline-list.stories.js
+++ b/packages/styles/stories/Components/List/list/byline/byline-list.stories.js
@@ -150,10 +150,30 @@ LongText.storyName = 'List with long Title and Byline';
 LongText.parameters = {
   docs: {
     description: {
-      story: `By default, To allow the title and byline text to wrap, add these following modifier classes to the the title and byline respectively:
+      story: `By default, long title and byline text is truncated with an ellipsis. Wrapping can be enabled at three levels:
 
+**List level** — add \`fd-list--wrap\` to the root element to wrap all items:
+\`\`\`html
+<ul class="fd-list fd-list--byline fd-list--wrap">
+\`\`\`
+
+**Item level** — add \`fd-list__item--wrap\` to a single list item:
+\`\`\`html
+<li class="fd-list__item fd-list__item--wrap">
+\`\`\`
+
+**Element level** — add modifier classes to individual elements:
 - \`fd-list__title--wrap\`
 - \`fd-list__byline--wrap\`
+
+**Show More / Show Less accessibility** — when a trigger link is present, use \`aria-expanded\` to communicate the current state to assistive technologies. Set \`aria-expanded="false"\` in the collapsed (truncated) state and \`aria-expanded="true"\` in the expanded (wrapped) state. The JS toggling logic lives in the consuming framework; fund-styles provides only the visual affordance via \`fd-list__link--more\`:
+\`\`\`html
+<!-- Collapsed -->
+<a href="#" class="fd-link fd-list__link--more" aria-expanded="false">More</a>
+
+<!-- Expanded -->
+<a href="#" class="fd-link fd-list__link--more" aria-expanded="true">Less</a>
+\`\`\`
 
 When more than 100 characters for small screens or 300 characters for medium to large screens are used, a clickable "MORE" link should be displayed to reveal the entire contents of the text.`
     }

--- a/packages/styles/stories/Components/List/list/byline/counter.example.html
+++ b/packages/styles/stories/Components/List/list/byline/counter.example.html
@@ -3,8 +3,8 @@
 <li role="listitem" tabindex="0" class="fd-list__item">
     <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
     <div class="fd-list__content">
-      <div class="fd-list__title fd-list__title--wrap">List Item Title List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</div>
-      <div class="fd-list__byline fd-list__byline--wrap">Byline (description) List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</div>
+      <div class="fd-list__title fd-list__title--wrap">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua</div>
+      <div class="fd-list__byline fd-list__byline--wrap">Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula</div>
     </div>
     <span class="fd-list__item-counter">123</span>
 </li>

--- a/packages/styles/stories/Components/List/list/byline/counter.example.html
+++ b/packages/styles/stories/Components/List/list/byline/counter.example.html
@@ -3,8 +3,8 @@
 <li role="listitem" tabindex="0" class="fd-list__item">
     <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
     <div class="fd-list__content">
-      <div class="fd-list__title fd-list__title--wrap">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua</div>
-      <div class="fd-list__byline fd-list__byline--wrap">Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula</div>
+      <div class="fd-list__title fd-list__title--wrap">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore</div>
+      <div class="fd-list__byline fd-list__byline--wrap">Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula. Proin elementum sapien vel enim facilisis, at faucibus nibh ornare. Pellentesque habitant morbi tristique senectus et netus</div>
     </div>
     <span class="fd-list__item-counter">123</span>
 </li>

--- a/packages/styles/stories/Components/List/list/byline/counter.example.html
+++ b/packages/styles/stories/Components/List/list/byline/counter.example.html
@@ -3,8 +3,8 @@
 <li role="listitem" tabindex="0" class="fd-list__item">
     <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
     <div class="fd-list__content">
-      <div class="fd-list__title">List Item Title</div>
-      <div class="fd-list__byline">Byline (description)</div>
+      <div class="fd-list__title fd-list__title--wrap">List Item Title List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</div>
+      <div class="fd-list__byline fd-list__byline--wrap">Byline (description) List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</div>
     </div>
     <span class="fd-list__item-counter">123</span>
 </li>

--- a/packages/styles/stories/Components/List/list/byline/long-text.example.html
+++ b/packages/styles/stories/Components/List/list/byline/long-text.example.html
@@ -4,8 +4,8 @@
         <li role="listitem" tabindex="0" class="fd-list__item">
             <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
             <div class="fd-list__content">
-                <div class="fd-list__title">Very long title truncated by default, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation.</div>
-                <div class="fd-list__byline">Very long byline truncated by default, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</div>
+                <div class="fd-list__title">Annual Budget Review for Q3 and Q4 — please review the attached documents and provide your feedback before the end of the fiscal quarter to ensure timely processing.</div>
+                <div class="fd-list__byline">Finance · Updated 2 hours ago by Michael Thompson, Senior Analyst, Global Finance Division, Central Europe · Reviewed by Anna Schmidt, Finance Controller · Pending approval from Regional CFO</div>
             </div>
         </li>
     </ul>
@@ -18,14 +18,7 @@
             <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--employee"></i></span>
             <div class="fd-list__content">
                 <div class="fd-list__title">All titles wrap at list level, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.</div>
-                <div class="fd-list__byline">All bylines wrap too, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.</div>
-            </div>
-        </li>
-        <li role="listitem" tabindex="0" class="fd-list__item">
-            <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
-            <div class="fd-list__content">
-                <div class="fd-list__title">Second item also wraps, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</div>
-                <div class="fd-list__byline">Second byline wraps, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor.</div>
+                <div class="fd-list__byline">All bylines wrap too, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.</div>
             </div>
         </li>
     </ul>
@@ -37,33 +30,18 @@
          visible even when the title truncates. -->
     <ul class="fd-list fd-list--byline" role="list">
         <li role="listitem" tabindex="0" class="fd-list__item">
-            <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
-            <div class="fd-list__content">
-                <div class="fd-list__title">This item truncates normally, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore.</div>
-                <div class="fd-list__byline">Byline truncates too, Lorem ipsum dolor sit amet, consectetur adipiscing elit.</div>
-            </div>
-        </li>
-        <li role="listitem" tabindex="0" class="fd-list__item">
             <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--employee"></i></span>
             <div class="fd-list__content">
                 <div class="fd-list__title">Collapsed — title truncated, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco.</div>
                 <a href="#" class="fd-link fd-list__link--more" aria-expanded="false" tabindex="0"><span class="fd-link__content">More</span></a>
-                <div class="fd-list__byline">Byline truncated, Lorem ipsum dolor sit amet, consectetur adipiscing elit.</div>
+                <div class="fd-list__byline">Byline truncated, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.</div>
             </div>
         </li>
         <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--wrap">
             <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--employee"></i></span>
             <div class="fd-list__content">
-                <div class="fd-list__title">Expanded — fd-list__item--wrap applied, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco.</div>
-                <a href="#" class="fd-link fd-list__link--more" aria-expanded="true" tabindex="0"><span class="fd-link__content">Less</span></a>
-                <div class="fd-list__byline">Byline wraps too, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</div>
-            </div>
-        </li>
-        <li role="listitem" tabindex="0" class="fd-list__item">
-            <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
-            <div class="fd-list__content">
-                <div class="fd-list__title">This item truncates normally again, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor.</div>
-                <div class="fd-list__byline">Byline truncates too, Lorem ipsum dolor sit amet, consectetur adipiscing elit.</div>
+                <div class="fd-list__title">Expanded — fd-list__item--wrap applied, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco. <a href="#" class="fd-link fd-list__link--more" aria-expanded="true" tabindex="0"><span class="fd-link__content">Less</span></a></div>
+                <div class="fd-list__byline">Byline wraps too, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation.</div>
             </div>
         </li>
     </ul>

--- a/packages/styles/stories/Components/List/list/byline/long-text.example.html
+++ b/packages/styles/stories/Components/List/list/byline/long-text.example.html
@@ -1,34 +1,87 @@
+<div style="margin-bottom: 2rem;">
+    <p class="fd-form-label" style="margin-bottom: 0.5rem;">Default — truncation</p>
+    <ul class="fd-list fd-list--byline" role="list">
+        <li role="listitem" tabindex="0" class="fd-list__item">
+            <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
+            <div class="fd-list__content">
+                <div class="fd-list__title">Very long title truncated by default, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation.</div>
+                <div class="fd-list__byline">Very long byline truncated by default, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</div>
+            </div>
+        </li>
+    </ul>
+</div>
 
-<ul class="fd-list fd-list--byline" role="list">
-<li role="listitem" tabindex="0" class="fd-list__item">
-    <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
-    <div class="fd-list__content">
-      <div class="fd-list__title">List Item Title</div>
-      <div class="fd-list__byline fd-list__byline--wrap">Very Long Byline (description), Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat... <a href="#" class="fd-link fd-list__link--more" tabindex="0"><span class="fd-link__content">More</span></a></div>
-    </div>
-    <span class="fd-list__item-counter">12345</span>
-</li>
-<li role="listitem" tabindex="0" class="fd-list__item">
-    <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--employee"></i></span>
-    <div class="fd-list__content">
-      <div class="fd-list__title fd-list__title--wrap">Very long list item with no byline, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</div>
-    </div>
-</li>
-<li role="listitem" tabindex="0" class="fd-list__item">
-  <span class="fd-image--s fd-list__thumbnail" aria-label="Godafoss waterfall in northern Iceland"
-style="background-image: url('assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg'); background-size:cover;"></span>
-  <div class="fd-list__content">
-      <div class="fd-list__title fd-list__title--wrap">Very long title, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</div>
-      <div class="fd-list__byline fd-list__byline--wrap">
-          <div class="fd-list__byline-left">First text item in byline (standard text), Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.<a href="#" class="fd-link fd-list__link--more" tabindex="0"><span class="fd-link__content">Less</span></a></div>
-          <div class="fd-list__byline-right">Second text item in byline (can be semantic)</div>
-      </div>
-  </div>
-</li>
-<li role="listitem" tabindex="0" class="fd-list__item">
-    <div class="fd-list__content">
-      <div class="fd-list__title">Text-only list item</div>
-      <div class="fd-list__byline">Byline (description)</div>
-    </div>
-</li>
-</ul>
+<div style="margin-bottom: 2rem;">
+    <p class="fd-form-label" style="margin-bottom: 0.5rem;">List level — <code>fd-list--wrap</code></p>
+    <ul class="fd-list fd-list--byline fd-list--wrap" role="list">
+        <li role="listitem" tabindex="0" class="fd-list__item">
+            <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--employee"></i></span>
+            <div class="fd-list__content">
+                <div class="fd-list__title">All titles wrap at list level, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.</div>
+                <div class="fd-list__byline">All bylines wrap too, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.</div>
+            </div>
+        </li>
+        <li role="listitem" tabindex="0" class="fd-list__item">
+            <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
+            <div class="fd-list__content">
+                <div class="fd-list__title">Second item also wraps, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</div>
+                <div class="fd-list__byline">Second byline wraps, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor.</div>
+            </div>
+        </li>
+    </ul>
+</div>
+
+<div style="margin-bottom: 2rem;">
+    <p class="fd-form-label" style="margin-bottom: 0.5rem;">Item level — <code>fd-list__item--wrap</code> (collapsed and expanded states)</p>
+    <!-- The fd-list__link--more element is placed outside fd-list__title so it stays
+         visible even when the title truncates. -->
+    <ul class="fd-list fd-list--byline" role="list">
+        <li role="listitem" tabindex="0" class="fd-list__item">
+            <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
+            <div class="fd-list__content">
+                <div class="fd-list__title">This item truncates normally, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore.</div>
+                <div class="fd-list__byline">Byline truncates too, Lorem ipsum dolor sit amet, consectetur adipiscing elit.</div>
+            </div>
+        </li>
+        <li role="listitem" tabindex="0" class="fd-list__item">
+            <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--employee"></i></span>
+            <div class="fd-list__content">
+                <div class="fd-list__title">Collapsed — title truncated, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco.</div>
+                <a href="#" class="fd-link fd-list__link--more" aria-expanded="false" tabindex="0"><span class="fd-link__content">More</span></a>
+                <div class="fd-list__byline">Byline truncated, Lorem ipsum dolor sit amet, consectetur adipiscing elit.</div>
+            </div>
+        </li>
+        <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--wrap">
+            <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--employee"></i></span>
+            <div class="fd-list__content">
+                <div class="fd-list__title">Expanded — fd-list__item--wrap applied, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco.</div>
+                <a href="#" class="fd-link fd-list__link--more" aria-expanded="true" tabindex="0"><span class="fd-link__content">Less</span></a>
+                <div class="fd-list__byline">Byline wraps too, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</div>
+            </div>
+        </li>
+        <li role="listitem" tabindex="0" class="fd-list__item">
+            <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
+            <div class="fd-list__content">
+                <div class="fd-list__title">This item truncates normally again, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor.</div>
+                <div class="fd-list__byline">Byline truncates too, Lorem ipsum dolor sit amet, consectetur adipiscing elit.</div>
+            </div>
+        </li>
+    </ul>
+</div>
+
+<div>
+    <p class="fd-form-label" style="margin-bottom: 0.5rem;">Element level — <code>fd-list__title--wrap</code> / <code>fd-list__byline--wrap</code></p>
+    <ul class="fd-list fd-list--byline" role="list">
+        <li role="listitem" tabindex="0" class="fd-list__item">
+            <span class="fd-image--s fd-list__thumbnail" role="img" aria-label="Godafoss waterfall in northern Iceland"
+                style="background-image: url('assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg'); background-size:cover;"></span>
+            <div class="fd-list__content">
+                <div class="fd-list__title fd-list__title--wrap">Only the title wraps here, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.</div>
+                <div class="fd-list__byline fd-list__byline--2-col fd-list__byline--wrap">
+                    <div class="fd-list__byline-left">First text item in byline, Lorem ipsum dolor sit amet, consectetur adipiscing elit.</div>
+                    <div class="fd-list__byline-right">Second text item (semantic)</div>
+                </div>
+            </div>
+        </li>
+    </ul>
+</div>

--- a/packages/styles/stories/Components/List/list/byline/navigation-indicator.example.html
+++ b/packages/styles/stories/Components/List/list/byline/navigation-indicator.example.html
@@ -3,8 +3,8 @@
   <a tabindex="0" class="fd-list__link fd-list__link--navigation-indicator" href="#">
     <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
     <div class="fd-list__content">
-      <div class="fd-list__title">Title</div>
-      <div class="fd-list__byline">Byline (description)</div>
+      <div class="fd-list__title fd-list__title--wrap">Title List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</div>
+      <div class="fd-list__byline fd-list__byline--wrap">Byline (description) List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</div>
     </div>
   </a>
 </li>

--- a/packages/styles/stories/Components/List/list/byline/navigation-indicator.example.html
+++ b/packages/styles/stories/Components/List/list/byline/navigation-indicator.example.html
@@ -3,8 +3,8 @@
   <a tabindex="0" class="fd-list__link fd-list__link--navigation-indicator" href="#">
     <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
     <div class="fd-list__content">
-      <div class="fd-list__title fd-list__title--wrap">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua</div>
-      <div class="fd-list__byline fd-list__byline--wrap">Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula</div>
+      <div class="fd-list__title fd-list__title--wrap">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore</div>
+      <div class="fd-list__byline fd-list__byline--wrap">Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula. Proin elementum sapien vel enim facilisis, at faucibus nibh ornare. Pellentesque habitant morbi tristique senectus et netus</div>
     </div>
   </a>
 </li>

--- a/packages/styles/stories/Components/List/list/byline/navigation-indicator.example.html
+++ b/packages/styles/stories/Components/List/list/byline/navigation-indicator.example.html
@@ -1,10 +1,10 @@
 <ul class="fd-list fd-list--byline fd-list--navigation fd-list--navigation-indication" role="list">
-<li role="listitem" tabindex="-1" class="fd-list__item fd-list__item--link">
+<li role="listitem" tabindex="-1" class="fd-list__item fd-list__item--link ">
   <a tabindex="0" class="fd-list__link fd-list__link--navigation-indicator" href="#">
     <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
     <div class="fd-list__content">
-      <div class="fd-list__title fd-list__title--wrap">Title List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</div>
-      <div class="fd-list__byline fd-list__byline--wrap">Byline (description) List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</div>
+      <div class="fd-list__title fd-list__title--wrap">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua</div>
+      <div class="fd-list__byline fd-list__byline--wrap">Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula</div>
     </div>
   </a>
 </li>

--- a/packages/styles/stories/Components/List/list/byline/selection.example.html
+++ b/packages/styles/stories/Components/List/list/byline/selection.example.html
@@ -8,8 +8,8 @@
         </div>
         <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
         <div class="fd-list__content">
-            <span class="fd-list__title" id="O09lk1">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua</span>
-            <span class="fd-list__byline">Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Donec velit neque, auctor sit amet aliquam vel</span>
+            <span class="fd-list__title" id="O09lk1">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit</span>
+            <span class="fd-list__byline">Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula. Proin elementum sapien vel enim facilisis</span>
         </div>
     </li>
     <li role="option" tabindex="0" class="fd-list__item">

--- a/packages/styles/stories/Components/List/list/byline/selection.example.html
+++ b/packages/styles/stories/Components/List/list/byline/selection.example.html
@@ -8,8 +8,8 @@
         </div>
         <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
         <div class="fd-list__content">
-            <span class="fd-list__title" id="O09lk1">List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</span>
-            <span class="fd-list__byline">Byline (description) List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</span>
+            <span class="fd-list__title" id="O09lk1">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua</span>
+            <span class="fd-list__byline">Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Donec velit neque, auctor sit amet aliquam vel</span>
         </div>
     </li>
     <li role="option" tabindex="0" class="fd-list__item">
@@ -22,9 +22,9 @@
         <span class="fd-image--s fd-list__thumbnail" aria-label="Godafoss waterfall in northern Iceland"
               style="background-image: url('assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg'); background-size:cover;"></span>
         <div class="fd-list__content">
-            <div class="fd-list__title fd-list__title--wrap" id="O09lk2">List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2</div>
+            <div class="fd-list__title fd-list__title--wrap" id="O09lk2">Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore</div>
             <div class="fd-list__byline fd-list__byline--wrap fd-list__byline--2-col">
-                <div class="fd-list__byline-left">First text item in byline (standard text) List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2</div>
+                <div class="fd-list__byline-left">Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur, excepteur sint occaecat cupidatat non proident</div>
                 <div class="fd-list__byline-right">Second text item in byline (can be semantic)</div>
             </div>
         </div>

--- a/packages/styles/stories/Components/List/list/byline/selection.example.html
+++ b/packages/styles/stories/Components/List/list/byline/selection.example.html
@@ -1,5 +1,5 @@
 <ul class="fd-list fd-list--selection fd-list--byline" role="listbox" aria-labelledby="O09lk9">
-    <li role="option" tabindex="0" class="fd-list__item is-selected">
+    <li role="option" tabindex="0" class="fd-list__item fd-list__item--wrap is-selected">
         <div class="fd-form-item fd-list__form-item">
             <input type="checkbox" class="fd-checkbox" id="Ai4ez6111Z" checked aria-labelledby="O09lk1">
             <label tabindex="-1" class="fd-checkbox__label" for="Ai4ez6111Z">
@@ -8,8 +8,8 @@
         </div>
         <span class="fd-list__thumbnail"><i role="presentation" class="sap-icon--activate"></i></span>
         <div class="fd-list__content">
-            <span class="fd-list__title" id="O09lk1">Title</span>
-            <span class="fd-list__byline">Byline (description)</span>
+            <span class="fd-list__title" id="O09lk1">List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</span>
+            <span class="fd-list__byline">Byline (description) List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</span>
         </div>
     </li>
     <li role="option" tabindex="0" class="fd-list__item">
@@ -22,9 +22,9 @@
         <span class="fd-image--s fd-list__thumbnail" aria-label="Godafoss waterfall in northern Iceland"
               style="background-image: url('assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg'); background-size:cover;"></span>
         <div class="fd-list__content">
-            <div class="fd-list__title" id="O09lk2">List item with 2-column byline</div>
-            <div class="fd-list__byline fd-list__byline--2-col">
-                <div class="fd-list__byline-left">First text item in byline (standard text)</div>
+            <div class="fd-list__title fd-list__title--wrap" id="O09lk2">List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2</div>
+            <div class="fd-list__byline fd-list__byline--wrap fd-list__byline--2-col">
+                <div class="fd-list__byline-left">First text item in byline (standard text) List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2</div>
                 <div class="fd-list__byline-right">Second text item in byline (can be semantic)</div>
             </div>
         </div>

--- a/packages/styles/stories/Components/List/list/standard/buttons.example.html
+++ b/packages/styles/stories/Components/List/list/standard/buttons.example.html
@@ -1,18 +1,18 @@
 <ul class="fd-list" role="list">
   <li tabindex="-1" role="listitem" class="fd-list__item fd-list__item--wrap">
-    <span class="fd-list__title">List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</span>
+    <span class="fd-list__title">List item 1 that wraps. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua, ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat</span>
     <button class="fd-button fd-button--transparent fd-list__button">
         <i class="sap-icon--edit"></i>
     </button>
   </li>
   <li tabindex="-1" role="listitem" class="fd-list__item">
-    <span class="fd-list__title fd-list__title--wrap">List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</span>
+    <span class="fd-list__title fd-list__title--wrap">List item 2 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur</span>
     <button class="fd-button fd-button--transparent fd-list__button">
         <i class="sap-icon--decline"></i>
     </button>
   </li>
   <li tabindex="-1" role="listitem" class="fd-list__item">
-    <span class="fd-list__title">List item 2</span>
+    <span class="fd-list__title">List item 3</span>
     <button class="fd-button fd-button--transparent fd-list__button">
         <i class="sap-icon--edit"></i>
     </button>

--- a/packages/styles/stories/Components/List/list/standard/buttons.example.html
+++ b/packages/styles/stories/Components/List/list/standard/buttons.example.html
@@ -1,12 +1,12 @@
 <ul class="fd-list" role="list">
   <li tabindex="-1" role="listitem" class="fd-list__item fd-list__item--wrap">
-    <span class="fd-list__title">List item 1 that wraps. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua, ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat</span>
+    <span class="fd-list__title">List item 1 that wraps. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua, ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur, excepteur sint occaecat cupidatat non proident</span>
     <button class="fd-button fd-button--transparent fd-list__button">
         <i class="sap-icon--edit"></i>
     </button>
   </li>
   <li tabindex="-1" role="listitem" class="fd-list__item">
-    <span class="fd-list__title fd-list__title--wrap">List item 2 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur</span>
+    <span class="fd-list__title fd-list__title--wrap">List item 2 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum</span>
     <button class="fd-button fd-button--transparent fd-list__button">
         <i class="sap-icon--decline"></i>
     </button>

--- a/packages/styles/stories/Components/List/list/standard/buttons.example.html
+++ b/packages/styles/stories/Components/List/list/standard/buttons.example.html
@@ -1,12 +1,12 @@
 <ul class="fd-list" role="list">
-  <li tabindex="-1" role="listitem" class="fd-list__item">
-    <span class="fd-list__title">List item 1</span>
+  <li tabindex="-1" role="listitem" class="fd-list__item fd-list__item--wrap">
+    <span class="fd-list__title">List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</span>
     <button class="fd-button fd-button--transparent fd-list__button">
         <i class="sap-icon--edit"></i>
     </button>
   </li>
   <li tabindex="-1" role="listitem" class="fd-list__item">
-    <span class="fd-list__title">List item 1</span>
+    <span class="fd-list__title fd-list__title--wrap">List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</span>
     <button class="fd-button fd-button--transparent fd-list__button">
         <i class="sap-icon--decline"></i>
     </button>

--- a/packages/styles/stories/Components/List/list/standard/icons.example.html
+++ b/packages/styles/stories/Components/List/list/standard/icons.example.html
@@ -1,18 +1,18 @@
 <ul class="fd-list" role="list">
-  <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--wrap">
+  <li role="listitem" tabindex="0" class="fd-list__item">
       <i role="presentation" class="fd-list__icon sap-icon--cart"></i>
-      <span class="fd-list__title">List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</span>
+      <span class="fd-list__title">List item 1</span>
   </li>
   <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--wrap">
       <i role="presentation" class="fd-list__icon sap-icon--wrench"></i>
-      <span class="fd-list__title">List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</span>
+      <span class="fd-list__title">List item 2 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur</span>
   </li>
   <li role="listitem" tabindex="0" class="fd-list__item">
       <span class="fd-list__title">List item 3</span>
       <i role="presentation" class="fd-list__icon sap-icon--lightbulb"></i>
   </li>
-  <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--wrap">
-      <span class="fd-list__title">List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</span>
+  <li role="listitem" tabindex="0" class="fd-list__item">
+      <span class="fd-list__title fd-list__title--wrap">List item 4 that wraps. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur, excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum</span>
       <i role="presentation" class="fd-list__icon sap-icon--history"></i>
   </li>
 </ul>

--- a/packages/styles/stories/Components/List/list/standard/icons.example.html
+++ b/packages/styles/stories/Components/List/list/standard/icons.example.html
@@ -5,14 +5,14 @@
   </li>
   <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--wrap">
       <i role="presentation" class="fd-list__icon sap-icon--wrench"></i>
-      <span class="fd-list__title">List item 2 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur</span>
+      <span class="fd-list__title">List item 2 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum</span>
   </li>
   <li role="listitem" tabindex="0" class="fd-list__item">
       <span class="fd-list__title">List item 3</span>
       <i role="presentation" class="fd-list__icon sap-icon--lightbulb"></i>
   </li>
   <li role="listitem" tabindex="0" class="fd-list__item">
-      <span class="fd-list__title fd-list__title--wrap">List item 4 that wraps. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur, excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum</span>
+      <span class="fd-list__title fd-list__title--wrap">List item 4 that wraps. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur, excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua</span>
       <i role="presentation" class="fd-list__icon sap-icon--history"></i>
   </li>
 </ul>

--- a/packages/styles/stories/Components/List/list/standard/icons.example.html
+++ b/packages/styles/stories/Components/List/list/standard/icons.example.html
@@ -1,18 +1,18 @@
 <ul class="fd-list" role="list">
-  <li role="listitem" tabindex="0" class="fd-list__item">
+  <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--wrap">
       <i role="presentation" class="fd-list__icon sap-icon--cart"></i>
-      <span class="fd-list__title">List item 1</span>
+      <span class="fd-list__title">List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</span>
   </li>
-  <li role="listitem" tabindex="0" class="fd-list__item">
+  <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--wrap">
       <i role="presentation" class="fd-list__icon sap-icon--wrench"></i>
-      <span class="fd-list__title">List item 2</span>
+      <span class="fd-list__title">List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</span>
   </li>
   <li role="listitem" tabindex="0" class="fd-list__item">
       <span class="fd-list__title">List item 3</span>
       <i role="presentation" class="fd-list__icon sap-icon--lightbulb"></i>
   </li>
-  <li role="listitem" tabindex="0" class="fd-list__item">
-      <span class="fd-list__title">List item 4</span>
+  <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--wrap">
+      <span class="fd-list__title">List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</span>
       <i role="presentation" class="fd-list__icon sap-icon--history"></i>
   </li>
 </ul>

--- a/packages/styles/stories/Components/List/list/standard/item-counter.example.html
+++ b/packages/styles/stories/Components/List/list/standard/item-counter.example.html
@@ -1,10 +1,10 @@
 <ul class="fd-list" role="list">
-  <li role="listitem" tabindex="0" class="fd-list__item">
-      <span class="fd-list__title">List item 1</span>
+  <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--wrap">
+      <span class="fd-list__title">List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</span>
       <span class="fd-list__item-counter">12345</span>
   </li>
   <li role="listitem" tabindex="0" class="fd-list__item">
-      <span class="fd-list__title">List item 2</span>
+      <span class="fd-list__title fd-list__title--wrap">List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2</span>
       <span class="fd-list__item-counter">12345</span>
   </li>
   <li role="listitem" tabindex="0" class="fd-list__item">

--- a/packages/styles/stories/Components/List/list/standard/item-counter.example.html
+++ b/packages/styles/stories/Components/List/list/standard/item-counter.example.html
@@ -1,15 +1,15 @@
 <ul class="fd-list" role="list">
   <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--wrap">
-      <span class="fd-list__title">List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</span>
+      <span class="fd-list__title">List item 1 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit</span>
       <span class="fd-list__item-counter">12345</span>
   </li>
   <li role="listitem" tabindex="0" class="fd-list__item">
-      <span class="fd-list__title fd-list__title--wrap">List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2</span>
+      <span class="fd-list__title fd-list__title--wrap">List item 2</span>
       <span class="fd-list__item-counter">12345</span>
   </li>
   <li role="listitem" tabindex="0" class="fd-list__item">
       <i role="presentation" class="fd-list__icon sap-icon--lightbulb"></i>
-      <span class="fd-list__title">List item 3</span>
+      <span class="fd-list__title fd-list__title--wrap">List item 3 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit</span>
       <span class="fd-list__item-counter">12345</span>
   </li>
   <li role="listitem" tabindex="0" class="fd-list__item">

--- a/packages/styles/stories/Components/List/list/standard/item-counter.example.html
+++ b/packages/styles/stories/Components/List/list/standard/item-counter.example.html
@@ -1,6 +1,6 @@
 <ul class="fd-list" role="list">
   <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--wrap">
-      <span class="fd-list__title">List item 1 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit</span>
+      <span class="fd-list__title">List item 1 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum</span>
       <span class="fd-list__item-counter">12345</span>
   </li>
   <li role="listitem" tabindex="0" class="fd-list__item">
@@ -9,7 +9,7 @@
   </li>
   <li role="listitem" tabindex="0" class="fd-list__item">
       <i role="presentation" class="fd-list__icon sap-icon--lightbulb"></i>
-      <span class="fd-list__title fd-list__title--wrap">List item 3 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit</span>
+      <span class="fd-list__title fd-list__title--wrap">List item 3 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum</span>
       <span class="fd-list__item-counter">12345</span>
   </li>
   <li role="listitem" tabindex="0" class="fd-list__item">

--- a/packages/styles/stories/Components/List/list/standard/long-text.example.html
+++ b/packages/styles/stories/Components/List/list/standard/long-text.example.html
@@ -1,0 +1,55 @@
+<div style="margin-bottom: 2rem;">
+    <p class="fd-form-label" style="margin-bottom: 0.5rem;">Default — truncation</p>
+    <ul class="fd-list" role="list">
+        <li role="listitem" tabindex="0" class="fd-list__item">
+            <span class="fd-list__title">Very long title truncated by default, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.</span>
+            <span class="fd-list__secondary">Secondary text also truncated, Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus.</span>
+        </li>
+    </ul>
+</div>
+
+<div style="margin-bottom: 2rem;">
+    <p class="fd-form-label" style="margin-bottom: 0.5rem;">List level — <code>fd-list--wrap</code></p>
+    <ul class="fd-list fd-list--wrap" role="list">
+        <li role="listitem" tabindex="0" class="fd-list__item">
+            <span class="fd-list__title">All titles wrap at list level, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip.</span>
+            <span class="fd-list__secondary">Secondary text wraps too, Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus nulla aliquid soluta aperiam.</span>
+        </li>
+        <li role="listitem" tabindex="0" class="fd-list__item">
+            <span class="fd-list__title">Second item also wraps, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</span>
+        </li>
+    </ul>
+</div>
+
+<div style="margin-bottom: 2rem;">
+    <p class="fd-form-label" style="margin-bottom: 0.5rem;">Item level — <code>fd-list__item--wrap</code> (collapsed and expanded states)</p>
+    <!-- In the collapsed state fd-list__link--more is a right-aligned sibling so it
+         stays visible when the title truncates. In the expanded state (fd-list__item--wrap
+         applied) the title is fully visible so the Less link can sit inline at the end. -->
+    <ul class="fd-list" role="list">
+        <li role="listitem" tabindex="0" class="fd-list__item">
+            <span class="fd-list__title">This item truncates normally, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore.</span>
+        </li>
+        <li role="listitem" tabindex="0" class="fd-list__item">
+            <span class="fd-list__title">Collapsed — title truncated, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco.</span>
+            <a href="#" class="fd-link fd-list__link--more" aria-expanded="false" tabindex="0"><span class="fd-link__content">More</span></a>
+        </li>
+        <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--wrap">
+            <span class="fd-list__title">Expanded — fd-list__item--wrap applied, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco. <a href="#" class="fd-link fd-list__link--more" aria-expanded="true" tabindex="0"><span class="fd-link__content">Less</span></a></span>
+            <span class="fd-list__secondary">Secondary text wraps too, Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus nulla aliquid.</span>
+        </li>
+        <li role="listitem" tabindex="0" class="fd-list__item">
+            <span class="fd-list__title">This item truncates normally again, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore.</span>
+        </li>
+    </ul>
+</div>
+
+<div>
+    <p class="fd-form-label" style="margin-bottom: 0.5rem;">Element level — <code>fd-list__title--wrap</code> / <code>fd-list__secondary--wrap</code></p>
+    <ul class="fd-list" role="list">
+        <li role="listitem" tabindex="0" class="fd-list__item">
+            <span class="fd-list__title fd-list__title--wrap">Only the title wraps here, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation.</span>
+            <span class="fd-list__secondary">Secondary still truncates, Lorem ipsum dolor sit amet consectetur adipisicing elit.</span>
+        </li>
+    </ul>
+</div>

--- a/packages/styles/stories/Components/List/list/standard/long-text.example.html
+++ b/packages/styles/stories/Components/List/list/standard/long-text.example.html
@@ -2,8 +2,8 @@
     <p class="fd-form-label" style="margin-bottom: 0.5rem;">Default — truncation</p>
     <ul class="fd-list" role="list">
         <li role="listitem" tabindex="0" class="fd-list__item">
-            <span class="fd-list__title">Very long title truncated by default, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.</span>
-            <span class="fd-list__secondary">Secondary text also truncated, Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus.</span>
+            <span class="fd-list__title">Annual Budget Review for Q3 and Q4 — please review the attached documents and provide your feedback before the end of the fiscal quarter to ensure timely processing.</span>
+            <span class="fd-list__secondary">Finance · Updated 2 hours ago by Michael Thompson, Senior Analyst, Global Finance Division</span>
         </li>
     </ul>
 </div>
@@ -50,6 +50,10 @@
         <li role="listitem" tabindex="0" class="fd-list__item">
             <span class="fd-list__title fd-list__title--wrap">Only the title wraps here, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation.</span>
             <span class="fd-list__secondary">Secondary still truncates, Lorem ipsum dolor sit amet consectetur adipisicing elit.</span>
+        </li>
+        <li role="listitem" tabindex="0" class="fd-list__item">
+            <span class="fd-list__title">Title still truncates, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</span>
+            <span class="fd-list__secondary fd-list__secondary--wrap">Only the secondary wraps here, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.</span>
         </li>
     </ul>
 </div>

--- a/packages/styles/stories/Components/List/list/standard/navigation-indicator.example.html
+++ b/packages/styles/stories/Components/List/list/standard/navigation-indicator.example.html
@@ -1,13 +1,13 @@
 <ul class="fd-list fd-list--navigation fd-list--navigation-indication" role="list">
   <li tabindex="-1" role="listitem" class="fd-list__item fd-list__item--wrap fd-list__item--link">
       <a tabindex="0" class="fd-list__link fd-list__link--navigation-indicator" href="#">
-        <span class="fd-list__title">List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</span>
+        <span class="fd-list__title">List item 1 that wraps. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua, ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat</span>
       </a>
   </li>
   <li tabindex="-1" role="listitem" class="fd-list__item fd-list__item--link">
       <a tabindex="0" class="fd-list__link fd-list__link--navigation-indicator is-selected" href="#">
         <i role="presentation" class="fd-list__icon sap-icon--history"></i>
-        <span class="fd-list__title fd-list__title--wrap">List item 2 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</span>
+        <span class="fd-list__title fd-list__title--wrap">List item 2 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur, excepteur sint occaecat cupidatat non proident</span>
       </a>
   </li>
   <li tabindex="0" role="listitem" class="fd-list__item">
@@ -20,7 +20,7 @@
   </li>
   <li tabindex="-1" role="listitem" class="fd-list__item fd-list__item--link">
       <a tabindex="0" class="fd-list__link fd-list__link--navigation-indicator is-navigated" href="#">
-        <span class="fd-list__title fd-list__title--wrap">List item 5 List item 2 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</span>
+        <span class="fd-list__title">List item 4</span>
         <i role="presentation" class="fd-list__icon sap-icon--map"></i>
       </a>
   </li>

--- a/packages/styles/stories/Components/List/list/standard/navigation-indicator.example.html
+++ b/packages/styles/stories/Components/List/list/standard/navigation-indicator.example.html
@@ -1,13 +1,13 @@
 <ul class="fd-list fd-list--navigation fd-list--navigation-indication" role="list">
-  <li tabindex="-1" role="listitem" class="fd-list__item fd-list__item--link">
+  <li tabindex="-1" role="listitem" class="fd-list__item fd-list__item--wrap fd-list__item--link">
       <a tabindex="0" class="fd-list__link fd-list__link--navigation-indicator" href="#">
-        <span class="fd-list__title">List item 1</span>
+        <span class="fd-list__title">List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</span>
       </a>
   </li>
   <li tabindex="-1" role="listitem" class="fd-list__item fd-list__item--link">
       <a tabindex="0" class="fd-list__link fd-list__link--navigation-indicator is-selected" href="#">
         <i role="presentation" class="fd-list__icon sap-icon--history"></i>
-        <span class="fd-list__title">List item 2</span>
+        <span class="fd-list__title fd-list__title--wrap">List item 2 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</span>
       </a>
   </li>
   <li tabindex="0" role="listitem" class="fd-list__item">
@@ -20,7 +20,7 @@
   </li>
   <li tabindex="-1" role="listitem" class="fd-list__item fd-list__item--link">
       <a tabindex="0" class="fd-list__link fd-list__link--navigation-indicator is-navigated" href="#">
-        <span class="fd-list__title">List item 5</span>
+        <span class="fd-list__title fd-list__title--wrap">List item 5 List item 2 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</span>
         <i role="presentation" class="fd-list__icon sap-icon--map"></i>
       </a>
   </li>

--- a/packages/styles/stories/Components/List/list/standard/navigation-indicator.example.html
+++ b/packages/styles/stories/Components/List/list/standard/navigation-indicator.example.html
@@ -1,13 +1,13 @@
 <ul class="fd-list fd-list--navigation fd-list--navigation-indication" role="list">
   <li tabindex="-1" role="listitem" class="fd-list__item fd-list__item--wrap fd-list__item--link">
       <a tabindex="0" class="fd-list__link fd-list__link--navigation-indicator" href="#">
-        <span class="fd-list__title">List item 1 that wraps. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua, ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat</span>
+        <span class="fd-list__title">List item 1 that wraps. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua, ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur, excepteur sint occaecat cupidatat non proident</span>
       </a>
   </li>
   <li tabindex="-1" role="listitem" class="fd-list__item fd-list__item--link">
       <a tabindex="0" class="fd-list__link fd-list__link--navigation-indicator is-selected" href="#">
         <i role="presentation" class="fd-list__icon sap-icon--history"></i>
-        <span class="fd-list__title fd-list__title--wrap">List item 2 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur, excepteur sint occaecat cupidatat non proident</span>
+        <span class="fd-list__title fd-list__title--wrap">List item 2 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur, excepteur sint occaecat cupidatat non proident. Sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit</span>
       </a>
   </li>
   <li tabindex="0" role="listitem" class="fd-list__item">

--- a/packages/styles/stories/Components/List/list/standard/secondary-data.example.html
+++ b/packages/styles/stories/Components/List/list/standard/secondary-data.example.html
@@ -1,10 +1,10 @@
 <ul class="fd-list" role="list">
-  <li role="listitem" tabindex="0" class="fd-list__item">
-      <span class="fd-list__title fd-list__title--wrap">List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</span>
-      <span class="fd-list__secondary">Neutral Status Neutral Status Neutral Status Neutral Status Neutral Status Neutral Status Neutral Status Neutral Status Neutral Status Neutral Status Neutral Status Neutral Status Neutral Status Neutral Status Neutral Status</span>
+  <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--wrap">
+      <span class="fd-list__title">List item 1 that wraps. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua</span>
+      <span class="fd-list__secondary">Neutral Status</span>
   </li>
   <li role="listitem" tabindex="0" class="fd-list__item">
-      <span class="fd-list__title fd-list__title--wrap">List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2</span>
+      <span class="fd-list__title fd-list__title--wrap">List item 2 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit</span>
       <span class="fd-list__secondary fd-list__secondary--positive">Positive Status</span>
   </li>
   <li role="listitem" tabindex="0" class="fd-list__item">

--- a/packages/styles/stories/Components/List/list/standard/secondary-data.example.html
+++ b/packages/styles/stories/Components/List/list/standard/secondary-data.example.html
@@ -1,10 +1,10 @@
 <ul class="fd-list" role="list">
   <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--wrap">
-      <span class="fd-list__title">List item 1 that wraps. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua</span>
+      <span class="fd-list__title">List item 1 that wraps. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore</span>
       <span class="fd-list__secondary">Neutral Status</span>
   </li>
   <li role="listitem" tabindex="0" class="fd-list__item">
-      <span class="fd-list__title fd-list__title--wrap">List item 2 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit</span>
+      <span class="fd-list__title fd-list__title--wrap">List item 2 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum</span>
       <span class="fd-list__secondary fd-list__secondary--positive">Positive Status</span>
   </li>
   <li role="listitem" tabindex="0" class="fd-list__item">

--- a/packages/styles/stories/Components/List/list/standard/secondary-data.example.html
+++ b/packages/styles/stories/Components/List/list/standard/secondary-data.example.html
@@ -1,10 +1,10 @@
 <ul class="fd-list" role="list">
   <li role="listitem" tabindex="0" class="fd-list__item">
-      <span class="fd-list__title">List item 1</span>
-      <span class="fd-list__secondary">Neutral Status</span>
+      <span class="fd-list__title fd-list__title--wrap">List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</span>
+      <span class="fd-list__secondary">Neutral Status Neutral Status Neutral Status Neutral Status Neutral Status Neutral Status Neutral Status Neutral Status Neutral Status Neutral Status Neutral Status Neutral Status Neutral Status Neutral Status Neutral Status</span>
   </li>
   <li role="listitem" tabindex="0" class="fd-list__item">
-      <span class="fd-list__title">List item 2</span>
+      <span class="fd-list__title fd-list__title--wrap">List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2</span>
       <span class="fd-list__secondary fd-list__secondary--positive">Positive Status</span>
   </li>
   <li role="listitem" tabindex="0" class="fd-list__item">

--- a/packages/styles/stories/Components/List/list/standard/selection.example.html
+++ b/packages/styles/stories/Components/List/list/standard/selection.example.html
@@ -8,7 +8,7 @@
       </div>
       <span class="fd-list__title" id="Az0bg1">List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</span>
   </li>
-  <li role="option" tabindex="0" class="fd-list__item is-selected" aria-selected="true">
+  <li role="option" tabindex="0" class="fd-list__item is-selected fd-list__item--wrap fd-list__item--wrap-top-aligned" aria-selected="true">
       <div class="fd-form-item fd-list__form-item">
           <input type="checkbox" class="fd-checkbox" id="Ai4ez2" checked aria-labelledby="Az0bg2">
           <label tabindex="-1" class="fd-checkbox__label" for="Ai4ez2">

--- a/packages/styles/stories/Components/List/list/standard/selection.example.html
+++ b/packages/styles/stories/Components/List/list/standard/selection.example.html
@@ -1,12 +1,12 @@
 <ul class="fd-list fd-list--selection" role="listbox" aria-labelledby="XezW11">
-  <li role="option" tabindex="0" class="fd-list__item">
+  <li role="option" tabindex="0" class="fd-list__item fd-list__item--wrap">
       <div class="fd-form-item fd-list__form-item">
           <input type="checkbox" class="fd-checkbox" id="Ai4ez1" aria-labelledby="Az0bg1">
           <label tabindex="-1" class="fd-checkbox__label" for="Ai4ez1">
             <span class="fd-checkbox__checkmark" aria-hidden="true"></span>
           </label>
       </div>
-      <span class="fd-list__title" id="Az0bg1">List item 1</span>
+      <span class="fd-list__title" id="Az0bg1">List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</span>
   </li>
   <li role="option" tabindex="0" class="fd-list__item is-selected" aria-selected="true">
       <div class="fd-form-item fd-list__form-item">
@@ -15,7 +15,7 @@
             <span class="fd-checkbox__checkmark" aria-hidden="true"></span>
           </label>
       </div>
-      <span class="fd-list__title" id="Az0bg2">List item 2</span>
+      <span class="fd-list__title fd-list__title--wrap" id="Az0bg2">List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2</span>
   </li>
   <li role="option" tabindex="0" class="fd-list__item">
       <div class="fd-form-item fd-list__form-item">

--- a/packages/styles/stories/Components/List/list/standard/selection.example.html
+++ b/packages/styles/stories/Components/List/list/standard/selection.example.html
@@ -6,7 +6,7 @@
             <span class="fd-checkbox__checkmark" aria-hidden="true"></span>
           </label>
       </div>
-      <span class="fd-list__title" id="Az0bg1">List item 1 that wraps with a centered checkbox. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua</span>
+      <span class="fd-list__title" id="Az0bg1">List item 1 that wraps with a centered checkbox. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore</span>
   </li>
   <li role="option" tabindex="0" class="fd-list__item is-selected fd-list__item--wrap fd-list__item--wrap-top-aligned" aria-selected="true">
       <div class="fd-form-item fd-list__form-item">
@@ -15,7 +15,7 @@
             <span class="fd-checkbox__checkmark" aria-hidden="true"></span>
           </label>
       </div>
-      <span class="fd-list__title fd-list__title--wrap" id="Az0bg2">List item 2 that wraps with a top-aligned checkbox. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur</span>
+      <span class="fd-list__title fd-list__title--wrap" id="Az0bg2">List item 2 that wraps with a top-aligned checkbox. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor</span>
   </li>
   <li role="option" tabindex="0" class="fd-list__item">
       <div class="fd-form-item fd-list__form-item">

--- a/packages/styles/stories/Components/List/list/standard/selection.example.html
+++ b/packages/styles/stories/Components/List/list/standard/selection.example.html
@@ -6,7 +6,7 @@
             <span class="fd-checkbox__checkmark" aria-hidden="true"></span>
           </label>
       </div>
-      <span class="fd-list__title" id="Az0bg1">List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1 List item 1</span>
+      <span class="fd-list__title" id="Az0bg1">List item 1 that wraps with a centered checkbox. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua</span>
   </li>
   <li role="option" tabindex="0" class="fd-list__item is-selected fd-list__item--wrap fd-list__item--wrap-top-aligned" aria-selected="true">
       <div class="fd-form-item fd-list__form-item">
@@ -15,7 +15,7 @@
             <span class="fd-checkbox__checkmark" aria-hidden="true"></span>
           </label>
       </div>
-      <span class="fd-list__title fd-list__title--wrap" id="Az0bg2">List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2 List item 2</span>
+      <span class="fd-list__title fd-list__title--wrap" id="Az0bg2">List item 2 that wraps with a top-aligned checkbox. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur</span>
   </li>
   <li role="option" tabindex="0" class="fd-list__item">
       <div class="fd-form-item fd-list__form-item">

--- a/packages/styles/stories/Components/List/list/standard/standard-list.stories.js
+++ b/packages/styles/stories/Components/List/list/standard/standard-list.stories.js
@@ -3,6 +3,7 @@ import inactiveExampleHtml from "./inactive.example.html?raw";
 import selectionExampleHtml from "./selection.example.html?raw";
 import borderlessExampleHtml from "./borderless.example.html?raw";
 import footerExampleHtml from "./footer.example.html?raw";
+import longTextExampleHtml from "./long-text.example.html?raw";
 import groupsExampleHtml from "./groups.example.html?raw";
 import iconsExampleHtml from "./icons.example.html?raw";
 import itemCounterExampleHtml from "./item-counter.example.html?raw";
@@ -218,6 +219,30 @@ SearchResults.parameters = {
   docs: {
     description: {
       story: `To be used in a popover containing sophisticated search results.`
+    }
+  }
+};
+
+export const LongText = () => longTextExampleHtml;
+LongText.storyName = 'List with long Title and Secondary Text';
+LongText.parameters = {
+  docs: {
+    description: {
+      story: `By default, long title and secondary text is truncated with an ellipsis. Wrapping can be enabled at three levels:
+
+**List level** — add \`fd-list--wrap\` to the root element to wrap all items:
+\`\`\`html
+<ul class="fd-list fd-list--wrap">
+\`\`\`
+
+**Item level** — add \`fd-list__item--wrap\` to a single list item:
+\`\`\`html
+<li class="fd-list__item fd-list__item--wrap">
+\`\`\`
+
+**Element level** — add modifier classes to individual elements:
+- \`fd-list__title--wrap\`
+- \`fd-list__secondary--wrap\``
     }
   }
 };

--- a/packages/styles/stories/Components/List/list/standard/standard-list.stories.js
+++ b/packages/styles/stories/Components/List/list/standard/standard-list.stories.js
@@ -19,6 +19,7 @@ import searchResultsExampleHtml from "./search-results.example.html?raw";
 import '../../../../../src/list.scss';
 import '../../../../../src/icon.scss';
 import '../../../../../src/checkbox.scss';
+import '../../../../../src/link.scss';
 import '../../../../../src/button.scss';
 import '../../../../../src/busy-indicator.scss';
 import '../../../../../src/avatar.scss';

--- a/packages/styles/stories/Components/List/list/standard/standard-list.stories.js
+++ b/packages/styles/stories/Components/List/list/standard/standard-list.stories.js
@@ -191,6 +191,8 @@ Selection.parameters = {
   docs: {
     description: {
       story: `Standard list items can display checkboxes that users can select from. To display standard list items with selection, add the \`fd-list--selection\` modifier class to the main element. To create checkbox form items, add the \`fd-list__form-item\` class within each list element.
+
+When items contain wrapping text (via \`fd-list__item--wrap\` or \`fd-list__title--wrap\`), the checkbox is **centered by default**. To top-align the checkbox instead, add \`fd-list__item--wrap-top-aligned\` to the \`<li>\` element.
 `
     }
   }

--- a/packages/styles/stories/Components/List/list/subline/long-text.example.html
+++ b/packages/styles/stories/Components/List/list/subline/long-text.example.html
@@ -1,53 +1,68 @@
-<!-- List level: fd-list--wrap makes all items wrap -->
-<ul class="fd-list fd-list--subline fd-list--wrap" role="list">
-    <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
-        <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-10" role="img" aria-label="John Doe">JD</span>
-        <div class="fd-list__content">
-            <div class="fd-list__title">All titles wrap at list level, Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo?</div>
-            <div class="fd-list__subline">All sublines wrap too, Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus nulla aliquid soluta aperiam, amet iste sint? Explicabo dicta doloremque amet minima perferendis.</div>
-        </div>
-    </li>
-    <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
-        <span class="fd-avatar fd-avatar--sm fd-avatar--thumbnail" style="background-image: url('/assets/images/landscape/L1.jpg')" role="img" aria-label="Jane Doe"></span>
-        <div class="fd-list__content">
-            <div class="fd-list__title">Second item wraps too, Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam.</div>
-            <div class="fd-list__subline">Second subline wraps, Lorem ipsum dolor sit amet consectetur adipisicing elit. Eaque asperiores id deleniti quae?</div>
-        </div>
-    </li>
-</ul>
+<div style="margin-bottom: 2rem;">
+    <p class="fd-form-label" style="margin-bottom: 0.5rem;">Default — truncation</p>
+    <ul class="fd-list fd-list--subline" role="list">
+        <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
+            <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-10" role="img" aria-label="Michael Thompson">MT</span>
+            <div class="fd-list__content">
+                <div class="fd-list__title">Annual Budget Review for Q3 and Q4 — please review the attached documents and provide your feedback before the end of the fiscal quarter to ensure timely processing.</div>
+                <div class="fd-list__subline">Finance · Updated 2 hours ago by Michael Thompson, Senior Analyst, Global Finance Division · Reviewed by Anna Schmidt · Pending CFO approval</div>
+            </div>
+        </li>
+    </ul>
+</div>
 
-<!-- Item level: fd-list__item--wrap wraps a single item -->
-<ul class="fd-list fd-list--subline" role="list">
-    <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
-        <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-10" role="img" aria-label="John Doe">JD</span>
-        <div class="fd-list__content">
-            <div class="fd-list__title">This item truncates normally, Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error.</div>
-            <div class="fd-list__subline">Subline also truncates, Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus nulla aliquid.</div>
-        </div>
-    </li>
-    <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive fd-list__item--wrap">
-        <span class="fd-avatar fd-avatar--sm fd-avatar--thumbnail" style="background-image: url('/assets/images/landscape/L1.jpg')" role="img" aria-label="Jane Doe"></span>
-        <div class="fd-list__content">
-            <div class="fd-list__title">Only this item wraps, Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo?</div>
-            <div class="fd-list__subline">Subline wraps too, Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus nulla aliquid soluta aperiam, amet iste sint? Explicabo dicta doloremque.</div>
-        </div>
-    </li>
-    <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
-        <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-10" role="img" aria-label="John Doe">JD</span>
-        <div class="fd-list__content">
-            <div class="fd-list__title">This item truncates normally again, Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum.</div>
-            <div class="fd-list__subline">Subline truncates again, Lorem ipsum dolor sit amet consectetur adipisicing elit.</div>
-        </div>
-    </li>
-</ul>
+<div style="margin-bottom: 2rem;">
+    <p class="fd-form-label" style="margin-bottom: 0.5rem;">List level — <code>fd-list--wrap</code></p>
+    <ul class="fd-list fd-list--subline fd-list--wrap" role="list">
+        <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
+            <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-10" role="img" aria-label="John Doe">JD</span>
+            <div class="fd-list__content">
+                <div class="fd-list__title">All titles wrap at list level, Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo?</div>
+                <div class="fd-list__subline">All sublines wrap too, Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus nulla aliquid soluta aperiam, amet iste sint? Explicabo dicta doloremque amet minima perferendis.</div>
+            </div>
+        </li>
+    </ul>
+</div>
 
-<!-- Element level: fd-list__title--wrap / fd-list__subline--wrap for individual control -->
-<ul class="fd-list fd-list--subline" role="list">
-    <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
-        <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-10" role="img" aria-label="John Doe">JD</span>
-        <div class="fd-list__content">
-            <div class="fd-list__title fd-list__title--wrap">Only the title wraps here, Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo?</div>
-            <div class="fd-list__subline fd-list__subline--wrap">Only this subline wraps, Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus nulla aliquid soluta aperiam, amet iste sint? Explicabo dicta doloremque amet minima perferendis.</div>
-        </div>
-    </li>
-</ul>
+<div style="margin-bottom: 2rem;">
+    <p class="fd-form-label" style="margin-bottom: 0.5rem;">Item level — <code>fd-list__item--wrap</code> (collapsed and expanded states)</p>
+    <!-- The fd-list__link--more element is placed outside fd-list__title so it stays
+         visible even when the title truncates. -->
+    <ul class="fd-list fd-list--subline" role="list">
+        <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
+            <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-10" role="img" aria-label="John Doe">JD</span>
+            <div class="fd-list__content">
+                <div class="fd-list__title">Collapsed — title truncated, Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo?</div>
+                <a href="#" class="fd-link fd-list__link--more" aria-expanded="false" tabindex="0"><span class="fd-link__content">More</span></a>
+                <div class="fd-list__subline">Subline truncated, Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus nulla aliquid soluta aperiam, amet iste sint? Explicabo dicta doloremque.</div>
+            </div>
+        </li>
+        <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive fd-list__item--wrap">
+            <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-10" role="img" aria-label="John Doe">JD</span>
+            <div class="fd-list__content">
+                <div class="fd-list__title">Expanded — fd-list__item--wrap applied, Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo? <a href="#" class="fd-link fd-list__link--more" aria-expanded="true" tabindex="0"><span class="fd-link__content">Less</span></a></div>
+                <div class="fd-list__subline">Subline wraps too, Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus nulla aliquid soluta aperiam, amet iste sint? Explicabo dicta doloremque amet minima perferendis.</div>
+            </div>
+        </li>
+    </ul>
+</div>
+
+<div>
+    <p class="fd-form-label" style="margin-bottom: 0.5rem;">Element level — <code>fd-list__title--wrap</code> / <code>fd-list__subline--wrap</code></p>
+    <ul class="fd-list fd-list--subline" role="list">
+        <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
+            <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-10" role="img" aria-label="John Doe">JD</span>
+            <div class="fd-list__content">
+                <div class="fd-list__title fd-list__title--wrap">Only the title wraps here, Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo?</div>
+                <div class="fd-list__subline">Subline still truncates, Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus nulla aliquid soluta aperiam, amet iste sint? Explicabo dicta doloremque.</div>
+            </div>
+        </li>
+        <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
+            <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-6" role="img" aria-label="Jane Doe">JD</span>
+            <div class="fd-list__content">
+                <div class="fd-list__title">Title still truncates, Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita.</div>
+                <div class="fd-list__subline fd-list__subline--wrap">Only the subline wraps here, Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus nulla aliquid soluta aperiam, amet iste sint? Explicabo dicta doloremque amet minima perferendis.</div>
+            </div>
+        </li>
+    </ul>
+</div>

--- a/packages/styles/stories/Components/List/list/subline/long-text.example.html
+++ b/packages/styles/stories/Components/List/list/subline/long-text.example.html
@@ -1,0 +1,53 @@
+<!-- List level: fd-list--wrap makes all items wrap -->
+<ul class="fd-list fd-list--subline fd-list--wrap" role="list">
+    <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
+        <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-10" role="img" aria-label="John Doe">JD</span>
+        <div class="fd-list__content">
+            <div class="fd-list__title">All titles wrap at list level, Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo?</div>
+            <div class="fd-list__subline">All sublines wrap too, Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus nulla aliquid soluta aperiam, amet iste sint? Explicabo dicta doloremque amet minima perferendis.</div>
+        </div>
+    </li>
+    <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
+        <span class="fd-avatar fd-avatar--sm fd-avatar--thumbnail" style="background-image: url('/assets/images/landscape/L1.jpg')" role="img" aria-label="Jane Doe"></span>
+        <div class="fd-list__content">
+            <div class="fd-list__title">Second item wraps too, Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam.</div>
+            <div class="fd-list__subline">Second subline wraps, Lorem ipsum dolor sit amet consectetur adipisicing elit. Eaque asperiores id deleniti quae?</div>
+        </div>
+    </li>
+</ul>
+
+<!-- Item level: fd-list__item--wrap wraps a single item -->
+<ul class="fd-list fd-list--subline" role="list">
+    <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
+        <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-10" role="img" aria-label="John Doe">JD</span>
+        <div class="fd-list__content">
+            <div class="fd-list__title">This item truncates normally, Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error.</div>
+            <div class="fd-list__subline">Subline also truncates, Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus nulla aliquid.</div>
+        </div>
+    </li>
+    <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive fd-list__item--wrap">
+        <span class="fd-avatar fd-avatar--sm fd-avatar--thumbnail" style="background-image: url('/assets/images/landscape/L1.jpg')" role="img" aria-label="Jane Doe"></span>
+        <div class="fd-list__content">
+            <div class="fd-list__title">Only this item wraps, Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo?</div>
+            <div class="fd-list__subline">Subline wraps too, Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus nulla aliquid soluta aperiam, amet iste sint? Explicabo dicta doloremque.</div>
+        </div>
+    </li>
+    <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
+        <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-10" role="img" aria-label="John Doe">JD</span>
+        <div class="fd-list__content">
+            <div class="fd-list__title">This item truncates normally again, Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum.</div>
+            <div class="fd-list__subline">Subline truncates again, Lorem ipsum dolor sit amet consectetur adipisicing elit.</div>
+        </div>
+    </li>
+</ul>
+
+<!-- Element level: fd-list__title--wrap / fd-list__subline--wrap for individual control -->
+<ul class="fd-list fd-list--subline" role="list">
+    <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
+        <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-10" role="img" aria-label="John Doe">JD</span>
+        <div class="fd-list__content">
+            <div class="fd-list__title fd-list__title--wrap">Only the title wraps here, Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo?</div>
+            <div class="fd-list__subline fd-list__subline--wrap">Only this subline wraps, Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus nulla aliquid soluta aperiam, amet iste sint? Explicabo dicta doloremque amet minima perferendis.</div>
+        </div>
+    </li>
+</ul>

--- a/packages/styles/stories/Components/List/list/subline/standard.example.html
+++ b/packages/styles/stories/Components/List/list/subline/standard.example.html
@@ -27,8 +27,9 @@
     <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
         <span class="fd-avatar fd-avatar--sm fd-avatar--thumbnail" style="background-image: url('/assets/images/landscape/L1.jpg')" role="img" aria-label="John Doe"></span>
         <div class="fd-list__content">
-            <div class="fd-list__title">List Item Title</div>
-            <div class="fd-list__subline">List Item Subline</div>
+            <div class="fd-list__title fd-list__title--wrap">List Item Title Lorem, ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo?</div>
+            <div class="fd-list__subline fd-list__subline--wrap">List Item Subline Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus nulla aliquid soluta aperiam, amet iste sint? Explicabo dicta doloremque amet minima perferendis.</div>
+            <div class="fd-list__subline fd-list__subline--wrap">List Item Subline Lorem ipsum dolor sit amet consectetur adipisicing elit. Eaque asperiores id deleniti quae? Amet officia cum assumenda.</div>
         </div>
     </li>
 </ul>

--- a/packages/styles/stories/Components/List/list/subline/standard.example.html
+++ b/packages/styles/stories/Components/List/list/subline/standard.example.html
@@ -17,19 +17,18 @@
         <span class="fd-list__active-indicator sap-icon--sys-enter-2"></span>
     </li>
     <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
-        <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-10" aria-role="img" aria-label="John Doe">JD</span>
+        <span class="fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-10" role="img" aria-label="John Doe">JD</span>
         <div class="fd-list__content">
-            <div class="fd-list__title">List Item Title Lorem, ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo? Lorem, ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo!</div>
-            <div class="fd-list__subline">List Item Subline Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus nulla aliquid soluta aperiam, amet iste sint? Explicabo dicta doloremque amet minima perferendis. Necessitatibus reiciendis voluptatum id nesciunt earum! Lorem, ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo.</div>
-            <div class="fd-list__subline">List Item Subline Lorem ipsum dolor sit amet consectetur adipisicing elit. Eaque asperiores id deleniti quae? Amet officia cum assumenda. Ab, dolores ea dignissimos, aliquid beatae magnam commodi, tenetur facere harum ex nemo? Lorem, ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo.</div>
+            <div class="fd-list__title">List Item Title Lorem, ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo?</div>
+            <div class="fd-list__subline">List Item Subline Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus nulla aliquid soluta aperiam, amet iste sint? Explicabo dicta doloremque amet minima perferendis.</div>
+            <div class="fd-list__subline">List Item Subline Lorem ipsum dolor sit amet consectetur adipisicing elit. Eaque asperiores id deleniti quae? Amet officia cum assumenda.</div>
         </div>
     </li>
     <li role="listitem" tabindex="0" class="fd-list__item fd-list__item--interractive">
         <span class="fd-avatar fd-avatar--sm fd-avatar--thumbnail" style="background-image: url('/assets/images/landscape/L1.jpg')" role="img" aria-label="John Doe"></span>
         <div class="fd-list__content">
-            <div class="fd-list__title fd-list__title--truncate">List Item Title Lorem, ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo? Lorem, ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo!</div>
-            <div class="fd-list__subline fd-list__subline--truncate">List Item Subline Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus nulla aliquid soluta aperiam, amet iste sint? Explicabo dicta doloremque amet minima perferendis. Necessitatibus reiciendis voluptatum id nesciunt earum! Lorem, ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo.</div>
-            <div class="fd-list__subline fd-list__subline--truncate">List Item Subline Lorem ipsum dolor sit amet consectetur adipisicing elit. Eaque asperiores id deleniti quae? Amet officia cum assumenda. Ab, dolores ea dignissimos, aliquid beatae magnam commodi, tenetur facere harum ex nemo? Lorem, ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo.</div>
+            <div class="fd-list__title">List Item Title</div>
+            <div class="fd-list__subline">List Item Subline</div>
         </div>
     </li>
 </ul>

--- a/packages/styles/stories/Components/List/list/subline/subline-list.stories.js
+++ b/packages/styles/stories/Components/List/list/subline/subline-list.stories.js
@@ -1,4 +1,5 @@
 import standardExampleHtml from "./standard.example.html?raw";
+import longTextExampleHtml from "./long-text.example.html?raw";
 
 import '../../../../../src/avatar.scss';
 import '../../../../../src/list.scss';
@@ -16,8 +17,32 @@ Standard.storyName = 'Custom List Item with Subline';
 Standard.parameters = {
   docs: {
     description: {
-      story: `This is structure of the custom list item is being used to display the accounts in USer Menu. 
+      story: `This list item structure is used to display accounts in the User Menu. By default, long title and subline text is truncated with an ellipsis. To allow the text to wrap across multiple lines, add the \`fd-list__title--wrap\` and \`fd-list__subline--wrap\` modifier classes respectively.
     `
+    }
+  }
+}
+
+export const LongText = () => longTextExampleHtml;
+LongText.storyName = 'Subline List with Wrapping Text';
+LongText.parameters = {
+  docs: {
+    description: {
+      story: `By default, long title and subline text is truncated with an ellipsis. Wrapping can be enabled at three levels:
+
+**List level** — add \`fd-list--wrap\` to the root element to wrap all items:
+\`\`\`html
+<ul class="fd-list fd-list--subline fd-list--wrap">
+\`\`\`
+
+**Item level** — add \`fd-list__item--wrap\` to a single list item:
+\`\`\`html
+<li class="fd-list__item fd-list__item--wrap">
+\`\`\`
+
+**Element level** — add modifier classes to individual elements:
+- \`fd-list__title--wrap\`
+- \`fd-list__subline--wrap\``
     }
   }
 }

--- a/packages/styles/stories/Components/user-menu/default.example.html
+++ b/packages/styles/stories/Components/user-menu/default.example.html
@@ -370,15 +370,15 @@
                             ></i>
                         </span>
                         <div class="fd-user-menu__header-container">
-                            <div class="fd-user-menu__user-name">
+                            <div class="fd-user-menu__user-name fd-user-menu__user-name--wrap">
                                 Lisa Miller Lorem ipsum dolor sit amet consectetur, adipisicing elit. Culpa consequuntur
                                 cum voluptate iure tenetu!
                             </div>
-                            <div class="fd-user-menu__subline">
+                            <div class="fd-user-menu__subline fd-user-menu__subline--wrap">
                                 lisa.miller@test.com Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptatem
                                 quod accusamus quis magnam, reprehenderit anim.
                             </div>
-                            <div class="fd-user-menu__subline">
+                            <div class="fd-user-menu__subline fd-user-menu__subline--wrap">
                                 A very long subline 2 that can be displayed by wrapping behaviour in the subtitle like
                                 this.
                             </div>
@@ -433,15 +433,15 @@
                                             aria-label="Jane Doe"
                                         ></span>
                                         <div class="fd-list__content">
-                                            <div class="fd-list__title">
+                                            <div class="fd-list__title fd-list__title--wrap">
                                                 Lisa Miller Lorem, ipsum dolor sit amet consectetur adipisicing elit.
                                                 Autem minima ex distinctio dolores vitae!
                                             </div>
-                                            <div class="fd-list__subline">
+                                            <div class="fd-list__subline fd-list__subline--wrap">
                                                 lisa.miller@test.com Lorem, ipsum dolor sit amet consectetur adipisicing
                                                 elit.
                                             </div>
-                                            <div class="fd-list__subline">
+                                            <div class="fd-list__subline fd-list__subline--wrap">
                                                 Delivery Manager Lorem ipsum dolor sit amet consectetur adipisicing
                                                 elit.
                                             </div>

--- a/packages/styles/stories/Components/user-menu/user-menu.stories.js
+++ b/packages/styles/stories/Components/user-menu/user-menu.stories.js
@@ -60,10 +60,10 @@ Represents the current user and includes:
 <ul>
     <li>Popover: Contains the entire User Menu content.</li>
     <li>Avatar: A key visual element displaying the user's profile picture. If no profile picture is available, it shows the user's initials. If the user is not signed in, an icon is displayed.</li>
-    <li>Title: A required UI element showing the user's First and Last names. To truncate long titles use the <code>.fd-user-menu\\_\\_user-name--truncate</code> modifier class.</li>
-    <li>Subtitle 1 (subline): An optional secondary identifier, such as user ID or email.</li>
-    <li>Subtitle 2 (subline): An optional identifier, such as role, position, organization, or unit.</li>
-    <li>Subtitle 3 (subline): An optional identifier, such as role, position, organization, or unit. To truncate long subtitles use the <code>.fd-user-menu\\_\\_subline--truncate</code> modifier class.</li>
+    <li>Title: A required UI element showing the user's First and Last names. By default, long titles are clamped to two lines. To allow the title to wrap across multiple lines, use the <code>.fd-user-menu\\_\\_user-name--wrap</code> modifier class.</li>
+    <li>Subtitle 1 (subline): An optional secondary identifier, such as user ID or email. By default, long subtitles are truncated. To allow a subtitle to wrap across multiple lines, use the <code>.fd-user-menu\\_\\_subline--wrap</code> modifier class.</li>
+    <li>Subtitle 2 (subline): An optional identifier, such as role, position, organization, or unit. To allow it to wrap across multiple lines, use the <code>.fd-user-menu\\_\\_subline--wrap</code> modifier class.</li>
+    <li>Subtitle 3 (subline): An optional identifier, such as role, position, organization, or unit. By default, long subtitles are truncated. To allow it to wrap across multiple lines, use the <code>.fd-user-menu\\_\\_subline--wrap</code> modifier class.</li>
     <li>Manage Account Button: Links to account settings.</li>
 </ul>
 

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -35250,8 +35250,9 @@ exports[`Check stories > Components/List/Subline > Story Standard > Should match
     <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-list__item--interractive\\">
         <span class=\\"fd-avatar fd-avatar--sm fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/landscape/L1.jpg')\\" role=\\"img\\" aria-label=\\"John Doe\\"></span>
         <div class=\\"fd-list__content\\">
-            <div class=\\"fd-list__title\\">List Item Title</div>
-            <div class=\\"fd-list__subline\\">List Item Subline</div>
+            <div class=\\"fd-list__title fd-list__title--wrap\\">List Item Title Lorem, ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo?</div>
+            <div class=\\"fd-list__subline fd-list__subline--wrap\\">List Item Subline Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus nulla aliquid soluta aperiam, amet iste sint? Explicabo dicta doloremque amet minima perferendis.</div>
+            <div class=\\"fd-list__subline fd-list__subline--wrap\\">List Item Subline Lorem ipsum dolor sit amet consectetur adipisicing elit. Eaque asperiores id deleniti quae? Amet officia cum assumenda.</div>
         </div>
     </li>
 </ul>

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -7730,8 +7730,8 @@ exports[`Check stories > BTP/User Menu > Story UserMenuExample > Should match sn
                             style=\\"background-image: url('assets/images/avatars/3.svg');\\"></span>
                     </div>
                     <div class=\\"fd-user-menu__subheader\\">
-                        <div class=\\"fd-user-menu__user-name fd-user-menu__user-name--wrap\\">Kevin Miller</div>
-                        <div class=\\"fd-user-menu__user-role fd-user-menu__user-role--wrap\\">Design Expert</div>
+                        <div class=\\"fd-user-menu__user-name\\">Kevin Miller</div>
+                        <div class=\\"fd-user-menu__user-role\\">Design Expert</div>
                     </div>
                     <div class=\\"fd-user-menu__navigation-menu\\">
                         <div class=\\"fd-navigation\\">
@@ -7916,8 +7916,8 @@ exports[`Check stories > BTP/User Menu > Story UserMenuPhoneExample > Should mat
                             style=\\"background-image: url('assets/images/avatars/3.svg');\\"></span>
                     </div>
                     <div class=\\"fd-user-menu__subheader\\">
-                        <div class=\\"fd-user-menu__user-name fd-user-menu__user-name--wrap\\">Kevin Miller</div>
-                        <div class=\\"fd-user-menu__user-role fd-user-menu__user-role--wrap\\">Design Expert</div>
+                        <div class=\\"fd-user-menu__user-name\\">Kevin Miller</div>
+                        <div class=\\"fd-user-menu__user-role\\">Design Expert</div>
                     </div>
                     <div class=\\"fd-user-menu__navigation-menu\\">
                         <div class=\\"fd-navigation fd-navigation--phone\\">
@@ -8155,8 +8155,8 @@ exports[`Check stories > BTP/User Menu > Story UserMenuTabletExample > Should ma
                             style=\\"background-image: url('assets/images/avatars/3.svg');\\"></span>
                     </div>
                     <div class=\\"fd-user-menu__subheader\\">
-                        <div class=\\"fd-user-menu__user-name fd-user-menu__user-name--wrap\\">Kevin Miller</div>
-                        <div class=\\"fd-user-menu__user-role fd-user-menu__user-role--wrap\\">Design Expert</div>
+                        <div class=\\"fd-user-menu__user-name\\">Kevin Miller</div>
+                        <div class=\\"fd-user-menu__user-role\\">Design Expert</div>
                     </div>
                     <div class=\\"fd-user-menu__navigation-menu\\">
                         <div class=\\"fd-navigation fd-navigation--tablet\\">

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -7730,8 +7730,8 @@ exports[`Check stories > BTP/User Menu > Story UserMenuExample > Should match sn
                             style=\\"background-image: url('assets/images/avatars/3.svg');\\"></span>
                     </div>
                     <div class=\\"fd-user-menu__subheader\\">
-                        <div class=\\"fd-user-menu__user-name\\">Kevin Miller</div>
-                        <div class=\\"fd-user-menu__user-role\\">Design Expert</div>
+                        <div class=\\"fd-user-menu__user-name fd-user-menu__user-name--wrap\\">Kevin Miller</div>
+                        <div class=\\"fd-user-menu__user-role fd-user-menu__user-role--wrap\\">Design Expert</div>
                     </div>
                     <div class=\\"fd-user-menu__navigation-menu\\">
                         <div class=\\"fd-navigation\\">
@@ -7916,8 +7916,8 @@ exports[`Check stories > BTP/User Menu > Story UserMenuPhoneExample > Should mat
                             style=\\"background-image: url('assets/images/avatars/3.svg');\\"></span>
                     </div>
                     <div class=\\"fd-user-menu__subheader\\">
-                        <div class=\\"fd-user-menu__user-name\\">Kevin Miller</div>
-                        <div class=\\"fd-user-menu__user-role\\">Design Expert</div>
+                        <div class=\\"fd-user-menu__user-name fd-user-menu__user-name--wrap\\">Kevin Miller</div>
+                        <div class=\\"fd-user-menu__user-role fd-user-menu__user-role--wrap\\">Design Expert</div>
                     </div>
                     <div class=\\"fd-user-menu__navigation-menu\\">
                         <div class=\\"fd-navigation fd-navigation--phone\\">
@@ -8155,8 +8155,8 @@ exports[`Check stories > BTP/User Menu > Story UserMenuTabletExample > Should ma
                             style=\\"background-image: url('assets/images/avatars/3.svg');\\"></span>
                     </div>
                     <div class=\\"fd-user-menu__subheader\\">
-                        <div class=\\"fd-user-menu__user-name\\">Kevin Miller</div>
-                        <div class=\\"fd-user-menu__user-role\\">Design Expert</div>
+                        <div class=\\"fd-user-menu__user-name fd-user-menu__user-name--wrap\\">Kevin Miller</div>
+                        <div class=\\"fd-user-menu__user-role fd-user-menu__user-role--wrap\\">Design Expert</div>
                     </div>
                     <div class=\\"fd-user-menu__navigation-menu\\">
                         <div class=\\"fd-navigation fd-navigation--tablet\\">
@@ -60888,15 +60888,15 @@ exports[`Check stories > Components/User Menu > Story Default > Should match sna
                             ></i>
                         </span>
                         <div class=\\"fd-user-menu__header-container\\">
-                            <div class=\\"fd-user-menu__user-name\\">
+                            <div class=\\"fd-user-menu__user-name fd-user-menu__user-name--wrap\\">
                                 Lisa Miller Lorem ipsum dolor sit amet consectetur, adipisicing elit. Culpa consequuntur
                                 cum voluptate iure tenetu!
                             </div>
-                            <div class=\\"fd-user-menu__subline\\">
+                            <div class=\\"fd-user-menu__subline fd-user-menu__subline--wrap\\">
                                 lisa.miller@test.com Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptatem
                                 quod accusamus quis magnam, reprehenderit anim.
                             </div>
-                            <div class=\\"fd-user-menu__subline\\">
+                            <div class=\\"fd-user-menu__subline fd-user-menu__subline--wrap\\">
                                 A very long subline 2 that can be displayed by wrapping behaviour in the subtitle like
                                 this.
                             </div>
@@ -60951,15 +60951,15 @@ exports[`Check stories > Components/User Menu > Story Default > Should match sna
                                             aria-label=\\"Jane Doe\\"
                                         ></span>
                                         <div class=\\"fd-list__content\\">
-                                            <div class=\\"fd-list__title\\">
+                                            <div class=\\"fd-list__title fd-list__title--wrap\\">
                                                 Lisa Miller Lorem, ipsum dolor sit amet consectetur adipisicing elit.
                                                 Autem minima ex distinctio dolores vitae!
                                             </div>
-                                            <div class=\\"fd-list__subline\\">
+                                            <div class=\\"fd-list__subline fd-list__subline--wrap\\">
                                                 lisa.miller@test.com Lorem, ipsum dolor sit amet consectetur adipisicing
                                                 elit.
                                             </div>
-                                            <div class=\\"fd-list__subline\\">
+                                            <div class=\\"fd-list__subline fd-list__subline--wrap\\">
                                                 Delivery Manager Lorem ipsum dolor sit amet consectetur adipisicing
                                                 elit.
                                             </div>
@@ -61178,9 +61178,9 @@ exports[`Check stories > Components/User Menu > Story Mobile > Should match snap
                                     <span class=\\"fd-menu__title\\">About</span>
                                 </a>
                             </li>
-                            
+
                         </ul>
-                    </nav>  
+                    </nav>
                 </div>
             </div>
             <div class=\\"fd-bar fd-bar--footer fd-user-menu__footer\\">
@@ -61233,7 +61233,7 @@ exports[`Check stories > Components/User Menu > Story Mobile > Should match snap
                             </div>
                         </li>
                     </ul>
-                </nav>  
+                </nav>
             </div>
         </div>
     </div>

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -33970,10 +33970,10 @@ exports[`Check stories > Components/List/Byline > Story Buttons > Should match s
             <span class=\\"fd-list__title fd-list__title--wrap\\">List item 1</span>
             <span class=\\"fd-list__byline\\">Byline (description) List item 1 </span>
         </div>
-        <button class=\\"fd-button fd-button--transparent fd-list__button\\">
+        <button class=\\"fd-button fd-button--transparent fd-list__button\\" aria-label=\\"Edit>
             <i class=\\"sap-icon--edit\\"></i>
         </button>
-        <button class=\\"fd-button fd-button--transparent fd-list__button\\">
+        <button class=\\"fd-button fd-button--transparent fd-list__button\\" aria-label=\\"Decline\\">
             <i class=\\"sap-icon--decline\\"></i>
         </button>
     </li>
@@ -33991,10 +33991,10 @@ exports[`Check stories > Components/List/Byline > Story Buttons > Should match s
                 nibh ornare. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas</span
             >
         </div>
-        <button class=\\"fd-button fd-button--transparent fd-list__button\\">
+        <button class=\\"fd-button fd-button--transparent fd-list__button\\" aria-label=\\"Edit\\">
             <i class=\\"sap-icon--edit\\"></i>
         </button>
-        <button class=\\"fd-button fd-button--transparent fd-list__button\\">
+        <button class=\\"fd-button fd-button--transparent fd-list__button\\" aria-label=\\"Decline\\">
             <i class=\\"sap-icon--decline\\"></i>
         </button>
     </li>

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -33951,7 +33951,7 @@ style=\\"background-image: url('assets/images/backgrounds/Godafoss_waterfall_in_
 <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
     <span class=\\"fd-list__thumbnail\\"><i role=\\"presentation\\" class=\\"sap-icon--world\\"></i></span>
   <div class=\\"fd-list__content\\">
-      <div class=\\"fd-list__title fd-list__title--wrap\\">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua, ut enim ad minim veniam</div>
+      <div class=\\"fd-list__title fd-list__title--wrap\\">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur</div>
       <div class=\\"fd-list__byline fd-list__byline--2-col\\">
           <div class=\\"fd-list__byline-left\\">First text item in byline (standard text)</div>
           <div class=\\"fd-list__byline-right fd-list__byline-right--informative\\">Second text item in byline (information)</div>
@@ -33982,11 +33982,13 @@ exports[`Check stories > Components/List/Byline > Story Buttons > Should match s
         <div class=\\"fd-list__content\\">
             <span class=\\"fd-list__title fd-list__title--wrap\\"
                 >Title that wraps. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
-                dolore magna aliqua</span
+                dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur</span
             >
             <span class=\\"fd-list__byline fd-list__byline--wrap\\"
                 >Byline that wraps. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Donec velit
-                neque, auctor sit amet aliquam vel</span
+                neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula. Proin elementum sapien vel enim facilisis, at faucibus
+                nibh ornare. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas</span
             >
         </div>
         <button class=\\"fd-button fd-button--transparent fd-list__button\\">
@@ -34006,8 +34008,8 @@ exports[`Check stories > Components/List/Byline > Story Counter > Should match s
 <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
     <span class=\\"fd-list__thumbnail\\"><i role=\\"presentation\\" class=\\"sap-icon--activate\\"></i></span>
     <div class=\\"fd-list__content\\">
-      <div class=\\"fd-list__title fd-list__title--wrap\\">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua</div>
-      <div class=\\"fd-list__byline fd-list__byline--wrap\\">Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula</div>
+      <div class=\\"fd-list__title fd-list__title--wrap\\">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore</div>
+      <div class=\\"fd-list__byline fd-list__byline--wrap\\">Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula. Proin elementum sapien vel enim facilisis, at faucibus nibh ornare. Pellentesque habitant morbi tristique senectus et netus</div>
     </div>
     <span class=\\"fd-list__item-counter\\">123</span>
 </li>
@@ -34275,8 +34277,8 @@ exports[`Check stories > Components/List/Byline > Story NavigationIndicator > Sh
   <a tabindex=\\"0\\" class=\\"fd-list__link fd-list__link--navigation-indicator\\" href=\\"#\\">
     <span class=\\"fd-list__thumbnail\\"><i role=\\"presentation\\" class=\\"sap-icon--activate\\"></i></span>
     <div class=\\"fd-list__content\\">
-      <div class=\\"fd-list__title fd-list__title--wrap\\">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua</div>
-      <div class=\\"fd-list__byline fd-list__byline--wrap\\">Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula</div>
+      <div class=\\"fd-list__title fd-list__title--wrap\\">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore</div>
+      <div class=\\"fd-list__byline fd-list__byline--wrap\\">Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula. Proin elementum sapien vel enim facilisis, at faucibus nibh ornare. Pellentesque habitant morbi tristique senectus et netus</div>
     </div>
   </a>
 </li>
@@ -34314,8 +34316,8 @@ exports[`Check stories > Components/List/Byline > Story Selection > Should match
         </div>
         <span class=\\"fd-list__thumbnail\\"><i role=\\"presentation\\" class=\\"sap-icon--activate\\"></i></span>
         <div class=\\"fd-list__content\\">
-            <span class=\\"fd-list__title\\" id=\\"O09lk1\\">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua</span>
-            <span class=\\"fd-list__byline\\">Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Donec velit neque, auctor sit amet aliquam vel</span>
+            <span class=\\"fd-list__title\\" id=\\"O09lk1\\">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit</span>
+            <span class=\\"fd-list__byline\\">Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula. Proin elementum sapien vel enim facilisis</span>
         </div>
     </li>
     <li role=\\"option\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
@@ -34622,13 +34624,13 @@ exports[`Check stories > Components/List/Standard > Story Borderless > Should ma
 exports[`Check stories > Components/List/Standard > Story Buttons > Should match snapshot 1`] = `
 "<ul class=\\"fd-list\\" role=\\"list\\">
   <li tabindex=\\"-1\\" role=\\"listitem\\" class=\\"fd-list__item fd-list__item--wrap\\">
-    <span class=\\"fd-list__title\\">List item 1 that wraps. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua, ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat</span>
+    <span class=\\"fd-list__title\\">List item 1 that wraps. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua, ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur, excepteur sint occaecat cupidatat non proident</span>
     <button class=\\"fd-button fd-button--transparent fd-list__button\\">
         <i class=\\"sap-icon--edit\\"></i>
     </button>
   </li>
   <li tabindex=\\"-1\\" role=\\"listitem\\" class=\\"fd-list__item\\">
-    <span class=\\"fd-list__title fd-list__title--wrap\\">List item 2 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur</span>
+    <span class=\\"fd-list__title fd-list__title--wrap\\">List item 2 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum</span>
     <button class=\\"fd-button fd-button--transparent fd-list__button\\">
         <i class=\\"sap-icon--decline\\"></i>
     </button>
@@ -34705,14 +34707,14 @@ exports[`Check stories > Components/List/Standard > Story Icons > Should match s
   </li>
   <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-list__item--wrap\\">
       <i role=\\"presentation\\" class=\\"fd-list__icon sap-icon--wrench\\"></i>
-      <span class=\\"fd-list__title\\">List item 2 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur</span>
+      <span class=\\"fd-list__title\\">List item 2 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum</span>
   </li>
   <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
       <span class=\\"fd-list__title\\">List item 3</span>
       <i role=\\"presentation\\" class=\\"fd-list__icon sap-icon--lightbulb\\"></i>
   </li>
   <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
-      <span class=\\"fd-list__title fd-list__title--wrap\\">List item 4 that wraps. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur, excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum</span>
+      <span class=\\"fd-list__title fd-list__title--wrap\\">List item 4 that wraps. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur, excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua</span>
       <i role=\\"presentation\\" class=\\"fd-list__icon sap-icon--history\\"></i>
   </li>
 </ul>"
@@ -34775,7 +34777,7 @@ exports[`Check stories > Components/List/Standard > Story Interactive > Should m
 exports[`Check stories > Components/List/Standard > Story ItemCounter > Should match snapshot 1`] = `
 "<ul class=\\"fd-list\\" role=\\"list\\">
   <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-list__item--wrap\\">
-      <span class=\\"fd-list__title\\">List item 1 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit</span>
+      <span class=\\"fd-list__title\\">List item 1 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum</span>
       <span class=\\"fd-list__item-counter\\">12345</span>
   </li>
   <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
@@ -34784,7 +34786,7 @@ exports[`Check stories > Components/List/Standard > Story ItemCounter > Should m
   </li>
   <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
       <i role=\\"presentation\\" class=\\"fd-list__icon sap-icon--lightbulb\\"></i>
-      <span class=\\"fd-list__title fd-list__title--wrap\\">List item 3 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit</span>
+      <span class=\\"fd-list__title fd-list__title--wrap\\">List item 3 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum</span>
       <span class=\\"fd-list__item-counter\\">12345</span>
   </li>
   <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
@@ -34886,13 +34888,13 @@ exports[`Check stories > Components/List/Standard > Story NavigationIndicator > 
 "<ul class=\\"fd-list fd-list--navigation fd-list--navigation-indication\\" role=\\"list\\">
   <li tabindex=\\"-1\\" role=\\"listitem\\" class=\\"fd-list__item fd-list__item--wrap fd-list__item--link\\">
       <a tabindex=\\"0\\" class=\\"fd-list__link fd-list__link--navigation-indicator\\" href=\\"#\\">
-        <span class=\\"fd-list__title\\">List item 1 that wraps. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua, ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat</span>
+        <span class=\\"fd-list__title\\">List item 1 that wraps. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua, ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur, excepteur sint occaecat cupidatat non proident</span>
       </a>
   </li>
   <li tabindex=\\"-1\\" role=\\"listitem\\" class=\\"fd-list__item fd-list__item--link\\">
       <a tabindex=\\"0\\" class=\\"fd-list__link fd-list__link--navigation-indicator is-selected\\" href=\\"#\\">
         <i role=\\"presentation\\" class=\\"fd-list__icon sap-icon--history\\"></i>
-        <span class=\\"fd-list__title fd-list__title--wrap\\">List item 2 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur, excepteur sint occaecat cupidatat non proident</span>
+        <span class=\\"fd-list__title fd-list__title--wrap\\">List item 2 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur, excepteur sint occaecat cupidatat non proident. Sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit</span>
       </a>
   </li>
   <li tabindex=\\"0\\" role=\\"listitem\\" class=\\"fd-list__item\\">
@@ -35055,11 +35057,11 @@ exports[`Check stories > Components/List/Standard > Story SearchResults > Should
 exports[`Check stories > Components/List/Standard > Story SecondaryData > Should match snapshot 1`] = `
 "<ul class=\\"fd-list\\" role=\\"list\\">
   <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-list__item--wrap\\">
-      <span class=\\"fd-list__title\\">List item 1 that wraps. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua</span>
+      <span class=\\"fd-list__title\\">List item 1 that wraps. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore</span>
       <span class=\\"fd-list__secondary\\">Neutral Status</span>
   </li>
   <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
-      <span class=\\"fd-list__title fd-list__title--wrap\\">List item 2 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit</span>
+      <span class=\\"fd-list__title fd-list__title--wrap\\">List item 2 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum</span>
       <span class=\\"fd-list__secondary fd-list__secondary--positive\\">Positive Status</span>
   </li>
   <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
@@ -35087,7 +35089,7 @@ exports[`Check stories > Components/List/Standard > Story Selection > Should mat
             <span class=\\"fd-checkbox__checkmark\\" aria-hidden=\\"true\\"></span>
           </label>
       </div>
-      <span class=\\"fd-list__title\\" id=\\"Az0bg1\\">List item 1 that wraps with a centered checkbox. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua</span>
+      <span class=\\"fd-list__title\\" id=\\"Az0bg1\\">List item 1 that wraps with a centered checkbox. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore</span>
   </li>
   <li role=\\"option\\" tabindex=\\"0\\" class=\\"fd-list__item is-selected fd-list__item--wrap fd-list__item--wrap-top-aligned\\" aria-selected=\\"true\\">
       <div class=\\"fd-form-item fd-list__form-item\\">
@@ -35096,7 +35098,7 @@ exports[`Check stories > Components/List/Standard > Story Selection > Should mat
             <span class=\\"fd-checkbox__checkmark\\" aria-hidden=\\"true\\"></span>
           </label>
       </div>
-      <span class=\\"fd-list__title fd-list__title--wrap\\" id=\\"Az0bg2\\">List item 2 that wraps with a top-aligned checkbox. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur</span>
+      <span class=\\"fd-list__title fd-list__title--wrap\\" id=\\"Az0bg2\\">List item 2 that wraps with a top-aligned checkbox. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor</span>
   </li>
   <li role=\\"option\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
       <div class=\\"fd-form-item fd-list__form-item\\">

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -33951,7 +33951,7 @@ style=\\"background-image: url('assets/images/backgrounds/Godafoss_waterfall_in_
 <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
     <span class=\\"fd-list__thumbnail\\"><i role=\\"presentation\\" class=\\"sap-icon--world\\"></i></span>
   <div class=\\"fd-list__content\\">
-      <div class=\\"fd-list__title\\">List item with 2-column byline (with an additional semantic byline)</div>
+      <div class=\\"fd-list__title fd-list__title--wrap\\">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua, ut enim ad minim veniam</div>
       <div class=\\"fd-list__byline fd-list__byline--2-col\\">
           <div class=\\"fd-list__byline-left\\">First text item in byline (standard text)</div>
           <div class=\\"fd-list__byline-right fd-list__byline-right--informative\\">Second text item in byline (information)</div>
@@ -33963,12 +33963,31 @@ style=\\"background-image: url('assets/images/backgrounds/Godafoss_waterfall_in_
 `;
 
 exports[`Check stories > Components/List/Byline > Story Buttons > Should match snapshot 1`] = `
-"
-<ul class=\\"fd-list fd-list--byline\\" role=\\"list\\">
+"<ul class=\\"fd-list fd-list--byline\\" role=\\"list\\">
     <li role=\\"listitem\\" class=\\"fd-list__item\\">
         <span class=\\"fd-list__thumbnail\\"><i role=\\"presentation\\" class=\\"sap-icon--activate\\"></i></span>
         <div class=\\"fd-list__content\\">
-            <span class=\\"fd-list__title\\">List item 1</span>
+            <span class=\\"fd-list__title fd-list__title--wrap\\">List item 1</span>
+            <span class=\\"fd-list__byline\\">Byline (description) List item 1 </span>
+        </div>
+        <button class=\\"fd-button fd-button--transparent fd-list__button\\">
+            <i class=\\"sap-icon--edit\\"></i>
+        </button>
+        <button class=\\"fd-button fd-button--transparent fd-list__button\\">
+            <i class=\\"sap-icon--decline\\"></i>
+        </button>
+    </li>
+    <li role=\\"listitem\\" class=\\"fd-list__item\\">
+        <span class=\\"fd-list__thumbnail\\"><i role=\\"presentation\\" class=\\"sap-icon--activate\\"></i></span>
+        <div class=\\"fd-list__content\\">
+            <span class=\\"fd-list__title fd-list__title--wrap\\"
+                >Title that wraps. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+                dolore magna aliqua</span
+            >
+            <span class=\\"fd-list__byline fd-list__byline--wrap\\"
+                >Byline that wraps. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Donec velit
+                neque, auctor sit amet aliquam vel</span
+            >
         </div>
         <button class=\\"fd-button fd-button--transparent fd-list__button\\">
             <i class=\\"sap-icon--edit\\"></i>
@@ -33987,8 +34006,8 @@ exports[`Check stories > Components/List/Byline > Story Counter > Should match s
 <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
     <span class=\\"fd-list__thumbnail\\"><i role=\\"presentation\\" class=\\"sap-icon--activate\\"></i></span>
     <div class=\\"fd-list__content\\">
-      <div class=\\"fd-list__title\\">List Item Title</div>
-      <div class=\\"fd-list__byline\\">Byline (description)</div>
+      <div class=\\"fd-list__title fd-list__title--wrap\\">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua</div>
+      <div class=\\"fd-list__byline fd-list__byline--wrap\\">Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula</div>
     </div>
     <span class=\\"fd-list__item-counter\\">123</span>
 </li>
@@ -34138,40 +34157,71 @@ exports[`Check stories > Components/List/Byline > Story Interractive > Should ma
 `;
 
 exports[`Check stories > Components/List/Byline > Story LongText > Should match snapshot 1`] = `
-"
-<ul class=\\"fd-list fd-list--byline\\" role=\\"list\\">
-<li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
-    <span class=\\"fd-list__thumbnail\\"><i role=\\"presentation\\" class=\\"sap-icon--activate\\"></i></span>
-    <div class=\\"fd-list__content\\">
-      <div class=\\"fd-list__title\\">List Item Title</div>
-      <div class=\\"fd-list__byline fd-list__byline--wrap\\">Very Long Byline (description), Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat... <a href=\\"#\\" class=\\"fd-link fd-list__link--more\\" tabindex=\\"0\\"><span class=\\"fd-link__content\\">More</span></a></div>
-    </div>
-    <span class=\\"fd-list__item-counter\\">12345</span>
-</li>
-<li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
-    <span class=\\"fd-list__thumbnail\\"><i role=\\"presentation\\" class=\\"sap-icon--employee\\"></i></span>
-    <div class=\\"fd-list__content\\">
-      <div class=\\"fd-list__title fd-list__title--wrap\\">Very long list item with no byline, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</div>
-    </div>
-</li>
-<li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
-  <span class=\\"fd-image--s fd-list__thumbnail\\" aria-label=\\"Godafoss waterfall in northern Iceland\\"
-style=\\"background-image: url('assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg'); background-size:cover;\\"></span>
-  <div class=\\"fd-list__content\\">
-      <div class=\\"fd-list__title fd-list__title--wrap\\">Very long title, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</div>
-      <div class=\\"fd-list__byline fd-list__byline--wrap\\">
-          <div class=\\"fd-list__byline-left\\">First text item in byline (standard text), Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.<a href=\\"#\\" class=\\"fd-link fd-list__link--more\\" tabindex=\\"0\\"><span class=\\"fd-link__content\\">Less</span></a></div>
-          <div class=\\"fd-list__byline-right\\">Second text item in byline (can be semantic)</div>
-      </div>
-  </div>
-</li>
-<li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
-    <div class=\\"fd-list__content\\">
-      <div class=\\"fd-list__title\\">Text-only list item</div>
-      <div class=\\"fd-list__byline\\">Byline (description)</div>
-    </div>
-</li>
-</ul>
+"<div style=\\"margin-bottom: 2rem;\\">
+    <p class=\\"fd-form-label\\" style=\\"margin-bottom: 0.5rem;\\">Default — truncation</p>
+    <ul class=\\"fd-list fd-list--byline\\" role=\\"list\\">
+        <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
+            <span class=\\"fd-list__thumbnail\\"><i role=\\"presentation\\" class=\\"sap-icon--activate\\"></i></span>
+            <div class=\\"fd-list__content\\">
+                <div class=\\"fd-list__title\\">Annual Budget Review for Q3 and Q4 — please review the attached documents and provide your feedback before the end of the fiscal quarter to ensure timely processing.</div>
+                <div class=\\"fd-list__byline\\">Finance · Updated 2 hours ago by Michael Thompson, Senior Analyst, Global Finance Division, Central Europe · Reviewed by Anna Schmidt, Finance Controller · Pending approval from Regional CFO</div>
+            </div>
+        </li>
+    </ul>
+</div>
+
+<div style=\\"margin-bottom: 2rem;\\">
+    <p class=\\"fd-form-label\\" style=\\"margin-bottom: 0.5rem;\\">List level — <code>fd-list--wrap</code></p>
+    <ul class=\\"fd-list fd-list--byline fd-list--wrap\\" role=\\"list\\">
+        <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
+            <span class=\\"fd-list__thumbnail\\"><i role=\\"presentation\\" class=\\"sap-icon--employee\\"></i></span>
+            <div class=\\"fd-list__content\\">
+                <div class=\\"fd-list__title\\">All titles wrap at list level, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.</div>
+                <div class=\\"fd-list__byline\\">All bylines wrap too, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.</div>
+            </div>
+        </li>
+    </ul>
+</div>
+
+<div style=\\"margin-bottom: 2rem;\\">
+    <p class=\\"fd-form-label\\" style=\\"margin-bottom: 0.5rem;\\">Item level — <code>fd-list__item--wrap</code> (collapsed and expanded states)</p>
+    <!-- The fd-list__link--more element is placed outside fd-list__title so it stays
+         visible even when the title truncates. -->
+    <ul class=\\"fd-list fd-list--byline\\" role=\\"list\\">
+        <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
+            <span class=\\"fd-list__thumbnail\\"><i role=\\"presentation\\" class=\\"sap-icon--employee\\"></i></span>
+            <div class=\\"fd-list__content\\">
+                <div class=\\"fd-list__title\\">Collapsed — title truncated, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco.</div>
+                <a href=\\"#\\" class=\\"fd-link fd-list__link--more\\" aria-expanded=\\"false\\" tabindex=\\"0\\"><span class=\\"fd-link__content\\">More</span></a>
+                <div class=\\"fd-list__byline\\">Byline truncated, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.</div>
+            </div>
+        </li>
+        <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-list__item--wrap\\">
+            <span class=\\"fd-list__thumbnail\\"><i role=\\"presentation\\" class=\\"sap-icon--employee\\"></i></span>
+            <div class=\\"fd-list__content\\">
+                <div class=\\"fd-list__title\\">Expanded — fd-list__item--wrap applied, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco. <a href=\\"#\\" class=\\"fd-link fd-list__link--more\\" aria-expanded=\\"true\\" tabindex=\\"0\\"><span class=\\"fd-link__content\\">Less</span></a></div>
+                <div class=\\"fd-list__byline\\">Byline wraps too, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation.</div>
+            </div>
+        </li>
+    </ul>
+</div>
+
+<div>
+    <p class=\\"fd-form-label\\" style=\\"margin-bottom: 0.5rem;\\">Element level — <code>fd-list__title--wrap</code> / <code>fd-list__byline--wrap</code></p>
+    <ul class=\\"fd-list fd-list--byline\\" role=\\"list\\">
+        <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
+            <span class=\\"fd-image--s fd-list__thumbnail\\" role=\\"img\\" aria-label=\\"Godafoss waterfall in northern Iceland\\"
+                style=\\"background-image: url('assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg'); background-size:cover;\\"></span>
+            <div class=\\"fd-list__content\\">
+                <div class=\\"fd-list__title fd-list__title--wrap\\">Only the title wraps here, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.</div>
+                <div class=\\"fd-list__byline fd-list__byline--2-col fd-list__byline--wrap\\">
+                    <div class=\\"fd-list__byline-left\\">First text item in byline, Lorem ipsum dolor sit amet, consectetur adipiscing elit.</div>
+                    <div class=\\"fd-list__byline-right\\">Second text item (semantic)</div>
+                </div>
+            </div>
+        </li>
+    </ul>
+</div>
 "
 `;
 
@@ -34221,12 +34271,12 @@ exports[`Check stories > Components/List/Byline > Story Navigation > Should matc
 
 exports[`Check stories > Components/List/Byline > Story NavigationIndicator > Should match snapshot 1`] = `
 "<ul class=\\"fd-list fd-list--byline fd-list--navigation fd-list--navigation-indication\\" role=\\"list\\">
-<li role=\\"listitem\\" tabindex=\\"-1\\" class=\\"fd-list__item fd-list__item--link\\">
+<li role=\\"listitem\\" tabindex=\\"-1\\" class=\\"fd-list__item fd-list__item--link \\">
   <a tabindex=\\"0\\" class=\\"fd-list__link fd-list__link--navigation-indicator\\" href=\\"#\\">
     <span class=\\"fd-list__thumbnail\\"><i role=\\"presentation\\" class=\\"sap-icon--activate\\"></i></span>
     <div class=\\"fd-list__content\\">
-      <div class=\\"fd-list__title\\">Title</div>
-      <div class=\\"fd-list__byline\\">Byline (description)</div>
+      <div class=\\"fd-list__title fd-list__title--wrap\\">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua</div>
+      <div class=\\"fd-list__byline fd-list__byline--wrap\\">Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula</div>
     </div>
   </a>
 </li>
@@ -34255,7 +34305,7 @@ exports[`Check stories > Components/List/Byline > Story NavigationIndicator > Sh
 
 exports[`Check stories > Components/List/Byline > Story Selection > Should match snapshot 1`] = `
 "<ul class=\\"fd-list fd-list--selection fd-list--byline\\" role=\\"listbox\\" aria-labelledby=\\"O09lk9\\">
-    <li role=\\"option\\" tabindex=\\"0\\" class=\\"fd-list__item is-selected\\">
+    <li role=\\"option\\" tabindex=\\"0\\" class=\\"fd-list__item fd-list__item--wrap is-selected\\">
         <div class=\\"fd-form-item fd-list__form-item\\">
             <input type=\\"checkbox\\" class=\\"fd-checkbox\\" id=\\"Ai4ez6111Z\\" checked aria-labelledby=\\"O09lk1\\">
             <label tabindex=\\"-1\\" class=\\"fd-checkbox__label\\" for=\\"Ai4ez6111Z\\">
@@ -34264,8 +34314,8 @@ exports[`Check stories > Components/List/Byline > Story Selection > Should match
         </div>
         <span class=\\"fd-list__thumbnail\\"><i role=\\"presentation\\" class=\\"sap-icon--activate\\"></i></span>
         <div class=\\"fd-list__content\\">
-            <span class=\\"fd-list__title\\" id=\\"O09lk1\\">Title</span>
-            <span class=\\"fd-list__byline\\">Byline (description)</span>
+            <span class=\\"fd-list__title\\" id=\\"O09lk1\\">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua</span>
+            <span class=\\"fd-list__byline\\">Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Donec velit neque, auctor sit amet aliquam vel</span>
         </div>
     </li>
     <li role=\\"option\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
@@ -34278,9 +34328,9 @@ exports[`Check stories > Components/List/Byline > Story Selection > Should match
         <span class=\\"fd-image--s fd-list__thumbnail\\" aria-label=\\"Godafoss waterfall in northern Iceland\\"
               style=\\"background-image: url('assets/images/backgrounds/Godafoss_waterfall_in_northern_Iceland.jpg'); background-size:cover;\\"></span>
         <div class=\\"fd-list__content\\">
-            <div class=\\"fd-list__title\\" id=\\"O09lk2\\">List item with 2-column byline</div>
-            <div class=\\"fd-list__byline fd-list__byline--2-col\\">
-                <div class=\\"fd-list__byline-left\\">First text item in byline (standard text)</div>
+            <div class=\\"fd-list__title fd-list__title--wrap\\" id=\\"O09lk2\\">Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore</div>
+            <div class=\\"fd-list__byline fd-list__byline--wrap fd-list__byline--2-col\\">
+                <div class=\\"fd-list__byline-left\\">Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur, excepteur sint occaecat cupidatat non proident</div>
                 <div class=\\"fd-list__byline-right\\">Second text item in byline (can be semantic)</div>
             </div>
         </div>
@@ -34571,20 +34621,20 @@ exports[`Check stories > Components/List/Standard > Story Borderless > Should ma
 
 exports[`Check stories > Components/List/Standard > Story Buttons > Should match snapshot 1`] = `
 "<ul class=\\"fd-list\\" role=\\"list\\">
-  <li tabindex=\\"-1\\" role=\\"listitem\\" class=\\"fd-list__item\\">
-    <span class=\\"fd-list__title\\">List item 1</span>
+  <li tabindex=\\"-1\\" role=\\"listitem\\" class=\\"fd-list__item fd-list__item--wrap\\">
+    <span class=\\"fd-list__title\\">List item 1 that wraps. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua, ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat</span>
     <button class=\\"fd-button fd-button--transparent fd-list__button\\">
         <i class=\\"sap-icon--edit\\"></i>
     </button>
   </li>
   <li tabindex=\\"-1\\" role=\\"listitem\\" class=\\"fd-list__item\\">
-    <span class=\\"fd-list__title\\">List item 1</span>
+    <span class=\\"fd-list__title fd-list__title--wrap\\">List item 2 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur</span>
     <button class=\\"fd-button fd-button--transparent fd-list__button\\">
         <i class=\\"sap-icon--decline\\"></i>
     </button>
   </li>
   <li tabindex=\\"-1\\" role=\\"listitem\\" class=\\"fd-list__item\\">
-    <span class=\\"fd-list__title\\">List item 2</span>
+    <span class=\\"fd-list__title\\">List item 3</span>
     <button class=\\"fd-button fd-button--transparent fd-list__button\\">
         <i class=\\"sap-icon--edit\\"></i>
     </button>
@@ -34653,16 +34703,16 @@ exports[`Check stories > Components/List/Standard > Story Icons > Should match s
       <i role=\\"presentation\\" class=\\"fd-list__icon sap-icon--cart\\"></i>
       <span class=\\"fd-list__title\\">List item 1</span>
   </li>
-  <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
+  <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-list__item--wrap\\">
       <i role=\\"presentation\\" class=\\"fd-list__icon sap-icon--wrench\\"></i>
-      <span class=\\"fd-list__title\\">List item 2</span>
+      <span class=\\"fd-list__title\\">List item 2 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur</span>
   </li>
   <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
       <span class=\\"fd-list__title\\">List item 3</span>
       <i role=\\"presentation\\" class=\\"fd-list__icon sap-icon--lightbulb\\"></i>
   </li>
   <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
-      <span class=\\"fd-list__title\\">List item 4</span>
+      <span class=\\"fd-list__title fd-list__title--wrap\\">List item 4 that wraps. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur, excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum</span>
       <i role=\\"presentation\\" class=\\"fd-list__icon sap-icon--history\\"></i>
   </li>
 </ul>"
@@ -34724,17 +34774,17 @@ exports[`Check stories > Components/List/Standard > Story Interactive > Should m
 
 exports[`Check stories > Components/List/Standard > Story ItemCounter > Should match snapshot 1`] = `
 "<ul class=\\"fd-list\\" role=\\"list\\">
-  <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
-      <span class=\\"fd-list__title\\">List item 1</span>
+  <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-list__item--wrap\\">
+      <span class=\\"fd-list__title\\">List item 1 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit</span>
       <span class=\\"fd-list__item-counter\\">12345</span>
   </li>
   <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
-      <span class=\\"fd-list__title\\">List item 2</span>
+      <span class=\\"fd-list__title fd-list__title--wrap\\">List item 2</span>
       <span class=\\"fd-list__item-counter\\">12345</span>
   </li>
   <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
       <i role=\\"presentation\\" class=\\"fd-list__icon sap-icon--lightbulb\\"></i>
-      <span class=\\"fd-list__title\\">List item 3</span>
+      <span class=\\"fd-list__title fd-list__title--wrap\\">List item 3 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit</span>
       <span class=\\"fd-list__item-counter\\">12345</span>
   </li>
   <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
@@ -34743,6 +34793,69 @@ exports[`Check stories > Components/List/Standard > Story ItemCounter > Should m
       <span class=\\"fd-list__item-counter\\">12345</span>
   </li>
 </ul>
+"
+`;
+
+exports[`Check stories > Components/List/Standard > Story LongText > Should match snapshot 1`] = `
+"<div style=\\"margin-bottom: 2rem;\\">
+    <p class=\\"fd-form-label\\" style=\\"margin-bottom: 0.5rem;\\">Default — truncation</p>
+    <ul class=\\"fd-list\\" role=\\"list\\">
+        <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
+            <span class=\\"fd-list__title\\">Annual Budget Review for Q3 and Q4 — please review the attached documents and provide your feedback before the end of the fiscal quarter to ensure timely processing.</span>
+            <span class=\\"fd-list__secondary\\">Finance · Updated 2 hours ago by Michael Thompson, Senior Analyst, Global Finance Division</span>
+        </li>
+    </ul>
+</div>
+
+<div style=\\"margin-bottom: 2rem;\\">
+    <p class=\\"fd-form-label\\" style=\\"margin-bottom: 0.5rem;\\">List level — <code>fd-list--wrap</code></p>
+    <ul class=\\"fd-list fd-list--wrap\\" role=\\"list\\">
+        <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
+            <span class=\\"fd-list__title\\">All titles wrap at list level, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip.</span>
+            <span class=\\"fd-list__secondary\\">Secondary text wraps too, Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus nulla aliquid soluta aperiam.</span>
+        </li>
+        <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
+            <span class=\\"fd-list__title\\">Second item also wraps, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</span>
+        </li>
+    </ul>
+</div>
+
+<div style=\\"margin-bottom: 2rem;\\">
+    <p class=\\"fd-form-label\\" style=\\"margin-bottom: 0.5rem;\\">Item level — <code>fd-list__item--wrap</code> (collapsed and expanded states)</p>
+    <!-- In the collapsed state fd-list__link--more is a right-aligned sibling so it
+         stays visible when the title truncates. In the expanded state (fd-list__item--wrap
+         applied) the title is fully visible so the Less link can sit inline at the end. -->
+    <ul class=\\"fd-list\\" role=\\"list\\">
+        <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
+            <span class=\\"fd-list__title\\">This item truncates normally, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore.</span>
+        </li>
+        <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
+            <span class=\\"fd-list__title\\">Collapsed — title truncated, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco.</span>
+            <a href=\\"#\\" class=\\"fd-link fd-list__link--more\\" aria-expanded=\\"false\\" tabindex=\\"0\\"><span class=\\"fd-link__content\\">More</span></a>
+        </li>
+        <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-list__item--wrap\\">
+            <span class=\\"fd-list__title\\">Expanded — fd-list__item--wrap applied, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco. <a href=\\"#\\" class=\\"fd-link fd-list__link--more\\" aria-expanded=\\"true\\" tabindex=\\"0\\"><span class=\\"fd-link__content\\">Less</span></a></span>
+            <span class=\\"fd-list__secondary\\">Secondary text wraps too, Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus nulla aliquid.</span>
+        </li>
+        <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
+            <span class=\\"fd-list__title\\">This item truncates normally again, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore.</span>
+        </li>
+    </ul>
+</div>
+
+<div>
+    <p class=\\"fd-form-label\\" style=\\"margin-bottom: 0.5rem;\\">Element level — <code>fd-list__title--wrap</code> / <code>fd-list__secondary--wrap</code></p>
+    <ul class=\\"fd-list\\" role=\\"list\\">
+        <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
+            <span class=\\"fd-list__title fd-list__title--wrap\\">Only the title wraps here, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation.</span>
+            <span class=\\"fd-list__secondary\\">Secondary still truncates, Lorem ipsum dolor sit amet consectetur adipisicing elit.</span>
+        </li>
+        <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
+            <span class=\\"fd-list__title\\">Title still truncates, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</span>
+            <span class=\\"fd-list__secondary fd-list__secondary--wrap\\">Only the secondary wraps here, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.</span>
+        </li>
+    </ul>
+</div>
 "
 `;
 
@@ -34771,15 +34884,15 @@ exports[`Check stories > Components/List/Standard > Story Navigation > Should ma
 
 exports[`Check stories > Components/List/Standard > Story NavigationIndicator > Should match snapshot 1`] = `
 "<ul class=\\"fd-list fd-list--navigation fd-list--navigation-indication\\" role=\\"list\\">
-  <li tabindex=\\"-1\\" role=\\"listitem\\" class=\\"fd-list__item fd-list__item--link\\">
+  <li tabindex=\\"-1\\" role=\\"listitem\\" class=\\"fd-list__item fd-list__item--wrap fd-list__item--link\\">
       <a tabindex=\\"0\\" class=\\"fd-list__link fd-list__link--navigation-indicator\\" href=\\"#\\">
-        <span class=\\"fd-list__title\\">List item 1</span>
+        <span class=\\"fd-list__title\\">List item 1 that wraps. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua, ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat</span>
       </a>
   </li>
   <li tabindex=\\"-1\\" role=\\"listitem\\" class=\\"fd-list__item fd-list__item--link\\">
       <a tabindex=\\"0\\" class=\\"fd-list__link fd-list__link--navigation-indicator is-selected\\" href=\\"#\\">
         <i role=\\"presentation\\" class=\\"fd-list__icon sap-icon--history\\"></i>
-        <span class=\\"fd-list__title\\">List item 2</span>
+        <span class=\\"fd-list__title fd-list__title--wrap\\">List item 2 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur, excepteur sint occaecat cupidatat non proident</span>
       </a>
   </li>
   <li tabindex=\\"0\\" role=\\"listitem\\" class=\\"fd-list__item\\">
@@ -34792,7 +34905,7 @@ exports[`Check stories > Components/List/Standard > Story NavigationIndicator > 
   </li>
   <li tabindex=\\"-1\\" role=\\"listitem\\" class=\\"fd-list__item fd-list__item--link\\">
       <a tabindex=\\"0\\" class=\\"fd-list__link fd-list__link--navigation-indicator is-navigated\\" href=\\"#\\">
-        <span class=\\"fd-list__title\\">List item 5</span>
+        <span class=\\"fd-list__title\\">List item 4</span>
         <i role=\\"presentation\\" class=\\"fd-list__icon sap-icon--map\\"></i>
       </a>
   </li>
@@ -34941,12 +35054,12 @@ exports[`Check stories > Components/List/Standard > Story SearchResults > Should
 
 exports[`Check stories > Components/List/Standard > Story SecondaryData > Should match snapshot 1`] = `
 "<ul class=\\"fd-list\\" role=\\"list\\">
-  <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
-      <span class=\\"fd-list__title\\">List item 1</span>
+  <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-list__item--wrap\\">
+      <span class=\\"fd-list__title\\">List item 1 that wraps. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua</span>
       <span class=\\"fd-list__secondary\\">Neutral Status</span>
   </li>
   <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
-      <span class=\\"fd-list__title\\">List item 2</span>
+      <span class=\\"fd-list__title fd-list__title--wrap\\">List item 2 that wraps. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit</span>
       <span class=\\"fd-list__secondary fd-list__secondary--positive\\">Positive Status</span>
   </li>
   <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
@@ -34967,23 +35080,23 @@ exports[`Check stories > Components/List/Standard > Story SecondaryData > Should
 
 exports[`Check stories > Components/List/Standard > Story Selection > Should match snapshot 1`] = `
 "<ul class=\\"fd-list fd-list--selection\\" role=\\"listbox\\" aria-labelledby=\\"XezW11\\">
-  <li role=\\"option\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
+  <li role=\\"option\\" tabindex=\\"0\\" class=\\"fd-list__item fd-list__item--wrap\\">
       <div class=\\"fd-form-item fd-list__form-item\\">
           <input type=\\"checkbox\\" class=\\"fd-checkbox\\" id=\\"Ai4ez1\\" aria-labelledby=\\"Az0bg1\\">
           <label tabindex=\\"-1\\" class=\\"fd-checkbox__label\\" for=\\"Ai4ez1\\">
             <span class=\\"fd-checkbox__checkmark\\" aria-hidden=\\"true\\"></span>
           </label>
       </div>
-      <span class=\\"fd-list__title\\" id=\\"Az0bg1\\">List item 1</span>
+      <span class=\\"fd-list__title\\" id=\\"Az0bg1\\">List item 1 that wraps with a centered checkbox. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua</span>
   </li>
-  <li role=\\"option\\" tabindex=\\"0\\" class=\\"fd-list__item is-selected\\" aria-selected=\\"true\\">
+  <li role=\\"option\\" tabindex=\\"0\\" class=\\"fd-list__item is-selected fd-list__item--wrap fd-list__item--wrap-top-aligned\\" aria-selected=\\"true\\">
       <div class=\\"fd-form-item fd-list__form-item\\">
           <input type=\\"checkbox\\" class=\\"fd-checkbox\\" id=\\"Ai4ez2\\" checked aria-labelledby=\\"Az0bg2\\">
           <label tabindex=\\"-1\\" class=\\"fd-checkbox__label\\" for=\\"Ai4ez2\\">
             <span class=\\"fd-checkbox__checkmark\\" aria-hidden=\\"true\\"></span>
           </label>
       </div>
-      <span class=\\"fd-list__title\\" id=\\"Az0bg2\\">List item 2</span>
+      <span class=\\"fd-list__title fd-list__title--wrap\\" id=\\"Az0bg2\\">List item 2 that wraps with a top-aligned checkbox. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat, duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur</span>
   </li>
   <li role=\\"option\\" tabindex=\\"0\\" class=\\"fd-list__item\\">
       <div class=\\"fd-form-item fd-list__form-item\\">
@@ -35035,6 +35148,78 @@ exports[`Check stories > Components/List/Standard > Story Unread > Should match 
 "
 `;
 
+exports[`Check stories > Components/List/Subline > Story LongText > Should match snapshot 1`] = `
+"<div style=\\"margin-bottom: 2rem;\\">
+    <p class=\\"fd-form-label\\" style=\\"margin-bottom: 0.5rem;\\">Default — truncation</p>
+    <ul class=\\"fd-list fd-list--subline\\" role=\\"list\\">
+        <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-list__item--interractive\\">
+            <span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-10\\" role=\\"img\\" aria-label=\\"Michael Thompson\\">MT</span>
+            <div class=\\"fd-list__content\\">
+                <div class=\\"fd-list__title\\">Annual Budget Review for Q3 and Q4 — please review the attached documents and provide your feedback before the end of the fiscal quarter to ensure timely processing.</div>
+                <div class=\\"fd-list__subline\\">Finance · Updated 2 hours ago by Michael Thompson, Senior Analyst, Global Finance Division · Reviewed by Anna Schmidt · Pending CFO approval</div>
+            </div>
+        </li>
+    </ul>
+</div>
+
+<div style=\\"margin-bottom: 2rem;\\">
+    <p class=\\"fd-form-label\\" style=\\"margin-bottom: 0.5rem;\\">List level — <code>fd-list--wrap</code></p>
+    <ul class=\\"fd-list fd-list--subline fd-list--wrap\\" role=\\"list\\">
+        <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-list__item--interractive\\">
+            <span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-10\\" role=\\"img\\" aria-label=\\"John Doe\\">JD</span>
+            <div class=\\"fd-list__content\\">
+                <div class=\\"fd-list__title\\">All titles wrap at list level, Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo?</div>
+                <div class=\\"fd-list__subline\\">All sublines wrap too, Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus nulla aliquid soluta aperiam, amet iste sint? Explicabo dicta doloremque amet minima perferendis.</div>
+            </div>
+        </li>
+    </ul>
+</div>
+
+<div style=\\"margin-bottom: 2rem;\\">
+    <p class=\\"fd-form-label\\" style=\\"margin-bottom: 0.5rem;\\">Item level — <code>fd-list__item--wrap</code> (collapsed and expanded states)</p>
+    <!-- The fd-list__link--more element is placed outside fd-list__title so it stays
+         visible even when the title truncates. -->
+    <ul class=\\"fd-list fd-list--subline\\" role=\\"list\\">
+        <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-list__item--interractive\\">
+            <span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-10\\" role=\\"img\\" aria-label=\\"John Doe\\">JD</span>
+            <div class=\\"fd-list__content\\">
+                <div class=\\"fd-list__title\\">Collapsed — title truncated, Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo?</div>
+                <a href=\\"#\\" class=\\"fd-link fd-list__link--more\\" aria-expanded=\\"false\\" tabindex=\\"0\\"><span class=\\"fd-link__content\\">More</span></a>
+                <div class=\\"fd-list__subline\\">Subline truncated, Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus nulla aliquid soluta aperiam, amet iste sint? Explicabo dicta doloremque.</div>
+            </div>
+        </li>
+        <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-list__item--interractive fd-list__item--wrap\\">
+            <span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-10\\" role=\\"img\\" aria-label=\\"John Doe\\">JD</span>
+            <div class=\\"fd-list__content\\">
+                <div class=\\"fd-list__title\\">Expanded — fd-list__item--wrap applied, Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo? <a href=\\"#\\" class=\\"fd-link fd-list__link--more\\" aria-expanded=\\"true\\" tabindex=\\"0\\"><span class=\\"fd-link__content\\">Less</span></a></div>
+                <div class=\\"fd-list__subline\\">Subline wraps too, Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus nulla aliquid soluta aperiam, amet iste sint? Explicabo dicta doloremque amet minima perferendis.</div>
+            </div>
+        </li>
+    </ul>
+</div>
+
+<div>
+    <p class=\\"fd-form-label\\" style=\\"margin-bottom: 0.5rem;\\">Element level — <code>fd-list__title--wrap</code> / <code>fd-list__subline--wrap</code></p>
+    <ul class=\\"fd-list fd-list--subline\\" role=\\"list\\">
+        <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-list__item--interractive\\">
+            <span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-10\\" role=\\"img\\" aria-label=\\"John Doe\\">JD</span>
+            <div class=\\"fd-list__content\\">
+                <div class=\\"fd-list__title fd-list__title--wrap\\">Only the title wraps here, Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo?</div>
+                <div class=\\"fd-list__subline\\">Subline still truncates, Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus nulla aliquid soluta aperiam, amet iste sint? Explicabo dicta doloremque.</div>
+            </div>
+        </li>
+        <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-list__item--interractive\\">
+            <span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-6\\" role=\\"img\\" aria-label=\\"Jane Doe\\">JD</span>
+            <div class=\\"fd-list__content\\">
+                <div class=\\"fd-list__title\\">Title still truncates, Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita.</div>
+                <div class=\\"fd-list__subline fd-list__subline--wrap\\">Only the subline wraps here, Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus nulla aliquid soluta aperiam, amet iste sint? Explicabo dicta doloremque amet minima perferendis.</div>
+            </div>
+        </li>
+    </ul>
+</div>
+"
+`;
+
 exports[`Check stories > Components/List/Subline > Story Standard > Should match snapshot 1`] = `
 "<ul class=\\"fd-list fd-list--subline\\" role=\\"list\\">
     <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-list__item--interractive\\">
@@ -35055,19 +35240,18 @@ exports[`Check stories > Components/List/Subline > Story Standard > Should match
         <span class=\\"fd-list__active-indicator sap-icon--sys-enter-2\\"></span>
     </li>
     <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-list__item--interractive\\">
-        <span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-10\\" aria-role=\\"img\\" aria-label=\\"John Doe\\">JD</span>
+        <span class=\\"fd-avatar fd-avatar--sm fd-avatar--circle fd-avatar--accent-color-10\\" role=\\"img\\" aria-label=\\"John Doe\\">JD</span>
         <div class=\\"fd-list__content\\">
-            <div class=\\"fd-list__title\\">List Item Title Lorem, ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo? Lorem, ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo!</div>
-            <div class=\\"fd-list__subline\\">List Item Subline Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus nulla aliquid soluta aperiam, amet iste sint? Explicabo dicta doloremque amet minima perferendis. Necessitatibus reiciendis voluptatum id nesciunt earum! Lorem, ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo.</div>
-            <div class=\\"fd-list__subline\\">List Item Subline Lorem ipsum dolor sit amet consectetur adipisicing elit. Eaque asperiores id deleniti quae? Amet officia cum assumenda. Ab, dolores ea dignissimos, aliquid beatae magnam commodi, tenetur facere harum ex nemo? Lorem, ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo.</div>
+            <div class=\\"fd-list__title\\">List Item Title Lorem, ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo?</div>
+            <div class=\\"fd-list__subline\\">List Item Subline Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus nulla aliquid soluta aperiam, amet iste sint? Explicabo dicta doloremque amet minima perferendis.</div>
+            <div class=\\"fd-list__subline\\">List Item Subline Lorem ipsum dolor sit amet consectetur adipisicing elit. Eaque asperiores id deleniti quae? Amet officia cum assumenda.</div>
         </div>
     </li>
     <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-list__item--interractive\\">
         <span class=\\"fd-avatar fd-avatar--sm fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/landscape/L1.jpg')\\" role=\\"img\\" aria-label=\\"John Doe\\"></span>
         <div class=\\"fd-list__content\\">
-            <div class=\\"fd-list__title fd-list__title--truncate\\">List Item Title Lorem, ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo? Lorem, ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo!</div>
-            <div class=\\"fd-list__subline fd-list__subline--truncate\\">List Item Subline Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia saepe doloribus nulla aliquid soluta aperiam, amet iste sint? Explicabo dicta doloremque amet minima perferendis. Necessitatibus reiciendis voluptatum id nesciunt earum! Lorem, ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo.</div>
-            <div class=\\"fd-list__subline fd-list__subline--truncate\\">List Item Subline Lorem ipsum dolor sit amet consectetur adipisicing elit. Eaque asperiores id deleniti quae? Amet officia cum assumenda. Ab, dolores ea dignissimos, aliquid beatae magnam commodi, tenetur facere harum ex nemo? Lorem, ipsum dolor sit amet consectetur adipisicing elit. Incidunt, quod deleniti optio earum voluptatem in, nam et ratione aliquam error facilis expedita magnam repudiandae rerum sint blanditiis rem quo.</div>
+            <div class=\\"fd-list__title\\">List Item Title</div>
+            <div class=\\"fd-list__subline\\">List Item Subline</div>
         </div>
     </li>
 </ul>
@@ -40242,10 +40426,12 @@ exports[`Check stories > Components/Object List > Story Standard > Should match 
 "
 <h4 id=\\"objectListItemHeader\\">Object List Item</h4>
 <ul class=\\"fd-list fd-object-list\\" role=\\"list\\" aria-labelledby=\\"objectListItemHeader\\">
+
+  <!-- Default: all text truncates -->
   <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-object-list__item\\">
     <div class=\\"fd-object-list__container\\">
       <div class=\\"fd-object-list__intro\\">
-       Optional inline text very very very long
+       Optional inline text very very very long optional inline text very very very long optional inline text Optional inline text very very very long optional inline text very very very long optional inline text
       </div>
       <div class=\\"fd-object-list__header\\">
         <span class=\\"fd-avatar fd-avatar--s\\"
@@ -40254,7 +40440,7 @@ exports[`Check stories > Components/Object List > Story Standard > Should match 
         <div class=\\"fd-object-list__header-left\\">
          <div class=\\"fd-object-identifier fd-object-list__object-identifier\\">
           <p class=\\"fd-object-identifier__title\\">
-           Fitbit Versa Smart Watch, Black Fitbit Versa Smart Watch
+           Fitbit Versa Smart Watch, Black Fitbit Versa Smart Watch Fitbit Versa Smart Watch, Black Fitbit Versa Smart Watch Fitbit Versa Smart Watch, Black Fitbit Versa Smart Watch Fitbit Versa Smart Watch, Black Fitbit Versa Smart Watch
           </p>
          </div>
         </div>
@@ -40269,46 +40455,47 @@ exports[`Check stories > Components/Object List > Story Standard > Should match 
         <div class=\\"fd-object-list__row\\">
           <div class=\\"fd-object-list__row-left\\">
             <div class=\\"fd-object-list__object-attribute\\">
-
-              First Attribute
+              First Attribute very very very long first attribute text that should truncate
             </div>
           </div>
           <div class=\\"fd-object-list__row-right\\">
             <div class=\\"fd-object-marker\\">
-              <i class=\\"fd-object-marker__icon sap-icon--flag\\"
+              <i role=\\"img\\" class=\\"fd-object-marker__icon sap-icon--flag\\"
                aria-label=\\"icon for flag\\"></i>
             </div>
             <div class=\\"fd-object-marker\\">
-              <i class=\\"fd-object-marker__icon sap-icon--favorite\\" aria-label=\\"icon for favourite\\"></i>
+              <i role=\\"img\\" class=\\"fd-object-marker__icon sap-icon--favorite\\" aria-label=\\"icon for favourite\\"></i>
             </div>
           </div>
         </div>
         <div class=\\"fd-object-list__row\\">
           <div class=\\"fd-object-list__row-left\\">
             <div class=\\"fd-object-list__object-attribute\\">
-              Second Attribute
+              Second Attribute  very very very long first attribute text that should truncate
             </div>
           </div>
           <div class=\\"fd-object-list__row-right\\">
             <span class=\\"fd-object-status fd-object-status--critical\\">
-              <span class=\\"fd-object-status__text\\">Critical very very very long</span>
+              <span class=\\"fd-object-status__text\\">Critical very very very long critical status text that should truncate  very very very long first attribute text that should truncate</span>
             </span>
           </div>
         </div>
         <div class=\\"fd-object-list__row\\">
           <div class=\\"fd-object-list__row-left\\">
             <div class=\\"fd-object-list__object-attribute\\">
-              Third Attribute
+              Third Attribute very very very long first attribute text that should truncate  very very very long first attribute text that should truncate  very very very long first attribute text that should truncate
             </div>
+          </div>
         </div>
       </div>
     </div>
-    </div>
   </li>
+
+  <!-- __intro--wrap: long intro text wraps -->
   <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-object-list__item\\">
     <div class=\\"fd-object-list__container\\">
-      <div class=\\"fd-object-list__intro\\">
-       Optional inline text very very very long
+      <div class=\\"fd-object-list__intro fd-object-list__intro--wrap\\">
+       Optional inline text very very very long optional inline text very very very long optional inline text very very very long optional inline text  optional inline text very very very long optional inline text 
       </div>
       <div class=\\"fd-object-list__header\\">
         <span class=\\"fd-avatar fd-avatar--s\\"
@@ -40316,8 +40503,8 @@ exports[`Check stories > Components/Object List > Story Standard > Should match 
         </span>
         <div class=\\"fd-object-list__header-left\\">
          <div class=\\"fd-object-identifier fd-object-list__object-identifier\\">
-          <p class=\\"fd-object-identifier__title\\">
-           Fitbit Versa Smart Watch, Black Fitbit Versa Smart Watch
+          <p class=\\"fd-object-identifier__title fd-object-identifier__title--wrap\\">
+           Fitbit Versa Smart Watch, Black Fitbit Versa Smart Watch Fitbit Versa Smart Watch, Black Fitbit Versa Smart Watch Fitbit Versa Smart Watch, Black Fitbit Versa Smart Watch Fitbit Versa Smart Watch, Black Fitbit Versa Smart Watch
           </p>
          </div>
         </div>
@@ -40359,12 +40546,14 @@ exports[`Check stories > Components/Object List > Story Standard > Should match 
             <div class=\\"fd-object-list__object-attribute\\">
               Third Attribute
             </div>
+          </div>
         </div>
       </div>
     </div>
-    </div>
   </li>
-  <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-object-list__item\\">
+
+  <!-- __row-right--wrap: long status text wraps -->
+  <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-object-list__item fd-list__item--wrap\\">
     <div class=\\"fd-object-list__container\\">
       <div class=\\"fd-object-list__intro\\">
        Optional inline text very very very long
@@ -40398,15 +40587,17 @@ exports[`Check stories > Components/Object List > Story Standard > Should match 
         </div>
         <div class=\\"fd-object-list__row\\">
           <div class=\\"fd-object-list__row-left\\"></div>
-          <div class=\\"fd-object-list__row-right\\">
+          <div class=\\"fd-object-list__row-right fd-object-list__row-right--wrap\\">
             <span class=\\"fd-object-status fd-object-status--critical\\">
-              <span class=\\"fd-object-status__text\\">Critical</span>
+              <span class=\\"fd-object-status__text\\">Critical very very very long critical status text that should now wrap instead of truncating with ellipsis</span>
             </span>
           </div>
         </div>
       </div>
     </div>
   </li>
+
+  <!-- __object-attribute--wrap: long attribute text wraps -->
   <li role=\\"listitem\\" tabindex=\\"0\\" class=\\"fd-list__item fd-object-list__item\\">
     <div class=\\"fd-object-list__container\\">
       <div class=\\"fd-object-list__intro\\">
@@ -40433,8 +40624,8 @@ exports[`Check stories > Components/Object List > Story Standard > Should match 
       <div class=\\"fd-object-list__content\\">
         <div class=\\"fd-object-list__row\\">
           <div class=\\"fd-object-list__row-left\\">
-            <div class=\\"fd-object-list__object-attribute\\">
-              First Attribute
+            <div class=\\"fd-object-list__object-attribute fd-object-list__object-attribute--wrap\\">
+              First Attribute very very very long first attribute text that should now wrap instead of truncating with ellipsis
             </div>
           </div>
           <div class=\\"fd-object-list__row-right\\">
@@ -40456,9 +40647,9 @@ exports[`Check stories > Components/Object List > Story Standard > Should match 
             <div class=\\"fd-object-list__object-attribute\\">
               Third Attribute
             </div>
+          </div>
         </div>
       </div>
-    </div>
     </div>
   </li>
 </ul>


### PR DESCRIPTION
## Related Issue
Closes [SAP/fundamental-styles#](https://github.com/SAP/fundamental-styles/issues/6319)

## Description

Implements updated truncation rules across Standard List, Byline List, and Subline List per the agreed design decision: **truncation is the default behavior; wrapping is opt-in via `--wrap` modifier classes.**

- **Subline List** — behavior inversion (breaking change): default changed from wrap → truncate; `--wrap` modifier added; `--truncate` kept as deprecated no-ops for backward compatibility
- **Byline List** — bug fix: existing `--wrap` modifiers were not resetting `overflow`, so text was still clipped even with the modifier applied; cleaned up a stale combined rule; fixed a second pre-existing bug in borderless mode where `max-height: 5rem; height: 100%` on items caused wrapped content to overflow out of the item boundary
- **Standard List** — additive: `--wrap` modifiers added to `__title`, `__secondary`, and group-header `__title`; new story added; checkbox alignment in wrapped selection items fixed

## Changed Files

### SCSS

- [packages/styles/src/mixins/list/_list-subline.scss](packages/styles/src/mixins/list/_list-subline.scss) — default behavior changed to truncate; `--wrap` modifier added; `--truncate` kept as deprecated no-ops; split combined `__item--wrap, :has()` rule so only `__item--wrap` wraps all children; removed stale `overflow: visible` from `__content:has()`; avatar kept vertically centered in all wrap scenarios
- [packages/styles/src/mixins/list/_list-byline.scss](packages/styles/src/mixins/list/_list-byline.scss) — `--wrap` on `__title` and `__byline` now correctly calls `@include fd-wrap()`; removed stale combined rule; removed `max-height`/`height: 100%` from borderless item override; fixed thumbnail/icon top-alignment in wrapped link items (`align-items: flex-start` on `fd-list__link`); navigation arrow kept centered via `align-self: center` on `::after`; updated padding-block-start to 0.75 rem to match the specs.
- [packages/styles/src/mixins/list/_list-base.scss](packages/styles/src/mixins/list/_list-base.scss) — `--wrap` added to `__title`, `__secondary`, and group-header `__title`; split combined `__item--wrap, :has()` rule; `__secondary` gets `align-self: center` in `:has()` rule; `__item-counter`, `__icon`, and `__button` get `align-self: center` in all wrap rules; breathing room via `margin-block: 0.75rem` scoped to `:not(.fd-list--byline)`
- [packages/styles/src/mixins/list/_list-selection.scss](packages/styles/src/mixins/list/_list-selection.scss) — checkbox centered by default in wrapped items (`top: 50%; transform: translateY(-50%)`); new `fd-list__item--wrap-top-aligned` modifier for top-aligned placement


### Stories

- [packages/styles/stories/Components/List/list/subline/standard.example.html](packages/styles/stories/Components/List/list/subline/standard.example.html) — removed `--truncate` classes; fixed `aria-role` → `role`; shortened text to demonstrate default truncation
- [packages/styles/stories/Components/List/list/subline/long-text.example.html](packages/styles/stories/Components/List/list/subline/long-text.example.html) — **new file**: all four wrap levels with visual separators; element-level section split into two items
- [packages/styles/stories/Components/List/list/subline/subline-list.stories.js](packages/styles/stories/Components/List/list/subline/subline-list.stories.js) — updated story description; added LongText story export
- [packages/styles/stories/Components/List/list/byline/borderless.example.html](packages/styles/stories/Components/List/list/byline/borderless.example.html) — added wrapping title item to demonstrate borderless bug fix
- [packages/styles/stories/Components/List/list/byline/long-text.example.html](packages/styles/stories/Components/List/list/byline/long-text.example.html) — restructured: all four sections with separators; `fd-list__link--more` placed outside `fd-list__title`; `aria-expanded` on More/Less links
- [packages/styles/stories/Components/List/list/byline/byline-list.stories.js](packages/styles/stories/Components/List/list/byline/byline-list.stories.js) — updated LongText story description
- [packages/styles/stories/Components/List/list/standard/long-text.example.html](packages/styles/stories/Components/List/list/standard/long-text.example.html) — **new file**: all four sections with separators; element-level section split into two items
- [packages/styles/stories/Components/List/list/standard/standard-list.stories.js](packages/styles/stories/Components/List/list/standard/standard-list.stories.js) — added LongText story export; updated Selection story description
- [packages/styles/stories/Components/user-menu/user-menu.stories.js](packages/styles/stories/Components/user-menu/user-menu.stories.js) — updated Anatomy section to document default truncation behavior and `--wrap` modifier classes for `fd-user-menu__user-name` and `fd-user-menu__subline`

## New Modifier Classes

| Class | Component | Effect |
|---|---|---|
| `fd-list--wrap` | Standard, Byline, Subline | Wraps text in all items (list level) |
| `fd-list__item--wrap` | Standard, Byline, Subline | Wraps text in a single item (item level) |
| `fd-list__title--wrap` | Standard, Byline, Subline | Title text wraps (element level) |
| `fd-list__secondary--wrap` | Standard | Secondary text wraps (element level) |
| `fd-list__item--wrap-top-aligned` | Standard (selection) | Top-aligns the checkbox in a wrapped item (default is centered) |
| `fd-list__byline--wrap` | Byline | Byline text wraps — was broken before, now fixed (element level) |
| `fd-list__subline--wrap` | Subline | Subline text wraps (element level) |

## Deprecated (no-op, kept for backward compatibility)

| Class | Component | Note |
|---|---|---|
| `fd-list__title--truncate` | Subline | Truncation is now the default; this class is redundant |
| `fd-list__subline--truncate` | Subline | Truncation is now the default; this class is redundant |

## Breaking Changes

**Subline List**: the default text behavior changes from wrapping to truncation. Consumers using `fd-list--subline` without the `--truncate` modifier will see their long text truncated after this update. To restore the previous wrapping behavior, add `fd-list__title--wrap` and/or `fd-list__subline--wrap`.


## Screenshots

<img width="1700" height="1345" alt="Screenshot 2026-08-13 at 14 06 58" src="https://github.com/user-attachments/assets/e9d67e93-7221-4bcb-bd8b-afca00675911" />
<img width="1701" height="1267" alt="Screenshot 2026-08-13 at 14 07 59" src="https://github.com/user-attachments/assets/4db52ffe-fa6a-4873-aa2a-e45059d7367c" />
<img width="979" height="737" alt="Screenshot 2026-08-13 at 14 08 13" src="https://github.com/user-attachments/assets/ade71cd2-922a-4a71-a069-6ee88f3f2110" />
<img width="1676" height="1262" alt="Screenshot 2026-08-13 at 14 08 33" src="https://github.com/user-attachments/assets/d8bdda85-1275-45d9-8f93-af368db1d545" />


