### PR TITLE
fix(styles): form layout fields spacing

### DIFF
--- a/packages/styles/src/form-group.scss
+++ b/packages/styles/src/form-group.scss
@@ -29,6 +29,10 @@ $block: #{$fd-namespace}-form-group;
     background-color: var(--sapGroup_TitleBackground);
     border-bottom: var(--sapGroup_TitleBorderWidth) solid var(--sapGroup_TitleBorderColor);
 
+    @include fd-compact-or-condensed() {
+      min-height: var(--sapElement_Compact_LineHeight);
+    }
+
     &--no-padding {
       --fdFormGroupPaddingInline: 0;
     }

--- a/packages/styles/src/form-item.scss
+++ b/packages/styles/src/form-item.scss
@@ -35,7 +35,7 @@ $block: #{$fd-namespace}-form-item;
     .#{$fd-namespace}-form-label {
       padding-block-end: 0;
       margin-block: auto;
-      margin-inline: 0 0.5rem;
+      margin-inline: 0 0.25rem;
     }
 
     .#{$fd-namespace}-input {

--- a/packages/styles/src/form-layout-grid.scss
+++ b/packages/styles/src/form-layout-grid.scss
@@ -15,9 +15,11 @@ $gridCol: #{$fd-namespace}-col;
   .#{$gridContainer}.#{$formContainer}.#{$verticalSelector} {
     &.#{$formGroup},
     .#{$formGroup} {
-      .#{$formItem}:not(:first-of-type) {
-        > .#{$gridCol} > .#{$fd-namespace}-form-label {
-          padding-block-start: $marginTop;
+      .#{$formItem} {
+        margin-top: $marginTop;
+
+        &:first-of-type {
+          margin-top: 0;
         }
       }
     }

--- a/packages/styles/src/form-layout-grid.scss
+++ b/packages/styles/src/form-layout-grid.scss
@@ -16,10 +16,10 @@ $gridCol: #{$fd-namespace}-col;
     &.#{$formGroup},
     .#{$formGroup} {
       .#{$formItem} {
-        margin-top: $marginTop;
+        margin-top: var(--fdFormLayoutGridItemMarginTop, #{$marginTop});
 
         &:first-of-type {
-          margin-top: 0;
+          margin-top: var(--fdFormLayoutGridItemFirstOfTypeMarginTop, 0);
         }
       }
     }
@@ -110,6 +110,19 @@ $gridCol: #{$fd-namespace}-col;
 }
 
 .#{$gridContainer}.#{$formContainer}.#{$formContainer}--display-mode {
+  @include fd-compact-or-condensed() {
+    --fdFormLayoutGridTextPaddingBlock: 0.3125rem;
+  }
+
+  // 1rem vertical spacing between label+value pairs (spec vertical C)
+  &.#{$formContainer}--vertical,
+  &.#{$formContainer}--md-vertical,
+  &.#{$formContainer}--lg-vertical,
+  &.#{$formContainer}--xl-vertical {
+    --fdFormLayoutGridItemMarginTop: 1rem;
+    --fdFormLayoutGridItemFirstOfTypeMarginTop: 0;
+  }
+
   &.#{$formGroup},
   .#{$formGroup} {
     .#{$formItem} {
@@ -118,11 +131,7 @@ $gridCol: #{$fd-namespace}-col;
       }
 
       .#{$fd-namespace}-text {
-        padding-block: 0.625rem;
-
-        @include fd-compact-or-condensed() {
-          padding-block: 0.3125rem;
-        }
+        padding-block: var(--fdFormLayoutGridTextPaddingBlock, 0.625rem);
       }
     }
   }
@@ -132,24 +141,6 @@ $gridCol: #{$fd-namespace}-col;
     .#{$gridCol}--12 {
       > .#{$fd-namespace}-form-label {
         padding-block-end: 0.25rem;
-      }
-    }
-  }
-
-  // 1rem vertical spacing between label+value pairs (spec vertical C)
-  // Covers explicit vertical modifiers at all breakpoints
-  &.#{$formContainer}--vertical,
-  &.#{$formContainer}--md-vertical,
-  &.#{$formContainer}--lg-vertical,
-  &.#{$formContainer}--xl-vertical {
-    &.#{$formGroup},
-    .#{$formGroup} {
-      .#{$formItem} {
-        margin-top: 1rem;
-
-        &:first-of-type {
-          margin-top: 0;
-        }
       }
     }
   }
@@ -165,16 +156,8 @@ $gridCol: #{$fd-namespace}-col;
 
   // Display mode at S breakpoint: all forms are vertical, use 1rem pair spacing
   .#{$gridContainer}.#{$formContainer}.#{$formContainer}--display-mode {
-    &.#{$formGroup},
-    .#{$formGroup} {
-      .#{$formItem} {
-        margin-top: 1rem;
-
-        &:first-of-type {
-          margin-top: 0;
-        }
-      }
-    }
+    --fdFormLayoutGridItemMarginTop: 1rem;
+    --fdFormLayoutGridItemFirstOfTypeMarginTop: 0;
   }
 }
 

--- a/packages/styles/src/form-layout-grid.scss
+++ b/packages/styles/src/form-layout-grid.scss
@@ -144,9 +144,11 @@ $gridCol: #{$fd-namespace}-col;
   &.#{$formContainer}--xl-vertical {
     &.#{$formGroup},
     .#{$formGroup} {
-      .#{$formItem}:not(:first-of-type) {
-        > .#{$gridCol} > .#{$fd-namespace}-form-label {
-          padding-block-start: 1rem;
+      .#{$formItem} {
+        margin-top: 1rem;
+
+        &:first-of-type {
+          margin-top: 0;
         }
       }
     }
