### PR TITLE
fix(styles): product switch design updates feedback

### DIFF
--- a/packages/styles/src/product-switch.scss
+++ b/packages/styles/src/product-switch.scss
@@ -9,6 +9,7 @@ $block: #{$fd-namespace}-product-switch;
 
 .#{$block} {
   --fdProduct_Switch_Item_Border_Color: transparent;
+  --fdProductSwitch_Body_BorderRadius: var(--sapPopover_BorderCornerRadius, var(--sapElement_BorderCornerRadius));
 
   @mixin fd-product-pseudo-element-background($background) {
     .#{$block}__title {
@@ -92,26 +93,6 @@ $block: #{$fd-namespace}-product-switch;
       }
     }
 
-    &.selected {
-      --fdProduct_Switch_Item_Border_Color: var(--sapContent_FocusColor);
-
-      background-color: var(--sapList_SelectionBackgroundColor);
-
-      @include fd-product-pseudo-element-background(var(--sapList_SelectionBackgroundColor));
-
-      @include fd-hover() {
-        background-color: var(--sapList_Hover_SelectionBackground);
-
-        @include fd-product-pseudo-element-background(var(--sapList_Hover_SelectionBackground));
-      }
-
-      @include fd-active() {
-        background-color: var(--sapList_Active_Background);
-
-        @include fd-product-pseudo-element-background(var(--sapList_Active_Background));
-      }
-    }
-
     @include fd-fiori-focus();
 
     &.dragged {
@@ -133,11 +114,6 @@ $block: #{$fd-namespace}-product-switch;
           .#{$block}__subtitle {
             color: var(--sapContent_LabelColor);
           }
-        }
-
-        &.selected {
-          border: none;
-          box-shadow: var(--sapContent_Shadow2);
         }
 
         @include fd-hover() {
@@ -202,12 +178,18 @@ $block: #{$fd-namespace}-product-switch;
     @include fd-scrollbar();
 
     width: fit-content;
-    max-height: calc(100vh - 76px);
+    max-height: 33rem;
     overflow-y: auto;
     padding-block: 1.5rem;
     padding-inline: 1rem;
     background-color: var(--sapList_Background);
-    border-radius: var(--sapElement_BorderCornerRadius);
+    border-radius: var(--fdProductSwitch_Body_BorderRadius);
+  }
+
+  &__body--col-2 {
+    .#{$block}__list {
+      width: 23rem;
+    }
   }
 
   &__body--col-3 {
@@ -240,7 +222,7 @@ $block: #{$fd-namespace}-product-switch;
         gap: 0.75rem;
       };
 
-      min-height: 5rem;
+      min-height: 6rem;
       max-width: 100%;
       padding-block: 1rem;
       padding-inline: 1rem;
@@ -259,18 +241,6 @@ $block: #{$fd-namespace}-product-switch;
 
         @include fd-fiori-focus() {
           outline-color: var(--sapContent_FocusColor);
-        }
-      }
-
-      &.selected {
-        @include fd-product-pseudo-element-background(var(--sapList_Background));
-
-        @include fd-hover() {
-          @include fd-product-pseudo-element-background(var(--sapList_Hover_SelectionBackground));
-        }
-
-        @include fd-active() {
-          @include fd-product-pseudo-element-background(var(--sapList_Active_Background));
         }
       }
 

--- a/packages/styles/stories/Components/product-switch/large.example.html
+++ b/packages/styles/stories/Components/product-switch/large.example.html
@@ -1,15 +1,13 @@
 <div class="fd-product-switch__body">
     <ul class="fd-product-switch__list" role="menu">
-        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Home Home Home Home Home Home Home Home Central Home Central Home Central Home Central Home" aria-posinset="1" aria-setsize="14">
-            <span class="fd-avatar fd-avatar--sm fd-avatar--transparent" role="img" aria-label="Home">
-                <i role="presentation" aria-hidden="true" class="fd-avatar__icon sap-icon--home"></i>
-            </span>
+        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="SAP Start Central Home" aria-posinset="1" aria-setsize="20">
+            <span class="fd-avatar fd-avatar--sm fd-avatar--thumbnail" style="background-image: url('/assets/images/landscape/demo-avatar.png')" role="img" aria-label="SAP Start"></span>
             <div class="fd-product-switch__text">
-                <div class="fd-product-switch__title">Home Home Home Home Home Home Home Home</div>
-                <div class="fd-product-switch__subtitle">Central Home Central Home Central Home Central Home</div>
+                <div class="fd-product-switch__title">SAP Start</div>
+                <div class="fd-product-switch__subtitle">Central Home</div>
             </div>
         </li>
-        <li class="fd-product-switch__item selected" tabindex="0" role="menuitem" aria-label="Analytics Cloud Analytics Cloud Analytics Cloud" aria-posinset="2" aria-setsize="14">
+        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Analytics Cloud Analytics Cloud Analytics Cloud" aria-posinset="2" aria-setsize="20">
             <span
                 class="fd-avatar fd-avatar--sm fd-avatar--thumbnail"
                 style="background-image: url('/assets/images/landscape/L1.jpg')"
@@ -21,7 +19,7 @@
                 <div class="fd-product-switch__subtitle">Analytics Cloud</div>
             </div>
         </li>
-        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Catalog Ariba" aria-posinset="3" aria-setsize="14">
+        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Catalog Ariba" aria-posinset="3" aria-setsize="20">
             <span class="fd-avatar fd-avatar--sm fd-avatar--thumbnail" role="img" aria-label="Catalog">
                 <i role="presentation" aria-hidden="true" class="fd-product-switch__icon sap-icon--contacts"></i>
             </span>
@@ -30,7 +28,7 @@
                 <div class="fd-product-switch__subtitle">Ariba</div>
             </div>
         </li>
-        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Guided Buying" aria-posinset="4" aria-setsize="14">
+        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Guided Buying" aria-posinset="4" aria-setsize="20">
             <span class="fd-avatar fd-avatar--sm fd-avatar--thumbnail" role="img" aria-label="Guided Buying">
                 <i role="presentation" aria-hidden="true" class="fd-product-switch__icon sap-icon--credit-card"></i>
             </span>
