### PR TITLE
docs(styles): product switch design updates - move some variables to the root

### DIFF
--- a/packages/styles/src/product-switch.scss
+++ b/packages/styles/src/product-switch.scss
@@ -7,11 +7,6 @@
 
 $block: #{$fd-namespace}-product-switch;
 
-:root {
-  --fdProduct_Switch_Item_Border_Color: transparent;
-  --fdProductSwitch_Body_BorderRadius: var(--sapPopover_BorderCornerRadius, var(--sapElement_BorderCornerRadius));
-}
-
 .#{$block} {
   @mixin fd-product-pseudo-element-background($background) {
     .#{$block}__title {
@@ -52,7 +47,7 @@ $block: #{$fd-namespace}-product-switch;
     background-color: var(--sapList_Background);
     border-radius: var(--sapElement_BorderCornerRadius);
     box-shadow: var(--fdProductSwitch_Shadow);
-    outline: 0.125rem solid var(--fdProduct_Switch_Item_Border_Color);
+    outline: 0.125rem solid var(--fdProduct_Switch_Item_Border_Color, transparent);
     outline-offset: -0.125rem;
 
     .#{$block}__title:not(:last-child) {
@@ -185,7 +180,7 @@ $block: #{$fd-namespace}-product-switch;
     padding-block: 1.5rem;
     padding-inline: 1rem;
     background-color: var(--sapList_Background);
-    border-radius: var(--fdProductSwitch_Body_BorderRadius);
+    border-radius: var(--sapPopover_BorderCornerRadius, var(--sapElement_BorderCornerRadius));
   }
 
   &__body--col-2 {

--- a/packages/styles/src/product-switch.scss
+++ b/packages/styles/src/product-switch.scss
@@ -7,9 +7,12 @@
 
 $block: #{$fd-namespace}-product-switch;
 
-.#{$block} {
+:root {
   --fdProduct_Switch_Item_Border_Color: transparent;
   --fdProductSwitch_Body_BorderRadius: var(--sapPopover_BorderCornerRadius, var(--sapElement_BorderCornerRadius));
+}
+
+.#{$block} {
 
   @mixin fd-product-pseudo-element-background($background) {
     .#{$block}__title {

--- a/packages/styles/src/product-switch.scss
+++ b/packages/styles/src/product-switch.scss
@@ -13,7 +13,6 @@ $block: #{$fd-namespace}-product-switch;
 }
 
 .#{$block} {
-
   @mixin fd-product-pseudo-element-background($background) {
     .#{$block}__title {
       &::after,


### PR DESCRIPTION
## Related Issue
Closes none

## Description
 `--fdProductSwitch_Body_BorderRadius` was defined on `.fd-product-switch`, but in fundamental-ngx this component renders `.fd-product-switch__body` without that ancestor, so the variable was out of scope: 
 <pre>

<img width="617" height="147" alt="Screenshot 2026-08-28 at 12 27 22" src="https://github.com/user-attachments/assets/6b249479-1fbe-4837-86ed-07151c31ae10" />

</pre>


Similar was the situation with `--fdProduct_Switch_Item_Border_Color` used for the outline of `fd-product-switch__item`:
<pre>

<img width="599" height="708" alt="Screenshot 2026-08-28 at 12 28 57" src="https://github.com/user-attachments/assets/33908220-f7da-4d43-ac0c-cd34dddeb5c5" />
</pre>

To remediate the issue, both variables are now on `:root`.