@@ -165,9 +167,11 @@ $gridCol: #{$fd-namespace}-col;
   .#{$gridContainer}.#{$formContainer}.#{$formContainer}--display-mode {
     &.#{$formGroup},
     .#{$formGroup} {
-      .#{$formItem}:not(:first-of-type) {
-        > .#{$gridCol} > .#{$fd-namespace}-form-label {
-          padding-block-start: 1rem;
+      .#{$formItem} {
+        margin-top: 1rem;
+
+        &:first-of-type {
+          margin-top: 0;
         }
       }
     }

--- a/packages/styles/src/form-layout-grid.scss
+++ b/packages/styles/src/form-layout-grid.scss
@@ -15,11 +15,9 @@ $gridCol: #{$fd-namespace}-col;
   .#{$gridContainer}.#{$formContainer}.#{$verticalSelector} {
     &.#{$formGroup},
     .#{$formGroup} {
-      .#{$formItem} {
-        margin-top: 0.625rem;
-
-        &:first-of-type {
-          margin-top: 0;
+      .#{$formItem}:not(:first-of-type) {
+        > .#{$gridCol} > .#{$fd-namespace}-form-label {
+          padding-block-start: $marginTop;
         }
       }
     }
@@ -85,8 +83,8 @@ $gridCol: #{$fd-namespace}-col;
 
         &--required {
           padding-inline-end: 0.5rem;
-          
-          &.#{$fd-namespace}-form-label--colon{
+
+          &.#{$fd-namespace}-form-label--colon {
             padding-inline-end: 0.75rem;
           }
         }
@@ -109,6 +107,50 @@ $gridCol: #{$fd-namespace}-col;
   }
 }
 