@@ -38,7 +36,7 @@
                 <div class="fd-product-switch__title">Guided Buying</div>
             </div>
         </li>
-        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Strategic Procurement" aria-posinset="5" aria-setsize="14">
+        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Strategic Procurement" aria-posinset="5" aria-setsize="20">
             <span class="fd-avatar fd-avatar--sm fd-avatar--thumbnail" role="img" aria-label="Strategic Procurement">
                 <i role="presentation" aria-hidden="true" class="fd-product-switch__icon sap-icon--cart-3"></i>
             </span>
@@ -46,7 +44,7 @@
                 <div class="fd-product-switch__title">Strategic Procurement</div>
             </div>
         </li>
-        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Travel &amp; Expense Concur" aria-posinset="6" aria-setsize="14">
+        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Travel &amp; Expense Concur" aria-posinset="6" aria-setsize="20">
             <span class="fd-avatar fd-avatar--sm fd-avatar--thumbnail" role="img" aria-label="Travel &amp; Expense">
                 <i role="presentation" aria-hidden="true" class="fd-product-switch__icon sap-icon--flight"></i>
             </span>
@@ -55,7 +53,7 @@
                 <div class="fd-product-switch__subtitle">Concur</div>
             </div>
         </li>
-        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Vendor Management Fieldglass" aria-posinset="7" aria-setsize="14">
+        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Vendor Management Fieldglass" aria-posinset="7" aria-setsize="20">
             <span class="fd-avatar fd-avatar--sm fd-avatar--thumbnail" role="img" aria-label="Vendor Management">
                 <i role="presentation" aria-hidden="true" class="fd-product-switch__icon sap-icon--shipping-status"></i>
             </span>
@@ -64,7 +62,7 @@
                 <div class="fd-product-switch__subtitle">Fieldglass</div>
             </div>
         </li>
-        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Human Capital Management Human Capital Management" aria-posinset="8" aria-setsize="14">
+        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Human Capital Management Human Capital Management" aria-posinset="8" aria-setsize="20">
             <span class="fd-avatar fd-avatar--sm fd-avatar--thumbnail" role="img" aria-label="Human Capital Management">
                 <i role="presentation" aria-hidden="true" class="fd-product-switch__icon sap-icon--customer"></i>
             </span>
@@ -72,7 +70,7 @@
                 <div class="fd-product-switch__title">Human Capital Management Human Capital Management</div>
             </div>
         </li>
-        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Sales Cloud Sales Cloud" aria-posinset="9" aria-setsize="14">
+        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Sales Cloud Sales Cloud" aria-posinset="9" aria-setsize="20">
             <span class="fd-avatar fd-avatar--sm fd-avatar--thumbnail" role="img" aria-label="Sales Cloud">
                 <i role="presentation" aria-hidden="true" class="fd-product-switch__icon sap-icon--sales-notification"></i>
             </span>
@@ -81,7 +79,7 @@
                 <div class="fd-product-switch__subtitle">Sales Cloud</div>
             </div>
         </li>
-        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Commerce Cloud Commerce Cloud" aria-posinset="10" aria-setsize="14">
+        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Commerce Cloud Commerce Cloud" aria-posinset="10" aria-setsize="20">
             <span class="fd-avatar fd-avatar--sm fd-avatar--thumbnail" role="img" aria-label="Commerce Cloud">
                 <i role="presentation" aria-hidden="true" class="fd-product-switch__icon sap-icon--retail-store"></i>
             </span>
@@ -90,7 +88,7 @@
                 <div class="fd-product-switch__subtitle">Commerce Cloud</div>
             </div>
         </li>
-        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Marketing Cloud Marketing Cloud" aria-posinset="11" aria-setsize="14">
+        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Marketing Cloud Marketing Cloud" aria-posinset="11" aria-setsize="20">
             <span class="fd-avatar fd-avatar--sm fd-avatar--thumbnail" role="img" aria-label="Marketing Cloud">
                 <i role="presentation" aria-hidden="true" class="fd-product-switch__icon sap-icon--marketing-campaign"></i>
             </span>
@@ -99,7 +97,7 @@
                 <div class="fd-product-switch__subtitle">Marketing Cloud</div>
             </div>
         </li>
-        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Service Cloud" aria-posinset="12" aria-setsize="14">
+        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Service Cloud" aria-posinset="12" aria-setsize="20">
             <span class="fd-avatar fd-avatar--sm fd-avatar--thumbnail" role="img" aria-label="Service Cloud">
                 <i role="presentation" aria-hidden="true" class="fd-product-switch__icon sap-icon--family-care"></i>
             </span>
@@ -107,7 +105,7 @@
                 <div class="fd-product-switch__title">Service Cloud</div>
             </div>
         </li>
-        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Customer Data Cloud" aria-posinset="13" aria-setsize="14">
+        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Customer Data Cloud" aria-posinset="13" aria-setsize="20">
             <span class="fd-avatar fd-avatar--sm fd-avatar--thumbnail" role="img" aria-label="Customer Data Cloud">
                 <i role="presentation" aria-hidden="true" class="fd-product-switch__icon sap-icon--customer-briefing"></i>
             </span>
@@ -115,12 +113,60 @@
                 <div class="fd-product-switch__title">Customer Data Cloud</div>
             </div>
         </li>
-        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="S/4HANA" aria-posinset="14" aria-setsize="14">
+        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="S/4HANA" aria-posinset="14" aria-setsize="20">
             <span class="fd-avatar fd-avatar--sm fd-avatar--thumbnail" role="img" aria-label="S/4HANA">
                 <i role="presentation" aria-hidden="true" class="fd-product-switch__icon sap-icon--batch-payments"></i>
             </span>
             <div class="fd-product-switch__text">
                 <div class="fd-product-switch__title">S/4HANA</div>
+            </div>
+        </li>
+        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Business Technology Platform" aria-posinset="15" aria-setsize="20">
+            <span class="fd-avatar fd-avatar--sm fd-avatar--transparent" role="img" aria-label="Business Technology Platform">
+                <i role="presentation" aria-hidden="true" class="fd-avatar__icon sap-icon--cloud"></i>
+            </span>
+            <div class="fd-product-switch__text">
+                <div class="fd-product-switch__title">Business Technology Platform</div>
+            </div>
+        </li>
+        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Intelligent Spend Management" aria-posinset="16" aria-setsize="20">
+            <span class="fd-avatar fd-avatar--sm fd-avatar--transparent" role="img" aria-label="Intelligent Spend Management">
+                <i role="presentation" aria-hidden="true" class="fd-avatar__icon sap-icon--expense-report"></i>
+            </span>
+            <div class="fd-product-switch__text">
+                <div class="fd-product-switch__title">Intelligent Spend Management</div>
+            </div>
+        </li>
+        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Supply Chain Management" aria-posinset="17" aria-setsize="20">
+            <span class="fd-avatar fd-avatar--sm fd-avatar--transparent" role="img" aria-label="Supply Chain Management">
+                <i role="presentation" aria-hidden="true" class="fd-avatar__icon sap-icon--supplier"></i>
+            </span>
+            <div class="fd-product-switch__text">
+                <div class="fd-product-switch__title">Supply Chain Management</div>
+            </div>
+        </li>
+        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Asset Management" aria-posinset="18" aria-setsize="20">
+            <span class="fd-avatar fd-avatar--sm fd-avatar--transparent" role="img" aria-label="Asset Management">
+                <i role="presentation" aria-hidden="true" class="fd-avatar__icon sap-icon--iphone"></i>
+            </span>
+            <div class="fd-product-switch__text">
+                <div class="fd-product-switch__title">Asset Management</div>
+            </div>
+        </li>
+        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Extended Planning &amp; Analysis" aria-posinset="19" aria-setsize="20">
+            <span class="fd-avatar fd-avatar--sm fd-avatar--transparent" role="img" aria-label="Extended Planning &amp; Analysis">
+                <i role="presentation" aria-hidden="true" class="fd-avatar__icon sap-icon--chart-axis"></i>
+            </span>
+            <div class="fd-product-switch__text">
+                <div class="fd-product-switch__title">Extended Planning & Analysis</div>
+            </div>
+        </li>
+        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Financial Management" aria-posinset="20" aria-setsize="20">
+            <span class="fd-avatar fd-avatar--sm fd-avatar--transparent" role="img" aria-label="Financial Management">
+                <i role="presentation" aria-hidden="true" class="fd-avatar__icon sap-icon--money-bills"></i>
+            </span>
+            <div class="fd-product-switch__text">
+                <div class="fd-product-switch__title">Financial Management</div>
             </div>
         </li>
     </ul>

--- a/packages/styles/stories/Components/product-switch/medium.example.html
+++ b/packages/styles/stories/Components/product-switch/medium.example.html
@@ -1,15 +1,13 @@
 <div class="fd-product-switch__body fd-product-switch__body--col-3">
     <ul class="fd-product-switch__list" role="menu">
-        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Home Home Home Home Home Home Home Central Home Central Home Central Home Central Home" aria-posinset="1" aria-setsize="5">
-            <span class="fd-avatar fd-avatar--sm fd-avatar--transparent" role="img" aria-label="Home">
-                <i role="presentation" aria-hidden="true" class="fd-avatar__icon sap-icon--home"></i>
-            </span>
+        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="SAP Start Central Home" aria-posinset="1" aria-setsize="5">
+            <span class="fd-avatar fd-avatar--sm fd-avatar--thumbnail" style="background-image: url('/assets/images/landscape/demo-avatar.png')" role="img" aria-label="SAP Start"></span>
             <div class="fd-product-switch__text">
-                <div class="fd-product-switch__title">Home Home Home Home Home Home Home</div>
-                <div class="fd-product-switch__subtitle">Central Home Central Home Central Home Central Home</div>
+                <div class="fd-product-switch__title">SAP Start</div>
+                <div class="fd-product-switch__subtitle">Central Home</div>
             </div>
         </li>
-        <li class="fd-product-switch__item selected" tabindex="0" role="menuitem" aria-label="Analytics Cloud Analytics Cloud Analytics Cloud" aria-posinset="2" aria-setsize="5">
+        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Analytics Cloud Analytics Cloud Analytics Cloud" aria-posinset="2" aria-setsize="5">
             <span
                 class="fd-avatar fd-avatar--sm fd-avatar--thumbnail"
                 style="background-image: url('/assets/images/landscape/L1.jpg')"

--- a/packages/styles/stories/Components/product-switch/product-switch.stories.js
+++ b/packages/styles/stories/Components/product-switch/product-switch.stories.js
@@ -1,6 +1,7 @@
 import smallExampleHtml from "./small.example.html?raw";
 import mediumExampleHtml from "./medium.example.html?raw";
 import largeExampleHtml from "./large.example.html?raw";
+import twoColumnExampleHtml from "./two-column.example.html?raw";
 import '../../../src/product-switch.scss';
 import '../../../src/popover.scss';
 import '../../../src/button.scss';
@@ -52,16 +53,14 @@ export const Shellbar = () => `${localStyles}
                     <div class="fd-popover__body fd-popover__body--right" role="dialog" aria-modal="false" aria-label="Products" aria-hidden="false" id="product-switch-body">
                         <div class="fd-product-switch__body">
                             <ul class="fd-product-switch__list" role="menu">
-                                <li class="fd-product-switch__item selected" tabindex="0" role="menuitem" aria-label="Home Home Home Home Home Home Home Home Central Home Central Home Central Home Central Home" aria-posinset="1" aria-setsize="14">
-                                    <span class="fd-avatar fd-avatar--sm fd-avatar--transparent" role="img" aria-label="Home">
-                                        <i role="presentation" aria-hidden="true" class="fd-avatar__icon sap-icon--home"></i>
-                                    </span>
+                                <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="SAP Start" aria-posinset="1" aria-setsize="14">
+                                     <span class="fd-avatar fd-avatar--sm fd-avatar--thumbnail" style="background-image: url('/assets/images/landscape/demo-avatar.png')" role="img" aria-label="Guided Buying"></span>
                                     <div class="fd-product-switch__text">
-                                        <div class="fd-product-switch__title">Home Home Home Home Home Home Home Home</div>
-                                        <div class="fd-product-switch__subtitle">Central Home Central Home Central Home Central Home</div>
+                                        <div class="fd-product-switch__title">SAP Start</div>
+                                        <div class="fd-product-switch__subtitle">Central Home</div>
                                     </div>
                                 </li>
-                                <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Analytics Cloud Analytics Cloud Analytics Cloud" aria-posinset="2" aria-setsize="14">
+                                <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Analytics Cloud" aria-posinset="2" aria-setsize="14">
                                     <span class="fd-avatar fd-avatar--sm fd-avatar--transparent" role="img" aria-label="Analytics Cloud">
                                         <i role="presentation" aria-hidden="true" class="fd-avatar__icon sap-icon--business-objects-experience"></i>
                                     </span>
@@ -80,7 +79,9 @@ export const Shellbar = () => `${localStyles}
                                     </div>
                                 </li>
                                 <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Guided Buying" aria-posinset="4" aria-setsize="14">