+.#{$gridContainer}.#{$formContainer}.#{$formContainer}--display-mode {
+  &.#{$formGroup},
+  .#{$formGroup} {
+    .#{$formItem} {
+      .#{$fd-namespace}-form-label {
+        margin-inline-end: 0.5rem;
+      }
+
+      .#{$fd-namespace}-text {
+        padding-block: 0.625rem;
+
+        @include fd-compact-or-condensed() {
+          padding-block: 0.3125rem;
+        }
+      }
+    }
+  }
+
+  .#{$gridRow} {
+    .#{$gridCol},
+    .#{$gridCol}--12 {
+      > .#{$fd-namespace}-form-label {
+        padding-block-end: 0.25rem;
+      }
+    }
+  }
+
+  // 1rem vertical spacing between label+value pairs (spec vertical C)
+  // Covers explicit vertical modifiers at all breakpoints
+  &.#{$formContainer}--vertical,
+  &.#{$formContainer}--md-vertical,
+  &.#{$formContainer}--lg-vertical,
+  &.#{$formContainer}--xl-vertical {
+    &.#{$formGroup},
+    .#{$formGroup} {
+      .#{$formItem}:not(:first-of-type) {
+        > .#{$gridCol} > .#{$fd-namespace}-form-label {
+          padding-block-start: 1rem;
+        }
+      }
+    }
+  }
+}
+
 @media (width >= 0) {
   @include fd-form-vertical(#{$formContainer}--vertical);
   @include fd-form-col-paddings('fd-col');
@@ -116,6 +158,18 @@ $gridCol: #{$fd-namespace}-col;
 
 @media (width >= 0) and (width <= 599px) {
   @include fd-form-vertical(#{$formContainer});
+
+  // Display mode at S breakpoint: all forms are vertical, use 1rem pair spacing
+  .#{$gridContainer}.#{$formContainer}.#{$formContainer}--display-mode {
+    &.#{$formGroup},
+    .#{$formGroup} {
+      .#{$formItem}:not(:first-of-type) {
+        > .#{$gridCol} > .#{$fd-namespace}-form-label {
+          padding-block-start: 1rem;
+        }
+      }
+    }
+  }
 }
 
 @media (width >= 600px) {

--- a/packages/styles/stories/Components/Forms/form-grid/form-grid.stories.js
+++ b/packages/styles/stories/Components/Forms/form-grid/form-grid.stories.js
@@ -6,6 +6,7 @@ import '../../../../src/popover.scss';
 import '../../../../src/select.scss';
 import '../../../../src/icon.scss';
 import '../../../../src/button.scss';
+import '../../../../src/text.scss';
 export default {
   title: 'Components/Forms/Form Grid',
   parameters: {
@@ -1726,6 +1727,124 @@ To display form in vertical layout under different breakpoints apply modifier cl
 | \`.fd-form-layout-grid-container--lg-vertical\` | **LG**
 | \`.fd-form-layout-grid-container--xl-vertical\` | **XL**
         `
+    }
+  }
+};
+
+export const DisplayModeHorizontal = () => `
+<div class="fd-container fd-form-layout-grid-container fd-form-layout-grid-container--display-mode fd-form-group">
+    <div class="fd-row fd-form-item">
+        <div class="fd-col fd-col-md--4">
+            <label class="fd-form-label fd-form-label--colon" for="dm-h-name">Name</label>
+        </div>
+        <div class="fd-col fd-col-md--8">
+            <p class="fd-text" id="dm-h-name">Amelia Perry</p>
+        </div>
+    </div>
+    <div class="fd-row fd-form-item">
+        <div class="fd-col fd-col-md--4">
+            <label class="fd-form-label fd-form-label--colon" for="dm-h-street">Street/No.</label>
+        </div>
+        <div class="fd-col fd-col-md--8">
+            <p class="fd-text" id="dm-h-street">Myrtle St. 495</p>
+        </div>
+    </div>
+    <div class="fd-row fd-form-item">
+        <div class="fd-col fd-col-md--4">
+            <label class="fd-form-label fd-form-label--colon" for="dm-h-zip">ZIP Code/City</label>
+        </div>
+        <div class="fd-col fd-col-md--8">
+            <p class="fd-text" id="dm-h-zip">43823 Downtown</p>
+        </div>
+    </div>
+    <div class="fd-row fd-form-item">
+        <div class="fd-col fd-col-md--4">
+            <label class="fd-form-label fd-form-label--colon" for="dm-h-country">Country</label>
+        </div>
+        <div class="fd-col fd-col-md--8">
+            <p class="fd-text" id="dm-h-country">United States</p>
+        </div>
+    </div>
+    <div class="fd-row fd-form-item">
+        <div class="fd-col fd-col-md--4">
+            <label class="fd-form-label fd-form-label--colon" for="dm-h-notes">Notes</label>
+        </div>
+        <div class="fd-col fd-col-md--8">
+            <p class="fd-text" id="dm-h-notes" style="font-style: italic;">&ndash;</p>
+        </div>
+    </div>
+</div>
+` + docsStyles;
+DisplayModeHorizontal.storyName = 'Display mode - Horizontal layout';
+DisplayModeHorizontal.parameters = {
+  docs: {
+    description: {
+      story: `
+Form in display mode renders field values as static text instead of interactive controls.
+Labels use the same \`fd-form-label\` classes as in edit mode. Values are rendered using the \`fd-text\` element.
+
+Empty fields are indicated by an en dash (–) in italic font style.
+
+The horizontal layout uses a label column (\`fd-col-md--4\`) and a value column (\`fd-col-md--8\`) at the MD breakpoint and above.
+      `
+    }
+  }
+};
+
+export const DisplayModeVertical = () => `
+<div class="fd-container fd-form-layout-grid-container fd-form-layout-grid-container--display-mode fd-form-layout-grid-container--vertical fd-form-group" style="max-width:600px;">
+    <div class="fd-row fd-form-item">
+        <div class="fd-col">
+            <label class="fd-form-label" for="dm-v-name">Name</label>
+        </div>
+        <div class="fd-col">
+            <p class="fd-text" id="dm-v-name">Amelia Perry</p>
+        </div>
+    </div>
+    <div class="fd-row fd-form-item">
+        <div class="fd-col">
+            <label class="fd-form-label" for="dm-v-street">Street/No.</label>
+        </div>
+        <div class="fd-col">
+            <p class="fd-text" id="dm-v-street">Myrtle St. 495</p>
+        </div>
+    </div>
+    <div class="fd-row fd-form-item">
+        <div class="fd-col">
+            <label class="fd-form-label" for="dm-v-zip">ZIP Code/City</label>
+        </div>
+        <div class="fd-col">
+            <p class="fd-text" id="dm-v-zip">43823 Downtown</p>
+        </div>
+    </div>
+    <div class="fd-row fd-form-item">
+        <div class="fd-col">
+            <label class="fd-form-label" for="dm-v-country">Country</label>
+        </div>
+        <div class="fd-col">
+            <p class="fd-text" id="dm-v-country">United States</p>
+        </div>
+    </div>
+    <div class="fd-row fd-form-item">
+        <div class="fd-col">
+            <label class="fd-form-label" for="dm-v-notes">Notes</label>
+        </div>
+        <div class="fd-col">
+            <p class="fd-text" id="dm-v-notes" style="font-style: italic;">&ndash;</p>
+        </div>
+    </div>
+</div>
+` + docsStyles;
+DisplayModeVertical.storyName = 'Display mode - Vertical layout';
+DisplayModeVertical.parameters = {
+  docs: {
+    description: {
+      story: `
+Form in display mode with vertical layout stacks the label above the value for each field.
+Apply \`fd-form-layout-grid-container--vertical\` (or the breakpoint-specific variants) to the container.
+
+Empty fields are indicated by an en dash (–) in italic font style.
+      `
     }
   }
 };

--- a/packages/styles/stories/Components/Forms/form-grid/form-grid.stories.js
+++ b/packages/styles/stories/Components/Forms/form-grid/form-grid.stories.js
@@ -1795,7 +1795,7 @@ export const DisplayModeVertical = () => `
 <div class="fd-container fd-form-layout-grid-container fd-form-layout-grid-container--display-mode fd-form-layout-grid-container--vertical fd-form-group" style="max-width:600px;">
     <div class="fd-row fd-form-item">
         <div class="fd-col">
-            <label class="fd-form-label" for="dm-v-name">Name</label>
+            <label class="fd-form-label fd-form-label--colon" for="dm-v-name">Name</label>
         </div>
         <div class="fd-col">
             <p class="fd-text" id="dm-v-name">Amelia Perry</p>
@@ -1803,7 +1803,7 @@ export const DisplayModeVertical = () => `
     </div>
     <div class="fd-row fd-form-item">
         <div class="fd-col">
-            <label class="fd-form-label" for="dm-v-street">Street/No.</label>
+            <label class="fd-form-label fd-form-label--colon" for="dm-v-street">Street/No.</label>
         </div>
         <div class="fd-col">
             <p class="fd-text" id="dm-v-street">Myrtle St. 495</p>