-                                    <span class="fd-avatar fd-avatar--sm fd-avatar--thumbnail" style="background-image: url('/assets/images/landscape/demo-avatar.png')" role="img" aria-label="Guided Buying"></span>
+                                    <span class="fd-avatar fd-avatar--sm fd-avatar--transparent" role="img" aria-label="Guided Buying">
+                                        <i role="presentation" aria-hidden="true" class="fd-avatar__icon sap-icon--home"></i>
+                                    </span>
                                     <div class="fd-product-switch__text">
                                         <div class="fd-product-switch__title">Guided Buying</div>
                                     </div>
@@ -194,7 +195,7 @@ export const Large = () => largeExampleHtml;
 Large.parameters = {
   docs: {
     description: {
-      story: 'Product switch is displayed with a maximum of 4 columns on large desktop screens. When the popover contains too many items, it will grow until the maximum is reached. Once the maximum is reached, the popover can be scrolled vertically.',
+      story: 'Product switch is displayed with a maximum of 4 columns on large desktop screens. The body grows to accommodate up to 4 rows of items (max-height: 33rem / 528px). Once that limit is reached, additional items are accessible via vertical scroll.',
     }
   }
 };
@@ -204,6 +205,15 @@ Medium.parameters = {
     description: {
       story: `If there are 6 (or less) items to display, it is recommended to use the 3-column layout (medium). To display a medium-sized product switch, add the \`fd-product-switchbody--col-3\` modifier class to the main element.
         `
+    }
+  }
+};
+export const TwoColumn = () => twoColumnExampleHtml;
+TwoColumn.storyName = 'Two Column';
+TwoColumn.parameters = {
+  docs: {
+    description: {
+      story: `When fewer than 3 items are provided, use the 2-column layout to hug the content width. Add the \`fd-product-switch__body--col-2\` modifier class to the body element.`
     }
   }
 };

--- a/packages/styles/stories/Components/product-switch/small.example.html
+++ b/packages/styles/stories/Components/product-switch/small.example.html
@@ -1,16 +1,14 @@
 <div style="width: 353px">
     <div class="fd-product-switch__body fd-product-switch__body--mobile">
         <ul class="fd-product-switch__list" role="menu">
-            <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Home Central Home" aria-posinset="1" aria-setsize="14">
-                <span class="fd-avatar fd-avatar--sm fd-avatar--thumbnail" role="img" aria-label="Home">
-                    <i role="presentation" aria-hidden="true" class="fd-product-switch__icon sap-icon--home"></i>
-                </span>
+            <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="SAP Start Central Home" aria-posinset="1" aria-setsize="14">
+                <span class="fd-avatar fd-avatar--sm fd-avatar--thumbnail" style="background-image: url('/assets/images/landscape/demo-avatar.png')" role="img" aria-label="SAP Start"></span>
                 <div class="fd-product-switch__text">
-                    <div class="fd-product-switch__title">Home</div>
+                    <div class="fd-product-switch__title">SAP Start</div>
                     <div class="fd-product-switch__subtitle">Central Home</div>
                 </div>
             </li>
-            <li class="fd-product-switch__item selected" tabindex="0" role="menuitem" aria-label="Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud" aria-posinset="2" aria-setsize="14">
+            <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud" aria-posinset="2" aria-setsize="14">
                 <span class="fd-avatar fd-avatar--sm fd-avatar--thumbnail" role="img" aria-label="SAP Start">
                     <i role="presentation" aria-hidden="true" class="fd-product-switch__icon sap-icon--business-objects-experience"></i>
                 </span>

--- a/packages/styles/stories/Components/product-switch/two-column.example.html
+++ b/packages/styles/stories/Components/product-switch/two-column.example.html
@@ -1,0 +1,20 @@
+<div class="fd-product-switch__body fd-product-switch__body--col-2">
+    <ul class="fd-product-switch__list" role="menu">
+        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="SAP Start Central Home" aria-posinset="1" aria-setsize="2">
+            <span class="fd-avatar fd-avatar--sm fd-avatar--thumbnail" style="background-image: url('/assets/images/landscape/demo-avatar.png')" role="img" aria-label="SAP Start"></span>
+            <div class="fd-product-switch__text">
+                <div class="fd-product-switch__title">SAP Start</div>
+                <div class="fd-product-switch__subtitle">Central Home</div>
+            </div>
+        </li>
+        <li class="fd-product-switch__item" tabindex="0" role="menuitem" aria-label="Analytics Cloud Analytics Cloud" aria-posinset="2" aria-setsize="2">
+            <span class="fd-avatar fd-avatar--sm fd-avatar--transparent" role="img" aria-label="Analytics Cloud">
+                <i role="presentation" aria-hidden="true" class="fd-avatar__icon sap-icon--business-objects-experience"></i>
+            </span>
+            <div class="fd-product-switch__text">
+                <div class="fd-product-switch__title">Analytics Cloud</div>
+                <div class="fd-product-switch__subtitle">Analytics Cloud</div>
+            </div>
+        </li>
+    </ul>
+</div>

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -44320,16 +44320,14 @@ exports[`Check stories > Components/Popover > Story Variants > Should match snap
 exports[`Check stories > Components/Product Switch > Story Large > Should match snapshot 1`] = `
 "<div class=\\"fd-product-switch__body\\">
     <ul class=\\"fd-product-switch__list\\" role=\\"menu\\">
-        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Home Home Home Home Home Home Home Home Central Home Central Home Central Home Central Home\\" aria-posinset=\\"1\\" aria-setsize=\\"14\\">
-            <span class=\\"fd-avatar fd-avatar--sm fd-avatar--transparent\\" role=\\"img\\" aria-label=\\"Home\\">
-                <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-avatar__icon sap-icon--home\\"></i>
-            </span>
+        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"SAP Start Central Home\\" aria-posinset=\\"1\\" aria-setsize=\\"20\\">
+            <span class=\\"fd-avatar fd-avatar--sm fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/landscape/demo-avatar.png')\\" role=\\"img\\" aria-label=\\"SAP Start\\"></span>
             <div class=\\"fd-product-switch__text\\">
-                <div class=\\"fd-product-switch__title\\">Home Home Home Home Home Home Home Home</div>
-                <div class=\\"fd-product-switch__subtitle\\">Central Home Central Home Central Home Central Home</div>
+                <div class=\\"fd-product-switch__title\\">SAP Start</div>
+                <div class=\\"fd-product-switch__subtitle\\">Central Home</div>
             </div>
         </li>
-        <li class=\\"fd-product-switch__item selected\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Analytics Cloud Analytics Cloud Analytics Cloud\\" aria-posinset=\\"2\\" aria-setsize=\\"14\\">
+        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Analytics Cloud Analytics Cloud Analytics Cloud\\" aria-posinset=\\"2\\" aria-setsize=\\"20\\">
             <span
                 class=\\"fd-avatar fd-avatar--sm fd-avatar--thumbnail\\"
                 style=\\"background-image: url('/assets/images/landscape/L1.jpg')\\"
@@ -44341,7 +44339,7 @@ exports[`Check stories > Components/Product Switch > Story Large > Should match 
                 <div class=\\"fd-product-switch__subtitle\\">Analytics Cloud</div>
             </div>
         </li>
-        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Catalog Ariba\\" aria-posinset=\\"3\\" aria-setsize=\\"14\\">
+        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Catalog Ariba\\" aria-posinset=\\"3\\" aria-setsize=\\"20\\">
             <span class=\\"fd-avatar fd-avatar--sm fd-avatar--thumbnail\\" role=\\"img\\" aria-label=\\"Catalog\\">
                 <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-product-switch__icon sap-icon--contacts\\"></i>
             </span>
@@ -44350,7 +44348,7 @@ exports[`Check stories > Components/Product Switch > Story Large > Should match 
                 <div class=\\"fd-product-switch__subtitle\\">Ariba</div>
             </div>
         </li>
-        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Guided Buying\\" aria-posinset=\\"4\\" aria-setsize=\\"14\\">
+        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Guided Buying\\" aria-posinset=\\"4\\" aria-setsize=\\"20\\">
             <span class=\\"fd-avatar fd-avatar--sm fd-avatar--thumbnail\\" role=\\"img\\" aria-label=\\"Guided Buying\\">
                 <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-product-switch__icon sap-icon--credit-card\\"></i>
             </span>
@@ -44358,7 +44356,7 @@ exports[`Check stories > Components/Product Switch > Story Large > Should match 
                 <div class=\\"fd-product-switch__title\\">Guided Buying</div>
             </div>
         </li>
-        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Strategic Procurement\\" aria-posinset=\\"5\\" aria-setsize=\\"14\\">
+        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Strategic Procurement\\" aria-posinset=\\"5\\" aria-setsize=\\"20\\">
             <span class=\\"fd-avatar fd-avatar--sm fd-avatar--thumbnail\\" role=\\"img\\" aria-label=\\"Strategic Procurement\\">
                 <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-product-switch__icon sap-icon--cart-3\\"></i>
             </span>
@@ -44366,7 +44364,7 @@ exports[`Check stories > Components/Product Switch > Story Large > Should match 
                 <div class=\\"fd-product-switch__title\\">Strategic Procurement</div>
             </div>
         </li>
-        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Travel &amp; Expense Concur\\" aria-posinset=\\"6\\" aria-setsize=\\"14\\">
+        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Travel &amp; Expense Concur\\" aria-posinset=\\"6\\" aria-setsize=\\"20\\">
             <span class=\\"fd-avatar fd-avatar--sm fd-avatar--thumbnail\\" role=\\"img\\" aria-label=\\"Travel &amp; Expense\\">
                 <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-product-switch__icon sap-icon--flight\\"></i>
             </span>
@@ -44375,7 +44373,7 @@ exports[`Check stories > Components/Product Switch > Story Large > Should match 
                 <div class=\\"fd-product-switch__subtitle\\">Concur</div>
             </div>
         </li>
-        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Vendor Management Fieldglass\\" aria-posinset=\\"7\\" aria-setsize=\\"14\\">
+        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Vendor Management Fieldglass\\" aria-posinset=\\"7\\" aria-setsize=\\"20\\">
             <span class=\\"fd-avatar fd-avatar--sm fd-avatar--thumbnail\\" role=\\"img\\" aria-label=\\"Vendor Management\\">
                 <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-product-switch__icon sap-icon--shipping-status\\"></i>
             </span>
@@ -44384,7 +44382,7 @@ exports[`Check stories > Components/Product Switch > Story Large > Should match 
                 <div class=\\"fd-product-switch__subtitle\\">Fieldglass</div>
             </div>
         </li>
-        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Human Capital Management Human Capital Management\\" aria-posinset=\\"8\\" aria-setsize=\\"14\\">
+        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Human Capital Management Human Capital Management\\" aria-posinset=\\"8\\" aria-setsize=\\"20\\">
             <span class=\\"fd-avatar fd-avatar--sm fd-avatar--thumbnail\\" role=\\"img\\" aria-label=\\"Human Capital Management\\">
                 <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-product-switch__icon sap-icon--customer\\"></i>
             </span>
@@ -44392,7 +44390,7 @@ exports[`Check stories > Components/Product Switch > Story Large > Should match 
                 <div class=\\"fd-product-switch__title\\">Human Capital Management Human Capital Management</div>
             </div>
         </li>
-        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Sales Cloud Sales Cloud\\" aria-posinset=\\"9\\" aria-setsize=\\"14\\">
+        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Sales Cloud Sales Cloud\\" aria-posinset=\\"9\\" aria-setsize=\\"20\\">
             <span class=\\"fd-avatar fd-avatar--sm fd-avatar--thumbnail\\" role=\\"img\\" aria-label=\\"Sales Cloud\\">
                 <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-product-switch__icon sap-icon--sales-notification\\"></i>
             </span>
@@ -44401,7 +44399,7 @@ exports[`Check stories > Components/Product Switch > Story Large > Should match 
                 <div class=\\"fd-product-switch__subtitle\\">Sales Cloud</div>
             </div>
         </li>
-        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Commerce Cloud Commerce Cloud\\" aria-posinset=\\"10\\" aria-setsize=\\"14\\">
+        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Commerce Cloud Commerce Cloud\\" aria-posinset=\\"10\\" aria-setsize=\\"20\\">
             <span class=\\"fd-avatar fd-avatar--sm fd-avatar--thumbnail\\" role=\\"img\\" aria-label=\\"Commerce Cloud\\">
                 <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-product-switch__icon sap-icon--retail-store\\"></i>
             </span>
@@ -44410,7 +44408,7 @@ exports[`Check stories > Components/Product Switch > Story Large > Should match 
                 <div class=\\"fd-product-switch__subtitle\\">Commerce Cloud</div>
             </div>
         </li>
-        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Marketing Cloud Marketing Cloud\\" aria-posinset=\\"11\\" aria-setsize=\\"14\\">
+        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Marketing Cloud Marketing Cloud\\" aria-posinset=\\"11\\" aria-setsize=\\"20\\">
             <span class=\\"fd-avatar fd-avatar--sm fd-avatar--thumbnail\\" role=\\"img\\" aria-label=\\"Marketing Cloud\\">
                 <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-product-switch__icon sap-icon--marketing-campaign\\"></i>
             </span>
@@ -44419,7 +44417,7 @@ exports[`Check stories > Components/Product Switch > Story Large > Should match 
                 <div class=\\"fd-product-switch__subtitle\\">Marketing Cloud</div>
             </div>
         </li>
-        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Service Cloud\\" aria-posinset=\\"12\\" aria-setsize=\\"14\\">
+        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Service Cloud\\" aria-posinset=\\"12\\" aria-setsize=\\"20\\">
             <span class=\\"fd-avatar fd-avatar--sm fd-avatar--thumbnail\\" role=\\"img\\" aria-label=\\"Service Cloud\\">
                 <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-product-switch__icon sap-icon--family-care\\"></i>
             </span>
@@ -44427,7 +44425,7 @@ exports[`Check stories > Components/Product Switch > Story Large > Should match 
                 <div class=\\"fd-product-switch__title\\">Service Cloud</div>
             </div>
         </li>
-        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Customer Data Cloud\\" aria-posinset=\\"13\\" aria-setsize=\\"14\\">
+        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Customer Data Cloud\\" aria-posinset=\\"13\\" aria-setsize=\\"20\\">
             <span class=\\"fd-avatar fd-avatar--sm fd-avatar--thumbnail\\" role=\\"img\\" aria-label=\\"Customer Data Cloud\\">
                 <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-product-switch__icon sap-icon--customer-briefing\\"></i>
             </span>
@@ -44435,12 +44433,60 @@ exports[`Check stories > Components/Product Switch > Story Large > Should match 
                 <div class=\\"fd-product-switch__title\\">Customer Data Cloud</div>
             </div>
         </li>
-        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"S/4HANA\\" aria-posinset=\\"14\\" aria-setsize=\\"14\\">
+        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"S/4HANA\\" aria-posinset=\\"14\\" aria-setsize=\\"20\\">
             <span class=\\"fd-avatar fd-avatar--sm fd-avatar--thumbnail\\" role=\\"img\\" aria-label=\\"S/4HANA\\">
                 <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-product-switch__icon sap-icon--batch-payments\\"></i>
             </span>
             <div class=\\"fd-product-switch__text\\">
                 <div class=\\"fd-product-switch__title\\">S/4HANA</div>
+            </div>
+        </li>
+        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Business Technology Platform\\" aria-posinset=\\"15\\" aria-setsize=\\"20\\">
+            <span class=\\"fd-avatar fd-avatar--sm fd-avatar--transparent\\" role=\\"img\\" aria-label=\\"Business Technology Platform\\">
+                <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-avatar__icon sap-icon--cloud\\"></i>
+            </span>
+            <div class=\\"fd-product-switch__text\\">
+                <div class=\\"fd-product-switch__title\\">Business Technology Platform</div>
+            </div>
+        </li>
+        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Intelligent Spend Management\\" aria-posinset=\\"16\\" aria-setsize=\\"20\\">
+            <span class=\\"fd-avatar fd-avatar--sm fd-avatar--transparent\\" role=\\"img\\" aria-label=\\"Intelligent Spend Management\\">
+                <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-avatar__icon sap-icon--expense-report\\"></i>
+            </span>
+            <div class=\\"fd-product-switch__text\\">
+                <div class=\\"fd-product-switch__title\\">Intelligent Spend Management</div>
+            </div>
+        </li>
+        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Supply Chain Management\\" aria-posinset=\\"17\\" aria-setsize=\\"20\\">
+            <span class=\\"fd-avatar fd-avatar--sm fd-avatar--transparent\\" role=\\"img\\" aria-label=\\"Supply Chain Management\\">
+                <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-avatar__icon sap-icon--supplier\\"></i>
+            </span>
+            <div class=\\"fd-product-switch__text\\">
+                <div class=\\"fd-product-switch__title\\">Supply Chain Management</div>
+            </div>
+        </li>
+        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Asset Management\\" aria-posinset=\\"18\\" aria-setsize=\\"20\\">
+            <span class=\\"fd-avatar fd-avatar--sm fd-avatar--transparent\\" role=\\"img\\" aria-label=\\"Asset Management\\">
+                <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-avatar__icon sap-icon--iphone\\"></i>
+            </span>
+            <div class=\\"fd-product-switch__text\\">
+                <div class=\\"fd-product-switch__title\\">Asset Management</div>
+            </div>
+        </li>
+        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Extended Planning &amp; Analysis\\" aria-posinset=\\"19\\" aria-setsize=\\"20\\">
+            <span class=\\"fd-avatar fd-avatar--sm fd-avatar--transparent\\" role=\\"img\\" aria-label=\\"Extended Planning &amp; Analysis\\">
+                <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-avatar__icon sap-icon--chart-axis\\"></i>
+            </span>
+            <div class=\\"fd-product-switch__text\\">
+                <div class=\\"fd-product-switch__title\\">Extended Planning & Analysis</div>
+            </div>
+        </li>
+        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Financial Management\\" aria-posinset=\\"20\\" aria-setsize=\\"20\\">
+            <span class=\\"fd-avatar fd-avatar--sm fd-avatar--transparent\\" role=\\"img\\" aria-label=\\"Financial Management\\">
+                <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-avatar__icon sap-icon--money-bills\\"></i>
+            </span>
+            <div class=\\"fd-product-switch__text\\">
+                <div class=\\"fd-product-switch__title\\">Financial Management</div>
             </div>
         </li>
     </ul>
@@ -44451,16 +44497,14 @@ exports[`Check stories > Components/Product Switch > Story Large > Should match 
 exports[`Check stories > Components/Product Switch > Story Medium > Should match snapshot 1`] = `
 "<div class=\\"fd-product-switch__body fd-product-switch__body--col-3\\">
     <ul class=\\"fd-product-switch__list\\" role=\\"menu\\">
-        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Home Home Home Home Home Home Home Central Home Central Home Central Home Central Home\\" aria-posinset=\\"1\\" aria-setsize=\\"5\\">
-            <span class=\\"fd-avatar fd-avatar--sm fd-avatar--transparent\\" role=\\"img\\" aria-label=\\"Home\\">
-                <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-avatar__icon sap-icon--home\\"></i>
-            </span>
+        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"SAP Start Central Home\\" aria-posinset=\\"1\\" aria-setsize=\\"5\\">
+            <span class=\\"fd-avatar fd-avatar--sm fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/landscape/demo-avatar.png')\\" role=\\"img\\" aria-label=\\"SAP Start\\"></span>
             <div class=\\"fd-product-switch__text\\">
-                <div class=\\"fd-product-switch__title\\">Home Home Home Home Home Home Home</div>
-                <div class=\\"fd-product-switch__subtitle\\">Central Home Central Home Central Home Central Home</div>
+                <div class=\\"fd-product-switch__title\\">SAP Start</div>
+                <div class=\\"fd-product-switch__subtitle\\">Central Home</div>
             </div>
         </li>
-        <li class=\\"fd-product-switch__item selected\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Analytics Cloud Analytics Cloud Analytics Cloud\\" aria-posinset=\\"2\\" aria-setsize=\\"5\\">
+        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Analytics Cloud Analytics Cloud Analytics Cloud\\" aria-posinset=\\"2\\" aria-setsize=\\"5\\">
             <span
                 class=\\"fd-avatar fd-avatar--sm fd-avatar--thumbnail\\"
                 style=\\"background-image: url('/assets/images/landscape/L1.jpg')\\"
@@ -44529,16 +44573,14 @@ exports[`Check stories > Components/Product Switch > Story Shellbar > Should mat
                     <div class=\\"fd-popover__body fd-popover__body--right\\" role=\\"dialog\\" aria-modal=\\"false\\" aria-label=\\"Products\\" aria-hidden=\\"false\\" id=\\"product-switch-body\\">
                         <div class=\\"fd-product-switch__body\\">
                             <ul class=\\"fd-product-switch__list\\" role=\\"menu\\">
-                                <li class=\\"fd-product-switch__item selected\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Home Home Home Home Home Home Home Home Central Home Central Home Central Home Central Home\\" aria-posinset=\\"1\\" aria-setsize=\\"14\\">
-                                    <span class=\\"fd-avatar fd-avatar--sm fd-avatar--transparent\\" role=\\"img\\" aria-label=\\"Home\\">
-                                        <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-avatar__icon sap-icon--home\\"></i>
-                                    </span>
+                                <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"SAP Start\\" aria-posinset=\\"1\\" aria-setsize=\\"14\\">
+                                     <span class=\\"fd-avatar fd-avatar--sm fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/landscape/demo-avatar.png')\\" role=\\"img\\" aria-label=\\"Guided Buying\\"></span>
                                     <div class=\\"fd-product-switch__text\\">
-                                        <div class=\\"fd-product-switch__title\\">Home Home Home Home Home Home Home Home</div>
-                                        <div class=\\"fd-product-switch__subtitle\\">Central Home Central Home Central Home Central Home</div>
+                                        <div class=\\"fd-product-switch__title\\">SAP Start</div>
+                                        <div class=\\"fd-product-switch__subtitle\\">Central Home</div>
                                     </div>
                                 </li>
-                                <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Analytics Cloud Analytics Cloud Analytics Cloud\\" aria-posinset=\\"2\\" aria-setsize=\\"14\\">
+                                <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Analytics Cloud\\" aria-posinset=\\"2\\" aria-setsize=\\"14\\">
                                     <span class=\\"fd-avatar fd-avatar--sm fd-avatar--transparent\\" role=\\"img\\" aria-label=\\"Analytics Cloud\\">
                                         <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-avatar__icon sap-icon--business-objects-experience\\"></i>
                                     </span>
@@ -44557,7 +44599,9 @@ exports[`Check stories > Components/Product Switch > Story Shellbar > Should mat
                                     </div>
                                 </li>
                                 <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Guided Buying\\" aria-posinset=\\"4\\" aria-setsize=\\"14\\">
-                                    <span class=\\"fd-avatar fd-avatar--sm fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/landscape/demo-avatar.png')\\" role=\\"img\\" aria-label=\\"Guided Buying\\"></span>
+                                    <span class=\\"fd-avatar fd-avatar--sm fd-avatar--transparent\\" role=\\"img\\" aria-label=\\"Guided Buying\\">
+                                        <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-avatar__icon sap-icon--home\\"></i>
+                                    </span>
                                     <div class=\\"fd-product-switch__text\\">
                                         <div class=\\"fd-product-switch__title\\">Guided Buying</div>
                                     </div>
@@ -44663,16 +44707,14 @@ exports[`Check stories > Components/Product Switch > Story Small > Should match 
 "<div style=\\"width: 353px\\">
     <div class=\\"fd-product-switch__body fd-product-switch__body--mobile\\">
         <ul class=\\"fd-product-switch__list\\" role=\\"menu\\">
-            <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Home Central Home\\" aria-posinset=\\"1\\" aria-setsize=\\"14\\">
-                <span class=\\"fd-avatar fd-avatar--sm fd-avatar--thumbnail\\" role=\\"img\\" aria-label=\\"Home\\">
-                    <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-product-switch__icon sap-icon--home\\"></i>
-                </span>
+            <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"SAP Start Central Home\\" aria-posinset=\\"1\\" aria-setsize=\\"14\\">
+                <span class=\\"fd-avatar fd-avatar--sm fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/landscape/demo-avatar.png')\\" role=\\"img\\" aria-label=\\"SAP Start\\"></span>
                 <div class=\\"fd-product-switch__text\\">
-                    <div class=\\"fd-product-switch__title\\">Home</div>
+                    <div class=\\"fd-product-switch__title\\">SAP Start</div>
                     <div class=\\"fd-product-switch__subtitle\\">Central Home</div>
                 </div>
             </li>
-            <li class=\\"fd-product-switch__item selected\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud\\" aria-posinset=\\"2\\" aria-setsize=\\"14\\">
+            <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud Analytics Cloud\\" aria-posinset=\\"2\\" aria-setsize=\\"14\\">
                 <span class=\\"fd-avatar fd-avatar--sm fd-avatar--thumbnail\\" role=\\"img\\" aria-label=\\"SAP Start\\">
                     <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-product-switch__icon sap-icon--business-objects-experience\\"></i>
                 </span>
@@ -44795,6 +44837,30 @@ exports[`Check stories > Components/Product Switch > Story Small > Should match 
             </li>
         </ul>
     </div>
+</div>
+"
+`;
+
+exports[`Check stories > Components/Product Switch > Story TwoColumn > Should match snapshot 1`] = `
+"<div class=\\"fd-product-switch__body fd-product-switch__body--col-2\\">
+    <ul class=\\"fd-product-switch__list\\" role=\\"menu\\">
+        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"SAP Start Central Home\\" aria-posinset=\\"1\\" aria-setsize=\\"2\\">
+            <span class=\\"fd-avatar fd-avatar--sm fd-avatar--thumbnail\\" style=\\"background-image: url('/assets/images/landscape/demo-avatar.png')\\" role=\\"img\\" aria-label=\\"SAP Start\\"></span>
+            <div class=\\"fd-product-switch__text\\">
+                <div class=\\"fd-product-switch__title\\">SAP Start</div>
+                <div class=\\"fd-product-switch__subtitle\\">Central Home</div>
+            </div>
+        </li>
+        <li class=\\"fd-product-switch__item\\" tabindex=\\"0\\" role=\\"menuitem\\" aria-label=\\"Analytics Cloud Analytics Cloud\\" aria-posinset=\\"2\\" aria-setsize=\\"2\\">
+            <span class=\\"fd-avatar fd-avatar--sm fd-avatar--transparent\\" role=\\"img\\" aria-label=\\"Analytics Cloud\\">
+                <i role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"fd-avatar__icon sap-icon--business-objects-experience\\"></i>
+            </span>
+            <div class=\\"fd-product-switch__text\\">
+                <div class=\\"fd-product-switch__title\\">Analytics Cloud</div>
+                <div class=\\"fd-product-switch__subtitle\\">Analytics Cloud</div>
+            </div>
+        </li>
+    </ul>
 </div>
 "
 `;


### PR DESCRIPTION
## Related Issue
Closes none

## Description

Brings spec-correct overrides from `fundamental-ngx` into the library and cleans up the Storybook examples.

### SCSS changes (`product-switch.scss`)

- **Border-radius token** — `&__body` now uses `--fdProductSwitch_Body_BorderRadius: var(--sapPopover_BorderCornerRadius, var(--sapElement_BorderCornerRadius))` instead of the hardcoded `--sapElement_BorderCornerRadius`. The body is a popover surface; `--sapPopover_BorderCornerRadius` (8 px) is the correct token. The fallback preserves compatibility with themes that do not define it.

- **Max-height cap** — `&__body` `max-height` changed from `calc(100vh - 76px)` to `33rem` (528 px). The spec limits the body to 4 rows of items, beyond which a vertical scrollbar appears.

- **Two-column modifier** — Added `&__body--col-2` which sets `__list` width to `23rem` (2 × 11.25 rem max-width + 0.5 rem gap). Use this modifier when fewer than 3 items are provided so the container hugs its content at 2 columns.

- **Mobile item min-height** — `&__body--mobile .fd-product-switch__item` `min-height` corrected from `5rem` to `6rem` (96 px) to match the spec.

- **Removed `.selected` styles** — Removed all three `&.selected` rule blocks (`&__item`, `&__item` inside `&.dragged`, and `&__body--mobile &__item`).

### Story changes

- Added `two-column.example.html` and a **Two Column** story (placed before *Small*) demonstrating the `--col-2` modifier with 2 items.
- **Large** example expanded from 14 to 20 items (5 rows) to visibly trigger vertical scroll; story description updated to reference the `33rem / 528 px` cap.
- First item replaced with the **SAP Start** thumbnail avatar across all examples (Large, Medium, Small, Two Column, Shellbar).
- `selected` class removed from all story examples.