@@ -1811,7 +1811,7 @@ export const DisplayModeVertical = () => `
     </div>
     <div class="fd-row fd-form-item">
         <div class="fd-col">
-            <label class="fd-form-label" for="dm-v-zip">ZIP Code/City</label>
+            <label class="fd-form-label fd-form-label--colon" for="dm-v-zip">ZIP Code/City</label>
         </div>
         <div class="fd-col">
             <p class="fd-text" id="dm-v-zip">43823 Downtown</p>
@@ -1819,7 +1819,7 @@ export const DisplayModeVertical = () => `
     </div>
     <div class="fd-row fd-form-item">
         <div class="fd-col">
-            <label class="fd-form-label" for="dm-v-country">Country</label>
+            <label class="fd-form-label fd-form-label--colon" for="dm-v-country">Country</label>
         </div>
         <div class="fd-col">
             <p class="fd-text" id="dm-v-country">United States</p>
@@ -1827,7 +1827,7 @@ export const DisplayModeVertical = () => `
     </div>
     <div class="fd-row fd-form-item">
         <div class="fd-col">
-            <label class="fd-form-label" for="dm-v-notes">Notes</label>
+            <label class="fd-form-label fd-form-label--colon" for="dm-v-notes">Notes</label>
         </div>
         <div class="fd-col">
             <p class="fd-text" id="dm-v-notes" style="font-style: italic;">&ndash;</p>

--- a/packages/styles/stories/Components/Forms/form-group/form-group.stories.js
+++ b/packages/styles/stories/Components/Forms/form-group/form-group.stories.js
@@ -1,4 +1,5 @@
 import groupHeaderInFormGridExampleHtml from "./group-header-in-form-grid.example.html?raw";
+import groupHeaderInFormGridDisplayModeExampleHtml from "./group-header-in-form-grid-display-mode.example.html?raw";
 import groupHeaderExampleHtml from "./group-header.example.html?raw";
 import requiredExampleHtml from "./required.example.html?raw";
 import primaryExampleHtml from "./primary.example.html?raw";
@@ -7,6 +8,7 @@ import '../../../../src/form-group.scss';
 import '../../../../src/form-item.scss';
 import '../../../../src/form-label.scss';
 import '../../../../src/input.scss';
+import '../../../../src/text.scss';
 export default {
   title: 'Components/Forms/Form Group',
   parameters: {
@@ -50,6 +52,18 @@ GroupHeaderInFormGrid.parameters = {
     description: {
       story: `
 When group headers are displayed in a **Form Grid**, paddings are added to the groups.
+        `
+    }
+  }
+};
+
+export const GroupHeaderInFormGridDisplayMode = () => groupHeaderInFormGridDisplayModeExampleHtml;
+GroupHeaderInFormGridDisplayMode.storyName = 'Group header (form grid) – display mode';
+GroupHeaderInFormGridDisplayMode.parameters = {
+  docs: {
+    description: {
+      story: `
+Display mode variant of the group header form grid. Add \`fd-form-layout-grid-container--display-mode\` to the container and replace \`fd-input\` controls with \`fd-text\` paragraphs to render field values as static text.
         `
     }
   }

--- a/packages/styles/stories/Components/Forms/form-group/group-header-in-form-grid-display-mode.example.html
+++ b/packages/styles/stories/Components/Forms/form-group/group-header-in-form-grid-display-mode.example.html
@@ -1,0 +1,106 @@
+<div class="fd-container fd-form-layout-grid-container fd-form-layout-grid-container--display-mode">
+    <div class="fd-row">
+        <!-- Group 1 -->
+        <div class="fd-form-group fd-form-group--with-spacing fd-col fd-col-md--6 fd-col-lg--6 fd-col-xl--6 fd-col--wrap" role="group" aria-labelledby="dm-grid1GroupHeader">
+            <div class="fd-form-group__header" id="dm-grid1GroupHeader">
+                <h4 class="fd-form-group__header-text">Personal Information</h4>
+            </div>
+
+            <div class="fd-form-item fd-row">
+                <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
+                    <label class="fd-form-label fd-form-label--colon" for="dm-input-14-name">Full Name</label>
+                </div>
+                <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--12">
+                    <p class="fd-text" id="dm-input-14-name">Amelia Perry</p>
+                </div>
+            </div>
+
+            <div class="fd-form-item fd-row">
+                <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
+                    <label class="fd-form-label fd-form-label--colon" for="dm-input-14x-name">City of Residence</label>
+                </div>
+                <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--12">
+                    <p class="fd-text" id="dm-input-14x-name">New York</p>
+                </div>
+            </div>
+
+            <div class="fd-form-item fd-row">
+                <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
+                    <label class="fd-form-label fd-form-label--colon" for="dm-input-14y-name">Job Title</label>
+                </div>
+                <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--12">
+                    <p class="fd-text" id="dm-input-14y-name">Product Designer</p>
+                </div>
+            </div>
+        </div>
+
+        <!-- Group 2 -->
+        <div class="fd-form-group fd-form-group--with-spacing fd-col fd-col-md--6 fd-col-lg--6 fd-col-xl--6 fd-col--wrap" role="group" aria-labelledby="dm-grid2GroupHeader">
+            <div class="fd-form-group__header">
+                <h4 class="fd-form-group__header-text" id="dm-grid2GroupHeader">Contact Details</h4>
+            </div>
+
+            <div class="fd-form-item fd-row">
+                <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
+                    <label class="fd-form-label fd-form-label--colon" for="dm-input-14a-name">Email Address</label>
+                </div>
+                <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--12">
+                    <p class="fd-text" id="dm-input-14a-name">amelia.perry@example.com</p>
+                </div>
+            </div>
+
+            <div class="fd-form-item fd-row">
+                <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
+                    <label class="fd-form-label fd-form-label--colon" for="dm-input-14b-name">Phone Number</label>
+                </div>
+                <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--12">
+                    <p class="fd-text" id="dm-input-14b-name">+1 555 123 4567</p>
+                </div>
+            </div>
+
+            <div class="fd-form-item fd-row">
+                <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
+                    <label class="fd-form-label fd-form-label--colon" for="dm-input-14c-name">LinkedIn Profile</label>
+                </div>
+                <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--12">
+                    <p class="fd-text" id="dm-input-14c-name">linkedin.com/in/amelia-perry</p>
+                </div>
+            </div>
+        </div>
+
+        <!-- Group 3 -->
+        <div class="fd-form-group fd-form-group--with-spacing fd-col fd-col-md--6 fd-col-lg--6 fd-col-xl--6 fd-col--wrap" role="group" aria-labelledby="dm-grid3GroupHeader">
+            <div class="fd-form-group__header">
+                <h4 class="fd-form-group__header-text" id="dm-grid3GroupHeader">Security Questions</h4>
+            </div>
+
+            <div class="fd-form-item fd-row">
+                <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
+                    <label class="fd-form-label fd-form-label--colon" for="dm-input-14j-name">What was your childhood nickname?</label>
+                </div>
+                <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--12">
+                    <p class="fd-text" id="dm-input-14j-name">Mimi</p>
+                </div>
+            </div>
+
+            <div class="fd-form-item fd-row">
+                <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
+                    <label class="fd-form-label fd-form-label--colon" for="dm-input-14h-name">What was the name of your first pet?</label>
+                </div>
+                <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--12">
+                    <p class="fd-text" id="dm-input-14h-name">Charlie</p>
+                </div>
+            </div>
+
+            <div class="fd-form-item fd-row">
+                <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
+                    <label class="fd-form-label fd-form-label--colon" for="dm-input-14k-name">What city were you born in?</label>
+                </div>
+                <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--12">
+                    <p class="fd-text" id="dm-input-14k-name">Boston</p>
+                </div>
+            </div>
+        </div>
+
+    </div>
+</div>

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -25973,6 +25973,116 @@ exports[`Check stories > Components/Forms/Form Group > Story GroupHeaderInFormGr
 "
 `;
 
+exports[`Check stories > Components/Forms/Form Group > Story GroupHeaderInFormGridDisplayMode > Should match snapshot 1`] = `
+"<div class=\\"fd-container fd-form-layout-grid-container fd-form-layout-grid-container--display-mode\\">
+    <div class=\\"fd-row\\">
+        <!-- Group 1 -->
+        <div class=\\"fd-form-group fd-form-group--with-spacing fd-col fd-col-md--6 fd-col-lg--6 fd-col-xl--6 fd-col--wrap\\" role=\\"group\\" aria-labelledby=\\"dm-grid1GroupHeader\\">
+            <div class=\\"fd-form-group__header\\" id=\\"dm-grid1GroupHeader\\">
+                <h4 class=\\"fd-form-group__header-text\\">Personal Information</h4>
+            </div>
+
+            <div class=\\"fd-form-item fd-row\\">
+                <div class=\\"fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12\\">
+                    <label class=\\"fd-form-label fd-form-label--colon\\" for=\\"dm-input-14-name\\">Full Name</label>
+                </div>
+                <div class=\\"fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--12\\">
+                    <p class=\\"fd-text\\" id=\\"dm-input-14-name\\">Amelia Perry</p>
+                </div>
+            </div>
+
+            <div class=\\"fd-form-item fd-row\\">
+                <div class=\\"fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12\\">
+                    <label class=\\"fd-form-label fd-form-label--colon\\" for=\\"dm-input-14x-name\\">City of Residence</label>
+                </div>
+                <div class=\\"fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--12\\">
+                    <p class=\\"fd-text\\" id=\\"dm-input-14x-name\\">New York</p>
+                </div>
+            </div>
+
+            <div class=\\"fd-form-item fd-row\\">
+                <div class=\\"fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12\\">
+                    <label class=\\"fd-form-label fd-form-label--colon\\" for=\\"dm-input-14y-name\\">Job Title</label>
+                </div>
+                <div class=\\"fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--12\\">
+                    <p class=\\"fd-text\\" id=\\"dm-input-14y-name\\">Product Designer</p>
+                </div>
+            </div>
+        </div>
+
+        <!-- Group 2 -->
+        <div class=\\"fd-form-group fd-form-group--with-spacing fd-col fd-col-md--6 fd-col-lg--6 fd-col-xl--6 fd-col--wrap\\" role=\\"group\\" aria-labelledby=\\"dm-grid2GroupHeader\\">
+            <div class=\\"fd-form-group__header\\">
+                <h4 class=\\"fd-form-group__header-text\\" id=\\"dm-grid2GroupHeader\\">Contact Details</h4>
+            </div>
+
+            <div class=\\"fd-form-item fd-row\\">
+                <div class=\\"fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12\\">
+                    <label class=\\"fd-form-label fd-form-label--colon\\" for=\\"dm-input-14a-name\\">Email Address</label>
+                </div>
+                <div class=\\"fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--12\\">
+                    <p class=\\"fd-text\\" id=\\"dm-input-14a-name\\">amelia.perry@example.com</p>
+                </div>
+            </div>
+
+            <div class=\\"fd-form-item fd-row\\">
+                <div class=\\"fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12\\">
+                    <label class=\\"fd-form-label fd-form-label--colon\\" for=\\"dm-input-14b-name\\">Phone Number</label>
+                </div>
+                <div class=\\"fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--12\\">
+                    <p class=\\"fd-text\\" id=\\"dm-input-14b-name\\">+1 555 123 4567</p>
+                </div>
+            </div>
+
+            <div class=\\"fd-form-item fd-row\\">
+                <div class=\\"fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12\\">
+                    <label class=\\"fd-form-label fd-form-label--colon\\" for=\\"dm-input-14c-name\\">LinkedIn Profile</label>
+                </div>
+                <div class=\\"fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--12\\">
+                    <p class=\\"fd-text\\" id=\\"dm-input-14c-name\\">linkedin.com/in/amelia-perry</p>
+                </div>
+            </div>
+        </div>
+
+        <!-- Group 3 -->
+        <div class=\\"fd-form-group fd-form-group--with-spacing fd-col fd-col-md--6 fd-col-lg--6 fd-col-xl--6 fd-col--wrap\\" role=\\"group\\" aria-labelledby=\\"dm-grid3GroupHeader\\">
+            <div class=\\"fd-form-group__header\\">
+                <h4 class=\\"fd-form-group__header-text\\" id=\\"dm-grid3GroupHeader\\">Security Questions</h4>
+            </div>
+
+            <div class=\\"fd-form-item fd-row\\">
+                <div class=\\"fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12\\">
+                    <label class=\\"fd-form-label fd-form-label--colon\\" for=\\"dm-input-14j-name\\">What was your childhood nickname?</label>
+                </div>
+                <div class=\\"fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--12\\">
+                    <p class=\\"fd-text\\" id=\\"dm-input-14j-name\\">Mimi</p>
+                </div>
+            </div>
+
+            <div class=\\"fd-form-item fd-row\\">
+                <div class=\\"fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12\\">
+                    <label class=\\"fd-form-label fd-form-label--colon\\" for=\\"dm-input-14h-name\\">What was the name of your first pet?</label>
+                </div>
+                <div class=\\"fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--12\\">
+                    <p class=\\"fd-text\\" id=\\"dm-input-14h-name\\">Charlie</p>
+                </div>
+            </div>
+
+            <div class=\\"fd-form-item fd-row\\">
+                <div class=\\"fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12\\">
+                    <label class=\\"fd-form-label fd-form-label--colon\\" for=\\"dm-input-14k-name\\">What city were you born in?</label>
+                </div>
+                <div class=\\"fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--12\\">
+                    <p class=\\"fd-text\\" id=\\"dm-input-14k-name\\">Boston</p>
+                </div>
+            </div>
+        </div>
+
+    </div>
+</div>
+"
+`;
+
 exports[`Check stories > Components/Forms/Form Group > Story Primary > Should match snapshot 1`] = `
 "<div class=\\"fd-form-group\\">
         <div class=\\"fd-form-item\\">

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -24474,7 +24474,7 @@ exports[`Check stories > Components/Forms/Form Grid > Story DisplayModeVertical 
 <div class=\\"fd-container fd-form-layout-grid-container fd-form-layout-grid-container--display-mode fd-form-layout-grid-container--vertical fd-form-group\\" style=\\"max-width:600px;\\">
     <div class=\\"fd-row fd-form-item\\">
         <div class=\\"fd-col\\">
-            <label class=\\"fd-form-label\\" for=\\"dm-v-name\\">Name</label>
+            <label class=\\"fd-form-label fd-form-label--colon\\" for=\\"dm-v-name\\">Name</label>
         </div>
         <div class=\\"fd-col\\">
             <p class=\\"fd-text\\" id=\\"dm-v-name\\">Amelia Perry</p>
@@ -24482,7 +24482,7 @@ exports[`Check stories > Components/Forms/Form Grid > Story DisplayModeVertical 
     </div>
     <div class=\\"fd-row fd-form-item\\">
         <div class=\\"fd-col\\">
-            <label class=\\"fd-form-label\\" for=\\"dm-v-street\\">Street/No.</label>
+            <label class=\\"fd-form-label fd-form-label--colon\\" for=\\"dm-v-street\\">Street/No.</label>
         </div>
         <div class=\\"fd-col\\">
             <p class=\\"fd-text\\" id=\\"dm-v-street\\">Myrtle St. 495</p>
@@ -24490,7 +24490,7 @@ exports[`Check stories > Components/Forms/Form Grid > Story DisplayModeVertical 
     </div>
     <div class=\\"fd-row fd-form-item\\">
         <div class=\\"fd-col\\">
-            <label class=\\"fd-form-label\\" for=\\"dm-v-zip\\">ZIP Code/City</label>
+            <label class=\\"fd-form-label fd-form-label--colon\\" for=\\"dm-v-zip\\">ZIP Code/City</label>
         </div>
         <div class=\\"fd-col\\">
             <p class=\\"fd-text\\" id=\\"dm-v-zip\\">43823 Downtown</p>
@@ -24498,7 +24498,7 @@ exports[`Check stories > Components/Forms/Form Grid > Story DisplayModeVertical 
     </div>
     <div class=\\"fd-row fd-form-item\\">
         <div class=\\"fd-col\\">
-            <label class=\\"fd-form-label\\" for=\\"dm-v-country\\">Country</label>
+            <label class=\\"fd-form-label fd-form-label--colon\\" for=\\"dm-v-country\\">Country</label>
         </div>
         <div class=\\"fd-col\\">
             <p class=\\"fd-text\\" id=\\"dm-v-country\\">United States</p>
@@ -24506,7 +24506,7 @@ exports[`Check stories > Components/Forms/Form Grid > Story DisplayModeVertical 
     </div>
     <div class=\\"fd-row fd-form-item\\">
         <div class=\\"fd-col\\">
-            <label class=\\"fd-form-label\\" for=\\"dm-v-notes\\">Notes</label>
+            <label class=\\"fd-form-label fd-form-label--colon\\" for=\\"dm-v-notes\\">Notes</label>
         </div>
         <div class=\\"fd-col\\">
             <p class=\\"fd-text\\" id=\\"dm-v-notes\\" style=\\"font-style: italic;\\">&ndash;</p>

--- a/packages/styles/tests/__snapshots__/styles.test.ts.snap
+++ b/packages/styles/tests/__snapshots__/styles.test.ts.snap
@@ -24414,6 +24414,116 @@ exports[`Check stories > Components/Forms/Form Grid > Story ColumnRecommended > 
 "
 `;
 
+exports[`Check stories > Components/Forms/Form Grid > Story DisplayModeHorizontal > Should match snapshot 1`] = `
+"
+<div class=\\"fd-container fd-form-layout-grid-container fd-form-layout-grid-container--display-mode fd-form-group\\">
+    <div class=\\"fd-row fd-form-item\\">
+        <div class=\\"fd-col fd-col-md--4\\">
+            <label class=\\"fd-form-label fd-form-label--colon\\" for=\\"dm-h-name\\">Name</label>
+        </div>
+        <div class=\\"fd-col fd-col-md--8\\">
+            <p class=\\"fd-text\\" id=\\"dm-h-name\\">Amelia Perry</p>
+        </div>
+    </div>
+    <div class=\\"fd-row fd-form-item\\">
+        <div class=\\"fd-col fd-col-md--4\\">
+            <label class=\\"fd-form-label fd-form-label--colon\\" for=\\"dm-h-street\\">Street/No.</label>
+        </div>
+        <div class=\\"fd-col fd-col-md--8\\">
+            <p class=\\"fd-text\\" id=\\"dm-h-street\\">Myrtle St. 495</p>
+        </div>
+    </div>
+    <div class=\\"fd-row fd-form-item\\">
+        <div class=\\"fd-col fd-col-md--4\\">
+            <label class=\\"fd-form-label fd-form-label--colon\\" for=\\"dm-h-zip\\">ZIP Code/City</label>
+        </div>
+        <div class=\\"fd-col fd-col-md--8\\">
+            <p class=\\"fd-text\\" id=\\"dm-h-zip\\">43823 Downtown</p>
+        </div>
+    </div>
+    <div class=\\"fd-row fd-form-item\\">
+        <div class=\\"fd-col fd-col-md--4\\">
+            <label class=\\"fd-form-label fd-form-label--colon\\" for=\\"dm-h-country\\">Country</label>
+        </div>
+        <div class=\\"fd-col fd-col-md--8\\">
+            <p class=\\"fd-text\\" id=\\"dm-h-country\\">United States</p>
+        </div>
+    </div>
+    <div class=\\"fd-row fd-form-item\\">
+        <div class=\\"fd-col fd-col-md--4\\">
+            <label class=\\"fd-form-label fd-form-label--colon\\" for=\\"dm-h-notes\\">Notes</label>
+        </div>
+        <div class=\\"fd-col fd-col-md--8\\">
+            <p class=\\"fd-text\\" id=\\"dm-h-notes\\" style=\\"font-style: italic;\\">&ndash;</p>
+        </div>
+    </div>
+</div>
+
+  <!-- Styles related to the docs -->
+  <style>
+      .fd-form-layout-grid-container {
+        border: 1px solid; margin: 0 auto;
+      }
+  </style>
+
+"
+`;
+
+exports[`Check stories > Components/Forms/Form Grid > Story DisplayModeVertical > Should match snapshot 1`] = `
+"
+<div class=\\"fd-container fd-form-layout-grid-container fd-form-layout-grid-container--display-mode fd-form-layout-grid-container--vertical fd-form-group\\" style=\\"max-width:600px;\\">
+    <div class=\\"fd-row fd-form-item\\">
+        <div class=\\"fd-col\\">
+            <label class=\\"fd-form-label\\" for=\\"dm-v-name\\">Name</label>
+        </div>
+        <div class=\\"fd-col\\">
+            <p class=\\"fd-text\\" id=\\"dm-v-name\\">Amelia Perry</p>
+        </div>
+    </div>
+    <div class=\\"fd-row fd-form-item\\">
+        <div class=\\"fd-col\\">
+            <label class=\\"fd-form-label\\" for=\\"dm-v-street\\">Street/No.</label>
+        </div>
+        <div class=\\"fd-col\\">
+            <p class=\\"fd-text\\" id=\\"dm-v-street\\">Myrtle St. 495</p>
+        </div>
+    </div>
+    <div class=\\"fd-row fd-form-item\\">
+        <div class=\\"fd-col\\">
+            <label class=\\"fd-form-label\\" for=\\"dm-v-zip\\">ZIP Code/City</label>
+        </div>
+        <div class=\\"fd-col\\">
+            <p class=\\"fd-text\\" id=\\"dm-v-zip\\">43823 Downtown</p>
+        </div>
+    </div>
+    <div class=\\"fd-row fd-form-item\\">
+        <div class=\\"fd-col\\">
+            <label class=\\"fd-form-label\\" for=\\"dm-v-country\\">Country</label>
+        </div>
+        <div class=\\"fd-col\\">
+            <p class=\\"fd-text\\" id=\\"dm-v-country\\">United States</p>
+        </div>
+    </div>
+    <div class=\\"fd-row fd-form-item\\">
+        <div class=\\"fd-col\\">
+            <label class=\\"fd-form-label\\" for=\\"dm-v-notes\\">Notes</label>
+        </div>
+        <div class=\\"fd-col\\">
+            <p class=\\"fd-text\\" id=\\"dm-v-notes\\" style=\\"font-style: italic;\\">&ndash;</p>
+        </div>
+    </div>
+</div>
+
+  <!-- Styles related to the docs -->
+  <style>
+      .fd-form-layout-grid-container {
+        border: 1px solid; margin: 0 auto;
+      }
+  </style>
+
+"
+`;
+
 exports[`Check stories > Components/Forms/Form Grid > Story LSizeDefault > Should match snapshot 1`] = `
 "<div class=\\"fd-container fd-form-layout-grid-container fd-form-group\\" style=\\"max-width:1440px;\\">
   <div class=\\"fd-row fd-form-item\\">


### PR DESCRIPTION
## Related Issue

Closes [SAP/fundamental-styles#](https://github.com/SAP/fundamental-styles/issues/4463)

## Description

### 1. Fix label-to-input gap in standalone horizontal form item (Spec E: 0.25rem)

**File**: [form-item.scss](packages/styles/src/form-item.scss)

`margin-inline-end` on `.fd-form-label` inside `.fd-form-item--horizontal` was `0.5rem`. The spec defines 0.25rem between the label and the input control in horizontal layout.

**Change**: `margin-inline: 0 0.5rem` → `margin-inline: 0 0.25rem`

---

### 2. Fix unused `$marginTop` parameter in `fd-form-vertical` mixin

**File**: [form-layout-grid.scss](packages/styles/src/form-layout-grid.scss) — `fd-form-vertical` mixin

The mixin accepted a `$marginTop` parameter (default `0.625rem`) but the body hardcoded `margin-top: 0.625rem`, ignoring the parameter.

**Change**: `margin-top: 0.625rem` → `margin-top: $marginTop` so callers can override the default spacing.

---

### 3. Add display mode CSS block (new)

**File**: [form-layout-grid.scss](packages/styles/src/form-layout-grid.scss)

Added a new `.fd-form-layout-grid-container--display-mode` block that implements all display mode spacing values from the spec:

| Spec item | Value | Implementation |
|-----------|-------|----------------|
| A: Label padding-bottom | 0.25rem | `padding-block-end: 0.25rem` on `fd-form-label` inside full-width columns |
| B: Text touch area (cozy) | 2.25rem | `padding-block: 0.625rem` on `fd-text` (text line-height ≈ 1rem → total ≈ 2.25rem) |
| B: Text touch area (compact) | 1.625rem | `padding-block: 0.3125rem` on `fd-text` inside `fd-compact-or-condensed()` |
| C: Spacing between pairs (vertical) | 1rem | `margin-top: 1rem` on `fd-form-item`, `margin-top: 0` on first item |

The C gap (1rem) is applied via `margin-top` on `fd-form-item` (not on the label element, to avoid displacing pseudo-element decorators such as `--colon::after`) to:
- Containers explicitly marked `--vertical`, `--md-vertical`, `--lg-vertical`, or `--xl-vertical` at any viewport width.
- All display mode containers at the S breakpoint (≤599px), where the grid collapses to full-width columns regardless of explicit modifier.

---

### 4. Add display mode Storybook stories (new)

**Files**: [form-grid.stories.js](packages/styles/stories/Components/Forms/form-grid/form-grid.stories.js), [form-group.stories.js](packages/styles/stories/Components/Forms/form-group/form-group.stories.js)

Added new stories and the missing `text.scss` import where needed:

- **Display mode – Horizontal layout** (`DisplayModeHorizontal`, form-grid): Uses `fd-col-md--4` / `fd-col-md--8` column split at MD+. Labels carry `fd-form-label--colon`. Empty fields rendered as an en dash in italic.
- **Display mode – Vertical layout** (`DisplayModeVertical`, form-grid): Uses `fd-form-layout-grid-container--vertical` with plain `fd-col` columns. Labels use `fd-form-label--colon` (no `--required` — required indicators are not shown in display mode).
- **Group header (form grid) – display mode** (`GroupHeaderInFormGridDisplayMode`, form-group): Display mode counterpart of the existing "Group header (form grid)" story. Same three-group structure; `fd-input` controls replaced with `fd-text` paragraphs, `fd-form-layout-grid-container--display-mode` added to the container, colons moved from label text to the `fd-form-label--colon` modifier.

---


### 5. Fix compact height on form group header (Spec: 2rem)

**File**: [form-group.scss](packages/styles/src/form-group.scss)

`fd-form-group__header` had `min-height: var(--sapElement_LineHeight)` (2.75rem) with no compact override. The spec defines 2rem in compact density.

**Change**: Added `fd-compact-or-condensed()` override with `min-height: var(--sapElement_Compact_LineHeight)`, consistent with the token used by the list component for compact row height.

---

## What is not in scope

The Tokenizer in display/readonly mode requires separate work. See https://github.com/SAP/fundamental-styles/issues/6378 for a full description of the gap and what needs to be done.


## Screenshots
<img width="984" height="1126" alt="Screenshot 2026-08-26 at 11 22 49" src="https://github.com/user-attachments/assets/73092938-537d-4bed-a86f-689e6512024c" />

<img width="1118" height="813" alt="Screenshot 2026-08-26 at 14 29 54" src="https://github.com/user-attachments/assets/a5f16e94-c29a-4ce9-af55-1d0cadeb1b4d" />
